### PR TITLE
Miscelaneous Pubby Fixes and OSHA update

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2956,15 +2956,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"anz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "anB" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance{
@@ -3139,6 +3130,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -39163,6 +39157,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "hCX" = (
@@ -44245,6 +44242,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "kIT" = (
@@ -48814,18 +48814,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"nKM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nLe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49154,6 +49142,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -85423,7 +85414,7 @@ alv
 nqc
 nTp
 alv
-anz
+alv
 alv
 alv
 alv
@@ -85680,7 +85671,7 @@ sYU
 pYS
 vMQ
 kIT
-nKM
+sow
 kIT
 sow
 vsu
@@ -85937,7 +85928,7 @@ cVO
 ajM
 amg
 amg
-apJ
+ayQ
 amg
 ayQ
 amg
@@ -86452,7 +86443,7 @@ alz
 amg
 amT
 amX
-amX
+awK
 aoS
 apJ
 bdt
@@ -86709,7 +86700,7 @@ ahL
 ahL
 amU
 amX
-amX
+awK
 aoT
 apK
 cAx

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27971,9 +27971,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cgG" = (
-/turf/open/floor/plating,
-/area/chapel/main/monastery)
 "cgH" = (
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
@@ -37029,6 +37026,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "gmh" = (
@@ -80388,13 +80386,13 @@ cfm
 dZZ
 cvy
 bWV
-cgG
-cgG
+mci
+mci
 bWV
 emE
 bWV
-cgG
-cgG
+mci
+mci
 bWV
 cvy
 dZZ
@@ -80644,7 +80642,7 @@ bWV
 cfm
 jqa
 cvy
-cgG
+mci
 chi
 cid
 cuM
@@ -80652,7 +80650,7 @@ fKI
 cvb
 ciT
 cvh
-cgG
+mci
 cvy
 jUl
 cwa
@@ -80901,7 +80899,7 @@ ceK
 cfm
 eHc
 cvy
-cgG
+mci
 cid
 cuA
 cib
@@ -80909,7 +80907,7 @@ vjm
 cgH
 ciS
 cid
-cgG
+mci
 cvy
 iKy
 qqc
@@ -81415,7 +81413,7 @@ dWH
 cfs
 vPt
 cvy
-cgG
+mci
 cgk
 cuA
 ciS
@@ -81423,7 +81421,7 @@ chk
 cgH
 cgH
 cvi
-cgG
+mci
 yhG
 dZZ
 cwa
@@ -82186,7 +82184,7 @@ ceK
 cfm
 hpI
 cvy
-cgG
+mci
 ciV
 cgH
 cgH
@@ -82194,7 +82192,7 @@ cgH
 cic
 ciV
 cjq
-cgG
+mci
 cvy
 jUl
 ckT
@@ -82443,7 +82441,7 @@ bWV
 cfm
 uLh
 cvy
-cgG
+mci
 cgm
 cuE
 cuO
@@ -82451,7 +82449,7 @@ cgH
 ciE
 ciW
 cjr
-cgG
+mci
 cvy
 sCt
 bgX
@@ -82701,13 +82699,13 @@ cfm
 rAU
 cvy
 bWV
-cgG
-cgG
+mci
+mci
 bWV
 cuY
 bWV
-cgG
-cgG
+mci
+mci
 bWV
 cvy
 rAU

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -360,13 +360,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"abI" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
 "abJ" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -1543,10 +1536,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "ahQ" = (
-/obj/machinery/vending/security,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "ahS" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/red{
@@ -1645,23 +1640,28 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aip" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/main)
+"air" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"ais" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -31
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"ais" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "ait" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1779,8 +1779,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiQ" = (
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/security/main)
 "aiR" = (
 /turf/closed/wall,
@@ -8245,10 +8244,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIR" = (
-/obj/vehicle/ridden/secway,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room"
-	},
+/obj/machinery/vending/security,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aIT" = (
@@ -8745,14 +8742,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "aLG" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -31
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -9604,60 +9601,27 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "aOt" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aOu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Security E.V.A. Storage";
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aOv" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aOw" = (
 /turf/closed/wall,
@@ -9776,17 +9740,44 @@
 /area/hallway/primary/central)
 "aOM" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aON" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/obj/item/key/security,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security E.V.A. Storage";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "aOO" = (
 /obj/structure/table,
@@ -9973,9 +9964,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aPy" = (
-/obj/structure/cable/yellow,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/tank_dispenser/oxygen,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aPz" = (
 /turf/open/floor/plating{
@@ -10245,36 +10248,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aQB" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/light/small,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/item/key/security,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aQD" = (
-/obj/machinery/door/airlock/security{
-	name = "Equipment Room";
-	req_access_txt = "1"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aQE" = (
@@ -10567,11 +10550,21 @@
 /turf/closed/wall,
 /area/hydroponics)
 "aRM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/door/airlock/security{
+	name = "Equipment Room";
+	req_access_txt = "1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aRN" = (
@@ -10868,7 +10861,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aSR" = (
-/obj/structure/chair/stool,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aTb" = (
@@ -11060,13 +11057,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aTR" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aTS" = (
@@ -11092,11 +11083,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aTZ" = (
+/obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -11161,12 +11153,11 @@
 /turf/open/space,
 /area/solar/starboard)
 "aUQ" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -11463,8 +11454,12 @@
 /turf/closed/wall,
 /area/janitor)
 "aVU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -12077,18 +12072,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aYd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/security/main)
 "aYe" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -14833,20 +14821,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bil" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/vehicle/ridden/secway,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bim" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
@@ -15160,22 +15137,18 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "bjR" = (
-/obj/machinery/door/airlock{
-	id_tag = "Potty1";
-	name = "Unisex Restrooms"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bjS" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -15546,17 +15519,20 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "blc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bld" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/dark,
@@ -28004,11 +27980,22 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgG" = (
-/obj/item/extinguisher,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/door/airlock{
+	id_tag = "Potty1";
+	name = "Unisex Restrooms"
 	},
-/area/maintenance/department/crew_quarters/bar)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "cgH" = (
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
@@ -29166,34 +29153,47 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "cnN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
+"cnP" = (
+/obj/item/extinguisher,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/crew_quarters/bar)
+"cnQ" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
-"cnP" = (
-/obj/machinery/door/airlock/maintenance{
-	id_tag = "Potty1";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"cnQ" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/crew_quarters/bar)
 "cnT" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/closet/bombcloset/security,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "cnV" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "cnW" = (
 /turf/open/floor/engine,
@@ -29813,21 +29813,19 @@
 /turf/open/space,
 /area/space/nearstation)
 "crn" = (
-/obj/structure/tank_dispenser/oxygen,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/main)
 "crt" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -30692,16 +30690,6 @@
 "cyB" = (
 /turf/closed/wall,
 /area/library/lounge)
-"cyD" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "cyM" = (
 /turf/closed/mineral,
 /area/chapel/asteroid/monastery)
@@ -31688,6 +31676,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cPX" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cRi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -32190,6 +32186,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"ddN" = (
+/obj/machinery/door/airlock{
+	name = "Service Access";
+	req_one_access_txt = "22;25;26;28;35;37;38;46"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "deV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -32361,6 +32370,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dmg" = (
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "dmT" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable/yellow{
@@ -33279,12 +33294,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "dRn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+/obj/machinery/door/airlock/maintenance{
+	id_tag = "Potty1";
+	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "dRO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33601,14 +33616,6 @@
 	},
 /turf/open/floor/plating,
 /area/lawoffice)
-"ecf" = (
-/obj/structure/kitchenspike,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "edl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35064,21 +35071,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"eVR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "eVS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -35725,6 +35717,16 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"fpq" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "fpF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -36602,6 +36604,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"fUL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fVh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37822,13 +37839,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"gHt" = (
-/obj/structure/bed/roller,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/medical/virology)
 "gHX" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -39499,12 +39509,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"hIO" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/crew_quarters/bar)
 "hJc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40847,14 +40851,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
-"izV" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "iAB" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -41133,10 +41129,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"iJc" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/hydroponics)
 "iJf" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -42253,6 +42245,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"jut" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "juI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Research Security Post";
@@ -44038,30 +44041,6 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
-"kBy" = (
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Janitor Delivery";
-	req_access_txt = "26"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Janitor"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/janitor)
 "kBG" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -44071,14 +44050,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "kBN" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/main)
 "kCc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -45183,28 +45159,6 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"liq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "liV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -46398,21 +46352,6 @@
 "lWy" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"lWC" = (
-/obj/machinery/power/apc{
-	name = "Hydroponics APC";
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "lWH" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -46877,18 +46816,14 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "mlL" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/radio/intercom{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
 /area/security/main)
 "mmc" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -48244,6 +48179,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nfU" = (
+/obj/machinery/power/apc{
+	name = "Hydroponics APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "ngi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -48476,6 +48426,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"npS" = (
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "npX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48630,6 +48587,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nvx" = (
+/obj/machinery/chem_master/condimaster,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "nwg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48909,15 +48873,10 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "nGY" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Bar Maintenance APC";
-	pixel_y = 24
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "nIm" = (
 /obj/machinery/computer/security/telescreen{
@@ -49358,11 +49317,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nXn" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nXz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -49375,21 +49335,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nYb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "nYh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49604,13 +49549,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"oea" = (
-/obj/machinery/chem_master/condimaster,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "oeh" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 26
@@ -50282,6 +50220,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"ozT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "oAw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50755,6 +50708,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
+"oMg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oMD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51446,6 +51411,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"pjZ" = (
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "pkd" = (
 /obj/machinery/computer/shuttle_flight/custom_shuttle/exploration{
 	dir = 8
@@ -51466,6 +51441,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"pkv" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/crew_quarters/bar)
 "pkM" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/dark,
@@ -52269,14 +52250,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pEF" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Bar Maintenance APC";
+	pixel_y = 24
+	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -52837,24 +52817,10 @@
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "pZK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -53202,13 +53168,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qkU" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access_txt = "35"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -54570,20 +54537,25 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "rls" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wirecutters,
-/obj/effect/turf_decal/bot,
-/obj/item/clothing/suit/apron,
-/obj/item/wrench,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/crew_quarters/bar)
 "rlz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55307,17 +55279,6 @@
 "rMV" = (
 /turf/open/floor/plating,
 /area/library/lounge)
-"rNf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "rNg" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
@@ -55551,6 +55512,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rUL" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "rUR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -56481,12 +56450,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"szL" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "sAn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -56813,6 +56776,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sKc" = (
+/obj/machinery/door/window/eastright{
+	name = "Hydroponics Delivery";
+	req_access_txt = "35"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 1;
+	freq = 1400;
+	location = "Hydroponics"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "sLc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -58123,6 +58104,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"tFW" = (
+/obj/structure/bed/roller,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/medical/virology)
 "tGk" = (
 /obj/structure/chair,
 /obj/item/clothing/mask/gas,
@@ -58272,6 +58260,30 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
+"tPb" = (
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Janitor Delivery";
+	req_access_txt = "26"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Janitor"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "tPl" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -58814,6 +58826,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"uln" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -59241,9 +59275,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uzH" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access_txt = "35"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -60847,19 +60888,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"vGK" = (
-/obj/machinery/door/airlock{
-	name = "Service Access";
-	req_one_access_txt = "22;25;26;28;35;37;38;46"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "vGY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61695,16 +61723,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "whF" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wirecutters,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/suit/apron,
+/obj/item/wrench,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
 	},
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "whH" = (
 /obj/structure/chair/wood/normal,
 /obj/item/radio/intercom/chapel{
@@ -61966,16 +61998,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"wrK" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "wrS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -62300,17 +62322,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wBg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "wCm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -62539,6 +62553,21 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wKn" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "wKB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -63304,20 +63333,16 @@
 /turf/open/floor/carpet,
 /area/library/lounge)
 "xhq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "Kitchen Cold Room"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "xhu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63460,24 +63485,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"xns" = (
-/obj/machinery/door/window/eastright{
-	name = "Hydroponics Delivery";
-	req_access_txt = "35"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 1;
-	freq = 1400;
-	location = "Hydroponics"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "xoq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -64127,6 +64134,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xHJ" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/hydroponics)
 "xHQ" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -88506,10 +88517,10 @@ aaa
 aaa
 pmj
 bRC
-agP
-agP
+aiQ
+aiQ
 agQ
-agP
+aiQ
 ahL
 ahL
 ahL
@@ -88547,7 +88558,7 @@ rlV
 aDZ
 sLZ
 aDZ
-dRn
+nXn
 aDZ
 aDZ
 aDZ
@@ -88766,7 +88777,7 @@ aaa
 agQ
 cnJ
 cnJ
-ais
+aLG
 ahM
 ain
 agP
@@ -88847,7 +88858,7 @@ bFI
 wlo
 iLs
 bGO
-gHt
+tFW
 bEr
 puQ
 bEr
@@ -89023,13 +89034,13 @@ aaa
 agQ
 alH
 alH
-aiQ
-aLG
+aOt
+aOv
 aio
-aQD
-rHJ
 aRM
-aTR
+rHJ
+aSR
+aTZ
 alC
 alE
 alC
@@ -89279,14 +89290,14 @@ pmj
 aaa
 agQ
 ahd
-ahQ
+aIR
 alH
-aOt
-cnJ
+aOM
+alH
 agP
 ajm
 ajW
-aTZ
+aUQ
 alD
 anM
 anc
@@ -89322,7 +89333,7 @@ aKT
 aKT
 aRI
 coV
-wBg
+oMg
 jnd
 aVS
 aVS
@@ -89534,17 +89545,17 @@ aaa
 aaa
 pmj
 bRC
-agP
-agP
-agP
-aIR
-aOt
-aON
+aiQ
+aiQ
+aiQ
+aOu
+aOM
+cnJ
 agP
 ajn
-aSR
+aTR
 iGd
-aVU
+aYd
 amp
 gzo
 eVS
@@ -89579,7 +89590,7 @@ aNc
 aKT
 aKT
 aKT
-xhq
+wKn
 aKT
 aVS
 aWM
@@ -89793,10 +89804,10 @@ aaa
 aaa
 bRC
 aaa
-cnV
+aiQ
 cnT
-aOu
-aPy
+aOM
+aQB
 agP
 ajo
 ajV
@@ -89833,12 +89844,12 @@ sLc
 gZh
 aKJ
 aLL
-pEF
+qkU
 dZP
 dZP
 tbr
 qqS
-kBy
+tPb
 aWN
 aXO
 aYM
@@ -90050,14 +90061,14 @@ aaa
 aaa
 pmj
 aaa
-cnV
+aiQ
 kBN
-aOv
+aON
 aip
 agP
 mKT
 alE
-aUQ
+aVU
 alF
 amq
 ane
@@ -90307,10 +90318,10 @@ aaa
 aaa
 pmj
 aaa
-cnV
+aiQ
 mlL
 crn
-aQB
+aQD
 agP
 fHO
 nbB
@@ -90349,8 +90360,8 @@ aKJ
 aLL
 bEp
 aRL
-rls
-xns
+whF
+sKc
 aUR
 aVS
 aVS
@@ -90564,17 +90575,17 @@ aaa
 aaa
 pmj
 aaa
+aiQ
 cnV
-cnV
-aOM
-cnV
-cnV
+aPy
+air
+aiQ
 agP
 agP
 cCS
 alH
 pfG
-alH
+bil
 anP
 agP
 bNN
@@ -90604,11 +90615,11 @@ aLA
 aMY
 aKP
 aNm
-pZK
-qkU
+rls
+uzH
 aUS
 aTQ
-lWC
+nfU
 aRL
 aWP
 aXQ
@@ -90821,11 +90832,11 @@ aaa
 aaa
 pmj
 bRC
-bRC
-bRC
-bRC
-bRC
-cnV
+ais
+ais
+ahQ
+ais
+aiQ
 ajr
 aiR
 akT
@@ -90866,7 +90877,7 @@ aRL
 aSB
 aTS
 aUU
-iJc
+xHJ
 aWP
 aXR
 utc
@@ -91082,7 +91093,7 @@ aaa
 aaa
 aaa
 bRC
-cnV
+aiQ
 ajs
 aiR
 akU
@@ -91116,14 +91127,14 @@ ney
 ezV
 mhT
 umH
-cnP
+dRn
 aPz
 lxE
 aRL
 aSD
 aTS
 aUU
-iJc
+xHJ
 aWP
 fep
 aYO
@@ -91379,7 +91390,7 @@ rUB
 aRL
 aSD
 jKb
-cyD
+pjZ
 aRL
 aWR
 aXT
@@ -91652,7 +91663,7 @@ mzT
 aDZ
 bim
 biY
-szL
+dmg
 bmq
 aab
 lcH
@@ -91893,7 +91904,7 @@ kFZ
 aRL
 aSF
 aXS
-wrK
+fpq
 aRL
 aWT
 aXV
@@ -92145,7 +92156,7 @@ aKT
 xsW
 aNd
 aKT
-nGY
+pEF
 jTj
 aRL
 aSG
@@ -92401,7 +92412,7 @@ unN
 aKT
 aPz
 aLL
-cnQ
+nGY
 aPA
 hSI
 aRN
@@ -92657,12 +92668,12 @@ aIO
 gAZ
 aKT
 aKQ
-cgG
+cnP
 aKT
 aLL
 hSI
 aRN
-uzH
+wBg
 aTX
 aUX
 aVW
@@ -92678,7 +92689,7 @@ aDZ
 aDZ
 cRi
 jkW
-izV
+cPX
 biY
 biY
 biY
@@ -92910,13 +92921,13 @@ aFx
 aGk
 awR
 aHQ
-aYd
+bjR
 nQP
 aOw
 aOw
 aOw
 aOw
-nXn
+pZK
 gZX
 aRO
 jAt
@@ -93176,10 +93187,10 @@ aOw
 aPB
 hSI
 aRN
-whF
+xhq
 aSK
 aSK
-oea
+nvx
 aRN
 aRN
 bgk
@@ -93425,18 +93436,18 @@ aGm
 awR
 pPv
 aIQ
-bil
-bjR
 blc
+cgG
 cnN
+cnQ
 aOw
 aLL
 hSI
 aRN
 aSI
-abI
+npS
 xMd
-ecf
+rUL
 aWU
 aRN
 aYR
@@ -95751,7 +95762,7 @@ aUe
 cpa
 aWg
 aXc
-vGK
+ddN
 cpg
 bah
 bag
@@ -96004,7 +96015,7 @@ aPE
 aPE
 tED
 aPE
-hIO
+pkv
 aPE
 aWh
 qTS
@@ -100630,7 +100641,7 @@ aZi
 aXr
 bbz
 aDZ
-eVR
+fUL
 aDZ
 bbz
 aXr
@@ -100887,7 +100898,7 @@ aLe
 aLe
 aPW
 baz
-liq
+uln
 baz
 aPW
 aLf
@@ -101144,7 +101155,7 @@ mLo
 aRf
 fue
 aPY
-nYb
+ozT
 aPY
 aWs
 aPW
@@ -101401,7 +101412,7 @@ wej
 oPA
 pEk
 gne
-rNf
+jut
 aPY
 aWu
 aXt

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -271,10 +271,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 35
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/camera{
@@ -407,6 +403,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"acb" = (
+/obj/machinery/power/emitter,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "acc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -548,6 +552,26 @@
 "acP" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"acQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/centcom{
+	name = "Chapel Office";
+	req_access_txt = "22"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "acT" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -648,11 +672,11 @@
 "ado" = (
 /obj/structure/table,
 /obj/item/pen,
+/obj/item/paper_bin,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/item/paper_bin,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "adp" = (
@@ -678,6 +702,9 @@
 /area/engine/atmos)
 "adu" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "adG" = (
@@ -1038,6 +1065,10 @@
 "afw" = (
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1497,7 +1528,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -27
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -1769,10 +1800,6 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
@@ -1780,6 +1807,10 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -2078,7 +2109,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -27
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -2555,15 +2586,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2821,7 +2852,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -4635,7 +4666,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
@@ -4918,11 +4949,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avl" = (
+/obj/item/kirbyplants/random,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avm" = (
@@ -5385,15 +5416,15 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -5409,16 +5440,16 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/machinery/computer/rdconsole{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6284,8 +6315,7 @@
 "aBB" = (
 /obj/machinery/computer/cargo/request,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -6823,11 +6853,11 @@
 "aDo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aDp" = (
@@ -6897,13 +6927,13 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDB" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -8108,12 +8138,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHW" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -9626,6 +9655,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aOw" = (
@@ -10099,7 +10132,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -10815,6 +10848,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aSR" = (
@@ -10825,12 +10862,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -11146,6 +11182,9 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/wirecutters,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUT" = (
@@ -11886,10 +11925,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -11899,6 +11934,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -12291,13 +12330,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -12590,7 +12629,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -12722,7 +12761,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = -26
 	},
 /turf/open/floor/grass,
 /area/hydroponics)
@@ -12875,6 +12914,10 @@
 	c_tag = "Cargo Office";
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bav" = (
@@ -12983,6 +13026,10 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -13459,10 +13506,6 @@
 /area/quartermaster/qm)
 "bcD" = (
 /obj/structure/closet/wardrobe/miner,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -13471,6 +13514,10 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -13823,6 +13870,10 @@
 	},
 /obj/item/clothing/head/crown,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bep" = (
@@ -14137,11 +14188,10 @@
 /area/science/robotics/mechbay)
 "bfx" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "bfy" = (
@@ -14181,6 +14231,10 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -14445,10 +14499,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgx" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
-	},
 /obj/structure/chair,
 /obj/item/clothing/mask/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -14456,6 +14506,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14792,11 +14845,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bil" = (
+/obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bim" = (
@@ -14850,6 +14903,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
+"bix" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "biH" = (
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -15270,6 +15330,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkm" = (
@@ -15282,6 +15346,10 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -15385,6 +15453,9 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab Chamber";
 	network = list("ss13","rd")
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -15526,12 +15597,10 @@
 /area/medical/medbay/central)
 "blp" = (
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = 28
+	pixel_y = 26
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "blq" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -15619,11 +15688,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bly" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 28
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -15840,6 +15904,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/engine,
 /area/science/explab)
 "blX" = (
@@ -15956,6 +16023,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -16190,10 +16261,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bny" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/machinery/light/small{
 	dir = 1;
 	light_color = "#ffc1c1"
@@ -16205,6 +16272,10 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bnz" = (
@@ -16254,10 +16325,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16268,6 +16335,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -16470,15 +16541,14 @@
 /area/medical/genetics)
 "boz" = (
 /obj/machinery/vending/clothing,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -16655,11 +16725,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boU" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -2;
-	pixel_y = -27
-	},
 /obj/machinery/camera{
 	c_tag = "Research Division Lobby";
 	dir = 1
@@ -16676,6 +16741,10 @@
 	dir = 8
 	},
 /obj/item/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boV" = (
@@ -17564,6 +17633,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "brD" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "brF" = (
@@ -17934,13 +18007,13 @@
 /obj/machinery/chem_dispenser{
 	layer = 2.7
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -17980,13 +18053,13 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -18057,10 +18130,6 @@
 /obj/structure/rack,
 /obj/item/crowbar,
 /obj/item/wrench,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/item/multitool,
 /obj/item/multitool,
 /obj/effect/turf_decal/tile/purple{
@@ -18068,6 +18137,10 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -18255,12 +18328,12 @@
 	dir = 8;
 	network = list("ss13","rd")
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -18573,15 +18646,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -19168,6 +19241,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "byu" = (
@@ -20226,26 +20303,26 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bBH" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBK" = (
 /obj/structure/closet/bombcloset,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -20407,6 +20484,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCa" = (
@@ -20489,14 +20570,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -2;
-	pixel_y = -27
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -20584,15 +20664,15 @@
 /obj/machinery/computer/robotics{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
@@ -21113,10 +21193,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -21134,6 +21210,10 @@
 	dir = 8
 	},
 /obj/machinery/meter,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEf" = (
@@ -21878,10 +21958,6 @@
 /area/hallway/primary/aft)
 "bGe" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -21922,7 +21998,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28
+	pixel_x = 26
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -22078,10 +22154,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/airalarm/mixingchamber{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
 "bGt" = (
@@ -22227,13 +22299,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -22325,8 +22397,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/airalarm/mixingchamber{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel/dark,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "bHA" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/button/ignition{
@@ -22361,7 +22437,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "bHE" = (
 /obj/structure/window/reinforced,
 /obj/machinery/doppler_array/research/science,
@@ -22763,10 +22839,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJH" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
 /obj/machinery/camera{
 	c_tag = "Research Division Entrance";
 	dir = 1
@@ -22775,6 +22847,10 @@
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -22976,15 +23052,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "bKE" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -23235,10 +23311,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bLF" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -58
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -23371,6 +23443,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMe" = (
@@ -23693,6 +23767,9 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -24216,8 +24293,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
@@ -24260,10 +24336,6 @@
 	pixel_y = 5
 	},
 /obj/item/stock_parts/cell/high/plus,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -24273,6 +24345,9 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -25243,15 +25318,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -25430,16 +25504,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Engineering Foyer APC";
-	pixel_y = 24
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "bUn" = (
 /obj/machinery/light{
 	dir = 1
@@ -25454,22 +25523,21 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "bUo" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "atmospherics security door"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "bUp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/machinery/shower{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -25615,15 +25683,14 @@
 /area/crew_quarters/heads/chief)
 "bUL" = (
 /obj/machinery/computer/station_alert,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -25645,7 +25712,22 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/closed/wall,
+/obj/structure/table,
+/obj/item/storage/box/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUQ" = (
 /obj/structure/cable/yellow{
@@ -25881,12 +25963,6 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bVL" = (
-/obj/structure/table,
-/obj/item/storage/box/smart_metal_foam{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/storage/box/lights/mixed,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -25983,6 +26059,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bWb" = (
@@ -26165,7 +26242,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWz" = (
-/obj/structure/tank_dispenser,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -26173,6 +26249,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWA" = (
@@ -26218,37 +26295,38 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
 "bWE" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bWG" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bWI" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWJ" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "bWL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -26367,16 +26445,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bXr" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXs" = (
-/obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -26515,21 +26594,9 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"bYm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bYo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -26568,12 +26635,6 @@
 /obj/item/clothing/head/hardhat/orange,
 /obj/item/clothing/glasses/meson/engine,
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -26669,6 +26730,9 @@
 /obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -26831,6 +26895,7 @@
 /obj/structure/table,
 /obj/item/rcl/pre_loaded,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cax" = (
@@ -26990,9 +27055,8 @@
 /turf/closed/wall,
 /area/chapel/asteroid/monastery)
 "caT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/tinted/fulltile,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
 /area/chapel/main/monastery)
 "caV" = (
 /obj/machinery/holopad,
@@ -27073,6 +27137,7 @@
 /obj/structure/table,
 /obj/item/storage/belt/utility,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbo" = (
@@ -27160,6 +27225,10 @@
 /area/chapel/main/monastery)
 "cbV" = (
 /obj/machinery/shieldgen,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cbX" = (
@@ -27256,6 +27325,7 @@
 	pixel_x = -2
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cck" = (
@@ -27337,17 +27407,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccR" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/gps/engineering,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccS" = (
@@ -27431,16 +27491,6 @@
 "cdo" = (
 /turf/open/floor/carpet,
 /area/chapel/office)
-"cdp" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	layer = 2.9;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/turf/open/floor/carpet/black,
-/area/chapel/office)
 "cdq" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance";
@@ -27493,27 +27543,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdK" = (
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdM" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -27522,9 +27559,6 @@
 /area/engine/engineering)
 "cdO" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -27534,9 +27568,6 @@
 /area/engine/engineering)
 "cdQ" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -27556,9 +27587,6 @@
 	name = "Shutters Control";
 	pixel_x = 25;
 	req_access_txt = "11"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -27691,32 +27719,25 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "ceB" = (
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/chapel/office)
 "ceC" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/button/crematorium{
+	id = "foo";
+	pixel_x = 25
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel Crematorium";
-	network = list("ss13","monastery")
+/obj/structure/bodycontainer/crematorium{
+	id = "foo"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ceF" = (
-/obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/landmark/start/chaplain,
+/obj/structure/chair/wood/normal{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/black,
 /area/chapel/office)
 "ceK" = (
 /obj/item/kirbyplants{
@@ -27736,20 +27757,17 @@
 "ceT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ceX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -27946,7 +27964,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cgG" = (
-/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "cgH" = (
@@ -28235,6 +28252,10 @@
 "ciy" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "ciz" = (
@@ -28283,6 +28304,10 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 5;
 	pixel_y = 6
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -28546,7 +28571,7 @@
 /obj/structure/chair/wood/normal,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
@@ -28763,6 +28788,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -29642,6 +29670,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cqR" = (
@@ -29684,31 +29715,49 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "crb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/chapel/office)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "crg" = (
-/obj/structure/chair/wood/normal,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Chapel Crematorium";
+	network = list("ss13","monastery")
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "crh" = (
-/obj/machinery/button/crematorium{
-	id = "foo";
-	pixel_x = 25
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/structure/bodycontainer/crematorium{
-	id = "foo"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "cri" = (
-/obj/machinery/door/poddoor{
-	id = "Secure Storage";
-	name = "secure storage"
-	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "crj" = (
 /obj/machinery/light/small{
@@ -29733,20 +29782,16 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "crt" = (
-/obj/structure/table/wood/fancy,
-/obj/item/folder,
-/obj/item/pen,
-/obj/item/organ/heart,
-/obj/item/soulstone/anybody/chaplain,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/obj/item/book/granter/spell/smoke/lesser,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"cru" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"cru" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "crv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "crx" = (
@@ -29776,11 +29821,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"crD" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "crH" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
@@ -29823,22 +29863,21 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "crT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "crU" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Chapel Office APC";
-	pixel_x = 24
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "crY" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/breadslice/plain,
@@ -29851,17 +29890,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "csd" = (
-/turf/open/floor/carpet/black,
-/area/chapel/office)
-"cse" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
@@ -29892,65 +29928,41 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"csn" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_x = -32
-	},
-/obj/structure/closet,
-/obj/item/storage/backpack/cultpack,
-/obj/item/clothing/head/nun_hood,
-/obj/item/clothing/suit/chaplainsuit/nun,
-/obj/item/clothing/suit/chaplainsuit/holidaypriest,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"cso" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/turf/open/floor/carpet/black,
-/area/chapel/office)
 "csp" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/chapel/office)
-"csr" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"csB" = (
-/obj/effect/landmark/start/chaplain,
-/obj/structure/chair/wood/normal{
+"csr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"csB" = (
+/obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csC" = (
-/obj/structure/table/wood,
+/obj/structure/chair/wood/normal{
+	dir = 8
+	},
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csR" = (
@@ -29979,23 +29991,6 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"csY" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "cth" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/fancy/candle_box,
@@ -30019,20 +30014,26 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ctu" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-22";
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctJ" = (
-/obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 8;
-	network = list("ss13","monastery")
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ctQ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small{
@@ -30048,7 +30049,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ctX" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
+/obj/structure/closet,
+/obj/machinery/light/small,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
+/obj/item/storage/book/bible,
 /turf/open/floor/carpet,
 /area/chapel/office)
 "cuc" = (
@@ -30058,13 +30063,13 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -30315,6 +30320,10 @@
 	dir = 1;
 	name = "Coffin Storage";
 	req_one_access_txt = "22"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -30654,8 +30663,7 @@
 	network = list("ss13","monastery")
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -30985,6 +30993,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAC" = (
@@ -31041,8 +31053,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "cBM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cBU" = (
 /turf/closed/wall/r_wall,
@@ -31368,6 +31390,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/library)
+"cIC" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/turf/open/floor/carpet/black,
+/area/chapel/office)
 "cJw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -31507,6 +31534,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"cNX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_y = -24;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -32184,6 +32232,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "djE" = (
@@ -32347,13 +32398,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"dpb" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
+"doX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"dpb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dpJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -32727,15 +32790,13 @@
 /area/crew_quarters/fitness/recreation)
 "dBh" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dBm" = (
@@ -32996,7 +33057,7 @@
 	dir = 6
 	},
 /turf/open/floor/goonplaque,
-/area/engine/break_room)
+/area/engine/engineering)
 "dOp" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -33131,15 +33192,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dQI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dRj" = (
@@ -33199,8 +33260,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dSM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Chapel Office APC";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dTV" = (
@@ -33296,13 +33363,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dXY" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dYp" = (
@@ -33325,10 +33392,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dYQ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dZd" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
@@ -33599,14 +33673,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "egd" = (
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/noslip/white,
 /area/medical/medbay/central)
 "egp" = (
@@ -33682,11 +33757,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ekC" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
+"ejz" = (
+/obj/machinery/camera{
+	c_tag = "Chapel Office";
+	dir = 8;
+	network = list("ss13","monastery")
 	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"ekC" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -33694,6 +33773,10 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -33874,6 +33957,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"eor" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "epd" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -34335,20 +34422,17 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "eEo" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eEQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -34467,6 +34551,28 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"eHc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "eHB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -34651,9 +34757,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eLv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -34738,6 +34841,11 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
+"ePI" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ePN" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -34793,6 +34901,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eQV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "eRC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -34864,9 +34982,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "eVW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor{
+	id = "Secure Storage";
+	name = "secure storage"
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "eWh" = (
@@ -35109,9 +35230,8 @@
 /area/hallway/primary/aft)
 "fdS" = (
 /obj/structure/plasticflaps/opaque,
-/obj/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/maintenance/department/engine)
 "fee" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -35170,6 +35290,14 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -35526,6 +35654,10 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "fqw" = (
@@ -35629,6 +35761,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"ftY" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "fue" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -36252,10 +36391,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "fSZ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -36267,6 +36402,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -36569,10 +36707,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gdL" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -36581,6 +36715,10 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -36731,8 +36869,8 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "giI" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	req_access_txt = "22"
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
@@ -36843,7 +36981,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "glS" = (
-/obj/structure/window/reinforced/fulltile,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -37223,19 +37360,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gxP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 27;
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "gyc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
@@ -37631,13 +37763,9 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "gKz" = (
-/obj/structure/table/wood,
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_y = 8
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/area/storage/tech)
 "gKL" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -37673,6 +37801,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"gLo" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "gLF" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -37728,9 +37862,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gMO" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "gNG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38024,7 +38165,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -38179,15 +38323,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hfD" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -29
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -38281,14 +38425,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hjh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "hjk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -38923,6 +39067,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hAb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -38930,10 +39077,21 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"hAj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "hAJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -39273,12 +39431,12 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "hKQ" = (
-/obj/structure/sign/warning/radiation/rad_area,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "hLb" = (
 /obj/structure/chair/stool,
 /obj/item/cigbutt/cigarbutt,
@@ -39502,12 +39660,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "hTr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engine/engineering)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hTz" = (
 /obj/item/beacon,
 /obj/structure/cable/yellow{
@@ -40180,6 +40340,12 @@
 "ilR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plasteel/stairs,
 /area/storage/tech)
 "imB" = (
@@ -40312,6 +40478,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"irr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "isg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
@@ -40470,17 +40646,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"iyJ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "SupermatterExternal";
-	name = "radiation shutters"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "iyX" = (
 /obj/machinery/suit_storage_unit/exploration,
 /obj/effect/turf_decal/stripes/line{
@@ -40488,7 +40653,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttledock)
@@ -41289,11 +41454,10 @@
 	name = "Private Channel";
 	pixel_x = -27
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/firealarm{
-	dir = 1;
 	pixel_y = 26
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "jab" = (
@@ -41317,6 +41481,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"jbj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jbF" = (
 /obj/structure/sign/departments/security{
 	pixel_y = 32
@@ -41579,11 +41754,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jlb" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/shower{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/turf/open/floor/noslip/standard,
+/area/engine/atmos)
 "jmB" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -41810,12 +41985,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/lounge)
 "jsD" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 28
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -41883,7 +42054,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "jtq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -41926,15 +42097,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -42014,9 +42185,10 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "jzk" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "jzx" = (
@@ -42348,13 +42520,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "jIh" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=BrigS1";
@@ -42666,14 +42835,14 @@
 /area/lawoffice)
 "jTE" = (
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jUe" = (
@@ -42981,11 +43150,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kfM" = (
-/obj/structure/closet,
-/obj/machinery/light/small,
-/obj/item/storage/book/bible,
-/obj/item/storage/book/bible,
-/obj/item/storage/book/bible,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
 /area/chapel/office)
 "kfV" = (
@@ -43332,12 +43497,10 @@
 	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "kuV" = (
@@ -43674,11 +43837,15 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "kCc" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "atmospherics security door"
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "kCg" = (
@@ -43691,7 +43858,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "kDf" = (
-/obj/machinery/light/small,
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "kDl" = (
@@ -43739,12 +43905,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "kEC" = (
@@ -43832,10 +43994,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -27
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -43844,6 +44002,10 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -43986,6 +44148,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"kIU" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "kIZ" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
@@ -44159,6 +44338,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kNU" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "kOO" = (
 /obj/structure/table/wood/fancy,
 /obj/item/gun/ballistic/revolver/russian{
@@ -44315,6 +44498,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "kSg" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -44325,8 +44511,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "kSw" = (
@@ -44356,6 +44546,9 @@
 "kSW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kTl" = (
@@ -44542,6 +44735,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "kZE" = (
@@ -44659,11 +44856,17 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "lhu" = (
-/obj/machinery/shieldgen,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
 	},
+/obj/item/gps/engineering,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "lhA" = (
@@ -45093,6 +45296,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lua" = (
@@ -45232,14 +45438,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "lzJ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/carpet,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
 /area/chapel/office)
 "lAf" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "lAs" = (
@@ -45792,6 +45998,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"lRL" = (
+/obj/machinery/light/small,
+/turf/open/floor/carpet/black,
+/area/chapel/office)
 "lTs" = (
 /obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -45984,17 +46194,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/supermatter)
-"lZg" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "SupermatterExternal";
-	name = "radiation shutters"
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "lZu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -46093,12 +46292,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mci" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/chapel/main/monastery)
 "mdw" = (
 /obj/structure/janitorialcart,
 /obj/structure/disposalpipe/segment,
@@ -46179,6 +46375,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"meD" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/turf/open/floor/carpet/black,
+/area/chapel/office)
 "meE" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -46392,6 +46598,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mmx" = (
@@ -47237,6 +47446,9 @@
 /area/maintenance/department/cargo)
 "mPb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "mPL" = (
@@ -47361,9 +47573,6 @@
 	network = list("tcomms");
 	pixel_y = 28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
@@ -47471,17 +47680,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel Office Tunnel";
-	dir = 1;
-	network = list("ss13","monastery")
-	},
 /obj/effect/turf_decal/sand,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/machinery/camera{
+	c_tag = "Chapel Office Tunnel";
+	dir = 1;
+	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel,
 /area/chapel/office)
@@ -47661,6 +47871,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nfa" = (
@@ -47992,16 +48205,12 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "nsL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Port Aft";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ntr" = (
@@ -48405,6 +48614,22 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"nIX" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "nJr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -48599,6 +48824,9 @@
 "nPh" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -48853,16 +49081,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "nZw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "nZF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49389,12 +49612,13 @@
 /area/tcommsat/server)
 "orZ" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -49472,21 +49696,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ous" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_y = -24;
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ovn" = (
@@ -49680,11 +49890,20 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oAW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "oBe" = (
@@ -49768,6 +49987,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "oCF" = (
@@ -49782,21 +50002,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "oCI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/chapel/office)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/noslip/standard,
+/area/engine/engineering)
 "oCX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -49897,6 +50110,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oFo" = (
@@ -49962,19 +50176,14 @@
 	},
 /area/maintenance/department/engine)
 "oIc" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oIf" = (
@@ -50109,6 +50318,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"oLa" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "EngLoad"
+	},
+/obj/structure/sign/warning/deathsposal{
+	desc = "A warning sign which reads 'DISPOSAL: LEADS TO ENGINE'.";
+	name = "\improper DISPOSAL: LEADS TO ENGINE";
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "oLe" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -50464,7 +50688,6 @@
 	location = "Engineering"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -50839,10 +51062,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pkM" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "22"
-	},
-/turf/open/floor/plating,
+/obj/structure/chair/wood/normal,
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "pkQ" = (
 /obj/structure/disposalpipe/segment,
@@ -50973,8 +51194,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "pps" = (
-/turf/closed/wall,
-/area/engine/break_room)
+/obj/structure/table/wood/fancy,
+/obj/item/folder,
+/obj/item/pen,
+/obj/item/organ/heart,
+/obj/item/soulstone/anybody/chaplain,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/book/granter/spell/smoke/lesser,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "ppv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -51082,8 +51310,18 @@
 /area/space/nearstation)
 "prr" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
 /obj/machinery/computer/atmos_control/tank/sm{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "burn_vent";
+	name = "Burn Chamber Vent";
+	pixel_x = 6;
+	pixel_y = -24;
+	req_access_txt = "10"
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Port Aft";
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -51399,12 +51637,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pAb" = (
-/obj/machinery/power/emitter,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "pAG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -52423,22 +52659,16 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "qgB" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "SupermatterExternal";
-	name = "radiation shutters"
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "qgF" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/supermatter)
 "qhL" = (
 /obj/structure/cable/yellow{
@@ -52456,6 +52686,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qhW" = (
@@ -52525,23 +52758,17 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qkS" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Crematorium";
-	req_access_txt = "27"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qkU" = (
 /obj/machinery/door/airlock{
 	id_tag = "Potty1";
@@ -52744,7 +52971,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -52954,25 +53181,8 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "qBp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/table/wood/fancy,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "qBx" = (
@@ -53026,6 +53236,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qDr" = (
@@ -53210,6 +53423,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "qIC" = (
@@ -53244,6 +53460,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qKr" = (
@@ -53255,6 +53475,10 @@
 /area/hallway/primary/central)
 "qKB" = (
 /mob/living/simple_animal/sloth/citrus,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "qLo" = (
@@ -53509,16 +53733,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "qWM" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -2
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -53534,6 +53755,9 @@
 "qXu" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -54260,8 +54484,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -54438,15 +54661,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rFq" = (
@@ -54696,6 +54919,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "rPa" = (
@@ -54808,14 +55032,11 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "rSD" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
 	name = "radiation shutters"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "rTz" = (
@@ -55451,6 +55672,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"sml" = (
+/obj/machinery/shieldgen,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "smr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plating,
@@ -55546,7 +55771,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -56113,6 +56337,9 @@
 	dir = 4
 	},
 /obj/item/clothing/glasses/meson,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sLc" = (
@@ -56136,9 +56363,6 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "sLT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -56806,6 +57030,10 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "tlw" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "tlU" = (
@@ -56961,15 +57189,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "tqO" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "atmospherics security door"
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -56979,6 +57211,11 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "atmospherics security door"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tqX" = (
@@ -56997,6 +57234,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "trt" = (
@@ -57130,12 +57371,16 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "tuL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/centcom{
+	name = "Crematorium";
+	req_access_txt = "27"
 	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "tuO" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -57293,29 +57538,20 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "tCx" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/door/airlock/centcom{
-	name = "Chapel Office";
-	req_access_txt = "22"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/chapel/office)
 "tCP" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"tCS" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tDl" = (
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
@@ -57502,6 +57738,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tLj" = (
@@ -57552,11 +57793,9 @@
 /turf/open/floor/plasteel,
 /area/storage/eva)
 "tPm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/engineering)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/chapel/office)
 "tPM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -57632,10 +57871,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
 "tWe" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/engine,
 /area/engine/supermatter)
 "tWw" = (
 /obj/machinery/ecto_sniffer,
@@ -57981,6 +58220,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "uhA" = (
@@ -57988,6 +58230,7 @@
 /obj/machinery/light{
 	light_color = "#e8eaff"
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uhF" = (
@@ -58159,12 +58402,12 @@
 	dir = 1
 	},
 /obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -58907,10 +59150,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -58926,6 +59165,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uLT" = (
@@ -58939,17 +59181,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "uMo" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "EngLoad"
+/obj/structure/sign/plaques/deempisi{
+	pixel_y = 28
 	},
-/obj/structure/sign/warning/deathsposal{
-	desc = "A warning sign which reads 'DISPOSAL: LEADS TO ENGINE'.";
-	name = "\improper DISPOSAL: LEADS TO ENGINE";
-	pixel_y = -32
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 3
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "uMC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -59000,6 +59240,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttledock)
+"uOI" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "EngLoad"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "uOO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59139,6 +59390,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"uWb" = (
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/obj/machinery/requests_console{
+	department = "Chapel";
+	departmentType = 2;
+	pixel_x = -32
+	},
+/obj/structure/closet,
+/obj/item/storage/backpack/cultpack,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/chaplainsuit/nun,
+/obj/item/clothing/suit/chaplainsuit/holidaypriest,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "uWk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59295,10 +59572,6 @@
 	luminosity = 2
 	},
 /area/ai_monitored/nuke_storage)
-"ved" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "veH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
@@ -59328,6 +59601,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/grass,
 /area/hydroponics)
+"vfL" = (
+/obj/machinery/vending/wardrobe/chap_wardrobe,
+/turf/open/floor/carpet,
+/area/chapel/office)
 "vfP" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
@@ -59916,6 +60193,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "vBs" = (
@@ -59944,11 +60225,13 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "vCs" = (
-/obj/structure/sign/warning/radiation/rad_area,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "vCE" = (
 /obj/structure/cable/yellow{
@@ -60313,6 +60596,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"vQK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vQP" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
@@ -60371,35 +60671,35 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "vRL" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vSC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "vTi" = (
 /obj/machinery/door/poddoor/preopen{
@@ -60538,6 +60838,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "vYN" = (
@@ -60636,6 +60940,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "waP" = (
@@ -60671,11 +60979,11 @@
 /turf/open/floor/carpet,
 /area/library/lounge)
 "wcs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "wcN" = (
 /obj/machinery/computer/cargo/request{
 	dir = 4
@@ -61182,7 +61490,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -28
+	pixel_x = -26
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -61624,6 +61932,15 @@
 	heat_capacity = 1e+006
 	},
 /area/medical/sleeper)
+"wGO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "wHm" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -61701,14 +62018,13 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "wKB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -61811,7 +62127,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "wMM" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -61891,7 +62207,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "wPH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -62097,6 +62413,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"wWS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wWY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Theatre Maintenance";
@@ -62274,10 +62596,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -62287,6 +62605,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -62365,11 +62686,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "xdO" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "xee" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -62621,9 +62942,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -62795,8 +63113,6 @@
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
 "xto" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "xtH" = (
@@ -62979,7 +63295,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "xyo" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xyq" = (
@@ -63533,18 +63851,18 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "xSX" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "xTi" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "EngLoad"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "xUc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -63624,9 +63942,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"xYl" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "xYH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Incinerator Output Pump"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -63855,18 +64184,7 @@
 /area/crew_quarters/dorms)
 "yjg" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering Port Aft";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/button/door{
-	id = "burn_vent";
-	name = "Burn Chamber Vent";
-	pixel_x = 6;
-	pixel_y = -24;
-	req_access_txt = "10"
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "yjM" = (
@@ -63875,9 +64193,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -74642,11 +74957,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bZY
+bZY
+tPm
+bZY
+bZY
 aaa
 aaa
 aaa
@@ -74898,13 +75213,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 bZY
 bZY
+uWb
 cBM
+kIU
 bZY
 bZY
-aaa
 aaa
 aaa
 aaa
@@ -75155,13 +75470,13 @@ aaa
 aaa
 aaa
 aaa
-bZY
-bZY
-csn
+tPm
+kDf
+kDf
 ceF
-csY
-bZY
-bZY
+kDf
+kDf
+tPm
 aaa
 aaa
 aaa
@@ -75408,18 +75723,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-cBM
+cyM
+cyM
+cyM
+bZY
+bZY
 csd
-csd
+cIC
 csB
-csd
-csd
-cBM
-aaa
+meD
+lRL
+bZY
+bZY
 aaa
 cyM
 cyM
@@ -75664,18 +75979,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-cyM
-cyM
 cyM
 bZY
 bZY
-cse
-cso
-csC
-cdp
+bZY
+bZY
+uMo
 kDf
-bZY
+csC
+csC
+csC
+kDf
+bix
 bZY
 cyM
 cyM
@@ -75921,19 +76236,19 @@ aaa
 aaa
 aaa
 aaa
-cyM
 bZY
 bZY
-bZY
+pps
+qBp
 bZY
 jsD
-csd
+csi
+owS
 csp
-csp
-csp
-csd
-dpb
-bZY
+rrU
+ctr
+cdo
+vfL
 bZY
 cyM
 cyM
@@ -76178,10 +76493,10 @@ aaa
 aaa
 aaa
 aaa
-bZY
-bZY
+lzJ
+pkM
 crt
-crD
+xto
 bZY
 xSX
 csi
@@ -76435,14 +76750,14 @@ aaa
 aaa
 aaa
 aaa
-crb
+bZY
 crg
 cru
 crv
-bZY
+tuL
 crT
-csi
-owS
+wcs
+doX
 kEy
 rrU
 ctr
@@ -76694,17 +77009,17 @@ aaa
 cyM
 bZY
 ceC
-ved
 xto
-qkS
+xto
+bZY
 dSM
 jzk
 hAb
 kSg
 rrU
 ctr
-cdo
-lzJ
+ejz
+bZY
 bWV
 cgb
 cut
@@ -76950,17 +77265,17 @@ aaa
 cyM
 cyM
 bZY
-crh
-crv
-crv
 bZY
-crU
+bZY
+bZY
+bZY
+bZY
 csh
-csr
-qBp
+owS
+dnb
 rrU
-ctr
-ctJ
+xYl
+bZY
 bZY
 bWV
 cul
@@ -77206,19 +77521,19 @@ aaa
 aaa
 cyM
 cyM
+cqW
+cyM
+cyM
 bZY
-bZY
-bZY
-bZY
-bZY
-bZY
+tCx
+giI
 lAf
 owS
 dnb
 rrU
 ctu
 bZY
-bZY
+cyM
 bWV
 cum
 chD
@@ -77463,17 +77778,17 @@ aaa
 bNs
 cyM
 cqW
-cqW
 cyM
 cyM
+bOw
 bZY
 giI
-pkM
-crv
-owS
-dnb
-rrU
-gKz
+bZY
+bZY
+bZY
+acQ
+bZY
+bZY
 bZY
 cyM
 bWV
@@ -77720,18 +78035,18 @@ aaa
 bNs
 cyM
 cyM
-cyM
-cyM
 bOw
-bZY
-pkM
-bZY
-bZY
-bZY
-tCx
-bZY
-bZY
-bZY
+bOw
+bOw
+bOw
+bOw
+bOw
+bOw
+ceB
+vCE
+ceB
+cyM
+cyM
 cyM
 bWV
 bWV
@@ -77977,7 +78292,7 @@ aaa
 bNs
 cqW
 bOw
-cyM
+bOw
 bOw
 bOw
 bOw
@@ -78243,7 +78558,7 @@ bUC
 bOw
 ceB
 naa
-ceB
+bZY
 cyM
 cyM
 cyM
@@ -78499,7 +78814,7 @@ bOw
 bOw
 bOw
 ceB
-oCI
+vCE
 ceB
 cyM
 cyM
@@ -80033,7 +80348,7 @@ bOw
 bOw
 bOw
 bOw
-bWV
+mci
 crj
 bXJ
 bXJ
@@ -80301,7 +80616,7 @@ cdu
 dZZ
 ceK
 cfm
-hpI
+eHc
 cvy
 cgG
 cid
@@ -80547,7 +80862,7 @@ bOw
 bOw
 bQe
 bWV
-bXJ
+nZw
 bXJ
 bZm
 bYB
@@ -81084,7 +81399,7 @@ cvg
 oxK
 glS
 mLZ
-dZZ
+nIX
 cwe
 cwe
 cwe
@@ -81832,7 +82147,7 @@ bOw
 bOw
 bOw
 bOw
-bWV
+mci
 crk
 bXJ
 bXJ
@@ -81840,7 +82155,7 @@ crN
 bXJ
 bXJ
 crk
-rAU
+hAj
 bWV
 cfm
 uLh
@@ -82616,7 +82931,7 @@ bXJ
 cfm
 kSC
 gGE
-gmh
+wGO
 geU
 gGE
 vnl
@@ -82812,7 +83127,7 @@ aQt
 aOf
 aWK
 aYG
-aZy
+crb
 xuM
 nLM
 lid
@@ -83382,7 +83697,7 @@ bOw
 bOw
 bOw
 bWV
-fIT
+mci
 bWV
 bWV
 bWV
@@ -85648,7 +85963,7 @@ eQx
 vqH
 vqH
 idu
-vqH
+crh
 vqH
 vqH
 dEc
@@ -89804,11 +90119,11 @@ bva
 bva
 quj
 bva
-bva
-bva
-bva
-bva
-bva
+bBX
+bBX
+bBX
+bBX
+bBX
 bva
 bva
 bva
@@ -90061,17 +90376,17 @@ chy
 chy
 xpi
 eub
-bva
-gMO
-kCc
+bDi
+bDi
+bXk
 oAW
-hTr
-aaa
-aaa
-aaa
-eNF
-aaa
-aaa
+bXk
+aht
+aht
+aht
+aht
+bRC
+bRC
 aaa
 aaa
 aaa
@@ -90320,15 +90635,15 @@ bBX
 kfK
 bBX
 fdS
-xTi
 bXk
-jlb
-bXk
+uOI
 bXk
 bXk
 bXk
 bXk
-aaa
+bXk
+bXk
+bXk
 aaa
 aaa
 aaa
@@ -90577,15 +90892,15 @@ scz
 gGe
 bXk
 oYj
-uMo
 bXk
-mci
+oLa
+bXk
 vKD
-pAb
+vKD
+acb
 ceq
 ceq
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -90834,15 +91149,15 @@ cci
 faW
 nLl
 nWP
-nZw
+cam
 cri
 eVW
+cbX
 cbX
 ceq
 ceq
 ceq
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -91091,15 +91406,15 @@ cci
 vyp
 nNX
 cam
-cdI
-cri
+cam
+jbj
 eVW
+cbX
 cbX
 ccQ
 ccQ
 ccQ
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -91347,16 +91662,16 @@ kyv
 cam
 sJP
 rwh
-cam
+pAb
 ous
+cNX
 bXk
-tuL
 ccR
 lhu
 cbV
+sml
 ccQ
 bXk
-aaa
 aaa
 aaa
 aaa
@@ -91603,17 +91918,17 @@ bXk
 sKa
 iFI
 eWh
-ccV
+vCs
 oAw
 cdK
-bXk
-jlb
-bXk
+vQK
 bXk
 bXk
 bXk
 bXk
-aht
+bXk
+bXk
+bXk
 aht
 aht
 aht
@@ -91861,8 +92176,8 @@ bTE
 cae
 iBr
 mmv
-cae
-tPm
+xdO
+bTE
 bXk
 ceT
 odQ
@@ -92628,11 +92943,11 @@ unf
 bXg
 bXZ
 cBV
-cam
-cam
-cam
-cam
-cam
+pAb
+ous
+ous
+vSC
+bZI
 cdM
 bXk
 xmE
@@ -92885,14 +93200,14 @@ phM
 oew
 nYh
 xHh
-cam
+bZI
 cai
 cbe
 cca
-cam
+bZI
 orZ
 bXk
-jlb
+bXk
 bXk
 bXk
 bXk
@@ -93085,7 +93400,7 @@ aKT
 aPD
 geY
 aRN
-aSK
+blp
 aUa
 aVb
 aVZ
@@ -93142,11 +93457,11 @@ bWr
 bXj
 qGZ
 cBV
-cam
+bZI
 cai
 cbf
 nFP
-cam
+bZI
 cdO
 cbj
 ceX
@@ -93157,7 +93472,7 @@ qSa
 poT
 xzn
 imB
-wqF
+irr
 cJw
 eDz
 wwn
@@ -93403,7 +93718,7 @@ kSW
 tuO
 oor
 lHH
-kSW
+xTi
 dBh
 oCC
 qhM
@@ -93419,8 +93734,8 @@ cWS
 vov
 iUE
 bXk
-aht
-aht
+eor
+eor
 aht
 aaa
 aaa
@@ -93650,13 +93965,13 @@ uLr
 bSE
 bTt
 bUf
-bQr
+gKz
 plP
 bWs
 bXk
 bYc
 cBV
-cam
+bZI
 cam
 erB
 cam
@@ -93675,11 +93990,11 @@ xxk
 qBV
 udy
 xyo
+wqF
+wWS
 bXk
-bXk
-bXk
-aht
-aht
+cdm
+cdm
 aht
 pWb
 aaa
@@ -93913,12 +94228,12 @@ bWt
 bXk
 bYd
 mTo
+bZI
 cam
 cam
 cam
 cam
-cam
-orZ
+cdI
 qFu
 ljX
 ulY
@@ -93931,12 +94246,12 @@ jEe
 jEe
 kJh
 hhi
-xdO
-poT
+hhi
+hhi
 nsL
-cbj
-cdm
-cdm
+tCS
+gLo
+ahi
 aht
 pWb
 aaa
@@ -94164,19 +94479,19 @@ vYU
 bSG
 bTv
 bUf
-bQr
+gKz
 tCb
 bWu
 bXk
 bYe
 cBV
-cam
+bZI
 can
 cbi
 ccc
 ccV
 cdR
-qFu
+rSD
 taF
 ulY
 ucl
@@ -94190,10 +94505,10 @@ gOl
 mZR
 tzZ
 lYf
-eEo
-dYQ
-vSC
+tzZ
+mZR
 ahi
+cdm
 aht
 aaa
 aaa
@@ -94427,13 +94742,13 @@ bQr
 bXk
 bTE
 kWL
-cam
+bZI
 cao
 cbj
 bXk
 ccW
-wcs
-iyJ
+bXk
+rSD
 xJz
 gzb
 ucl
@@ -94447,10 +94762,10 @@ tGV
 wNl
 dZj
 cnW
-cnW
+ftY
 mZR
-ahi
-cdm
+bRC
+aht
 aht
 pWb
 aaa
@@ -94631,7 +94946,7 @@ kve
 eHB
 aPE
 aWf
-aXb
+bWJ
 aPE
 aYY
 bae
@@ -94684,13 +94999,13 @@ bWv
 gBa
 bYf
 fgf
-cam
+bZI
 cat
 bXk
 ccd
 ceu
 cdS
-lZg
+rSD
 doy
 cfu
 eEi
@@ -94903,7 +95218,7 @@ aDZ
 aDZ
 bjg
 bki
-blp
+bkh
 cqs
 boG
 boN
@@ -94941,13 +95256,13 @@ bWw
 bXm
 bYg
 wpu
-kSw
+qkS
 caq
 cbk
 cce
 ccZ
 cfc
-lZg
+rSD
 qEB
 cfx
 lEw
@@ -95455,13 +95770,13 @@ bWy
 bXo
 bYi
 ezv
-kSw
+qkS
 caq
 cbk
 ceY
 cex
 cfe
-lZg
+rSD
 iDC
 wAS
 sqX
@@ -95706,19 +96021,19 @@ gHX
 bSK
 qlL
 bQr
-bUT
-bVN
+gMO
+hKQ
 bWz
 bVN
 bYf
 fgf
-cam
+bZI
 cat
 bXk
 ccg
 cey
 cdW
-lZg
+rSD
 cet
 hsK
 ucl
@@ -95969,7 +96284,7 @@ bUU
 bUU
 bUT
 uLR
-cam
+bZI
 cau
 cbj
 bXk
@@ -96226,7 +96541,7 @@ bWA
 mCe
 bYj
 cBV
-cam
+bZI
 cav
 cbl
 cch
@@ -96483,7 +96798,7 @@ bWB
 mCe
 bYk
 cBV
-cam
+bZI
 cam
 cam
 cam
@@ -96503,8 +96818,8 @@ qmQ
 ciI
 ftb
 dfr
-kzB
-mZR
+cnW
+dak
 bRC
 aaa
 aaa
@@ -96746,7 +97061,7 @@ nNX
 cci
 cam
 ogX
-hKQ
+cbj
 cwu
 otV
 ulY
@@ -97001,7 +97316,7 @@ adu
 caw
 cbn
 ccj
-adu
+ePI
 bWa
 ktM
 rOh
@@ -97016,9 +97331,9 @@ ulY
 ulY
 hGe
 prr
-bXk
-aht
-aht
+mZR
+kNU
+kNU
 bRC
 aaa
 aaa
@@ -97246,13 +97561,13 @@ ocb
 bRp
 iBx
 bSM
-pps
+bTE
 bUl
 wOM
 hjh
 bWE
-bXk
-bYm
+kCc
+bYo
 uhF
 bZG
 cax
@@ -97260,11 +97575,11 @@ cbo
 cck
 cam
 cdI
-vCs
+cbj
 spn
 qrw
 htk
-cfY
+eQV
 kbV
 lua
 lyp
@@ -97516,7 +97831,7 @@ cam
 cci
 cci
 cam
-cdI
+orZ
 bXk
 gKL
 bXk
@@ -97760,12 +98075,12 @@ qpq
 bmC
 oui
 uhA
-pps
+bTE
 bUn
 wMy
 gxP
 bWG
-bXk
+kCc
 bYo
 cam
 bZI
@@ -98017,13 +98332,13 @@ bQD
 bSM
 bSM
 bSP
-pps
+bPQ
 bUo
 tqO
 bUo
-bTE
-bXk
-bTE
+bJP
+bJP
+oCI
 bZc
 bZJ
 cCU
@@ -98275,10 +98590,10 @@ bQE
 bSa
 bJP
 bJP
-bJP
+eEo
 vRL
-bJP
-bJP
+hTr
+jlb
 bJP
 bJP
 bXk
@@ -98524,14 +98839,14 @@ cqD
 bKO
 bLW
 bOg
-bOg
+ctJ
 pzQ
 heP
 bQF
 bQF
 bSb
 bLW
-bTH
+dYQ
 bUp
 hxo
 bVV
@@ -98792,7 +99107,7 @@ kQm
 csl
 cFh
 adp
-bWJ
+bQI
 bXs
 bJP
 bRC
@@ -99807,7 +100122,7 @@ ega
 cqx
 bJJ
 bJP
-bTH
+crU
 wQV
 lyl
 bQI
@@ -100321,7 +100636,7 @@ bHr
 bID
 bJL
 bJP
-bTH
+csr
 jvz
 iVp
 bOV
@@ -100578,7 +100893,7 @@ bHs
 bBA
 bJM
 bJP
-bTH
+csr
 jvz
 wXl
 bOW
@@ -103155,7 +103470,7 @@ bLa
 bRC
 bNn
 bRC
-bLa
+dpb
 bRC
 bNn
 bRC
@@ -105721,7 +106036,7 @@ aaa
 aht
 aaa
 aht
-aaa
+aht
 aaa
 aaa
 aaa
@@ -105978,7 +106293,7 @@ iUX
 iUX
 iUX
 bOs
-aaa
+aht
 aaa
 aaa
 aaa
@@ -106235,7 +106550,7 @@ bIM
 bMl
 bNp
 bOt
-aaa
+aht
 aaa
 aaa
 aaa
@@ -106492,7 +106807,7 @@ bLf
 bMm
 bNp
 bOt
-aaa
+aht
 aaa
 aaa
 aaa
@@ -106749,7 +107064,7 @@ bIM
 bMn
 bNp
 bOt
-aaa
+aht
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -360,6 +360,13 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
+"abI" = (
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "abJ" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -1372,9 +1379,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "ahd" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "ahh" = (
 /obj/structure/lattice/catwalk,
@@ -1426,9 +1433,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"ahq" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "ahr" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -1526,23 +1530,22 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "ahM" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "ahQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/vending/security,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "ahS" = (
 /obj/structure/table/optable,
@@ -1592,6 +1595,7 @@
 /obj/item/storage/box/trackimp{
 	pixel_x = -3
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aij" = (
@@ -1620,6 +1624,7 @@
 	pixel_x = -4
 	},
 /obj/structure/table,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ain" = (
@@ -1627,28 +1632,35 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aio" = (
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aip" = (
-/obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"air" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ais" = (
-/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -31
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "ait" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1734,6 +1746,7 @@
 /obj/item/storage/lockbox/loyalty{
 	layer = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiM" = (
@@ -1762,20 +1775,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiQ" = (
-/obj/machinery/door/airlock/security{
-	name = "Equipment Room";
-	req_access_txt = "1"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aiR" = (
 /turf/closed/wall,
@@ -1872,6 +1877,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajh" = (
@@ -1903,6 +1909,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aji" = (
@@ -1944,10 +1951,10 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajk" = (
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -1958,10 +1965,15 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/photocopier,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajm" = (
-/obj/structure/table,
 /obj/item/storage/fancy/donut_box{
 	pixel_y = 2
 	},
@@ -1974,10 +1986,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajn" = (
-/obj/structure/table,
 /obj/structure/sign/plaques/golden{
 	pixel_y = 32
 	},
@@ -1994,10 +2006,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajo" = (
-/obj/machinery/vending/coffee,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
@@ -2007,6 +2019,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/flashlight/seclite,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajr" = (
@@ -2114,6 +2129,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajR" = (
@@ -2140,6 +2156,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajT" = (
@@ -2153,6 +2170,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ajU" = (
@@ -2169,6 +2187,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2304,9 +2325,6 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "akE" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/blood,
 /obj/item/reagent_containers/blood/AMinus,
@@ -2320,6 +2338,9 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -2349,6 +2370,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "akN" = (
@@ -2378,6 +2400,7 @@
 	pixel_y = -3
 	},
 /obj/item/gun/ballistic/shotgun/riot,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "akQ" = (
@@ -2583,6 +2606,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "alB" = (
@@ -2659,8 +2683,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -2802,10 +2825,6 @@
 /area/security/processing/cremation)
 "amO" = (
 /obj/structure/closet/crate/freezer,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/effect/turf_decal/tile/red,
@@ -2814,6 +2833,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -3593,8 +3615,8 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/fore)
 "aqG" = (
-/obj/structure/window/reinforced,
 /obj/structure/lattice,
+/obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
 "aqI" = (
@@ -3826,14 +3848,13 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "arB" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Bridge MiniSat Access";
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/bridge)
@@ -6541,9 +6562,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCs" = (
 /obj/structure/extinguisher_cabinet{
@@ -6556,9 +6575,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCt" = (
 /obj/structure/table,
@@ -6574,9 +6591,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCu" = (
 /obj/structure/table,
@@ -6594,9 +6609,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCv" = (
 /obj/structure/table,
@@ -6618,9 +6631,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCw" = (
 /obj/structure/table,
@@ -6639,9 +6650,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCx" = (
 /obj/structure/sign/poster/official/obey{
@@ -6668,9 +6677,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCz" = (
 /obj/structure/cable/yellow{
@@ -6879,9 +6886,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aDx" = (
 /obj/structure/cable/yellow{
@@ -7089,9 +7094,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aEu" = (
 /obj/structure/cable/yellow{
@@ -7163,10 +7166,6 @@
 	},
 /obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/item/aiModule/core/full/custom,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = -28
@@ -7177,6 +7176,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -7219,10 +7221,6 @@
 /obj/item/aiModule/reset/purge,
 /obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/item/aiModule/supplied/protectStation,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 28
@@ -7233,6 +7231,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -7419,9 +7420,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aFt" = (
 /obj/structure/cable/yellow{
@@ -7586,7 +7585,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGf" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -7594,7 +7593,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGg" = (
 /obj/structure/table,
@@ -7611,7 +7610,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGh" = (
 /obj/structure/table,
@@ -7625,12 +7624,24 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aGi" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellowsiding,
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	layer = 3.2
+	},
+/obj/item/stack/sheet/iron{
+	amount = 20;
+	layer = 3.1
+	},
+/obj/item/stack/rods{
+	amount = 20;
+	layer = 3.3
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGk" = (
 /obj/machinery/vending/boozeomat/pubby_captain,
@@ -8055,15 +8066,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aHR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -8074,6 +8076,18 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aHR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHS" = (
@@ -8231,18 +8245,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIR" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/vehicle/ridden/secway,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aIT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -8591,8 +8599,11 @@
 /turf/closed/wall,
 /area/crew_quarters/cafeteria)
 "aKQ" = (
-/turf/closed/wall,
-/area/crew_quarters/toilet/auxiliary)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/crew_quarters/bar)
 "aKT" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/bar)
@@ -8734,40 +8745,47 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "aLG" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"aLI" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
 /obj/machinery/button/door{
 	id = "Potty1";
 	name = "Bathroom Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 25;
-	pixel_y = 4;
+	pixel_x = 8;
+	pixel_y = 24;
 	specialfunctions = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 36;
-	pixel_y = 6
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
-"aLH" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
-"aLI" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
 "aLK" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/area/maintenance/department/crew_quarters/bar)
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "aLL" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -9099,9 +9117,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aMB" = (
-/obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -9161,10 +9181,6 @@
 /obj/item/storage/toolbox/artistic{
 	pixel_x = -3
 	},
-/obj/machinery/light_switch{
-	dir = 9;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -9174,6 +9190,13 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/item/instrument/glockenspiel{
+	pixel_y = 3
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
@@ -9198,6 +9221,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/hand_labeler,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aMY" = (
@@ -9207,6 +9233,13 @@
 /obj/machinery/light_switch{
 	dir = 9;
 	pixel_x = -22
+	},
+/obj/machinery/power/apc{
+	name = "Cafeteria APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
@@ -9219,6 +9252,9 @@
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "aNb" = (
@@ -9226,32 +9262,41 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "aNc" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
-"aNd" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
-"aNf" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/crew_quarters/bar)
-"aNg" = (
+"aNd" = (
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"aNh" = (
-/obj/item/extinguisher,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+"aNg" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/light/small,
+/obj/machinery/shower{
+	dir = 4
 	},
-/area/maintenance/department/crew_quarters/bar)
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
+"aNh" = (
+/obj/machinery/power/apc/highcap/five_k{
+	name = "Auxiliary Restrooms APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "aNm" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -9559,82 +9604,64 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "aOt" = (
-/obj/structure/table,
-/obj/item/instrument/glockenspiel{
-	pixel_y = 3
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/storage/art)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aOu" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Art Storage";
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security E.V.A. Storage";
+	req_access_txt = "3"
+	},
 /turf/open/floor/plasteel,
-/area/storage/art)
+/area/security/main)
 "aOv" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron{
-	amount = 20;
-	layer = 3.1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	layer = 3.2
-	},
-/obj/item/stack/rods{
-	amount = 20;
-	layer = 3.3
-	},
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/nineteen_nineteen,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
 /turf/open/floor/plasteel,
-/area/storage/art)
+/area/security/main)
 "aOw" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/crew_quarters/bar)
+/turf/closed/wall,
+/area/crew_quarters/toilet/auxiliary)
 "aOB" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
@@ -9739,34 +9766,29 @@
 /area/teleporter)
 "aOL" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOM" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aON" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
-/area/security/checkpoint/supply)
+/area/security/main)
+"aON" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/item/key/security,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aOO" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -9951,13 +9973,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aPy" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/crew_quarters/bar)
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/main)
 "aPz" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -9978,13 +9997,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aPD" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Bar Maintenance APC";
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -10066,6 +10080,9 @@
 /area/teleporter)
 "aPR" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPV" = (
@@ -10228,16 +10245,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aQB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aQD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/light/small,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -10248,11 +10257,29 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/security/main)
+"aQD" = (
+/obj/machinery/door/airlock/security{
+	name = "Equipment Room";
+	req_access_txt = "1"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/main)
 "aQE" = (
 /obj/structure/grille/broken,
+/obj/item/weldingtool,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aQS" = (
@@ -10457,11 +10484,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
@@ -10472,8 +10498,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
@@ -10484,12 +10509,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
@@ -10544,34 +10567,25 @@
 /turf/closed/wall,
 /area/hydroponics)
 "aRM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access_txt = "35"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/main)
 "aRN" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aRO" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen Maintenance";
+	req_access_txt = "28"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
 /turf/open/floor/plating,
-/area/crew_quarters/kitchen)
-"aRP" = (
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
 /area/maintenance/department/crew_quarters/bar)
 "aRQ" = (
 /obj/item/gun/ballistic/shotgun/doublebarrel{
@@ -10706,10 +10720,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sunnybush,
+/mob/living/simple_animal/butterfly,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "aSw" = (
@@ -10723,42 +10737,58 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "aSB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aSC" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aSD" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aSE" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Storage"
 	},
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aSF" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10770,17 +10800,32 @@
 /obj/item/reagent_containers/glass/bottle/mutagen,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/watertank,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aSI" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -4
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "sink";
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aSJ" = (
-/obj/machinery/gibber,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aSK" = (
@@ -10797,10 +10842,10 @@
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aSM" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aSN" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -10823,9 +10868,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aSR" = (
-/obj/item/weldingtool,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/security/main)
 "aTb" = (
 /obj/machinery/light{
 	dir = 1
@@ -10965,10 +11010,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "aTL" = (
@@ -10986,11 +11031,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 4
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "aTO" = (
@@ -11001,20 +11045,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aTR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"aTR" = (
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "aTS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11023,37 +11077,29 @@
 /area/hydroponics)
 "aTW" = (
 /obj/structure/table,
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 3
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/watertank,
-/turf/open/floor/plasteel,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aTX" = (
-/obj/structure/kitchenspike,
-/obj/item/assembly/mousetrap,
-/obj/item/reagent_containers/food/snacks/deadmouse,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aTZ" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	departmentType = 2;
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/security/main)
 "aUa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -11077,9 +11123,8 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aUe" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood{
-	icon_state = "wood-broken5"
+	icon_state = "wood-broken6"
 	},
 /area/crew_quarters/bar)
 "aUf" = (
@@ -11116,72 +11161,56 @@
 /turf/open/space,
 /area/solar/starboard)
 "aUQ" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"aUR" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"aUR" = (
-/obj/machinery/door/window/eastright{
-	name = "Hydroponics Delivery";
-	req_access_txt = "35"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 1;
-	freq = 1400;
-	location = "Hydroponics"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aUS" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wirecutters,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"aUT" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUU" = (
-/obj/machinery/power/apc{
-	name = "Hydroponics APC";
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUW" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aUX" = (
-/obj/machinery/icecream_vat,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aUY" = (
@@ -11198,7 +11227,6 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aVc" = (
@@ -11212,7 +11240,10 @@
 	location = "Bar"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aVg" = (
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -11432,38 +11463,24 @@
 /turf/closed/wall,
 /area/janitor)
 "aVU" = (
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Janitor Delivery";
-	req_access_txt = "26"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Janitor"
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/janitor)
+/turf/open/floor/plasteel,
+/area/security/main)
 "aVW" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/freezer,
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aVZ" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/gibber,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aWb" = (
 /obj/structure/extinguisher_cabinet{
@@ -11683,18 +11700,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/janitor)
-"aWN" = (
-/obj/machinery/camera{
-	c_tag = "Custodial Quarters"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
+"aWN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -11724,6 +11735,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Custodial Quarters"
+	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aWP" = (
@@ -11735,19 +11749,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/grass,
 /area/hydroponics)
 "aWT" = (
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 30
-	},
 /obj/structure/sink/kitchen{
 	name = "utility sink";
 	pixel_y = 28
@@ -11755,12 +11760,16 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "aWU" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/freezer,
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aWW" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/freezer,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aWX" = (
 /obj/structure/disposalpipe/segment{
@@ -11776,9 +11785,8 @@
 /area/crew_quarters/bar)
 "aXc" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aXh" = (
@@ -12017,6 +12025,10 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "aXS" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXT" = (
@@ -12065,18 +12077,18 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aYd" = (
-/obj/machinery/door/airlock{
-	name = "Service Access";
-	req_one_access_txt = "22;25;26;28;35;37;38;46"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aYe" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -12512,7 +12524,13 @@
 /area/crew_quarters/bar)
 "aYZ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "barshutters";
+	name = "Bar Lockdown";
+	pixel_y = 26;
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -14815,10 +14833,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bil" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15135,13 +15160,35 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "bjR" = (
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/storage/emergency/port)
-"bjS" = (
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 23
+/obj/machinery/door/airlock{
+	id_tag = "Potty1";
+	name = "Unisex Restrooms"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
+"bjS" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay"
+	},
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Medbay Delivery";
+	req_access_txt = "6"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bjU" = (
@@ -15499,12 +15546,17 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "blc" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/turf/open/floor/plating,
-/area/storage/emergency/port)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "bld" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/dark,
@@ -17558,20 +17610,18 @@
 /obj/item/scalpel{
 	pixel_y = 12
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/item/razor{
 	pixel_y = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -17592,12 +17642,11 @@
 "brC" = (
 /obj/item/clothing/gloves/color/latex,
 /obj/item/surgical_drapes,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17696,15 +17745,14 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -17727,15 +17775,14 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -18061,12 +18108,11 @@
 "bta" = (
 /obj/item/retractor,
 /obj/item/hemostat,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -18657,16 +18703,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvT" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -18966,13 +19011,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxC" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -19055,15 +19099,14 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -19091,15 +19134,14 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -19123,15 +19165,14 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -19158,8 +19199,7 @@
 /area/medical/genetics)
 "bye" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
@@ -19261,10 +19301,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "byz" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/machinery/door/window/eastright{
 	dir = 1;
 	name = "Chemistry Testing";
@@ -19276,14 +19312,16 @@
 /mob/living/simple_animal/mouse/white{
 	name = "Labrette"
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/medical/chemistry)
 "byA" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -19426,16 +19464,15 @@
 /area/science/explab)
 "bzb" = (
 /obj/structure/closet/radiation,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -19939,11 +19976,10 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bAP" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bAQ" = (
@@ -20346,8 +20382,7 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -22176,14 +22211,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bGO" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
 /obj/structure/bed/roller,
-/obj/structure/window/reinforced,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
@@ -22974,27 +23007,24 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bKn" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/door/window/eastleft{
 	name = "Quarantine Pen B";
 	req_access_txt = "39"
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "bKt" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/structure/bed/roller,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bKu" = (
@@ -23262,13 +23292,12 @@
 /area/science/mixing/chamber)
 "bLh" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -23280,6 +23309,9 @@
 /obj/machinery/door/window/eastleft{
 	name = "Quarantine Pen C";
 	req_access_txt = "39"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
@@ -27971,6 +28003,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"cgG" = (
+/obj/item/extinguisher,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/crew_quarters/bar)
 "cgH" = (
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
@@ -28541,8 +28579,7 @@
 	id = "chapelgun"
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -28608,8 +28645,7 @@
 /area/chapel/main/monastery)
 "ckN" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -29125,41 +29161,39 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cnJ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "cnN" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room"
+/obj/effect/landmark/xeno_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/item/radio/intercom{
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/auxiliary)
 "cnP" = (
-/obj/machinery/vending/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
+/obj/machinery/door/airlock/maintenance{
+	id_tag = "Potty1";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "cnQ" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/crew_quarters/bar)
 "cnT" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/main)
 "cnV" = (
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/closed/wall/r_wall,
 /area/security/main)
 "cnW" = (
 /turf/open/floor/engine,
@@ -29227,7 +29261,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "coL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -29323,12 +29357,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpg" = (
-/obj/machinery/button/door{
-	id = "barshutters";
-	name = "Bar Lockdown";
-	pixel_y = 26;
-	req_access_txt = "28"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -29338,6 +29366,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -29782,9 +29813,21 @@
 /turf/open/space,
 /area/space/nearstation)
 "crn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/tank_dispenser/oxygen,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "crt" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -30649,6 +30692,16 @@
 "cyB" = (
 /turf/closed/wall,
 /area/library/lounge)
+"cyD" = (
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "cyM" = (
 /turf/closed/mineral,
 /area/chapel/asteroid/monastery)
@@ -31441,10 +31494,6 @@
 /obj/structure/transit_tube_pod{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/transit_tube/station/reverse/flipped{
 	dir = 1
@@ -31457,6 +31506,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/bridge)
@@ -31624,16 +31676,15 @@
 /area/hallway/primary/central)
 "cPT" = (
 /obj/structure/table/glass,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
 /obj/structure/window/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -32099,9 +32150,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "ddd" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -32110,6 +32158,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -32245,13 +32296,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "djE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "djM" = (
@@ -32588,11 +32636,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "duF" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/machinery/modular_fabricator/component_printer,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "duQ" = (
@@ -32964,7 +33011,11 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
-/turf/open/floor/plasteel/freezer,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "dJc" = (
 /obj/machinery/light{
@@ -33228,18 +33279,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "dRn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dRO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33376,11 +33421,14 @@
 /area/medical/surgery)
 "dXY" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -33553,6 +33601,14 @@
 	},
 /turf/open/floor/plating,
 /area/lawoffice)
+"ecf" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "edl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35008,6 +35064,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"eVR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eVS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -36148,10 +36219,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "fHO" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -36162,8 +36229,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/security/main)
 "fIu" = (
@@ -36807,9 +36873,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -36970,9 +37033,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "gkW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -37069,6 +37130,9 @@
 "gne" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "gnE" = (
@@ -37758,6 +37822,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"gHt" = (
+/obj/structure/bed/roller,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/medical/virology)
 "gHX" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -38286,6 +38357,18 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
+	},
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/nineteen_nineteen,
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Art Storage";
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
@@ -39416,6 +39499,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"hIO" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/crew_quarters/bar)
 "hJc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -39460,12 +39549,14 @@
 	dir = 8
 	},
 /obj/machinery/door/window/westright{
+	dir = 4;
 	name = "Cargo Delivery";
 	req_one_access_txt = "31;48"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "hKx" = (
@@ -40234,15 +40325,14 @@
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -40601,7 +40691,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "itL" = (
 /obj/structure/cable/yellow{
@@ -40757,6 +40847,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"izV" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iAB" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -40774,6 +40872,9 @@
 "iAD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iAR" = (
@@ -40963,7 +41064,10 @@
 /area/medical/virology)
 "iGd" = (
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41029,6 +41133,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"iJc" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/hydroponics)
 "iJf" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -41620,7 +41728,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "jcB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -41868,20 +41976,23 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jnd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "jng" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mining/glass{
@@ -42291,14 +42402,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "jAt" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Kitchen Maintenance";
-	req_access_txt = "28"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "jAw" = (
 /obj/machinery/turretid{
@@ -42630,6 +42741,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "jKc" = (
@@ -42714,12 +42826,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -42894,6 +43008,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -43137,7 +43254,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "kcx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -43688,7 +43805,10 @@
 "kxH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/freezer,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "kya" = (
 /obj/effect/turf_decal/stripes/line{
@@ -43918,6 +44038,30 @@
 	},
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
+"kBy" = (
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Janitor Delivery";
+	req_access_txt = "26"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Janitor"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "kBG" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -43927,10 +44071,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "kBN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
 /area/security/main)
 "kCc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44051,6 +44199,15 @@
 	pixel_y = 2
 	},
 /obj/structure/table/wood,
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	pixel_y = 30
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
+	},
 /turf/open/floor/grass,
 /area/hydroponics)
 "kFm" = (
@@ -45026,6 +45183,28 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"liq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "liV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -45223,7 +45402,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellowsiding,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "los" = (
 /obj/structure/cable/yellow{
@@ -46218,6 +46398,21 @@
 "lWy" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lWC" = (
+/obj/machinery/power/apc{
+	name = "Hydroponics APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "lWH" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -46682,11 +46877,18 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "mlL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "mmc" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -47434,7 +47636,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "mLX" = (
@@ -47904,8 +48108,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ncm" = (
@@ -48606,7 +48811,7 @@
 "nDS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "nDT" = (
 /obj/structure/transit_tube/horizontal,
@@ -48704,12 +48909,16 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "nGY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Bar Maintenance APC";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "nIm" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
@@ -49149,14 +49358,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nXn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "nXz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -49169,6 +49375,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nYb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "nYh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49383,6 +49604,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"oea" = (
+/obj/machinery/chem_master/condimaster,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/kitchen)
 "oeh" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 26
@@ -49588,14 +49816,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ooh" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/item/wrench/medical,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/medical/chemistry)
 "ook" = (
@@ -51972,12 +52199,19 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "pDC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pDO" = (
@@ -52023,6 +52257,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "pEt" = (
@@ -52033,11 +52270,16 @@
 /area/maintenance/department/engine)
 "pEF" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "pEZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52315,7 +52557,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -52595,17 +52837,25 @@
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "pZK" = (
-/obj/machinery/power/apc/highcap/five_k{
-	name = "Auxiliary Restrooms APC";
-	pixel_y = -24
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/item/soap/nanotrasen,
-/obj/machinery/shower{
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/crew_quarters/bar)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -52952,22 +53202,16 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qkU" = (
-/obj/machinery/door/airlock{
-	id_tag = "Potty1";
-	name = "Unisex Restrooms"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access_txt = "35"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "qkY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -53134,16 +53378,8 @@
 	},
 /area/maintenance/department/engine)
 "qqS" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "qrw" = (
 /obj/machinery/disposal/deliveryChute{
@@ -53329,9 +53565,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -53452,10 +53690,6 @@
 /area/engine/engineering)
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -4
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "qFo" = (
@@ -53882,9 +54116,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qTS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Bar APC";
@@ -54339,12 +54570,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "rls" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wirecutters,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/suit/apron,
+/obj/item/wrench,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "rlz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54642,18 +54881,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "rvH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay"
-	},
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Medbay Delivery";
-	req_access_txt = "6"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
 /area/medical/morgue)
 "rwh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -54909,18 +55138,18 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "rHJ" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/photocopier,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/main)
 "rIS" = (
@@ -55078,6 +55307,17 @@
 "rMV" = (
 /turf/open/floor/plating,
 /area/library/lounge)
+"rNf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "rNg" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
@@ -55920,10 +56160,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "smZ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/transit_tube/horizontal,
 /obj/structure/cable/yellow{
@@ -55934,6 +56170,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/bridge)
@@ -56242,6 +56481,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"szL" = (
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "sAn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -56575,7 +56820,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -56585,7 +56829,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/storage/art)
 "sLT" = (
@@ -57005,10 +57251,14 @@
 /area/science/xenobiology)
 "tbr" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "tbw" = (
@@ -57637,6 +57887,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "tvj" = (
@@ -58573,7 +58827,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/yellowsiding,
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "ulV" = (
 /obj/structure/rack,
@@ -58585,6 +58839,7 @@
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher/security,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ulY" = (
@@ -58612,11 +58867,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "umH" = (
-/obj/machinery/power/apc{
-	name = "Cafeteria APC";
-	pixel_y = -24
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "und" = (
@@ -58988,12 +59241,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uzH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -59003,8 +59253,7 @@
 /area/lawoffice)
 "uAZ" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -59112,12 +59361,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_y = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -60354,21 +60602,9 @@
 	},
 /area/maintenance/department/security/brig)
 "vww" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "vxp" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -60611,6 +60847,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vGK" = (
+/obj/machinery/door/airlock{
+	name = "Service Access";
+	req_one_access_txt = "22;25;26;28;35;37;38;46"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "vGY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -60677,13 +60926,14 @@
 /area/security/brig)
 "vJj" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
@@ -60983,9 +61233,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "vTN" = (
 /obj/machinery/door/airlock/research{
@@ -61205,10 +61453,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wbr" = (
@@ -61270,6 +61515,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "wem" = (
@@ -61447,20 +61695,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "whF" = (
-/obj/machinery/door/airlock/security{
-	name = "Equipment Room";
-	req_access_txt = "1"
+/obj/machinery/camera{
+	c_tag = "Kitchen Cold Room"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	pixel_y = 30
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen)
 "whH" = (
 /obj/structure/chair/wood/normal,
 /obj/item/radio/intercom/chapel{
@@ -61722,6 +61966,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"wrK" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "wrS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -61730,6 +61984,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wrU" = (
@@ -62043,12 +62300,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wBg" = (
-/obj/machinery/door/airlock/maintenance{
-	id_tag = "Potty1";
-	req_access_txt = "12"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wCm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -62712,14 +62974,13 @@
 /area/engine/atmos)
 "wXu" = (
 /obj/machinery/disposal/bin,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "wXP" = (
@@ -62748,13 +63009,6 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "wYc" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
@@ -62766,6 +63020,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -62785,6 +63045,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "wZB" = (
@@ -63046,21 +63307,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "xhu" = (
 /obj/structure/disposalpipe/segment{
@@ -63204,6 +63460,24 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"xns" = (
+/obj/machinery/door/window/eastright{
+	name = "Hydroponics Delivery";
+	req_access_txt = "35"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 1;
+	freq = 1400;
+	location = "Hydroponics"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "xoq" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -63339,17 +63613,9 @@
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "xsW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/auxiliary)
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/bar)
 "xtb" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable/yellow{
@@ -64011,9 +64277,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "xMd" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -64138,6 +64401,9 @@
 /area/science/explab)
 "xVc" = (
 /obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -80278,8 +80544,8 @@ aaa
 aaa
 aaa
 aaa
-ait
-ait
+aiu
+aiu
 ait
 ait
 aiu
@@ -88241,7 +88507,7 @@ aaa
 pmj
 bRC
 agP
-agQ
+agP
 agQ
 agP
 ahL
@@ -88281,7 +88547,7 @@ rlV
 aDZ
 sLZ
 aDZ
-aDZ
+dRn
 aDZ
 aDZ
 aDZ
@@ -88497,13 +88763,13 @@ aaa
 aaa
 pmj
 aaa
-agP
+agQ
 cnJ
-ahq
-ahq
+cnJ
+ais
 ahM
 ain
-aiQ
+agP
 ajk
 ajU
 akQ
@@ -88539,10 +88805,10 @@ aDZ
 sLZ
 aDZ
 aDZ
-aQB
-uzH
-rls
-aPR
+aDZ
+ibi
+vBa
+aDZ
 jNP
 wun
 aEa
@@ -88581,7 +88847,7 @@ bFI
 wlo
 iLs
 bGO
-iLs
+gHt
 bEr
 puQ
 bEr
@@ -88755,15 +89021,15 @@ aaa
 pmj
 aaa
 agQ
-ahd
-ahq
-ahq
-ahq
+alH
+alH
+aiQ
+aLG
 aio
-agP
+aQD
 rHJ
-ajV
-ajV
+aRM
+aTR
 alC
 alE
 alC
@@ -88796,7 +89062,7 @@ cKI
 uiH
 cKI
 cKI
-nXn
+cKI
 aHG
 mOd
 dXY
@@ -89005,7 +89271,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -89013,14 +89279,14 @@ pmj
 aaa
 agQ
 ahd
-ahq
-cnT
-ahq
-ahd
+ahQ
+alH
+aOt
+cnJ
 agP
 ajm
 ajW
-ajV
+aTZ
 alD
 anM
 anc
@@ -89051,12 +89317,12 @@ gAZ
 aKJ
 aKK
 aKJ
-aKK
 aKJ
-aQD
+aKT
+aKT
 aRI
 coV
-aKT
+wBg
 jnd
 aVS
 aVS
@@ -89265,20 +89531,20 @@ aaa
 aaa
 aaa
 aaa
-cFB
-pmj
 aaa
-agQ
-ahd
-ahq
-ahq
-ahq
-ahd
+pmj
+bRC
+agP
+agP
+agP
+aIR
+aOt
+aON
 agP
 ajn
-ajW
+aSR
 iGd
-alE
+aVU
 amp
 gzo
 eVS
@@ -89308,13 +89574,13 @@ unN
 aKK
 xkr
 aMV
-aOt
 aKJ
+aNc
 aKT
 aKT
 aKT
+xhq
 aKT
-dRn
 aVS
 aWM
 aXN
@@ -89523,14 +89789,14 @@ aaa
 aaa
 aaa
 aaa
-pmj
+aaa
+aaa
 bRC
-agP
-cnN
-ahq
+aaa
+cnV
 cnT
-ahq
-ahd
+aOu
+aPy
 agP
 ajo
 ajV
@@ -89565,14 +89831,14 @@ ney
 mLX
 sLc
 gZh
-aOu
 aKJ
-aQE
-vJj
-tbr
+aLL
+pEF
+dZP
+dZP
 tbr
 qqS
-aVS
+kBy
 aWN
 aXO
 aYM
@@ -89780,18 +90046,18 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 pmj
 aaa
-agQ
-ahd
-ahq
+cnV
 kBN
-ahq
+aOv
 aip
 agP
 mKT
-ajV
-aMB
+alE
+aUQ
 alF
 amq
 ane
@@ -89822,14 +90088,14 @@ unN
 aKK
 aLz
 aMX
-aOv
 aKJ
+aLL
 vJj
+aRL
+aRL
 qqS
 aRL
-aRL
-aUQ
-aVU
+aVS
 aWO
 aXP
 aVS
@@ -90037,15 +90303,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 pmj
 aaa
-agQ
-cnP
-ahq
+cnV
 mlL
 crn
-crn
-whF
+aQB
+agP
 fHO
 nbB
 qAg
@@ -90074,17 +90340,17 @@ xWD
 aGg
 aBi
 aHJ
-pEF
-nGY
+aIO
+unN
 aKJ
 aKJ
 aKJ
 aKJ
-aKJ
+aLL
 bEp
 aRL
-aRL
-aRL
+rls
+xns
 aUR
 aVS
 aVS
@@ -90294,15 +90560,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 pmj
 aaa
-agQ
-cnQ
-ahq
 cnV
-ahq
-air
-agP
+cnV
+aOM
+cnV
+cnV
 agP
 agP
 cCS
@@ -90338,11 +90604,11 @@ aLA
 aMY
 aKP
 aNm
-bEp
-aRL
+pZK
+qkU
 aUS
 aTQ
-aXS
+lWC
 aRL
 aWP
 aXQ
@@ -90551,15 +90817,15 @@ aaa
 aaa
 aaa
 aaa
-pmj
 aaa
-agP
-cnQ
-ahq
-ahq
-ahQ
-ais
-agP
+aaa
+pmj
+bRC
+bRC
+bRC
+bRC
+bRC
+cnV
 ajr
 aiR
 akT
@@ -90595,12 +90861,12 @@ vEi
 aMZ
 aKP
 aPx
-xhq
-aRM
-aSB
-aTR
-aUT
+hSI
 aRL
+aSB
+aTS
+aUU
+iJc
 aWP
 aXR
 utc
@@ -90615,8 +90881,8 @@ oWZ
 aDZ
 bii
 bjL
-bjR
-blc
+blb
+blb
 bjL
 bny
 boB
@@ -90808,15 +91074,15 @@ aaa
 aaa
 aaa
 aaa
-pmj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bRC
-agP
-agQ
-agQ
-agQ
-agP
-agP
-agP
+cnV
 ajs
 aiR
 akU
@@ -90850,14 +91116,14 @@ ney
 ezV
 mhT
 umH
-aKP
-aPy
+cnP
+aPz
 lxE
 aRL
-aSC
+aSD
 aTS
 aUU
-aRL
+iJc
 aWP
 fep
 aYO
@@ -91068,10 +91334,10 @@ aaa
 aaa
 aaa
 aaa
-bRC
-bRC
-bRC
-bRC
+aaa
+aaa
+aaa
+aaa
 bRC
 bRC
 ajs
@@ -91113,7 +91379,7 @@ rUB
 aRL
 aSD
 jKb
-aXS
+cyD
 aRL
 aWR
 aXT
@@ -91361,10 +91627,10 @@ aGX
 xvO
 aIO
 unN
-aKQ
-aKQ
-aKQ
-aKQ
+aKT
+aKT
+aKT
+aKT
 aLL
 iSh
 aRL
@@ -91384,9 +91650,9 @@ bfm
 bdm
 mzT
 aDZ
-bil
+bim
 biY
-bmq
+szL
 bmq
 aab
 lcH
@@ -91618,16 +91884,16 @@ aAN
 gNG
 aIO
 rCx
-aKQ
+aKT
 vww
 aNc
-aKQ
+aKT
 aLL
 kFZ
 aRL
 aSF
 aXS
-aXS
+wrK
 aRL
 aWT
 aXV
@@ -91875,11 +92141,11 @@ aHb
 xvO
 wbg
 djE
-qkU
+aKT
 xsW
 aNd
-wBg
-aLL
+aKT
+nGY
 jTj
 aRL
 aSG
@@ -92132,10 +92398,10 @@ aHc
 aHO
 aIO
 unN
-aKQ
-aLG
-pZK
-aKQ
+aKT
+aPz
+aLL
+cnQ
 aPA
 hSI
 aRN
@@ -92389,14 +92655,14 @@ awR
 xvO
 aIO
 gAZ
+aKT
 aKQ
-aKQ
-aKQ
-aKQ
+cgG
+aKT
 aLL
 hSI
 aRN
-aRN
+uzH
 aTX
 aUX
 aVW
@@ -92412,7 +92678,7 @@ aDZ
 aDZ
 cRi
 jkW
-bim
+izV
 biY
 biY
 biY
@@ -92644,13 +92910,13 @@ aFx
 aGk
 awR
 aHQ
-aIO
-jfr
-aKT
-aLH
-aNf
-aKT
-aLL
+aYd
+nQP
+aOw
+aOw
+aOw
+aOw
+nXn
 gZX
 aRO
 jAt
@@ -92901,19 +93167,19 @@ aFy
 aGl
 awR
 aHR
-aIR
-nQP
-aKT
+aIO
+jfr
+aOw
 aLI
 aNg
-aKT
+aOw
 aPB
 hSI
 aRN
-aRN
-aTZ
+whF
 aSK
 aSK
+oea
 aRN
 aRN
 bgk
@@ -93158,19 +93424,19 @@ aFz
 aGm
 awR
 pPv
-aIO
-jfr
-aKT
-aPz
-aLL
+aIQ
+bil
+bjR
+blc
+cnN
 aOw
 aLL
 hSI
 aRN
 aSI
-aSK
+abI
 xMd
-aSK
+ecf
 aWU
 aRN
 aYR
@@ -93417,10 +93683,10 @@ awR
 aHS
 aIO
 jfr
-aKT
+aOw
 aLK
 aNh
-aKT
+aOw
 aPC
 hSI
 aRN
@@ -93674,10 +93940,10 @@ aHd
 aHT
 aIT
 jfr
-aKT
-aKT
-aKT
-aKT
+aOw
+aOw
+aOw
+aOw
 aPD
 geY
 aRN
@@ -94194,7 +94460,7 @@ aKT
 bEp
 aLL
 aLL
-aRP
+qqS
 aSM
 aUb
 aVc
@@ -94456,7 +94722,7 @@ aPE
 aPE
 qEN
 bah
-aXc
+aXb
 aRN
 aYU
 bab
@@ -95485,7 +95751,7 @@ aUe
 cpa
 aWg
 aXc
-aPE
+vGK
 cpg
 bah
 bag
@@ -95738,11 +96004,11 @@ aPE
 aPE
 tED
 aPE
-aPE
+hIO
 aPE
 aWh
 qTS
-aYd
+aPE
 aYZ
 bag
 cpo
@@ -95994,7 +96260,7 @@ bEp
 aQE
 aLL
 kUk
-aSR
+aPE
 aPE
 aPE
 cpe
@@ -100359,12 +100625,12 @@ aDZ
 aDZ
 bbz
 bbz
-aOM
+bbz
 aZi
 aXr
 bbz
 aDZ
-xhu
+eVR
 aDZ
 bbz
 aXr
@@ -100616,12 +100882,12 @@ aDZ
 aLe
 aLe
 aRf
-aON
+aRf
 aLe
 aLe
 aPW
 baz
-fRH
+liq
 baz
 aPW
 aLf
@@ -100878,7 +101144,7 @@ mLo
 aRf
 fue
 aPY
-kIr
+nYb
 aPY
 aWs
 aPW
@@ -101135,7 +101401,7 @@ wej
 oPA
 pEk
 gne
-jVb
+rNf
 aPY
 aWu
 aXt

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27068,11 +27068,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbj" = (
@@ -27203,14 +27201,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccc" = (
-/obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccd" = (
@@ -27531,6 +27527,8 @@
 	c_tag = "Engineering Port Aft";
 	dir = 1
 	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdR" = (
@@ -27547,6 +27545,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdS" = (
@@ -62762,6 +62762,16 @@
 /obj/machinery/telecomms/relay/preset/exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"wJK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wKd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -95030,7 +95040,7 @@ cam
 cam
 cam
 cam
-cdI
+wJK
 qFu
 ljX
 ulY

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35321,13 +35321,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -2
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -49840,6 +49836,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"otR" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit/departure_lounge)
 "otV" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -51259,10 +51276,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = 32
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -51432,9 +51445,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
-	},
-/obj{
-	name = "---Merge conflict marker---"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -53926,9 +53936,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -87503,7 +87517,7 @@ aQx
 aRG
 qWM
 oEA
-qQP
+otR
 dTV
 aWK
 aXI

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4144,39 +4144,39 @@
 /area/security/brig)
 "asx" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/door_timer{
 	id = "Cell 1";
 	name = "Cell 1";
 	pixel_y = -32
 	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"asz" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"asz" = (
 /obj/machinery/door_timer{
 	id = "Cell 2";
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asB" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
 	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4389,11 +4389,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "atB" = (
+/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/closed/wall,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "atD" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -6059,7 +6060,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aAD" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6202,6 +6203,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aBs" = (
@@ -7894,13 +7898,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"aHf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/central)
 "aHh" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -8127,12 +8124,13 @@
 /area/hallway/primary/central)
 "aHX" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/primary/central)
 "aHY" = (
 /obj/structure/cable/yellow{
@@ -8265,22 +8263,20 @@
 /area/hallway/primary/central)
 "aIW" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/primary/central)
 "aIX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /obj/effect/landmark/observer_start,
 /obj/structure/cable/yellow{
@@ -8290,12 +8286,10 @@
 /area/hallway/primary/central)
 "aIY" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/primary/central)
 "aJb" = (
 /obj/structure/disposalpipe/segment{
@@ -13637,8 +13631,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bdh" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bdi" = (
@@ -20431,6 +20427,10 @@
 /area/science/xenobiology)
 "bBV" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bBW" = (
@@ -22434,8 +22434,16 @@
 /turf/closed/wall/r_wall,
 /area/chapel/dock)
 "bHT" = (
-/turf/open/space/basic,
-/area/maintenance/department/cargo)
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "bHX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -35999,10 +36007,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "fBz" = (
@@ -43749,19 +43753,6 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kyP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kyY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -45687,9 +45678,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
 "lDW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -45699,6 +45687,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -49853,6 +49844,9 @@
 	c_tag = "Bridge Starboard Entrance";
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "otV" = (
@@ -52109,14 +52103,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "pKJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge";
-	req_access_txt = "19"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52124,6 +52111,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "pLe" = (
@@ -63868,9 +63859,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "xHQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/button/door{
 	id = "bridge blast";
 	name = "Bridge Entrance Lockdown";
@@ -86984,7 +86972,7 @@ apJ
 pBy
 amd
 asz
-atB
+ajM
 ajM
 ajM
 ajM
@@ -88012,7 +88000,7 @@ amg
 fSZ
 arp
 asB
-atB
+ajM
 ajM
 ajM
 ajM
@@ -94707,10 +94695,10 @@ aCK
 aEE
 aAB
 aGo
-aHf
-wKT
-aIW
-dRO
+bdh
+aHV
+aIO
+jfr
 bdh
 ovF
 aKT
@@ -94964,11 +94952,11 @@ aDL
 aEF
 aAB
 aGp
-aHf
 aHX
-aIW
-dRO
-bdh
+aHV
+aIO
+jfr
+aHX
 pZp
 aKT
 qFF
@@ -95221,11 +95209,11 @@ aDM
 aEG
 aAB
 aGq
-aHf
+aIW
 wKT
 aIX
 dRO
-bdh
+bHT
 vfP
 aKT
 qFF
@@ -95478,11 +95466,11 @@ aDL
 aEH
 aAB
 aGr
-aHf
 aHX
-aIW
-dRO
-bdh
+aHV
+aDZ
+jfr
+aHX
 wcX
 aKT
 loV
@@ -95735,11 +95723,11 @@ aCK
 aEE
 aAB
 aGs
-aHf
-wKT
 aIY
-dRO
-bdh
+aHV
+aDZ
+jfr
+aIY
 cNN
 aKT
 loV
@@ -95995,7 +95983,7 @@ aGn
 axi
 aHZ
 aDZ
-kyP
+jfr
 aAN
 aSt
 aKT
@@ -96501,7 +96489,7 @@ jKi
 wpm
 aAD
 aBr
-aDO
+atB
 otz
 fbl
 aDO
@@ -96758,7 +96746,7 @@ doV
 rjJ
 xHQ
 pKJ
-rPK
+fEg
 lDW
 pvI
 scL
@@ -108091,7 +108079,7 @@ aaa
 aaa
 aaa
 aaa
-bHT
+aaa
 aEj
 aEj
 aEj
@@ -108348,7 +108336,7 @@ aaa
 aaa
 aaa
 aaa
-bHT
+aaa
 aEl
 lVZ
 gHi

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -735,7 +735,7 @@
 /area/space/nearstation)
 "adT" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "adW" = (
 /obj/structure/lattice,
@@ -1135,7 +1135,10 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "afR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1226,7 +1229,7 @@
 "agn" = (
 /obj/machinery/power/generator,
 /obj/structure/cable,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "agp" = (
 /obj/item/soap/nanotrasen,
@@ -2692,7 +2695,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "amj" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -2702,13 +2705,11 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "aml" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/closed/wall/r_wall,
-/area/security/warden)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "amm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2857,11 +2858,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ana" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/security/warden)
+/obj/effect/spawner/room/tenxfive,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "anb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2961,24 +2960,25 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anB" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/security/warden)
+/area/maintenance/department/crew_quarters/dorms)
 "anC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -3137,19 +3137,12 @@
 /mob/living/simple_animal/pet/dog/pug{
 	name = "McGriff"
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"aos" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"aos" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -3157,6 +3150,19 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security{
+	name = "Brig Control";
+	req_access_txt = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aot" = (
@@ -3285,6 +3291,9 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/glasses/sunglasses/advanced,
 /obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aoS" = (
@@ -3440,14 +3449,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "apI" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/security/warden)
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "apJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -3459,13 +3465,6 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "apK" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	name = "Armory Desk";
@@ -3483,20 +3482,25 @@
 	pixel_y = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"apN" = (
+/obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"apO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+"apN" = (
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/turf/closed/wall/r_wall,
-/area/security/warden)
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
+"apO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "apQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -3589,7 +3593,7 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/grimy,
 /area/security/brig)
 "aqF" = (
 /turf/closed/wall/r_wall,
@@ -3791,6 +3795,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "arr" = (
@@ -3808,16 +3815,19 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"arz" = (
 /obj/machinery/camera{
 	c_tag = "Brig Interrogation";
 	dir = 8;
 	network = list("interrogation")
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/grimy,
 /area/security/brig)
+"arz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "arA" = (
 /turf/closed/wall/r_wall,
 /area/bridge)
@@ -4086,9 +4096,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ash" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/crew_quarters/dorms)
+/area/ai_monitored/security/armory)
 "asi" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
@@ -4130,9 +4143,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asx" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/light,
 /obj/machinery/door_timer{
 	id = "Cell 1";
@@ -4374,23 +4384,10 @@
 /area/security/brig)
 "aty" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/closed/wall,
-/area/security/brig)
-"atz" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "atB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4398,9 +4395,6 @@
 /turf/closed/wall,
 /area/security/brig)
 "atD" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -4413,9 +4407,6 @@
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4432,11 +4423,9 @@
 /area/security/brig)
 "atF" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
@@ -4456,14 +4445,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	name = "Emergency Escape";
-	req_access_txt = "20"
+/obj/effect/decal/cleanable/robot_debris{
+	icon_state = "gib6"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/department/crew_quarters/dorms)
 "atN" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
@@ -5272,15 +5260,13 @@
 /area/maintenance/department/security/brig)
 "awI" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "awJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -5293,22 +5279,15 @@
 	name = "brig shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/security/brig)
 "awK" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "awL" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -5317,9 +5296,6 @@
 	id_tag = "outerbrig";
 	name = "Brig";
 	req_access_txt = "63"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5395,7 +5371,7 @@
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "awT" = (
 /obj/structure/cable/yellow{
@@ -5534,23 +5510,17 @@
 /area/hallway/primary/fore)
 "axN" = (
 /obj/structure/dresser,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "axP" = (
 /obj/structure/closet/secure_closet/captains,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Captain's Quarters"
-	},
 /obj/item/clothing/suit/armor/riot/knight/blue,
 /obj/item/clothing/head/helmet/knight/blue,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "axQ" = (
 /obj/machinery/suit_storage_unit/captain,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "axR" = (
 /obj/structure/cable/yellow{
@@ -5760,9 +5730,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayQ" = (
-/obj/item/beacon,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/warden)
 "ayR" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -5776,10 +5749,13 @@
 "ayS" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "ayT" = (
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "ayY" = (
 /obj/structure/cable/yellow{
@@ -5994,7 +5970,7 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "aAq" = (
 /obj/structure/table/wood,
@@ -6005,18 +5981,22 @@
 	},
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/item/reagent_containers/food/drinks/flask/gold,
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/camera{
+	c_tag = "Captain's Quarters";
+	dir = 10
+	},
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "aAr" = (
 /obj/structure/chair/fancy/comfy{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "aAs" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/fork,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "aAt" = (
 /obj/structure/disposalpipe/segment,
@@ -6146,13 +6126,12 @@
 /turf/closed/wall,
 /area/security/detectives_office)
 "aBe" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "datboidetective";
 	name = "privacy shutters"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/detectives_office)
 "aBg" = (
 /obj/effect/turf_decal/tile/red{
@@ -7281,7 +7260,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "aEP" = (
 /obj/machinery/computer/card{
@@ -7290,7 +7269,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "aEQ" = (
 /obj/structure/chair/office,
@@ -7317,7 +7296,7 @@
 	pixel_x = 38;
 	pixel_y = -35
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "aER" = (
 /obj/structure/table/wood,
@@ -7331,7 +7310,7 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "aES" = (
 /obj/machinery/camera{
@@ -7383,9 +7362,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "aFd" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet/restrooms)
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/warden)
 "aFe" = (
 /obj/machinery/light{
 	dir = 4
@@ -7749,25 +7729,25 @@
 "aGt" = (
 /obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aGu" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aGv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aGw" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aGx" = (
 /obj/machinery/flasher{
@@ -7776,7 +7756,7 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aGy" = (
 /obj/structure/table,
@@ -7785,7 +7765,7 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aGz" = (
 /obj/machinery/vending/cigarette,
@@ -7803,12 +7783,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aGX" = (
-/obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "assistantshutters";
 	name = "storage shutters"
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
 "aGY" = (
@@ -7923,14 +7902,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "aHh" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hopqueue";
-	name = "HoP Queue Shutters"
-	},
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "hopqueue";
+	name = "HoP Queue Shutters"
+	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -7943,12 +7922,12 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "aHl" = (
-/obj/machinery/door/poddoor/shutters/preopen{
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/door/poddoor/shutters/window/preopen{
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHm" = (
 /obj/structure/cable/yellow{
@@ -8157,19 +8136,11 @@
 /area/hallway/primary/central)
 "aHY" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/warden)
 "aHZ" = (
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
@@ -8645,13 +8616,13 @@
 /turf/open/floor/plating,
 /area/storage/eva)
 "aLa" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "evashutter";
-	name = "EVA Storage Shutters"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "evashutter";
+	name = "EVA Storage Shutters"
+	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
 "aLb" = (
@@ -8720,6 +8691,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"aLs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "aLu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral{
@@ -10241,7 +10221,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aQz" = (
 /obj/machinery/door/airlock/public/glass{
@@ -21808,19 +21788,14 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bFx" = (
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/item/trash/cheesie,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
 "bFy" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/fore)
 "bFz" = (
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plating,
@@ -24309,9 +24284,6 @@
 "bQs" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/item/aicard,
 /obj/item/aiModule/reset,
 /obj/item/assembly/flash/handheld,
@@ -24327,6 +24299,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -24608,9 +24583,6 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bRg" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -24628,6 +24600,12 @@
 "bRh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -24659,6 +24637,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -24900,15 +24881,13 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bSD" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
 /area/storage/tech)
 "bSE" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -24951,6 +24930,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bSL" = (
@@ -25142,9 +25127,21 @@
 /area/engine/gravity_generator)
 "bTt" = (
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTu" = (
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTv" = (
@@ -27686,7 +27683,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceu" = (
 /obj/item/stack/cable_coil{
@@ -27769,7 +27766,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27841,14 +27838,17 @@
 /area/chapel/main/monastery)
 "cfu" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfC" = (
 /obj/machinery/biogenerator,
@@ -27899,7 +27899,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfU" = (
 /obj/structure/cable/yellow{
@@ -27918,7 +27918,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cgb" = (
 /obj/machinery/airalarm{
@@ -27952,7 +27955,7 @@
 	pixel_x = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cgy" = (
 /obj/structure/disposalpipe/segment{
@@ -27960,6 +27963,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -28029,7 +28035,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "chb" = (
 /obj/machinery/camera{
@@ -28276,7 +28282,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ciJ" = (
 /obj/structure/closet/emcloset,
@@ -30472,7 +30478,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cww" = (
 /obj/structure/table/wood,
@@ -31049,9 +31055,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "cBv" = (
-/obj/effect/spawner/room/fivexthree,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/turf/open/floor/carpet/grimy,
+/area/security/brig)
 "cBM" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/neutral{
@@ -31108,7 +31113,7 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cCM" = (
 /obj/structure/cable/yellow{
@@ -31195,9 +31200,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cDB" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/structure/table,
+/obj/item/dice/d20,
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "cDV" = (
 /obj/structure/table/glass,
@@ -31406,7 +31411,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cJx" = (
 /obj/structure/cable/yellow{
@@ -31565,13 +31570,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cOt" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -31580,6 +31578,16 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "cPy" = (
@@ -31881,7 +31889,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cWV" = (
 /obj/structure/cable/yellow{
@@ -32008,7 +32016,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "daD" = (
 /obj/structure/cable/yellow{
@@ -32362,7 +32370,7 @@
 /area/ai_monitored/turret_protected/ai)
 "doo" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -32374,7 +32382,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "doH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -32493,6 +32501,9 @@
 "drW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -32756,11 +32767,13 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "dAF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dAL" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -33391,6 +33404,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dYz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dYQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -33414,10 +33442,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dZj" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "dZr" = (
@@ -33519,7 +33544,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ebD" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -33648,7 +33673,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ega" = (
 /obj/effect/turf_decal/tile/purple{
@@ -33957,6 +33982,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"eor" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "epd" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -34363,7 +34395,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "eDC" = (
 /obj/structure/cable/yellow{
@@ -34403,7 +34435,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "eEk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -34668,7 +34700,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "eJL" = (
 /obj/structure/cable{
@@ -34905,7 +34938,7 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "eRC" = (
 /obj/structure/cable/yellow{
@@ -34962,6 +34995,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -35154,10 +35190,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Bridge Starboard Entrance";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -35227,7 +35259,7 @@
 "fdS" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/engine/engineering)
 "fee" = (
 /obj/item/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -35277,7 +35309,7 @@
 /area/science/explab)
 "feW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -35460,7 +35492,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fkm" = (
 /obj/structure/disposalpipe/segment,
@@ -35635,6 +35667,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"fpQ" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall,
+/area/science/mixing)
 "fqo" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
@@ -35710,15 +35746,15 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ftb" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ftj" = (
 /obj/structure/bodycontainer/crematorium,
@@ -35787,9 +35823,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fuB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fuO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35814,7 +35856,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fwl" = (
 /obj/structure/disposalpipe/segment{
@@ -35839,7 +35881,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fzc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -35922,7 +35964,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fBp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -35946,11 +35988,21 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "fBy" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "fBz" = (
@@ -36086,8 +36138,11 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "fHD" = (
-/turf/open/space/basic,
-/area/maintenance/department/science)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/carpet/grimy,
+/area/security/brig)
 "fHH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -37056,13 +37111,17 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "goF" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command{
+	name = "Emergency Escape";
+	req_access_txt = "20"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/fore)
 "goN" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -37331,9 +37390,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "gxe" = (
-/obj/effect/spawner/room/tenxfive,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/fore)
 "gxi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -37400,7 +37459,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "gzo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -37720,6 +37779,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "gIG" = (
@@ -37798,11 +37860,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "gLo" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/crew_quarters/dorms)
 "gLF" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -37831,15 +37891,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway Bridge";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Bridge";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -37905,7 +37965,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"gOn" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "gOI" = (
 /obj/machinery/light/small{
@@ -38231,7 +38301,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "gZX" = (
 /obj/structure/cable/yellow{
@@ -38293,16 +38363,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
 "heC" = (
-/obj/machinery/power/apc/highcap/five_k{
-	dir = 8;
-	name = "Science Maintenance APC";
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/science)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
 "heP" = (
 /obj/machinery/conveyor_switch{
 	id = "atmosdeliver"
@@ -38372,7 +38435,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "hhi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "hhu" = (
 /obj/machinery/newscaster{
@@ -38736,13 +38799,13 @@
 	dir = 8;
 	name = "Atmos Supermatter Mix"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "hsO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "hsW" = (
 /obj/effect/turf_decal/tile/blue{
@@ -38773,7 +38836,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "htC" = (
 /obj/machinery/door/airlock/public/glass{
@@ -38916,10 +38979,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hxn" = (
-/obj/structure/chair,
-/obj/item/clothing/glasses/regular,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/item/beacon,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hxo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39105,7 +39167,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "hDU" = (
 /obj/machinery/door/firedoor,
@@ -39238,7 +39300,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "hGm" = (
 /obj/structure/disposalpipe/segment,
@@ -39246,6 +39308,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"hGp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/storage/tech)
 "hGA" = (
 /obj/effect/landmark/start/exploration,
 /obj/structure/cable/yellow{
@@ -39460,6 +39526,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"hLD" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "hMG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -39838,12 +39911,6 @@
 	name = "Armory";
 	req_access_txt = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -39857,8 +39924,17 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "hXt" = (
 /obj/effect/spawner/room/tenxten,
 /turf/open/floor/plating,
@@ -40270,7 +40346,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ikO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40354,7 +40430,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "inv" = (
 /obj/structure/disposalpipe/segment{
@@ -40482,7 +40558,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "isg" = (
 /obj/structure/rack,
@@ -40834,7 +40910,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "iEj" = (
 /obj/effect/landmark/event_spawn,
@@ -41068,7 +41147,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "iLs" = (
 /obj/structure/bed/roller,
@@ -41173,7 +41252,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -41190,6 +41268,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iPU" = (
@@ -41231,7 +41312,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "iRu" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -41346,7 +41427,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "iUP" = (
 /obj/structure/cable/yellow{
@@ -41763,7 +41844,7 @@
 	dir = 8;
 	pixel_y = -5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jmH" = (
 /obj/structure/disposalpipe/segment{
@@ -41789,7 +41870,7 @@
 	dir = 10
 	},
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jnd" = (
 /obj/structure/cable/yellow{
@@ -41850,7 +41931,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jpg" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -41861,7 +41942,7 @@
 	pixel_x = -5
 	},
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jpx" = (
 /obj/item/kirbyplants/photosynthetic{
@@ -41903,6 +41984,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge Port Entrance";
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -42357,7 +42442,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jEk" = (
 /obj/machinery/door/poddoor/preopen{
@@ -42507,7 +42592,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2,
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jHt" = (
 /obj/structure/cable/yellow{
@@ -42985,8 +43070,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "jYA" = (
-/turf/open/space/basic,
-/area/science/shuttledock)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet/restrooms)
 "kbe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -43037,7 +43132,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kca" = (
 /obj/structure/disposalpipe/junction/flip,
@@ -43124,7 +43219,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-24"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "kfK" = (
 /obj/machinery/door/airlock/maintenance{
@@ -43173,6 +43268,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"kgO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
+	dir = 8;
+	icon_state = "vent_map_on-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "khc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -43313,7 +43421,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kkQ" = (
-/obj/machinery/vending/cola/pwr_game,
+/obj/structure/chair,
+/obj/item/reagent_containers/food/snacks/donkpocket,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -43599,7 +43708,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
 	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kyf" = (
 /obj/effect/turf_decal/tile/blue{
@@ -43609,6 +43718,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kyu" = (
@@ -43640,16 +43750,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kyP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/robot_debris{
-	icon_state = "gib6"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kyY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -43705,6 +43817,12 @@
 "kzB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -44010,7 +44128,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kFZ" = (
 /obj/structure/grille/broken,
@@ -44133,6 +44251,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "kIT" = (
@@ -44202,7 +44323,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kJH" = (
 /obj/machinery/advanced_airlock_controller{
@@ -44332,8 +44454,19 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kNU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "kOO" = (
 /obj/structure/table/wood/fancy,
 /obj/item/gun/ballistic/revolver/russian{
@@ -44351,8 +44484,6 @@
 	},
 /area/crew_quarters/bar)
 "kPi" = (
-/obj/structure/table,
-/obj/machinery/microwave,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -44585,6 +44716,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kUC" = (
@@ -44964,7 +45101,7 @@
 /obj/item/pipe_dispenser,
 /obj/item/pipe_dispenser,
 /obj/item/pipe_dispenser,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lkm" = (
 /obj/structure/cable/yellow{
@@ -45222,7 +45359,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/grimy,
 /area/security/brig)
 "lqX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -45299,15 +45436,11 @@
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lvp" = (
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge Port Entrance";
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -45377,7 +45510,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2,
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lyH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -45392,7 +45525,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lzh" = (
 /obj/structure/cable/yellow{
@@ -45405,7 +45538,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "lzv" = (
 /obj/machinery/light/small{
@@ -45601,7 +45734,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lFa" = (
 /obj/machinery/airalarm{
@@ -45817,7 +45953,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "lLv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -45829,7 +45965,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/layer4,
 /obj/machinery/atmospherics/components/binary/pump/layer2,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lLK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -45890,22 +46026,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "lOz" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/supermatter)
 "lPJ" = (
 /obj/machinery/light/small{
@@ -46271,9 +46400,6 @@
 	id = "Cell 3";
 	name = "Cell 3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46281,6 +46407,15 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mci" = (
@@ -46398,7 +46533,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "meW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -46544,7 +46679,7 @@
 /area/medical/medbay/central)
 "mlr" = (
 /obj/structure/lattice,
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -46780,6 +46915,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"mrO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "msg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -47061,6 +47203,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"mBM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Port Aft";
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "mBR" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_x = -26;
@@ -47170,7 +47322,7 @@
 	dir = 8;
 	pixel_y = -5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mGn" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -47221,10 +47373,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mIr" = (
 /obj/effect/decal/remains/human,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "mJs" = (
@@ -47524,7 +47685,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mUn" = (
 /obj/structure/cable/yellow{
@@ -47888,6 +48049,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ngi" = (
@@ -47985,6 +48149,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nkY" = (
@@ -48197,13 +48362,14 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "nsL" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering Port Aft";
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ntr" = (
 /obj/item/shovel/spade,
@@ -48281,7 +48447,7 @@
 /obj/machinery/atmospherics/components/unary/heat_exchanger{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "nwI" = (
 /obj/structure/transit_tube/diagonal,
@@ -48843,7 +49009,7 @@
 	dir = 10
 	},
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "nQP" = (
 /obj/effect/turf_decal/tile/blue{
@@ -48958,7 +49124,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "nUM" = (
 /obj/structure/disposalpipe/segment{
@@ -49032,16 +49198,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer";
-	req_access_txt = "56"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49049,6 +49205,16 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer";
+	req_access_txt = "56"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "nYn" = (
@@ -49175,14 +49341,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "obP" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stack/sheet/mineral/copper{
-	amount = 5
-	},
 /turf/open/floor/plating{
-	luminosity = 2
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/science)
 "ocb" = (
@@ -49269,6 +49429,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oew" = (
@@ -49286,6 +49447,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"oex" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/copper{
+	amount = 5
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "ofY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49319,6 +49488,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ohj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "oiL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -49547,7 +49728,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oqa" = (
 /obj/structure/cable/yellow{
@@ -49668,6 +49849,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Bridge Starboard Entrance";
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "otV" = (
@@ -49675,7 +49860,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oui" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -50099,7 +50284,10 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oFo" = (
 /obj/structure/closet/emcloset/anchored,
@@ -50198,7 +50386,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oII" = (
 /obj/structure/chair/fancy/comfy,
@@ -50279,14 +50470,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oKa" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/item/stack/sheet/mineral/copper{
-	amount = 5
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -50296,7 +50482,7 @@
 /obj/machinery/atmospherics/components/binary/circulator/cold{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oKU" = (
 /obj/effect/turf_decal/tile/blue{
@@ -50398,6 +50584,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oNN" = (
@@ -50429,22 +50618,15 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "oOK" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/supermatter)
 "oON" = (
 /obj/structure/disposalpipe/segment,
@@ -50565,6 +50747,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"oVB" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "oWu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50662,7 +50849,7 @@
 "oXU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oYj" = (
 /obj/machinery/door/window/southleft{
@@ -50716,6 +50903,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "oZr" = (
@@ -51166,7 +51356,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ppc" = (
 /obj/structure/cable/yellow{
@@ -51312,7 +51502,10 @@
 	c_tag = "Engineering Port Aft";
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "prt" = (
 /obj/machinery/door/window/westleft{
@@ -51494,12 +51687,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pwS" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/maintenance/department/science)
 "pxc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51805,6 +51994,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pEa" = (
@@ -51900,7 +52092,6 @@
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/security/warden)
 "pKd" = (
@@ -52146,6 +52337,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pQT" = (
@@ -52155,7 +52349,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "pQW" = (
 /obj/structure/disposalpipe/segment{
@@ -52452,7 +52649,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/engine/supermatter)
 "qbq" = (
 /obj/structure/cable/yellow{
@@ -52472,6 +52670,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
 	dir = 8;
 	icon_state = "vent_map_on-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -52590,7 +52794,7 @@
 "qeW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qfv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -52677,7 +52881,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qhW" = (
 /obj/structure/cable/yellow{
@@ -52746,7 +52950,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qkS" = (
 /obj/structure/cable/yellow{
@@ -52833,7 +53037,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qnk" = (
 /turf/closed/wall,
@@ -52961,7 +53165,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qrG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -52973,7 +53177,7 @@
 /obj/machinery/atmospherics/components/unary/heat_exchanger{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qtk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53207,7 +53411,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qCM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -53251,7 +53455,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
@@ -53530,6 +53737,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"qNK" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "qOA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -53644,7 +53858,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qTG" = (
 /obj/machinery/power/solar{
@@ -53690,15 +53904,20 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "qVj" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
 	},
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
+/turf/open/floor/engine,
 /area/engine/supermatter)
 "qVI" = (
 /obj/structure/cable/yellow{
@@ -53747,7 +53966,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qXD" = (
 /obj/structure/transit_tube/horizontal,
@@ -53837,7 +54056,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qZR" = (
 /obj/structure/extinguisher_cabinet{
@@ -53926,7 +54145,7 @@
 "ree" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "reV" = (
 /obj/structure/grille/broken,
@@ -53954,7 +54173,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rfF" = (
 /obj/effect/turf_decal/tile/bar,
@@ -54483,7 +54702,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ryD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -54661,8 +54880,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rFq" = (
-/obj/structure/chair,
-/obj/item/reagent_containers/food/snacks/donkpocket,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -54714,7 +54934,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rJb" = (
 /obj/structure/disposalpipe/segment,
@@ -54815,9 +55035,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "rKL" = (
-/obj/item/trash/cheesie,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stack/sheet/mineral/copper{
+	amount = 5
+	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	luminosity = 2
 	},
 /area/maintenance/department/science)
 "rKP" = (
@@ -54908,7 +55133,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rPa" = (
 /obj/machinery/computer/mech_bay_power_console{
@@ -55431,7 +55656,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sgc" = (
 /obj/machinery/vending/cigarette,
@@ -55498,9 +55726,6 @@
 	},
 /area/maintenance/department/engine)
 "siG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
@@ -55627,8 +55852,23 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"smb" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "smg" = (
 /obj/structure/chair/stool,
 /obj/machinery/airalarm{
@@ -55765,7 +56005,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "spU" = (
 /obj/machinery/door/window/southleft{
@@ -55791,7 +56031,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "sqh" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -55832,7 +56072,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "srZ" = (
 /obj/structure/closet/crate{
@@ -55968,12 +56211,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "syQ" = (
-/obj/machinery/vending/games,
+/obj/structure/chair,
+/obj/item/clothing/glasses/regular,
 /obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg3"
+	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
 "szv" = (
@@ -56407,7 +56651,7 @@
 /area/medical/sleeper)
 "sMY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sNj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -56552,7 +56796,7 @@
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sUm" = (
 /obj/machinery/door/airlock/external,
@@ -56617,7 +56861,7 @@
 /area/chapel/main/monastery)
 "sWj" = (
 /obj/machinery/atmospherics/components/trinary/filter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sWM" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -56640,7 +56884,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sXb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -56661,9 +56905,11 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "sXR" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "sYD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -56676,6 +56922,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"sYE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "sYU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -56739,7 +57000,7 @@
 	},
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "taT" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
@@ -57103,7 +57364,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "tnK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -57452,7 +57713,7 @@
 "txD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "typ" = (
 /obj/effect/spawner/room/threexfive,
@@ -57463,17 +57724,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tzZ" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/machinery/vending/cola/pwr_game,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "tAs" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -57536,10 +57789,9 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "tCS" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/vending/games,
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/maintenance/department/science)
 "tDl" = (
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
@@ -57668,7 +57920,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "tHO" = (
 /obj/machinery/telecomms/hub/preset/exploration,
@@ -58012,15 +58265,12 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "uaQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "uaU" = (
@@ -58082,7 +58332,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ucu" = (
 /obj/structure/disposalpipe/segment,
@@ -58126,7 +58376,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "udN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -58153,9 +58403,12 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ueV" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/power/apc/highcap/five_k{
+	dir = 8;
+	name = "Science Maintenance APC";
+	pixel_x = -24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -58341,7 +58594,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ulY" = (
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "uml" = (
 /obj/machinery/light/small{
@@ -58488,7 +58741,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "upi" = (
 /obj/effect/turf_decal/tile/blue{
@@ -58643,7 +58896,7 @@
 /area/lawoffice)
 "uvq" = (
 /obj/structure/table,
-/obj/item/dice/d20,
+/obj/machinery/microwave,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "uwz" = (
@@ -58766,9 +59019,6 @@
 	id = "Cell 2";
 	name = "Cell 2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -58776,6 +59026,15 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uBe" = (
@@ -59249,7 +59508,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "uRB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -59458,6 +59717,12 @@
 "uZQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vak" = (
@@ -59534,7 +59799,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "vdw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -59703,7 +59968,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "vjC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -59910,7 +60175,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "voS" = (
 /obj/structure/chair/office{
@@ -60011,9 +60276,6 @@
 	id = "Cell 1";
 	name = "Cell 1"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -60021,6 +60283,15 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vtT" = (
@@ -60917,21 +61188,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wab" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "waP" = (
@@ -60992,7 +61253,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wdK" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -61029,6 +61290,9 @@
 "wen" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -61219,12 +61483,9 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "wiT" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/effect/spawner/room/fivexthree,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/science)
 "wiX" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/reagent_containers/glass/beaker/synthflesh,
@@ -61447,7 +61708,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wru" = (
 /obj/effect/turf_decal/tile/green{
@@ -61647,7 +61911,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wxa" = (
 /obj/structure/cable/yellow{
@@ -61711,7 +61975,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "wyH" = (
 /obj/structure/cable/yellow{
@@ -61779,7 +62043,10 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wBg" = (
 /obj/machinery/door/airlock/maintenance{
@@ -61861,7 +62128,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wEY" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -61900,6 +62167,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -62263,7 +62533,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wRz" = (
 /obj/machinery/door/airlock/maintenance{
@@ -62335,7 +62605,7 @@
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wUm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -62405,7 +62675,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wWY" = (
 /obj/machinery/door/airlock/maintenance{
@@ -62612,7 +62885,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "xcc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -62827,7 +63100,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xjK" = (
 /obj/item/radio/intercom{
@@ -63198,7 +63471,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xwo" = (
 /obj/structure/cable/yellow{
@@ -63219,7 +63495,7 @@
 /area/crew_quarters/bar)
 "xxk" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump,
@@ -63227,7 +63503,7 @@
 /area/science/xenobiology)
 "xxz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xxK" = (
 /obj/effect/turf_decal/delivery/red,
@@ -63286,7 +63562,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xyq" = (
 /obj/structure/cable/yellow{
@@ -63327,7 +63603,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xzp" = (
 /obj/effect/turf_decal/tile/blue,
@@ -63649,7 +63925,7 @@
 	light_color = "#c1caff"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xKc" = (
 /obj/structure/sign/warning/biohazard,
@@ -63879,7 +64155,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xWl" = (
 /obj/item/pen,
@@ -63959,6 +64235,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"xZD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
+	dir = 8;
+	icon_state = "vent_map_on-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "xZN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -63977,6 +64266,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"yba" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "ybh" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Airlock";
@@ -64171,9 +64472,10 @@
 	},
 /area/crew_quarters/dorms)
 "yjg" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "yjM" = (
 /obj/item/radio/intercom{
@@ -78204,8 +78506,8 @@ aht
 pmj
 pmj
 pmj
-aaa
-aaa
+aht
+aht
 azH
 aaa
 aaa
@@ -81276,8 +81578,8 @@ ajD
 ajD
 ajD
 aiu
-aaa
-aaa
+aht
+aht
 aiu
 sZe
 aiu
@@ -84886,7 +85188,7 @@ asu
 atv
 bXN
 avs
-awI
+atv
 axF
 axG
 xov
@@ -85134,12 +85436,12 @@ nqc
 nTp
 alv
 anz
-aon
-aon
-aon
+alv
+alv
+alv
 pDO
 kNu
-uZQ
+dAF
 vtC
 mIi
 eUr
@@ -85397,10 +85699,10 @@ vsu
 liV
 drW
 asC
-atz
+atD
 auz
 avu
-awJ
+atD
 ewl
 ayH
 peO
@@ -85647,17 +85949,17 @@ cVO
 ajM
 amg
 amg
-anB
-ana
-pIv
-apI
+apJ
+amg
+ayQ
+amg
 siG
-alv
+amd
 asx
-aty
 ajM
 ajM
-atB
+ajM
+ajM
 mNf
 hNV
 aAf
@@ -85907,14 +86209,14 @@ eeM
 anC
 aop
 aoR
-apJ
+ayQ
 uKi
-aon
+amd
 asC
-atz
+atv
 bXN
 avv
-awK
+atv
 jvV
 jSL
 aAi
@@ -86167,7 +86469,7 @@ aoS
 apJ
 bdt
 uZQ
-uZQ
+dAF
 uBc
 wGm
 nfl
@@ -86416,19 +86718,19 @@ ahL
 ahL
 ahL
 ahL
-amg
+ahL
 amU
 amX
 amX
 aoT
 apK
 cAx
-aon
+amd
 asC
-atz
+atD
 auz
 avx
-awJ
+atD
 wVm
 ayL
 aAi
@@ -86680,12 +86982,12 @@ hCo
 aoU
 apJ
 pBy
-aon
+amd
 asz
 atB
 ajM
 ajM
-atB
+ajM
 hZn
 sHr
 gYG
@@ -86937,12 +87239,12 @@ nWs
 aoV
 apJ
 uKi
-aon
+amd
 asC
-atz
+atv
 bXN
 avy
-awK
+atv
 wVm
 ayL
 aAi
@@ -87195,7 +87497,7 @@ oZi
 cOt
 fSl
 kUB
-uZQ
+dAF
 mcf
 wGm
 pQn
@@ -87446,17 +87748,17 @@ wEx
 gLc
 hXh
 wen
-amX
-amX
+aty
+awI
 aoX
-apJ
+aHY
 uKi
 arp
 asC
 atD
 auz
 avA
-awJ
+atD
 wVm
 ayL
 fSg
@@ -87701,19 +88003,19 @@ ajj
 ajT
 akP
 alA
-amj
+ash
 amZ
 anJ
-amX
+awK
 aoY
-apN
+amg
 fSZ
 arp
 asB
 atB
 ajM
 ajM
-atB
+ajM
 jbF
 fVh
 loJ
@@ -87958,12 +88260,12 @@ ahL
 ahL
 ahL
 ahL
-aml
-ana
+ahL
+amg
 pIv
 aos
-pIv
-apO
+aFd
+amg
 ekV
 arp
 asC
@@ -88223,7 +88525,7 @@ apa
 agP
 ppG
 cgy
-asC
+fuB
 atF
 hpj
 ppW
@@ -89069,7 +89371,7 @@ hSK
 bva
 bva
 bva
-bIZ
+bva
 bva
 bva
 bva
@@ -89257,7 +89559,7 @@ aqC
 aqC
 awP
 axG
-axG
+hxn
 aAn
 aBi
 aCs
@@ -89323,7 +89625,7 @@ bCe
 fLO
 bEr
 hSK
-bIZ
+bva
 bDi
 bDi
 bUb
@@ -89514,7 +89816,7 @@ auG
 avF
 awQ
 axG
-ayQ
+axG
 kqZ
 aBi
 aCt
@@ -89767,9 +90069,9 @@ ajM
 xgW
 ajM
 ajM
-auH
-auH
-auH
+awR
+awR
+awR
 axM
 ayR
 aAo
@@ -90020,11 +90322,11 @@ anP
 agP
 bNN
 ajM
-aqC
+cBv
 lqG
-aqC
-aqC
-auH
+cBv
+cBv
+awR
 avH
 awR
 awR
@@ -90277,13 +90579,13 @@ akT
 aiR
 lkm
 ajM
-aqC
+cBv
 vIK
 uSo
-aqC
-auH
+cBv
+awR
 avI
-auH
+heC
 axN
 ayS
 aAp
@@ -90537,8 +90839,8 @@ ajM
 aqD
 arx
 asJ
-aqC
-auH
+cBv
+awR
 avJ
 awS
 ayT
@@ -90610,18 +90912,18 @@ bEr
 hSK
 bva
 bva
-bva
+bIZ
 bva
 bva
 jXV
 bva
 bva
 weI
-bBX
-bBX
-bBX
+bXk
+bXk
+bXk
 kfK
-bBX
+bXk
 fdS
 bXk
 uOI
@@ -90791,13 +91093,13 @@ anS
 aiR
 vhl
 ajM
-aqC
+cBv
 ary
-ary
-aqC
-auH
+fHD
+cBv
+awR
 avK
-auH
+heC
 axP
 vjs
 aAr
@@ -91048,13 +91350,13 @@ jvi
 aiR
 lkm
 ajM
-aqC
-arz
-aqC
-aqC
-auH
-auH
-auH
+ajM
+ajM
+ajM
+akA
+awR
+awR
+awR
 axQ
 xba
 aAs
@@ -91304,14 +91606,14 @@ anj
 anU
 aiR
 hFO
-ajM
-ajM
-ajM
-ajM
-ajM
-ajM
+bFy
+bFy
+bFy
+aqF
+gxe
+bFy
 avL
-auH
+awR
 auH
 gqN
 auH
@@ -91564,8 +91866,8 @@ ntL
 apQ
 xmp
 xmp
+goF
 xmp
-atK
 auJ
 xmp
 awT
@@ -93208,8 +93510,8 @@ cbj
 bXk
 bXk
 bXk
-aaa
-aaa
+cdm
+ahi
 aaa
 aaa
 aaa
@@ -93465,8 +93767,8 @@ cJw
 eDz
 wwn
 bXk
-aht
-aht
+gOn
+cdm
 aht
 aht
 aht
@@ -93691,7 +93993,7 @@ bNW
 cJx
 bPE
 bQr
-bQr
+hGp
 lLb
 bSD
 bQr
@@ -93722,7 +94024,7 @@ cWS
 vov
 iUE
 bXk
-bXk
+eor
 bXk
 aht
 aaa
@@ -93890,8 +94192,8 @@ aAB
 aAB
 aAB
 aAB
-arA
-arA
+axi
+axi
 qdy
 jkh
 kyf
@@ -93978,11 +94280,11 @@ xxk
 qBV
 udy
 xyo
-wqF
+mBM
 wWS
 bXk
-cdm
-cdm
+bRC
+aht
 aht
 pWb
 aaa
@@ -94233,14 +94535,14 @@ fAM
 jEe
 jEe
 kJh
-hhi
-hhi
-hhi
+mrO
+mrO
+aLs
 nsL
-tCS
-gLo
-ahi
-aht
+bXk
+bRC
+aaa
+aaa
 pWb
 aaa
 aaa
@@ -94491,13 +94793,13 @@ iRh
 iRh
 gOl
 mZR
-tzZ
 lYf
-tzZ
+smb
+lYf
 mZR
-ahi
-cdm
-aht
+bRC
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94749,12 +95051,12 @@ sWj
 tGV
 wNl
 dZj
-cnW
+hLD
 ftY
 mZR
 bRC
-aht
-aht
+aaa
+aaa
 pWb
 aaa
 aaa
@@ -94920,7 +95222,7 @@ aEG
 aAB
 aGq
 aHf
-aHY
+wKT
 aIX
 dRO
 bdh
@@ -95260,11 +95562,11 @@ oIC
 cfY
 cfY
 cfY
-lEw
+sYE
 lYf
 qbF
-qbF
-qbF
+kgO
+xZD
 mZR
 bRC
 aaa
@@ -95521,7 +95823,7 @@ dzV
 wdK
 mIr
 frN
-cnW
+oVB
 qfZ
 bRC
 aht
@@ -95693,7 +95995,7 @@ aGn
 axi
 aHZ
 aDZ
-jfr
+kyP
 aAN
 aSt
 aKT
@@ -95774,13 +96076,13 @@ slE
 wqF
 wqF
 wqF
-sqX
+dYz
 lYf
 kzB
-kzB
-kzB
+ohj
+yba
 mZR
-aaa
+bRC
 aaa
 aaa
 pWb
@@ -95946,8 +96248,8 @@ aAB
 aAB
 aAB
 aAB
-arA
-arA
+axi
+axi
 qdy
 aJs
 nkm
@@ -96037,7 +96339,7 @@ pes
 cFQ
 aaX
 mZR
-aaa
+bRC
 aaa
 aaa
 aaa
@@ -96207,7 +96509,7 @@ asS
 aHe
 aHV
 aDZ
-uJH
+jfr
 aKY
 aKY
 aKY
@@ -96294,7 +96596,7 @@ afO
 llI
 rQG
 jMx
-aaa
+bRC
 aaa
 aaa
 pWb
@@ -96547,7 +96849,7 @@ qZJ
 feW
 mUe
 tno
-tno
+qNK
 dOi
 hrU
 dak
@@ -100026,17 +100328,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aiS
+aiS
+aiT
+aiT
+aiT
+aiS
+aiS
+aiS
+aiT
+aiS
+aiS
 aaa
 aaa
 cBU
@@ -100284,15 +100586,15 @@ aaa
 aaa
 aaa
 aiS
+sbk
+sbk
+sbk
+sbk
+ana
 aiS
-aiT
-aiT
-aiT
-aiS
-aiS
-aiS
-aiT
-aiS
+sbk
+sbk
+aiU
 aiS
 aaa
 aaa
@@ -100545,11 +100847,11 @@ sbk
 sbk
 sbk
 sbk
-gxe
+sbk
 aiS
 sbk
 sbk
-aiU
+sbk
 aiT
 aaa
 aaa
@@ -101054,18 +101356,18 @@ aaa
 aaa
 aaa
 aaa
-aiS
-sbk
-sbk
-sbk
-sbk
-sbk
-aiS
-sbk
-sbk
-sbk
 aiT
-aaa
+sbk
+sbk
+sbk
+sbk
+sbk
+aiS
+aiS
+apN
+aiS
+aiS
+aiS
 aaa
 aaa
 aaa
@@ -101314,14 +101616,14 @@ aaa
 aiT
 sbk
 sbk
+aml
+lam
+lam
+anB
+lam
+lam
+apO
 sbk
-sbk
-sbk
-aiS
-aiS
-wiT
-aiS
-aiS
 aiS
 aiS
 aiT
@@ -101571,13 +101873,13 @@ aaa
 aiT
 sbk
 sbk
-fuB
-lam
-lam
-goF
-lam
-lam
-lam
+sbk
+sbk
+sbk
+aiS
+sbk
+sbk
+arz
 lam
 lam
 lam
@@ -102082,7 +102384,7 @@ aaa
 aaa
 aaa
 aaa
-aiT
+aiS
 sbk
 sbk
 sbk
@@ -102339,7 +102641,7 @@ aaa
 aaa
 aaa
 aaa
-aiS
+aiT
 sbk
 sbk
 sbk
@@ -102853,12 +103155,12 @@ aaa
 aaa
 aaa
 aaa
+aiS
+aiS
 aiT
-sbk
-sbk
-sbk
-sbk
-sbk
+aiT
+aiT
+aiS
 aiS
 aiS
 rzZ
@@ -103110,13 +103412,13 @@ aaa
 aaa
 aaa
 aaa
-aiS
-aiS
-aiT
-aiT
-aiT
-aiS
-aiS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aiT
 esA
 aiT
@@ -103642,7 +103944,7 @@ aaa
 aaa
 aaa
 aaa
-ash
+apX
 apX
 apX
 dbi
@@ -104158,7 +104460,7 @@ aaa
 aaa
 asj
 atl
-apX
+gLo
 dbi
 fIu
 dbi
@@ -104914,16 +105216,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aiS
+aiS
 aiS
 niE
 aiS
 aiS
-aiT
-aiT
-aiT
 aiS
+aiT
+aiT
+aiT
 aiS
 aiS
 kzk
@@ -105171,15 +105473,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aiT
+apI
+sbk
 vZQ
 haw
 haw
 haw
-kyP
 haw
+atK
 haw
 haw
 kqy
@@ -105196,8 +105498,8 @@ rgW
 aBU
 atn
 aEg
-aFd
-eDJ
+aGF
+jYA
 aGF
 aEd
 aEd
@@ -105428,8 +105730,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aiS
+aiS
+aiS
 aiS
 aiS
 aiS
@@ -105437,7 +105740,6 @@ aiS
 aiT
 aiT
 aiT
-aiS
 aiS
 riH
 kzk
@@ -107561,7 +107863,7 @@ bFr
 eEk
 xYH
 bIN
-dAF
+pdF
 pdF
 pdF
 dDx
@@ -108075,9 +108377,9 @@ jhg
 ikO
 cxb
 fBz
-bCV
+fpQ
 bAF
-bCV
+bAF
 ahi
 aht
 aht
@@ -108265,7 +108567,7 @@ aaa
 aaa
 aaa
 aaa
-aiS
+aiT
 sbk
 riH
 sbk
@@ -108838,7 +109140,7 @@ wNw
 ugC
 gdJ
 bkF
-lWy
+obP
 gTV
 gtE
 jbY
@@ -109096,9 +109398,9 @@ uLi
 pXg
 bkF
 kPi
-cDB
-hxn
-uvq
+tSL
+lWy
+lWy
 bFx
 eAj
 bwm
@@ -109355,8 +109657,8 @@ bkF
 syQ
 cDB
 rFq
-obP
-bFy
+lWy
+tSL
 fjG
 bwm
 lWy
@@ -109562,7 +109864,7 @@ avm
 avm
 avm
 avm
-atn
+avm
 atn
 atn
 aFj
@@ -109611,8 +109913,8 @@ hfZ
 bkF
 kkQ
 rKL
-lWy
-lWy
+sXR
+obP
 bFz
 fJh
 eOO
@@ -109622,8 +109924,8 @@ aht
 bwm
 bwm
 rNB
-bwm
 rNB
+bwm
 bwm
 aht
 pmj
@@ -109809,8 +110111,8 @@ aaa
 aaa
 aiS
 aiS
-aiS
 aiT
+aiS
 aiS
 aaa
 aaa
@@ -109869,9 +110171,9 @@ bkF
 bkF
 bkF
 bkF
-bwm
-bwm
-bwm
+tzZ
+tCS
+uvq
 bwm
 gbY
 bwm
@@ -109881,7 +110183,7 @@ lWy
 lWy
 lWy
 rEh
-rNB
+bwm
 aaa
 pmj
 aaa
@@ -110126,9 +110428,9 @@ bAH
 blX
 blX
 bkF
-lWy
-lWy
-cBs
+bwm
+bwm
+bwm
 bwm
 huJ
 uek
@@ -110138,7 +110440,7 @@ lWy
 lWy
 lWy
 lWy
-bwm
+rNB
 aht
 aed
 aht
@@ -110385,7 +110687,7 @@ bDe
 bkF
 lWy
 lWy
-lWy
+cBs
 dWk
 oNl
 gPf
@@ -110395,7 +110697,7 @@ ggq
 xqd
 lWy
 lWy
-bwm
+rNB
 aaa
 pmj
 aaa
@@ -110645,14 +110947,14 @@ lWy
 lWy
 bwm
 gyS
-bwm
+tSL
 izF
 bwm
 lWy
 lWy
 lWy
 lWy
-bwm
+rNB
 aht
 pmj
 aaa
@@ -110897,19 +111199,19 @@ bnj
 bnj
 bnj
 bkF
-bwm
-bwm
-bwm
+lWy
+lWy
+lWy
 bwm
 gyS
 bwm
-bwm
-bwm
-lWy
-lWy
-lWy
-lWy
 rNB
+bwm
+lWy
+lWy
+lWy
+lWy
+bwm
 aaa
 pmj
 aaa
@@ -111154,9 +111456,9 @@ bAH
 blX
 blX
 bkF
-lWy
-lWy
-cBv
+bwm
+bwm
+bwm
 bwm
 gyS
 bwm
@@ -111164,8 +111466,8 @@ aht
 bwm
 bwm
 rNB
-bwm
 rNB
+bwm
 bwm
 aht
 aed
@@ -111413,7 +111715,7 @@ bDe
 bkF
 lWy
 lWy
-lWy
+wiT
 bwm
 lNl
 bwm
@@ -111673,7 +111975,7 @@ lWy
 lWy
 eCK
 fDB
-bwm
+rNB
 aed
 aht
 pmj
@@ -111930,8 +112232,8 @@ lWy
 lWy
 bwm
 huJ
-bwm
-pmj
+rNB
+aht
 aaa
 aed
 aaa
@@ -112187,7 +112489,7 @@ lWy
 lWy
 bwm
 huJ
-rNB
+bwm
 pmj
 aaa
 aaa
@@ -112439,13 +112741,13 @@ blX
 blX
 bDe
 bkF
-bwm
-bwm
-bwm
+lWy
+lWy
+lWy
 bwm
 huJ
-rNB
-fHD
+bwm
+pmj
 aaa
 aaa
 aaa
@@ -112696,8 +112998,8 @@ blX
 blX
 blX
 bkF
-ueV
-heC
+bwm
+bwm
 bwm
 bwm
 vBw
@@ -112954,7 +113256,7 @@ bkF
 bkF
 bkF
 doo
-tSL
+ueV
 bwm
 lWy
 huJ
@@ -113720,8 +114022,8 @@ mGn
 xKc
 bkF
 bkF
-bwm
-bwm
+lWy
+oex
 vuQ
 vsH
 vuQ
@@ -113730,9 +114032,9 @@ vuQ
 vuQ
 dPS
 vuQ
-sNj
-sNj
-sNj
+vuQ
+vuQ
+vuQ
 aaa
 aaa
 aaa
@@ -113976,8 +114278,8 @@ eIL
 vxC
 pMG
 iPz
-sXR
-sXR
+bkF
+bkF
 pwS
 vuQ
 fRG
@@ -114234,7 +114536,7 @@ ccv
 sDy
 oNE
 oep
-bnd
+kNU
 mlr
 hSG
 uzd
@@ -115016,8 +115318,8 @@ tGE
 sNj
 efl
 vuQ
-jYA
 aht
+aaa
 aaa
 aaa
 aaa
@@ -115265,7 +115567,7 @@ dmT
 bkF
 aaa
 aaa
-aaa
+aht
 vuQ
 sNj
 sNj
@@ -115273,8 +115575,8 @@ sNj
 sNj
 svR
 sNj
-jYA
 aht
+aaa
 aaa
 aaa
 aaa
@@ -115777,7 +116079,7 @@ blX
 blX
 blX
 bkF
-aht
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2509,6 +2509,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"alm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "alo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5693,22 +5709,10 @@
 /turf/open/space,
 /area/solar/port)
 "ayz" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/solars/port)
 "ayA" = (
-/obj/machinery/power/solar_control{
-	dir = 4;
-	id = "portsolar";
-	name = "Port Solar Control"
-	},
-/obj/structure/cable/yellow{
-	cable_color = "red";
-	color = "#ff0000";
-	icon_state = "0-2"
-	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "ayD" = (
@@ -6124,9 +6128,9 @@
 /turf/open/space,
 /area/solar/port)
 "aAW" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/multitool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "aAX" = (
@@ -6844,23 +6848,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aDp" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall,
+/area/maintenance/solars/port)
 "aDq" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -9163,12 +9153,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"aMR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "aMV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/artistic{
@@ -9333,6 +9317,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/eva)
+"aNs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "aNt" = (
 /obj/structure/rack,
 /obj/item/tank/jetpack/carbondioxide,
@@ -12964,9 +12964,15 @@
 /turf/closed/wall,
 /area/maintenance/solars/starboard)
 "baH" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/multitool,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "baJ" = (
@@ -13271,20 +13277,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bbL" = (
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall,
 /area/maintenance/solars/starboard)
 "bbM" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
+/obj/machinery/power/smes,
+/obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -18363,9 +18361,21 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "buz" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/science/explab)
+/area/maintenance/solars/port)
 "buC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20767,6 +20777,7 @@
 /turf/closed/wall,
 /area/science/storage)
 "bCT" = (
+/obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -21982,28 +21993,9 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
-"bGj" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
-"bGk" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "bGl" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/science/explab)
 "bGm" = (
 /obj/machinery/light_switch{
@@ -24634,7 +24626,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -24885,33 +24877,24 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bSD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/multitool,
 /turf/open/floor/plating,
-/area/storage/tech)
+/area/maintenance/solars/port)
 "bSE" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bSG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -24920,18 +24903,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bSI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -25117,9 +25094,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
@@ -25514,7 +25488,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bUn" = (
 /obj/machinery/light{
@@ -25529,7 +25503,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bUo" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -26305,7 +26279,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bWG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26315,7 +26289,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bWI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -26346,10 +26320,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bWO" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "bWP" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -26613,8 +26583,11 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "bYv" = (
-/turf/closed/wall,
-/area/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bYw" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -26668,9 +26641,6 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 22
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -26678,7 +26648,10 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -26792,31 +26765,57 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bZO" = (
-/obj/machinery/power/smes,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
+"bZR" = (
+/obj/machinery/computer/turbine_computer{
+	dir = 8;
+	id = "incineratorturbine"
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = 24;
+	pixel_y = -6
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable/yellow,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"bZR" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_x = -6;
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZT" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"bZU" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "bZY" = (
 /turf/closed/wall,
@@ -26992,22 +26991,33 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
-	pixel_x = -6;
-	pixel_y = -26
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
-	icon_state = "dpvent_map-1";
-	id = "atmos_incinerator_airlock_pump";
-	piping_layer = 1
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -27015,11 +27025,29 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
+"caP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -27030,7 +27058,7 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"caP" = (
+"caQ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -27045,16 +27073,6 @@
 /obj/machinery/camera{
 	c_tag = "Turbine Chamber";
 	network = list("turbine")
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
-"caQ" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/turbine{
-	dir = 4;
-	luminosity = 2
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -27191,12 +27209,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"cbF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "cbK" = (
 /obj/structure/chair/wood/normal{
@@ -27374,10 +27386,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
-"ccs" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
-/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "ccu" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -28001,9 +28009,6 @@
 /area/hydroponics/garden/monastery)
 "cgI" = (
 /mob/living/simple_animal/butterfly,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "cgJ" = (
@@ -28086,9 +28091,6 @@
 /area/hydroponics/garden/monastery)
 "chl" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "chr" = (
@@ -29220,19 +29222,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
-"cog" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "coj" = (
 /obj/structure/chair/fancy/comfy{
 	dir = 8
@@ -30157,9 +30146,6 @@
 "cuo" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "cup" = (
@@ -30335,9 +30321,6 @@
 "cvg" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "cvh" = (
@@ -31830,13 +31813,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cVi" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -31950,10 +31939,8 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cWZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/meter,
+/turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "cXW" = (
 /obj/structure/grille,
@@ -31976,10 +31963,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cYB" = (
@@ -32100,18 +32083,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "dbO" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -32199,6 +32173,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"ddS" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "deV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -32430,6 +32408,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"dob" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "doo" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -32705,13 +32689,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"dvX" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "dwm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -32728,12 +32705,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "dwt" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/multitool,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "dwG" = (
 /obj/item/clothing/suit/apron/chef,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -32744,6 +32720,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/chapel/main/monastery)
+"dwK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dxX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -32982,12 +32964,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -33134,7 +33116,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 6
 	},
-/turf/open/floor/goonplaque,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dOp" = (
 /obj/item/kirbyplants{
@@ -33560,6 +33542,34 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"eaE" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
+"eaT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "ebk" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -36119,8 +36129,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "fEJ" = (
@@ -36884,6 +36896,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "geY" = (
@@ -37101,12 +37116,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "glS" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/chapel/main/monastery)
+/area/maintenance/solars/starboard)
 "gmh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -37494,7 +37506,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "gyc" = (
 /obj/structure/rack,
@@ -37729,20 +37741,21 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "gFz" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 26
-	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -37786,9 +37799,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "gGP" = (
@@ -38575,7 +38586,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "hjk" = (
 /obj/machinery/light/small{
@@ -38637,10 +38648,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "hlH" = (
@@ -38865,11 +38883,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39522,17 +39537,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hJL" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Starboard Solar APC";
-	pixel_x = -24
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard)
+/area/maintenance/department/cargo)
 "hJQ" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -39590,9 +39609,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "hLb" = (
-/obj/structure/chair/stool,
-/obj/item/cigbutt/cigarbutt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Starboard Solar APC";
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "hLt" = (
@@ -39675,13 +39697,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hOi" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "hOo" = (
@@ -39918,24 +39945,17 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "hUX" = (
-/obj/machinery/computer/turbine_computer{
-	dir = 8;
-	id = "incineratorturbine"
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = 24;
-	pixel_y = 6
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = 24;
-	pixel_y = -6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -40179,9 +40199,6 @@
 /area/crew_quarters/dorms)
 "ibY" = (
 /obj/item/beacon,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
@@ -40315,10 +40332,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "igl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "igE" = (
@@ -40931,8 +40944,7 @@
 /area/hallway/primary/aft)
 "iBB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8;
-	level = 2
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41129,6 +41141,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"iIX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "iJf" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -41723,14 +41751,22 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "jcB" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -41834,17 +41870,24 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jhK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/solars/starboard)
 "jhP" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -42066,12 +42109,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jpP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/depleteduranium,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "jpU" = (
 /obj/effect/turf_decal/tile/blue{
@@ -42232,7 +42274,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jtq" = (
 /obj/structure/cable/yellow{
@@ -42245,6 +42287,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"juq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "jut" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42362,17 +42410,10 @@
 /turf/open/floor/plasteel,
 /area/science/shuttledock)
 "jza" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "jzk" = (
 /obj/structure/cable/yellow{
@@ -42589,18 +42630,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jEG" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -42712,7 +42755,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jIh" = (
 /obj/machinery/navbeacon{
@@ -42776,6 +42819,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jKU" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall,
+/area/maintenance/disposal/incinerator)
 "jMx" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
@@ -42880,6 +42927,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"jPo" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "jPy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -43277,6 +43333,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/grass,
 /area/hydroponics)
+"kdp" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "keh" = (
 /obj/machinery/power/apc{
 	name = "Security Checkpoint APC";
@@ -43602,7 +43662,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "kol" = (
@@ -43679,7 +43738,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
@@ -44105,9 +44164,6 @@
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -44968,18 +45024,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -46128,17 +46182,10 @@
 	},
 /area/maintenance/department/science)
 "lNu" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/engine,
+/turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "lNW" = (
 /obj/structure/grille,
@@ -46242,6 +46289,19 @@
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
 /area/chapel/office)
+"lSF" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "lTs" = (
 /obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -46278,20 +46338,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lUd" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "lUe" = (
 /obj/structure/cable/yellow{
@@ -46492,18 +46552,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -46669,7 +46727,7 @@
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "meY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "mfN" = (
@@ -46972,7 +47030,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "mpm" = (
@@ -47486,7 +47546,6 @@
 	name = "Port Solar APC";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "mIi" = (
@@ -47604,7 +47663,7 @@
 	dir = 8
 	},
 /obj/structure/cable/cyan{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -47692,17 +47751,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "mOH" = (
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 26;
-	pixel_y = -6
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "mOT" = (
@@ -47824,21 +47875,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mVx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -48627,6 +48678,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"nwW" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
@@ -48792,12 +48853,7 @@
 /turf/open/floor/plating,
 /area/chapel/dock)
 "nEA" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "nEY" = (
@@ -49131,18 +49187,14 @@
 /area/engine/engineering)
 "nPo" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "nQt" = (
@@ -49280,14 +49332,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "nUZ" = (
-/obj/machinery/power/solar_control{
-	dir = 8;
-	id = "starboardsolar";
-	name = "Starboard Solar Control"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -49598,21 +49644,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "ofY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "ogX" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
@@ -49980,9 +50013,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "otz" = (
@@ -50128,13 +50159,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "oxK" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
+/obj/structure/chair/stool,
+/obj/item/cigbutt/cigarbutt,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "oxT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -50364,18 +50392,17 @@
 /turf/open/floor/noslip/standard,
 /area/engine/engineering)
 "oCX" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -50406,7 +50433,16 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oDG" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/power/solar_control{
+	dir = 4;
+	id = "portsolar";
+	name = "Port Solar Control"
+	},
+/obj/structure/cable/yellow{
+	cable_color = "red";
+	color = "#ff0000";
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "oDM" = (
@@ -50540,7 +50576,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oIf" = (
 /obj/structure/cable/yellow{
@@ -50840,6 +50876,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"oPn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "oPy" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -51804,6 +51856,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"puk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "puP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52172,13 +52243,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "pDq" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "starboardsolar";
+	name = "Starboard Solar Control"
 	},
-/turf/open/floor/grass,
-/area/hydroponics/garden/monastery)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "pDC" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -52299,9 +52371,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"pIh" = (
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
 "pIv" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -52363,16 +52432,13 @@
 /area/crew_quarters/heads/cmo)
 "pLp" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -52858,6 +52924,18 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/supermatter)
+"qaS" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "qbq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53218,21 +53296,23 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "qmy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "qmQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -53283,7 +53363,7 @@
 	dir = 8
 	},
 /obj/structure/cable/cyan{
-	icon_state = "1-2"
+	icon_state = "1-6"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -53702,8 +53782,7 @@
 	},
 /area/maintenance/department/crew_quarters/bar)
 "qFJ" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "qGd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53935,6 +54014,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"qNY" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "qOA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -54650,15 +54733,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "rol" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -54693,7 +54772,6 @@
 /area/maintenance/department/engine)
 "rqx" = (
 /obj/machinery/atmospherics/components/trinary/filter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "rrI" = (
@@ -54890,6 +54968,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"rxW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "6-10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "ryb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -54908,6 +54998,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ryF" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "rzl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -55205,18 +55315,23 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "rKr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 26
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -55409,6 +55524,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"rQL" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "rRy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55535,6 +55657,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
+"rVj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "rVB" = (
 /obj/machinery/telecomms/processor/preset_exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -55905,21 +56043,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sif" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
+/area/science/explab)
 "siC" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
@@ -56317,13 +56444,14 @@
 /area/hallway/primary/fore)
 "stR" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Solar Access";
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -56331,10 +56459,8 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "sut" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/closed/wall,
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "suV" = (
 /obj/structure/chair{
@@ -56559,7 +56685,6 @@
 	dir = 6
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "sDq" = (
@@ -57492,9 +57617,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -57543,17 +57665,14 @@
 	},
 /area/maintenance/department/security/brig)
 "tmx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 26
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -57751,12 +57870,6 @@
 "tsT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -58220,7 +58333,7 @@
 	name = "engineering security door"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "tLj" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
@@ -58958,6 +59071,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uof" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "uol" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -59518,8 +59647,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-10"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -60097,6 +60227,22 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"vdG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "vdJ" = (
 /obj/structure/cable/yellow,
 /turf/closed/wall,
@@ -60422,9 +60568,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -61749,7 +61896,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "wit" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/turbine{
+	dir = 4;
+	luminosity = 2
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "wiT" = (
@@ -62020,23 +62176,21 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "wsA" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = -26
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
@@ -62202,6 +62356,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"wxb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "wxQ" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 28
@@ -62260,21 +62422,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "wza" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
+/area/science/explab)
 "wzS" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -62467,6 +62621,9 @@
 	dir = 8;
 	pixel_x = 26
 	},
+/obj/structure/cable/cyan{
+	icon_state = "2-9"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "wHm" = (
@@ -62551,7 +62708,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wKn" = (
 /obj/structure/cable/yellow{
@@ -62630,9 +62787,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wMe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/power/smes,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "wMk" = (
@@ -62669,7 +62834,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wMM" = (
 /obj/structure/cable/yellow{
@@ -62749,7 +62914,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wPH" = (
 /obj/structure/cable/yellow{
@@ -62996,8 +63161,7 @@
 /area/hallway/primary/central)
 "wXl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8;
-	level = 2
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -63912,9 +64076,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -76055,11 +76221,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+baG
+bbL
+stR
+baG
+baG
 aaa
 aaa
 aaa
@@ -76312,11 +76478,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+baG
+bbM
+hOi
+hLb
+baG
 aaa
 aaa
 aaa
@@ -76569,11 +76735,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+baG
+baH
+pLp
+nUZ
+baG
 aaa
 aaa
 aaa
@@ -76826,11 +76992,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+baG
+meY
+dbO
+ofY
+baG
 aaa
 aaa
 aaa
@@ -77083,11 +77249,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+baG
+sut
+tmx
+oxK
+baG
 aaa
 aaa
 aaa
@@ -77340,11 +77506,11 @@ bBW
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+baG
+dwt
+oCX
+pDq
+baG
 aaa
 aaa
 aaa
@@ -77597,11 +77763,11 @@ fIT
 fIT
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+baG
+baG
+jhK
+baG
+baG
 aaa
 aaa
 aaa
@@ -77855,9 +78021,9 @@ fIT
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+baG
+jEG
+baG
 aaa
 aaa
 aaa
@@ -78112,9 +78278,9 @@ fIT
 fIT
 aaa
 aaa
-aaa
-aaa
-aaa
+glS
+mVx
+glS
 aaa
 aaa
 aaa
@@ -80060,9 +80226,9 @@ ajD
 ajD
 aiu
 aht
-aaa
-azH
-aaa
+ayz
+buz
+ayz
 aaa
 aaa
 aaa
@@ -80157,7 +80323,7 @@ kZx
 kbw
 uYz
 bDZ
-fED
+ryF
 hKD
 cwa
 ckf
@@ -80317,9 +80483,9 @@ aiu
 aiu
 aiu
 axC
-oDG
+axC
 rKr
-oDG
+axC
 axC
 aaa
 aaa
@@ -80404,17 +80570,17 @@ mNB
 bXI
 cfl
 wgI
+uof
 cvy
 cvy
 cvy
 cvy
-mVx
 fkq
-sif
 cvy
 cvy
 cvy
 cvy
+oPn
 jUl
 cwa
 cwm
@@ -80576,7 +80742,7 @@ tpb
 axC
 ayz
 gFz
-oDG
+axC
 axC
 aaa
 aaa
@@ -80833,7 +80999,7 @@ aAa
 axC
 oDG
 rol
-oDG
+bSD
 axC
 aaa
 aaa
@@ -81859,15 +82025,15 @@ aiu
 aiu
 mPL
 axC
-axC
+aDp
 tcQ
 axC
 axC
 aiu
-aiu
-aiu
 ait
 ait
+ait
+aiu
 aiu
 aaa
 aaa
@@ -81946,16 +82112,16 @@ kBv
 nar
 bWX
 qpg
-ofY
-glS
+cvy
+mci
 cuo
-pDq
+ciV
 cgI
 chl
-dwt
+cib
 cvg
-oxK
-glS
+cid
+mci
 mLZ
 nIX
 cwe
@@ -82203,7 +82369,7 @@ rAU
 cth
 cfm
 nnY
-cvy
+eaT
 bWV
 cup
 cuE
@@ -82213,7 +82379,7 @@ cgH
 cgj
 cvj
 bWV
-cvy
+mLZ
 vjO
 cwe
 cjP
@@ -82460,7 +82626,7 @@ rAU
 ceK
 cfm
 hpI
-cvy
+mLZ
 mci
 ciV
 cgH
@@ -82470,7 +82636,7 @@ cic
 ciV
 cjq
 mci
-cvy
+mLZ
 jUl
 ckT
 xhj
@@ -82717,7 +82883,7 @@ hAj
 bWV
 cfm
 uLh
-cvy
+rVj
 mci
 cgm
 cuE
@@ -82727,7 +82893,7 @@ ciE
 ciW
 cjr
 mci
-cvy
+mLZ
 sCt
 bgX
 kMA
@@ -82973,7 +83139,7 @@ bWV
 qGw
 bWV
 cfm
-rAU
+rxW
 cvy
 bWV
 mci
@@ -82984,7 +83150,7 @@ bWV
 mci
 mci
 bWV
-cvy
+rVj
 rAU
 cwe
 cwr
@@ -83231,17 +83397,17 @@ mNt
 bXJ
 cel
 rAU
+puk
 cvy
 cvy
 cvy
 cvy
-qmy
 bXJ
-wza
 cvy
-cvy
-cvy
-cvy
+iIX
+vdG
+aNs
+alm
 hpI
 cwe
 cwe
@@ -83491,9 +83657,9 @@ kSC
 gGE
 wGO
 geU
-gGE
+qaS
 vnl
-gmh
+wxb
 uIB
 nqj
 pxh
@@ -94263,7 +94429,7 @@ bPE
 bQr
 hGp
 lLb
-bSD
+hGp
 bQr
 bQr
 bUH
@@ -102758,9 +102924,9 @@ bYw
 mQp
 bYw
 bYw
-bYw
-bYw
-aht
+qFJ
+qFJ
+aaa
 pmj
 aaa
 aaa
@@ -103008,7 +103174,7 @@ bVj
 adr
 jHn
 tYk
-bYv
+bYw
 bZf
 bZO
 caI
@@ -103017,7 +103183,7 @@ ccp
 aac
 aae
 mHb
-aaa
+aht
 pmj
 aaa
 aaa
@@ -103273,9 +103439,9 @@ vcQ
 wLq
 qYg
 tlU
-bYw
+qFJ
 aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -103522,7 +103688,7 @@ bVk
 bWb
 bQN
 bXF
-bYv
+bYw
 wMe
 cVi
 kmU
@@ -103532,7 +103698,7 @@ nEA
 ots
 oiL
 ceA
-aaa
+aht
 aaa
 aaa
 aaa
@@ -103780,16 +103946,16 @@ bLW
 bWR
 bJP
 bYw
-aMR
+qFJ
 hUX
 cYq
 mOH
 igl
-cog
-jza
-bYw
+mOH
+tlU
+qFJ
 aaa
-gYo
+aht
 aaa
 aaa
 aaa
@@ -104037,14 +104203,14 @@ bRC
 bNn
 bRC
 aht
-dvX
+qFJ
 bZR
 caL
-bZT
-bYw
+eaE
+jPo
 lUd
-bYw
-bYw
+nwW
+mHb
 aht
 pWb
 aaa
@@ -104273,8 +104439,8 @@ bBH
 kED
 diy
 bCT
-bGj
-buz
+bGl
+bRC
 bRC
 bJP
 bLb
@@ -104298,10 +104464,10 @@ cWZ
 lNu
 caM
 jpP
-bWO
+qFJ
 wsA
-bYw
-pIh
+qFJ
+qFJ
 aaa
 mau
 aaa
@@ -104529,9 +104695,9 @@ uYA
 xci
 ppc
 gZf
-bwa
-bGk
-buz
+sif
+bGl
+bRC
 aaa
 bJP
 bLc
@@ -104551,13 +104717,13 @@ bWe
 bWT
 bJP
 aaa
-bYw
+qFJ
 bZT
 caN
-bZT
-bYw
+rQL
+qFJ
 jcB
-bYw
+qFJ
 bRC
 aht
 pWb
@@ -104786,10 +104952,10 @@ bAE
 bFf
 uds
 hIL
-bFf
+wza
 bGl
-buz
 bRC
+aaa
 bJP
 bLd
 bLe
@@ -104808,16 +104974,16 @@ bWf
 bVo
 bJP
 aht
-bYw
-bZU
+qFJ
+jpP
 caO
-cbF
-ccs
-cdm
-cdm
+jpP
+qFJ
+lSF
+qFJ
 aaa
 aaa
-aaa
+gYo
 aaa
 aaa
 aaa
@@ -105046,7 +105212,7 @@ dQp
 bCV
 bAF
 bHy
-bRC
+aaa
 bJP
 bLe
 bMk
@@ -105065,13 +105231,13 @@ bWg
 bVo
 bJP
 aht
-bYw
-bYw
+qFJ
+jza
 caP
-bYw
-bYw
-aaa
-aaa
+dob
+ddS
+cdm
+cdm
 aaa
 aaa
 aaa
@@ -105303,7 +105469,7 @@ tGT
 bFh
 bGm
 bHy
-aaa
+bRC
 bJP
 bJP
 bJP
@@ -105322,11 +105488,11 @@ bJP
 bJP
 bJP
 aaa
-aaa
-bYw
+qFJ
+qFJ
 caQ
-bYw
-aaa
+qFJ
+qFJ
 aaa
 aaa
 aaa
@@ -105579,11 +105745,11 @@ aaa
 aaa
 bRC
 bRC
-bRC
+buC
 qFJ
 wit
 qFJ
-aaa
+qNY
 aaa
 aaa
 aaa
@@ -105836,11 +106002,11 @@ pmj
 pmj
 pmj
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+buC
+jKU
+kdp
+jKU
+qNY
 aaa
 aaa
 aaa
@@ -106093,11 +106259,11 @@ bRC
 aaa
 aaa
 aaa
+bYv
+juq
 aaa
-aaa
-aaa
-aaa
-aaa
+juq
+dwK
 aaa
 aaa
 aaa
@@ -108873,11 +109039,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aEj
-aEj
-aDp
-aEj
-aEj
+pEa
+aFi
+aFi
 kbe
 aEj
 bkF
@@ -109131,9 +109297,9 @@ aaa
 aaa
 aaa
 aEj
-aFi
-pEa
-hOz
+aEj
+qmy
+aEj
 aEj
 qTI
 lEn
@@ -109390,7 +109556,7 @@ aEj
 aEj
 aFi
 pEa
-aFi
+hOz
 aEj
 kbe
 lEn
@@ -109641,12 +109807,12 @@ aEl
 aaa
 aaa
 aEl
-dQd
-gHi
-nPo
-jhK
-gHi
-ppF
+aFi
+aFi
+aFi
+aEj
+aFi
+pEa
 aFi
 aEj
 kbe
@@ -109898,12 +110064,12 @@ aEj
 aEj
 aEj
 aEj
-pEa
-aGO
-kbe
-aEj
-aFi
-aFi
+dQd
+gHi
+hJL
+nPo
+gHi
+ppF
 aFi
 aEj
 qTI
@@ -110412,13 +110578,13 @@ aEj
 phd
 aEj
 aEj
-baG
-baG
-jEG
-baG
-baG
 aEj
+aGO
+kbe
 aEj
+aFi
+aFi
+aFi
 aEj
 tAs
 feR
@@ -110672,7 +110838,7 @@ bGM
 baG
 bbL
 stR
-hJL
+baG
 baG
 aEj
 aEj
@@ -111443,7 +111609,7 @@ aFi
 baG
 meY
 dbO
-meY
+ofY
 baG
 aFi
 ldu
@@ -111700,7 +111866,7 @@ aFi
 baG
 sut
 tmx
-meY
+oxK
 baG
 aFi
 aFi
@@ -111953,11 +112119,11 @@ aEj
 aEj
 aEl
 aEl
-aEl
+aEj
 baG
-meY
+dwt
 oCX
-meY
+pDq
 baG
 aFi
 aFi
@@ -112211,11 +112377,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-bcQ
-aaa
-aEj
+baG
+baG
+jhK
+baG
+baG
 aEj
 aEj
 aEj
@@ -112469,9 +112635,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bcQ
-aaa
+baG
+jEG
+baG
 aaa
 aaa
 aaa
@@ -112726,9 +112892,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bcQ
-aaa
+glS
+mVx
+glS
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13,7 +13,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/closet/radiation,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "aae" = (
@@ -25,6 +25,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "aaf" = (
@@ -102,19 +103,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aax" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridgespace";
-	name = "bridge external shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/bridge)
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel,
+/area/security/main)
 "aaA" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/green{
@@ -133,19 +124,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aaB" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/computer/security{
+	dir = 8
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridgespace";
-	name = "bridge external shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/bridge)
+/turf/open/floor/plasteel,
+/area/security/main)
 "aaC" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/tile/green{
@@ -1995,10 +1978,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 1;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -2006,6 +1985,12 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 7
+	},
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajo" = (
@@ -2021,6 +2006,10 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/flashlight/seclite,
 /obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajr" = (
@@ -2418,6 +2407,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/landmark/start/security_officer,
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
@@ -2654,16 +2647,15 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "alD" = (
-/obj/machinery/computer/secure_data,
+/obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plasteel,
 /area/security/main)
 "alE" = (
 /turf/open/floor/plasteel,
 /area/security/main)
 "alF" = (
-/obj/machinery/computer/security,
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/closed/wall,
+/area/maintenance/fore)
 "alH" = (
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -2693,10 +2685,6 @@
 /area/security/processing/cremation)
 "alZ" = (
 /obj/structure/bodycontainer/morgue,
-/obj/machinery/camera{
-	c_tag = "Brig Infirmary";
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -2773,7 +2761,8 @@
 /area/security/main)
 "amp" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "amq" = (
 /obj/structure/chair/office{
@@ -2884,13 +2873,18 @@
 /area/security/warden)
 "amZ" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26
+	},
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
+/obj/machinery/recharger{
+	pixel_x = 7
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -2912,13 +2906,21 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/chair/stool{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "anc" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/machinery/computer/crew,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "and" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -2935,8 +2937,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ane" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3011,10 +3011,26 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "anJ" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/item/folder/yellow{
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "anL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -3533,15 +3549,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "apQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/computer/card,
+/obj/machinery/camera{
+	c_tag = "Bridge - Central"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "apT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
@@ -3635,24 +3654,24 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aqI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/machinery/computer/communications,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridgespace";
-	name = "bridge external shutters"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aqJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/computer/station_alert,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aqL" = (
 /obj/machinery/computer/bank_machine,
@@ -3874,146 +3893,52 @@
 /turf/open/floor/plating,
 /area/bridge)
 "arH" = (
-/obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arI" = (
-/obj/machinery/computer/med_data,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arJ" = (
-/obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arK" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/item/folder/yellow{
-	pixel_y = 4
-	},
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arL" = (
-/obj/machinery/computer/card,
-/obj/machinery/camera{
-	c_tag = "Bridge - Central"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arM" = (
-/obj/machinery/computer/communications,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arN" = (
-/obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/bridge)
 "arO" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arP" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/bridge)
 "arQ" = (
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"arR" = (
-/obj/machinery/computer/prisoner/management,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
+	},
+/turf/open/floor/plating,
+/area/bridge)
+"arR" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
 /area/bridge)
 "arS" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -4243,8 +4168,18 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "asQ" = (
-/obj/structure/chair/office{
+/obj/machinery/modular_computer/console/preset/command,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = -24;
@@ -4257,20 +4192,15 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "asR" = (
-/obj/structure/chair/office{
+/obj/machinery/computer/med_data,
+/obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -4278,15 +4208,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "asT" = (
-/obj/structure/chair/office{
+/obj/machinery/computer/prisoner/management,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "bridgespace";
-	name = "Bridge Space Lockdown";
-	pixel_x = 24;
-	pixel_y = -2;
-	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -4294,6 +4218,13 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	id = "bridgespace";
+	name = "Bridge Space Lockdown";
+	pixel_x = 24;
+	pixel_y = -2;
+	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -4525,44 +4456,22 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"atS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"atT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"atU" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atV" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -4590,6 +4499,13 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "bridgespace";
+	name = "Bridge Space Lockdown";
+	pixel_x = 24;
+	pixel_y = -2;
+	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -4855,9 +4771,21 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auR" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666"
+/obj/machinery/status_display/ai{
+	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auS" = (
@@ -5140,35 +5068,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"avV" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/ids{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/PDAs,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"avW" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "avX" = (
-/obj/structure/table/glass,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"avY" = (
-/obj/structure/table/glass,
-/obj/item/aicard,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "avZ" = (
-/obj/structure/table/glass,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/obj/item/laser_pointer/blue,
+/obj/structure/chair/fancy/comfy{
+	color = "#666666"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "awb" = (
@@ -5436,10 +5354,12 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axb" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/ids{
+	pixel_x = 4;
+	pixel_y = 4
 	},
+/obj/item/storage/box/PDAs,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "axe" = (
@@ -11083,12 +11003,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aTZ" = (
-/obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
+	},
+/obj/machinery/computer/secure_data{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -14510,6 +14432,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bgA" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/circuit,
+/area/bridge)
 "bgB" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -15928,13 +15856,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bmc" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/item/reagent_containers/food/drinks/britcup{
-	desc = "Kingston's personal cup."
-	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bmk" = (
@@ -16859,9 +16786,12 @@
 /area/science/xenobiology)
 "bpt" = (
 /obj/structure/table,
-/obj/item/folder,
-/obj/item/pen,
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/britcup{
+	desc = "Kingston's personal cup."
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bpv" = (
@@ -24109,9 +24039,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bPA" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bPB" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -26473,6 +26409,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXI" = (
@@ -26653,6 +26592,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZl" = (
@@ -26771,6 +26714,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/power/smes,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -28
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZR" = (
@@ -26796,9 +26746,6 @@
 /obj/machinery/button/ignition/incinerator/atmos{
 	pixel_x = -6;
 	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -26962,9 +26909,6 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "caI" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Incinerator";
 	dir = 4
@@ -26982,9 +26926,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caL" = (
@@ -26995,11 +26939,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -27206,8 +27150,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbK" = (
@@ -27380,11 +27322,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccu" = (
@@ -31816,18 +31756,10 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cVs" = (
@@ -31962,6 +31894,9 @@
 "cYq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -32903,12 +32838,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "dEc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "dEN" = (
@@ -33552,6 +33485,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "eaT" = (
@@ -33788,12 +33724,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -34400,7 +34338,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "eAR" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/chair/fancy/comfy{
+	color = "#666666";
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "eAT" = (
@@ -34900,13 +34841,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -35082,7 +35023,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "eVS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/security/main)
 "eVW" = (
@@ -37547,9 +37488,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "gzo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "gzp" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -38650,9 +38597,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -39213,17 +39157,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "hzY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable/cyan{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hAb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -39724,6 +39660,10 @@
 /obj/effect/spawner/room/fivexthree,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hPB" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "hPN" = (
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/science,
@@ -39948,14 +39888,19 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -40288,6 +40233,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "iel" = (
@@ -40332,6 +40280,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "igl" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "igE" = (
@@ -41019,6 +40971,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"iDR" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "iEj" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/camera{
@@ -41216,6 +41174,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Infirmary";
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -42044,13 +42006,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "jnj" = (
-/obj/structure/transit_tube/curved{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /obj/structure/cable/cyan{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -42474,6 +42437,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "jAy" = (
@@ -42695,6 +42661,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jFo" = (
+/obj/structure/chair/fancy/comfy{
+	color = "#666666";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "jGg" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/yellow,
@@ -42891,6 +42868,26 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"jOA" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "jOX" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -42934,6 +42931,11 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "jPy" = (
@@ -43659,9 +43661,13 @@
 	},
 /area/maintenance/department/engine)
 "kmU" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "kol" = (
@@ -44636,6 +44642,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kNz" = (
+/obj/structure/chair/fancy/comfy{
+	color = "#666666";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "kNU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -45108,6 +45121,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"ldF" = (
+/obj/structure/table/glass,
+/obj/item/aicard,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ldG" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -45774,9 +45792,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "lBH" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -45786,6 +45801,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
+/obj/structure/transit_tube/crossing/horizontal,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "lBK" = (
@@ -46348,9 +46364,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "lUe" = (
@@ -47088,6 +47102,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mqy" = (
+/obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mrj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47331,9 +47356,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
@@ -47356,11 +47378,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mzU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/structure/transit_tube/curved,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
 	},
-/area/maintenance/department/engine)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mAb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -48636,6 +48661,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "nvx" = (
@@ -48686,6 +48714,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "nxT" = (
@@ -48853,7 +48883,9 @@
 /turf/open/floor/plating,
 /area/chapel/dock)
 "nEA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "nEY" = (
@@ -50014,6 +50046,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "otz" = (
@@ -51202,17 +51236,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "pbD" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /obj/structure/cable/cyan{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -52294,16 +52325,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"pEe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "pEk" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -53355,6 +53376,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"qow" = (
+/obj/structure/table/glass,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/item/laser_pointer/blue,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "qpg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -53561,7 +53589,6 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "qxy" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -53968,12 +53995,12 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "qMl" = (
-/obj/structure/transit_tube/curved,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
+/obj/structure/transit_tube/crossing,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qMz" = (
@@ -54268,8 +54295,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qYg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -54771,7 +54798,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rqx" = (
-/obj/machinery/atmospherics/components/trinary/filter,
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "rrI" = (
@@ -56151,6 +56180,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/noslip/white,
 /area/medical/sleeper)
+"skE" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "skK" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -56317,10 +56357,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "soW" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -57637,6 +57673,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "tlY" = (
@@ -57868,11 +57909,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "tsT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -58884,9 +58929,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uiu" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "uiy" = (
@@ -59451,14 +59503,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uBe" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 4
 	},
 /obj/structure/cable/cyan{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -60205,7 +60260,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vcQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "vdv" = (
@@ -60215,8 +60269,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "vdw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -60306,6 +60361,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -60687,6 +60745,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"vtn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "vts" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Port Fore";
@@ -62753,10 +62817,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "wLq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "wLE" = (
@@ -62787,10 +62848,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wMe" = (
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -62798,6 +62855,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "wMk" = (
@@ -62993,6 +63051,21 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"wSd" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "wSB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76221,11 +76294,11 @@ aaa
 aaa
 aaa
 aaa
-baG
-bbL
-stR
-baG
-baG
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -76478,11 +76551,11 @@ aaa
 aaa
 aaa
 aaa
-baG
-bbM
-hOi
-hLb
-baG
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -76735,11 +76808,11 @@ aaa
 aaa
 aaa
 aaa
-baG
-baH
-pLp
-nUZ
-baG
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -76992,11 +77065,11 @@ aaa
 aaa
 aaa
 aaa
-baG
-meY
-dbO
-ofY
-baG
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -77249,11 +77322,11 @@ aaa
 aaa
 aaa
 aaa
-baG
-sut
-tmx
-oxK
-baG
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -77506,11 +77579,11 @@ bBW
 aaa
 aaa
 aaa
-baG
-dwt
-oCX
-pDq
-baG
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -77763,11 +77836,11 @@ fIT
 fIT
 aaa
 aaa
-baG
-baG
-jhK
-baG
-baG
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -78021,9 +78094,9 @@ fIT
 aaa
 aaa
 aaa
-baG
-jEG
-baG
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -78278,9 +78351,9 @@ fIT
 fIT
 aaa
 aaa
-glS
-mVx
-glS
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84646,18 +84719,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aht
-xAW
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+wSd
 aaa
 aht
 aaa
@@ -84903,17 +84976,17 @@ aaa
 aaa
 aaa
 aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
-aht
+jnj
+mzU
+prc
+prc
+prc
+qMl
+prc
+prc
+prc
+prc
+mqy
 pbD
 aht
 aht
@@ -85161,17 +85234,17 @@ aaa
 aaa
 aht
 uBe
-qMl
-prc
-prc
-prc
-prc
-prc
-prc
-prc
-prc
-jnj
-hzY
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aaa
 aht
 aaa
@@ -85418,9 +85491,9 @@ aaa
 aaa
 aht
 lBH
+aaa
 aht
-aht
-aht
+aaa
 aht
 bva
 bva
@@ -86689,8 +86762,8 @@ vqH
 idu
 crh
 vqH
+bmc
 vqH
-dEc
 vqH
 xMo
 vqH
@@ -86947,11 +87020,11 @@ bfZ
 bfZ
 bga
 bfZ
-aYG
-bmc
-bnt
-bnt
 bpt
+bnt
+bnt
+dEc
+aYG
 aYG
 aYG
 nrn
@@ -87209,8 +87282,8 @@ aYG
 aYG
 aYG
 aYG
-aYG
-bsn
+hzY
+bDi
 epO
 bva
 bws
@@ -88439,7 +88512,7 @@ akP
 alA
 ash
 amZ
-anJ
+amX
 awK
 aoY
 amg
@@ -89031,13 +89104,13 @@ bEr
 bEr
 bEr
 hSK
-bIZ
+bva
 bLC
 bTf
 hoE
 jEU
 bVv
-mzU
+bva
 quj
 bva
 bva
@@ -89209,8 +89282,8 @@ aSR
 aTZ
 alC
 alE
+aaB
 alC
-alE
 aou
 apb
 agP
@@ -89288,13 +89361,13 @@ bDm
 aar
 bEr
 hSK
-bva
+vtn
 bLC
 bTg
 qQy
 jYh
 bVv
-bva
+vtn
 kkk
 rpm
 llj
@@ -89464,9 +89537,9 @@ agP
 ajm
 ajW
 aUQ
-alD
+alE
 anM
-anc
+alE
 anM
 aou
 apb
@@ -89723,7 +89796,7 @@ aTR
 iGd
 aYd
 amp
-gzo
+alE
 eVS
 nlz
 cAi
@@ -89978,9 +90051,9 @@ agP
 ajo
 ajV
 aMB
-alC
+aax
 alE
-alC
+alD
 alE
 aow
 tfs
@@ -90235,7 +90308,7 @@ agP
 mKT
 alE
 aVU
-alF
+alE
 amq
 ane
 anN
@@ -91597,9 +91670,9 @@ bKu
 aaw
 aaC
 bEr
-bDi
-bPA
+hPB
 bNX
+bDi
 vFq
 chy
 chy
@@ -92297,7 +92370,7 @@ alJ
 anV
 aiR
 ntL
-apQ
+xmp
 xmp
 xmp
 goF
@@ -92554,7 +92627,7 @@ ank
 anT
 aqF
 npf
-aoz
+aqF
 aqF
 arA
 arA
@@ -92811,7 +92884,7 @@ dvK
 jke
 aqF
 iei
-aoz
+alF
 aqG
 arB
 jcu
@@ -94097,7 +94170,7 @@ aht
 aYP
 cej
 bRC
-arA
+atY
 arA
 arA
 atQ
@@ -94354,7 +94427,7 @@ aYP
 nwI
 aht
 aaa
-aax
+aaa
 arH
 asQ
 atR
@@ -94611,10 +94684,10 @@ nwI
 aht
 aaa
 aaa
-aqI
-arI
+aaa
+arQ
 asR
-atS
+atV
 soW
 qxy
 auQ
@@ -94868,14 +94941,14 @@ aht
 aht
 aaa
 aaa
-aqI
-arJ
-asR
+aaa
+arQ
+anc
+atV
 asS
 asS
-uiu
 eAR
-eAR
+asS
 eOd
 aAB
 aBs
@@ -95125,14 +95198,14 @@ aht
 aht
 aht
 bRC
-aqJ
-arK
+bRC
+arO
+anJ
 asS
-atT
-auR
-avV
+asS
+avZ
 axb
-ayb
+jFo
 nvp
 aAB
 aBt
@@ -95382,14 +95455,14 @@ aaa
 aaa
 aaa
 aaa
-aqI
-arL
-asR
-atT
-auR
-avW
-axb
-ayb
+aaa
+arQ
+apQ
+atV
+asS
+avZ
+iDR
+jFo
 vgr
 aAB
 aBu
@@ -95639,13 +95712,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+arQ
 aqI
-arM
-asR
-atU
-auR
+atV
+asS
 avX
-axb
+bgA
 ayb
 egp
 uMC
@@ -95896,14 +95969,14 @@ aaa
 aaa
 aaa
 aaa
-aqI
-arN
-asR
-atT
-auR
-avY
-axb
-ayb
+aaa
+arQ
+aqJ
+atV
+asS
+avZ
+ldF
+jFo
 jAw
 aAB
 aBw
@@ -96153,15 +96226,15 @@ aht
 aht
 aht
 bRC
-aqJ
+bRC
 arO
-asS
-atT
 auR
+asS
+asS
 avZ
-axb
-ayb
-nvp
+qow
+jFo
+jOA
 aAB
 aBx
 aCL
@@ -96410,13 +96483,13 @@ aaa
 aaa
 aaa
 aaa
-aqI
-arP
-asR
+aaa
+arQ
+bPA
+atV
 asS
 asS
-asS
-asS
+kNz
 asS
 xzP
 aAB
@@ -96667,11 +96740,11 @@ aaa
 aaa
 aaa
 aaa
-aqI
+aaa
 arQ
-asR
+gzo
 atV
-pEe
+soW
 mzo
 auS
 aDJ
@@ -96924,10 +96997,10 @@ aaa
 aaa
 aaa
 aaa
-aaB
+aaa
 arR
 asT
-atW
+uiu
 atW
 kFn
 rPK
@@ -97181,7 +97254,7 @@ aht
 aht
 aht
 bRC
-arA
+atY
 arA
 arA
 atX
@@ -103951,8 +104024,8 @@ hUX
 cYq
 mOH
 igl
-mOH
-tlU
+vcQ
+skE
 qFJ
 aaa
 aht

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -33957,10 +33957,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"eor" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "epd" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -44338,10 +44334,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kNU" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "kOO" = (
 /obj/structure/table/wood/fancy,
 /obj/item/gun/ballistic/revolver/russian{
@@ -49294,10 +49286,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"oex" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "ofY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -93628,7 +93616,7 @@ aht
 aht
 aYP
 nwI
-oex
+aht
 aaa
 aax
 arH
@@ -93734,8 +93722,8 @@ cWS
 vov
 iUE
 bXk
-eor
-eor
+bXk
+bXk
 aht
 aaa
 aaa
@@ -97332,8 +97320,8 @@ ulY
 hGe
 prr
 mZR
-kNU
-kNU
+mZR
+mZR
 bRC
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

This PR aims at fixing some major oversights and modernize zones in pubby, alongside reviving some PRs that aimed at fixing said oversights.

The fixes are:
del: [PubbyStation] Removed decals under glass in tool storage
tweak: [PubbyStation] Uncursed some pipes by engineering
tweak: [PubbyStation] Changed the Engineering foyer and atmospherics to have more room
tweak: [PubbyStation] Changed walls around interrogation and captain's room to rwalls and Added grimy carpet to interrogation
tweak: [PubbyStation] Changed captain's office bathroom to use tinted window and captain's room carpet to royal blue from grimy
tweak: [PubbyStation] Darkened HoP queue flooring and Changed HoP room carpet to blue carpet
tweak: [PubbyStation] Changed areas between bridge and central primary hall
tweak: [PubbyStation] Cleaned up xenobio disposals
tweak: [PubbyStation] Shifted Dorms maints room over
tweak: [PubbyStation] Moved windows in dorms airlock
tweak: [PubbyStation] Shifted table and vendors in xenobio maints, shifted maints rooms and added spawners
tweak: [PubbyStation] Moved portable scrubbers and pumps in atmos to a better, less cramped, location
tweak: [PubbyStation] Redid engineering entrance doorway and decals, fixed area being marked as "break room"
tweak: [PubbyStation] Changed engineering storage to use space more efficiently.
tweak: [PubbyStation] Changed SM chamber flooring, adjusted decals.
tweak: [PubbyStation] Adjusted size of engineering maints and tweaked some windows
tweak: [PubbyStation] Adjusted size of chapel *slightly*
tweak: [PubbyStation] Replaced reinforced windows inside chapel with a regular ones, added some windows inside.
tweak: [PubbyStation] Moved portable scrubber in dorms bathroom down one tile (why is this even here?)
tweak: [PubbyStation] Dramatically changed the security equipment room, now EVA suits locked behind a door
tweak: [PubbyStation] Overhauled the service maints, alongside the cool room, botany's backroom, aux bathroom, bar backroom and art room
tweak: [PubbyStation] Replaced all the odd layered and nudged directional windows
tweak: [PubbyStation] Made the blue cable in the monastery worse
tweak: [PubbyStation] Reshaped the two solars into a less wasteful solution
tweak: [PubbyStation] Adjusted the turbine with a new, more interesting design
fix: [PubbyStation] Fixed nearstation being incorrectly marked as space on AI sat tube
fix: [PubbyStation] Redid engineering disposals
fix: [PubbyStation] Fixed tinted window in confession to use a spawner
fix: [PubbyStation] Moved toxins chamber air alarm around the corner
fix: [PubbyStation] Fixed windows in garden to use a spawner
fix: [PubbyStation] Fixed improper area markings and lattices in engineering space.
fix: [PubbyStation] Standardized all fire alarms
fix: [PubbyStation] Moved cameras in bridge
fix: [PubbyStation] Fixed maintenance area markings around interrogation and widened it
fix: [PubbyStation] Fixed brig wiring
fix: [PubbyStation] Fixed parts of armory being counted as the Warden's office
fix: [PubbyStation] Moved a random lattice in explo space
add: [PubbyStation] Added grippy floortiles beneath all emergency showers
add: [PubbyStation] Added extra fire alarms and fire locks, mainly in the chapel, AI core and T-comm satellite
add: [PubbyStation] Added lights outside bridge and Renamed a camera outside bridge
add: [PubbyStation] Added a chair in dorms maints and Added/moved windows in dorms maints
add: [PubbyStation] Improved decals and flooring in shared engineering storage, also expanded it slightly
## Why It's Good For The Game

QOL updates people, QOL.

## Testing Photographs and Procedure

![immagine](https://user-images.githubusercontent.com/75247747/198840744-9726becc-4358-446c-8e41-9d41127f43bd.png)

</details>

## Changelog
:cl: PigeonVerde322, TeomanTheGreat
tweak: [PubbyStation] Adjusted... a lot of stuff, see the PR itself to see what changed.
/:cl: