### PR TITLE
Nerf cleanbot knives

### DIFF
--- a/code/datums/components/larryknife.dm
+++ b/code/datums/components/larryknife.dm
@@ -6,7 +6,7 @@
 	var/static/list/default_connections = list(COMSIG_ATOM_ENTERED = .proc/knife_crossed)
 
 /datum/component/knife_attached_to_movable/Initialize(damage = 0)
-	knife_damage = damage
+	knife_damage = damage * 0.2
 	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/knife_crossed)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/knife_move)
 	add_connect_loc_behalf_to_parent()

--- a/code/datums/components/larryknife.dm
+++ b/code/datums/components/larryknife.dm
@@ -6,7 +6,7 @@
 	var/static/list/default_connections = list(COMSIG_ATOM_ENTERED = .proc/knife_crossed)
 
 /datum/component/knife_attached_to_movable/Initialize(damage = 0)
-	knife_damage = damage * 0.2
+	knife_damage = damage * 0.5
 	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/knife_crossed)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/knife_move)
 	add_connect_loc_behalf_to_parent()
@@ -16,7 +16,7 @@
 		AddComponent(/datum/component/connect_loc_behalf, parent, default_connections)
 
 /datum/component/knife_attached_to_movable/proc/stab(mob/living/carbon/C)
-	if(!TIMER_COOLDOWN_CHECK(src, COOLDOWN_LARRYKNIFE))
+	if(!TIMER_COOLDOWN_CHECK(src, COOLDOWN_LARRYKNIFE) && prob(50)) // fail half the time, but don't reset the cooldown
 		var/atom/movable/P = parent
 		var/leg
 		if(prob(50))


### PR DESCRIPTION
## About The Pull Request

So basically, pAIs can become cleanbots right? And you can attach knives to them.

This gives pAIs the power to actually affect round outcomes significantly and directly by just validhunting traitors by running under them with knives (then can do this repeatedly and easily, while also being small sprites that are hard to hit).

Doing TEN BRUTE DAMAGE per hit to one leg, meaning they can easily crit/disable you in a few swipes. 

This nerfs that to 5 brute damage and makes it fail half the time.

## Why It's Good For The Game

pAIs should not be drastically affecting the round flow, or validhunting. The knife gimmick is funny, but it's not funny when two pAIs armed with knives can murder you singlehandedly, while being fast, unstunnable, and hard to click on.

Either way, pAIs should not have a method to do actual damage, as it goes against the principle of being a stationside "assistant" ghost role. They are not supposed to be combat capable.

## Testing Photographs and Procedure

The damage is reduced.

## Changelog
:cl:
balance: Nerfed cleanbot knife damage from 10 to 5, and it only does damage half the time.
/:cl: