### PR TITLE
Alert quality of life

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -619,13 +619,15 @@ so as to remain in compliance with the most up-to-date laws."
 	var/mob/dead/observer/ghost_owner = usr
 	if(!istype(ghost_owner))
 		return
+	//Any actions that cause you to jump to the target turf
+	if (action == NOTIFY_ATTACK || action == NOTIFY_JUMP)
+		var/turf/T = get_turf(target)
+		if(isturf(T))
+			ghost_owner.abstract_move(T)
+	//Other additional actions
 	switch(action)
 		if(NOTIFY_ATTACK)
 			target.attack_ghost(ghost_owner)
-		if(NOTIFY_JUMP)
-			var/turf/T = get_turf(target)
-			if(T && isturf(T))
-				ghost_owner.abstract_move(T)
 		if(NOTIFY_ORBIT)
 			ghost_owner.ManualFollow(target)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simple PR, makes you jump to a target when clicking on the button to control a mob.
Lets you decide if you actually want to be that mob based on their situation without having to find them in the player list.

The only usecase that could potentially be considered odd is the magic eightball which will jump you to the user when activated.

## Why It's Good For The Game

A minor QOL think that lets you see who you are about to become before you become them.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/198872921-ef8e46e2-4b17-4dfb-a19f-0806e38c0a91.png)

![image](https://user-images.githubusercontent.com/26465327/198877203-d0bb4482-fb40-41e8-8ec4-73c656655b5d.png)

## Changelog
:cl:
tweak: Ghost alert to control a mob will now jump you to the target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
