### PR TITLE
Fixes null ref in mob holder

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -26,6 +26,8 @@
 	deposit(M)
 
 /obj/item/clothing/head/mob_holder/Destroy()
+	if(destroying)
+		return
 	destroying = TRUE
 	if(held_mob)
 		release(FALSE)
@@ -56,19 +58,21 @@
 
 /obj/item/clothing/head/mob_holder/proc/release(del_on_release = TRUE)
 	if(!held_mob)
-		if(del_on_release && !destroying)
+		if(del_on_release)
 			qdel(src)
 		return FALSE
 	if(isliving(loc))
 		var/mob/living/L = loc
 		to_chat(L, "<span class='warning'>[held_mob] wriggles free!</span>")
 		L.dropItemToGround(src)
-	held_mob.forceMove(get_turf(held_mob))
-	held_mob.reset_perspective()
-	held_mob.setDir(SOUTH)
-	held_mob.visible_message("<span class='warning'>[held_mob] uncurls!</span>")
-	held_mob = null
-	if(del_on_release && !destroying)
+	//in some very specific cases dropItemToGround will call release() again, deleting the mob ref
+	if(held_mob)
+		held_mob.forceMove(get_turf(held_mob))
+		held_mob.reset_perspective()
+		held_mob.setDir(SOUTH)
+		held_mob.visible_message("<span class='warning'>[held_mob] uncurls!</span>")
+		held_mob = null
+	if(del_on_release)
 		qdel(src)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In some situations the proc will be called inside drop to ground nulling the mob ref.
Now, we return early if another attempt was made before us.

## Why It's Good For The Game

Less runtime

## Testing Photographs and Procedure
I am not able to reproduce the runtime myself but compiled and game worked
Tested with 2 clients, no runtimes

## Changelog
:cl:
fix: fixed possible null reference when release mob from holder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
