### PR TITLE
Fire extinguishers move with speed according to move_resist, fixes secway exploit

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -188,6 +188,9 @@
 
 //Chair movement loop
 /obj/item/extinguisher/proc/move_chair(obj/buckled_object, movementdirection)
+	//Only move things with weak move resist
+	if (buckled_object.move_resist > MOVE_FORCE_NORMAL)
+		return
 	var/datum/move_loop/loop = SSmove_manager.move(buckled_object, movementdirection, 1, timeout = 9, flags = MOVEMENT_LOOP_START_FAST, priority = MOVEMENT_ABOVE_SPACE_PRIORITY)
 	//This means the chair slowing down is dependant on the extinguisher existing, which is weird
 	//Couldn't figure out a better way though
@@ -195,11 +198,18 @@
 
 /obj/item/extinguisher/proc/manage_chair_speed(datum/move_loop/move/source)
 	SIGNAL_HANDLER
+	var/multiplier = 3
+	if (source.moving.move_resist <= MOVE_FORCE_VERY_WEAK)
+		multiplier = 1
+	else if(source.moving.move_resist <= MOVE_FORCE_WEAK)
+		multiplier = 2
 	switch(source.lifetime)
-		if(5 to 4)
-			source.delay = 2
-		if(3 to 1)
-			source.delay = 3
+		if(6 to INFINITY)
+			source.delay = multiplier
+		if(4 to 5)
+			source.delay = multiplier + 1
+		if(1 to 3)
+			source.delay = multiplier + 2
 
 /obj/item/extinguisher/AltClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -53,6 +53,7 @@
 	icon_state = "down"
 	anchored = FALSE
 	resistance_flags = NONE
+	move_resist = MOVE_FORCE_WEAK
 	var/foldabletype = /obj/item/roller
 
 /obj/structure/bed/roller/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -9,6 +9,7 @@
 	resistance_flags = NONE
 	max_integrity = 250
 	integrity_failure = 25
+	move_resist = MOVE_FORCE_WEAK
 	var/buildstacktype = /obj/item/stack/sheet/iron
 	var/buildstackamount = 1
 	var/item_chair = /obj/item/chair // if null it can't be picked up

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -24,6 +24,7 @@
 	buckle_lying = FALSE
 	buckle_prevents_pull = TRUE
 	layer = ABOVE_MOB_LAYER
+	move_resist = MOVE_FORCE_STRONG
 	var/blade_status = GUILLOTINE_BLADE_RAISED
 	var/blade_sharpness = GUILLOTINE_BLADE_MAX_SHARP // How sharp the blade is
 	var/kill_count = 0

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -46,6 +46,7 @@
 	buckle_lying = 0
 	can_buckle = 1
 	max_integrity = 250
+	move_resist = MOVE_FORCE_STRONG
 
 /obj/structure/kitchenspike/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -11,6 +11,7 @@
 	max_integrity = 100
 	buckle_lying = FALSE
 	layer = ABOVE_MOB_LAYER
+	move_resist = MOVE_FORCE_STRONG
 	var/view_range = 2.5
 	var/cooldown = 0
 	var/projectile_type = /obj/item/projectile/bullet/manned_turret

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -2,6 +2,7 @@
 	name = "motorized wheelchair"
 	desc = "A chair with big wheels. It seems to have a motor in it."
 	max_integrity = 150
+	move_resist = MOVE_FORCE_DEFAULT
 	var/speed = 2
 	var/power_efficiency = 1
 	var/power_usage = 25

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -9,6 +9,7 @@
 	legs_required = 0	//You'll probably be using this if you don't have legs
 	canmove = TRUE
 	density = FALSE		//Thought I couldn't fix this one easily, phew
+	move_resist = MOVE_FORCE_WEAK
 	// Run speed delay is multiplied with this for vehicle move delay.
 	var/delay_multiplier = 6.7
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 - Fixes a bug with the switch statement that made it so it didn't work, the thing will slow down when it approaches the end.
 - Makes it so that the delay between moves from fire extinguisher moves are dependent on the move_resist of the moving object.
 - You can no longer move things with a move_resist above normal.

## Why It's Good For The Game

Removes an exploit that allows you to use fire exinguishers on secways to move ridiculously fast across the map, changed it so that while you can still use it on a secway its much slower.

## Testing Photographs and Procedure

https://user-images.githubusercontent.com/26465327/198902856-fa8071c9-d9b6-4c88-a3ce-b5e04fe3a13f.mp4

## Changelog
:cl:
balance: Fire extinguisher propel speed on secways has been significantly decreased.
balance: Fire extinguisher propel speed on office chairs and other movables has been decreased.
fix: Fixes fire extinguisher propel speed not slowing down over time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
