### PR TITLE
Fix abductor not properly being muted during non-user saycalls

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -129,6 +129,9 @@
 /obj/item/organ/tongue/abductor/handle_speech(datum/source, list/speech_args)
 	//Hacks
 	var/message = speech_args[SPEECH_MESSAGE]
+	speech_args[SPEECH_MESSAGE] = ""
+	if(!ishuman(usr))
+		return
 	var/mob/living/carbon/human/user = usr
 	var/rendered = "<span class='abductor'><b>[user.real_name]:</b> [message]</span>"
 	user.log_talk(message, LOG_SAY, tag="abductor")
@@ -142,8 +145,6 @@
 	for(var/mob/M in GLOB.dead_mob_list)
 		var/link = FOLLOW_LINK(M, user)
 		to_chat(M, "[link] [rendered]")
-
-	speech_args[SPEECH_MESSAGE] = ""
 
 /obj/item/organ/tongue/zombie
 	name = "rotting tongue"


### PR DESCRIPTION
## About The Pull Request

There was a runtime that existed previously `Runtime in tongue.dm, line 133: Cannot read null.real_name`

This fixes that and also fixes them not being mute from things like Tourette's

## Why It's Good For The Game

Fixes a bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

No runtime + no speech

![image](https://user-images.githubusercontent.com/10366817/199213866-68838681-b028-4c73-a327-ac4350c5e21e.png)

</details>

## Changelog
:cl:
fix: Fixed abductors ignoring their muteness due to tourette's
/:cl:
