### PR TITLE
Fix character slot resetting

### DIFF
--- a/code/modules/client/preferences2/preferences2.dm
+++ b/code/modules/client/preferences2/preferences2.dm
@@ -91,7 +91,7 @@
 	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	UI_style		= sanitize_inlist(UI_style, GLOB.available_ui_styles, GLOB.available_ui_styles[1])
 
-	default_slot	= sanitize_integer(default_slot, TRUE, max_usable_slots, initial(default_slot))
+	default_slot	= sanitize_integer(default_slot, TRUE, TRUE_MAX_SAVE_SLOTS, initial(default_slot))
 	toggles			= sanitize_integer(toggles, FALSE, INFINITY, initial(toggles)) // yes
 	toggles2		= sanitize_integer(toggles2, FALSE, INFINITY, initial(toggles2))
 	clientfps		= sanitize_integer(clientfps, FALSE, 1000, FALSE)


### PR DESCRIPTION
## About The Pull Request

Basically, default_slot is what selects the character slot it should use, but it gets truncated before the "extra character slot" addition occurs (after the DB load), so now it's going to reset. It's fine if it's not truncated at DB load because it will reset to 1 if the slot is locked anyway.

## Why It's Good For The Game

People getting their slots reset is really annoying.

## Testing Photographs and Procedure

Can't really test without database but the logic is pretty clear if you look at it.

## Changelog
:cl:
fix: Fixed selection of 4th character slot resetting every round.
/:cl: