### PR TITLE
Fix flammable & malfunction traits - xenoarch goof

### DIFF
--- a/code/__DEFINES/xenoartifact_materials.dm
+++ b/code/__DEFINES/xenoartifact_materials.dm
@@ -32,12 +32,14 @@
 #define XENOA_MAX_VENDORS 8
 
 //Specific trait defines
-///Bear limit
+///Bear limit at once
 #define XENOA_MAX_BEARS 3
 ///Max targets on expansive
 #define XENOA_MAX_TARGETS 6
 ///Tick chance to untick
 #define XENOA_TICK_CANCEL_PROB 13
+///Max amount of evil clones at once
+#define XENOA_MAX_CLONES 5
 
 ///Chance to avoid target if wearing bomb suit
 #define XENOA_DEFLECT_CHANCE 45

--- a/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
@@ -7,20 +7,21 @@
 	label_desc = "Parallel Bearspace Retrieval: A strange malfunction causes the Artifact to open a gateway to deep bearspace."
 	weight = 15
 	flags = URANIUM_TRAIT
-	var/bears //bear per bears
+	var/list/bears = list() //bear per bears
 
 /datum/xenoartifact_trait/malfunction/bear/activate(obj/item/xenoartifact/X)
-	if(bears < XENOA_MAX_BEARS)
-		bears++
-		var/mob/living/simple_animal/hostile/bear/new_bear = new(get_turf(X.loc))
-		new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Paddington", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
-		log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear) at [world.time]. [X] located at [AREACOORD(X)]")
-	else
-		X.visible_message("<span class='danger'>The [X.name] shatters as bearspace collapses! Too many bears!</span>")
-		var/obj/effect/decal/cleanable/ash/A = new(get_turf(X))
-		A.color = X.material
-		qdel(X)
+	if(bears.len >= XENOA_MAX_BEARS)
+		return
+	var/mob/living/simple_animal/hostile/bear/new_bear = new(get_turf(X.loc))
+	new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Paddington", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
+	bears += new_bear
+	RegisterSignal(new_bear, COMSIG_PARENT_QDELETING, .proc/handle_death)
+	log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear) at [world.time]. [X] located at [AREACOORD(X)]")
 	X.cooldown += 20 SECONDS
+
+/datum/xenoartifact_trait/malfunction/bear/proc/handle_death(datum/source)
+	bears -= source
+	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 
 //============
 // Badtarget, changes target to user
@@ -156,8 +157,13 @@
 	label_name = "Anti-Cloning"
 	label_desc = "Anti-Cloning: The Artifact produces an arguably maleviolent clone of target."
 	flags = BLUESPACE_TRAIT | URANIUM_TRAIT | PLASMA_TRAIT
+	var/list/clones = list()
 
 /datum/xenoartifact_trait/malfunction/twin/activate(obj/item/xenoartifact/X, mob/living/target, atom/user, setup)
+	//Stop artifact making one morbillion clones
+	if(clones.len >= XENOA_MAX_CLONES)
+		return
+	//Twin setup
 	var/mob/living/simple_animal/hostile/twin/T = new(get_turf(X))
 	//Setup appearence for evil twin
 	T.name = target.name
@@ -168,6 +174,13 @@
 	T.pixel_y = initial(T.pixel_y)
 	T.pixel_x = initial(T.pixel_x)
 	T.color = COLOR_BLUE
+	//Handle limit and hardel
+	clones += T
+	RegisterSignal(T, COMSIG_PARENT_QDELETING, .proc/handle_death)
+
+/datum/xenoartifact_trait/malfunction/twin/proc/handle_death(datum/source)
+	clones -= source
+	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 
 /mob/living/simple_animal/hostile/twin
 	name = "evil twin"
@@ -199,6 +212,7 @@
 /datum/xenoartifact_trait/malfunction/explode
 	label_name = "Delaminating"
 	label_desc = "Delaminating: The Artifact violently collapses, exploding."
+	flags = URANIUM_TRAIT
 
 /datum/xenoartifact_trait/malfunction/explode/activate(obj/item/xenoartifact/X, atom/target, atom/user, setup)
 	. = ..()

--- a/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
@@ -10,10 +10,11 @@
 	var/list/bears = list() //bear per bears
 
 /datum/xenoartifact_trait/malfunction/bear/activate(obj/item/xenoartifact/X)
-	if(bears.len >= XENOA_MAX_BEARS)
+	if(length(bears) >= XENOA_MAX_BEARS)
 		return
-	var/mob/living/simple_animal/hostile/bear/new_bear = new(get_turf(X.loc))
-	new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Paddington", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
+	var/turf/T = get_turf(X)
+	var/mob/living/simple_animal/hostile/bear/new_bear = new(T)
+	new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
 	bears += new_bear
 	RegisterSignal(new_bear, COMSIG_MOB_DEATH, .proc/handle_death)
 	log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear) at [world.time]. [X] located at [AREACOORD(X)]")
@@ -161,7 +162,7 @@
 
 /datum/xenoartifact_trait/malfunction/twin/activate(obj/item/xenoartifact/X, mob/living/target, atom/user, setup)
 	//Stop artifact making one morbillion clones
-	if(clones.len >= XENOA_MAX_CLONES)
+	if(length(clones) >= XENOA_MAX_CLONES)
 		return
 	//Twin setup
 	var/mob/living/simple_animal/hostile/twin/T = new(get_turf(X))

--- a/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
@@ -15,13 +15,13 @@
 	var/mob/living/simple_animal/hostile/bear/new_bear = new(get_turf(X.loc))
 	new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Paddington", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
 	bears += new_bear
-	RegisterSignal(new_bear, COMSIG_PARENT_QDELETING, .proc/handle_death)
+	RegisterSignal(new_bear, COMSIG_MOB_DEATH, .proc/handle_death)
 	log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear) at [world.time]. [X] located at [AREACOORD(X)]")
 	X.cooldown += 20 SECONDS
 
 /datum/xenoartifact_trait/malfunction/bear/proc/handle_death(datum/source)
 	bears -= source
-	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(source, COMSIG_MOB_DEATH)
 
 //============
 // Badtarget, changes target to user

--- a/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
@@ -421,7 +421,7 @@
 ///Used for ghost command
 /datum/xenoartifact_trait/minor/haunted/proc/activate_parent(obj/item/xenoartifact/ref)
 	//Get a target to style on
-	ref.true_target = list(ref.get_target_in_proximity(min(ref.max_range+1, 5)))
+	ref.true_target = ref.get_target_in_proximity(min(ref.max_range+1, 5))
 	if(ref.true_target.len)
 		ref.check_charge(ref.true_target[1])
 

--- a/code/modules/xenoarchaeology/xenoartifact.dm
+++ b/code/modules/xenoarchaeology/xenoartifact.dm
@@ -401,7 +401,7 @@
 /obj/item/xenoartifact/process(delta_time)
 	switch(process_type)
 		if(PROCESS_TYPE_LIT) //Burning
-			true_target = list(get_target_in_proximity(min(max_range, 5)))
+			true_target = get_target_in_proximity(min(max_range, 5))
 			if(true_target[1])
 				visible_message("<span class='danger' size='4'>The [name] flicks out.</span>")
 				default_activate(25, null, null)
@@ -410,7 +410,7 @@
 		if(PROCESS_TYPE_TICK) //Clock-ing
 			playsound(get_turf(src), 'sound/effects/clock_tick.ogg', 50, TRUE) 
 			visible_message("<span class='danger' size='10'>The [name] ticks.</span>")
-			true_target = list(get_target_in_proximity(min(max_range, 5)))
+			true_target = get_target_in_proximity(min(max_range, 5))
 			default_activate(25, null, null)
 			if(DT_PROB(XENOA_TICK_CANCEL_PROB, delta_time) && COOLDOWN_FINISHED(src, xenoa_cooldown))
 				process_type = null

--- a/code/modules/xenoarchaeology/xenoartifact.dm
+++ b/code/modules/xenoarchaeology/xenoartifact.dm
@@ -402,7 +402,7 @@
 	switch(process_type)
 		if(PROCESS_TYPE_LIT) //Burning
 			true_target = list(get_target_in_proximity(min(max_range, 5)))
-			if(isliving(true_target[1]))
+			if(true_target[1])
 				visible_message("<span class='danger' size='4'>The [name] flicks out.</span>")
 				default_activate(25, null, null)
 				process_type = null


### PR DESCRIPTION
## About The Pull Request

Another fix PR for the not broken xenoarchaeology.

Fixes flammable trait - The flammable trait at some point has been broken, I swear it worked last time I tested it. I assume this is either due to byond updates or code changes idk. No-one even told me it was broken, I just had to discover it did at some point while playing.

Fixes malfunctions (blacklist) - Classic gamer goof, malfunction blacklists weren't working properly on the explosive malfunction.

Fixes malfunctions (entity overflow) - The clone malfunction didn't have a cap, you could make infinite evil clones, now it has a cap of 5 at once. Swaps the bear limit over to this, it's better than destroying the artifact.

## Why It's Good For The Game

Bugs aren't great, neither is server stress. 

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/40559528/199649856-077a021f-ff23-481f-87cd-28d754e27db3.png)
![image](https://user-images.githubusercontent.com/40559528/199649973-5cb1398b-5fdd-4df2-86cd-6465d8c195d8.png)
![image](https://user-images.githubusercontent.com/40559528/199651523-7bff9609-6725-4c7c-afa7-81aadf94f2ab.png)
![image](https://user-images.githubusercontent.com/40559528/199653413-cbab9c57-a9d2-4105-bd9d-7fe4b0e9b37b.png)

</details>

## Changelog
:cl:
fix: Fix flammable trait not activating
fix: Fix haunted activation.
fix: Fix blacklisting on explosive malfunction
tweak: Add limit to clone & bear malfunction.
/:cl:
