### PR TITLE
fixes some bugs of encryption key & compression box

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -12,8 +12,8 @@
 
 /obj/item/encryptionkey/Initialize(mapload)
 	. = ..()
-	if(!channels.len)
-		desc = "An encryption key for a radio headset.  Has no special codes in it. You should probably tell a coder!"
+	if(!(translate_binary || syndie || independent || amplification || length(channels)))
+		desc = "An encryption key for a radio headset. Has no special codes in it. You should probably tell a coder!"
 
 /obj/item/encryptionkey/examine(mob/user)
 	. = ..()
@@ -32,17 +32,14 @@
 
 /obj/item/encryptionkey/binary
 	name = "binary translator key"
+	desc = "An encryption key that interchanges the form of anaologue sounds and binary electric signals."
 	icon_state = "bin_cypherkey"
 	translate_binary = TRUE
 
 /obj/item/encryptionkey/amplification
 	name = "amplification module key"
-	amplification = TRUE
-
-// Makes sure neither channel messages show up.
-/obj/item/encryptionkey/amplification/Initialize()
-	. = ..()
 	desc = "An amplification module key for a radio headset. It will enable the \"Loud mode\" ability on any headset it is inserted into."
+	amplification = TRUE
 
 /obj/item/encryptionkey/headset_sec
 	name = "security radio encryption key"
@@ -101,7 +98,7 @@
 	name = "\proper the research director's encryption key"
 	icon_state = "rd_cypherkey"
 	channels = list(RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_EXPLORATION = 1, RADIO_CHANNEL_COMMAND = 1)
-	
+
 /obj/item/encryptionkey/heads/rd/fake
 	channels = list(RADIO_CHANNEL_SERVICE = 1)
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -32,7 +32,7 @@
 
 /obj/item/encryptionkey/binary
 	name = "binary translator key"
-	desc = "An encryption key that interchanges the form of anaologue sounds and binary electric signals."
+	desc = "An encryption key that interchanges the form of anaologue brainwave and binary electric signals."
 	icon_state = "bin_cypherkey"
 	translate_binary = TRUE
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -94,6 +94,7 @@
 /obj/item/storage/box/suitbox/dropped(mob/living/user)
 	..()
 	addtimer(CALLBACK(src, .proc/box_check, user), 1 SECONDS)
+	// character's contents are checked too earlier than when it supposed to be done, making you perma-slow down.
 
 /obj/item/storage/box/suitbox/proc/box_check(mob/living/user)
 	var/box_exists = FALSE

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -93,6 +93,9 @@
 
 /obj/item/storage/box/suitbox/dropped(mob/living/user)
 	..()
+	addtimer(CALLBACK(src, .proc/box_check, user), 1 SECONDS)
+
+/obj/item/storage/box/suitbox/proc/box_check(mob/living/user)
 	var/box_exists = FALSE
 	for(var/obj/item/storage/box/suitbox/B in user.get_contents())
 		box_exists = TRUE // `var/obj/item/storage/box/suitbox/B` is already type check

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -37,7 +37,7 @@
 	new /obj/item/storage/belt/sabre(src)
 	new /obj/item/gun/energy/e_gun/mini/heads(src)
 
-/obj/item/storage/box/suitbox/cap/PopulateContents()
+/obj/item/storage/box/suitbox/cap
 	name = "compression box of captain outfits"
 
 /obj/item/storage/box/suitbox/cap/PopulateContents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes some bugs to encryption key & compression box

* fixes #7957

I made it as `addtimer` because checking a character's contents is done earlier than I want, so I had to make it with some minor delays.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/200108388-2208dd8d-6ee4-40f2-87c0-560cdaf8b6a5.png)

I put this into a safe, and the character walk very well.


![image](https://user-images.githubusercontent.com/87972842/200108445-f2a2d254-e1e5-4334-9324-ec49b0cd831b.png)

keys are fine

</details>

## Changelog
:cl:
fix: compression box no longer keeps you slowdown when you remove those in specific situations (put it into safe, fold, etc)
fix: Captain's comp box is now properly named
fix: encryption keys no longer say "This is nothing special. ask coder!" description even if it is special
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
