### PR TITLE
Tweaks how brain death is handled and adds repeatable brain surgery

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -625,10 +625,8 @@
 				else
 					var/obj/item/organ/brain/BR = H.getorgan(/obj/item/organ/brain)
 					if(BR)
-						if(BR.organ_flags & ORGAN_FAILING)
+						if(BR.organ_flags & ORGAN_FAILING || BR.brain_death)
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain tissue is damaged making recovery of patient impossible via defibrillator. Further attempts futile.</span>"
-						if(BR.brain_death)
-							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain damaged beyond point of no return. Further attempts futile.</span>"
 						if(BR.suicided || BR.brainmob?.suiciding)
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - No intelligence pattern can be detected in patient's brain. Further attempts futile.</span>"
 					else

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -74,6 +74,12 @@
 	if(iszombie(H))//braaaaaains... otherwise, too important to eat.
 		..()
 
+/obj/item/organ/brain/setOrganDamage(d)
+	. = ..()
+	if(!(organ_flags & ORGAN_FAILING))
+		brain_death = FALSE
+		brainmob.revive(TRUE) // We fixed the brain, fix the brainmob too.
+
 /obj/item/organ/brain/proc/transfer_identity(mob/living/L)
 	name = "[L.name]'s brain"
 	if(brainmob || decoy_override)
@@ -107,9 +113,6 @@
 
 	if((organ_flags & ORGAN_FAILING) && O.is_drainable() && O.reagents.has_reagent(/datum/reagent/medicine/mannitol)) //attempt to heal the brain
 		. = TRUE //don't do attack animation.
-		if(brain_death || brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
-			to_chat(user, "<span class='warning'>[src] is far too damaged, there's nothing else we can do for it!</span>")
-			return
 
 		if(!O.reagents.has_reagent(/datum/reagent/medicine/mannitol, 10))
 			to_chat(user, "<span class='warning'>There's not enough mannitol in [O] to restore [src]!</span>")

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -76,7 +76,7 @@
 
 /obj/item/organ/brain/setOrganDamage(d)
 	. = ..()
-	if(!(organ_flags & ORGAN_FAILING))
+	if(brain_death && !(organ_flags & ORGAN_FAILING))
 		brain_death = FALSE
 		brainmob.revive(TRUE) // We fixed the brain, fix the brainmob too.
 

--- a/code/modules/surgery/brain_recalibration.dm
+++ b/code/modules/surgery/brain_recalibration.dm
@@ -16,6 +16,7 @@
 	name = "fix brain"
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	time = 120 //long and complicated
+	repeatable = TRUE
 
 /datum/surgery/brain_recalibration/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
@@ -36,6 +37,8 @@
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	target.setOrganLoss(ORGAN_SLOT_BRAIN, target.getOrganLoss(ORGAN_SLOT_BRAIN) - 60)	//we set damage in this case in order to clear the "failing" flag
 	target.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
+	if(target.getOrganLoss(ORGAN_SLOT_BRAIN))
+		to_chat(user, "<span class='notice'>It looks like [target]'s brain could be fixed further.</span>")
 	return TRUE
 
 /datum/surgery_step/fix_brain/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This makes it so that brain death can be repaired with mannitol or surgery. At present it's only repairable through a combination of brain re-calibration and revival surgery, which IMO is really unintuitive.

This also allows brain surgery to be repeated, so that you can fully repair someone's brain with enough time.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This makes fixing brain death a bit less unintuitive and tedious, and adds a bit of additional functionality to brain surgery.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Surgery is repeatable, brain death is properly set after surgery/mannitol application

## Changelog
:cl:
tweak: Brain surgery is now repeatable.
balance: Brain death can now be repaired with mannitol/surgery without needing revival surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
