### PR TITLE
Remove Text Macros in strings without interpolated expression

### DIFF
--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/eminence
-	name = "\the Eminence"
+	name = "the Eminence"
 	desc = "A glowing ball of light."
 	icon = 'icons/effects/clockwork_effects.dmi'
 	icon_state = "eminence"

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -176,7 +176,7 @@
 	if(!isliving(usr))
 		return
 	if(!robe_charge)
-		to_chat(usr, "<span class='warning'>\The robe's internal magic supply is still recharging!</span>")
+		to_chat(usr, "<span class='warning'>The robe's internal magic supply is still recharging!</span>")
 		return
 
 	usr.say("Rise, my creation! Off your page into this realm!", forced = "stickman summoning")
@@ -187,7 +187,7 @@
 	src.robe_charge = FALSE
 	sleep(30)
 	src.robe_charge = TRUE
-	to_chat(usr, "<span class='notice'>\The robe hums, its internal magic supply restored.</span>")
+	to_chat(usr, "<span class='notice'>The robe hums, its internal magic supply restored.</span>")
 
 
 //Shielded Armour

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -361,13 +361,13 @@
 			renamedByPlayer = TRUE
 
 		if(penchoice == "Plant Description")
-			var/input = stripped_input(user,"What do you want to change the description of \the plant to?", default=plantdesc, max_length=MAX_NAME_LEN)
+			var/input = stripped_input(user,"What do you want to change the description of the plant to?", default=plantdesc, max_length=MAX_NAME_LEN)
 			if(QDELETED(src) || !user.canUseTopic(src, BE_CLOSE))
 				return
 			plantdesc = input
 
 		if(penchoice == "Seed Description")
-			var/input = stripped_input(user,"What do you want to change the description of \the seeds to?", default=desc, max_length=MAX_NAME_LEN)
+			var/input = stripped_input(user,"What do you want to change the description of the seeds to?", default=desc, max_length=MAX_NAME_LEN)
 			if(QDELETED(src) || !user.canUseTopic(src, BE_CLOSE))
 				return
 			desc = input


### PR DESCRIPTION
## About The Pull Request

Removes unnecesary text macros, there are no interpolated expressions in these strings so the text macros will not do anything. Noticed this when compiling in OpenDream, this won't cause any issues that I know of in BYOND, but is just not required and bad practice imho.

https://github.com/BeeStation/NSV13/pull/2168, just for reference.

## Changelog
:cl: Loorey
fix: removed unnecesary text macros in strings without interpolation
/:cl:
