### PR TITLE
Removes romerol from floorpills

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1867,7 +1867,7 @@
 		host, upon which, the secondary structures activate and take control \
 		of the host body."
 	color = "#123524" // RGB (18, 53, 36)
-	chem_flags = CHEMICAL_NOT_SYNTH | CHEMICAL_RNG_FUN // romerol zombie outbreak from a maint pill? how can this go not fun.
+	chem_flags = CHEMICAL_NOT_SYNTH // romerol zombie outbreak from a maint pill? how can this go not fun.
 	metabolization_rate = INFINITY
 	taste_description = "brains"
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1867,7 +1867,7 @@
 		host, upon which, the secondary structures activate and take control \
 		of the host body."
 	color = "#123524" // RGB (18, 53, 36)
-	chem_flags = CHEMICAL_NOT_SYNTH // romerol zombie outbreak from a maint pill? how can this go not fun.
+	chem_flags = CHEMICAL_NOT_SYNTH
 	metabolization_rate = INFINITY
 	taste_description = "brains"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Romerol no longer has the CHEMICAL_RNG_FUN flag, the flag used by floorpills.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
I love Romerol as much the next person, but this isn't the way it should be getting introduced into rounds.
Also potentially encourages people to pop floorpills in hopes of becoming a zombie, which isn't really something we can feasibly prevent via enforcement unfortunately.
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Spawned a fuck ton of pills, selected their contents with SDQL, control + F'd the list.

Has Romerol.
![image](https://user-images.githubusercontent.com/80382633/200349594-7e748687-11e5-4a39-89fa-ccfbeab42856.png)
![image](https://user-images.githubusercontent.com/80382633/200349653-ee9574b0-b9e7-4e91-846a-8512fdf8413c.png)

No longer has Romerol.
![image](https://user-images.githubusercontent.com/80382633/200349760-d0598c08-7965-4656-bd1e-30e86af81c13.png)
![image](https://user-images.githubusercontent.com/80382633/200349802-7308570e-850f-4d42-abf0-7a9f7d2fda21.png)

</details>

## Changelog
:cl:
del: Removes romerol from the floorpill reagent pool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
