### PR TITLE
Tweaks xeno hijacking

### DIFF
--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -15,6 +15,7 @@
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
 	show_to_ghosts = TRUE
+	hijack_speed = 1
 	var/datum/team/xeno/xeno_team
 
 /datum/antagonist/xeno/create_team(datum/team/xeno/new_team)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -420,12 +420,11 @@
 		if(isbrain(player)) //also technically dead
 			continue
 		if(shuttle_areas[get_area(player)])
-			//Non-xeno present. Can't hijack.
-			if(!istype(player, /mob/living/carbon/alien))
-				return FALSE
-			has_xenos = TRUE
+			if(istype(player, /mob/living/carbon/alien))
+				has_xenos = TRUE
+				break
 
-	return has_xenos
+	return has_xenos && SSshuttle.emergency.is_hijacked()
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked()
 	return hijack_status == HIJACKED

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -411,20 +411,16 @@
 	return has_people && ((hijacker_count == 1) || (hijacker_count && !solo_hijack))
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked_by_xenos()
-	var/has_xenos = FALSE
+	var/living_xenos = 0
+	var/has_queen = FALSE
 	for(var/mob/living/player in GLOB.alive_mob_list)
-		if(issilicon(player)) //Borgs are technically dead anyways
-			continue
-		if(isanimal(player)) //animals don't count
-			continue
-		if(isbrain(player)) //also technically dead
-			continue
 		if(shuttle_areas[get_area(player)])
-			if(istype(player, /mob/living/carbon/alien))
-				has_xenos = TRUE
-				break
+			if(istype(player, /mob/living/carbon/alien) && player.stat != DEAD)
+				living_xenos++
+			if(istype(player, /mob/living/carbon/alien/humanoid/royal/queen) && player.stat != DEAD)
+				has_queen = TRUE
 
-	return has_xenos && SSshuttle.emergency.is_hijacked()
+	return (has_queen || (living_xenos > 2)) && SSshuttle.emergency.is_hijacked()
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked()
 	return hijack_status == HIJACKED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This changes the xenomorph hijack objective to be in line with all other hijack objectives, meaning: have a xeno on the shuttle, and override the flight computer.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Consistency is good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/200432880-06f3d6d8-44c8-4a96-ab64-ef20cb08058b.png)
</details>

## Changelog
:cl:
tweak: Xenomorphs now hijack the escape shuttle by overriding the flight controls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
