### PR TITLE
Add shuttle danger warning

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -84,3 +84,12 @@
 #define SHUTTLE_UNLOCK_ALIENTECH "abductor"
 #define SHUTTLE_UNLOCK_MEDISIM "holodeck"
 #define SHUTTLE_UNLOCK_NARNAR "bcult"
+
+//Shuttle preset danger levels
+
+/// Generally safe for station consumption, has everything a typical shuttle needs
+#define SHUTTLE_DANGER_SAFE 0
+/// Missing key components or has mild elements of danger, but generally won't kill you
+#define SHUTTLE_DANGER_SUBPAR 1
+/// Possibility for most people on this shuttle to die with little effort
+#define SHUTTLE_DANGER_HIGH 2

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -13,6 +13,9 @@
 	var/can_be_bought = TRUE
 	var/illegal_shuttle = FALSE	//makes you able to buy the shuttle at a hacked/emagged comms console even if can_be_bought is FALSE
 
+	/// How dangerous this shuttle is, used for alerting foolish captains not to buy it (or traitors to buy it)
+	var/danger_level = SHUTTLE_DANGER_SAFE
+
 	var/list/movement_force // If set, overrides default movement_force on shuttle
 	var/untowable = FALSE // If set, the shuttle becomes untowable
 
@@ -283,6 +286,7 @@
 	description = "Dis is a high-quality shuttle, da. Many seats, lots of space, all equipment! Even includes entertainment! Such as lots to drink, and a fighting arena for drunk crew to have fun! If arena not fun enough, simply press button of releasing bears. Do not worry, bears trained not to break out of fighting pit, so totally safe so long as nobody stupid or drunk enough to leave door open. Try not to let asimov babycons ruin fun!"
 	admin_notes = "Includes a small variety of weapons. And bears. Only captain-access can release the bears. Bears won't smash the windows themselves, but they can escape if someone lets them."
 	credit_cost = 5000 // While the shuttle is rusted and poorly maintained, trained bears are costly.
+	danger_level = SHUTTLE_DANGER_SUBPAR
 
 /datum/map_template/shuttle/emergency/meteor
 	suffix = "meteor"
@@ -291,6 +295,7 @@
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = 15000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+	danger_level = SHUTTLE_DANGER_HIGH
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"
@@ -299,6 +304,7 @@
 	extra_desc = "This shuttle costs 500 credits to board."
 	admin_notes = "Due to the limited space for non paying crew, this shuttle may cause a riot."
 	credit_cost = 10000
+	danger_level = SHUTTLE_DANGER_SUBPAR
 
 /datum/map_template/shuttle/emergency/discoinferno
 	suffix = "discoinferno"
@@ -306,13 +312,15 @@
 	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
 	credit_cost = 10000
+	danger_level = SHUTTLE_DANGER_HIGH
 
 /datum/map_template/shuttle/emergency/arena
 	suffix = "arena"
 	name = "The Arena"
 	description = "The crew must pass through an otherworldy arena to board this shuttle. Expect massive casualties. The source of the Bloody Signal must be tracked down and eliminated to unlock this shuttle."
-	admin_notes = "RIP AND TEAR."
+	admin_notes = "RIP AND TEAR. Creates an entire internal Z-level where you have to kill each other in a massive battle royale to get to the actual shuttle."
 	credit_cost = 10000
+	danger_level = SHUTTLE_DANGER_HIGH
 	/// Whether the arena z-level has been created
 	var/arena_loaded = FALSE
 
@@ -360,6 +368,7 @@
 	Have a fun ride!"
 	admin_notes = "Brig is replaced by anchored greentext book surrounded by lavaland chasms, stationside door has been removed to prevent accidental dropping. No brig."
 	credit_cost = 8000
+	danger_level = SHUTTLE_DANGER_SUBPAR
 
 /datum/map_template/shuttle/emergency/cramped
 	suffix = "cramped"
@@ -367,8 +376,9 @@
 	description = "Well, looks like CentCom only had this ship in the area, they probably weren't expecting you to need evac for a while. \
 	Probably best if you don't rifle around in whatever equipment they were transporting. I hope you're friendly with your coworkers, because there is very little space in this thing.\n\
 	\n\
-	Contains contraband armory guns, maintenance loot, and abandoned crates!"
+	Contains contraband armory guns, some random stuff we found in maintenance, and potentially explosive abandoned crates!"
 	admin_notes = "Due to origin as a solo piloted secure vessel, has an active GPS onboard labeled STV5. Has roughly as much space as Hi Daniel, except with explosive crates."
+	danger_level = SHUTTLE_DANGER_HIGH
 
 /datum/map_template/shuttle/emergency/meta
 	suffix = "meta"
@@ -408,6 +418,7 @@
 	description = "Due to a lack of functional emergency shuttles, we bought this second hand from a scrapyard and pressed it into service. Please do not lean too heavily on the exterior windows, they are fragile."
 	admin_notes = "An abomination with no functional medbay, sections missing, and some very fragile windows. Surprisingly airtight."
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+	danger_level = SHUTTLE_DANGER_SUBPAR
 
 /datum/map_template/shuttle/emergency/narnar
 	suffix = "narnar"
@@ -415,6 +426,7 @@
 	description = "Looks like this shuttle may have wandered into the darkness between the stars on route to the station. Let's not think too hard about where all the bodies came from."
 	admin_notes = "Contains real cult ruins, mob eyeballs, and inactive constructs. Cult mobs will automatically be sentienced by fun balloon. \
 	Cloning pods in 'medbay' area are showcases and nonfunctional."
+	danger_level = SHUTTLE_DANGER_SUBPAR
 
 /datum/map_template/shuttle/emergency/narnar/prerequisites_met()
 	if(SHUTTLE_UNLOCK_NARNAR in SSshuttle.shuttle_purchase_requirements_met)
@@ -449,15 +461,17 @@
 	Emitters spawn powered on, expect admin notices, they are harmless."
 	credit_cost = 100000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+	danger_level = SHUTTLE_DANGER_HIGH
 
 /datum/map_template/shuttle/emergency/imfedupwiththisworld
 	suffix = "imfedupwiththisworld"
 	name = "Oh, Hi Daniel"
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
-	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
+	Aw, come space on. Why not? No, I can't. Anyway, how is your space life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
 	credit_cost = -5000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
+	danger_level = SHUTTLE_DANGER_SUBPAR
 
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"
@@ -473,6 +487,7 @@
 	Needless to say, no engineering team wanted to go near the thing, and it's only being used as an Emergency Escape Shuttle because there is literally nothing else available."
 	admin_notes = "If the crew can solve the puzzle, they will wake the wabbajack statue. It will likely not end well. There's a reason it's boarded up. Maybe they should have just left it alone."
 	credit_cost = 15000
+	danger_level = SHUTTLE_DANGER_HIGH
 
 /datum/map_template/shuttle/emergency/omega
 	suffix = "omega"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -417,6 +417,7 @@
 						"description" = shuttle_template.description,
 						"creditCost" = shuttle_template.credit_cost,
 						"illegal" = shuttle_template.illegal_shuttle,
+						"danger" = shuttle_template.danger_level,
 						"prerequisites" = shuttle_template.prerequisites,
 						"ref" = REF(shuttle_template),
 					))

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -182,27 +182,40 @@ const PageBuyingShuttle = (props, context) => {
                       </span>
                     )}
                     buttons={(
-                      <Button
-                        content={
-                          `${shuttle.creditCost.toLocaleString()} credits`
-                        }
-                        color={shuttle.illegal ? "red" : "default"}
-                        disabled={
-                          !canBuyShuttles || data.budget < shuttle.creditCost
-                        }
-                        onClick={() => act("purchaseShuttle", {
-                          shuttle: shuttle.ref,
-                        })}
-                        tooltip={
-                          data.budget < shuttle.creditCost ? (`You need ${
-                            shuttle.creditCost - data.budget
-                          } more credits.`
-                          ) : (shuttle.illegal
-                            ? ILLEGAL_SHUTTLE_NOTICE
-                            : undefined)
-                        }
-                        tooltipPosition="left"
-                      />
+                      <>
+                        {shuttle.danger === 1 ? (
+                          <Tooltip content="According to our analysis, this shuttle will not properly fulfill the duties of a typical escape shuttle.">
+                            <Icon mr={1} name="exclamation-triangle" color="yellow" />
+                          </Tooltip>
+                        ) : (
+                          shuttle.danger === 2 ? (
+                            <Tooltip content="According to our analysis, this shuttle has a high risk potential, and may result in the death of large amounts of crew.">
+                              <Icon mr={1.25} name="exclamation" color="red" />
+                            </Tooltip>
+                          ) : null
+                        )}
+                        <Button
+                          content={
+                            `${shuttle.creditCost.toLocaleString()} credits`
+                          }
+                          color={shuttle.illegal ? "red" : "default"}
+                          disabled={
+                            !canBuyShuttles || data.budget < shuttle.creditCost
+                          }
+                          onClick={() => act("purchaseShuttle", {
+                            shuttle: shuttle.ref,
+                          })}
+                          tooltip={
+                            data.budget < shuttle.creditCost ? (`You need ${
+                              shuttle.creditCost - data.budget
+                            } more credits.`
+                            ) : (shuttle.illegal
+                              ? ILLEGAL_SHUTTLE_NOTICE
+                              : undefined)
+                          }
+                          tooltipPosition="left"
+                        />
+                      </>
                     )}>
                     <Box textAlign="justify">{shuttle.description}</Box>
                     {


### PR DESCRIPTION
## About The Pull Request

If you are not attentive it's a bit difficult to tell what shuttle is dangerous or not, so foolish captains often buy dangerous shuttles.

This adds a warning level to shuttles in the communications console.

## Why It's Good For The Game

Makes it more clear what shuttle is dangerous, for the average comdon or traitor to enjoy.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/200439195-3d7e3c5a-be66-4384-98ae-45cd0a462dcb.png)

![image](https://user-images.githubusercontent.com/10366817/200439218-9c6ac201-38c3-4416-a626-366b1f0f604d.png)

</details>

## Changelog
:cl:
add: Added dangerous shuttle warnings to the communications console.
tweak: Tweaked the description on Oh Hi Daniel shuttle to not reference "space roleplay".
tweak: Tweaked the description on STV5 shuttle to include the fact that the crates included are potentially explosive.
/:cl: