### PR TITLE
Xeno "hijack" tweaks++

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -390,7 +390,7 @@ SUBSYSTEM_DEF(shuttle)
 			null, ANNOUNCER_SHUTTLEDOCK, "Priority")
 
 /datum/controller/subsystem/shuttle/proc/checkInfestedEnvironment()
-	for(var/d in infestedEnvironments)
+	for(var/datum/d in infestedEnvironments)
 		var/turf/T = get_turf(d)
 		if(!istype(d) || QDELETED(d) || !is_station_level(T.z)) //If they have been destroyed or left the station Z level, the queen will not trigger this check
 			infestedEnvironments -= d

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -394,7 +394,7 @@ SUBSYSTEM_DEF(shuttle)
 		var/turf/T = get_turf(d)
 		if(!istype(d) || QDELETED(d) || !is_station_level(T.z)) //If they have been destroyed or left the station Z level, the queen will not trigger this check
 			infestedEnvironments -= d
-	emergencyDelayArrival = infestedEnvironments.len
+	emergencyDelayArrival = length(infestedEnvironments)
 	return emergencyDelayArrival
 
 /datum/controller/subsystem/shuttle/proc/delayForInfestedStation()

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -374,10 +374,6 @@ SUBSYSTEM_DEF(shuttle)
 		priority_announce("Hostile environment detected. \
 			Departure has been postponed indefinitely pending \
 			conflict resolution.", null, 'sound/misc/notice1.ogg', "Priority")
-		for(var/i in hostileEnvironments)
-			if(istype(i, /mob/living/carbon/alien/humanoid/royal/queen) && !hostileEnvTrackPlayed)
-				play_soundtrack_music(/datum/soundtrack_song/bee/mind_crawler, only_station = TRUE)
-				hostileEnvTrackPlayed = TRUE
 	if(!emergencyNoEscape && (emergency.mode == SHUTTLE_STRANDED))
 		emergency.mode = SHUTTLE_DOCKED
 		emergency.setTimer(emergencyDockTime)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -390,7 +390,7 @@ SUBSYSTEM_DEF(shuttle)
 			null, ANNOUNCER_SHUTTLEDOCK, "Priority")
 
 /datum/controller/subsystem/shuttle/proc/checkInfestedEnvironment()
-	for(var/datum/d in infestedEnvironments)
+	for(var/d in infestedEnvironments)
 		var/turf/T = get_turf(d)
 		if(!istype(d) || QDELETED(d) || !is_station_level(T.z)) //If they have been destroyed or left the station Z level, the queen will not trigger this check
 			infestedEnvironments -= d

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -390,9 +390,9 @@ SUBSYSTEM_DEF(shuttle)
 			null, ANNOUNCER_SHUTTLEDOCK, "Priority")
 
 /datum/controller/subsystem/shuttle/proc/checkInfestedEnvironment()
-	for(var/datum/d in infestedEnvironments)
+	for(var/mob/d in infestedEnvironments)
 		var/turf/T = get_turf(d)
-		if(!istype(d) || QDELETED(d) || !is_station_level(T.z)) //If they have been destroyed or left the station Z level, the queen will not trigger this check
+		if(QDELETED(d) || !is_station_level(T.z)) //If they have been destroyed or left the station Z level, the queen will not trigger this check
 			infestedEnvironments -= d
 	emergencyDelayArrival = length(infestedEnvironments)
 	return emergencyDelayArrival

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -24,10 +24,13 @@ SUBSYSTEM_DEF(shuttle)
 	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
 	var/area/emergencyLastCallLoc
 	var/emergencyCallAmount = 0		//how many times the escape shuttle was called
-	var/emergencyNoEscape
+	var/emergencyNoEscape			//Hostile environment that prevents the shuttle from leaving after it has arrived
+	var/emergencyDelayArrival 		//Infestation that delays the shuttle arrival while contingency plans are put into place 
 	var/emergencyNoRecall = FALSE
 	var/adminEmergencyNoRecall = FALSE
 	var/list/hostileEnvironments = list() //Things blocking escape shuttle from leaving
+	var/list/infestedEnvironments = list() //Things that can trigger a delay on escape shuttle arrival
+	var/infestationActive = FALSE //So unusual circumstances can't trigger a second infestation warning and delay
 	var/hostileEnvTrackPlayed = FALSE
 	var/list/tradeBlockade = list() //Things blocking cargo from leaving.
 	var/supplyBlocked = FALSE
@@ -337,6 +340,11 @@ SUBSYSTEM_DEF(shuttle)
 	hostileEnvironments -= bad
 	checkHostileEnvironment()
 
+/datum/controller/subsystem/shuttle/proc/registerInfestation(datum/bad)
+	infestedEnvironments[bad] = TRUE //This only matters when shuttle is at a specific stage in evacuation, there is no need to update or check the validity of the list every time it is updated
+
+/datum/controller/subsystem/shuttle/proc/clearInfestation(datum/bad)
+	infestedEnvironments -= bad
 
 /datum/controller/subsystem/shuttle/proc/registerTradeBlockade(datum/bad)
 	tradeBlockade[bad] = TRUE
@@ -380,6 +388,27 @@ SUBSYSTEM_DEF(shuttle)
 		priority_announce("Hostile environment resolved. \
 			You have 3 minutes to board the Emergency Shuttle.",
 			null, ANNOUNCER_SHUTTLEDOCK, "Priority")
+
+/datum/controller/subsystem/shuttle/proc/checkInfestedEnvironment()
+	for(var/datum/d in infestedEnvironments)
+		var/turf/T = get_turf(d)
+		if(!istype(d) || QDELETED(d) || !is_station_level(T.z)) //If they have been destroyed or left the station Z level, the queen will not trigger this check
+			infestedEnvironments -= d
+	emergencyDelayArrival = infestedEnvironments.len
+	return emergencyDelayArrival
+
+/datum/controller/subsystem/shuttle/proc/delayForInfestedStation()
+	if(infestationActive)
+		return
+	infestationActive = TRUE
+	emergencyNoRecall = TRUE
+	priority_announce("Xenomorph infestation detected: crisis shuttle protocols activated - jamming recall signals across all frequencies.")
+	play_soundtrack_music(/datum/soundtrack_song/bee/mind_crawler, only_station = TRUE)
+	if(EMERGENCY_IDLE_OR_RECALLED)
+		emergency.request(null, set_coefficient=1) //If a shuttle wasn't already called, call one now, with 10 minute delay
+	else if(emergency.mode == SHUTTLE_CALL)
+		emergency.setTimer(10 MINUTES) //If shuttle was already in transit, delay the arrival time to 10 minutes
+		//If the emergency shuttle has already passed the point of no return before a queen existed, do not delay round for Xenomorphs - they spawned too late on a round that was already coming to an end. 
 
 //try to move/request to dockHome if possible, otherwise dockAway. Mainly used for admin buttons
 /datum/controller/subsystem/shuttle/proc/toggleShuttle(shuttleId, dockHome, dockAway, timed)

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -4,7 +4,9 @@
 //Simply lists them.
 /datum/team/xeno/roundend_report()
 	var/list/parts = list()
-	parts += "<span class='header'>The [name] [SSshuttle.emergency.is_hijacked_by_xenos() ? "were <span class='greentext'>successful</span>" : "have <span class='redtext'>failed</span>"] in hijacking the shuttle!</span>\n"
+	var/success = SSshuttle.emergency.is_hijacked_by_xenos()
+	parts += "<span class='header'>The [name] [success ? "have <span class='greentext'>succeeded!</span>" : "have <span class='redtext'>failed!</span>"]</span>\n"
+	parts += "<b>[success ? "The Queen has left the station alive and the colony will continue to spread!" : "The remnants of the colony will wither in isolation"]</b>"
 	parts += "The [name] were:"
 	parts += printplayerlist(members)
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -411,21 +411,17 @@
 	return has_people && ((hijacker_count == 1) || (hijacker_count && !solo_hijack))
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked_by_xenos()
-	var/has_xenos = FALSE
+	var/queen_alive_on_shuttle = FALSE
+	//checking all players
 	for(var/mob/living/player in GLOB.alive_mob_list)
-		if(issilicon(player)) //Borgs are technically dead anyways
+		if(issilicon(player)) //Borged queen brain is dead, skip
 			continue
-		if(isanimal(player)) //animals don't count
-			continue
-		if(isbrain(player)) //also technically dead
+		if(isbrain(player)) //loose brain is also dead, skip
 			continue
 		if(shuttle_areas[get_area(player)])
-			//Non-xeno present. Can't hijack.
-			if(!istype(player, /mob/living/carbon/alien))
-				return FALSE
-			has_xenos = TRUE
-
-	return has_xenos
+			if(isalienqueen(player))
+				queen_alive_on_shuttle = TRUE
+	return queen_alive_on_shuttle
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked()
 	return hijack_status == HIJACKED

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -420,10 +420,6 @@
 	var/queen_alive_on_shuttle = FALSE
 	//checking all players
 	for(var/mob/living/player in GLOB.alive_mob_list)
-		if(issilicon(player)) //Borged queen brain is dead, skip
-			continue
-		if(isbrain(player)) //loose brain is also dead, skip
-			continue
 		if(shuttle_areas[get_area(player)])
 			if(isalienqueen(player))
 				queen_alive_on_shuttle = TRUE

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -417,13 +417,11 @@
 	return has_people && ((hijacker_count == 1) || (hijacker_count && !solo_hijack))
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked_by_xenos()
-	var/queen_alive_on_shuttle = FALSE
 	//checking all players
 	for(var/mob/living/player in GLOB.alive_mob_list)
 		if(shuttle_areas[get_area(player)])
 			if(isalienqueen(player))
-				queen_alive_on_shuttle = TRUE
-	return queen_alive_on_shuttle
+				return TRUE
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked()
 	return hijack_status == HIJACKED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Changes the wording of green/redtext so it no longer references hijacking
* Changes the success check for Xenos to greentext - now the only requirement for greentext is to have the Queen escape alive on the shuttle.
* Gets rid of the hostile environment, replacing it with a 10 minute shuttle delay.
   * If a queen has been alive for 30 minutes, shuttle is called with a 10 minute timer
   * If shuttle is called while a queen is present, it will be delayed at a random point during transit
   * Once the shuttle arrives it will behave normally, and survivors will be able to board the shuttle and flee

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
### Wording of objective: 

Hijacking was changed some time ago to involve actually hacking the navigation console, something that makes **no sense** whatsoever for a Xenomorph to be doing. Changing the text to a different wording that better matches their actual goal prevents confusion for newer players that are perhaps not as familiar with Xenos. 

### Changing the actual objective

This is good for the same reason the hijack objective was changed for everyone else: Complete, 100% eradication of all other life on the shuttle simply doesn't make sense. However, for Xenos the goal is simply spreading their colony beyond the confines of an isolated space station, not literally hijacking the controls of the shuttle. The new goal reflects success if a viable queen arrives at Central Command, because as far as Xenos in the current round are concerned, this is successful. 

> But this means Xenos can just try to hide on the shuttle for greentext. 

Yes it does, and tbh this makes sense just fine. Again, their goal is not eradication, it is to avoid isolation and to spread their colony. While this is ultimately just as lame of a greentext strategy as it is a redtext strategy for the opposition, it at least makes some sense IC when it happens this way. It is also substantially harder (but I acknowledge it is still possible!) for aliens to pull off sneaking into the shuttle since they lack the dexterity that normal player races have. 

### Hostile Environment

Holding rounds hostage is dumb for an auxilliary antagonist. They aren't a cult where the entire round revolves around them, they're a secondary spawn that happens to keep things interesting. Sometimes they aren't needed because the round is already wrapping up and screeching the conclusion to a halt because some worms want to murderbone everyone isn't any better than doing it for a nightmare that wants to murderbone everyone.

And most importantly, 90% of the station crew and players are actively expected to avoid combat whenever possible. Xenos are a threat that everyone should be absolutely *terrified* of and this is an RP server. Forcing the crew into the same response of "fight to the death" only contributes to making the encounter stale.

### Shuttle Delay

Following in line with the above - while it makes sense for players to run immediately any time and every time they see Xenomorphs... this isn't particularly good game design either. A much shorter delay on evacuation ensures the event remains a tense life-or-death situation, but no longer a forced fight to the death with little alternative. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/200610668-4f561c8e-a403-4d99-b78a-df483855ebdc.png)
![image](https://user-images.githubusercontent.com/9547572/200610703-0d32a642-b2c4-49ca-a545-13dbef44abeb.png)

### Testing process for shuttle delay + alien event announcement and music:

**30 minute queen timer runs out while queen is on station with no shuttle called:**
	Shuttle is force called, 10 minutes, no-recall active
	Announcement and music triggers
	Working as intended
	
**30 minute queen timer runs out while queen is on station, but shuttle happened to be called already**
	Shuttle timer is adjusted to 10 minutes, no-recall active
	Announcement and music triggers
	Working as intended

**Calling a shuttle while when a queen is on the station, too soon for 30 minute queen timer to run its course**
	Shuttle is delayed at a random point during transit, transit timer set to 10 minutes and no-recall is triggered
	Announcement and music triggers
	Working as intended*

**Calling, then canceling a shuttle while queen is on station**
	Timer is deleted and no event is triggered until the spawn timer fires
	Shuttle must be canceled before random transit event fires
	Working as intended

**Queen leaves Z-level, timeout runs its course**
	Timeout results in no event being triggered, game continues as normal
	Working as intended*

**Queen leaves Z-level, shuttle is called**
	Infested environment is not detected, shuttle arrives as normal
	Working as intended*
	
Attempt calling a second Xeno event, through any means
	Nothing happens, event can only be fired once per round
	Working as intended

*Misc. Info:
 * Xeno event firing during shuttle transit occurs between 2:30 into the shuttle call and the end of it. If the event triggers *before* 2:30 then it was the 30 minute timer associated with the queen.
 * An infestation can theoretically stall the round indefinitely by pulling off a total genocide while their queen is off-station or dies at precisely the right timing. I couldn't think of any feasible way this could be pulled off by creatures that can't use shuttles or other cross-Z travel on their own, so I think this falls into the realm of "Admin enforcement issue" in the rare event it happens.
 * Under specific circumstances, the infestation event will not fire when players may perceive that it should have. The following circumstances are intentionally left out to prevent rounds that were already ending from being held hostage by a fresh antag:
   * Shuttle is already called before any queen exists
   * Due to event proc relying on a queen being active *at the time it runs out* rare cases where the queen is killed but replaced will result in shuttle not being delayed because there was no queen when the event was checked. Chalk this up to Nanotrasen failing to detect the infestation.


</details>

## Changelog
:cl:
tweak: Xeno win condition has been altered and reworded slightly to better fit expectations and avoid confusion regarding hijacking. The goal of Xenomorphs is now to get a living queen to Central Command so that the colony may continue to spread.
tweak: Xenos no longer force a hostile environment just by existing, instead triggering a delayed shuttle arrival under most circumstances. Aside from a delay on arrival, evacuations may be performed normally, including early launches to escape the threat if the crew held out during the delay. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
