### PR TITLE
Fixes primal lasso and drake armor crafting for ashwalkers

### DIFF
--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -31,7 +31,9 @@
 /datum/antagonist/ashwalker/on_gain()
 	. = ..()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, .proc/on_examinate)
-	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key, /datum/crafting_recipe/drakecloak)
+	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
+	owner.teach_crafting_recipe(/datum/crafting_recipe/drakecloak)
+	owner.teach_crafting_recipe(/datum/crafting_recipe/primal_lasso)
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -85,15 +85,3 @@
 	inherent_traits = list(TRAIT_NOGUNS,TRAIT_NOBREATH)
 	species_language_holder = /datum/language_holder/lizard/ash
 	digitigrade_customization = DIGITIGRADE_FORCED
-
-/datum/species/lizard/ashwalker/after_equip_job(datum/job/J, mob/living/carbon/human/H, client/preference_source = null) // For roundstart
-	H.mind?.teach_crafting_recipe(/datum/crafting_recipe/primal_lasso)
-	return ..()
-
-/datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load) // For transformations
-	C.mind?.teach_crafting_recipe(/datum/crafting_recipe/primal_lasso)
-	return ..()
-
-/datum/species/lizard/ashwalker/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
-	C.mind?.forget_crafting_recipe(/datum/crafting_recipe/primal_lasso)
-	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes a bug in how crafting recipes were added to the minds of ashwalkers, allowing them to craft primal lassos and ash drake armor when they otherwise couldn't. 

The bug was caused in one case by trying to pass invalid arguments to teach_crafting_recipe, and in another case by trying to add teach_crafting_recipe at the species addition point instead of the antagonist addition point, which meant that it wouldn't be added to the ashie's mind.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Bugs are bad. Goliath herding good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/201369749-34c73b93-703b-43ec-820b-6c150e44ba54.png)

</details>

## Changelog
:cl:
fix: Fixes primal lasso crafting and ash drake armor crafting for ashwalkers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
