### PR TITLE
Staffwho and Mentorwho minor changes.

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -59,66 +59,19 @@
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"
-	
-	var/msg = "<b>Current Admins:</b>\n"
-	if(holder)
-		for(var/client/C in GLOB.admins)
-			msg += "\t[C] is a [C.holder.rank]"
-
-			if(C.holder.fakekey)
-				msg += " <i>(as [C.holder.fakekey])</i>"
-
-			if(isobserver(C.mob))
-				msg += " - Observing"
-			else if(isnewplayer(C.mob))
-				msg += " - Lobby"
-			else
-				msg += " - Playing"
-
-			if(C.is_afk())
-				msg += " (AFK)"
-			msg += "\n"
-		msg += "<b>Current Mentors:</b>\n"
-		for(var/client/C in GLOB.mentors)
-			msg += "\t[C] is a mentor"
-
-			if(isobserver(C.mob))
-				msg += " - Observing"
-			else if(isnewplayer(C.mob))
-				msg += " - Lobby"
-			else
-				msg += " - Playing"
-
-			if(C.is_afk())
-				msg += " (AFK)"
-			msg += "\n"
-	else
-		for(var/client/C in GLOB.admins)
-			if(C.is_afk())
-				continue //Don't show afk admins to adminwho
-			if(!C.holder.fakekey)
-				msg += "\t[C] is a [C.holder.rank]\n"
-		msg += "<b>Current Mentors:</b>\n"
-		for(var/client/C in GLOB.mentors)
-			if(C.is_afk())
-				continue //Don't show afk admins to adminwho
-			msg += "\t[C] is a mentor\n"
-
-		msg += "<span class='info'>Adminhelps are also sent through TGS to services like IRC and Discord. If no admins are available in game adminhelp anyways and an admin will see it and respond.</span>"
-		if(world.time - src.staff_check_rate > 1 MINUTES)
-			message_admins("[ADMIN_LOOKUPFLW(src.mob)] has checked online staff.")
-			log_admin("[key_name(src)] has checked online staff.")
-			src.staff_check_rate = world.time
-	to_chat(src, msg)
+	staff_who("Staffwho")
 
 /client/verb/mentorwho()  // redundant with staffwho, but people wont check the admin tab for if there are mentors on
 	set category = "Mentor"
 	set name = "Mentorwho"
+	staff_who("Mentorwho")
 
+/client/proc/staff_who(via)
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)
-			msg += "\t[C] is a [C.holder.rank]"
+			var/rank = "\improper [C.holder.rank]"
+			msg += "\t[C] is \a [rank]"
 
 			if(C.holder.fakekey)
 				msg += " <i>(as [C.holder.fakekey])</i>"
@@ -135,7 +88,7 @@
 			msg += "\n"
 		msg += "<b>Current Mentors:</b>\n"
 		for(var/client/C in GLOB.mentors)
-			msg += "\t[C] is a mentor"
+			msg += "\t[C] is a Mentor"
 
 			if(isobserver(C.mob))
 				msg += " - Observing"
@@ -152,17 +105,18 @@
 			if(C.is_afk())
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
-				msg += "\t[C] is a [C.holder.rank]\n"
+				var/rank = "\improper [C.holder.rank]"
+				msg += "\t[C] is \a [rank]\n"
 		msg += "<b>Current Mentors:</b>\n"
 		for(var/client/C in GLOB.mentors)
 			if(C.is_afk())
 				continue //Don't show afk admins to adminwho
-			msg += "\t[C] is a mentor\n"
+			msg += "\t[C] is a Mentor\n"
 
 		msg += "<span class='info'>Adminhelps are also sent through TGS to services like IRC and Discord. If no admins are available in game adminhelp anyways and an admin will see it and respond.</span>"
 		if(world.time - src.staff_check_rate > 1 MINUTES)
-			message_admins("[ADMIN_LOOKUPFLW(src.mob)] has checked online staff.")
-			log_admin("[key_name(src)] has checked online staff.")
+			message_admins("[ADMIN_LOOKUPFLW(src.mob)] has checked online staff[via ? " (via [via])" : ""].")
+			log_admin("[key_name(src)] has checked online staff[via ? " (via [via])" : ""].")
 			src.staff_check_rate = world.time
 	to_chat(src, msg)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Merges the code for Staffwho and Mentorwho (it was literally copy-pasted).
Adds 'an' to ranks in Staffwho where needed.
Adds logging to Mentorwho as well as notifying admins about it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Seeing 'x is a Admin' was somewhat painful, so this fixes that. Also prevents people from cheating the system to check for current non-stealthed admins without that being logged by using Mentorwho.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
'an' being applied when needed

![image](https://user-images.githubusercontent.com/110184118/201481337-d9e17ed8-1521-4a66-bfb8-f582eb7bc87a.png)
Staffwho and Adminwho messages

![image](https://user-images.githubusercontent.com/110184118/201481369-00e4463e-dbd2-4d5d-bc4d-4cee1b6a5557.png)


</details>

## Changelog
:cl:
fix: Fixed staffwho using "a" wrongly in the rank text.
code: Merged Staffwho and Mentorwho's code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
