### PR TITLE
Area dependant airlock hack difficulty

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -29,6 +29,7 @@
 #include "code\__DEFINES\actionspeed_modification.dm"
 #include "code\__DEFINES\admin.dm"
 #include "code\__DEFINES\ai.dm"
+#include "code\__DEFINES\airlock.dm"
 #include "code\__DEFINES\antagonists.dm"
 #include "code\__DEFINES\aquarium.dm"
 #include "code\__DEFINES\areas.dm"

--- a/code/__DEFINES/airlock.dm
+++ b/code/__DEFINES/airlock.dm
@@ -1,0 +1,26 @@
+#define AIRLOCK_SECURITY_NONE			0 //Normal airlock				//Wires are not secured
+#define AIRLOCK_SECURITY_IRON			1 //Medium security airlock		//There is a simple iron over wires (use welder)
+#define AIRLOCK_SECURITY_PLASTEEL_I_S	2 								//Sliced inner plating (use crowbar), jumps to 0
+#define AIRLOCK_SECURITY_PLASTEEL_I		3 								//Removed outer plating, second layer here (use welder)
+#define AIRLOCK_SECURITY_PLASTEEL_O_S	4 								//Sliced outer plating (use crowbar)
+#define AIRLOCK_SECURITY_PLASTEEL_O		5 								//There is first layer of plasteel (use welder)
+#define AIRLOCK_SECURITY_PLASTEEL		6 //Max security airlock		//Fully secured wires (use wirecutters to remove grille, that is electrified)
+
+#define AIRLOCK_WIRE_SECURITY_NONE 0	// Airlocks that are super easy to hack and have mostly labelled wires. No risk.
+#define AIRLOCK_WIRE_SECURITY_SIMPLE 1	// Airlock with less labelled wires, takes longer to hack but not shock risk.
+#define AIRLOCK_WIRE_SECURITY_PROTECTED 2	// Airlock has no labelled wires and has a single shock wire
+#define AIRLOCK_WIRE_SECURITY_ADVANCED 3	// Airlock has 2 duds and 1 shock wire
+#define AIRLOCK_WIRE_SECURITY_ELITE 4	// Airlock has 2 duds and 2 shock wires
+#define AIRLOCK_WIRE_SECURITY_MAXIMUM 5	// Airlock has 2 duds, 2 shock wires and only a single power cable.
+
+#define AIRLOCK_CLOSED	1
+#define AIRLOCK_CLOSING	2
+#define AIRLOCK_OPEN	3
+#define AIRLOCK_OPENING	4
+#define AIRLOCK_DENY	5
+#define AIRLOCK_EMAG	6
+
+#define AIRLOCK_INTEGRITY_N			 300 // Normal airlock integrity
+#define AIRLOCK_INTEGRITY_MULTIPLIER 1.5 // How much reinforced doors health increases
+#define AIRLOCK_DAMAGE_DEFLECTION_N  21  // Normal airlock damage deflection
+#define AIRLOCK_DAMAGE_DEFLECTION_R  30  // Reinforced airlock damage deflection

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -27,12 +27,14 @@
 	var/holder_type = null // The holder's typepath (used to make wire colors common to all holders).
 	var/proper_name = "Unknown" // The display name for the wire set shown in station blueprints. Not used if randomize is true or it's an item NT wouldn't know about (Explosives/Nuke)
 
-	var/list/wires = list() // List of wires.
+	var/list/wires = list() // Dictionary of wires to colours.
 	var/list/cut_wires = list() // List of wires that have been cut.
 	var/list/colors = list() // Dictionary of colors to wire.
+	var/list/wire_to_colors = list() // Dictionary of colors to wire.
 	var/list/assemblies = list() // List of attached assemblies.
 	var/randomize = 0 // If every instance of these wires should be random.
 					  // Prevents wires from showing up in station blueprints
+	var/list/labelled_wires = list() // Associative List of wires that have labels. Key = wire, Value = Bool (Revealed) [To be refactored into skills]
 
 /datum/wires/New(atom/holder)
 	..()
@@ -49,6 +51,10 @@
 			GLOB.wire_name_directory[holder_type] = proper_name
 		else
 			colors = GLOB.wire_color_directory[holder_type]
+
+	for (var/colour in colors)
+		var/wire = colors[colour]
+		wire_to_colors[wire] = colour
 
 /datum/wires/Destroy()
 	holder = null
@@ -100,10 +106,7 @@
 	return colors[color]
 
 /datum/wires/proc/get_color_of_wire(wire_type)
-	for(var/color in colors)
-		var/other_type = colors[color]
-		if(wire_type == other_type)
-			return color
+	return wire_to_colors[wire_type]
 
 /datum/wires/proc/get_attached(color)
 	if(assemblies[color])
@@ -257,9 +260,10 @@
 		reveal_wires = TRUE
 
 	for(var/color in colors)
+		var/wire_type = get_wire(color)
 		payload.Add(list(list(
 			"color" = color,
-			"wire" = ((reveal_wires && !is_dud_color(color)) ? get_wire(color) : null),
+			"wire" = (((reveal_wires || labelled_wires[wire_type]) && !is_dud_color(color)) ? wire_type : null),
 			"cut" = is_color_cut(color),
 			"attached" = is_attached(color)
 		)))

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -14,28 +14,28 @@
 	)
 	src.security_level = security_level
 	//Add more power wires
-	if (security_level <= 4)
+	if (security_level <= AIRLOCK_WIRE_SECURITY_ELITE)
 		wires |= WIRE_POWER2
 		wires |= WIRE_BACKUP2
 	//Add zap wires
-	if (security_level >= 2)
+	if (security_level >= AIRLOCK_WIRE_SECURITY_PROTECTED)
 		wires |= WIRE_ZAP1
-	if (security_level >= 4)
+	if (security_level >= AIRLOCK_WIRE_SECURITY_ELITE)
 		wires |= WIRE_ZAP2
 	//Add dud wires
-	if (security_level >= 3)
+	if (security_level >= AIRLOCK_WIRE_SECURITY_ADVANCED)
 		add_duds(2)
-	else if (security_level >= 1)
+	else if (security_level >= AIRLOCK_WIRE_SECURITY_SIMPLE)
 		add_duds(1)
 
 	//Add labelled wires
-	if (security_level <= 0)
+	if (security_level <= AIRLOCK_WIRE_SECURITY_NONE)
 		//At security level 0, the following wires could be unknowns:
 		//POWER1, BACKUP1, IDSCAN, AI WIRE, LIGHT
 		labelled_wires[WIRE_OPEN] = TRUE
 		labelled_wires[WIRE_BOLTS] = TRUE
 		labelled_wires[WIRE_SHOCK] = TRUE
-	if (security_level <= 1)
+	if (security_level <= AIRLOCK_WIRE_SECURITY_SIMPLE)
 		//At security level 1, there are duds and the open, bolt and shock wires are not revealed.
 		labelled_wires[WIRE_SAFETY] = TRUE
 		labelled_wires[WIRE_TIMING] = TRUE

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -2,16 +2,44 @@
 	holder_type = /obj/machinery/door/airlock
 	proper_name = "Airlock"
 	randomize = TRUE
+	var/security_level = 0
 
-/datum/wires/airlock/New(atom/holder)
+/datum/wires/airlock/New(atom/holder, security_level)
+	//Set the default wires
 	wires = list(
-		WIRE_POWER1, WIRE_POWER2,
-		WIRE_BACKUP1, WIRE_BACKUP2,
+		WIRE_POWER1,
+		WIRE_BACKUP1,
 		WIRE_OPEN, WIRE_BOLTS, WIRE_IDSCAN, WIRE_AI,
 		WIRE_SHOCK, WIRE_SAFETY, WIRE_TIMING, WIRE_LIGHT,
-		WIRE_ZAP1, WIRE_ZAP2
 	)
-	add_duds(2)
+	src.security_level = security_level
+	//Add more power wires
+	if (security_level <= 4)
+		wires |= WIRE_POWER2
+		wires |= WIRE_BACKUP2
+	//Add zap wires
+	if (security_level >= 2)
+		wires |= WIRE_ZAP1
+	if (security_level >= 4)
+		wires |= WIRE_ZAP2
+	//Add dud wires
+	if (security_level >= 3)
+		add_duds(2)
+	else if (security_level >= 1)
+		add_duds(1)
+
+	//Add labelled wires
+	if (security_level <= 0)
+		//At security level 0, the following wires could be unknowns:
+		//POWER1, BACKUP1, IDSCAN, AI WIRE, LIGHT
+		labelled_wires[WIRE_OPEN] = TRUE
+		labelled_wires[WIRE_BOLTS] = TRUE
+		labelled_wires[WIRE_SHOCK] = TRUE
+	if (security_level <= 1)
+		//At security level 1, there are duds and the open, bolt and shock wires are not revealed.
+		labelled_wires[WIRE_SAFETY] = TRUE
+		labelled_wires[WIRE_TIMING] = TRUE
+
 	..()
 
 /datum/wires/airlock/interactable(mob/user)
@@ -31,6 +59,7 @@
 	status += "The timer is powered [A.autoclose ? "on" : "off"]."
 	status += "The speed light is [A.normalspeed ? "on" : "off"]."
 	status += "The emergency light is [A.emergency ? "on" : "off"]."
+
 	return status
 
 /datum/wires/airlock/on_pulse(wire)
@@ -82,7 +111,7 @@
 				A.update_icon()
 			if(WIRE_ZAP1, WIRE_ZAP2) // Doors have a lot of power coursing through them, even a multitool can be overloaded on the wrong wires
 				if(isliving(usr))
-					A.shock(usr, 100) 
+					A.shock(usr, 100)
 	ui_update()
 	A.ui_update()
 
@@ -96,8 +125,8 @@
 
 /datum/wires/airlock/on_cut(wire, mend)
 	var/obj/machinery/door/airlock/A = holder
-	if(isliving(usr) && A.hasPower())	
-		A.shock(usr, 100) //Cutting wires directly on powered doors without protection is not advised. 
+	if(isliving(usr) && A.hasPower())
+		A.shock(usr, 100) //Cutting wires directly on powered doors without protection is not advised.
 	switch(wire)
 		if(WIRE_POWER1, WIRE_POWER2) // Cut to loose power, repair all to gain power.
 			if(mend && !is_cut(WIRE_POWER1) && !is_cut(WIRE_POWER2))

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -124,6 +124,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_job_reverse = TRUE
 	lighting_colour_tube = "#ffe5cb"
 	lighting_colour_bulb = "#ffdbb4"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 //Maintenance - Departmental
 
@@ -463,6 +464,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_brightness_tube = 8
 	sound_environment = SOUND_AREA_STANDARD_STATION
 
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
+
 /area/bridge/meeting_room
 	name = "Heads of Staff Meeting Room"
 	icon_state = "meeting"
@@ -482,31 +485,38 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Captain's Office"
 	icon_state = "captain"
 	sound_environment = SOUND_AREA_WOODFLOOR
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/crew_quarters/heads/captain/private
 	name = "Captain's Quarters"
 	icon_state = "captain_private"
 	sound_environment = SOUND_AREA_WOODFLOOR
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/crew_quarters/heads/chief
 	name = "Chief Engineer's Office"
 	icon_state = "ce_office"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/cmo
 	name = "Chief Medical Officer's Office"
 	icon_state = "cmo_office"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/hop
 	name = "Head of Personnel's Office"
 	icon_state = "hop_office"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/hos
 	name = "Head of Security's Office"
 	icon_state = "hos_office"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/hor
 	name = "Research Director's Office"
 	icon_state = "rd_office"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/comms
 	name = "Communications Relay"
@@ -514,11 +524,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#e2feff"
 	lighting_colour_bulb = "#d5fcff"
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/server
 	name = "Messaging Server Room"
 	icon_state = "server"
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 //Crew
 
@@ -633,6 +645,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#fff4d6"
 	lighting_colour_bulb = "#ffebc1"
 	sound_environment = SOUND_AREA_WOODFLOOR
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/crew_quarters/bar/mood_check(mob/living/carbon/subject)
 	if(istype(subject) && HAS_TRAIT(subject, TRAIT_LIGHT_DRINKER))
@@ -690,6 +703,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#ffce99"
 	lighting_colour_bulb = "#ffdbb4"
 	lighting_brightness_tube = 8
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/library/lounge
 	name = "Library Lounge"
@@ -708,6 +722,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	clockwork_warp_allowed = FALSE
 	clockwork_warp_fail = "The consecration here prevents you from warping in."
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/chapel/main
 	name = "Chapel"
@@ -735,6 +750,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Law Office"
 	icon_state = "law"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 
 //Engineering
@@ -744,6 +760,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 	lighting_colour_tube = "#ffce93"
 	lighting_colour_bulb = "#ffbc6f"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/engine/engine_smes
 	name = "Engineering SMES"
@@ -767,6 +784,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "atmos_engine"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/engine/engine_room //donut station specific
 	name = "Engine Room"
@@ -775,12 +793,14 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/engine/engine_room/external
 	name = "Supermatter External Access"
 	icon_state = "engine_foyer"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/engine/supermatter
 	name = "Supermatter Engine"
 	icon_state = "engine_sm_room"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/engine/break_room
 	name = "Engineering Foyer"
@@ -794,6 +814,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "grav_gen"
 	clockwork_warp_allowed = FALSE
 	clockwork_warp_fail = "The gravitons generated here could throw off your warp's destination and possibly throw you into deep space."
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/engine/storage
 	name = "Engineering Storage"
@@ -898,12 +919,14 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Teleporter Room"
 	icon_state = "teleporter"
 	ambience_index = AMBIENCE_ENGI
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/gateway
 	name = "Gateway"
 	icon_state = "gateway"
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 //MedBay
 
@@ -916,6 +939,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_message = "<span class='nicegreen'>I feel safe in here!\n</span>"
 	lighting_colour_tube = "#e7f8ff"
 	lighting_colour_bulb = "#d5f2ff"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/medical/medbay/zone2
 	name = "Medbay"
@@ -978,6 +1002,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Virology"
 	icon_state = "virology"
 	flags_1 = NONE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/medical/morgue
 	name = "Morgue"
@@ -986,10 +1011,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 	mood_bonus = -2
 	mood_message = "<span class='warning'>It smells like death in here!\n</span>"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/medical/chemistry
 	name = "Chemistry"
 	icon_state = "chem"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/medical/chemistry/upper
 	name = "Upper Chemistry"
@@ -1002,6 +1029,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/medical/surgery
 	name = "Surgery"
 	icon_state = "surgery"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/medical/surgery/aux
 	name = "Auxillery Surgery"
@@ -1018,6 +1046,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/medical/genetics
 	name = "Genetics Lab"
 	icon_state = "genetics"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/medical/genetics/cloning
 	name = "Cloning Lab"
@@ -1037,6 +1066,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	lighting_colour_tube = "#ffeee2"
 	lighting_colour_bulb = "#ffdfca"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/security/main
 	name = "Security Office"
@@ -1055,6 +1085,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Courtroom"
 	icon_state = "courtroom"
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/security/prison
 	name = "Prison Wing"
@@ -1110,10 +1141,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/ai_monitored/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/security/checkpoint
 	name = "Security Checkpoint"
@@ -1186,6 +1219,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#ffe3cc"
 	lighting_colour_bulb = "#ffdbb8"
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/quartermaster/sorting
 	name = "Delivery Office"
@@ -1209,6 +1243,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/cargo/lobby
 	name = "\improper Cargo Lobby"
 	icon_state = "cargo_lobby"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/quartermaster/qm
 	name = "Quartermaster's Office"
@@ -1247,11 +1282,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_bonus = -1
 	mood_message = "<span class='warning'>It feels dirty in here!\n</span>"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/hydroponics
 	name = "Hydroponics"
 	icon_state = "hydro"
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/hydroponics/garden
 	name = "Garden"
@@ -1277,6 +1314,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#f0fbff"
 	lighting_colour_bulb = "#e4f7ff"
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/science/lobby
 	name = "\improper Science Lobby"
@@ -1302,6 +1340,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/science/storage
 	name = "Toxins Storage"
 	icon_state = "tox_storage"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/science/test_area
 	name = "Toxins Test Area"
@@ -1311,6 +1350,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/science/mixing
 	name = "Toxins Mixing Lab"
 	icon_state = "tox_mix"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/science/mixing/chamber
 	name = "Toxins Mixing Chamber"
@@ -1328,6 +1368,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/science/server
 	name = "Research Division Server Room"
 	icon_state = "server"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/science/explab
 	name = "Experimentation Lab"
@@ -1365,6 +1406,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Storage
 /area/storage
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/storage/tools
 	name = "Auxiliary Tool Storage"
@@ -1407,6 +1449,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "yellow"
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/construction/mining/aux_base
 	name = "Auxiliary Base Construction"
@@ -1452,6 +1495,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/ai_monitored
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/ai_monitored/security/armory
 	name = "Armory"
@@ -1544,6 +1588,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg', 'sound/ambience/ambitech.ogg',\
 											'sound/ambience/ambitech2.ogg', 'sound/ambience/ambitech3.ogg', 'sound/ambience/ambimystery.ogg')
 	network_root_id = STATION_NETWORK_ROOT	// They should of unpluged the router before they left
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/tcommsat/computer
 	name = "Telecomms Control Room"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -102,6 +102,9 @@
 	/// Area network id when you want to find all devices hooked up to this area
 	var/network_area_id = null
 
+	/// How hard it is to hack airlocks in this area
+	var/airlock_hack_difficulty = AIRLOCK_SECURITY_NONE
+
 /**
   * A list of teleport locations
   *

--- a/code/game/area/areas/away_content.dm
+++ b/code/game/area/areas/away_content.dm
@@ -10,6 +10,7 @@ Unused icons for new areas are "awaycontent1" ~ "awaycontent30"
 	has_gravity = STANDARD_GRAVITY
 	ambience_index = AMBIENCE_AWAY
 	sound_environment = SOUND_ENVIRONMENT_ROOM
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/awaymission/beach
 	name = "Beach"

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -14,6 +14,7 @@
 	teleport_restriction = TELEPORT_ALLOW_NONE
 	area_flags = VALID_TERRITORY | UNIQUE_AREA
 	flags_1 = NONE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/centcom/control
 	name = "CentCom Docks"
@@ -128,6 +129,7 @@
 	area_flags = VALID_TERRITORY | UNIQUE_AREA
 	flags_1 = NONE
 	network_root_id = "MAGIC_NET"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 //Abductors
 /area/abductor_ship
@@ -139,6 +141,7 @@
 	has_gravity = STANDARD_GRAVITY
 	flags_1 = NONE
 	network_root_id = "ALIENS"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 //Syndicates
 /area/syndicate_mothership
@@ -151,6 +154,7 @@
 	flags_1 = NONE
 	ambience_index = AMBIENCE_DANGER
 	network_root_id = SYNDICATE_NETWORK_ROOT
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/syndicate_mothership/control
 	name = "Syndicate Control Room"
@@ -170,6 +174,7 @@
 	icon_state = "yellow"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/ctf/control_room
 	name = "Control Room A"
@@ -208,6 +213,7 @@
 	teleport_restriction = TELEPORT_ALLOW_CLOCKWORK
 	area_flags = VALID_TERRITORY | UNIQUE_AREA | HIDDEN_AREA
 	ambience_index = AMBIENCE_REEBE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/reebe/city_of_cogs
 	name = "Reebe - City of Cogs"

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -6,6 +6,7 @@
 	lighting_colour_tube = "#ffe8d2"
 	lighting_colour_bulb = "#ffdcb7"
 	area_flags = VALID_TERRITORY | UNIQUE_AREA | FLORA_ALLOWED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/mine/explored
 	name = "Mine"

--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -8,6 +8,7 @@
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	ambience_index = AMBIENCE_RUINS
 	sound_environment = SOUND_ENVIRONMENT_STONEROOM
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/ruin/unpowered
 	always_unpowered = FALSE

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -13,6 +13,7 @@
 	lighting_colour_tube = "#fff0dd"
 	lighting_colour_bulb = "#ffe1c1"
 	sound_environment = SOUND_ENVIRONMENT_ROOM
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 	//The mobile port attached to this area
 	var/obj/docking_port/mobile/mobile_port
 
@@ -66,6 +67,7 @@
 	name = "Syndicate Infiltrator"
 	ambience_index = AMBIENCE_DANGER
 	canSmoothWithAreas = /area/shuttle/syndicate
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/shuttle/syndicate/bridge
 	name = "Syndicate Infiltrator Control"
@@ -219,6 +221,7 @@
 
 /area/shuttle/syndicate_scout
 	name = "Syndicate Scout"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/shuttle/caravan
 	requires_power = TRUE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -31,26 +31,6 @@
 
 // Wires for the airlock are located in the datum folder, inside the wires datum folder.
 
-#define AIRLOCK_CLOSED	1
-#define AIRLOCK_CLOSING	2
-#define AIRLOCK_OPEN	3
-#define AIRLOCK_OPENING	4
-#define AIRLOCK_DENY	5
-#define AIRLOCK_EMAG	6
-
-#define AIRLOCK_SECURITY_NONE			0 //Normal airlock				//Wires are not secured
-#define AIRLOCK_SECURITY_IRON			1 //Medium security airlock		//There is a simple iron over wires (use welder)
-#define AIRLOCK_SECURITY_PLASTEEL_I_S	2 								//Sliced inner plating (use crowbar), jumps to 0
-#define AIRLOCK_SECURITY_PLASTEEL_I		3 								//Removed outer plating, second layer here (use welder)
-#define AIRLOCK_SECURITY_PLASTEEL_O_S	4 								//Sliced outer plating (use crowbar)
-#define AIRLOCK_SECURITY_PLASTEEL_O		5 								//There is first layer of plasteel (use welder)
-#define AIRLOCK_SECURITY_PLASTEEL		6 //Max security airlock		//Fully secured wires (use wirecutters to remove grille, that is electrified)
-
-#define AIRLOCK_INTEGRITY_N			 300 // Normal airlock integrity
-#define AIRLOCK_INTEGRITY_MULTIPLIER 1.5 // How much reinforced doors health increases
-#define AIRLOCK_DAMAGE_DEFLECTION_N  21  // Normal airlock damage deflection
-#define AIRLOCK_DAMAGE_DEFLECTION_R  30  // Reinforced airlock damage deflection
-
 /obj/machinery/door/airlock
 	name = "airlock"
 	icon = 'icons/obj/doors/airlocks/station/public.dmi'
@@ -75,7 +55,8 @@
 
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
 
-	var/security_level = 0 //How much are wires secured
+	var/security_level = AIRLOCK_SECURITY_NONE //How much are wires secured
+	var/wire_security_level = 0	//How difficult the door is to hack
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = FALSE // if true, this door can't be hacked by the AI
 	var/secondsMainPowerLost = 0 //The number of seconds until power is restored.
@@ -129,7 +110,12 @@
 
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/airlock(src)
+
+	//Get the area hack difficulty
+	var/area/A = get_area(src)
+	wire_security_level = max(wire_security_level, A.airlock_hack_difficulty)
+
+	wires = new /datum/wires/airlock(src, wire_security_level)
 	if(frequency)
 		set_frequency(frequency)
 
@@ -1665,23 +1651,3 @@
 		close()
 	else
 		open()
-
-#undef AIRLOCK_CLOSED
-#undef AIRLOCK_CLOSING
-#undef AIRLOCK_OPEN
-#undef AIRLOCK_OPENING
-#undef AIRLOCK_DENY
-#undef AIRLOCK_EMAG
-
-#undef AIRLOCK_SECURITY_NONE
-#undef AIRLOCK_SECURITY_IRON
-#undef AIRLOCK_SECURITY_PLASTEEL_I_S
-#undef AIRLOCK_SECURITY_PLASTEEL_I
-#undef AIRLOCK_SECURITY_PLASTEEL_O_S
-#undef AIRLOCK_SECURITY_PLASTEEL_O
-#undef AIRLOCK_SECURITY_PLASTEEL
-
-#undef AIRLOCK_INTEGRITY_N
-#undef AIRLOCK_INTEGRITY_MULTIPLIER
-#undef AIRLOCK_DAMAGE_DEFLECTION_N
-#undef AIRLOCK_DAMAGE_DEFLECTION_R

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -112,8 +112,9 @@
 	. = ..()
 
 	//Get the area hack difficulty
-	var/area/A = get_area(src)
-	wire_security_level = max(wire_security_level, A.airlock_hack_difficulty)
+	if (mapload)
+		var/area/A = get_area(src)
+		wire_security_level = max(wire_security_level, A.airlock_hack_difficulty)
 
 	wires = new /datum/wires/airlock(src, wire_security_level)
 	if(frequency)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
-	security_level = 6
+	security_level = AIRLOCK_SECURITY_PLASTEEL_O_S
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
@@ -86,7 +86,7 @@
 	opacity = 0
 	glass = TRUE
 	normal_integrity = 400
-	security_level =  6
+	security_level = AIRLOCK_SECURITY_PLASTEEL_O_S
 
 /obj/machinery/door/airlock/engineering/glass
 	opacity = 0
@@ -379,7 +379,7 @@
 	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_centcom
 	normal_integrity = 1000
-	security_level = 6
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 	explosion_block = 2
 
 /obj/machinery/door/airlock/grunge
@@ -400,7 +400,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_vault
 	explosion_block = 2
 	normal_integrity = 400 // reverse engieneerd: 400 * 1.5 (sec lvl 6) = 600 = original
-	security_level = 6
+	security_level = AIRLOCK_SECURITY_PLASTEEL
 
 //////////////////////////////////
 /*
@@ -444,7 +444,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_highsecurity
 	explosion_block = 2
 	normal_integrity = 500
-	security_level = 1
+	security_level = AIRLOCK_SECURITY_IRON
 	damage_deflection = 30
 
 //////////////////////////////////
@@ -476,7 +476,7 @@
 	hackProof = TRUE
 	aiControlDisabled = 1
 	normal_integrity = 700
-	security_level = 1
+	security_level = AIRLOCK_SECURITY_IRON
 	allow_repaint = FALSE
 
 //////////////////////////////////

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -266,7 +266,7 @@
 				//door.req_access = req_access
 				door.electronics = electronics
 				door.heat_proof = heat_proof_finished
-				door.security_level = 0
+				door.security_level = AIRLOCK_SECURITY_NONE
 				if(electronics.one_access)
 					door.req_one_access = electronics.accesses
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements hack difficulty levels for airlocks. This is independant from security_level and defines how difficult an airlock is to hack.

There are 6 levels:
None: 4 power wires, 0 shock wires, 0 dud wires, Labelled wires: Open, Bolts, Shock, Safety, Timing
Basic: 4 Power wires, 0 shock wires, 1 dud wire, Labelled wires: Safety, Timing
Protected: 4 power wires, 1 shock wire, 1 dud wire
Advanced: 4 power wires, 1 shock wire, 2 dud wires
Elite: 4 power wires, 2 shock wires, 2 dud wires
Maximum: 2 power wires, 2 shock wires, 2 dud wires

The more secure an area should be, the more dangerous it is to hack an airlock and the more time it will take (more dud wires and less labels to make you waste time hacking).

## Why It's Good For The Game

Overall, randomising airlock wires has been a good change for the main reason that it makes the time to hack consistent, as oppossed to an upfront cost and then free access to areas. However, it has made it a lot more difficult to hack into areas that should be relatively easy to hack into. This PR makes it easier to hack into areas that should be easy to hack into, such as maintenance and other public/insecure areas while maintaining harder to hack airlocks in security zones.

## Testing Photographs and Procedure

Hacking maints:
![image](https://user-images.githubusercontent.com/26465327/201536081-c8e8aad2-b540-4039-8ba5-083164f97849.png)

Hacking the showers:
![image](https://user-images.githubusercontent.com/26465327/201536096-f509dd84-f43b-49b2-a7b5-896353d65955.png)

Hacking security:
![image](https://user-images.githubusercontent.com/26465327/201536115-fe327b9b-4682-42f9-8b54-055e2bab3453.png)

<details>

Hacking bridge:
![image](https://user-images.githubusercontent.com/26465327/201536150-477410ff-3291-42ad-94ec-117c446db615.png)

Hacking cargo:
![image](https://user-images.githubusercontent.com/26465327/201536172-baf314dd-d32b-4f37-9c06-9e003e2eb60f.png)

Hacking science:
![image](https://user-images.githubusercontent.com/26465327/201536184-af9dec1d-3f00-43ed-ab27-05cf441536fc.png)

etc.

</details>

## Changelog
:cl:
add: Airlock hack difficulty now depends on the area. Easier to hack areas will have more labelled wires and less shock wires, while higher security areas will have shock and dud wires.
code: Adds the ability to label only specific wires on the hacking UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
