### PR TITLE
Fix vis overlays poking through multiz

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -52,7 +52,7 @@
 	vis_flags = NONE
 	var/unused = 0 //When detected to be unused it gets set to world.time, after a while it gets removed
 	var/cache_expiration = 2 MINUTES // overlays which go unused for 2 minutes get cleaned up
-	vis_flags = VIS_INHERIT_ID
+	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE
 
 /obj/effect/overlay/airlock_part
 	anchored = TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes vis_overlays poking through multiz rendering.

## Why It's Good For The Game

Removes weird visual artifacts near transparent turfs.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Lower level.
![image](https://user-images.githubusercontent.com/10366817/201597949-9f79f38b-455b-4210-9baa-200204f3cb1a.png)

On upper level, overlays are no longer visible.
![image](https://user-images.githubusercontent.com/10366817/201597960-944664a5-2c75-4458-ad45-6d24b3ff6cdc.png)

Still working as intended.
![image](https://user-images.githubusercontent.com/10366817/201597970-e226cf0a-b851-40d5-a874-4c923136b0a1.png)


</details>

## Changelog
:cl:
fix: Fixed fire alarm and APC overlays poking through Z levels.
/:cl:
