### PR TITLE
Minor BoxStation improvements

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12158,7 +12158,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/techmaint,
 /area/gateway)
 "bNM" = (
@@ -23185,9 +23184,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "epj" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -23634,9 +23630,6 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "eyd" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
@@ -31695,9 +31688,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "iOf" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw{
 	dir = 4
@@ -53759,9 +53749,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "tLX" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/ai_slipper{
 	uses = 8
 	},
@@ -53907,9 +53894,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "tSC" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw{
 	dir = 8
@@ -58661,9 +58645,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark_blue,
@@ -59097,9 +59078,6 @@
 /area/crew_quarters/heads/chief)
 "wUh" = (
 /obj/structure/railing/corner,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12158,6 +12158,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/techmaint,
 /area/gateway)
 "bNM" = (
@@ -55208,7 +55209,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "uEN" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7242,6 +7242,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bch" = (
@@ -9628,12 +9629,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "buy" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	sortType = 15
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buB" = (
@@ -11160,6 +11164,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bHq" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bHs" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -18624,6 +18635,9 @@
 /area/quartermaster/storage)
 "cBq" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cBr" = (
@@ -22814,6 +22828,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "efF" = (
@@ -25200,6 +25215,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -27713,6 +27731,10 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"gMk" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gMy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -33234,6 +33256,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "jBu" = (
@@ -35612,7 +35637,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kJC" = (
-/obj/machinery/porta_turret/ai,
 /obj/structure/sign/plaques/kiddie{
 	pixel_y = 32
 	},
@@ -37722,6 +37746,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -40887,6 +40914,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"nlP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "nlV" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -41079,9 +41112,6 @@
 /area/maintenance/port)
 "nrB" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "nrJ" = (
@@ -42189,10 +42219,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 15
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "nXq" = (
@@ -46386,6 +46413,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"qnI" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qnN" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
@@ -50882,7 +50916,6 @@
 /area/hydroponics)
 "sxy" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
-/obj/structure/rack,
 /obj/item/flashlight/flare{
 	pixel_x = -3;
 	pixel_y = -3
@@ -50904,6 +50937,7 @@
 	pixel_y = 3
 	},
 /obj/item/flashlight/flare,
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel/techmaint,
 /area/gateway)
 "sxD" = (
@@ -58726,6 +58760,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wKA" = (
@@ -85908,7 +85943,7 @@ aZK
 bnJ
 bbR
 bbR
-bbR
+nlP
 bty
 bty
 qJM
@@ -86165,7 +86200,7 @@ aZK
 bnK
 bnK
 pVd
-pVd
+bHq
 bnK
 bnK
 sdX
@@ -86410,19 +86445,19 @@ aJq
 aJq
 qVS
 exD
-hzi
-aJq
+gMk
+gMk
 bbV
-bfo
-bfo
-bfo
+qnI
+qnI
+qnI
 efv
-bfo
+qnI
 wKs
-bfo
-bfo
-aJq
-aJq
+qnI
+qnI
+gMk
+hzi
 bfo
 bfo
 ftu

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -641,6 +641,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "acQ" = (
@@ -2148,6 +2151,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -6146,6 +6152,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aSN" = (
@@ -8780,6 +8789,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"bma" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "bmh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19705,6 +19721,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"cGH" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "cGM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating/airless,
@@ -21527,7 +21555,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "duz" = (
@@ -23549,6 +23576,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"exD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "exE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/cable/yellow{
@@ -23597,6 +23630,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -24597,6 +24633,12 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -26474,6 +26516,9 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "gdS" = (
@@ -27473,6 +27518,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "gGK" = (
@@ -27937,7 +27985,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "gUz" = (
@@ -28436,6 +28483,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"hfr" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "hfu" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -28906,6 +28962,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"hsH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_upload)
 "hsU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29157,8 +29220,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"hzi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hzA" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -29256,7 +29328,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
@@ -29428,6 +29500,9 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hIk" = (
@@ -29617,6 +29692,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"hNU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_upload)
 "hNY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -30055,6 +30140,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -31903,6 +31991,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "iXc" = (
@@ -33006,6 +33097,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "jzB" = (
@@ -33357,6 +33454,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "jKn" = (
@@ -33372,9 +33472,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
@@ -35062,13 +35159,15 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Head of Personnel's Desk";
 	departmentType = 5;
 	name = "Head of Personnel RC";
 	pixel_y = 30
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -36161,9 +36260,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "kYi" = (
@@ -36216,6 +36312,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "lad" = (
@@ -37044,9 +37141,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "luc" = (
@@ -37370,6 +37464,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lAN" = (
@@ -37520,9 +37617,6 @@
 	dir = 6
 	},
 /obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "lCw" = (
@@ -38656,9 +38750,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
@@ -38725,9 +38816,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "mmx" = (
@@ -40740,6 +40828,9 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "nkW" = (
@@ -40816,6 +40907,9 @@
 "nmS" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "nnx" = (
@@ -40985,6 +41079,9 @@
 /area/maintenance/port)
 "nrB" = (
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "nrJ" = (
@@ -41168,6 +41265,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -6;
 	pixel_y = -22
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -41353,6 +41453,12 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "nBm" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
 "nBC" = (
@@ -42082,8 +42188,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	sortType = 15
+	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "nXq" = (
@@ -42685,9 +42794,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "omb" = (
@@ -45342,6 +45448,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pNv" = (
@@ -46055,9 +46164,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "qfK" = (
@@ -46237,6 +46343,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "qmP" = (
@@ -48205,6 +48314,9 @@
 /area/storage/tech)
 "rhN" = (
 /obj/machinery/vending/cart,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "rhX" = (
@@ -49102,6 +49214,9 @@
 	dir = 10;
 	network = list("aiupload")
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/ai_monitored/turret_protected/ai_upload)
 "rDh" = (
@@ -49323,6 +49438,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
@@ -49447,6 +49565,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "rNt" = (
@@ -51703,9 +51824,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "sRO" = (
@@ -51860,6 +51978,9 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -52226,9 +52347,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -52638,9 +52756,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "tsu" = (
@@ -52879,6 +52994,9 @@
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "tyb" = (
@@ -55740,20 +55858,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"vbf" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
 "vbg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -59953,9 +60057,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 15
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -61349,6 +61452,7 @@
 /area/ai_monitored/turret_protected/aisat/service)
 "xXW" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/bridge)
 "xYb" = (
@@ -61594,6 +61698,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "yfq" = (
@@ -61627,6 +61734,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"yga" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "ygo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85250,7 +85364,7 @@ xoh
 aaa
 aaa
 bfv
-nBm
+hsH
 nBm
 bfv
 aaa
@@ -85765,7 +85879,7 @@ aaa
 bfv
 fAK
 sef
-sef
+bma
 psE
 bfv
 gXs
@@ -86295,8 +86409,8 @@ aJq
 aJq
 aJq
 qVS
-aJq
-aJq
+exD
+hzi
 aJq
 bbV
 bfo
@@ -87066,7 +87180,7 @@ hzA
 fJZ
 mfX
 eWC
-bkT
+cGH
 eWC
 eWC
 spF
@@ -87580,7 +87694,7 @@ wfq
 vfO
 hem
 eWC
-hEA
+hfr
 mxi
 bmr
 hcL
@@ -87820,8 +87934,8 @@ fFH
 aaa
 aaa
 bfv
-nBm
-nBm
+hsH
+hNU
 bfv
 aaa
 aaa
@@ -87833,11 +87947,11 @@ dgB
 aaa
 aaa
 aPR
-xXW
+yga
 jzA
 xXW
 bjz
-hEA
+hfr
 hoQ
 bmr
 aNt
@@ -88094,7 +88208,7 @@ kcl
 akZ
 lyg
 bjz
-hEA
+hfr
 bmr
 bmr
 wQJ
@@ -88608,7 +88722,7 @@ qud
 gdO
 lel
 bjz
-hEA
+hfr
 bmr
 rhN
 yev
@@ -90670,7 +90784,7 @@ nyR
 sEx
 mPs
 qmr
-vbf
+exE
 pZR
 exE
 exE
@@ -93487,7 +93601,7 @@ dgB
 aaa
 aaa
 aPR
-xXW
+yga
 fdL
 xXW
 aZV

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -8795,10 +8795,6 @@
 "bmx" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/captain)
-"bmE" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bmF" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue{
@@ -9142,15 +9138,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"boW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bpk" = (
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet/royalblue,
@@ -9551,13 +9538,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"btz" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "btA" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
@@ -10522,9 +10502,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "bCd" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 15
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -12191,9 +12170,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOa" = (
@@ -17979,7 +17956,8 @@
 "cvv" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
-	dir = 5
+	dir = 5;
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -21838,7 +21816,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dCJ" = (
 /obj/structure/disposalpipe/segment{
@@ -22218,7 +22196,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dPd" = (
 /obj/structure/transit_tube/curved/flipped{
@@ -22261,7 +22239,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "dPD" = (
 /obj/structure/cable/yellow{
@@ -23918,7 +23896,7 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 4;
-	network = list("ss13, engine")
+	network = list("minisat")
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
@@ -25120,7 +25098,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ftu" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/sign/departments/minsky/supply/cargo{
 	pixel_x = -32
 	},
@@ -25350,7 +25327,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
 	dir = 4;
-	network = list("ss13, engine")
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -26462,7 +26439,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "gds" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29270,6 +29247,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"hCs" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "hCC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -29864,7 +29854,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hVa" = (
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "hVk" = (
 /obj/machinery/door/airlock/command{
@@ -30033,9 +30023,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "hYn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -30127,7 +30114,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "hZH" = (
 /obj/structure/cable/yellow{
@@ -31163,7 +31150,6 @@
 	codes_txt = "patrol;next_patrol=AftH";
 	location = "AIW"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iBQ" = (
@@ -32001,8 +31987,9 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/camera/autoname{
+	c_tag = null;
 	dir = 4;
-	network = list("ss13, engine")
+	network = list("minisat")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -32232,21 +32219,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"jdI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "jeB" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -34038,7 +34010,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "jYO" = (
 /obj/machinery/disposal/bin,
@@ -35331,7 +35303,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "kEB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35795,7 +35767,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 1
+	dir = 1;
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -36182,14 +36155,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
@@ -36206,13 +36179,16 @@
 	c_tag = "Captain's Quarters";
 	dir = 1
 	},
-/obj/item/storage/lockbox/medal{
-	pixel_y = 12
-	},
-/obj/item/storage/secure/briefcase{
-	pixel_y = -2
-	},
 /obj/structure/table/wood,
+/obj/item/clothing/gloves/color/black,
+/obj/item/lighter{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/storage/fancy/cigarettes/cigars/havana{
+	pixel_x = 2;
+	pixel_y = 10
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "kZb" = (
@@ -37163,6 +37139,7 @@
 /obj/machinery/cell_charger{
 	pixel_y = 1
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "lww" = (
@@ -37542,10 +37519,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "lCw" = (
@@ -37993,7 +37970,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "lPJ" = (
 /obj/machinery/computer/security/telescreen/interrogation{
@@ -38549,6 +38526,14 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"mgh" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/tile/black/fourcorners,
+/obj/item/radio/intercom{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/ai_monitored/storage/eva)
 "mgt" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -38740,6 +38725,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "mmx" = (
@@ -38829,15 +38817,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mnS" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mod" = (
 /obj/machinery/light{
 	dir = 8
@@ -39106,7 +39085,8 @@
 "mvl" = (
 /obj/machinery/light/small,
 /obj/machinery/camera/autoname{
-	dir = 1
+	dir = 1;
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -39752,7 +39732,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "mPh" = (
 /obj/structure/disposalpipe/segment{
@@ -39971,6 +39951,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/item/radio/intercom{
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "mTL" = (
@@ -40410,7 +40393,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "ncy" = (
 /obj/effect/turf_decal/stripes/line,
@@ -41551,7 +41534,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "nFW" = (
 /obj/structure/window/reinforced{
@@ -41896,7 +41879,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "nSL" = (
 /obj/machinery/computer/nanite_cloud_controller,
@@ -42908,6 +42891,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "osI" = (
@@ -43606,9 +43592,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "oOI" = (
@@ -43738,7 +43721,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "oUq" = (
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -44248,7 +44231,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "pnC" = (
 /obj/structure/sign/warning/electricshock{
@@ -44735,9 +44718,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "pxL" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
 /obj/structure/sign/directions/engineering{
 	pixel_x = -32;
 	pixel_y = -40
@@ -44754,6 +44734,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -45306,13 +45289,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"pLj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -45330,7 +45306,8 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/camera/autoname{
-	dir = 1
+	dir = 1;
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -45778,7 +45755,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "pWH" = (
 /obj/machinery/power/apc/auto_name/west{
@@ -45891,7 +45868,8 @@
 "pZC" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
-	dir = 9
+	dir = 9;
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -46077,6 +46055,9 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "qfK" = (
@@ -46256,9 +46237,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "qmP" = (
@@ -47364,13 +47342,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"qNF" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "qNU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/microwave,
@@ -47446,7 +47417,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "qPP" = (
-/obj/machinery/camera/autoname,
+/obj/machinery/camera/autoname{
+	network = list("minisat")
+	},
 /turf/open/space,
 /area/space/nearstation)
 "qPU" = (
@@ -47935,7 +47908,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "rcN" = (
 /obj/structure/disposalpipe/segment{
@@ -48271,7 +48244,8 @@
 "rje" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
-	dir = 8
+	dir = 8;
+	network = list("minisat")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -48795,14 +48769,11 @@
 	pixel_x = 6;
 	pixel_y = -30
 	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/storage/fancy/cigarettes/cigars/havana{
-	pixel_x = 2;
-	pixel_y = 10
+/obj/item/storage/secure/briefcase{
+	pixel_y = -2
 	},
-/obj/item/lighter{
-	pixel_x = -8;
-	pixel_y = 4
+/obj/item/storage/lockbox/medal{
+	pixel_y = 12
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -50619,10 +50590,6 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "stf" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -50794,10 +50761,28 @@
 /area/hydroponics)
 "sxy" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
-/obj/structure/tank_dispenser/oxygen{
-	pixel_x = -1;
-	pixel_y = 2
+/obj/structure/rack,
+/obj/item/flashlight/flare{
+	pixel_x = -3;
+	pixel_y = -3
 	},
+/obj/item/flashlight/flare{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/flashlight/flare{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/flashlight/flare{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/flashlight/flare{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/flashlight/flare,
 /turf/open/floor/plasteel/techmaint,
 /area/gateway)
 "sxD" = (
@@ -52146,7 +52131,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "tdp" = (
 /obj/structure/cable/yellow{
@@ -52654,7 +52639,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
@@ -53862,7 +53847,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "tVm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -54165,13 +54150,13 @@
 	},
 /obj/machinery/light,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = -7
 	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/techmaint,
 /area/ai_monitored/storage/eva)
 "udD" = (
@@ -55755,6 +55740,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"vbf" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "vbg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -56174,6 +56173,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vmV" = (
@@ -56660,7 +56660,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "vFr" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -57941,7 +57941,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "wnQ" = (
 /obj/structure/lattice/catwalk,
@@ -58805,6 +58805,9 @@
 /obj/item/clothing/glasses/meson{
 	pixel_y = 5
 	},
+/obj/item/flashlight{
+	pixel_y = -11
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/storage/tech)
 "wPc" = (
@@ -59436,7 +59439,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "xfo" = (
 /obj/structure/chair{
@@ -59478,7 +59481,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/tank_dispenser,
+/obj/structure/tank_dispenser/oxygen{
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/storage/tech)
 "xgn" = (
@@ -59938,9 +59944,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xqa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -59949,6 +59952,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 15
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -60220,15 +60227,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"xwk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark_blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xwr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60655,7 +60653,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "xGD" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
@@ -61344,7 +61342,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 8
+	dir = 8;
+	network = list("minisat")
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -86061,7 +86060,7 @@ bwe
 bwe
 bwe
 bwe
-jdI
+lRI
 bCd
 bCq
 bCq
@@ -86307,17 +86306,17 @@ efv
 bfo
 wKs
 bfo
-boW
-bmE
-bmE
-btz
-btz
+bfo
+aJq
+aJq
+bfo
+bfo
 ftu
-btz
-btz
-btz
-btz
-qNF
+bfo
+bfo
+bfo
+bfo
+bTz
 hYn
 eUj
 rng
@@ -86564,7 +86563,7 @@ vPD
 keR
 bjQ
 keR
-pLj
+keR
 pvy
 aJq
 aJq
@@ -86821,7 +86820,7 @@ aYl
 sEj
 aLh
 klN
-xwk
+klN
 klN
 klN
 klN
@@ -88847,7 +88846,7 @@ sse
 ayL
 tlM
 nbl
-tlM
+mgh
 fuF
 wFf
 vPu
@@ -90426,7 +90425,7 @@ hbS
 etb
 rsX
 tpv
-mnS
+ogJ
 iBG
 pxL
 vcg
@@ -90671,7 +90670,7 @@ nyR
 sEx
 mPs
 qmr
-exE
+vbf
 pZR
 exE
 exE
@@ -90927,7 +90926,7 @@ cMU
 lDI
 seL
 ifH
-tsb
+hCs
 mmm
 ahH
 hZX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a couple of minor issues on Box, most of these are my fault, some are not.


To elaborate on a few parts of the CL a little bit.
> tweak: Slightly modified the contents of Tech Storage, Gateway, and EVA (BoxStation)

EVA storage had high cap+ batteries, should have been normal high cap.
Tech storage's tank dispenser contained plasma tanks too, it shouldn't have.
Also tossed in a flashlight.
Gateway had it's tank storage replaced with a crate of flares. Didn't need another one so close to tech storage.

> tweak: Moved the captain's medal box to a slightly less secure location. (BoxStation)

Behind 3 doors instead of 4.

> del: Removed the central turret in AI upload (BoxStation)

This was more obnoxious than I thought it'd be.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bad design is, shockingly, not good for the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I can't think of anything here that really needs screenshots to explain. These are all very minor changes and the CL explains them adequately.
</details>

## Changelog
:cl:
fix: Fixed disposals not properly sorting packages to the HoP office (BoxStation)
fix: Fixed the AI satellites cameras not being on the 'minisat' network. (BoxStation)
fix: Fixes discolored flooring in the CMO's office (BoxStation)
fix: Fixed AI upload and northern bridge airlock windows not being shocked. (BoxStation)
tweak: Slightly modified the contents of Tech Storage, Gateway, and EVA (BoxStation)
tweak: Moved a single poorly placed light in Gateway and added an additional one to tech storage. (BoxStation)
tweak: Moved the captain's medal box to a slightly less secure location. (BoxStation)
add: Added an intercom to the teleporter room and EVA (BoxStation)
del: Removed a duplicate air alarm outside gravity generator. (BoxStation)
del: Removed the central turret in AI upload (BoxStation)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
