### PR TITLE
Fix bluescreen in new playerpanel

### DIFF
--- a/tgui/packages/tgui/interfaces/PlayerPanel.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.js
@@ -204,10 +204,20 @@ class PlayerDetails extends Component {
   }
 
   shouldComponentUpdate(new_props, new_state) {
+    const {
+      previous_names = [],
+      log_client = {},
+      log_mob = {},
+    } = this.props;
+    const {
+      previous_names_new = [],
+      log_client_new = {},
+      log_mob_new = {},
+    } = new_props;
     return shallow_diff(this.props, new_props, ["log_client", "log_mob", "previous_names"])
-    || this.countEntries(this.props.log_client, this.props.log_mob)
-    !== this.countEntries(new_props.log_client, new_props.log_mob)
-    || this.props.previous_names.join("") !== new_props.previous_names.join("")
+    || this.countEntries(log_client, log_mob)
+    !== this.countEntries(log_client_new, log_mob_new)
+    || previous_names.join("") !== previous_names_new.join("")
     || shallow_diff(this.state, new_state);
   }
 


### PR DESCRIPTION
## About The Pull Request

Fixes a bluescreen error caused by trying to interact with a disconnected player.

## Why It's Good For The Game

Having a usable player panel is good.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Here is bug, not happening.
![image](https://user-images.githubusercontent.com/10366817/201658942-f61a4377-3562-485e-8c8d-ffb2ab9a2e9d.png)

</details>

## Changelog
:cl:
fix: Fixed a bluescreen in the admin player panel.
/:cl: