### PR TITLE
Changes some Lasso code and adds an ash drake lasso for ashwalkers

### DIFF
--- a/code/datums/ai/tamed/tamed_behaviour.dm
+++ b/code/datums/ai/tamed/tamed_behaviour.dm
@@ -24,10 +24,7 @@
 /datum/ai_behavior/tamed_follow/attack/perform(delta_time, datum/ai_controller/controller)
 	// Pawn + target
 	var/mob/living/simple_animal/pawn = controller.pawn
-	var/mob/living/simple_animal/hostile/hostile_pawn
 	var/mob/living/target = controller.blackboard[BB_ATTACK_TARGET]
-	if(istype(pawn, /mob/living/simple_animal/hostile))
-		hostile_pawn = pawn
 
 	// Dead? finish
 	if(istype(target) && IS_DEAD_OR_INCAP(target))
@@ -38,8 +35,11 @@
 		finish_action(controller, TRUE)
 
 	// Attack
-	else if((hostile_pawn?.ranged || get_dist(pawn, controller.blackboard[BB_ATTACK_TARGET]) <= 1) && COOLDOWN_FINISHED(src, attack_cooldown))
-		pawn.UnarmedAttack(target)
+	else if(COOLDOWN_FINISHED(src, attack_cooldown))
+		if(get_dist(pawn, controller.blackboard[BB_ATTACK_TARGET]) > 1)
+			pawn.RangedAttack(target)
+		else
+			pawn.UnarmedAttack(target)
 		COOLDOWN_START(src, attack_cooldown, 1.3 SECONDS)
 	..()
 

--- a/code/datums/ai/tamed/tamed_behaviour.dm
+++ b/code/datums/ai/tamed/tamed_behaviour.dm
@@ -22,15 +22,24 @@
 	COOLDOWN_DECLARE(attack_cooldown)
 
 /datum/ai_behavior/tamed_follow/attack/perform(delta_time, datum/ai_controller/controller)
+	// Pawn + target
 	var/mob/living/simple_animal/pawn = controller.pawn
-	//If pawn can't access target, finish
+	var/mob/living/simple_animal/hostile/hostile_pawn
+	var/mob/living/target = controller.blackboard[BB_ATTACK_TARGET]
+	if(istype(pawn, /mob/living/simple_animal/hostile))
+		hostile_pawn = pawn
+
+	// Dead? finish
+	if(istype(target) && IS_DEAD_OR_INCAP(target))
+		finish_action(controller, TRUE)
+
+	// If pawn can't access target, finish
 	if(get_dist(pawn, controller.blackboard[BB_ATTACK_TARGET]) > FOLLOW_TOLERANCE)
 		finish_action(controller, TRUE)
-	else if(get_dist(pawn, controller.blackboard[BB_ATTACK_TARGET]) <= 1 && COOLDOWN_FINISHED(src, attack_cooldown))
-		var/mob/living/target = controller.blackboard[BB_ATTACK_TARGET]
-		if(istype(target) && IS_DEAD_OR_INCAP(target))
-			finish_action(controller, TRUE)
-		target.attack_animal(pawn)
+
+	// Attack
+	else if((hostile_pawn?.ranged || get_dist(pawn, controller.blackboard[BB_ATTACK_TARGET]) <= 1) && COOLDOWN_FINISHED(src, attack_cooldown))
+		pawn.UnarmedAttack(target)
 		COOLDOWN_START(src, attack_cooldown, 1.3 SECONDS)
 	..()
 

--- a/code/datums/ai/tamed/tamed_behaviour.dm
+++ b/code/datums/ai/tamed/tamed_behaviour.dm
@@ -19,7 +19,14 @@
 //Agressive >:)
 /datum/ai_behavior/tamed_follow/attack
 	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
-	COOLDOWN_DECLARE(attack_cooldown)
+	COOLDOWN_DECLARE(attack_cooldown) // Time between attacks
+	COOLDOWN_DECLARE(turf_attack_timeout) // Time before we stop firing at a static position
+
+/datum/ai_behavior/tamed_follow/attack/setup(datum/ai_controller/controller, ...)
+	var/mob/living/target = controller.blackboard[BB_ATTACK_TARGET]
+	if(!istype(target))
+		COOLDOWN_START(src, turf_attack_timeout, 10 SECONDS)
+	return ..()
 
 /datum/ai_behavior/tamed_follow/attack/perform(delta_time, datum/ai_controller/controller)
 	// Pawn + target
@@ -32,6 +39,10 @@
 
 	// If pawn can't access target, finish
 	if(get_dist(pawn, controller.blackboard[BB_ATTACK_TARGET]) > FOLLOW_TOLERANCE)
+		finish_action(controller, TRUE)
+
+	// If we've been firing at a turf for a while, finish
+	if(!istype(target) && COOLDOWN_FINISHED(src, turf_attack_timeout))
 		finish_action(controller, TRUE)
 
 	// Attack

--- a/code/datums/ai/tamed/tamed_controller.dm
+++ b/code/datums/ai/tamed/tamed_controller.dm
@@ -1,7 +1,7 @@
-#define TAMED_COMMAND_FOLLOW "tamed_command_follow"
-#define TAMED_COMMAND_STOP "tamed_command_stop"
-#define TAMED_COMMAND_WANDER "tamed_command_wander"
-#define TAMED_COMMAND_ATTACK "tamed_command_attack"
+#define TAMED_COMMAND_FOLLOW "Follow"
+#define TAMED_COMMAND_STOP "Stop"
+#define TAMED_COMMAND_WANDER "Wander"
+#define TAMED_COMMAND_ATTACK "Attack"
 
 ///default jps fails pathfinding too often, this work better
 /datum/ai_movement/jps/expensive

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -994,7 +994,7 @@
 	reqs = list(/obj/item/paper = 5)
 	category = CAT_MISC
 	tools = list(TOOL_WIRECUTTER)
-  
+
 /datum/crafting_recipe/basic_lasso
 	name= "Basic Lasso"
 	result = /obj/item/mob_lasso
@@ -1008,6 +1008,16 @@
 	always_available = FALSE
 	time = 20
 	reqs = list(/obj/item/stack/sheet/animalhide/goliath_hide = 3)
+	category = CAT_PRIMAL
+
+/datum/crafting_recipe/dragon_lasso
+	name = "Ash Drake Lasso"
+	result = /obj/item/mob_lasso/drake
+	always_available = FALSE
+	time = 20
+	reqs = list(/obj/item/stack/sheet/bone = 10,
+				/obj/item/stack/sheet/sinew = 2,
+				/obj/item/stack/sheet/animalhide/ashdrake = 5)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/foldable

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -8,52 +8,64 @@
 	///Ref to lasso'd carp
 	var/mob/living/simple_animal/mob_target
 	///Whitelist of allowed animals
-	var/list/whitelist_mobs = list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin)
+	var/list/whitelist_mobs
+
+/obj/item/mob_lasso/Initialize(mapload)
+	. = ..()
+	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin))
 
 /obj/item/mob_lasso/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(isliving(target) && check_allowed(target) && !iscarbon(target) && !issilicon(target) && locate(target) in oview(9, get_turf(src)))
-		var/mob/living/simple_animal/C = target
-		if(IS_DEAD_OR_INCAP(C))
-			to_chat(user, "<span class='warning'>[target] is dead.</span>")
-			return
-		if(user.a_intent == INTENT_HELP && C == mob_target) //if trying to tie up previous target
-			to_chat(user, "<span class='notice'>You begin to untie [C]</span>")
-			if(proximity_flag && do_after(user, 2 SECONDS, FALSE, target))
-				user.faction |= "carpboy_[user]"
-				C.faction |= "carpboy_[user]"
-				C.faction |= user.faction
-				C.transform = transform.Turn(0)
-				C.toggle_ai(AI_ON)
-				var/datum/component/tamed_command/T = C.AddComponent(/datum/component/tamed_command)
-				T.add_ally(user)
-				to_chat(user, "<span class='notice'>[C] nuzzles you.</span>")
-				UnregisterSignal(mob_target, COMSIG_PARENT_QDELETING)
-				mob_target = null
-				if(timer)
-					deltimer(timer)
-					timer = null
-				return
-		else if(timer) //if trying to add new target while old target is still flipped
-			to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-			return
-		//Do lasso/beam for style points
-		var/datum/beam/B = new(loc, C, time=1 SECONDS, beam_icon='icons/effects/beam.dmi', beam_icon_state="carp_lasso", btype=/obj/effect/ebeam)
-		INVOKE_ASYNC(B, /datum/beam/.proc/Start)
-		C.unbuckle_all_mobs()
-		mob_target = C
-		C.throw_at(get_turf(src), 9, 2, user, FALSE, force = 0)
-		C.transform = transform.Turn(180)
-		C.toggle_ai(AI_OFF)
-		RegisterSignal(C, COMSIG_PARENT_QDELETING, .proc/handle_hard_del)
-		to_chat(user, "<span class='notice'>You lasso [C]!</span>")
-		timer = addtimer(CALLBACK(src, .proc/fail_ally), 6 SECONDS, TIMER_STOPPABLE) //after 6 seconds set the carp back
-	else
+	var/failed = FALSE
+	if(!isliving(target))
+		failed = TRUE
+	if(!check_allowed(target))
+		failed = TRUE
+	if(iscarbon(target) || issilicon(target))
+		failed = TRUE
+	if(!(locate(target) in oview(9, get_turf(src))))
+		failed = TRUE
+	if(failed)
 		to_chat(user, "<span class='notice'>[target] seems a bit big for this...</span>")
+		return
+	var/mob/living/simple_animal/C = target
+	if(IS_DEAD_OR_INCAP(C))
+		to_chat(user, "<span class='warning'>[target] is dead.</span>")
+		return
+	if(user.a_intent == INTENT_HELP && C == mob_target) //if trying to tie up previous target
+		to_chat(user, "<span class='notice'>You begin to untie [C]</span>")
+		if(proximity_flag && do_after(user, 2 SECONDS, FALSE, target))
+			user.faction |= "carpboy_[user]"
+			C.faction |= "carpboy_[user]"
+			C.faction |= user.faction
+			C.transform = transform.Turn(0)
+			C.toggle_ai(AI_ON)
+			var/datum/component/tamed_command/T = C.AddComponent(/datum/component/tamed_command)
+			T.add_ally(user)
+			to_chat(user, "<span class='notice'>[C] nuzzles you.</span>")
+			UnregisterSignal(mob_target, COMSIG_PARENT_QDELETING)
+			mob_target = null
+			if(timer)
+				deltimer(timer)
+				timer = null
+			return
+	else if(timer) //if trying to add new target while old target is still flipped
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	//Do lasso/beam for style points
+	var/datum/beam/B = new(loc, C, time=1 SECONDS, beam_icon='icons/effects/beam.dmi', beam_icon_state="carp_lasso", btype=/obj/effect/ebeam)
+	INVOKE_ASYNC(B, /datum/beam/.proc/Start)
+	C.unbuckle_all_mobs()
+	mob_target = C
+	C.throw_at(get_turf(src), 9, 2, user, FALSE, force = 0)
+	C.transform = transform.Turn(180)
+	C.toggle_ai(AI_OFF)
+	RegisterSignal(C, COMSIG_PARENT_QDELETING, .proc/handle_hard_del)
+	to_chat(user, "<span class='notice'>You lasso [C]!</span>")
+	timer = addtimer(CALLBACK(src, .proc/fail_ally), 6 SECONDS, TIMER_STOPPABLE) //after 6 seconds set the carp back
 
 /obj/item/mob_lasso/proc/check_allowed(atom/target)
-	return (locate(target) in whitelist_mobs)
-
+	return is_type_in_typecache(target, whitelist_mobs)
 
 /obj/item/mob_lasso/proc/fail_ally()
 	visible_message("<span class='warning'>[mob_target] breaks free!</span>")
@@ -69,21 +81,25 @@
 ///Primal version, allows lavaland goobers to tame goliaths
 /obj/item/mob_lasso/primal
 	name = "primal lasso"
-	desc = "Found amongst Ash Walker tools.\nCan be used to tame goliaths."
-	whitelist_mobs = list(/mob/living/simple_animal/hostile/asteroid/goliath/beast, /mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/goldgrub)
+	desc = "A lasso fashioned out of goliath plating that is often found in the possession of Ash Walkers.\nCan be used to tame some lavaland animals."
+
+/obj/item/mob_lasso/primal/Initialize(mapload)
+	. = ..()
+	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/goldgrub,\
+		/mob/living/simple_animal/hostile/asteroid/basilisk/watcher, /mob/living/simple_animal/hostile/asteroid/gutlunch))
 
 /obj/item/mob_lasso/antag
 	name = "bluespace lasso"
 	desc = "Comes standard with every evil space-cowboy!\nCan be used to tame almost anything."
 	///blacklist of disallowed mobs
-	var/list/blacklist_mobs = list(/mob/living/simple_animal/hostile/megafauna, /mob/living/simple_animal/hostile/alien, /mob/living/simple_animal/hostile/syndicate)
+	var/list/blacklist_mobs
+
+/obj/item/mob_lasso/antag/Initialize(mapload)
+	. = ..()
+	blacklist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/megafauna, /mob/living/simple_animal/hostile/alien, /mob/living/simple_animal/hostile/syndicate))
 
 /obj/item/mob_lasso/antag/check_allowed(atom/target)
-	//do type checking becuase I didn't think this through
-	for(var/atom/type as () in blacklist_mobs)
-		if(istype(target, type))
-			return FALSE
-	return(!locate(target) in blacklist_mobs)
+	return !is_type_in_typecache(target, blacklist_mobs)
 
 /obj/item/mob_lasso/antag/debug
 	name = "debug lasso"

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -16,7 +16,8 @@
 
 /obj/item/mob_lasso/Initialize(mapload)
 	. = ..()
-	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin), only_root_path = TRUE)
+	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/hostile/carp/megacarp, /mob/living/simple_animal/hostile/carp/lia,\
+	 /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin), only_root_path = TRUE)
 	blacklist_mobs = list()
 
 /obj/item/mob_lasso/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
@@ -78,7 +79,7 @@
 /obj/item/mob_lasso/proc/fail_ally()
 	visible_message("<span class='warning'>[mob_target] breaks free!</span>")
 	mob_target?.transform = transform.Turn(0)
-	mob_target.toggle_ai(AI_ON)
+	mob_target?.toggle_ai(AI_ON)
 	UnregisterSignal(mob_target, COMSIG_PARENT_QDELETING)
 	mob_target = null
 	timer = null

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -26,10 +26,12 @@
 	if(iscarbon(target) || issilicon(target))
 		failed = TRUE
 	if(!(locate(target) in oview(range, user)))
-		failed = TRUE
+		if(ismob(target))
+			to_chat(user, "<span class='warning'>you can't lasso [target] from here!</span>")
+		return
 	if(failed)
 		if(ismob(target))
-			to_chat(user, "<span class='notice'>[target] seems a bit big for this...</span>")
+			to_chat(user, "<span class='warning'>[target] seems a bit big for this...</span>")
 		return
 	var/mob/living/simple_animal/C = target
 	if(IS_DEAD_OR_INCAP(C))

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -80,6 +80,7 @@
 
 /obj/item/mob_lasso/proc/handle_hard_del()
 	mob_target = null
+	timer = null
 
 ///Primal version, allows lavaland goobers to tame goliaths
 /obj/item/mob_lasso/primal

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -1,6 +1,6 @@
 /obj/item/mob_lasso
 	name = "space lasso"
-	desc = "Comes standard with every space-cowboy.\nCan be used to tame space carp."
+	desc = "Comes standard with every space-cowboy.\n<span class='notice'>Can be used to tame space carp.</span>"
 	icon = 'icons/obj/carp_lasso.dmi'
 	icon_state = "lasso"
 	///Ref to timer
@@ -11,10 +11,13 @@
 	var/range = 8
 	///Whitelist of allowed animals
 	var/list/whitelist_mobs
+	///blacklist of disallowed animals
+	var/list/blacklist_mobs
 
 /obj/item/mob_lasso/Initialize(mapload)
 	. = ..()
 	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin), only_root_path = TRUE)
+	blacklist_mobs = list()
 
 /obj/item/mob_lasso/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
@@ -25,13 +28,13 @@
 		failed = TRUE
 	if(iscarbon(target) || issilicon(target))
 		failed = TRUE
-	if(!(locate(target) in oview(range, user)))
-		if(ismob(target))
-			to_chat(user, "<span class='warning'>you can't lasso [target] from here!</span>")
-		return
 	if(failed)
 		if(ismob(target))
 			to_chat(user, "<span class='warning'>[target] seems a bit big for this...</span>")
+		return
+	if(!(locate(target) in oview(range, user)))
+		if(ismob(target))
+			to_chat(user, "<span class='warning'>You can't lasso [target] from here!</span>")
 		return
 	var/mob/living/simple_animal/C = target
 	if(IS_DEAD_OR_INCAP(C))
@@ -70,7 +73,7 @@
 	timer = addtimer(CALLBACK(src, .proc/fail_ally), 6 SECONDS, TIMER_STOPPABLE) //after 6 seconds set the carp back
 
 /obj/item/mob_lasso/proc/check_allowed(atom/target)
-	return is_type_in_typecache(target, whitelist_mobs)
+	return (is_type_in_typecache(target, whitelist_mobs) && !is_type_in_typecache(target, blacklist_mobs))
 
 /obj/item/mob_lasso/proc/fail_ally()
 	visible_message("<span class='warning'>[mob_target] breaks free!</span>")
@@ -87,7 +90,8 @@
 ///Primal version, allows lavaland goobers to tame goliaths
 /obj/item/mob_lasso/primal
 	name = "primal lasso"
-	desc = "A lasso fashioned out of goliath plating that is often found in the possession of Ash Walkers.\nCan be used to tame some lavaland animals."
+	desc = "A lasso fashioned out of goliath plating that is often found in the possession of Ash Walkers.\n\
+		<span class='notice'>Can be used to tame some lavaland animals</span>."
 
 /obj/item/mob_lasso/primal/Initialize(mapload)
 	. = ..()
@@ -96,7 +100,8 @@
 
 /obj/item/mob_lasso/drake
 	name = "drake lasso"
-	desc = "A lasso fashioned out of the scaly hide of an ash drake.\nCan be used to tame one, if you can get close enough."
+	desc = "A lasso fashioned out of the scaly hide of an ash drake.\n\
+		<span class='notice'>Can be used to tame one, if you can get close enough.</span>"
 	range = 3
 
 /obj/item/mob_lasso/drake/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
@@ -109,24 +114,19 @@
 	. = ..()
 	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/megafauna/dragon), only_root_path = TRUE)
 
-/obj/item/mob_lasso/antag
+/obj/item/mob_lasso/traitor
 	name = "bluespace lasso"
-	desc = "Comes standard with every evil space-cowboy!\nCan be used to tame almost anything."
-	///blacklist of disallowed mobs
-	var/list/blacklist_mobs
+	desc = "Comes standard with every evil space-cowboy!\n<span class='notice'>Can be used to tame almost anything.</span>"
 
 /obj/item/mob_lasso/antag/Initialize(mapload)
 	. = ..()
 	blacklist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/megafauna, /mob/living/simple_animal/hostile/alien, /mob/living/simple_animal/hostile/syndicate))
 
-/obj/item/mob_lasso/antag/check_allowed(atom/target)
-	return !is_type_in_typecache(target, blacklist_mobs)
-
-/obj/item/mob_lasso/antag/debug
+/obj/item/mob_lasso/debug
 	name = "debug lasso"
-	desc = "Comes standard with every administrator space-cowboy!\nCan be used to tame anything."
+	desc = "Comes standard with every administrator space-cowboy!\n<span class='notice'>Can be used to tame anything.</span>"
 
-/obj/item/mob_lasso/antag/debug/Initialize(mapload)
+/obj/item/mob_lasso/debug/Initialize(mapload)
 	. = ..()
-	blacklist_mobs = list()
+	whitelist_mobs = list()
 

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -13,12 +13,20 @@
 	var/list/whitelist_mobs
 	///blacklist of disallowed animals
 	var/list/blacklist_mobs
+	///Typecache caches
+	var/static/list/whitelist_mob_cache = list()
+	var/static/list/blacklist_mob_cache = list()
 
 /obj/item/mob_lasso/Initialize(mapload)
 	. = ..()
-	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/hostile/carp/megacarp, /mob/living/simple_animal/hostile/carp/lia,\
+	if(!whitelist_mob_cache[type] && !blacklist_mob_cache[type])
+		init_whitelists()
+	whitelist_mobs = whitelist_mob_cache[type]
+	blacklist_mobs = blacklist_mob_cache[type]
+
+/obj/item/mob_lasso/proc/init_whitelists()
+	whitelist_mob_cache[type] = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/hostile/carp/megacarp, /mob/living/simple_animal/hostile/carp/lia,\
 	 /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin), only_root_path = TRUE)
-	blacklist_mobs = list()
 
 /obj/item/mob_lasso/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
@@ -74,7 +82,7 @@
 	timer = addtimer(CALLBACK(src, .proc/fail_ally), 6 SECONDS, TIMER_STOPPABLE) //after 6 seconds set the carp back
 
 /obj/item/mob_lasso/proc/check_allowed(atom/target)
-	return (is_type_in_typecache(target, whitelist_mobs) && !is_type_in_typecache(target, blacklist_mobs))
+	return ((!whitelist_mobs || is_type_in_typecache(target, whitelist_mobs)) && (!blacklist_mobs || !is_type_in_typecache(target, blacklist_mobs)))
 
 /obj/item/mob_lasso/proc/fail_ally()
 	visible_message("<span class='warning'>[mob_target] breaks free!</span>")
@@ -94,9 +102,8 @@
 	desc = "A lasso fashioned out of goliath plating that is often found in the possession of Ash Walkers.\n\
 		<span class='notice'>Can be used to tame some lavaland animals</span>."
 
-/obj/item/mob_lasso/primal/Initialize(mapload)
-	. = ..()
-	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/goldgrub,\
+/obj/item/mob_lasso/primal/init_whitelists(mapload)
+	whitelist_mob_cache[type] = typecacheof(list(/mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/goldgrub,\
 		/mob/living/simple_animal/hostile/asteroid/basilisk/watcher, /mob/living/simple_animal/hostile/asteroid/gutlunch))
 
 /obj/item/mob_lasso/drake
@@ -111,23 +118,20 @@
 		return
 	. = ..()
 
-/obj/item/mob_lasso/drake/Initialize(mapload)
-	. = ..()
-	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/megafauna/dragon), only_root_path = TRUE)
+/obj/item/mob_lasso/drake/init_whitelists(mapload)
+	whitelist_mob_cache[type] = typecacheof(list(/mob/living/simple_animal/hostile/megafauna/dragon), only_root_path = TRUE)
 
 /obj/item/mob_lasso/traitor
 	name = "bluespace lasso"
 	desc = "Comes standard with every evil space-cowboy!\n<span class='notice'>Can be used to tame almost anything.</span>"
 
-/obj/item/mob_lasso/traitor/Initialize(mapload)
-	. = ..()
-	blacklist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/megafauna, /mob/living/simple_animal/hostile/alien, /mob/living/simple_animal/hostile/syndicate))
+/obj/item/mob_lasso/traitor/init_whitelists(mapload)
+	blacklist_mob_cache[type] = typecacheof(list(/mob/living/simple_animal/hostile/megafauna, /mob/living/simple_animal/hostile/alien, /mob/living/simple_animal/hostile/syndicate))
 
 /obj/item/mob_lasso/debug
 	name = "debug lasso"
 	desc = "Comes standard with every administrator space-cowboy!\n<span class='notice'>Can be used to tame anything.</span>"
 
-/obj/item/mob_lasso/debug/Initialize(mapload)
-	. = ..()
-	whitelist_mobs = list()
+/obj/item/mob_lasso/debug/init_whitelists(mapload)
+	blacklist_mob_cache[type] = list() // An empty list so we know this got initialized
 

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -118,7 +118,7 @@
 	name = "bluespace lasso"
 	desc = "Comes standard with every evil space-cowboy!\n<span class='notice'>Can be used to tame almost anything.</span>"
 
-/obj/item/mob_lasso/antag/Initialize(mapload)
+/obj/item/mob_lasso/traitor/Initialize(mapload)
 	. = ..()
 	blacklist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/megafauna, /mob/living/simple_animal/hostile/alien, /mob/living/simple_animal/hostile/syndicate))
 

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -14,7 +14,7 @@
 
 /obj/item/mob_lasso/Initialize(mapload)
 	. = ..()
-	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin))
+	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/carp, /mob/living/simple_animal/cow, /mob/living/simple_animal/hostile/retaliate/dolphin), only_root_path = TRUE)
 
 /obj/item/mob_lasso/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
@@ -28,7 +28,8 @@
 	if(!(locate(target) in oview(range, user)))
 		failed = TRUE
 	if(failed)
-		to_chat(user, "<span class='notice'>[target] seems a bit big for this...</span>")
+		if(ismob(target))
+			to_chat(user, "<span class='notice'>[target] seems a bit big for this...</span>")
 		return
 	var/mob/living/simple_animal/C = target
 	if(IS_DEAD_OR_INCAP(C))
@@ -94,6 +95,12 @@
 	name = "drake lasso"
 	desc = "A lasso fashioned out of the scaly hide of an ash drake.\nCan be used to tame one, if you can get close enough."
 	range = 3
+
+/obj/item/mob_lasso/drake/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(!user.mind?.has_antag_datum(/datum/antagonist/ashwalker))
+		to_chat(user, "<span class='warning'>You don't know how to use this!</span>")
+		return
+	. = ..()
 
 /obj/item/mob_lasso/drake/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -7,6 +7,8 @@
 	var/timer
 	///Ref to lasso'd carp
 	var/mob/living/simple_animal/mob_target
+	///Range we can lasso things at
+	var/range = 8
 	///Whitelist of allowed animals
 	var/list/whitelist_mobs
 
@@ -23,7 +25,7 @@
 		failed = TRUE
 	if(iscarbon(target) || issilicon(target))
 		failed = TRUE
-	if(!(locate(target) in oview(9, get_turf(src))))
+	if(!(locate(target) in oview(range, user)))
 		failed = TRUE
 	if(failed)
 		to_chat(user, "<span class='notice'>[target] seems a bit big for this...</span>")
@@ -88,6 +90,15 @@
 	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/goldgrub,\
 		/mob/living/simple_animal/hostile/asteroid/basilisk/watcher, /mob/living/simple_animal/hostile/asteroid/gutlunch))
 
+/obj/item/mob_lasso/drake
+	name = "drake lasso"
+	desc = "A lasso fashioned out of the scaly hide of an ash drake.\nCan be used to tame one, if you can get close enough."
+	range = 3
+
+/obj/item/mob_lasso/drake/Initialize(mapload)
+	. = ..()
+	whitelist_mobs = typecacheof(list(/mob/living/simple_animal/hostile/megafauna/dragon), only_root_path = TRUE)
+
 /obj/item/mob_lasso/antag
 	name = "bluespace lasso"
 	desc = "Comes standard with every evil space-cowboy!\nCan be used to tame almost anything."
@@ -104,5 +115,8 @@
 /obj/item/mob_lasso/antag/debug
 	name = "debug lasso"
 	desc = "Comes standard with every administrator space-cowboy!\nCan be used to tame anything."
-	blacklist_mobs = list() //anything goes
+
+/obj/item/mob_lasso/antag/debug/Initialize(mapload)
+	. = ..()
+	blacklist_mobs = list()
 

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -34,6 +34,7 @@
 	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
 	owner.teach_crafting_recipe(/datum/crafting_recipe/drakecloak)
 	owner.teach_crafting_recipe(/datum/crafting_recipe/primal_lasso)
+	owner.teach_crafting_recipe(/datum/crafting_recipe/dragon_lasso)
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2397,6 +2397,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/antag_lasso
 	name = "Mindslave Lasso"
 	desc = "A state of the art taming device.\n Use this device to tame almost any animal by lassoing and untying them.\n Tamed animals can be rode & commanded!"
-	item = /obj/item/mob_lasso/antag
+	item = /obj/item/mob_lasso/traitor
 	cost = 3
 	surplus = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR does a few things:
1. It updates lasso code to use mob visibility instead of turf visibility and use typecaches. This should make lassoing a bit more consistent, removing the fairly common issue where you could see something but inexplicably not lasso it.
2. It makes tamed animal attacking code more robust. This should theoretically allow these mobs to do things like use their ranged and special attacks.
3. It fixes the tooltips in the tamed command wheel
4. It lets the primal lasso tame more mobs, notably the other goliath subtypes, watcher subtypes, and gubbucks. 
5. It adds a special lasso that ash walkers can craft that allows them to tame ash drakes. This requires the same materials as a set of ash drake armor would, and can only be used by ash walkers. It also has a a shorter range than the standard lasso.  

To make an animal perform a ranged attack, you tell them to attack and then point to a turf you'd like them to target. To have an animal perform melee attacks, just point to the target as normal. They'll then approach and attack the target. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Removing a little bit of jank from lassos is good, and allowing tamed mobs to use more attacks should open up more options for the antag lasso. 
Adding more uses for primal lassos should also be interesting, since you can now add watchers and ancient goliaths to your herd of animals. 
Giving ashies the ability to tame ash drakes is *probably* a horrible idea, but I think it'd be cool, and restricting it to ashies only means that miners can't use it to powergame harder. Also, making it require the materials drake armor would means that you need to kill a drake first, or find one that died. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/9423435/202074764-e297c103-af5e-49cb-a3e0-81190e403061.mp4


https://user-images.githubusercontent.com/9423435/202078053-2e22e149-4baf-4fe7-9e33-7a703f9f51f0.mp4

 

</details>

## Changelog
:cl:
add: Adds an ash drake lasso. This can only be crafted and used by ash walkers, and can be used to tame ash drakes.
balance: Adds more lavaland mobs to the list of mobs that the primal lasso can tame.
code: Makes tamed animal attack code a bit more robust.
code: Refactors lasso code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
