### PR TITLE
Overall reverses lavaland powercreep

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -165,7 +165,6 @@
 
 //LAVALAND
 #define MAXIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE 90 //! what pressure you have to be under to increase the effect of equipment meant for lavaland
-#define MINIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE 25 //! what pressure you have to be over to increase the effect of equipment meant for lavaland
 #define LAVALAND_DEFAULT_ATMOS		"o2=14;n2=5;co2=13;TEMP=300"
 
 //ATMOS MIX IDS

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -553,7 +553,7 @@
 	if(!istype(environment))
 		return
 	var/pressure = environment.return_pressure()
-	if(pressure <= MAXIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE && pressure >= MINIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
+	if(pressure <= MAXIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
 		. = TRUE
 
 /proc/ispipewire(item)

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/lavaland/terrain.dmi'
 	icon_state = "geyser"
 	anchored = TRUE
+	max_integrity = 150 //default is 300, override to have 1/2 half
 
 	var/erupting_state = null //set to null to get it greyscaled from "[icon_state]_soup". Not very usable with the whole random thing, but more types can be added if you change the spawn prob
 	var/activated = FALSE //whether we are active and generating chems

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -8,7 +8,7 @@
 
 	faction = list("mining")
 	max_mobs = 3
-	max_integrity = 250
+	max_integrity = 125
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril)
 
 	move_resist=INFINITY // just killing it tears a massive hole in the ground, let's not move it

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -31,7 +31,7 @@
 /obj/item/kinetic_crusher/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 110) //technically it's huge and bulky, but this provides an incentive to use it
-	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=10)
+	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=14)
 
 /obj/item/kinetic_crusher/Destroy()
 	QDEL_LIST(trophies)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -31,7 +31,7 @@
 /obj/item/kinetic_crusher/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 110) //technically it's huge and bulky, but this provides an incentive to use it
-	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=20)
+	AddComponent(/datum/component/two_handed, force_unwielded=0, force_wielded=10)
 
 /obj/item/kinetic_crusher/Destroy()
 	QDEL_LIST(trophies)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -25,8 +25,8 @@
 	var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15
-	var/detonation_damage = 50
-	var/backstab_bonus = 30
+	var/detonation_damage = 25
+	var/backstab_bonus = 15
 
 /obj/item/kinetic_crusher/ComponentInitialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -22,8 +22,8 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner
 	name = "blood-drunk miner"
 	desc = "A miner destined to wander forever, engaged in an endless hunt."
-	health = 900
-	maxHealth = 900
+	health = 450
+	maxHealth = 450
 	icon_state = "miner"
 	icon_living = "miner"
 	icon = 'icons/mob/broadMobs.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -27,8 +27,8 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum
 	name = "bubblegum"
 	desc = "In what passes for a hierarchy among slaughter demons, this one is king."
-	health = 2500
-	maxHealth = 2500
+	health = 1250
+	maxHealth = 1250
 	attacktext = "rends"
 	attack_sound = 'sound/magic/demon_attack1.ogg'
 	icon_state = "bubblegum"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -24,8 +24,8 @@ Difficulty: Very Hard
 /mob/living/simple_animal/hostile/megafauna/colossus
 	name = "colossus"
 	desc = "A monstrous creature protected by heavy shielding."
-	health = 2500
-	maxHealth = 2500
+	health = 1250
+	maxHealth = 1250
 	attacktext = "judges"
 	attack_sound = 'sound/magic/clockwork/ratvar_attack.ogg'
 	icon_state = "eva"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -29,8 +29,8 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/dragon
 	name = "ash drake"
 	desc = "Guardians of the necropolis."
-	health = 2500
-	maxHealth = 2500
+	health = 1250
+	maxHealth = 1250
 	attacktext = "chomps"
 	attack_sound = 'sound/magic/demon_attack1.ogg'
 	icon = 'icons/mob/lavaland/64x64megafauna.dmi'
@@ -46,8 +46,8 @@ Difficulty: Medium
 	ranged = TRUE
 	pixel_x = -16
 	loot = list(/obj/effect/spawner/lootdrop/megafaunaore, /obj/structure/closet/crate/necropolis/dragon)
-	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30) 
-	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/ashdrake = 10)									  
+	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
+	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/ashdrake = 10)
 	var/swooping = NONE
 	var/player_cooldown = 0
 	gps_name = "Fiery Signal"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -37,8 +37,8 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/hierophant
 	name = "hierophant"
 	desc = "A massive metal club that hangs in the air as though waiting. It'll make you dance to its beat."
-	health = 2500
-	maxHealth = 2500
+	health = 1250
+	maxHealth = 1250
 	attacktext = "clubs"
 	attack_sound = 'sound/weapons/sonic_jackhammer.ogg'
 	icon_state = "hierophant"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -11,8 +11,8 @@ Difficulty: Medium
 
 /mob/living/simple_animal/hostile/megafauna/legion
 	name = "Legion"
-	health = 800
-	maxHealth = 800
+	health = 400
+	maxHealth = 400
 	icon_state = "legion"
 	icon_living = "legion"
 	desc = "One of many."
@@ -214,7 +214,7 @@ Difficulty: Medium
 		A.name = "ash storm"
 		log_game("[user] ([key_name(user)]) has summoned [A] at [AREACOORD(user_turf)]")
 		if (!(is_special_character(user)))
-			message_admins("[A] has been summoned in [ADMIN_VERBOSEJMP(user_turf)] by [ADMIN_LOOKUPFLW(user)], a non-antagonist!") //This check actually did the opposite before now and only reported when antagonists used it, but called them non-antagonists. 
+			message_admins("[A] has been summoned in [ADMIN_VERBOSEJMP(user_turf)] by [ADMIN_LOOKUPFLW(user)], a non-antagonist!") //This check actually did the opposite before now and only reported when antagonists used it, but called them non-antagonists.
 		A.area_type = user_area.type
 		A.telegraph_duration = 100
 		A.end_duration = 100

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -1,8 +1,8 @@
 /mob/living/simple_animal/hostile/megafauna
 	name = "boss of this gym"
 	desc = "Attack the weak point for massive damage."
-	health = 1000
-	maxHealth = 1000
+	health = 500
+	maxHealth = 500
 	spacewalk = TRUE
 	a_intent = INTENT_HARM
 	sentience_type = SENTIENCE_BOSS
@@ -43,7 +43,7 @@
 	var/chosen_attack = 1 // chosen attack num
 	var/list/attack_action_types = list()
 	var/small_sprite_type
-	/// Determines what a megafauna will say or do to telegraph its next attack. (Currently only used by Colossus). Set to 1 by default so the opening attack will always be the same. 
+	/// Determines what a megafauna will say or do to telegraph its next attack. (Currently only used by Colossus). Set to 1 by default so the opening attack will always be the same.
 	var/random_attack_num = 1
 
 /mob/living/simple_animal/hostile/megafauna/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -45,8 +45,8 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	desc = "That name is a bit of a mouthful, but stop paying attention to your mouth they're eating everything!"
 	icon = 'icons/mob/swarmer.dmi'
 	icon_state = "swarmer_console"
-	health = 750
-	maxHealth = 750 //""""low-ish"""" HP because it's a passive boss, and the swarm itself is the real foe
+	health = 375
+	maxHealth = 375 //""""low-ish"""" HP because it's a passive boss, and the swarm itself is the real foe
 	mob_biotypes = list(MOB_ROBOTIC)
 	gps_name = "Hungry Signal"
 	achievement_type = /datum/award/achievement/boss/swarmer_beacon_kill

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -18,8 +18,8 @@
 	throw_message = "does nothing against the hard shell of"
 	vision_range = 2
 	speed = 3
-	maxHealth = 200
-	health = 200
+	maxHealth = 100
+	health = 100
 	obj_damage = 60
 	melee_damage = 12
 	attacktext = "bites into"
@@ -97,8 +97,8 @@
 	icon_living = "watcher_magmawing"
 	icon_aggro = "watcher_magmawing"
 	icon_dead = "watcher_magmawing_dead"
-	maxHealth = 215 //Compensate for the lack of slowdown on projectiles with a bit of extra health
-	health = 215
+	maxHealth = 108 //Compensate for the lack of slowdown on projectiles with a bit of extra health
+	health = 108
 	light_system = MOVABLE_LIGHT
 	light_range = 3
 	light_power = 2.5
@@ -114,8 +114,8 @@
 	icon_living = "watcher_icewing"
 	icon_aggro = "watcher_icewing"
 	icon_dead = "watcher_icewing_dead"
-	maxHealth = 170
-	health = 170
+	maxHealth = 85
+	health = 85
 	projectiletype = /obj/item/projectile/temp/basilisk/icewing
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/bone = 1) //No sinew; the wings are too fragile to be usable
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -13,8 +13,8 @@
 	aggro_vision_range = 9
 	move_to_delay = 5
 	friendly = "harmlessly rolls into"
-	maxHealth = 45
-	health = 45
+	maxHealth = 23
+	health = 23
 	melee_damage = 0
 	attacktext = "barrels into"
 	attack_sound = 'sound/weapons/punch1.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -17,8 +17,8 @@
 	speak_emote = list("bellows")
 	vision_range = 4
 	speed = 3
-	maxHealth = 300
-	health = 300
+	maxHealth = 150
+	health = 150
 	obj_damage = 100
 	melee_damage = 25
 	attacktext = "pulverizes"
@@ -111,8 +111,8 @@
 	icon_living = "Goliath"
 	icon_aggro = "Goliath_alert"
 	icon_dead = "Goliath_dead"
-	maxHealth = 400
-	health = 400
+	maxHealth = 200
+	health = 200
 	speed = 4
 	pre_attack_icon = "Goliath_preattack"
 	throw_message = "does nothing to the rocky hide of the"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -14,8 +14,8 @@
 	vision_range = 5
 	aggro_vision_range = 9
 	speed = 3
-	maxHealth = 75
-	health = 75
+	maxHealth = 38
+	health = 38
 	melee_damage = 0
 	attacktext = "lashes out at"
 	speak_emote = list("telepathically cries")
@@ -125,8 +125,8 @@
 	icon_living = "dwarf_legion"
 	icon_aggro = "dwarf_legion"
 	icon_dead = "dwarf_legion"
-	maxHealth = 60
-	health = 60
+	maxHealth = 30
+	health = 30
 	speed = 2 //faster!
 	crusher_drop_mod = 20
 	dwarf_mob = TRUE
@@ -198,8 +198,8 @@
 //Advanced Legion is slightly tougher to kill and can raise corpses (revive other legions)
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced
 	stat_attack = DEAD
-	maxHealth = 120
-	health = 120
+	maxHealth = 60
+	health = 60
 	brood_type = /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/advanced
 	icon_state = "dwarf_legion"
 	icon_living = "dwarf_legion"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -164,14 +164,14 @@
 /obj/item/projectile/kinetic
 	name = "kinetic force"
 	icon_state = null
-	damage = 40
+	damage = 20
 	damage_type = BRUTE
 	flag = "bomb"
 	range = 3
 	log_override = TRUE
 
 	var/pressure_decrease_active = FALSE
-	var/pressure_decrease = 0.25
+	var/pressure_decrease = 0.5
 	var/obj/item/gun/energy/kinetic_accelerator/kinetic_gun
 
 /obj/item/projectile/kinetic/Destroy()
@@ -507,10 +507,10 @@
 //Indoors
 /obj/item/borg/upgrade/modkit/indoors
 	name = "decrease pressure penalty"
-	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure and full vacuum environments."
+	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure environments."
 	modifier = 2
 	denied_type = /obj/item/borg/upgrade/modkit/indoors
-	maximum_of_type = 2
+	maximum_of_type = 1
 	cost = 35
 
 /obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/item/projectile/kinetic/K)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2230,11 +2230,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/role_restricted/pressure_mod
 	name = "Kinetic Accelerator Pressure Mod"
-	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors and in a vacuum. \
+	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
 			Occupies 35% mod capacity."
 	item = /obj/item/borg/upgrade/modkit/indoors
-	cost = 5 //you need two for full damage, so total of 10 for maximum damage
-	limited_stock = 2 //you can't use more than two!
+	cost = 10 //you need one for full damage, so total of 10 for maximum damage
+	limited_stock = 1 //you can't use more than one!
 	restricted_roles = list(JOB_NAME_SHAFTMINER)
 
 /datum/uplink_item/role_restricted/esaw

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2233,7 +2233,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
 			Occupies 35% mod capacity."
 	item = /obj/item/borg/upgrade/modkit/indoors
-	cost = 10 //you need one for full damage, so total of 10 for maximum damage
+	cost = 5 //you need one for full damage, so total of 5 for maximum damage
 	limited_stock = 1 //you can't use more than one!
 	restricted_roles = list(JOB_NAME_SHAFTMINER)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This overall reverses the powercreep present in lavaland where very tanky mobs require very tanky weaponry to fight by bringing miners down to somewhat-reasonable amounts of possible damage per second able to be given and also brings down the typical lavaland mobs health as well. As a consequence, reverts https://github.com/BeeStation/BeeStation-Hornet/pull/7552

<details>
<summary>Path Changes</summary>

```
/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient
/mob/living/simple_animal/hostile/asteroid/goliath
/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing
/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing
/mob/living/simple_animal/hostile/asteroid/basilisk
/mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf
/mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced
/mob/living/simple_animal/hostile/asteroid/hivelord/legion
/mob/living/simple_animal/hostile/asteroid/hivelord
/mob/living/simple_animal/hostile/asteroid/goldgrub
/mob/living/simple_animal/hostile/megafauna
/mob/living/simple_animal/hostile/megafauna/drake
/mob/living/simple_animal/hostile/megafauna/colossus
/mob/living/simple_animal/hostile/megafauna/bubblegum
/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner
/mob/living/simple_animal/hostile/megafauna/hierophant
/mob/living/simple_animal/hostile/megafauna/legion
/mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon
/obj/structure/spawner/lavaland
/obj/structure/geyser (set max_integrity to 150)
```
</details>

PKA: 40 per hit -> 20 per hit
PKC: 50 per bubble pop -> 25 per bubble pop (holy cow)

For comparison, the laser gun does 20 burn damage on a successful hit.

This will by no means make the typical miner's job easier or harder, it will just address miners fighting crew head-on and maybe give them a fighting chance. Also, the occasional ash drake on the station will be 50% easier to fight (probably).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Powerfulbacon (a not-well-known contributor for this codebase) suggested it, additionally addresses https://github.com/BeeStation/BeeStation-Hornet/issues/8010

Additional Note: If the maintainers want this to go more than 1/2 overall damage we can try out lower amounts.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

damage to naked ashwalker with stock PKA lavaland atmos (4 shots to crit):

https://user-images.githubusercontent.com/30960302/202105790-b60caefd-6855-42c5-8713-1fe64e4517e3.mp4

damage to naked ashwalker with stock PKA weakened atmos (10 shots to crit):

https://user-images.githubusercontent.com/30960302/202106474-8e5ebf6a-4484-4725-97d9-64ac7bfac2f9.mp4

 

</details>

## Changelog
:cl:
balance: halved lavaland mobs health
balance: halved PKA and PKC damage
balance: Removed minimum pressure requirement from PKA and PKC, so they do the same amount of damage in vacuums again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
