### PR TITLE
Fixes a minebot repair bug

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -170,7 +170,7 @@
 		return
 	if(maxHealth == health)
 		to_chat(user, "<span class='info'>[src] is at full integrity.</span>")
-		return
+		return TRUE
 	if(welder.use_tool(src, user, 0, volume = 40))
 		if(stat == DEAD && health > 0)
 			to_chat(user, "<span class='info'>You restart [src].</span>")
@@ -578,6 +578,7 @@
 
 /// Handles adding upgrades. This checks for any duplicate mods and links the mod to the minebot. Returns FALSE if the upgrade fails, otherwise returns TRUE
 /obj/item/minebot_upgrade/proc/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/minebot, mob/user)
+	SHOULD_CALL_PARENT(TRUE)
 	if(is_type_in_list(src, minebot.installed_upgrades))
 		minebot.balloon_alert(user, "A similar mod has already been installed.")
 		return FALSE
@@ -591,6 +592,7 @@
 
 /// Handles removing upgrades. This handles unlinking the minebot as well, so it should be called after any upgrade-specific unequip actions.
 /obj/item/minebot_upgrade/proc/unequip()
+	SHOULD_CALL_PARENT(TRUE)
 	LAZYREMOVE(linked_bot.installed_upgrades, src)
 	forceMove(get_turf(linked_bot))
 	linked_bot = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
So I forgot a TRUE on this return, and apparently i just forgot to PR the fix for that.
This also adds a couple SDMM flags to the minebot upgrade procs to enforce parent calls, just in case anyone else makes more upgrades.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Bugfixes are good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Compiles properly, repairing works.

## Changelog
:cl:
fix: You don't hit minebots when trying to repair them at full health anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
