### PR TITLE
Examine atmos machinery will tell the piping layer

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -19,6 +19,11 @@
 		var/datum/gas_mixture/A = new(200)
 		airs[i] = A
 
+/obj/machinery/atmospherics/components/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
+
+
 // Iconnery
 
 /obj/machinery/atmospherics/components/proc/update_icon_nopipes()

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -25,6 +25,10 @@
 	volume = 35 * device_type
 	..()
 
+/obj/machinery/atmospherics/pipe/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>[src] is on layer [piping_layer].</span>"
+
 /obj/machinery/atmospherics/pipe/nullifyNode(i)
 	var/obj/machinery/atmospherics/oldN = nodes[i]
 	..()


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/57937

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Atmos component and the pipes will now tell on what piping layer they are on examine

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less pain when trying to understand the position just by the sprite

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

![ballin](https://user-images.githubusercontent.com/62388554/202610764-6241b807-96c6-466f-ab66-274c7f057881.png)
![pipekind_redefined](https://user-images.githubusercontent.com/62388554/202610788-b4db9aaa-833f-4f1b-8154-35839ae8f543.png)


## Changelog
:cl: Ghilker, RKz
qol: atmos components and pipes now show the piping layer on examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
