### PR TITLE
Increases Experimentor Linking Range

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -176,7 +176,7 @@
 		usr << browse(null, "window=experimentor")
 		return
 	if(scantype == "search")
-		var/obj/machinery/computer/rdconsole/D = locate(/obj/machinery/computer/rdconsole) in oview(3,src)
+		var/obj/machinery/computer/rdconsole/D = locate(/obj/machinery/computer/rdconsole) in oview(5,src)
 		if(D)
 			linked_console = D
 	else if(scantype == "eject")


### PR DESCRIPTION
Port:
- https://github.com/Monkestation/MonkeStation/pull/652

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the range that the Experimentor searches to link with the R&D console from oview(3,src) to oview(5,src).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I get too many mhelps about why the experimentor is not linking on Box and other stations. This saves me, other mentors, and a hell of a lot of new players some headaches.



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure


![expericringe](https://user-images.githubusercontent.com/62388554/202653713-1d260d07-99d3-4a02-91ae-57fc513c5267.png)



## Changelog
:cl: DoctorSquishy
tweak: Tweaked Experimentor linking range, so now BoxStation's Experimentor can detect the console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
