### PR TITLE
Make player panel search bar empty on open

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -13,6 +13,7 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		log_admin("[key_name(user)] checked the player panel.")
+		search_text = null
 		ui = new(user, src, "PlayerPanel", "Player Panel")
 		ui.open()
 


### PR DESCRIPTION
## About The Pull Request

Deletes the search contents on open.

## Why It's Good For The Game

Requested by admins due to muscle memory.

## Testing Photographs and Procedure
 
<details>
<summary>Screenshots&Videos</summary>

Search bar, empty after closing with text in it

![image](https://user-images.githubusercontent.com/10366817/202820336-c8cb604e-2d3a-4d5e-a641-ec990201a0b9.png)

</details>

## Changelog
:cl:
tweak: The admin player panel now empties the search bar on open.
/:cl: