### PR TITLE
Port attempt of /tg/ deadchat control

### DIFF
--- a/code/__DEFINES/dcs/helpers.dm
+++ b/code/__DEFINES/dcs/helpers.dm
@@ -6,6 +6,14 @@
 
 #define SEND_GLOBAL_SIGNAL(sigtype, arguments...) ( SEND_SIGNAL(SSdcs, sigtype, ##arguments) )
 
+/// Signifies that this proc is used to handle signals.
+/// Every proc you pass to RegisterSignal must have this.
+#define SIGNAL_HANDLER SHOULD_NOT_SLEEP(TRUE)
+
+/// Signifies that this proc is used to handle signals, but also sleeps.
+/// Do not use this for new work.
+#define SIGNAL_HANDLER_DOES_SLEEP
+
 /// A wrapper for _AddElement that allows us to pretend we're using normal named arguments
 #define AddElement(arguments...) _AddElement(list(##arguments))
 /// A wrapper for _RemoveElement that allows us to pretend we're using normal named arguments

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1,3 +1,2 @@
-/// Signifies that this proc is used to handle signals.
-/// Every proc you pass to RegisterSignal must have this.
-#define SIGNAL_HANDLER SHOULD_NOT_SLEEP(TRUE)
+#define COMSIG_VV_TOPIC "vv_topic"
+	#define COMPONENT_VV_HANDLED (1<<0)

--- a/code/__DEFINES/dcs/signals/mob_signals/mob_signals.dm
+++ b/code/__DEFINES/dcs/signals/mob_signals/mob_signals.dm
@@ -48,6 +48,9 @@
 	#define SPEECH_LANGUAGE 5
 	#define SPEECH_IGNORE_SPAM 6
 	#define SPEECH_FORCED 7 */
+#define COMSIG_MOB_AUTOMUTE_CHECK "client_automute_check" // The check is performed by the client.
+	/// Prevents the automute system checking this client for repeated messages.
+	#define WAIVE_AUTOMUTE_CHECK (1<<0)
 #define COMSIG_MOB_EMOTE "mob_emote" // from /mob/living/emote(): ()
 #define COMSIG_MOB_SWAP_HANDS "mob_swap_hands"        //from base of mob/swap_hand()
   #define COMPONENT_BLOCK_SWAP 1

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -89,6 +89,9 @@
 #define VV_HK_REMOVE_EMITTER "remove_emitter"
 #define VV_HK_ADD_AI "add_ai"
 
+// /atmo/movable
+#define VV_HK_DEADCHAT_PLAYS "deadchat_plays"
+
 // /datum/gas_mixture
 #define VV_HK_SET_MOLES "set_moles"
 #define VV_HK_EMPTY "empty"

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -77,7 +77,7 @@
 
 	if(deadchat_mode & DEMOCRACY_MODE)
 		ckey_to_cooldown[source.ckey] = message
-		to_chat(source, span_notice("You have voted for \"[message]\"."))
+		to_chat(source, "<span class='notice'>You have voted for \"[message]\".</span>")
 		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
 /datum/component/deadchat_control/proc/democracy_loop()
@@ -178,9 +178,9 @@
 		if(QDELETED(src))
 			return
 
-		to_chat(user, span_notice("Deadchat can no longer control [parent]."))
+		to_chat(user, "<span class='notice'>Deadchat can no longer control [parent].</span>")
 		log_admin("[key_name(user)] has removed deadchat control from [parent]")
-		message_admins(span_notice("[key_name(user)] has removed deadchat control from [parent]"))
+		message_admins("<span class='notice'>[key_name(user)] has removed deadchat control from [parent]</span>")
 
 		qdel(src)
 
@@ -191,12 +191,12 @@
 	if(!isobserver(user))
 		return
 
-	examine_list += span_notice("[A.p_theyre(TRUE)] currently under deadchat control using the [(deadchat_mode & DEMOCRACY_MODE) ? "democracy" : "anarchy"] ruleset!")
+	examine_list += "<span class='notice'>[A.p_theyre(TRUE)] currently under deadchat control using the [(deadchat_mode & DEMOCRACY_MODE) ? "democracy" : "anarchy"] ruleset!</span>"
 
 	if(deadchat_mode & DEMOCRACY_MODE)
-		examine_list += span_notice("Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] second\s.")
+		examine_list += "<span class='notice'>Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] second\s.</span>"
 	else if(deadchat_mode & ANARCHY_MODE)
-		examine_list += span_notice("Type a command into chat to perform. You may do this once every [input_cooldown * 0.1] second\s.")
+		examine_list += "<span class='notice'>Type a command into chat to perform. You may do this once every [input_cooldown * 0.1] second\s.</span>"
 
 	var/extended_examine = "<span class='notice'>Command list:"
 

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -1,64 +1,97 @@
-#define DEMOCRACY_MODE "democracy"
-#define ANARCHY_MODE "anarchy"
+///Will execute a single command after the cooldown based on player votes.
+#define DEMOCRACY_MODE (1<<0)
+///Allows each player to do a single command every cooldown.
+#define ANARCHY_MODE (1<<1)
+///Mutes the democracy mode messages send to orbiters at the end of each cycle. Useful for when the cooldown is so low it'd get spammy.
+#define MUTE_DEMOCRACY_MESSAGES (1<<2)
 
+/**
+ * Deadchat Plays Things - The Componenting
+ *
+ * Allows deadchat to control stuff and things by typing commands into chat.
+ * These commands will then trigger callbacks to execute procs!
+ */
 /datum/component/deadchat_control
 	dupe_mode = COMPONENT_DUPE_UNIQUE
-	var/timerid
 
+	/// The id for the DEMOCRACY_MODE looping vote timer.
+	var/timerid
+	/// Assoc list of key-chat command string, value-callback pairs. list("right" = CALLBACK(GLOBAL_PROC, .proc/_step, src, EAST))
 	var/list/datum/callback/inputs = list()
+	/// Assoc list of ckey:value pairings. In DEMOCRACY_MODE, value is the player's vote. In ANARCHY_MODE, value is world.time when their cooldown expires.
 	var/list/ckey_to_cooldown = list()
+	/// List of everything orbitting this component's parent.
 	var/orbiters = list()
+	/// A bitfield containing the mode which this component uses (DEMOCRACY_MODE or ANARCHY_MODE) and other settings)
 	var/deadchat_mode
+	/// In DEMOCRACY_MODE, this is how long players have to vote on an input. In ANARCHY_MODE, this is how long between inputs for each unique player.
 	var/input_cooldown
 
-/datum/component/deadchat_control/Initialize(_deadchat_mode, _inputs, _input_cooldown = 12 SECONDS)
+	/// Callback invoked when this component is Destroy()ed to allow the parent to return to a non-deadchat controlled state.
+	var/datum/callback/on_removal
+
+/datum/component/deadchat_control/Initialize(_deadchat_mode, _inputs, _input_cooldown = 12 SECONDS, _on_removal)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	RegisterSignal(parent, COMSIG_ATOM_ORBIT_BEGIN, .proc/orbit_begin)
 	RegisterSignal(parent, COMSIG_ATOM_ORBIT_STOP, .proc/orbit_stop)
+	RegisterSignal(parent, COMSIG_VV_TOPIC, .proc/handle_vv_topic)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 	deadchat_mode = _deadchat_mode
 	inputs = _inputs
 	input_cooldown = _input_cooldown
-	if(deadchat_mode == DEMOCRACY_MODE)
+	on_removal = _on_removal
+	if(deadchat_mode & DEMOCRACY_MODE)
+		if(deadchat_mode & ANARCHY_MODE) // Choose one, please.
+			stack_trace("deadchat_control component added to [parent.type] with both democracy and anarchy modes enabled.")
 		timerid = addtimer(CALLBACK(src, .proc/democracy_loop), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
 	notify_ghosts("[parent] is now deadchat controllable!", source = parent, action = NOTIFY_ORBIT, header="Something Interesting!")
 
-
 /datum/component/deadchat_control/Destroy(force, silent)
+	on_removal?.Invoke()
 	inputs = null
 	orbiters = null
 	ckey_to_cooldown = null
 	return ..()
 
 /datum/component/deadchat_control/proc/deadchat_react(mob/source, message)
+	SIGNAL_HANDLER
+
 	message = lowertext(message)
+
 	if(!inputs[message])
 		return
-	if(deadchat_mode == ANARCHY_MODE)
-		var/cooldown = ckey_to_cooldown[source.ckey]
-		if(cooldown)
-			return MOB_DEADSAY_SIGNAL_INTERCEPT
-		inputs[message].Invoke()
-		ckey_to_cooldown[source.ckey] = TRUE
-		addtimer(CALLBACK(src, .proc/remove_cooldown, source.ckey), input_cooldown)
-	else if(deadchat_mode == DEMOCRACY_MODE)
-		ckey_to_cooldown[source.ckey] = message
-	return MOB_DEADSAY_SIGNAL_INTERCEPT
 
-/datum/component/deadchat_control/proc/remove_cooldown(ckey)
-	ckey_to_cooldown.Remove(ckey)
+	if(deadchat_mode & ANARCHY_MODE)
+		if(!source || !source.ckey)
+			return
+		var/cooldown = ckey_to_cooldown[source.ckey] - world.time
+		if(cooldown > 0)
+			to_chat(source, "span class='warning'>Your deadchat control inputs are still on cooldown for another [CEILING(cooldown * 0.1, 1)] second\s.</span>")
+			return MOB_DEADSAY_SIGNAL_INTERCEPT
+		ckey_to_cooldown[source.ckey] = world.time + input_cooldown
+		addtimer(CALLBACK(src, .proc/end_cooldown, source.ckey), input_cooldown)
+		inputs[message].Invoke()
+		to_chat(source, "<span class='userdanger'>\"[message]\" input accepted. You are now on cooldown for [input_cooldown * 0.1] second\s.</span>")
+		return MOB_DEADSAY_SIGNAL_INTERCEPT
+
+	if(deadchat_mode & DEMOCRACY_MODE)
+		ckey_to_cooldown[source.ckey] = message
+		to_chat(source, span_notice("You have voted for \"[message]\"."))
+		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
 /datum/component/deadchat_control/proc/democracy_loop()
-	if(QDELETED(parent) || deadchat_mode != DEMOCRACY_MODE)
+	if(QDELETED(parent) || !(deadchat_mode & DEMOCRACY_MODE))
 		deltimer(timerid)
 		return
 	var/result = count_democracy_votes()
 	if(!isnull(result))
 		inputs[result].Invoke()
-		var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown/10] seconds.</span>"
-		for(var/M in orbiters)
-			to_chat(M, message)
-	else
+		if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
+			var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown * 0.1] second\s.</span>"
+			for(var/M in orbiters)
+				to_chat(M, message)
+	else if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
 		var/message = "<span class='deadsay italics bold'>No votes were cast this cycle.</span>"
 		for(var/M in orbiters)
 			to_chat(M, message)
@@ -97,10 +130,121 @@
 		deltimer(timerid)
 
 /datum/component/deadchat_control/proc/orbit_begin(atom/source, atom/orbiter)
+	SIGNAL_HANDLER
+
 	RegisterSignal(orbiter, COMSIG_MOB_DEADSAY, .proc/deadchat_react)
+	RegisterSignal(orbiter, COMSIG_MOB_AUTOMUTE_CHECK, .proc/waive_automute)
 	orbiters |= orbiter
 
+
 /datum/component/deadchat_control/proc/orbit_stop(atom/source, atom/orbiter)
+	SIGNAL_HANDLER
+
 	if(orbiter in orbiters)
-		UnregisterSignal(orbiter, COMSIG_MOB_DEADSAY)
+		UnregisterSignal(orbiter, list(
+			COMSIG_MOB_DEADSAY,
+			COMSIG_MOB_AUTOMUTE_CHECK,
+		))
 		orbiters -= orbiter
+
+/**
+ * Prevents messages used to control the parent from counting towards the automute threshold for repeated identical messages.
+ *
+ * Arguments:
+ * - [speaker][/client]: The mob that is trying to speak.
+ * - [client][/client]: The client that is trying to speak.
+ * - message: The message that the speaker is trying to say.
+ * - mute_type: Which type of mute the message counts towards.
+ */
+/datum/component/deadchat_control/proc/waive_automute(mob/speaker, client/client, message, mute_type)
+	SIGNAL_HANDLER
+	if(mute_type == MUTE_DEADCHAT && inputs[lowertext(message)])
+		return WAIVE_AUTOMUTE_CHECK
+	return NONE
+
+
+/// Allows for this component to be removed via a dedicated VV dropdown entry.
+/datum/component/deadchat_control/proc/handle_vv_topic(datum/source, mob/user, list/href_list)
+	SIGNAL_HANDLER
+	if(!href_list[VV_HK_DEADCHAT_PLAYS] || !check_rights(R_FUN))
+		return
+	. = COMPONENT_VV_HANDLED
+	INVOKE_ASYNC(src, .proc/async_handle_vv_topic, user, href_list)
+
+/// Async proc handling the alert input and associated logic for an admin removing this component via the VV dropdown.
+/datum/component/deadchat_control/proc/async_handle_vv_topic(mob/user, list/href_list)
+	if(tgui_alert(user, "Remove deadchat control from [parent]?", "Deadchat Plays [parent]", list("Remove", "Cancel")) == "Remove")
+		// Quick sanity check as this is an async call.
+		if(QDELETED(src))
+			return
+
+		to_chat(user, span_notice("Deadchat can no longer control [parent]."))
+		log_admin("[key_name(user)] has removed deadchat control from [parent]")
+		message_admins(span_notice("[key_name(user)] has removed deadchat control from [parent]"))
+
+		qdel(src)
+
+/// Informs any examiners to the inputs available as part of deadchat control, as well as the current operating mode and cooldowns.
+/datum/component/deadchat_control/proc/on_examine(atom/A, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	if(!isobserver(user))
+		return
+
+	examine_list += span_notice("[A.p_theyre(TRUE)] currently under deadchat control using the [(deadchat_mode & DEMOCRACY_MODE) ? "democracy" : "anarchy"] ruleset!")
+
+	if(deadchat_mode & DEMOCRACY_MODE)
+		examine_list += span_notice("Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] second\s.")
+	else if(deadchat_mode & ANARCHY_MODE)
+		examine_list += span_notice("Type a command into chat to perform. You may do this once every [input_cooldown * 0.1] second\s.")
+
+	var/extended_examine = "<span class='notice'>Command list:"
+
+	for(var/possible_input in inputs)
+		extended_examine += " [possible_input]"
+
+	extended_examine += ".</span>"
+
+	examine_list += extended_examine
+
+///Removes the ghost from the ckey_to_cooldown list and lets them know they are free to submit a command for the parent again.
+/datum/component/deadchat_control/proc/end_cooldown(ghost_ckey)
+	ckey_to_cooldown -= ghost_ckey
+	var/mob/ghost = get_mob_by_ckey(ghost_ckey)
+	if(!ghost || isliving(ghost))
+		return
+	to_chat(ghost, "[FOLLOW_LINK(ghost, parent)] <span class='nicegreen'>Your deadchat control inputs for [parent] are no longer on cooldown.</span>")
+
+/**
+ * Deadchat Moves Things
+ *
+ * A special variant of the deadchat_control component that comes pre-baked with all the hottest inputs for a spicy
+ * singularity or vomit goose.
+ */
+/datum/component/deadchat_control/cardinal_movement/Initialize(_deadchat_mode, _inputs, _input_cooldown, _on_removal)
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	. = ..()
+
+	inputs["up"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, NORTH)
+	inputs["down"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, SOUTH)
+	inputs["left"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, WEST)
+	inputs["right"] = CALLBACK(GLOBAL_PROC, .proc/_step, parent, EAST)
+
+/**
+ * Deadchat Moves Things
+ *
+ * A special variant of the deadchat_control component that comes pre-baked with all the hottest inputs for spicy
+ * immovable rod.
+ */
+/datum/component/deadchat_control/immovable_rod/Initialize(_deadchat_mode, _inputs, _input_cooldown, _on_removal)
+	if(!istype(parent, /obj/effect/immovablerod))
+		return COMPONENT_INCOMPATIBLE
+
+	. = ..()
+
+	inputs["up"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, NORTH)
+	inputs["down"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, SOUTH)
+	inputs["left"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, WEST)
+	inputs["right"] = CALLBACK(parent, /obj/effect/immovablerod.proc/walk_in_direction, EAST)

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -173,7 +173,7 @@
 
 /// Async proc handling the alert input and associated logic for an admin removing this component via the VV dropdown.
 /datum/component/deadchat_control/proc/async_handle_vv_topic(mob/user, list/href_list)
-	if(tgui_alert(user, "Remove deadchat control from [parent]?", "Deadchat Plays [parent]", list("Remove", "Cancel")) == "Remove")
+	if(alert(user, "Remove deadchat control from [parent]?", "Deadchat Plays [parent]", list("Remove", "Cancel")) == "Remove")
 		// Quick sanity check as this is an async call.
 		if(QDELETED(src))
 			return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -151,8 +151,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
  *
  */
 /client/proc/handle_spam_prevention(message, mute_type)
+
 	if(!(CONFIG_GET(flag/automute_on)))
-		return FALSE
+		if(SEND_SIGNAL(mob, COMSIG_MOB_AUTOMUTE_CHECK, src, last_message, mute_type) & WAIVE_AUTOMUTE_CHECK)
+			return FALSE
 
 	if(COOLDOWN_FINISHED(src, total_count_reset))
 		total_message_count = 0 //reset the count if it's been more than 5 seconds since the first message
@@ -161,7 +163,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	total_message_count++
 
 	if(total_message_count >= SPAM_TRIGGER_AUTOMUTE)
-		to_chat(src, "<span class='userdanger'>You have exceeded the spam filter limit for too many messages. An auto-mute was applied. Make an adminhelp ticket if you think this was in error.</span>")
+		to_chat(src, "<span class='userdanger'>You have exceeded the spam filter limit for too many messages. An auto-mute was applied for the current round. Make an adminhelp ticket if you think this was in error.</span>")
 		cmd_admin_mute(src, mute_type, TRUE)
 		return TRUE
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -175,3 +175,16 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 				new /obj/structure/festivus/anchored(drop_location())
 				new /obj/effect/anomaly/flux(drop_location())
 				qdel(src)
+
+/obj/effect/immovablerod/deadchat_plays(mode = DEMOCRACY_MODE, cooldown = 6 SECONDS)
+	return AddComponent(/datum/component/deadchat_control/immovable_rod, mode, list(), cooldown)
+
+/**
+ * Rod will walk towards edge turf in the specified direction.
+ *
+ * Arguements:
+ * * direction - the direct to walk the rod towards: NORTH, SOUTH, EAST, WEST
+ */
+/obj/effect/immovablerod/proc/walk_in_direction(direction)
+	destination = get_edge_target_turf(src, direction)
+	SSmove_manager.move_towards(src, destination)


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/47110
- https://github.com/tgstation/tgstation/pull/52761 (partial)
- https://github.com/tgstation/tgstation/pull/55314
- https://github.com/tgstation/tgstation/pull/56888
- https://github.com/tgstation/tgstation/pull/57926
- ~https://github.com/tgstation/tgstation/pull/58419~ (someone else is doing it #8080)
- ~https://github.com/tgstation/tgstation/pull/59645~ (maybe one day....)
- https://github.com/tgstation/tgstation/pull/65195
- https://github.com/tgstation/tgstation/pull/66621


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This ports the entirety of /tg/'s deadchat_control.dmi functions for beestation! Included are a partial implementation of TG's signal_handling tweak(tgstation#52761), applied only to deadchat_control, which I will remove if it proves problematic.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Frankly this VV feature is rather underdeveloped and underwhelming on our codebase. This PR should give administrative staff more opportunities using deadchat_controls for entertaining dchat and themselves other than the usual CTF and Battle Royale.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: RKz
add: added very basic support for signal callback unblocks in helpers.dm, thus far only applied to deadchat_controls.dm
add: more dchat stuff!
spellcheck: added more specific 
code: complete rewrite of dead_chat control VV
admin: expanded VV deadchat_control options including controlling an immovableRod, birdboat, and whatever the admin chooses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
