### PR TITLE
Fix fire alarm under sign

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13143,10 +13143,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSC" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen{
 	pixel_x = -8
@@ -33298,6 +33294,13 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"jFV" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jGm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -92092,7 +92095,7 @@ cwm
 cwr
 fSm
 lig
-bOd
+jFV
 bMK
 gXu
 bOd


### PR DESCRIPTION
## About The Pull Request

Fixes #8088

## Why It's Good For The Game

Being able to see and press the fire alarm is good.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

I moved it

![image](https://user-images.githubusercontent.com/10366817/202822674-1cf2f867-8453-48b1-b226-d96138a57181.png)


</details>

## Changelog
:cl:
fix: BoxStation: Moved a fire alarm out from under the atmos sign in atmos storage.
/:cl: