### PR TITLE
Adjustements to the IV Drip, Anesthetic Tank Holder, Defibrillator Wall Mount and other wall-mounted items.

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -23,7 +23,9 @@
 
 /obj/machinery/defibrillator_mount/Destroy()
 	if(defib)
-		QDEL_NULL(defib)
+		defib.forceMove(get_turf(src))
+		defib.visible_message("<span class='notice'>[defib] falls to the ground from the broken [src].</span>")
+		defib = null
 		end_processing()
 	. = ..()
 
@@ -138,6 +140,19 @@
 	end_processing()
 	defib = null
 	update_icon()
+
+/obj/machinery/defibrillator_mount/crowbar_act(mob/living/user, obj/item/W)
+	if(!defib)
+		W.play_tool_sound(src, 75)
+		user.visible_message("[user.name] starts prying the [src] off the wall.", \
+							"<span class='notice'>You start prying the defibrillator mount off the wall.</span>")
+		if(W.use_tool(src, user, 30, volume=50, amount = 0))
+			new /obj/item/wallframe/defib_mount(loc)
+			user.visible_message(\
+				"[user.name] has pried [src] off the wall with [W].",\
+				"<span class='notice'>You pry the defibrillator mount off the wall.</span>")
+			qdel(src)
+			return TRUE
 
 //wallframe, for attaching the mounts easily
 /obj/item/wallframe/defib_mount

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -23,11 +23,18 @@
 
 /obj/machinery/defibrillator_mount/Destroy()
 	if(defib)
-		defib.forceMove(get_turf(src))
-		defib.visible_message("<span class='notice'>[defib] falls to the ground from the broken [src].</span>")
-		defib = null
+		QDEL_NULL(defib)
 		end_processing()
 	. = ..()
+
+/obj/machinery/defibrillator_mount/obj_destruction()
+	if(defib)
+		defib.forceMove(get_turf(src))
+		defib.visible_message("<span class='notice'>[defib] falls to the ground from the destroyed wall mount.</span>")
+		defib = null
+		end_processing()
+	return ..()
+
 
 /obj/machinery/defibrillator_mount/examine(mob/user)
 	. = ..()
@@ -37,6 +44,8 @@
 			. += "<span class='notice'>Due to a security situation, its locking clamps can be toggled by swiping any ID.</span>"
 		else
 			. += "<span class='notice'>Its locking clamps can be [clamps_locked ? "dis" : ""]engaged by swiping an ID with access.</span>"
+	else
+		. += "<span class='notice'>It's <i>empty</i> and can be <b>pried</b> off with a crowbar.</span>"
 
 /obj/machinery/defibrillator_mount/process()
 	if(defib?.cell && defib.cell.charge < defib.cell.maxcharge && is_operational)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -45,7 +45,7 @@
 		else
 			. += "<span class='notice'>Its locking clamps can be [clamps_locked ? "dis" : ""]engaged by swiping an ID with access.</span>"
 	else
-		. += "<span class='notice'>It's <i>empty</i> and can be <b>pried</b> off with a crowbar.</span>"
+		. += "<span class='notice'>It's <i>empty</i> and can be <b>pried</b> off the wall.</span>"
 
 /obj/machinery/defibrillator_mount/process()
 	if(defib?.cell && defib.cell.charge < defib.cell.maxcharge && is_operational)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -153,12 +153,12 @@
 /obj/machinery/defibrillator_mount/crowbar_act(mob/living/user, obj/item/W)
 	if(!defib)
 		W.play_tool_sound(src, 75)
-		user.visible_message("[user.name] starts prying the [src] off the wall.", \
+		user.visible_message("<span class='notice'>[user.name] starts prying the [src] off the wall.</span>", \
 							"<span class='notice'>You start prying the defibrillator mount off the wall.</span>")
 		if(W.use_tool(src, user, 30, volume=50, amount = 0))
 			new /obj/item/wallframe/defib_mount(loc)
 			user.visible_message(\
-				"[user.name] has pried [src] off the wall with [W].",\
+				"<span class='notice'>[user.name] pries the [src] off the wall with [W].</span>",\
 				"<span class='notice'>You pry the defibrillator mount off the wall.</span>")
 			qdel(src)
 			return TRUE

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -228,7 +228,7 @@
 
 	. += "<span class='notice'>[attached ? attached : "No one"] is attached.</span>"
 	if(!attached && !beaker)
-		. += "<span class='notice'>It can be converted into an Anesthetic Tank Holder with a screwdriver and a breath mask.</span>"
+		. += "<span class='notice'>A breath mask could be <b>attached</b> to it.</span>"
 
 
 /obj/machinery/iv_drip/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -26,6 +26,13 @@
 	QDEL_NULL(beaker)
 	return ..()
 
+/obj/machinery/iv_drip/obj_destruction()
+	if(beaker)
+		beaker.forceMove(drop_location())
+		beaker.visible_message("<span class='notice'>[beaker] falls to the ground from the destroyed IV drip.</span>")
+		beaker = null
+	return ..()
+
 /obj/machinery/iv_drip/update_icon()
 	if(attached)
 		if(mode)
@@ -213,17 +220,22 @@
 
 	if(beaker)
 		if(beaker.reagents && beaker.reagents.reagent_list.len)
-			. += "<span class='notice'>Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>"
+			. += "<span class='notice'>[icon2html(beaker, user)] Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.</span>"
 		else
 			. += "<span class='notice'>Attached is an empty [beaker.name].</span>"
 	else
 		. += "<span class='notice'>No chemicals are attached.</span>"
 
 	. += "<span class='notice'>[attached ? attached : "No one"] is attached.</span>"
+	if(!attached && !beaker)
+		. += "<span class='notice'>It can be converted into an Anesthetic Tank Holder with a screwdriver and a breath mask.</span>"
 
 
 /obj/machinery/iv_drip/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()
+	if(beaker)
+		to_chat(user, "<span class='warning'>You need to remove the [beaker] first!</span>")
+		return
 	if(user.is_holding_item_of_type(/obj/item/clothing/mask/breath) && can_convert)
 		visible_message("<span class='warning'>[user] attempts to attach the breath mask to [src].</span>", "<span class='notice'>You attempt to attach the breath mask to [src].</span>")
 		if(!do_after(user, 100, FALSE, src))

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -29,6 +29,7 @@
 /obj/machinery/iv_drip/obj_destruction()
 	if(beaker)
 		beaker.forceMove(drop_location())
+		beaker.SplashReagents(drop_location())
 		beaker.visible_message("<span class='notice'>[beaker] falls to the ground from the destroyed IV drip.</span>")
 		beaker = null
 	return ..()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -148,6 +148,7 @@
 	else
 		safety = TRUE
 		to_chat(user, "<span class='notice'>You silently enable [src]'s safety protocols with the cryptographic sequencer.</span>")
+	update_icon()
 
 /obj/item/defibrillator/emp_act(severity)
 	. = ..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -27,7 +27,7 @@
 	if(!unscrewed)
 		. += "<span class='notice'>It's <b>screwed</b> and secured to the wall.</span>"
 	else
-		. += "<span class='notice'>It's <i>unscrewed</i> from the wall, and can be <b>detached</b>.</span>"
+		. += "<span class='notice'>It's <i>unscrewed</i> from the wall, and can be <b>detached</b> with a wrench.</span>"
 
 /obj/item/radio/intercom/attackby(obj/item/I, mob/living/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -27,7 +27,7 @@
 	if(!unscrewed)
 		. += "<span class='notice'>It's <b>screwed</b> and secured to the wall.</span>"
 	else
-		. += "<span class='notice'>It's <i>unscrewed</i> from the wall, and can be <b>detached</b> with a wrench.</span>"
+		. += "<span class='notice'>It's <i>unscrewed</i> from the wall, and can be <b>detached</b>.</span>"
 
 /obj/item/radio/intercom/attackby(obj/item/I, mob/living/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -25,6 +25,7 @@
 /obj/structure/extinguisher_cabinet/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Alt-click to [opened ? "close":"open"] it.</span>"
+	. += "<span class='notice'>It can be unsecured from the wall with a wrench.</span>"
 
 /obj/structure/extinguisher_cabinet/Destroy()
 	if(stored_extinguisher)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -25,7 +25,8 @@
 /obj/structure/extinguisher_cabinet/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Alt-click to [opened ? "close":"open"] it.</span>"
-	. += "<span class='notice'>It can be unsecured from the wall with a wrench.</span>"
+	if(!stored_extinguisher)
+		. += "<span class='notice'>It is <i>empty</i> and can be <b>unsecured</b> from the wall.</span>"
 
 /obj/structure/extinguisher_cabinet/Destroy()
 	if(stored_extinguisher)

--- a/code/modules/surgery/anesthetic_machine.dm
+++ b/code/modules/surgery/anesthetic_machine.dm
@@ -133,6 +133,8 @@
 	. = ..()
 	if(attached_tank)
 		. += "<span class='notice'>[icon2html(attached_tank, user)] It has \a [attached_tank] mounted onto it. The tank's gauge reads [round(attached_tank.air_contents.total_moles(), 0.01)] mol at [round(attached_tank.air_contents.return_pressure(),0.01)] kPa.</span>"
+	else if(!mask_out)
+		. += "<span class='notice'>There is no tank mounted and the breath mask could be <b>detached</b> from it.</span>"
 
 /obj/item/clothing/mask/breath/machine
 	var/obj/machinery/anesthetic_machine/machine_attached

--- a/code/modules/surgery/anesthetic_machine.dm
+++ b/code/modules/surgery/anesthetic_machine.dm
@@ -101,8 +101,38 @@
 	if(mask_out)
 		retract_mask()
 	QDEL_NULL(attached_mask)
-	new /obj/item/clothing/mask/breath(src)
 	. = ..()
+
+/obj/machinery/anesthetic_machine/obj_destruction()
+	if(mask_out)
+		retract_mask()
+	QDEL_NULL(attached_mask)
+	new /obj/item/clothing/mask/breath(src)
+	if(attached_tank)
+		attached_tank.forceMove(get_turf(src))
+		attached_tank.visible_message("<span class='notice'>[attached_tank] falls to the ground from the destroyed Anesthetic Tank Holder.</span>")
+	return ..()
+
+/obj/machinery/anesthetic_machine/screwdriver_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(attached_tank)
+		to_chat(user, "<span class='warning'>You need to remove the anesthetic tank first!</span>")
+		return
+	if(!mask_out)
+		visible_message("<span class='warning'>[user] attempts to detach the breath mask from [src].</span>", "<span class='notice'>You attempt to detach the breath mask from [src].</span>")
+		if(!do_after(user, 100, FALSE, src))
+			to_chat(user, "<span class='warning'>You fail to dettach the breath mask from [src]!</span>")
+			return
+		visible_message("<span class='warning'>[user] detaches the breath mask from [src].</span>", "<span class='notice'>You detach the breath mask from [src].</span>")
+		new /obj/machinery/iv_drip(loc)
+		QDEL_NULL(attached_mask)
+		user.put_in_hands(new /obj/item/clothing/mask/breath)
+		qdel(src)
+
+/obj/machinery/anesthetic_machine/examine(mob/user)
+	. = ..()
+	if(attached_tank)
+		. += "<span class='notice'>[icon2html(attached_tank, user)] It has \a [attached_tank] mounted onto it. The tank's gauge reads [round(attached_tank.air_contents.total_moles(), 0.01)] mol at [round(attached_tank.air_contents.return_pressure(),0.01)] kPa.</span>"
 
 /obj/item/clothing/mask/breath/machine
 	var/obj/machinery/anesthetic_machine/machine_attached


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds deconstruction tips to the defibrillator wall mount, allows for said wall mount to be crowbarred off the wall, allows for deconstruction of the Anesthetic Tank Holder back into an IV drip, makes the defib wall mount, the IV drip and the Anesthetic Tank Holder drop their contents upon being smashed to pieces.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's kind of inconsistent how you can make an IV drip into the tank holder but not the other way around, so this resolves that. Also allows people to 'normally' remove defib wall mounts of the wall instead of smashing them apart. Also more in-game accessibility through tips in the item descriptions is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
New defib wall mount description:

![image](https://user-images.githubusercontent.com/110184118/203612441-97fbdd37-79f5-495e-aa99-385bd56e05c1.png)

Defib wall mount being pried off the wall:

https://user-images.githubusercontent.com/110184118/203541006-cdf233b1-102b-49e0-a6fe-b65e0d6b2b5d.mp4

Defib wall mount with an emagged defib inside being smashed apart, the defib dropping on the floor and keeping the emagged state:

https://user-images.githubusercontent.com/110184118/203541028-60099a82-0ec8-4f16-947a-d4f786b709c7.mp4

New Fire Extinguisher Cabinet tooltip while examining:

![image](https://user-images.githubusercontent.com/110184118/203612476-140996bc-8f59-4541-88a3-f2e62ffb86da.png)

New IV Drip tooltip while examining it when it is empty: 

![image](https://user-images.githubusercontent.com/110184118/203612551-7c201d49-9bc2-4ce0-86f3-342cb085f961.png)

IV Drip dropping its contents on the floor upon being destroyed, with them splashing it if possible:

https://user-images.githubusercontent.com/110184118/203624802-ae97a661-9507-49f2-a1c2-8764d0733fb3.mp4


New Anesthetic Tank Holder tooltip while examining : 

![image](https://user-images.githubusercontent.com/110184118/203612650-cbcb5d25-e0c9-4273-a224-f8f3bd76d2b1.png)

The Anesthetic Tank Holder being de-converted into an IV Drip:

https://user-images.githubusercontent.com/110184118/203541177-f462e76d-b5ad-4190-87b7-994dbdf6bdc2.mp4

New Anaesthetic Tank Holder description that shows the attached tank and the volume/pressure inside of the tank :

![image](https://user-images.githubusercontent.com/110184118/203541101-c3323c84-f5e3-41d2-888e-7ea92c60c7dd.png)

Anaesthetic Tank Holder dropping its contents on the floor upon being destroyed:

https://user-images.githubusercontent.com/110184118/203541200-155a0b7a-ce8f-4813-a60f-e3c14b8a69e7.mp4

</details>

## Changelog
:cl:
add: Added the ability to pry the Defibrillator Wall Mount off the wall with a crowbar when it's empty
add: Added deconstruction tooltips to the Defibrillator Wall Mount, Fire Extinguisher Cabinet and Anesthetic Tank Holder
add: Added the ability to convert the Anesthetic Tank Holder into an IV drip by using a screwdriver on it 
add: Added the attached tank and the gas pressure and volume of the tank to the description of the Anesthetic Tank Holder
tweak: Defibrillator Wall Mount, IV Drip and Anesthetic Tank Holder now drop their respective attached items when destroyed
fix: Fixed the defibrillator not updating its icon upon being emagged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
