### PR TITLE
Ecto sniffer logging and slight tweak

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "ecto_sniffer"
 	density = FALSE
-	anchored = FALSE
+	anchored = TRUE
 	pass_flags = PASSTABLE
 	circuit = /obj/item/circuitboard/machine/ecto_sniffer
 	///determines if the device if the power switch is turned on or off. Useful if the ghosts are too annoying.
@@ -38,6 +38,7 @@
 	use_power(10)
 	if(activator?.ckey)
 		ectoplasmic_residues[activator.ckey] = TRUE
+		activator.log_message("activated an ecto sniffer", LOG_ATTACK)
 		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 30 SECONDS)
 
 /obj/machinery/ecto_sniffer/attack_hand(mob/living/user, list/modifiers)
@@ -57,7 +58,8 @@
 
 
 /obj/machinery/ecto_sniffer/wrench_act(mob/living/user, obj/item/tool)
-	return default_unfasten_wrench(user, tool)
+	to_chat(user, "<span class='notice'>You need to deconstruct the [src] before moving it.</span>")
+	return TRUE
 
 /obj/machinery/ecto_sniffer/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1) Adds logging to ecto sniffer, so that if someone is abusing it in some form or fashion they can be traced
2) Ecto sniffer can no longer be unwrenched and dragged around

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This PR was made in response to a player report, where an ecto sniffer has been used to metagame antagonists. Valid-hunter drags sniffer around and compliant ghosts ping in a game of hot/cold. This is not the intended function of this device. 

While this PR doesn't entirely prevent abuse, it does make it a great deal less convenient while having negligible negative impact on the machine's intended use. It's pretty rare for someone to need to move the machine from its starting position, and even rarer to need to move it multiple times since it isn't a solid obstacle. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Logging ghost use
![image](https://user-images.githubusercontent.com/9547572/203785375-8059f686-4702-40e6-8cad-66decdb99a9b.png)

Attempting to unfasten with a wrench gives this message, with no attack occurring. 
![image](https://user-images.githubusercontent.com/9547572/203785458-adf4403d-2d07-4117-8f5f-20ec84f2b440.png)

Attempting to add circuit board to an unwrenched machine frame
![image](https://user-images.githubusercontent.com/9547572/203785404-c09ea1dc-e24a-43ef-8388-83de0f28f8f7.png)

</details>

## Changelog
:cl:
tweak: Ectoscopic sniffers are now anchored in place and cannot be moved without being deconstructed
admin: Added logging to ectoscopic sniffers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
