### PR TITLE
Adds maint-dead-assistants into crew manifest

### DIFF
--- a/_maps/RandomRooms/10x5/sk_rdm105_phage.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm105_phage.dmm
@@ -56,7 +56,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mob_spawn/human/clown/corpse,
+/obj/effect/mob_spawn/human/clown/corpse{
+	inject_crew_manifest = STATION_SPAWN_ONLY
+	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel,
 /area/template_noop)

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -350,3 +350,7 @@
 #define JOB_CHATCOLOR_NOTCENTCOM "#6D6AEC" // i.e. space police
 #define JOB_CHATCOLOR_PRISONER   "#D38A5C"
 #define JOB_CHATCOLOR_UNKNOWN    "#DDA583" // grey hud icon gets this
+
+//-----------
+
+#define JOB_SPAWN_NOT_USER "not_a_player" // used to prevent injecting lock-manifest for mindless corpse

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1106,10 +1106,10 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	return 0
 
 //For creating consistent icons for human looking simple animals
-/proc/get_flat_human_icon(icon_id, datum/job/J, datum/character_save/CS, dummy_key, showDirs = GLOB.cardinals, outfit_override = null)
+/proc/get_flat_human_icon(icon_id, datum/job/J, datum/character_save/CS, dummy_key, showDirs = GLOB.cardinals, outfit_override = null, mob/living/carbon/human/dummy/prepared = null)
 	var/static/list/humanoid_icon_cache = list()
 	if(!icon_id || !humanoid_icon_cache[icon_id])
-		var/mob/living/carbon/human/dummy/body = generate_or_wait_for_human_dummy(dummy_key)
+		var/mob/living/carbon/human/dummy/body = prepared || generate_or_wait_for_human_dummy(dummy_key)
 
 		if(CS)
 			CS.copy_to(body,TRUE,FALSE)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -90,30 +90,30 @@ SUBSYSTEM_DEF(job)
 	return 1
 
 
-/datum/controller/subsystem/job/proc/GetJob(rank)
+/datum/controller/subsystem/job/proc/GetJob(rank, skip_error=FALSE)
 	if(!rank)
 		CRASH("proc has taken no job name")
 	if(!occupations.len)
 		SetupOccupations()
-	if(!name_occupations[rank])
+	if(!name_occupations[rank] && skip_error)
 		CRASH("job name [rank] is not valid")
 	return name_occupations[rank]
 
-/datum/controller/subsystem/job/proc/GetJobType(jobtype)
+/datum/controller/subsystem/job/proc/GetJobType(jobtype, skip_error=FALSE)
 	if(!jobtype)
 		CRASH("proc has taken no job type")
 	if(!occupations.len)
 		SetupOccupations()
-	if(!type_occupations[jobtype])
+	if(!type_occupations[jobtype] && skip_error)
 		CRASH("job type [jobtype] is not valid")
 	return type_occupations[jobtype]
 
-/datum/controller/subsystem/job/proc/GetJobActiveDepartment(rank)
+/datum/controller/subsystem/job/proc/GetJobActiveDepartment(rank, skip_error=FALSE)
 	if(!rank)
 		CRASH("proc has taken no job name")
 	if(!occupations.len)
 		SetupOccupations()
-	if(!name_occupations[rank])
+	if(!name_occupations[rank] && skip_error)
 		CRASH("job name [rank] is not valid")
 	var/datum/job/J = name_occupations[rank]
 	return J.departments

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -210,12 +210,12 @@
 	return dat
 
 
-/datum/datacore/proc/manifest_inject(mob/living/carbon/human/H, client/C)
+/datum/datacore/proc/manifest_inject(mob/living/carbon/human/H, client/C, force=FALSE)
 	set waitfor = FALSE
 	var/static/list/show_directions = list(SOUTH, WEST)
-	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
+	if(force || H.mind && (H.mind.assigned_role != H.mind.special_role))
 		var/assignment
-		if(H.mind.assigned_role)
+		if(H.mind?.assigned_role)
 			assignment = H.mind.assigned_role
 		else if(H.job)
 			assignment = H.job
@@ -226,7 +226,7 @@
 		var/id = num2hex(record_id_num++,6)
 		if(!C)
 			C = H.client
-		var/image = get_id_photo(H, C, show_directions)
+		var/image = C ? get_id_photo(H, C, show_directions) : get_flat_human_icon(null, SSjob.GetJob(H.job), null, DUMMY_HUMAN_SLOT_MANIFEST, list(SOUTH), TRUE, H)
 		var/datum/picture/pf = new
 		var/datum/picture/ps = new
 		pf.picture_name = "[H]"
@@ -247,7 +247,7 @@
 		G.fields["hud"]			= get_hud_by_jobname(assignment)
 		G.fields["active_dept"]	= SSjob.GetJobActiveDepartment(assignment)
 		G.fields["age"]			= H.age
-		G.fields["species"]	= H.dna.species.name
+		G.fields["species"]	    = H.dna.species.name
 		G.fields["fingerprint"]	= rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)
 		G.fields["p_stat"]		= "Active"
 		G.fields["m_stat"]		= "Stable"
@@ -283,6 +283,8 @@
 		S.fields["notes"]		= "No notes."
 		security += S
 
+		if(force == JOB_SPAWN_NOT_USER)
+			return
 		//Locked Record
 		var/datum/data/record/L = new()
 		L.fields["id"]			= rustg_hash_string(RUSTG_HASH_MD5, "[H.real_name][H.mind.assigned_role]")	//surely this should just be id, like the others?

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -1,3 +1,5 @@
+#define STATION_SPAWN_ONLY "station_spawn_only" // inject crew manifest only a corpse is on station
+
 //If someone can do this in a neater way, be my guest-Kor
 
 //To do: Allow corpses to appear mangled, bloody, etc. Allow customizing the bodies appearance (they're all bald and white right now).
@@ -146,6 +148,7 @@
 	var/id_access = null		//This is for access. See access.dm for which jobs give what access. Use JOB_NAME_CAPTAIN if you want it to be all access.
 	var/id_access_list = null	//Allows you to manually add access to an ID card.
 	assignedrole = "Ghost Role"
+	var/inject_crew_manifest = FALSE // TRUE: always injects crew manifest / STATION_SPAWN_ONLY: injects when it's spawned in station
 
 	var/husk = null
 	//these vars are for lazy mappers to override parts of the outfit
@@ -221,6 +224,8 @@
 			var/obj/item/clothing/under/C = H.w_uniform
 			if(istype(C))
 				C.update_sensors(NO_SENSORS)
+	if(SSjob.GetJob(name, skip_error=TRUE))
+		H.job = name
 
 	var/obj/item/card/id/W = H.wear_id
 	if(W)
@@ -238,6 +243,11 @@
 			W.assignment = id_job
 		W.registered_name = H.real_name
 		W.update_label()
+	if(inject_crew_manifest == STATION_SPAWN_ONLY)
+		if(is_station_level(z))
+			GLOB.data_core.manifest_inject(H, null, JOB_SPAWN_NOT_USER)
+	else if(inject_crew_manifest)
+		GLOB.data_core.manifest_inject(H, null, JOB_SPAWN_NOT_USER)
 
 //Instant version - use when spawning corpses during runtime
 /obj/effect/mob_spawn/human/corpse
@@ -309,6 +319,7 @@
 /obj/effect/mob_spawn/human/corpse/assistant
 	name = JOB_NAME_ASSISTANT
 	outfit = /datum/outfit/job/assistant
+	inject_crew_manifest = STATION_SPAWN_ONLY
 
 /obj/effect/mob_spawn/human/corpse/assistant/beesease_infection
 	disease = /datum/disease/beesease
@@ -610,3 +621,5 @@
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	suit = /obj/item/clothing/suit/armor/vest
 	glasses = /obj/item/clothing/glasses/sunglasses/advanced/reagent
+
+#undef STATION_SPAWN_ONLY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds maint-dead-assistants into crew manifest

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Although dead assistants in maint are something that can be interesting, we already know they are not a real player because they aren't in crew manifest - They don't create any story. By adding them to the crew manifest, people will be capable of using them actively - especially cheating people with their identity.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/204881224-6bf699df-579b-4ff8-bee2-3b3181fcb1d5.png)


</details>

## Changelog
:cl:
code: adjusted some manifest related codes
code: added 'skip_error' parameter in job subsystem
tweak: dead assistants spawned in maints are now added to crew manifest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
