### PR TITLE
Optional objective is no longer refreshed by unlisted target cryo

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -110,6 +110,11 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 		RegisterSignal(target, COMSIG_MIND_CRYOED, .proc/on_target_cryo)
 		target.isAntagTarget = TRUE
 
+/datum/objective/proc/unset_target()
+	if(target)
+		UnregisterSignal(target, COMSIG_MIND_CRYOED)
+		target = null
+
 /datum/objective/proc/get_crewmember_minds()
 	. = list()
 	for(var/datum/data/record/R as() in GLOB.data_core.locked)
@@ -447,6 +452,8 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 	var/selected_gimmick = pick(gimmick_list)
 	selected_gimmick = replacetext(selected_gimmick, "%DEPARTMENT", selected_department)
+	if(!findtext(selected_gimmick, "%TARGET"))
+		unset_target()
 	if(target?.current)
 		selected_gimmick = replacetext(selected_gimmick, "%TARGET", target.name)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* fixes #7203
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/205204203-dedf84b3-7fd8-4298-a930-615a3cee83cf.png)

-------------

![image](https://user-images.githubusercontent.com/87972842/205204365-0af146a3-e6a2-4135-894c-627014d7188e.png)

![image](https://user-images.githubusercontent.com/87972842/205204407-53520d12-6ccd-4253-89f0-f58324c2c215.png)



</details>

## Changelog
:cl:
fix: Gimmick objective is weirdly no longer changed upon your unlisted target's cryo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
