### PR TITLE
Dynamic Abductor Tweak + Sleeper Agent Fix

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -204,28 +204,30 @@
 
 /datum/dynamic_ruleset/midround/autotraitor/trim_candidates()
 	..()
-	for(var/mob/living/player in living_players)
+	candidates = living_players
+	for(var/mob/living/player in candidates)
 		if(issilicon(player)) // Your assigned role doesn't change when you are turned into a silicon.
-			living_players -= player
+			candidates -= player
 			continue
 		if(is_centcom_level(player.z))
-			living_players -= player // We don't autotator people in CentCom
+			candidates -= player // We don't autotator people in CentCom
 			continue
 		if(player.mind && (player.mind.special_role || length(player.mind.antag_datums)))
-			living_players -= player // We don't autotator people with roles already
+			candidates -= player // We don't autotator people with roles already
 
 /datum/dynamic_ruleset/midround/autotraitor/ready(forced = FALSE)
-	if (required_candidates > length(living_players))
-		log_game("DYNAMIC: FAIL: [src] does not have enough candidates, using living_players ([required_candidates] needed, [living_players.len] found)")
+	var/candidates_amt = length(candidates)
+	if (required_candidates > candidates_amt)
+		log_game("DYNAMIC: FAIL: [src] does not have enough candidates ([required_candidates] needed, [candidates_amt] found)")
 		return FALSE
 	if (mode.check_lowpop_lowimpact_injection())
 		return FALSE
 	return ..()
 
 /datum/dynamic_ruleset/midround/autotraitor/execute()
-	var/mob/M = pick(living_players)
+	var/mob/M = pick(candidates)
 	assigned += M
-	living_players -= M
+	candidates -= M
 	var/datum/antagonist/traitor/newTraitor = new
 	M.mind.add_antag_datum(newTraitor)
 	return TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -490,9 +490,8 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors
 	name = "Abductors"
-	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
-	antag_flag = "Abductor"
-	antag_flag_override = ROLE_ABDUCTOR
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
+	antag_flag = ROLE_ABDUCTOR
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 2


### PR DESCRIPTION
## About The Pull Request

Ports:
- https://github.com/tgstation/tgstation/pull/70324
- https://github.com/tgstation/tgstation/pull/69384

Abductors are set to low impact, although I did not port the weight changes since with our current midround system this puts them between nightmares in revenants in weight, while costing more. I think this should be enough to balance out their spawns. A weight of 2 would be the lowest weight of any of the light midrounds which I disagree with given their higher cost.

The sleeper agent thing fixes a bug, but I think in our current implementation it's not actually an issue, but regardless it should not be editing the living_players list.

I also removed a redundant antag_flag_override on the abductor and set it to use the ROLE defines.

## Why It's Good For The Game

The original PR explains quite well why abductors do not belong in the heavy category.

> Looking at what other threats are contained in the heavy rulesets:
>
>    Blob
>    Space Dragon
>    Xenomorphs
>    Spiders
>    Space Ninja
>    Sentient Disease
>    Pirates
>
> I don't think abductors really belong among them (I don't think 2/3 of the Pirates in their current state do either, but that's neither here nor there for this PR), seeing as the other members of this grouping are considerably more lethal or are capable of summoning a lethal threat in the case of ninja. Current dynamic also has this addiction of only spawning heavy rulesets when the round is almost over, and abductors need a good amount of time to get their objective done, so letting them spawn earlier to allow for that is also good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Dynamic now classifies Abductors as a light midround ruleset, allowing them to spawn earlier in the round instead of right near the end, as well as allowing it to spawn alongside other light rulesets.
fix: Fixed a bug with Syndicate Sleeper Agent not properly updating its candidates.
/:cl: