### PR TITLE
change required access of radiant dance machine mark IV

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -18,7 +18,7 @@
 	name = "radiant dance machine mark IV"
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon_state = "disco"
-	req_access = list(ACCESS_ENGINE)
+	req_access = list(ACCESS_HEADS, ACCESS_THEATRE)
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -18,7 +18,8 @@
 	name = "radiant dance machine mark IV"
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon_state = "disco"
-	req_access = list(ACCESS_HEADS, ACCESS_THEATRE)
+	req_access = null
+	req_one_access = list(ACCESS_HEADS, ACCESS_THEATRE) // you need one of these
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()
@@ -27,6 +28,7 @@
 	name = "radiant dance machine mark V"
 	desc = "Now redesigned with data gathered from the extensive disco and plasma research."
 	req_access = null
+	req_one_access = null
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -19,7 +19,7 @@
 	desc = "The first three prototypes were discontinued after mass casualty incidents."
 	icon_state = "disco"
 	req_access = null
-	req_one_access = list(ACCESS_HEADS, ACCESS_THEATRE) // you need one of these
+	req_one_access = list(ACCESS_HEADS, ACCESS_THEATRE, ACCESS_BAR) // you need one of these
 	anchored = FALSE
 	var/list/spotlights = list()
 	var/list/sparkles = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
change required access of radiant dance machine mark IV
now it needs one of these: bridge, bar, or theatre access
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it's a party machine. it's weird that it requires engineering access.
the reason why it had engine access was that it was introduced with engineering theme musics, but since we don't have such tracks, it's fair enough to change its access

also, basically allow a new gimmick method for clown, mime, stage magician, and bartender. and heads can turn it on or off whenever they want.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://user-images.githubusercontent.com/87972842/205418024-dc58fcae-4829-4449-9dd3-6fd48e0208d5.png)

</details>

## Changelog
:cl:
tweak: change required access of radiant dance machine mark IV. now it needs one of these: bridge, bar, or theatre access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
