### PR TITLE
Revert "Server reboot delay reason will be notified in Status Tab"

### DIFF
--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -168,8 +168,6 @@
 		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
-	if(SSticker.admin_delay_notice)
-		tab_data["Server reboot is delayed"] = GENERATE_STAT_TEXT("[SSticker.admin_delay_notice]")
 	return tab_data
 
 /mob/proc/get_stat_tab_master_controller()


### PR DESCRIPTION
Admins don't like this.

:cl:
del: Reverts server reboot delay reason showing in status tab
/:cl: