### PR TITLE
Fix invalid turfs on golem ship

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -879,10 +879,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
-"cM" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/area/ruin/powered/golem_ship)
 "jC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -947,11 +943,11 @@ aC
 aR
 ab
 bd
-cM
-cM
-cM
-cM
-cM
+ac
+ac
+ac
+ac
+ac
 cd
 ab
 cl

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -349,6 +349,8 @@
 	var/first_turf_index = 1
 	while(!ispath(members[first_turf_index], /turf)) //find first /turf object in members
 		first_turf_index++
+		if(first_turf_index > length(members))
+			CRASH("No turf found on x [crds.x] y [crds.y] z [crds.z] at [areaCache[1]]")
 
 	//turn off base new Initialization until the whole thing is loaded
 	SSatoms.map_loader_begin()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Also adds better message for when it happens again.
Ideally we should have some regex checking if every turf has it's "turf".

## Testing Photographs and Procedure
I edited the file manually since no turfs broke strongdmm (I couldn't add any other turfs there) but then it opened back in the editor.

## Changelog
:cl:
fix: fixed a turf with "turf" on the golem ship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
