### PR TITLE
Revert "Revert "Server reboot delay reason will be notified in Status Tab"" and put a default reasoning

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -494,7 +494,7 @@
 	set desc= "Delay server from rebooting the server after the round has ended"
 	set name= "Delay round end"
 	if(!SSticker.delay_end)
-		SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
+		SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason", "Server Administration (handling tickets, coding, etc)") as null|text
 		if(isnull(SSticker.admin_delay_notice))
 			return
 		for(var/client/admin in GLOB.admins)

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -168,6 +168,8 @@
 		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
+	if(SSticker.admin_delay_notice)
+		tab_data["delayed"] = GENERATE_STAT_TEXT("Server reboot is delayed: [SSticker.admin_delay_notice]")
 	return tab_data
 
 /mob/proc/get_stat_tab_master_controller()

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -169,7 +169,7 @@
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
 	if(SSticker.admin_delay_notice)
-		tab_data["delayed"] = GENERATE_STAT_TEXT("Server reboot is delayed: [SSticker.admin_delay_notice]")
+		tab_data["Server reboot is delayed"] = GENERATE_STAT_TEXT("[SSticker.admin_delay_notice]")
 	return tab_data
 
 /mob/proc/get_stat_tab_master_controller()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Revert "Revert "Server reboot delay reason will be notified in Status Tab"" and put a default reasoning

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it seems admin wanted to have a default reasoning not that they totally dislike it
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/205500334-40ca424c-333d-415a-a58a-6bd74fafcaa0.png)


![image](https://user-images.githubusercontent.com/87972842/205500315-6b8af960-9ecc-4987-9da7-abf14d612974.png)

</details>

## Changelog
:cl:
add: Server reboot delay reason will be notified in Status Tab 'again'
admin: Server delay reason has now a default value 'Server Administration (handling tickets, coding, etc)'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
