### PR TITLE
ghosts can no longer rename syndie shuttle pod 

### DIFF
--- a/code/modules/shuttle/bluespace_shuttle_pod/pod_computer.dm
+++ b/code/modules/shuttle/bluespace_shuttle_pod/pod_computer.dm
@@ -20,10 +20,10 @@
 	shuttle_creator.reset_saved_area(FALSE)
 
 /obj/machinery/computer/shuttle_flight/custom_shuttle/bluespace_pod/ui_interact(mob/user, datum/tgui/ui)
-	if(isobserver(user))
-		user.visible_message("<span class ='warning'>Ghosts can't rename the shuttle!.<span>")
-		return
 	if(!shuttle_named)
+		if(isobserver(user))
+			user.visible_message("<span class ='warning'>Ghosts can't rename the shuttle!.<span>")
+			return
 		var/area/area_instance = get_area(src)
 		var/obj/docking_port/mobile/port = locate(/obj/docking_port/mobile) in area_instance
 		if(port)

--- a/code/modules/shuttle/bluespace_shuttle_pod/pod_computer.dm
+++ b/code/modules/shuttle/bluespace_shuttle_pod/pod_computer.dm
@@ -20,6 +20,9 @@
 	shuttle_creator.reset_saved_area(FALSE)
 
 /obj/machinery/computer/shuttle_flight/custom_shuttle/bluespace_pod/ui_interact(mob/user, datum/tgui/ui)
+	if(isobserver(user))
+		user.visible_message("<span class ='warning'>Ghosts can't rename the shuttle!.<span>")
+		return
 	if(!shuttle_named)
 		var/area/area_instance = get_area(src)
 		var/obj/docking_port/mobile/port = locate(/obj/docking_port/mobile) in area_instance

--- a/code/modules/shuttle/bluespace_shuttle_pod/pod_computer.dm
+++ b/code/modules/shuttle/bluespace_shuttle_pod/pod_computer.dm
@@ -20,10 +20,7 @@
 	shuttle_creator.reset_saved_area(FALSE)
 
 /obj/machinery/computer/shuttle_flight/custom_shuttle/bluespace_pod/ui_interact(mob/user, datum/tgui/ui)
-	if(!shuttle_named)
-		if(isobserver(user))
-			user.visible_message("<span class ='warning'>Ghosts can't rename the shuttle!.<span>")
-			return
+	if(!shuttle_named && !isobserver(user))
 		var/area/area_instance = get_area(src)
 		var/obj/docking_port/mobile/port = locate(/obj/docking_port/mobile) in area_instance
 		if(port)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ghosts can currently edit the syndie shuttle pod name. This implements a if(observer(user)) check that will print a warning and stop any further interaction.

Fixes:
- #8169 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs are bad. I dont loik em
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
![ghost1](https://user-images.githubusercontent.com/62388554/205721436-4a2c610d-075f-4046-8fe3-932b8eb9fa7f.png)


![Ghost2](https://user-images.githubusercontent.com/62388554/205721406-b37ee37a-2f5f-49e8-94b4-b82f139ee699.png)

![ghost3](https://user-images.githubusercontent.com/62388554/205721372-7376d9b8-c646-4f27-8fda-2440eaf4e174.png)


</details>

## Changelog
:cl: RKz
fix: removed observer ability to edit syndie shuttle pods names. Agents spending that 8 TC no longer have to worry about the dead's opinions on their unimaginative naming schemes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
