### PR TITLE
Abductor jammer no longer blocks cameras, abductors can teleport to their agent, fixes agent vest exploit

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -76,6 +76,7 @@
 #include "code\__DEFINES\interaction_flags.dm"
 #include "code\__DEFINES\inventory.dm"
 #include "code\__DEFINES\is_helpers.dm"
+#include "code\__DEFINES\jamming_defines.dm"
 #include "code\__DEFINES\jobs.dm"
 #include "code\__DEFINES\keybinding.dm"
 #include "code\__DEFINES\language.dm"

--- a/code/__DEFINES/jamming_defines.dm
+++ b/code/__DEFINES/jamming_defines.dm
@@ -1,7 +1,7 @@
 
 //Radio jammer levels
 //They will jam any signals that have the same or lower protection value
-#define RAIDO_JAMMER_ABDUCTOR_LEVEL 1	//Power of the abductor radio jammer
+#define RADIO_JAMMER_ABDUCTOR_LEVEL 1	//Power of the abductor radio jammer
 #define RADIO_JAMMER_TRAITOR_LEVEL 3	//Power of the traitor radio jammer
 
 //Radio jammer protection level

--- a/code/__DEFINES/jamming_defines.dm
+++ b/code/__DEFINES/jamming_defines.dm
@@ -1,0 +1,14 @@
+
+//Radio jammer levels
+//They will jam any signals that have the same or lower protection value
+#define RAIDO_JAMMER_ABDUCTOR_LEVEL 1	//Power of the abductor radio jammer
+#define RADIO_JAMMER_TRAITOR_LEVEL 3	//Power of the traitor radio jammer
+
+//Radio jammer protection level
+#define JAMMER_PROTECTION_RADIO_BASIC 0		//Basic comms channels
+#define JAMMER_PROTECTION_RADIO_ADVANCED 1	//Superspace comms channels (CC, Syndicate)
+#define JAMMER_PROTECTION_SENSOR_NETWORK 0	//Suit sensor network
+#define JAMMER_PROTECTION_CAMERAS 2			//Cameras are stronger than abductor jammers
+#define JAMMER_PROTECTION_WIRELESS 1		//Wireless networking
+#define JAMMER_PROTECTION_AI_SHELL 2		//AI shell protection
+#define JAMMER_PROTECTION_SILICON_COMMS 1	//Silicon comms

--- a/code/datums/components/radio_jamming.dm
+++ b/code/datums/components/radio_jamming.dm
@@ -5,10 +5,13 @@
 	var/active = FALSE
 	/// The range of this radio jammer
 	var/range
+	/// The intensity level of this jammer
+	var/intensity = 1
 
-/datum/component/radio_jamming/Initialize(_range = 12)
+/datum/component/radio_jamming/Initialize(_range = 12, _intensity = RADIO_JAMMER_TRAITOR_LEVEL)
 	//Set the range
 	range = _range
+	intensity = _intensity
 	RegisterSignal(parent, COMSIG_TOGGLE_JAMMER, .proc/toggle)
 
 /datum/component/radio_jamming/Destroy(force, silent)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -395,7 +395,7 @@
 		return FALSE
 	if(machine_stat & EMPED)
 		return FALSE
-	if(is_jammed())
+	if(is_jammed(JAMMER_PROTECTION_CAMERAS))
 		return FALSE
 	return TRUE
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -186,7 +186,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			continue
 
 		// Radio transmitters are jammed
-		if(tracked_human.is_jammed())
+		if(tracked_human.is_jammed(JAMMER_PROTECTION_WIRELESS))
 			continue
 
 		// The entry for this human

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -258,7 +258,7 @@
 		return
 
 	//Check radio signal jamming
-	if(is_jammed())
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
 		return
 
 
@@ -453,14 +453,14 @@
 /obj/machinery/door/airlock/proc/canAIControl(mob/user)
 	if(protected_door)
 		return FALSE
-	if(is_jammed())
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
 		return FALSE
 	return ((aiControlDisabled != 1) && !isAllPowerCut())
 
 /obj/machinery/door/airlock/proc/canAIHack()
 	if(protected_door)
 		return FALSE
-	if(is_jammed())
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
 		return FALSE
 	return ((aiControlDisabled==1) && (!hackProof) && (!isAllPowerCut()));
 
@@ -771,7 +771,7 @@
 	if(detonated)
 		to_chat(user, "<span class='warning'>Unable to interface. Airlock control panel damaged.</span>")
 		return
-	if(is_jammed())
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
 		to_chat(user, "<span class='warning'>Unable to interface. Remote communications not responding.</span>")
 		return
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -332,7 +332,7 @@
 		return
 
 	//Check radio signal jamming
-	if(is_jammed())
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
 		return
 
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -272,7 +272,7 @@
 		channel = null
 
 	// Nearby active jammers prevent the message from transmitting
-	if(is_jammed())
+	if(is_jammed(freq == FREQ_CENTCOM || freq == FREQ_SYNDICATE ? JAMMER_PROTECTION_RADIO_ADVANCED : JAMMER_PROTECTION_RADIO_BASIC))
 		return
 
 	// Determine the identity information which will be attached to the signal.

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -287,9 +287,15 @@ effective or pretty fucking useless.
 /obj/item/jammer/attack_self(mob/user)
 	SEND_SIGNAL(src, COMSIG_TOGGLE_JAMMER, user, FALSE)
 
-/atom/proc/is_jammed()
+///Checks if an atom is jammed by a radio jammer
+///Parameters:
+/// - Protection level: The amount of protection that the atom has. See jamming_defines.dm
+/atom/proc/is_jammed(protection_level)
 	var/turf/position = get_turf(src)
 	for(var/datum/component/radio_jamming/jammer as anything in GLOB.active_jammers)
+		//Check to see if the jammer is strong enough to block this signal
+		if (protection_level > jammer.intensity)
+			continue
 		var/turf/jammer_turf = get_turf(jammer.parent)
 		if(position?.get_virtual_z_level() == jammer_turf.get_virtual_z_level() && (get_dist(position, jammer_turf) <= jammer.range))
 			return TRUE

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -106,7 +106,7 @@
 		var/obj/item/clothing/under/U = H.w_uniform
 
 		//Suit sensors radio transmitter must not be jammed.
-		if(U.is_jammed())
+		if(U.is_jammed(JAMMER_PROTECTION_SENSOR_NETWORK))
 			return FALSE
 
 		// Suit sensors must be on maximum.

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -261,7 +261,7 @@
 	. = ..()
 	//Activate the jammer
 	//This jammer will not block cameras or AI shells
-	var/datum/component/radio_jamming/added_component = AddComponent(/datum/component/radio_jamming, 5, RAIDO_JAMMER_ABDUCTOR_LEVEL)
+	var/datum/component/radio_jamming/added_component = AddComponent(/datum/component/radio_jamming, 5, RADIO_JAMMER_ABDUCTOR_LEVEL)
 	added_component.enable()
 
 /obj/item/abductor/mind_device

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -260,7 +260,8 @@
 /obj/item/abductor/silencer/ComponentInitialize()
 	. = ..()
 	//Activate the jammer
-	var/datum/component/radio_jamming/added_component = AddComponent(/datum/component/radio_jamming)
+	//This jammer will not block cameras or AI shells
+	var/datum/component/radio_jamming/added_component = AddComponent(/datum/component/radio_jamming, 5, RAIDO_JAMMER_ABDUCTOR_LEVEL)
 	added_component.enable()
 
 /obj/item/abductor/mind_device

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -130,17 +130,26 @@
 		to_chat(owner, "<span class='warning'>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
+	var/specimin_nearby = FALSE
+	var/agent_nearby = FALSE
 	for(var/mob/living/carbon/human/specimin in view(5, target_loc))
+		//They are an abductor agent, we can always go near them
+		if (isabductor(specimin))
+			agent_nearby = TRUE
+			break
 		var/obj/item/organ/heart/gland/temp = locate() in specimin.internal_organs
 		//Not a specimin
 		if(istype(temp))
 			continue
 		//No heart, not considered a specimin
-		if (!specimin.getorganslot(ORGAN_SLOT_HEART) || isabductor(specimin))
+		if (!specimin.getorganslot(ORGAN_SLOT_HEART))
 			continue
 		//Technically a specimin, however we should avoid meta tactics
 		if (!specimin.client)
 			continue
+		specimin_nearby = TRUE
+
+	if (specimin_nearby && !agent_nearby)
 		to_chat(owner, "<span class='warning'>You cannot warp to this location, an unprocessed specimen might spot you, tampering with the experiment!</span>")
 		return
 

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -75,17 +75,26 @@
 		to_chat(owner, "<span class='warning'>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
+	var/specimin_nearby = FALSE
+	var/agent_nearby = FALSE
 	for(var/mob/living/carbon/human/specimin in view(5, target_loc))
+		//They are an abductor agent, we can always go near them
+		if (isabductor(specimin))
+			agent_nearby = TRUE
+			break
 		var/obj/item/organ/heart/gland/temp = locate() in specimin.internal_organs
 		//Not a specimin
 		if(istype(temp))
 			continue
 		//No heart, not considered a specimin
-		if (!specimin.getorganslot(ORGAN_SLOT_HEART) || isabductor(specimin))
+		if (!specimin.getorganslot(ORGAN_SLOT_HEART))
 			continue
 		//Technically a specimin, however we should avoid meta tactics
 		if (!specimin.client)
 			continue
+		specimin_nearby = TRUE
+
+	if (specimin_nearby && !agent_nearby)
 		to_chat(owner, "<span class='warning'>You cannot warp to this location, an unprocessed specimen might spot you, tampering with the experiment!</span>")
 		return
 

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -18,6 +18,13 @@
 		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 		to_chat(target, "<span class='warning'>The instability of the warp leaves you disoriented!</span>")
 		target.SetSleeping(60)
+		//If the target is wearing an abductor vest, increase the stimulant cooldown
+		if (ishuman(target))
+			var/mob/living/carbon/human/abductor = target
+			var/obj/item/clothing/suit/armor/abductor/vest/abductor_vest = abductor.wear_suit
+			if (istype(abductor_vest))
+				//Set a minimum 6 second cooldown
+				abductor_vest.combat_cooldown = max(abductor_vest.combat_cooldown, 6)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -344,7 +344,7 @@
 	if ((ai.get_virtual_z_level() != target.get_virtual_z_level()) && !is_station_level(ai.z))
 		return FALSE
 
-	if(A.is_jammed())
+	if(A.is_jammed(JAMMER_PROTECTION_WIRELESS))
 		return FALSE
 
 	if (istype(loc, /obj/item/aicard))
@@ -1059,7 +1059,7 @@
 	if (!target || target.stat || target.deployed || !(!target.connected_ai ||(target.connected_ai == src)) || (target.ratvar && !is_servant_of_ratvar(src)))
 		return
 
-	if(target.is_jammed())
+	if(target.is_jammed(JAMMER_PROTECTION_AI_SHELL))
 		to_chat(src, "<span class='warning robot'>Unable to establish communication link with target.</span>")
 		return
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -8,7 +8,7 @@
 	handle_robot_cell()
 
 /mob/living/silicon/robot/proc/handle_jamming()
-	if(deployed && is_jammed())
+	if(deployed && is_jammed(JAMMER_PROTECTION_AI_SHELL))
 		to_chat(src, "<span class='warning robot'>Remote connection with target lost.</span>")
 		undeploy()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -419,7 +419,7 @@
 	var/turf/T1 = get_turf(A)
 	if (!T0 || ! T1)
 		return FALSE
-	if(A.is_jammed())
+	if(A.is_jammed(JAMMER_PROTECTION_WIRELESS))
 		return FALSE
 	return ISINRANGE(T1.x, T0.x - interaction_range, T0.x + interaction_range) && ISINRANGE(T1.y, T0.y - interaction_range, T0.y + interaction_range)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,6 +1,6 @@
 /mob/living/proc/robot_talk(message)
 	//Cannot transmit wireless messages while jammed
-	if(is_jammed())
+	if(is_jammed(JAMMER_PROTECTION_SILICON_COMMS))
 		return
 	if(CHAT_FILTER_CHECK(message))
 		to_chat(usr, "<span class='warning'>Your message contains forbidden words.</span>")

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -949,7 +949,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/proc/topic_denied(mob/user) //Access check proc for bot topics! Remember to place in a bot's individual Topic if desired.
 	//Silicons cannot remotely interfact with robots while the robot is jammed
-	if(issilicon(user) && is_jammed())
+	if(issilicon(user) && is_jammed(JAMMER_PROTECTION_WIRELESS))
 		return TRUE
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return TRUE

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -252,12 +252,12 @@
 		return FALSE
 	if(..())
 		if(HAS_TRAIT(humanoid, TRAIT_NANITE_SENSORS))
-			if(humanoid.is_jammed())
+			if(humanoid.is_jammed(JAMMER_PROTECTION_SENSOR_NETWORK))
 				return FALSE
 			return TRUE
 		if(istype(humanoid.w_uniform, /obj/item/clothing/under))
 			var/obj/item/clothing/under/uniform = humanoid.w_uniform
-			if(uniform.is_jammed())
+			if(uniform.is_jammed(JAMMER_PROTECTION_SENSOR_NETWORK))
 				return FALSE
 			if(uniform.has_sensor && uniform.sensor_mode >= SENSOR_COORDS) // Suit sensors must be on maximum
 				return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a system where signal jammed things can be given a protection level.
This means that the abductor silencer will no longer block cameras.
Abductor silencer also has had its ranged reduced from 11 to 5, to make it less obvious where the abductors are at any time by the radio silence.

## Why It's Good For The Game

Slight balance changes to abductors to improve their quality of life and make them slightly less obvious and more localised.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/205723317-6b0813bb-6083-4be3-891f-b80fbf94cde2.png)


## Changelog
:cl:
balance: Abductor silencer range reduced to a range of 5
balance: Abductor silencer can no longer block camera's vision.
balance: Abductors can now teleport near other abductors regardless of if there are specimin nearby or not.
balance: Using the emergency teleport will set the combat stimulant injector's cooldown to a minimum of 6 seconds to prevent an exploit where it could be used to bypass the 6 second sleep applied by emergency teleport.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
