### PR TITLE
Some changes to list related wiremod components to make them behave better.

### DIFF
--- a/code/modules/wiremod/components/abstract/indexer.dm
+++ b/code/modules/wiremod/components/abstract/indexer.dm
@@ -65,7 +65,9 @@
 	var/list/list_input = list_port.input_value
 	list_input = list_input?.Copy() //input_value of an input port isn't typecasted to a list, so it doesn't reconize Copy() until you put it in a typed var
 
-	if(!islist(list_input) || isnull(index))
+	if(isnull(index))
+		index = 0
+	if(!islist(list_input))
 		output.set_output(null)
 		return
 

--- a/code/modules/wiremod/components/list/append.dm
+++ b/code/modules/wiremod/components/list/append.dm
@@ -43,7 +43,7 @@
 		output.set_output(null)
 		return
 
-	if(input_list.len < COMPONENT_MAXIMUM_LIST_SIZE) //Prevents lists from growing too large
+	if(input_list.len < COMPONENT_MAXIMUM_LIST_SIZE && !islist(value)) //Prevents lists from growing too large and prevents recursive lists
 		input_list += value
 	output.set_output(input_list)
 

--- a/code/modules/wiremod/components/list/list_constructor.dm
+++ b/code/modules/wiremod/components/list/list_constructor.dm
@@ -19,6 +19,6 @@
 
 /obj/item/circuit_component/arbitrary_input_amount/list_constructor/calculate_output(datum/port/input/port, datum/port/input/first_port, list/ports)
 	. = list()
-	. += first_port.input_value
+	ports.Insert(1, first_port)
 	for(var/datum/port/input/input_port as anything in ports)
-		. += input_port.input_value
+		. += islist(input_port.input_value) ? null : input_port.input_value

--- a/code/modules/wiremod/components/list/write.dm
+++ b/code/modules/wiremod/components/list/write.dm
@@ -23,6 +23,7 @@
 	return ..()
 
 /obj/item/circuit_component/indexer/write/calculate_output(var/index, var/list/list_input)
-	list_input[index] = value_port.input_value
+
+	list_input[index] = islist(value_port.input_value) ? null : value_port.input_value
 	output.set_output(list_input)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes WireMod components that modifies entries in lists to prevent a list being indexed in another list. Also, WireMod components that can access specified indexes of a list now treat null as 0 instead of aborting their input received function.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nested lists in WireMod could have resulted in a memory leak if a player were to recursively insert massive lists into each other indefinitely. Now, the maximum amount of lists in a WireMod circuit is dependent on the amount of list components and ram components in the IC, which is dependent on finite materials collected during the round and cannot be automated to indefinitely without manual player interaction. Changing indexer components to treat null as 0 makes them more consistent with other components such as the arithmetic circuit which have a default value for a null in a number input port.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing Video</summary>

https://user-images.githubusercontent.com/51838176/205797159-9dfaded4-899d-44b0-a7eb-dce6cad9172a.mp4

Shows null indexing defaulting to 0 on write and index components, then shows list inputs for written values in a list being treated as null.

</details>

## Changelog
:cl:
fix: List related WireMod components can no longer store lists inside other lists.
tweak: List related WireMod with an index input now treat a null index as a 0.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
