### PR TITLE
Shuttle Designator now has the proper weight_class for its use

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -67,7 +67,8 @@
 		/obj/item/pipe_dispenser,
 		/obj/item/inducer,
 		/obj/item/plunger,
-		/obj/item/airlock_painter
+		/obj/item/airlock_painter,
+		/obj/item/shuttle_creator
 		))
 	STR.can_hold = can_hold
 

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -10,20 +10,20 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 //============ Shuttle Creator Object ============
 /obj/item/shuttle_creator
 	name = "Rapid Shuttle Designator"
+	desc = "A device used to define the area required for custom ships. Uses bluespace crystals to create bluespace-capable ships."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rsd"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	desc = "A device used to define the area required for custom ships. Uses bluespace crystals to create bluespace-capable ships."
 	density = FALSE
 	anchored = FALSE
 	flags_1 = CONDUCT_1
-	item_flags = NOBLUDGEON
+	slot_flags = ITEM_SLOT_BELT
 	force = 0
 	throwforce = 8
 	throw_speed = 3
 	throw_range = 5
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_TINY
 	req_access_txt = "11"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "stamina" = 0)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	density = FALSE
 	anchored = FALSE
 	flags_1 = CONDUCT_1
+	item_flags = NOBLUDGEON
 	slot_flags = ITEM_SLOT_BELT
 	force = 0
 	throwforce = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For whatever reason, Shuttle designator was set to WEIGHT_CLASS_NORMAL, preventing its storage in pockets like basically every other tool can. I believe that as supercruise has been developed, this tool is lacking the proper flags to match the changing features. Especially those of:
- https://github.com/BeeStation/BeeStation-Hornet/pull/6260

The designator now fits in pockets, the beltslot, as well as a toolbelt to mirror other the other tools. 
However, I have set the weight class on designators even lower, using quantum keycards as the baseline, to WEIGHT_CLASS_TINY. This is for several reasons, most significantly being that the designator really only has one purpose(unlike all other tools), can only really be used for a single instance, and the infeasibility of a item the size of a crowbar fitting inside a control console like an ID.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of Life mostly. Makes dealing with shuttles more feasible as the designator is stored more like a set of car keys and doesnt have to be juggled around or managed like a regular tool would need to be.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

![des3](https://user-images.githubusercontent.com/62388554/205856713-ee168008-9e8b-4b26-a6f5-3ac1cf7ce4b5.png)

![des2](https://user-images.githubusercontent.com/62388554/205856730-11e1bc42-a547-4688-b534-d3b4536f0b55.png)

![des1](https://user-images.githubusercontent.com/62388554/205856754-22dcaa8d-c5c6-4b75-b253-19edc70673d4.png)

## Changelog
:cl:
tweak: Rapid Shuttle Designator has had its weight changed to now fit in pockets, toolbelt, and belt slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
