### PR TITLE
Map config settings for planetary based maps

### DIFF
--- a/_maps/corgstation.json
+++ b/_maps/corgstation.json
@@ -8,5 +8,9 @@
 		"ferry": "ferry_fancy",
 		"whiteship": "whiteship_box",
 		"emergency": "emergency_corg"
-	}
+	},
+	"planettary_station": 1,
+	"planet_name": "Corgtopia",
+	"planet_mass": 20000,
+	"planet_radius": 500
 }

--- a/_maps/corgstation.json
+++ b/_maps/corgstation.json
@@ -8,9 +8,5 @@
 		"ferry": "ferry_fancy",
 		"whiteship": "whiteship_box",
 		"emergency": "emergency_corg"
-	},
-	"planettary_station": 1,
-	"planet_name": "Corgtopia",
-	"planet_mass": 20000,
-	"planet_radius": 500
+	}
 }

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -38,7 +38,10 @@ GLOBAL_VAR(command_name)
 
 	//Rename the station on the orbital charter.
 	if(SSorbits.station_instance)
-		SSorbits.station_instance.name = newname
+		if (SSmapping.config.planet_name)
+			SSorbits.station_instance.name = "[SSmapping.config.planet_name] ([newname])"
+		else
+			SSorbits.station_instance.name = newname
 
 
 /proc/new_station_name()

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -41,11 +41,11 @@
 	var/allow_night_lighting = TRUE
 
 	//======
-	// Planettary Settings
+	// planetary Settings
 	//======
 
 	/// Is this station considered a planet for the supercruise map
-	var/planettary_station = FALSE
+	var/planetary_station = FALSE
 	/// The name of the planet on the supercruise map
 	var/planet_name = ""
 	/// Radius of the planet
@@ -166,7 +166,7 @@
 
 	allow_custom_shuttles = !isnull(json["allow_custom_shuttles"]) && json["allow_custom_shuttles"] != FALSE
 	allow_night_lighting = !isnull(json["allow_night_lighting"]) && json["allow_night_lighting"] != FALSE
-	planettary_station = !isnull(json["planettary_station"]) && json["planettary_station"] != FALSE
+	planetary_station = !isnull(json["planetary_station"]) && json["planetary_station"] != FALSE
 	planet_name = json["planet_name"]
 	planet_mass = text2num(json["planet_mass"]) || planet_mass
 	planet_radius = text2num(json["planet_radius"]) || planet_radius

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -19,19 +19,46 @@
 	var/map_path = "map_files/BoxStation"
 	var/map_file = "BoxStation.dmm"
 
+	//This should probably be refactored into a system like the regular configuration
+
 	var/traits = null
 	var/space_ruin_levels = 4	//Keep this low, as new ones are created dynamically when needed.
 	var/space_empty_levels = 1
 
+	///Type of the mining level to use
 	var/minetype = "lavaland"
 
+	///Does the map allow custom shuttles to be purchased
 	var/allow_custom_shuttles = TRUE
-	var/allow_night_lighting = TRUE
+	///Default list of json shuttles. Not all shuttles use this system; most use the template variable.
 	var/shuttles = list(
 		"cargo" = "cargo_box",
 		"ferry" = "ferry_fancy",
 		"whiteship" = "whiteship_box",
 		"emergency" = "emergency_box")
+
+	/// Is night lighting allowed to occur on this station?
+	var/allow_night_lighting = TRUE
+
+	//======
+	// Planettary Settings
+	//======
+
+	/// Is this station considered a planet for the supercruise map
+	var/planettary_station = FALSE
+	/// The name of the planet on the supercruise map
+	var/planet_name = ""
+	/// Radius of the planet
+	var/planet_radius = 300
+	/// Supercruise planet gravity
+	var/planet_mass = 15000
+
+	//======
+	// Performance Settings
+	//======
+
+	/// Disable station level parallax. For levels which have no parallax background
+	var/no_station_parallax = FALSE
 
 /proc/load_map_config(filename = "next_map", foldername = DATA_DIRECTORY, default_to_box, delete_after, error_if_missing = TRUE)
 	if(IsAdminAdvancedProcCall())
@@ -132,14 +159,17 @@
 	if ("minetype" in json)
 		minetype = json["minetype"]
 
-	if("map_link" in json)						
+	if("map_link" in json)
 		map_link = json["map_link"]
 	else
 		log_world("map_link missing from json!")
 
-	allow_custom_shuttles = json["allow_custom_shuttles"] != FALSE
-
-	allow_night_lighting = json["allow_night_lighting"] != FALSE
+	allow_custom_shuttles = !isnull(json["allow_custom_shuttles"]) && json["allow_custom_shuttles"] != FALSE
+	allow_night_lighting = !isnull(json["allow_night_lighting"]) && json["allow_night_lighting"] != FALSE
+	planettary_station = !isnull(json["planettary_station"]) && json["planettary_station"] != FALSE
+	planet_name = json["planet_name"]
+	planet_mass = text2num(json["planet_mass"]) || planet_mass
+	planet_radius = text2num(json["planet_radius"]) || planet_radius
 
 	defaulted = FALSE
 	return TRUE

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -436,7 +436,7 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	var/prefalltime = 8 SECONDS
 	layer = METEOR_LAYER
 
-/obj/effect/falling_meteor/Initialize(mapload, loc, meteor_type)
+/obj/effect/falling_meteor/Initialize(mapload, meteor_type)
 	. = ..()
 	if(!meteor_type)
 		meteor_type = /obj/effect/meteor/big

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -468,10 +468,31 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	animate(src, 5, alpha = 255)
 	animate(src, falltime, transform = matrix(), flags = ANIMATION_PARALLEL)
 	sleep(falltime)
+	if (istype(loc, /turf/open/openspace))
+		fall_below()
+	//Trigger multiple simulated bumps (Z levels are much more expensive to travel)
 	contained_meteor.forceMove(loc)
-	contained_meteor.make_debris()
-	contained_meteor.meteor_effect()
-	qdel(src)
+	contained_meteor.hits -= rand(4, 10)
+	contained_meteor.Bump(loc)
+	//If the meteor was deleted by the bumps, destroy the falling meteor
+	if (QDELETED(contained_meteor))
+		qdel(src)
+	else
+		//Fall down and repeat if possible
+		contained_meteor.forceMove(src)
+		fall_below()
+
+/obj/effect/falling_meteor/proc/fall_below()
+	var/turf/current = loc
+	if (!istype(current))
+		return FALSE
+	var/turf/below = current.below()
+	//Move down a layer and fall again
+	if (below != null)
+		forceMove(below)
+		fall_animation()
+		return TRUE
+	return FALSE
 
 /obj/effect/meteor_shadow
 	name = "shadow"

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -480,7 +480,9 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	else
 		//Fall down and repeat if possible
 		contained_meteor.forceMove(src)
-		fall_below()
+		//Try to fall down
+		if (!fall_below())
+			qdel(src)
 
 /obj/effect/falling_meteor/proc/fall_below()
 	var/turf/current = loc

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -61,7 +61,7 @@
 		if(space_level.traits[ZTRAIT_CENTCOM] || space_level.traits[ZTRAIT_REEBE])
 			return
 		//Check level flags for planetary bodies
-		if(space_level.traits[ZTRAIT_MINING])
+		if(space_level.traits[ZTRAIT_MINING] || (space_level.traits[ZTRAIT_STATION] && SSmapping.config.planettary_station))
 			for(var/i in 1 to 5)
 				meteor_impact(locate(rand(10, world.maxx - 10), rand(10, world.maxx-10), space_level.z_value))
 		else
@@ -75,4 +75,10 @@
 
 //Fall from the sky
 /datum/orbital_object/meteor/proc/meteor_impact(turf/T)
-	new /obj/effect/falling_meteor(T, meteor_types ? pick(meteor_types) : null)
+	//Make it so meteors fall from high Z and will impact the top Z-Levels first
+	var/turf/target_turf = T
+	var/turf/next = target_turf.above()
+	while (next != null)
+		target_turf = next
+		next = target_turf.above()
+	new /obj/effect/falling_meteor(target_turf, meteor_types ? pick(meteor_types) : null)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -61,7 +61,7 @@
 		if(space_level.traits[ZTRAIT_CENTCOM] || space_level.traits[ZTRAIT_REEBE])
 			return
 		//Check level flags for planetary bodies
-		if(space_level.traits[ZTRAIT_MINING] || (space_level.traits[ZTRAIT_STATION] && SSmapping.config.planettary_station))
+		if(space_level.traits[ZTRAIT_MINING] || (space_level.traits[ZTRAIT_STATION] && SSmapping.config.planetary_station))
 			for(var/i in 1 to 5)
 				meteor_impact(locate(rand(10, world.maxx - 10), rand(10, world.maxx-10), space_level.z_value))
 		else

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/space_station.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/space_station.dm
@@ -12,7 +12,7 @@
 	. = ..()
 	SSorbits.station_instance = src
 	//SSorbits initialises after mapping
-	if (SSmapping.config.planettary_station)
+	if (SSmapping.config.planetary_station)
 		render_mode = RENDER_MODE_PLANET
 		radius = SSmapping.config.planet_radius
 		mass = SSmapping.config.planet_mass

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/space_station.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/space_station.dm
@@ -11,6 +11,13 @@
 /datum/orbital_object/z_linked/station/New()
 	. = ..()
 	SSorbits.station_instance = src
+	//SSorbits initialises after mapping
+	if (SSmapping.config.planettary_station)
+		render_mode = RENDER_MODE_PLANET
+		radius = SSmapping.config.planet_radius
+		mass = SSmapping.config.planet_mass
+		if (SSmapping.config.planet_name)
+			name = "[SSmapping.config.planet_name] (Outpost 13)"
 
 #ifdef LOWMEMORYMODE
 	var/datum/orbital_map/linked_map = SSorbits.orbital_maps[orbital_map_index]

--- a/tgui/packages/tgui/components/OrbitalMapSvg.js
+++ b/tgui/packages/tgui/components/OrbitalMapSvg.js
@@ -21,7 +21,7 @@ export class OrbitalMapSvg extends Component {
     this.renderTypeDict = {
       "broken": Broken,
       "default": RenderableObjectType,
-      "planet": planetaryBody,
+      "planet": PlanetaryBody,
       "beacon": Beacon,
       "shuttle": Shuttle,
       "projectile": Projectile,
@@ -435,7 +435,7 @@ class RenderableObjectType {
 // ===========================
 
 // Planets
-class planetaryBody extends RenderableObjectType {
+class PlanetaryBody extends RenderableObjectType {
   constructor() {
     super();
     this.outlineColour = "#fca635";

--- a/tgui/packages/tgui/components/OrbitalMapSvg.js
+++ b/tgui/packages/tgui/components/OrbitalMapSvg.js
@@ -21,7 +21,7 @@ export class OrbitalMapSvg extends Component {
     this.renderTypeDict = {
       "broken": Broken,
       "default": RenderableObjectType,
-      "planet": PlanettaryBody,
+      "planet": planetaryBody,
       "beacon": Beacon,
       "shuttle": Shuttle,
       "projectile": Projectile,
@@ -435,7 +435,7 @@ class RenderableObjectType {
 // ===========================
 
 // Planets
-class PlanettaryBody extends RenderableObjectType {
+class planetaryBody extends RenderableObjectType {
   constructor() {
     super();
     this.outlineColour = "#fca635";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in some new mapping config options:
 - planetary_station (Set to 1 to enable planetary maps): Will reskin the station on supercruise maps to have the planet rendering mode. Will also enable planettary meteors for the station
 - planet_name: Sets a prefix to the name of the station object on the maps. Only takes effect if planetary_station is enabled.
 - planet_mass: Sets the mass of the planet, if planettary station is enabled. (Lavaland has a mass of 10000 for reference. This affects the gravitational pull of the planet. This will most likely result in all supercruise objects going fucking crazy since they are setup with velocities to orbit around lavaland and not your planet)
 - planet_radius: Sets the radius of the supercruise map object for the station. Does nothing else.

Planetary meteors now work as the following:
 - They will spawn at the turf with the highest Z value on multi-z maps.
 - If they impact an openspace turf, they will fall down and then repeat the falling animation.
 - If they impact a normal turf, they will trigger 6-10 bumps and then do their effect if they got destroyed. Otherwise they will fall through the ceiling and travel to the turf below.
 - If they reach the bottom, they automatically blow up.

## Why It's Good For The Game

Allows mappers to create planetary maps.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/206262033-b124edef-3b38-4f97-8d2c-dbee53c0df41.png)

![image](https://user-images.githubusercontent.com/26465327/206262081-0ef7bf6c-5347-436c-8687-f3d9e7d43f62.png)

![image](https://user-images.githubusercontent.com/26465327/206262219-9ad5f1d1-79a3-48e4-ada4-ceee3ab4a423.png)

## Changelog
:cl:
add: Adds in new config settings for mappers that allow for the creation of planetary based maps on the supercruise map. See PR #8178 for more details.
add: Planetary meteors will now spawn on the highest z-level and drop down until they hit the bottom or explode.
fix: Planetary meteors will no longer only spawn mini rocks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
