### PR TITLE
Changes filtered(?) brain damage word to a more better one

### DIFF
--- a/strings/traumas.json
+++ b/strings/traumas.json
@@ -33,7 +33,7 @@
 		"closd for merbegging",
 		"@pick(semicolon)pray can u @pick(create_verbs) @pick(create_nouns)???",
 		"GEY AWAY FROM ME U GREIFING PRICK!!!!",
-		"ur a fuckeing autist!",
+		"ur a fuckeing jackass!",
 		"@pick(semicolon)HELP SHITECIRTY MURDERIN  MEE!!!",
 		"hwat dose tha @pick(random_gibberish) mean?????",
 		"@pick(semicolon)CAL; TEH SHUTTLE!!!!!",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As someone who plays with brain trauma I constantly worry about getting reported when this speech blurb gets said. I'm not sure if it's even a filtered word. I'm also debating replacing it with 'shitter' but jackass can stay for now.


## Why It's Good For The Game

Possibly helps protect brain damaged players not get reported for breaking the 'be excellent to each other' rule.


## Changelog

:cl:
tweak: Tweaked a brain damage line
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
