### PR TITLE
fixes engineering circuit imprinters not receiving research

### DIFF
--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2752,7 +2752,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "ii" = (
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -48326,7 +48326,6 @@
 /turf/open/floor/engine/light,
 /area/storage/tech)
 "rhN" = (
-/obj/machinery/vending/cart,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -45386,7 +45386,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -48326,7 +48326,7 @@
 /turf/open/floor/engine/light,
 /area/storage/tech)
 "rhN" = (
-/obj/machinery/vending/job_disk,
+/obj/machinery/vending/cart,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -24474,7 +24474,7 @@
 /area/science/mixing/chamber)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -82446,7 +82446,7 @@
 /area/medical/medbay/central)
 "sZg" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -74102,7 +74102,7 @@
 /area/hallway/primary/aft)
 "sQn" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /turf/open/floor/plasteel/dark,
 /area/engine/storage_shared)
 "sQo" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -14159,7 +14159,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axp" = (
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -69478,7 +69478,7 @@
 /area/engine/atmos)
 "upP" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20115,7 +20115,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cCU" = (
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cCV" = (

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -2864,7 +2864,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/rnd/production/circuit_imprinter/department,
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-8"

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -822,6 +822,11 @@
 	icon_state = "science"
 	build_path = /obj/machinery/rnd/production/circuit_imprinter/department/science
 
+/obj/item/circuitboard/machine/circuit_imprinter/department/engineering
+	name = "departmental circuit imprinter - engineering (Machine Board)"
+	icon_state = "science"
+	build_path = /obj/machinery/rnd/production/circuit_imprinter/department/engineering
+
 /obj/item/circuitboard/machine/cyborgrecharger
 	name = "cyborg recharger (Machine Board)"
 	icon_state = "science"

--- a/code/modules/research/machinery/departmental_circuit_imprinter.dm
+++ b/code/modules/research/machinery/departmental_circuit_imprinter.dm
@@ -9,3 +9,9 @@
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/department/science
 	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_SCIENCE
 	department_tag = "Science"
+
+/obj/machinery/rnd/production/circuit_imprinter/department/engineering
+	name = "department circuit imprinter (Engineering)"
+	circuit = /obj/item/circuitboard/machine/circuit_imprinter/department/engineering
+	allowed_department_flags = DEPARTMENTAL_FLAG_ALL|DEPARTMENTAL_FLAG_ENGINEERING
+	department_tag = "Engineering"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR replaces the /obj/machinery/rnd/production/circuit_imprinter/ that were in engineering and instead has them as /obj/machinery/rnd/production/circuit_imprinter/department/engineering. This allows these circuit imprinters to actually be able to receive the correct research upgrades, like shuttle parts, rather than be stuck at the same ones all round.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure



</details>

## Changelog
:cl:
fix: split engineering circuit imprinter into its own machine, allowing it to receive research equipment as researched like before
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
