### PR TITLE
Fixes a faction bug with tamed animals

### DIFF
--- a/code/game/objects/items/carp_lasso.dm
+++ b/code/game/objects/items/carp_lasso.dm
@@ -53,6 +53,7 @@
 		to_chat(user, "<span class='notice'>You begin to untie [C]</span>")
 		if(proximity_flag && do_after(user, 2 SECONDS, FALSE, target))
 			user.faction |= "carpboy_[user]"
+			C.faction = list("neutral")
 			C.faction |= "carpboy_[user]"
 			C.faction |= user.faction
 			C.transform = transform.Turn(0)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -773,13 +773,14 @@
 		..()
 
 /obj/item/slimepotion/slime/sentience/proc/after_success(mob/living/user, mob/living/simple_animal/SM)
-	return
+	SM.faction = user.faction.Copy()
 
 /obj/item/slimepotion/slime/sentience/nuclear
 	name = "syndicate intelligence potion"
 	desc = "A miraculous chemical mix that grants human like intelligence to living beings. It has been modified with Syndicate technology to also grant an internal radio implant to the target and authenticate with identification systems."
 
 /obj/item/slimepotion/slime/sentience/nuclear/after_success(mob/living/user, mob/living/simple_animal/SM)
+	..()
 	var/obj/item/implant/radio/syndicate/imp = new(src)
 	imp.implant(SM, user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This was an issue I thought I'd fixed on my last lasso PR, but evidently I forgot about it.
This makes it so that factions for tamed/sentience-potioned animals are properly reset (sort of like how it's handled for sentient elites) so that other non-tamed animals properly aggro on them.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This bug effectively allowed you to cheese various simplemobs, and cheese is lame.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Compiles properly, mobs draw aggro from other mobs properly. 

## Changelog
:cl:
fix: Tamed and sentience-potioned mobs now properly draw aggro from other mobs of the same type. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
