### PR TITLE
Disable SM Singularity (TEMPORARY FIX)

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination.dm
+++ b/code/modules/power/supermatter/supermatter_delamination.dm
@@ -59,7 +59,7 @@
 
 /datum/supermatter_delamination/proc/setup_delamination_type()
 	if(supermatter_gas_amount > MOLE_PENALTY_THRESHOLD)
-		call_singulo()
+		//call_singulo()
 		return
 
 	if(supermatter_power > POWER_PENALTY_THRESHOLD)


### PR DESCRIPTION
Temporarily disables the SM singularity delamination spawn, because it keeps happening every few rounds due to an unknown bug.

Singulos every round is NOT fun.