### PR TITLE
Supercruise now runs using continuous time, orbital map uses velocity multiplier to predict smoother shuttle movement

### DIFF
--- a/code/controllers/subsystem/processing/orbits.dm
+++ b/code/controllers/subsystem/processing/orbits.dm
@@ -230,5 +230,6 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 				"radius" = object.radius,
 				"render_mode" = object.render_mode,
 				"priority" = object.priority,
+				"vel_mult" = object.velocity_multiplier,
 			))
 	return data

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -25,7 +25,7 @@ SUBSYSTEM_DEF(processing)
 	if (!resumed)
 		currentrun = processing.Copy()
 
-	var/continuous_delta_time = world.timeofday - last_time_fired
+	var/continuous_delta_time = last_time_fired == 0 ? wait : world.timeofday - last_time_fired
 	last_time_fired = world.timeofday
 
 	//cache for sanic speed (lists are references anyways)
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(processing)
 		current_run.len--
 		if(QDELETED(thing))
 			processing -= thing
-		else if(thing.process((flags & SS_KEEP_TIMING) ? continuous_delta_time : wait * 0.1) == PROCESS_KILL)
+		else if(thing.process(((flags & SS_KEEP_TIMING) ? continuous_delta_time : wait) * 0.1) == PROCESS_KILL)
 			// fully stop so that a future START_PROCESSING will work
 			STOP_PROCESSING(src, thing)
 		if (MC_TICK_CHECK)

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -10,6 +10,8 @@ SUBSYSTEM_DEF(processing)
 	var/list/processing = list()
 	var/list/currentrun = list()
 
+	var/last_time_fired = 0
+
 /datum/controller/subsystem/processing/stat_entry()
 	. = ..("[stat_tag]:[processing.len]")
 
@@ -22,6 +24,10 @@ SUBSYSTEM_DEF(processing)
 /datum/controller/subsystem/processing/fire(resumed = 0)
 	if (!resumed)
 		currentrun = processing.Copy()
+
+	var/continuous_delta_time = world.timeofday - last_time_fired
+	last_time_fired = world.timeofday
+
 	//cache for sanic speed (lists are references anyways)
 	var/list/current_run = currentrun
 
@@ -30,7 +36,7 @@ SUBSYSTEM_DEF(processing)
 		current_run.len--
 		if(QDELETED(thing))
 			processing -= thing
-		else if(thing.process(wait * 0.1) == PROCESS_KILL)
+		else if(thing.process((flags & SS_KEEP_TIMING) ? continuous_delta_time : wait * 0.1) == PROCESS_KILL)
 			// fully stop so that a future START_PROCESSING will work
 			STOP_PROCESSING(src, thing)
 		if (MC_TICK_CHECK)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_object.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_object.dm
@@ -95,18 +95,11 @@
 	return
 
 //Process orbital objects, calculate gravity
-/datum/orbital_object/process()
+/datum/orbital_object/process(delta_time)
 	//Dont process updates for static objects.
 	if(static_object)
 		return PROCESS_KILL
 
-	//NOTE TO SELF: This does nothing because world.time is in ticks not realtime.
-	var/delta_time = 0
-	if(last_update_tick)
-		//Don't go too crazy.
-		delta_time = CLAMP(world.time - last_update_tick, 10, 50) * 0.1
-	else
-		delta_time = 1
 	last_update_tick = world.time
 
 	var/datum/orbital_map/parent_map = SSorbits.orbital_maps[orbital_map_index]

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/custom_shuttle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/custom_shuttle.dm
@@ -7,10 +7,10 @@
 	attached_console = null
 	. = ..()
 
-/datum/orbital_object/shuttle/custom_shuttle/process()
+/datum/orbital_object/shuttle/custom_shuttle/process(delta_time)
 	if(!attached_console)
 		return
-	attached_console.consume_fuel(ORBITAL_UPDATE_RATE_SECONDS * fuel_consumption_rate * thrust / 100)
+	attached_console.consume_fuel(ORBITAL_UPDATE_RATE_SECONDS * fuel_consumption_rate * delta_time * thrust / 100)
 	if(attached_console.check_stranded())
 		return
 	max_thrust = (5 * arctan(attached_console.calculated_acceleration / 20)) / 90

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -16,8 +16,9 @@
 
 /datum/orbital_object/meteor/New()
 	. = ..()
-	start_tick = world.time
-	end_tick = world.time + 10 MINUTES
+	//Use continuous time for smoother meteors
+	start_tick = SSorbits.times_fired
+	end_tick = SSorbits.times_fired + (10 MINUTES / SSorbits.wait)
 	radius = rand(10, 50)
 
 /datum/orbital_object/meteor/Destroy()
@@ -25,12 +26,11 @@
 	meteor_types = null
 	. = ..()
 
-/datum/orbital_object/meteor/process()
-	. = ..()
+/datum/orbital_object/meteor/process(delta_time)
 	if(!QDELETED(target))
 		end_x = target.position.x
 		end_y = target.position.y
-	var/current_tick = world.time
+	var/current_tick = SSorbits.times_fired
 	var/tick_proportion = min((current_tick - start_tick) / (end_tick - start_tick), 1)
 	//stop when reached the target
 	if(tick_proportion == 1)
@@ -38,6 +38,10 @@
 		velocity.y = 0
 	var/current_x = (end_x * tick_proportion) + (start_x * (1 - tick_proportion))
 	var/current_y = (end_y * tick_proportion) + (start_y * (1 - tick_proportion))
+	//Set the velocity for better rendering
+	velocity.x = current_x - position.x
+	velocity.y = current_y - position.y
+	. = ..()
 	MOVE_ORBITAL_BODY(src, current_x, current_y)
 	if(abs(position.x) > 10000 || abs(position.y) > 10000)
 		qdel(src)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/shuttle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/shuttle.dm
@@ -70,7 +70,7 @@
 		port.jumpToNullSpace()
 	qdel(src)
 
-/datum/orbital_object/shuttle/process()
+/datum/orbital_object/shuttle/process(delta_time)
 	if(check_stuck())
 		return
 
@@ -99,7 +99,7 @@
 	var/thrust_amount = thrust * max_thrust / 100
 	var/thrust_x = cos(angle) * thrust_amount
 	var/thrust_y = sin(angle) * thrust_amount
-	accelerate_towards(new /datum/orbital_vector(thrust_x, thrust_y), ORBITAL_UPDATE_RATE_SECONDS)
+	accelerate_towards(new /datum/orbital_vector(thrust_x, thrust_y), ORBITAL_UPDATE_RATE_SECONDS * delta_time)
 	//Do gravity and movement
 	can_dock_with = null
 	. = ..()

--- a/tgui/packages/tgui/components/OrbitalMapSvg.js
+++ b/tgui/packages/tgui/components/OrbitalMapSvg.js
@@ -66,6 +66,7 @@ export class OrbitalMapSvg extends Component {
         mapObject.velocity_x,
         mapObject.velocity_y,
         mapObject.radius,
+        mapObject.vel_mult,
         mapObject.created_at,
       );
     });
@@ -281,11 +282,11 @@ export class OrbitalMapSvg extends Component {
             <line
               x1={Math.max(Math.min((ourRenderableObject.position_x
                 + xOffset
-                + ourRenderableObject.velocity_x * elapsed)
+                + ourRenderableObject.velocity_x * elapsed * ourRenderableObject.vel_mult)
                 * zoomScale * mapDistanceScale, 250), -250)}
               y1={Math.max(Math.min((ourRenderableObject.position_y
                 + yOffset
-                + ourRenderableObject.velocity_y * elapsed)
+                + ourRenderableObject.velocity_y * elapsed * ourRenderableObject.vel_mult)
                 * zoomScale * mapDistanceScale, 250), -250)}
               x2={Math.max(Math.min((shuttleTargetX
                 + xOffset)
@@ -300,11 +301,11 @@ export class OrbitalMapSvg extends Component {
           <circle
             cx={(ourRenderableObject.position_x
               + xOffset
-              + ourRenderableObject.velocity_x * elapsed)
+              + ourRenderableObject.velocity_x * elapsed * ourRenderableObject.vel_mult)
               * zoomScale * mapDistanceScale}
             cy={(ourRenderableObject.position_y
               + yOffset
-              + ourRenderableObject.velocity_y * elapsed)
+              + ourRenderableObject.velocity_y * elapsed * ourRenderableObject.vel_mult)
               * zoomScale * mapDistanceScale}
             r={Math.max(5 * zoomScale, interdiction_range
               * zoomScale)}
@@ -352,7 +353,7 @@ class RenderableObjectType {
   // Called every second
   // Updates the data
   onTick(name, position_x, position_y, velocity_x, velocity_y, radius,
-    created_at)
+    vel_mult, created_at)
   {
     this.name = name;
     this.position_x = position_x;
@@ -361,6 +362,7 @@ class RenderableObjectType {
     this.velocity_y = velocity_y;
     this.radius = radius;
     this.created_at = created_at;
+    this.vel_mult = vel_mult;
   }
 
   // Called on render()
@@ -378,11 +380,11 @@ class RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed)
+      + this.velocity_x * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed)
+      + this.velocity_y * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
     let outputRadius = this.radius * zoomScale;
 
@@ -489,11 +491,11 @@ class Beacon extends RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed)
+      + this.velocity_x * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed)
+      + this.velocity_y * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
 
     let beaconTimer = ((elapsed + this.random_offset) % 1);
@@ -566,12 +568,12 @@ class Shuttle extends RenderableObjectType {
   // Called every updateTick
   // Record the path and update variables.
   onTick(name, position_x, position_y, velocity_x, velocity_y, radius,
-    created_at)
+    vel_mult, created_at)
   {
     // wtf is this
     RenderableObjectType.prototype.onTick.call(
       this, name, position_x, position_y, velocity_x, velocity_y, radius,
-      created_at);
+      vel_mult, created_at);
     // Set the position
     this.recordedTrack[this.recordedTrackLastIndex] = {
       x: this.position_x,
@@ -611,11 +613,11 @@ class Shuttle extends RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed)
+      + this.velocity_x * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed)
+      + this.velocity_y * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
     let outputRadius = this.radius * zoomScale;
 
@@ -752,13 +754,12 @@ class Projectile extends RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed)
+      + this.velocity_x * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed)
+      + this.velocity_y * elapsed * this.vel_mult)
       * zoomScale * mapDistanceScale;
-    let outputRadius = this.radius * zoomScale;
 
     this.inBounds = outputXPosition < 250 && outputYPosition < 250
       && outputXPosition > -250 && outputYPosition > -250;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

SSorbits is now a continuous time subsystem. This means it will run at every 1 real time second rather than every 1 in-game second. Its delta time will be calculated according to realtime rather than tick time too.
This is because the supercruise map does not use a discrete representation of space and time like the rest of the game does, instead the map is represented as model with continuous time and space. As such rather than updating with ticks, we should update with time. (It also means that the predictions should be slightly smoother when lagging and should jolt back less).

In addition to this, orbital map objects will also take into account the objects velocity multiplier for calculating the predicted movement, so that shuttles will appear to be a lot less jolty and more smooth. All thats left to do now is to calculate acceleration and make the client side map rendering accurate to the actual positions.

I also fixed meteor velocities being extremely weird on the orbital map, making them appear extremely fast but then constantly teleport backwards.

## Why It's Good For The Game

See above.

## Testing Photographs and Procedure

https://user-images.githubusercontent.com/26465327/206813456-1a5318c0-94ed-45a3-89cb-2a6951f9db6f.mp4

https://user-images.githubusercontent.com/26465327/206813489-6a5f24a7-05f3-4f46-a4f6-b926aa169b69.mp4

## Changelog
:cl:
tweak: Improved the smoothness of shuttles on the orbital map.
tweak: Orbital map now updates according to real time rather than tick time.
fix: Meteors should move at the correct speed on the map now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
