### PR TITLE
Adds clarity to the initial pirate payoff message

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -29,7 +29,7 @@
 		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 	threat.title = "Business proposition"
-	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank. We'll pilfer it from yer cargo budget. don't try and cheat us, make sure it's all there!"
+	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank. We'll pilfer it from yer cargo budget. Don't try and cheat us, make sure it's all there!"
 	threat.possible_answers = list(
 		PIRATE_RESPONSE_PAY = "We'll pay.",
 		PIRATE_RESPONSE_NO_PAY = "No way.",

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -29,7 +29,7 @@
 		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 	threat.title = "Business proposition"
-	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
+	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank. We'll pilfer it from yer cargo budget. don't try and cheat us, make sure it's all there!"
 	threat.possible_answers = list(
 		PIRATE_RESPONSE_PAY = "We'll pay.",
 		PIRATE_RESPONSE_NO_PAY = "No way.",

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -29,7 +29,7 @@
 		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 	threat.title = "Business proposition"
-	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank. We'll pilfer it from yer cargo budget. Don't try and cheat us, make sure it's all there!"
+	threat.content = "Avast, ye scurvy dogs! Our fine ship <i>[ship_name]</i> has come for yer booty. Immediately transfer [payoff] space doubloons from yer Cargo budget or ye'll be walkin' the plank. Don't try and cheat us, make sure it's all tharr!"
 	threat.possible_answers = list(
 		PIRATE_RESPONSE_PAY = "We'll pay.",
 		PIRATE_RESPONSE_NO_PAY = "No way.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A short IC addition to the pirate's initial ransom/payoff note.

## Why It's Good For The Game

It appears that the payoff coming from the cargo budget isn't common knowledge, even amongst command/AI players. This creates a situation where command/AI players that think they are choosing one thing, actually choose the opposite, since if you click "we'll pay" without the necessary funds in the cargo budget it actually just makes the pirate attack happen sooner.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2022-12-13 181856](https://user-images.githubusercontent.com/39484008/207416583-45ae7744-24f8-4d67-8446-f00aca9067f3.png)

Thanks to Tyranicranger4 and LodedDiper for the assistance on the initial concept.
</details>

## Changelog
:cl:
tweak: added some text to the "Business proposition" message that appears on the communication console before pirates show up.
/:cl:
