### PR TITLE
another cig solution

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -190,6 +190,7 @@
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_logging.dm"
 #include "code\__HELPERS\_string_lists.dm"
+#include "code\__HELPERS\antag_check.dm"
 #include "code\__HELPERS\areas.dm"
 #include "code\__HELPERS\atmos.dm"
 #include "code\__HELPERS\chat.dm"

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -26,3 +26,5 @@
 	message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]', but it is rejected as they are not antag, and have not enough playtime. ([playing_time] minutes)")
 	log_admin("[key_name(M)] tried '[behavior]', but it is rejected as they are not antag, and have not enough playtime. ([playing_time] minutes)")
 	return FALSE
+
+#undef ANTAGONISM_MINIMAL_TIME

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -1,0 +1,29 @@
+#define ANTAGONISM_MINIMAL_TIME 5 // 1 is identical to 1 min in DB
+
+/// prevents non-antag griefing - returns TRUE if they are eligible to do so
+/proc/check_antagonism_minimal_playtime(mob/M, behavior="unknown activity", req_time=ANTAGONISM_MINIMAL_TIME)
+	world.log << "checking antagonism"
+	if (!CONFIG_GET(flag/use_exp_track_for_antagonism_behavior))
+		return TRUE // if this system is not used in config, returns TRUE
+	if (!CONFIG_GET(flag/use_exp_tracking))
+		return TRUE // if we don't exp tracking, no way to track playtime. returns TRUE
+	if(locate(/datum/antagonist) in M.mind.antag_datums)
+		return TRUE // antag shouldn't be restricted by this.
+
+	// copy-paste from `job_report.dm`
+	var/client/owner = M.client
+	var/list/play_records = owner.prefs.exp
+	if (!play_records.len)
+		owner.set_exp_from_db()
+		play_records = owner.prefs.exp
+		if (!play_records.len)
+			return TRUE // having nothing seems DB is broken. returns TRUE anyway.
+	var/playing_time = play_records[EXP_TYPE_LIVING]
+	if(playing_time >= req_time)
+		message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]' - they are not antag, but accepted with [playing_time] minutes playing time.")
+		log_admin("[key_name(M)] tried '[behavior]' - they are not antag, but accepted with [playing_time] minutes playing time.")
+		return TRUE
+
+	message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]', but it is rejected as they are not antag, and have not enough playtime. ([playing_time] minutes)")
+	log_admin("[key_name(M)] tried '[behavior]', but it is rejected as they are not antag, and have not enough playtime. ([playing_time] minutes)")
+	return FALSE

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -2,10 +2,10 @@
 
 /// checks if antagonism configuration has been set
 /proc/check_antagonism_config()
-	if (!CONFIG_GET(flag/use_exp_track_for_antagonism_behavior))
-		return FALSE // if this system is not used in config, returns FALSE
 	if (!CONFIG_GET(flag/use_exp_tracking))
 		return FALSE // if we don't exp tracking, no way to track playtime. returns FALSE
+	if (!CONFIG_GET(flag/use_exp_track_for_antagonism_behavior))
+		return FALSE // if this system is not used in config, returns FALSE
 	if(locate(/datum/antagonist) in M.mind.antag_datums)
 		return FALSE // antags shouldn't be restricted by this.
 	return TRUE
@@ -45,9 +45,9 @@
 		if(locate(each_reagent) in reagents.reagent_list)
 			if((src != user.wear_mask) && (fingerprintslast == reagents.fingerprint_transfer))
 				if(!check_antagonism_minimal_playtime(user, "lighting an explosive cigar on someone's mouth or somewhere"))
-					user.ghostize(FALSE)
 					message_admins("[ADMIN_LOOKUPFLW(user)] has been force-ghosted. explosive cigar is automatically removed.")
 					log_game("[key_name(user)] has been force-ghosted. explosive cigar is automatically removed.")
+					user.ghostize(FALSE)
 					return TRUE
 	return FALSE
 

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -6,7 +6,7 @@
 		return FALSE // if we don't exp tracking, no way to track playtime. returns FALSE
 	if (!CONFIG_GET(flag/use_exp_track_for_antagonism_behavior))
 		return FALSE // if this system is not used in config, returns FALSE
-	if(locate(/datum/antagonist) in M.mind.antag_datums)
+	if(length(M.mind.antag_datums))
 		return FALSE // antags shouldn't be restricted by this.
 	return TRUE
 
@@ -18,10 +18,10 @@
 	// copy-paste from `job_report.dm`
 	var/client/owner = M.client
 	var/list/play_records = owner.prefs.exp
-	if (!play_records.len)
+	if (!length(play_records.len))
 		owner.set_exp_from_db()
 		play_records = owner.prefs.exp
-		if (!play_records.len)
+		if (length(play_records.len))
 			return TRUE // having nothing seems DB is broken. returns TRUE anyway.
 	var/playing_time = play_records[EXP_TYPE_LIVING]
 	if(playing_time >= req_time)
@@ -29,25 +29,29 @@
 		log_admin("[key_name(M)] tried '[behavior]' - they are not antag, but accepted with [playing_time] minutes playing time.")
 		return TRUE
 
-	message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]', but it is rejected as they are not antag, and are below the minimum playtime threshold. ([playing_time] minutes)")
-	log_admin("[key_name(M)] tried '[behavior]', but it is rejected as they are not antag, and are below the minimum playtime threshold. ([playing_time] minutes)")
+	message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]', but it has been blocked as they are not antag, and are below the minimum playtime threshold. ([playing_time] minutes)")
+	log_admin("[key_name(M)] tried '[behavior]', but it has been blocked as they are not antag, and are below the minimum playtime threshold. ([playing_time] minutes)")
 	return FALSE
 
 /obj/item/clothing/mask/cigarette/proc/check_cigar_antagonism(mob/living/carbon/user)
 	if(!check_antagonism_config(user))
 		return FALSE
 
-	var/static/restricted_reagents = typecacheof(list(
-		/datum/reagent/fuel,
-		/datum/reagent/toxin/plasma)
-	)
-	for(var/each_reagent in restricted_reagents)
+	for(var/each_reagent in GLOB.restricted_reagents)
 		if(locate(each_reagent) in reagents.reagent_list)
-			if((src != user.wear_mask) && (fingerprintslast == reagents.fingerprint_transfer))
-				if(!check_antagonism_minimal_playtime(user, "lighting an explosive cigar on someone's mouth or somewhere"))
+			if((src != user.wear_mask) && ((fingerprintslast == reagents.fingerprint_transfer) || (fingerprintslast == user.ckey)))
+				if(!check_antagonism_minimal_playtime(user, "lighting an explosive cigar on someone's mouth"))
 					message_admins("[ADMIN_LOOKUPFLW(user)] has been force-ghosted. explosive cigar is automatically removed.")
 					log_game("[key_name(user)] has been force-ghosted. explosive cigar is automatically removed.")
+					user.log_message("[key_name(user)] has been force-ghosted. explosive cigar is automatically removed.", LOG_GAME)
 					user.ghostize(FALSE)
+					if(reagents.fingerprint_transfer != fingerprintslast)
+						var/mob/M = get_mob_by_ckey(reagents.fingerprint_transfer)
+						message_admins("[ADMIN_LOOKUPFLW(M)] has been force-ghosted. explosive cigar is made by them.")
+						log_game("[key_name(M)] has been force-ghosted. explosive cigar is made by them.")
+						M.log_message("[key_name(user)] has been force-ghosted. explosive cigar is made by them.", LOG_GAME)
+						to_chat(M, "<span class='boldwarning'>You have been ghostized because the explosive cigar you made has been abused in-game. Don't help anyone to make an explosive cigar next time. Please call an admin if it was in an error.</span>")
+						M.ghostize(FALSE)
 					return TRUE
 	return FALSE
 

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -23,7 +23,7 @@
 		log_admin("[key_name(M)] tried '[behavior]' - they are not antag, but accepted with [playing_time] minutes playing time.")
 		return TRUE
 
-	message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]', but it is rejected as they are not antag, and have not enough playtime. ([playing_time] minutes)")
+	message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]', but it is rejected as they are not antag, and are below the minimum playtime threshold. ([playing_time] minutes)")
 	log_admin("[key_name(M)] tried '[behavior]', but it is rejected as they are not antag, and have not enough playtime. ([playing_time] minutes)")
 	return FALSE
 

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -1,4 +1,4 @@
-#define ANTAGONISM_MINIMAL_TIME 5 // 1 is identical to 1 min in DB
+#define ANTAGONISM_MINIMAL_TIME 180 // 1 is identical to 1 min in DB
 
 /// prevents non-antag griefing - returns TRUE if they are eligible to do so
 /proc/check_antagonism_minimal_playtime(mob/M, behavior="unknown activity", req_time=ANTAGONISM_MINIMAL_TIME)

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -2,7 +2,6 @@
 
 /// prevents non-antag griefing - returns TRUE if they are eligible to do so
 /proc/check_antagonism_minimal_playtime(mob/M, behavior="unknown activity", req_time=ANTAGONISM_MINIMAL_TIME)
-	world.log << "checking antagonism"
 	if (!CONFIG_GET(flag/use_exp_track_for_antagonism_behavior))
 		return TRUE // if this system is not used in config, returns TRUE
 	if (!CONFIG_GET(flag/use_exp_tracking))

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -36,6 +36,9 @@
 /obj/item/clothing/mask/cigarette/proc/check_cigar_antagonism(mob/living/carbon/user)
 	if(!check_antagonism_config(user))
 		return FALSE
+	var/mob/M = get_mob_by_ckey(reagents.fingerprint_transfer)
+	if(length(M.mind.antag_datums)) // if the injector is an antag, it will be allowed
+		return FALSE
 
 	for(var/each_reagent in GLOB.restricted_reagents)
 		if(locate(each_reagent) in reagents.reagent_list)
@@ -46,7 +49,6 @@
 					user.log_message("[key_name(user)] has been force-ghosted. explosive cigar is automatically removed.", LOG_GAME)
 					user.ghostize(FALSE)
 					if(reagents.fingerprint_transfer != fingerprintslast)
-						var/mob/M = get_mob_by_ckey(reagents.fingerprint_transfer)
 						message_admins("[ADMIN_LOOKUPFLW(M)] has been force-ghosted. explosive cigar is made by them.")
 						log_game("[key_name(M)] has been force-ghosted. explosive cigar is made by them.")
 						M.log_message("[key_name(user)] has been force-ghosted. explosive cigar is made by them.", LOG_GAME)

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -24,7 +24,7 @@
 		return TRUE
 
 	message_admins("[ADMIN_LOOKUPFLW(M)] tried '[behavior]', but it is rejected as they are not antag, and are below the minimum playtime threshold. ([playing_time] minutes)")
-	log_admin("[key_name(M)] tried '[behavior]', but it is rejected as they are not antag, and have not enough playtime. ([playing_time] minutes)")
+	log_admin("[key_name(M)] tried '[behavior]', but it is rejected as they are not antag, and are below the minimum playtime threshold. ([playing_time] minutes)")
 	return FALSE
 
 #undef ANTAGONISM_MINIMAL_TIME

--- a/code/__HELPERS/antag_check.dm
+++ b/code/__HELPERS/antag_check.dm
@@ -1,7 +1,7 @@
 #define ANTAGONISM_MINIMAL_TIME 180 // 1 is identical to 1 min in DB
 
 /// checks if antagonism configuration has been set
-/proc/check_antagonism_config()
+/proc/check_antagonism_config(mob/M)
 	if (!CONFIG_GET(flag/use_exp_tracking))
 		return FALSE // if we don't exp tracking, no way to track playtime. returns FALSE
 	if (!CONFIG_GET(flag/use_exp_track_for_antagonism_behavior))
@@ -12,7 +12,7 @@
 
 /// prevents non-antag griefing - returns TRUE if they are eligible to do so
 /proc/check_antagonism_minimal_playtime(mob/M, behavior="unknown activity", req_time=ANTAGONISM_MINIMAL_TIME)
-	if(!check_antagonism_config)
+	if(!check_antagonism_config(M))
 		return TRUE
 
 	// copy-paste from `job_report.dm`
@@ -34,7 +34,7 @@
 	return FALSE
 
 /obj/item/clothing/mask/cigarette/proc/check_cigar_antagonism(mob/living/carbon/user)
-	if(!check_antagonism_config)
+	if(!check_antagonism_config(user))
 		return FALSE
 
 	var/static/restricted_reagents = typecacheof(list(

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -193,6 +193,8 @@
 
 /datum/config_entry/flag/use_exp_tracking
 
+/datum/config_entry/flag/use_exp_track_for_antagonism_behavior
+
 /datum/config_entry/flag/use_exp_restrictions_heads
 
 /datum/config_entry/number/use_exp_restrictions_heads_hours

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -96,6 +96,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				if(M.wear_mask==src)
 					M.wear_mask = null
 				qdel(cig)
+				return
 			cig.light("<span class='notice'>[user] holds [src] out for [M], and lights [cig].</span>")
 	else
 		..()
@@ -340,6 +341,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				if(M.wear_mask==src)
 					M.wear_mask = null
 				qdel(cig)
+				return
 			cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights [M.p_their()] [cig.name].</span>")
 
 	else
@@ -732,6 +734,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					if(M.wear_mask==src)
 						M.wear_mask = null
 					qdel(cig)
+					return
 				cig.light("<span class='rose'>[user] whips the [name] out and holds it for [M]. [user.p_their(TRUE)] arm is as steady as the unflickering flame [user.p_they()] light[user.p_s()] \the [cig] with.</span>")
 			else
 				if(cig.reagents.get_reagent_amount(/datum/reagent/toxin/plasma))
@@ -744,6 +747,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					if(M.wear_mask==src)
 						M.wear_mask = null
 					qdel(cig)
+					return
 				cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights [M.p_their()] [cig.name].</span>")
 	else
 		..()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -92,6 +92,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 				message_admins("[cig] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 				log_game("[cig] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
+			if(cig.check_cigar_antagonism(user))
+				if(M.wear_mask==src)
+					M.wear_mask = null
+				qdel(cig)
 			cig.light("<span class='notice'>[user] holds [src] out for [M], and lights [cig].</span>")
 	else
 		..()
@@ -164,13 +168,16 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(lighting_text)
 			if(src.reagents.get_reagent_amount(/datum/reagent/toxin/plasma))
 				message_admins("[src] that contains plasma was lit by [ADMIN_LOOKUPFLW(user)]!")
-				log_game("[src] that contains plasma was lit by  [key_name(user)]!")
+				log_game("[src] that contains plasma was lit by [key_name(user)]!")
 			if(src.reagents.get_reagent_amount(/datum/reagent/fuel))
 				message_admins("[src] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)]!")
 				log_game("[src] that contains fuel was lit by [key_name(user)]!")
+
 			light(lighting_text)
 	else
 		return ..()
+
+
 
 /obj/item/clothing/mask/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
 	. = ..()
@@ -329,6 +336,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 				message_admins("[cig] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 				log_game("[cig] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
+			if(cig.check_cigar_antagonism(user))
+				if(M.wear_mask==src)
+					M.wear_mask = null
+				qdel(cig)
 			cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights [M.p_their()] [cig.name].</span>")
 
 	else
@@ -717,6 +728,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 					message_admins("[cig.name] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 					log_game("[cig.name] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
+				if(cig.check_cigar_antagonism(user))
+					if(M.wear_mask==src)
+						M.wear_mask = null
+					qdel(cig)
 				cig.light("<span class='rose'>[user] whips the [name] out and holds it for [M]. [user.p_their(TRUE)] arm is as steady as the unflickering flame [user.p_they()] light[user.p_s()] \the [cig] with.</span>")
 			else
 				if(cig.reagents.get_reagent_amount(/datum/reagent/toxin/plasma))
@@ -725,6 +740,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 					message_admins("[cig.name] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 					log_game("[cig.name] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
+				if(cig.check_cigar_antagonism(user))
+					if(M.wear_mask==src)
+						M.wear_mask = null
+					qdel(cig)
 				cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights [M.p_their()] [cig.name].</span>")
 	else
 		..()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -92,7 +92,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 				message_admins("[cig] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 				log_game("[cig] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
-			if(cig.check_cigar_antagonism(user))
+			if(M.mind && cig.check_cigar_antagonism(user))
 				if(M.wear_mask==src)
 					M.wear_mask = null
 				qdel(cig)
@@ -336,7 +336,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 				message_admins("[cig] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 				log_game("[cig] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
-			if(cig.check_cigar_antagonism(user))
+			if(M.mind && cig.check_cigar_antagonism(user))
 				if(M.wear_mask==src)
 					M.wear_mask = null
 				qdel(cig)
@@ -728,7 +728,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 					message_admins("[cig.name] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 					log_game("[cig.name] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
-				if(cig.check_cigar_antagonism(user))
+				if(M.mind && cig.check_cigar_antagonism(user))
 					if(M.wear_mask==src)
 						M.wear_mask = null
 					qdel(cig)
@@ -740,7 +740,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				if(cig.reagents.get_reagent_amount(/datum/reagent/fuel))
 					message_admins("[cig.name] that contains fuel was lit by [ADMIN_LOOKUPFLW(user)] for [key_name_admin(M)]!")
 					log_game("[cig.name] that contains fuel was lit by [key_name(user)] for [key_name(M)]!")
-				if(cig.check_cigar_antagonism(user))
+				if(M.mind && cig.check_cigar_antagonism(user))
 					if(M.wear_mask==src)
 						M.wear_mask = null
 					qdel(cig)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -53,6 +53,7 @@
 	var/addiction_tick = 1
 	var/list/datum/reagent/addiction_list = new/list()
 	var/flags
+	var/fingerprint_transfer = ""
 
 /datum/reagents/New(maximum=100, new_flags=0)
 	maximum_volume = maximum
@@ -185,6 +186,7 @@
 
 	if(transfered_by && target_atom)
 		target_atom.add_hiddenprint(transfered_by) //log prints so admins can figure out who touched it last.
+		target_atom.reagents.fingerprint_transfer = transfered_by.ckey
 		log_combat(transfered_by, target_atom, "transferred reagents ([log_list()]) from [my_atom] to")
 
 	amount = min(min(amount, src.total_volume), R.maximum_volume-R.total_volume)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -186,7 +186,10 @@
 
 	if(transfered_by && target_atom)
 		target_atom.add_hiddenprint(transfered_by) //log prints so admins can figure out who touched it last.
-		target_atom.reagents.fingerprint_transfer = transfered_by.ckey
+		for(var/each_reagent in GLOB.restricted_reagents)
+			if(locate(each_reagent) in target_atom.reagents.reagent_list)
+				target_atom.reagents.fingerprint_transfer = transfered_by.ckey
+				break
 		log_combat(transfered_by, target_atom, "transferred reagents ([log_list()]) from [my_atom] to")
 
 	amount = min(min(amount, src.total_volume), R.maximum_volume-R.total_volume)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -2,6 +2,10 @@
 
 GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 
+GLOBAL_LIST_INIT(restricted_reagents, list(
+		/datum/reagent/fuel,
+		/datum/reagent/toxin/plasma))
+
 /proc/build_name2reagent()
 	. = list()
 	for (var/t in subtypesof(/datum/reagent))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -147,22 +147,6 @@
 				balloon_alert(user, "You cannot inject [target].")
 				return
 
-			// setting up
-			var/static/restricted_items = typecacheof(list(
-				/obj/item/clothing/mask/cigarette // put more items that something shouldn't
-			))
-			var/static/restricted_reagents = typecacheof(list(
-				/datum/reagent/fuel,
-				/datum/reagent/toxin/plasma)
-			)
-			// no to random antagonism
-			if(is_type_in_typecache(target, restricted_items))
-				for(var/datum/reagent/R in reagents.reagent_list)
-					if(is_type_in_typecache(R, restricted_reagents))
-						if(!check_antagonism_minimal_playtime(user, "injecting [R] into a cigarette"))
-							balloon_alert(user, "You cannot inject [target].")
-							return
-
 			if(target.reagents.total_volume >= target.reagents.maximum_volume)
 				balloon_alert(user, "[target] is full.")
 				return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -147,6 +147,22 @@
 				balloon_alert(user, "You cannot inject [target].")
 				return
 
+			// setting up
+			var/static/restricted_items = typecacheof(list(
+				/obj/item/clothing/mask/cigarette // put more items that something shouldn't
+			))
+			var/static/restricted_reagents = typecacheof(list(
+				/datum/reagent/fuel,
+				/datum/reagent/toxin/plasma)
+			)
+			// no to random antagonism
+			if(is_type_in_typecache(target, restricted_items))
+				for(var/datum/reagent/R in reagents.reagent_list)
+					if(is_type_in_typecache(R, restricted_reagents))
+						if(!check_antagonism_minimal_playtime(user, "injecting [R] into a cigarette"))
+							balloon_alert(user, "You cannot inject [target].")
+							return
+
 			if(target.reagents.total_volume >= target.reagents.maximum_volume)
 				balloon_alert(user, "[target] is full.")
 				return

--- a/config/config.txt
+++ b/config/config.txt
@@ -88,7 +88,7 @@ ENABLE_LOCALHOST_RANK
 ## Unhash this to track player playtime in the database. Requires database to be enabled.
 USE_EXP_TRACKING
 ## If uncommented, uses player's living time for player antagonism
-#USE_EXP_TRACK_FOR_ANTAGONISM_BEHAVIOR
+USE_EXP_TRACK_FOR_ANTAGONISM_BEHAVIOR
 ## Unhash this to enable playtime requirements for head jobs.
 USE_EXP_RESTRICTIONS_HEADS
 ## Unhash this to override head jobs' playtime requirements with this number of hours.

--- a/config/config.txt
+++ b/config/config.txt
@@ -87,6 +87,8 @@ ENABLE_LOCALHOST_RANK
 
 ## Unhash this to track player playtime in the database. Requires database to be enabled.
 USE_EXP_TRACKING
+## If uncommented, uses player's living time for player antagonism
+#USE_EXP_TRACK_FOR_ANTAGONISM_BEHAVIOR
 ## Unhash this to enable playtime requirements for head jobs.
 USE_EXP_RESTRICTIONS_HEADS
 ## Unhash this to override head jobs' playtime requirements with this number of hours.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If someone injects a specific reagent into a cigar and the same person tries to light the cigar, it will ghotize them and remove the cigar from the game.
they still need to have 3 hours account time or be an antag if they're going to light on the explosive cigar.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
since #8182 isn't what people would like, I made the feature more specifically.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/207726963-2c8ef0c0-99f0-4ae8-b7bf-2f706588075e.png)

![image](https://user-images.githubusercontent.com/87972842/207726982-fa46748f-458b-401e-83f9-4030c356791e.png)

forcefully ghosted

![image](https://user-images.githubusercontent.com/87972842/207726999-da078b30-ef69-48e4-9261-491970989cb8.png)

cigar will not explode

</details>

## Changelog
:cl:
add: added grief management system
server: new config 'USE_EXP_TRACK_FOR_ANTAGONISM_BEHAVIOR' to check non-antag players have living time enough
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
