### PR TITLE
Increase pirate response time

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -21,7 +21,7 @@
 	var/payoff_min = 20000
 	var/payoff = 0
 	var/initial_send_time = world.time
-	var/response_max_time = 2 MINUTES
+	var/response_max_time = 10 MINUTES
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
 	var/datum/comm_message/threat = new
 	var/datum/bank_account/D = SSeconomy.get_budget_account(ACCOUNT_CAR_ID)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -21,7 +21,7 @@
 	var/payoff_min = 20000
 	var/payoff = 0
 	var/initial_send_time = world.time
-	var/response_max_time = rand(4,7) MINUTES
+	var/response_max_time = rand(3,5) MINUTES
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
 	var/datum/comm_message/threat = new
 	var/datum/bank_account/D = SSeconomy.get_budget_account(ACCOUNT_CAR_ID)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -21,7 +21,7 @@
 	var/payoff_min = 20000
 	var/payoff = 0
 	var/initial_send_time = world.time
-	var/response_max_time = 10 MINUTES
+	var/response_max_time = rand(4,7) MINUTES
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
 	var/datum/comm_message/threat = new
 	var/datum/bank_account/D = SSeconomy.get_budget_account(ACCOUNT_CAR_ID)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -21,7 +21,7 @@
 	var/payoff_min = 20000
 	var/payoff = 0
 	var/initial_send_time = world.time
-	var/response_max_time = rand(3,5) MINUTES
+	var/response_max_time = rand(4,7) MINUTES
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
 	var/datum/comm_message/threat = new
 	var/datum/bank_account/D = SSeconomy.get_budget_account(ACCOUNT_CAR_ID)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the amount of time the command staff have to see the communication console message, get money to the cargo budget and accept/deny the payoff from 2 minutes to 10 minutes.

## Why It's Good For The Game

Right now, there's very little time to respond to the message. Captains don't always have time to immediately check the console, and there's not always an AI there to warn them. Additionally, sometimes the station has the money in other budgets and needs to transfer, etc. This might even see comms going out from the captain begging the crew to pitch in, which would be hilarious. 

Thanks to Ruko for giving me the nod on this one.

## Testing Photographs and Procedure

Booted into test server, pirate raid run. Changed the message to print response_max_time and confirmed in game. see pic below.
![image](https://user-images.githubusercontent.com/39484008/207975899-bda994b2-2b55-44c2-aed2-a8a6549a91ca.png)

The actual commit does not print the response_max_time variable in the message.
</details>

## Changelog
:cl:
tweak: Changed the pirate respose timer from 2 minutes to a random number of minutes chosen between (and including) 4-7.
/:cl:
