### PR TITLE
Componentize /obj/effect/mob_spawn

### DIFF
--- a/_maps/RandomRooms/10x10/sk_rdm130_benoegg.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm130_benoegg.dmm
@@ -14,7 +14,7 @@
 /area/template_noop)
 "d" = (
 /obj/structure/alien/weeds,
-/obj/effect/mob_spawn/facehugger,
+/obj/effect/mapping_facehugger,
 /turf/open/floor/plating,
 /area/template_noop)
 "e" = (
@@ -44,7 +44,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "k" = (
-/obj/effect/mob_spawn/facehugger,
+/obj/effect/mapping_facehugger,
 /turf/closed/wall,
 /area/template_noop)
 "l" = (
@@ -77,7 +77,7 @@
 /area/template_noop)
 "q" = (
 /obj/structure/alien/weeds,
-/obj/effect/mob_spawn/facehugger,
+/obj/effect/mapping_facehugger,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
@@ -92,7 +92,7 @@
 /area/template_noop)
 "s" = (
 /obj/structure/alien/weeds,
-/obj/effect/mob_spawn/facehugger,
+/obj/effect/mapping_facehugger,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,

--- a/code/__DEFINES/dcs/signals/datum_signals/datum_signals.dm
+++ b/code/__DEFINES/dcs/signals/datum_signals/datum_signals.dm
@@ -85,3 +85,11 @@
 
 ///Called to all children when a parent moves, as long as it has the moved relay component.
 #define COMSIG_PARENT_MOVED_RELAY "parent_moved_relay"
+
+// /datum/component/mob_spawner signals, from [code/modules/awaymissions/corpse.dm]
+/// Creates the mob object.
+/// 	Args: ckey (client to put in control), name
+#define COMSIG_MOB_SPAWNER_CREATE "mob_spawner_create"
+/// Allows the parent to configure special behavior on the mob during create(). Sent by the component.
+/// 	Args: mob/M (the new mob), name (from create())
+#define COMSIG_MOB_SPAWNER_DOSPECIAL "mob_spawner_do_special"

--- a/code/datums/spawners_menu.dm
+++ b/code/datums/spawners_menu.dm
@@ -20,8 +20,8 @@
 		for(var/spawner_obj in GLOB.mob_spawners[spawner])
 			this["refs"] += "[REF(spawner_obj)]"
 			if(!this["desc"])
-				if(istype(spawner_obj, /obj/effect/mob_spawn))
-					var/obj/effect/mob_spawn/MS = spawner_obj
+				if(istype(spawner_obj, /datum/component/mob_spawner))
+					var/datum/component/mob_spawner/MS = spawner_obj
 					this["short_desc"] = MS.short_desc
 					this["flavor_text"] = MS.flavour_text
 					this["important_info"] = MS.important_info

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -264,8 +264,7 @@
 		/obj/item/organ/heart/cybernetic = 2,
 		/obj/item/organ/wings/cybernetic = 2,
 		/obj/item/organ/tongue/robot/clockwork/better = 2,
-		/obj/effect/gibspawner/robot = 4,
-		/obj/item/drone_shell = 1)
+		/obj/effect/gibspawner/robot = 4)
 
 /obj/effect/spawner/lootdrop/teratoma/major/clown
 	name = "funny teratoma spawner"

--- a/code/game/objects/structures/fugitive_role_spawners.dm
+++ b/code/game/objects/structures/fugitive_role_spawners.dm
@@ -14,7 +14,12 @@
 	. = ..()
 	notify_ghosts("Hunters are waking up looking for refugees!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_FUGITIVE)
 
-/obj/effect/mob_spawn/human/fugitive/special(mob/living/new_spawn)
+/obj/effect/mob_spawn/human/fugitive/pre_configure()
+	RegisterSignal(src, COMSIG_MOB_SPAWNER_DOSPECIAL, .proc/special)
+
+/obj/effect/mob_spawn/human/fugitive/proc/special(datum/source, mob/living/new_spawn, name)
+	SIGNAL_HANDLER
+
 	var/datum/antagonist/fugitive_hunter/fughunter = new
 	fughunter.backstory = back_story
 	new_spawn.mind.add_antag_datum(fughunter)

--- a/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
@@ -51,9 +51,11 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 
 //====Shell====
 
-/obj/effect/mob_spawn/drone/cogscarab
+/obj/effect/mob_spawn/cogscarab
 	name = "cogscarab construct"
 	desc = "The shell of an ancient construction drone, loyal to Ratvar."
+	icon = 'icons/mob/drone.dmi'
+	layer = BELOW_MOB_LAYER
 	icon_state = "drone_clock_hat"
 	mob_name = "cogscarab"
 	mob_type = /mob/living/simple_animal/drone/cogscarab
@@ -61,29 +63,12 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 	flavour_text = "You are a cogscarab, a tiny building construct of Ratvar. While you're weak and can't leave Reebe, \
 	you have a set of quick tools, as well as a replica fabricator that can create brass for construction. Work with the servants of Ratvar \
 	to construct and maintain defenses at the City of Cogs."
+	ban_type = ROLE_SERVANT_OF_RATVAR
 
-/obj/effect/mob_spawn/drone/cogscarab/attack_ghost(mob/user)
-	if(is_banned_from(user.ckey, ROLE_SERVANT_OF_RATVAR) || QDELETED(src) || QDELETED(user))
-		return
-	if(CONFIG_GET(flag/use_age_restriction_for_jobs))
-		if(!isnum(user.client.player_age)) //apparently what happens when there's no DB connected. just don't let anybody be a drone without admin intervention
-			if(user.client.player_age < 14)
-				to_chat(user, "<span class='danger'>You're too new to play as a drone! Please try again in [14 - user.client.player_age] days.</span>")
-				return
-	if(!SSticker.mode)
-		to_chat(user, "Can't become a cogscarab before the game has started.")
-		return
-	var/be_drone = alert("Become a cogscarab? (Warning, You can no longer be cloned!)",,"Yes","No")
-	if(be_drone == "No" || QDELETED(src) || !isobserver(user))
-		return
-	var/mob/living/simple_animal/drone/D = new mob_type(get_turf(loc))
-	if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
-		var/hat_type = pick(possible_seasonal_hats)
-		var/obj/item/new_hat = new hat_type(D)
-		D.equip_to_slot_or_del(new_hat, ITEM_SLOT_HEAD)
-	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
-	D.key = user.key
-	add_servant_of_ratvar(D, silent=TRUE)
-	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of \a [src] in [AREACOORD(src)].")
-	log_game("[key_name(user)] has taken possession of \a [src] in [AREACOORD(src)].")
-	qdel(src)
+/obj/effect/mob_spawn/cogscarab/pre_configure()
+	RegisterSignal(src, COMSIG_MOB_SPAWNER_DOSPECIAL, .proc/special)
+
+/obj/effect/mob_spawn/cogscarab/proc/special(datum/source, mob/living/new_spawn, name)
+	SIGNAL_HANDLER
+
+	add_servant_of_ratvar(new_spawn, silent=TRUE)

--- a/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
@@ -97,7 +97,7 @@
 			if(!cogger.grab_ghost(TRUE))
 				//Replace the mob with a shell
 				qdel(cogger)
-				new /obj/effect/mob_spawn/drone/cogscarab(get_turf(M))
+				new /obj/effect/mob_spawn/cogscarab(get_turf(M))
 			add_servant_of_ratvar(cogger, silent=TRUE)
 			return
 		if(M.client)

--- a/code/modules/antagonists/clock_cult/scriptures/summon_cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/summon_cogscarab.dm
@@ -28,4 +28,4 @@
 	. = ..()
 
 /datum/clockcult/scripture/cogscarab/invoke_success()
-	new /obj/effect/mob_spawn/drone/cogscarab(get_turf(invoker))
+	new /obj/effect/mob_spawn/cogscarab(get_turf(invoker))

--- a/code/modules/antagonists/devil/devil.dm
+++ b/code/modules/antagonists/devil/devil.dm
@@ -520,7 +520,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 		var/mob/living/silicon/robot_devil = owner.current
 		var/laws = list("You may not use violence to coerce someone into selling their soul.", "You may not directly and knowingly physically harm a devil, other than yourself.", GLOB.lawlorify[LAW][ban], GLOB.lawlorify[LAW][obligation], "Accomplish your objectives at all costs.")
 		robot_devil.set_law_sixsixsix(laws)
-	sleep(10)
+
 	handle_clown_mutation(owner.current, "Your infernal nature has allowed you to overcome your clownishness.")
 	.=..()
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -1,87 +1,282 @@
-//If someone can do this in a neater way, be my guest-Kor
-
-//To do: Allow corpses to appear mangled, bloody, etc. Allow customizing the bodies appearance (they're all bald and white right now).
-
-/obj/effect/mob_spawn
-	name = "Unknown"
-	density = TRUE
-	anchored = TRUE
+/// Usage: AddComponent(/datum/component/mob_spawner, list(mob_type = /mob/..., mob_name = "..."))
+/datum/component/mob_spawner
+	var/name = ""
+	/// Typepath of the mob to be spawned
 	var/mob_type = null
+	/// Name of the mob to be spawned
 	var/mob_name = ""
+	/// Gender of the mob to be spawned
 	var/mob_gender = null
-	var/death = TRUE //Kill the mob
-	var/roundstart = TRUE //fires on initialize
-	var/instant = FALSE	//fires on New
+	/// If the mob should be dead
+	var/death = TRUE
+	/// If the spawner should trigger when Initialize() is called
+	var/roundstart = TRUE
+	/// If the spawner should trigger when New() is called
+	var/instant = FALSE
+	/// A short description shown to whoever takes this mob spawn, in large text. See flavour_text for longer text.
 	var/short_desc = "The mapper forgot to set this!"
+	/// A longer portion of text shown to whoever takes the spawn, similar to short_desc
 	var/flavour_text = ""
+	/// A large red text shown to the whoever takes the spawn.
 	var/important_info = ""
+	/// The faction to set on the spaned mob
 	var/faction = null
-	var/permanent = FALSE	//If true, the spawner will not disappear upon running out of uses.
-	var/random = FALSE		//Don't set a name or gender, just go random
+	/// If the parent object should be deleted after running out of uses
+	var/permanent = FALSE
+	/// If it should randomly generate a name, gender, etc.
+	var/random = FALSE
+	/// The typepath of any antag datum to add to the mob
 	var/antagonist_type
+	/// A list of objective datums to add to the mob.
 	var/objectives = null
-	var/uses = 1			//how many times can we spawn from it. set to -1 for infinite.
+	/// How many times a mob can spawned from this. -1 is infinite.
+	var/uses = 1
+	/// Starting brute damage of the mob.
 	var/brute_damage = 0
+	/// Starting oxygen damage of the mob.
 	var/oxy_damage = 0
+	/// Starting burn damage of the mob.
 	var/burn_damage = 0
-	var/datum/disease/disease = null //Do they start with a pre-spawned disease?
-	var/mob_color //Change the mob's color
+	/// Any disease datum that should be spawned with the mob.
+	var/datum/disease/disease = null
+	/// The color value applied to the mob on spawn.
+	var/mob_color
+	/// What the mind.assigned_role will be on spawn.
 	var/assignedrole
+	/// If we should show the short_desc/flavortext
 	var/show_flavour = TRUE
-	var/banType = ROLE_LAVALAND
+	/// The role used for determining if the player is banned from taking this spawn.
+	var/ban_type = ROLE_LAVALAND
+	/// If ghosts can click on this object to take a spawn.
 	var/ghost_usable = TRUE
+	/// If this should use the player's ghost role cooldown.
 	var/use_cooldown = FALSE
+	/// If you can click on this to delete your mob and re-enter "cryo"
+	var/can_re_enter = FALSE
+	/// Amount of living playtime in hours required to take this spawn
+	var/byond_account_age_required = null
 
-//ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/attack_ghost(mob/user)
-	if(!SSticker.HasRoundStarted() || !loc || !ghost_usable)
+	/// Typepath for the species, if the mob is human
+	var/mob_species = null
+	/// Instance of typepath of /datum/outfit, if the mob is human. If this is a path, it will be instanced in Initialize()
+	var/datum/outfit/outfit = /datum/outfit
+	/// If their PDA should be hidden from the list of PDAs, if the mob's outfit has one.
+	var/disable_pda = TRUE
+	/// If their suit sensors should be off by default, if the mob has one.
+	var/disable_sensors = TRUE
+	/// Use JOB_NAME defines or put a custom job name. Only affects the ID that the outfit has placed in the ID slot.
+	var/id_job = null
+	/// Access on their ID, using JOB_NAME defines. Only affects the ID that the outfit has placed in the ID slot.
+	var/id_access = null
+	/// Manual access list on their ID, as opposed to JOB_NAME based. Only affects the ID that the outfit has placed in the ID slot.
+	var/id_access_list = null
+	/// If the mob should start husked.
+	var/husk = FALSE
+	/// Implant typepath to implant in the mob
+	var/implant_type
+
+	/// Hair to set on the mob, if human.
+	var/hair_style
+	/// Facial hair to set on the mob, if human.
+	var/facial_hair_style
+	/// Skin tone to set on the mob, if human.
+	var/skin_tone
+	/// If we should delete any radio or PDA in the mob's contents on spawn, if they are human.
+	var/delete_pda_and_radio = FALSE
+
+	//These vars are for lazy mappers to override parts of the outfit
+	//These cannot be null by default, or mappers cannot set them to null if they want nothing in that slot
+	var/uniform = -1
+	var/r_hand = -1
+	var/l_hand = -1
+	var/suit = -1
+	var/shoes = -1
+	var/gloves = -1
+	var/ears = -1
+	var/glasses = -1
+	var/mask = -1
+	var/head = -1
+	var/belt = -1
+	var/r_pocket = -1
+	var/l_pocket = -1
+	var/back = -1
+	var/id = -1
+	var/neck = -1
+	var/backpack_contents = -1
+	var/suit_store = -1
+
+/// Pass all the variables wanted above in as arguments to the component rather than creating subtypes
+/datum/component/mob_spawner/Initialize(list/arguments)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	var/atom/A = parent
+	// This is used for the spawner menu's "Groups". Actually terrible but I'm leaving it for now
+	name = A.name
+	// Replace vars
+	for(var/index in arguments)
+		if(index in vars)
+			vars[index] = arguments[index]
+	if(ispath(mob_type, /mob/living/carbon/human))
+		if(ispath(outfit))
+			outfit = new outfit()
+		if(!outfit)
+			outfit = new /datum/outfit
+	// SSatoms.initialized == INITIALIZATION_INNEW_MAPLOAD is equivalent to the "mapload" arg on Intialize()
+	if(instant || (roundstart && ((SSatoms.initialized == INITIALIZATION_INNEW_MAPLOAD) || (SSticker && SSticker.current_state > GAME_STATE_SETTING_UP))))
+		create()
+	else if(ghost_usable)
+		GLOB.poi_list |= parent
+		LAZYADD(GLOB.mob_spawners[name], src)
+		SSmobs.update_spawners()
+		RegisterSignal(parent, COMSIG_ATOM_ATTACK_GHOST, .proc/attack_ghost)
+	if(can_re_enter)
+		RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, .proc/attack_hand)
+	RegisterSignal(parent, COMSIG_MOB_SPAWNER_CREATE, .proc/create_signalled)
+
+/datum/component/mob_spawner/proc/attack_hand(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	if(!isliving(user))
 		return
-	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
+	var/despawn = alert(user, "Return to cryosleep? (Warning, Your mob will be deleted!)", "", "Yes", "No")
+	var/atom/A = parent
+	if(despawn != "Yes" || !A.loc || !A.Adjacent(user))
+		return
+	user.visible_message("<span class='notice'>[user.name] climbs back into cryosleep...</span>")
+	qdel(user)
+
+/datum/component/mob_spawner/proc/attack_ghost(datum/source, mob/user)
+	SIGNAL_HANDLER
+	var/atom/A = parent
+	if(!SSticker.HasRoundStarted() || !A.loc || !ghost_usable)
+		return
+	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(A.flags_1 & ADMIN_SPAWNED_1))
 		to_chat(user, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
 		return
 	if(!uses)
 		to_chat(user, "<span class='warning'>This spawner is out of charges!</span>")
 		return
-	if(is_banned_from(user.key, banType))
+	if(is_banned_from(user.key, ban_type))
 		to_chat(user, "<span class='warning'>You are jobanned!</span>")
 		return
-	if(QDELETED(src) || QDELETED(user))
+	if(byond_account_age_required && CONFIG_GET(flag/use_age_restriction_for_jobs))
+		//apparently what happens when there's no DB connected. just don't let anybody be a drone without admin intervention
+		if(!isnum_safe(user.client.player_age))
+			return
+		if(user.client.player_age < byond_account_age_required)
+			to_chat(user, "<span class='danger'>You're too new to play as a drone! Please try again in [byond_account_age_required - user.client.player_age] days.</span>")
+			return
+	if(QDELETED(src) || QDELETED(parent) || QDELETED(user))
 		return
 	if(use_cooldown && user.client.next_ghost_role_tick > world.time)
 		to_chat(user, "<span class='warning'>You have died recently, you must wait [(user.client.next_ghost_role_tick - world.time)/10] seconds until you can use a ghost spawner.</span>")
 		return
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
-	if(ghost_role == "No" || !loc)
+	if(ghost_role == "No" || !A.loc)
 		return
 	log_game("[key_name(user)] became [mob_name]")
 	create(ckey = user.ckey)
 
-/obj/effect/mob_spawn/Initialize(mapload)
-	. = ..()
-	if(instant || (roundstart && (mapload || (SSticker && SSticker.current_state > GAME_STATE_SETTING_UP))))
-		create()
-	else if(ghost_usable)
-		GLOB.poi_list |= src
-		LAZYADD(GLOB.mob_spawners[name], src)
+/datum/component/mob_spawner/Destroy()
+	UnregisterSignal(parent, COMSIG_MOB_SPAWNER_CREATE)
+	if(ghost_usable)
+		UnregisterSignal(parent, COMSIG_ATOM_ATTACK_GHOST)
+		GLOB.poi_list -= parent
+		var/list/spawners = GLOB.mob_spawners[name]
+		LAZYREMOVE(spawners, src)
+		if(!LAZYLEN(spawners))
+			GLOB.mob_spawners -= name
 		SSmobs.update_spawners()
-
-/obj/effect/mob_spawn/Destroy()
-	GLOB.poi_list -= src
-	var/list/spawners = GLOB.mob_spawners[name]
-	LAZYREMOVE(spawners, src)
-	if(!LAZYLEN(spawners))
-		GLOB.mob_spawners -= name
-	SSmobs.update_spawners()
+	if(can_re_enter)
+		UnregisterSignal(parent, COMSIG_ATOM_ATTACK_HAND)
 	return ..()
 
-/obj/effect/mob_spawn/proc/special(mob/M)
+/datum/component/mob_spawner/proc/special(mob/M, name)
+	SEND_SIGNAL(parent, COMSIG_MOB_SPAWNER_DOSPECIAL, M, name)
+
+/datum/component/mob_spawner/proc/equip(mob/M)
+	if(implant_type)
+		if(!ispath(implant_type, /obj/item/implant))
+			CRASH("Implant type \"[implant_type]\" on [src] of [parent] is invalid. It must be a subtype of /obj/item/implant!")
+		var/obj/item/implant/implant = new implant_type(M)
+		implant.implant(M)
+	if(!iscarbon(M))
+		return
+	var/mob/living/carbon/C = M
+	if(husk)
+		C.Drain()
+	else //Because for some reason I can't track down, things are getting turned into husks even if husk = false. It's in some damage proc somewhere.
+		C.cure_husk()
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/H = M
+	if(mob_species)
+		H.set_species(mob_species)
+	H.underwear = "Nude"
+	H.undershirt = "Nude"
+	H.socks = "Nude"
+	if(hair_style)
+		H.hair_style = hair_style
+	else
+		H.hair_style = random_hair_style(H.gender)
+	if(facial_hair_style)
+		H.facial_hair_style = facial_hair_style
+	else
+		H.facial_hair_style = random_facial_hair_style(H.gender)
+	if(skin_tone)
+		H.skin_tone = skin_tone
+	else
+		H.skin_tone = random_skin_tone()
+	H.update_hair()
+	H.update_body()
+	if(outfit)
+		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id", "neck", "backpack_contents", "suit_store")
+		for(var/slot in slots)
+			var/T = vars[slot]
+			if(!isnum_safe(T))
+				outfit.vars[slot] = T
+		H.equipOutfit(outfit)
+		if(disable_pda)
+			// We don't want corpse PDAs to show up in the messenger list.
+			var/obj/item/modular_computer/tablet/pda/PDA = locate(/obj/item/modular_computer/tablet/pda) in H
+			if(PDA)
+				PDA.messenger_invisible = TRUE
+		if(disable_sensors)
+			// Using crew monitors to find corpses while creative makes finding certain ruins too easy.
+			var/obj/item/clothing/under/cloth = H.w_uniform
+			if(istype(cloth))
+				cloth.update_sensors(NO_SENSORS)
+
+	var/obj/item/card/id/W = H.wear_id
+	if(W)
+		if(id_access)
+			for(var/jobtype in typesof(/datum/job))
+				var/datum/job/J = new jobtype
+				if(J.title == id_access)
+					W.access = J.get_access()
+					break
+		if(id_access_list)
+			if(!islist(W.access))
+				W.access = list()
+			W.access |= id_access_list
+		if(id_job)
+			W.assignment = id_job
+		W.registered_name = H.real_name
+		W.update_label()
+	if(delete_pda_and_radio)
+		// Remove radio and PDA so they wouldn't annoy station crew.
+		var/list/del_types = list(/obj/item/modular_computer/tablet/pda, /obj/item/radio/headset)
+		for(var/del_type in del_types)
+			var/obj/item/I = locate(del_type) in H
+			qdel(I)
 	return
 
-/obj/effect/mob_spawn/proc/equip(mob/M)
-	return
+/datum/component/mob_spawner/proc/create_signalled(datum/source, ckey, name)
+	SIGNAL_HANDLER
+	create(ckey, name)
 
-/obj/effect/mob_spawn/proc/create(ckey, name)
-	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
+/datum/component/mob_spawner/proc/create(ckey, name)
+	var/mob/living/M = new mob_type(get_turf(parent)) //living mobs only
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
 		if(!mob_gender)
@@ -98,6 +293,9 @@
 	M.adjustBruteLoss(brute_damage)
 	M.adjustFireLoss(burn_damage)
 	M.color = mob_color
+	var/atom/parent_atom = parent
+	// Copy admin spawned from parent
+	M.flags_1 |= (parent_atom.flags_1 & ADMIN_SPAWNED_1)
 	equip(M)
 
 	if(ckey)
@@ -131,25 +329,101 @@
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)
-		qdel(src)
+		qdel(parent)
 
-// Base version - place these on maps/templates.
-/obj/effect/mob_spawn/human
+/datum/component/mob_spawner/human
 	mob_type = /mob/living/carbon/human
-	//Human specific stuff.
-	var/mob_species = null		//Set to make them a mutant race such as lizard or skeleton. Uses the datum typepath instead of the ID.
-	var/datum/outfit/outfit = /datum/outfit	//If this is a path, it will be instanced in Initialize()
-	var/disable_pda = TRUE
-	var/disable_sensors = TRUE
-	//All of these only affect the ID that the outfit has placed in the ID slot
-	var/id_job = null			//Such as JOB_NAME_CLOWN or "Chef." This just determines what the ID reads as, not their access
-	var/id_access = null		//This is for access. See access.dm for which jobs give what access. Use JOB_NAME_CAPTAIN if you want it to be all access.
-	var/id_access_list = null	//Allows you to manually add access to an ID card.
 	assignedrole = "Ghost Role"
 
-	var/husk = null
-	//these vars are for lazy mappers to override parts of the outfit
-	//these cannot be null by default, or mappers cannot set them to null if they want nothing in that slot
+/// Shitty mapping placeholder. Use the component instead if you actually want to do something that isn't for mappers.
+/obj/effect/mob_spawn
+	// Copypasta from component, it all gets passed into the component anyway
+
+	/// Typepath of the mob to be spawned
+	var/mob_type = null
+	/// Name of the mob to be spawned
+	var/mob_name = ""
+	/// Gender of the mob to be spawned
+	var/mob_gender = null
+	/// If the mob should be dead
+	var/death = TRUE
+	/// If the spawner should trigger when Initialize() is called
+	var/roundstart = TRUE
+	/// If the spawner should trigger when New() is called
+	var/instant = FALSE
+	/// A short description shown to whoever takes this mob spawn, in large text. See flavour_text for longer text.
+	var/short_desc = "The mapper forgot to set this!"
+	/// A longer portion of text shown to whoever takes the spawn, similar to short_desc
+	var/flavour_text = ""
+	/// A large red text shown to the whoever takes the spawn.
+	var/important_info = ""
+	/// The faction to set on the spaned mob
+	var/faction = null
+	/// If the parent object should be deleted after running out of uses
+	var/permanent = FALSE
+	/// If it should randomly generate a name, gender, etc.
+	var/random = FALSE
+	/// The typepath of any antag datum to add to the mob
+	var/antagonist_type
+	/// A list of objective datums to add to the mob.
+	var/objectives = null
+	/// How many times a mob can spawned from this. -1 is infinite.
+	var/uses = 1
+	/// Starting brute damage of the mob.
+	var/brute_damage = 0
+	/// Starting oxygen damage of the mob.
+	var/oxy_damage = 0
+	/// Starting burn damage of the mob.
+	var/burn_damage = 0
+	/// Any disease datum that should be spawned with the mob.
+	var/datum/disease/disease = null
+	/// The color value applied to the mob on spawn.
+	var/mob_color
+	/// What the mind.assigned_role will be on spawn.
+	var/assignedrole
+	/// If we should show the short_desc/flavortext
+	var/show_flavour = TRUE
+	/// The role used for determining if the player is banned from taking this spawn.
+	var/ban_type = ROLE_LAVALAND
+	/// If ghosts can click on this object to take a spawn.
+	var/ghost_usable = TRUE
+	/// If this should use the player's ghost role cooldown.
+	var/use_cooldown = FALSE
+	/// If you can click on this to delete your mob and re-enter "cryo"
+	var/can_re_enter = FALSE
+	/// Amount of living playtime in hours required to take this spawn
+	var/byond_account_age_required = null
+
+	/// Typepath for the species, if the mob is human
+	var/mob_species = null
+	/// Instance of typepath of /datum/outfit, if the mob is human. If this is a path, it will be instanced in Initialize()
+	var/datum/outfit/outfit = /datum/outfit
+	/// If their PDA should be hidden from the list of PDAs, if the mob's outfit has one.
+	var/disable_pda = TRUE
+	/// If their suit sensors should be off by default, if the mob has one.
+	var/disable_sensors = TRUE
+	/// Use JOB_NAME defines or put a custom job name. Only affects the ID that the outfit has placed in the ID slot.
+	var/id_job = null
+	/// Access on their ID, using JOB_NAME defines. Only affects the ID that the outfit has placed in the ID slot.
+	var/id_access = null
+	/// Manual access list on their ID, as opposed to JOB_NAME based. Only affects the ID that the outfit has placed in the ID slot.
+	var/id_access_list = null
+	/// If the mob should start husked.
+	var/husk = FALSE
+	/// Implant typepath to implant in the mob
+	var/implant_type
+
+	/// Hair to set on the mob, if human.
+	var/hair_style
+	/// Facial hair to set on the mob, if human.
+	var/facial_hair_style
+	/// Skin tone to set on the mob, if human.
+	var/skin_tone
+	/// If we should delete any radio or PDA in the mob's contents on spawn, if they are human.
+	var/delete_pda_and_radio = FALSE
+
+	//These vars are for lazy mappers to override parts of the outfit
+	//These cannot be null by default, or mappers cannot set them to null if they want nothing in that slot
 	var/uniform = -1
 	var/r_hand = -1
 	var/l_hand = -1
@@ -169,75 +443,81 @@
 	var/backpack_contents = -1
 	var/suit_store = -1
 
-	var/hair_style
-	var/facial_hair_style
-	var/skin_tone
+/// Allow subtypes to configure args before adding component
+/obj/effect/mob_spawn/proc/pre_configure()
+	return
 
-/obj/effect/mob_spawn/human/Initialize(mapload)
-	if(ispath(outfit))
-		outfit = new outfit()
-	if(!outfit)
-		outfit = new /datum/outfit
-	return ..()
+/obj/effect/mob_spawn/ComponentInitialize()
+	pre_configure()
+	// So cursed
+	AddComponent(/datum/component/mob_spawner, list(
+	mob_type = mob_type,
+	mob_name = mob_name,
+	mob_gender = mob_gender,
+	death = death,
+	roundstart = roundstart,
+	instant = instant,
+	short_desc = short_desc,
+	flavour_text = flavour_text,
+	important_info = important_info,
+	faction = faction,
+	permanent = permanent,
+	random = random,
+	antagonist_type = antagonist_type,
+	objectives = objectives,
+	uses = uses,
+	brute_damage = brute_damage,
+	oxy_damage = oxy_damage,
+	burn_damage = burn_damage,
+	disease = disease,
+	mob_color = mob_color,
+	assignedrole = assignedrole,
+	show_flavour = show_flavour,
+	ban_type = ban_type,
+	ghost_usable = ghost_usable,
+	use_cooldown = use_cooldown,
+	can_re_enter = can_re_enter,
+	byond_account_age_required = byond_account_age_required,
+	mob_species = mob_species,
+	outfit = outfit,
+	disable_pda = disable_pda,
+	disable_sensors = disable_sensors,
+	id_job = id_job,
+	id_access = id_access,
+	id_access_list = id_access_list,
+	husk = husk,
+	implant_type = implant_type,
+	hair_style = hair_style,
+	facial_hair_style = facial_hair_style,
+	skin_tone = skin_tone,
+	delete_pda_and_radio = delete_pda_and_radio,
+	uniform = uniform,
+	r_hand = r_hand,
+	l_hand = l_hand,
+	suit = suit,
+	shoes = shoes,
+	gloves = gloves,
+	ears = ears,
+	glasses = glasses,
+	mask = mask,
+	head = head,
+	belt = belt,
+	r_pocket = r_pocket,
+	l_pocket = l_pocket,
+	back = back,
+	id = id,
+	neck = neck,
+	backpack_contents = backpack_contents,
+	suit_store = suit_store,
+	))
 
-/obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
-	if(mob_species)
-		H.set_species(mob_species)
-	if(husk)
-		H.Drain()
-	else //Because for some reason I can't track down, things are getting turned into husks even if husk = false. It's in some damage proc somewhere.
-		H.cure_husk()
-	H.underwear = "Nude"
-	H.undershirt = "Nude"
-	H.socks = "Nude"
-	if(hair_style)
-		H.hair_style = hair_style
-	else
-		H.hair_style = random_hair_style(H.gender)
-	if(facial_hair_style)
-		H.facial_hair_style = facial_hair_style
-	else
-		H.facial_hair_style = random_facial_hair_style(H.gender)
-	if(skin_tone)
-		H.skin_tone = skin_tone
-	else
-		H.skin_tone = random_skin_tone()
-	H.update_hair()
-	H.update_body()
-	if(outfit)
-		var/static/list/slots = list("uniform", "r_hand", "l_hand", "suit", "shoes", "gloves", "ears", "glasses", "mask", "head", "belt", "r_pocket", "l_pocket", "back", "id", "neck", "backpack_contents", "suit_store")
-		for(var/slot in slots)
-			var/T = vars[slot]
-			if(!isnum_safe(T))
-				outfit.vars[slot] = T
-		H.equipOutfit(outfit)
-		if(disable_pda)
-			// We don't want corpse PDAs to show up in the messenger list.
-			var/obj/item/modular_computer/tablet/pda/PDA = locate(/obj/item/modular_computer/tablet/pda) in H
-			if(PDA)
-				PDA.messenger_invisible = TRUE
-		if(disable_sensors)
-			// Using crew monitors to find corpses while creative makes finding certain ruins too easy.
-			var/obj/item/clothing/under/C = H.w_uniform
-			if(istype(C))
-				C.update_sensors(NO_SENSORS)
+/// Shorthand for sending COMSIG_MOB_SPAWNER_CREATE to the inner component
+/obj/effect/mob_spawn/proc/create(ckey, name)
+	SEND_SIGNAL(src, COMSIG_MOB_SPAWNER_CREATE, ckey, name)
 
-	var/obj/item/card/id/W = H.wear_id
-	if(W)
-		if(id_access)
-			for(var/jobtype in typesof(/datum/job))
-				var/datum/job/J = new jobtype
-				if(J.title == id_access)
-					W.access = J.get_access()
-					break
-		if(id_access_list)
-			if(!islist(W.access))
-				W.access = list()
-			W.access |= id_access_list
-		if(id_job)
-			W.assignment = id_job
-		W.registered_name = H.real_name
-		W.update_label()
+/obj/effect/mob_spawn/human
+	mob_type = /mob/living/carbon/human
+	assignedrole = "Ghost Role"
 
 //Instant version - use when spawning corpses during runtime
 /obj/effect/mob_spawn/human/corpse
@@ -246,63 +526,6 @@
 
 /obj/effect/mob_spawn/human/corpse/damaged
 	brute_damage = 1000
-
-/obj/effect/mob_spawn/human/alive
-	icon = 'icons/obj/machines/sleeper.dmi'
-	icon_state = "sleeper"
-	death = FALSE
-	roundstart = FALSE //you could use these for alive fake humans on roundstart but this is more common scenario
-
-/obj/effect/mob_spawn/human/corpse/delayed
-	ghost_usable = FALSE //These are just not-yet-set corpses.
-	instant = FALSE
-
-//Non-human spawners
-
-/obj/effect/mob_spawn/AICorpse/create(ckey) //Creates a corrupted AI
-	var/A = locate(/mob/living/silicon/ai) in loc
-	if(A)
-		return
-	var/mob/living/silicon/ai/spawned/M = new(loc) //spawn new AI at landmark as var M
-	M.name = src.name
-	M.real_name = src.name
-	M.modularInterface.messenger_invisible = TRUE //turns the AI's PDA messenger off, stopping it showing up on player PDAs
-	M.death() //call the AI's death proc
-	qdel(src)
-
-/obj/effect/mob_spawn/slime
-	mob_type = 	/mob/living/simple_animal/slime
-	var/mobcolour = "grey"
-	icon = 'icons/mob/slimes.dmi'
-	icon_state = "grey baby slime" //sets the icon in the map editor
-
-/obj/effect/mob_spawn/slime/equip(mob/living/simple_animal/slime/S)
-	S.colour = mobcolour
-
-/obj/effect/mob_spawn/facehugger/create(ckey) //Creates a squashed facehugger
-	var/obj/item/clothing/mask/facehugger/O = new(src.loc) //variable O is a new facehugger at the location of the landmark
-	O.name = src.name
-	O.Die() //call the facehugger's death proc
-	qdel(src)
-
-/obj/effect/mob_spawn/mouse
-	name = "sleeper"
-	mob_type = 	/mob/living/simple_animal/mouse
-	death = FALSE
-	roundstart = FALSE
-	icon = 'icons/obj/machines/sleeper.dmi'
-	icon_state = "sleeper"
-
-/obj/effect/mob_spawn/cow
-	name = "sleeper"
-	mob_type = 	/mob/living/simple_animal/cow
-	death = FALSE
-	roundstart = FALSE
-	mob_gender = FEMALE
-	icon = 'icons/obj/machines/sleeper.dmi'
-	icon_state = "sleeper"
-
-// I'll work on making a list of corpses people request for maps, or that I think will be commonly used. Syndicate operatives for example.
 
 ///////////Civilians//////////////////////
 
@@ -343,14 +566,7 @@
 	short_desc = "You are a space doctor!"
 	assignedrole = "Space Doctor"
 	use_cooldown = TRUE // Use cooldown
-
-/obj/effect/mob_spawn/human/doctor/alive/equip(mob/living/carbon/human/H)
-	..()
-	// Remove radio and PDA so they wouldn't annoy station crew.
-	var/list/del_types = list(/obj/item/modular_computer/tablet/pda, /obj/item/radio/headset)
-	for(var/del_type in del_types)
-		var/obj/item/I = locate(del_type) in H
-		qdel(I)
+	delete_pda_and_radio = TRUE
 
 /obj/effect/mob_spawn/human/engineer
 	name = "Engineer"
@@ -551,12 +767,9 @@
 	short_desc = "By unknown powers, your skeletal remains have been reanimated!"
 	flavour_text = "Walk this mortal plain and terrorize all living adventurers who dare cross your path."
 	assignedrole = "Skeleton"
+	mob_species = /datum/species/skeleton
 	use_cooldown = TRUE
-
-/obj/effect/mob_spawn/human/skeleton/alive/equip(mob/living/carbon/human/H)
-	var/obj/item/implant/exile/implant = new/obj/item/implant/exile(H)
-	implant.implant(H)
-	H.set_species(/datum/species/skeleton)
+	implant_type = /obj/item/implant/exile
 
 /obj/effect/mob_spawn/human/zombie
 	name = "rotting corpse"
@@ -583,30 +796,3 @@
 	name = "Abductor Corpse"
 	uniform = /obj/item/clothing/under/color/grey
 	shoes = /obj/item/clothing/shoes/combat
-
-
-//For ghost bar.
-/obj/effect/mob_spawn/human/alive/space_bar_patron
-	name = "Bar cryogenics"
-	mob_name = "Bar patron"
-	random = TRUE
-	permanent = TRUE
-	uses = -1
-	outfit = /datum/outfit/spacebartender
-	assignedrole = "Space Bar Patron"
-
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/human/alive/space_bar_patron/attack_hand(mob/user)
-	var/despawn = alert("Return to cryosleep? (Warning, Your mob will be deleted!)",,"Yes","No")
-	if(despawn == "No" || !loc || !Adjacent(user))
-		return
-	user.visible_message("<span class='notice'>[user.name] climbs back into cryosleep...</span>")
-	qdel(user)
-
-/datum/outfit/cryobartender
-	name = "Cryogenic Bartender"
-	uniform = /obj/item/clothing/under/rank/civilian/bartender
-	back = /obj/item/storage/backpack
-	shoes = /obj/item/clothing/shoes/sneakers/black
-	suit = /obj/item/clothing/suit/armor/vest
-	glasses = /obj/item/clothing/glasses/sunglasses/advanced/reagent

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -273,3 +273,10 @@
 
 #undef MIN_IMPREGNATION_TIME
 #undef MAX_IMPREGNATION_TIME
+
+/obj/effect/mapping_facehugger/Initialize(mapload)
+	. = ..()
+	if(mapload || (SSticker?.current_state > GAME_STATE_SETTING_UP))
+		var/obj/item/clothing/mask/facehugger/O = new(loc) //variable O is a new facehugger at the location of the landmark
+		O.Die() //call the facehugger's death proc
+		qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -18,6 +18,8 @@
 	short_desc = "You are a drone."
 	flavour_text = "You are a drone, a tiny insect-like creature. Follow your assigned laws to the best of your ability."
 	mob_type = /mob/living/simple_animal/drone
+	ban_type = ROLE_DRONE
+	byond_account_age_required = DRONE_MINIMUM_AGE
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
 
@@ -26,7 +28,6 @@
 	var/area/A = get_area(src)
 	if(A)
 		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE, notify_suiciders = FALSE)
-	GLOB.poi_list |= src
 	if(isnull(possible_seasonal_hats))
 		build_seasonal_hats()
 
@@ -39,33 +40,12 @@
 		if(holiday.drone_hat)
 			possible_seasonal_hats += holiday.drone_hat
 
-/obj/item/drone_shell/Destroy()
-	GLOB.poi_list -= src
-	. = ..()
-
-//ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/drone/attack_ghost(mob/user)
-	if(is_banned_from(user.ckey, ROLE_DRONE) || QDELETED(src) || QDELETED(user))
+/obj/effect/mob_spawn/drone/proc/special(datum/source, mob/living/new_spawn)
+	if(!isdrone(new_spawn))
 		return
-	if(CONFIG_GET(flag/use_age_restriction_for_jobs))
-		if(!isnum_safe(user.client.player_age)) //apparently what happens when there's no DB connected. just don't let anybody be a drone without admin intervention
-			return
-		if(user.client.player_age < DRONE_MINIMUM_AGE)
-			to_chat(user, "<span class='danger'>You're too new to play as a drone! Please try again in [DRONE_MINIMUM_AGE - user.client.player_age] days.</span>")
-			return
-	if(!SSticker.mode)
-		to_chat(user, "Can't become a drone before the game has started.")
-		return
-	var/be_drone = alert("Become a drone? (Warning, You can no longer be cloned!)",,"Yes","No")
-	if(be_drone == "No" || QDELETED(src) || !isobserver(user))
-		return
-	var/mob/living/simple_animal/drone/D = new mob_type(get_turf(loc))
+	var/mob/living/simple_animal/drone/D = new_spawn
 	if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
 		var/hat_type = pick(possible_seasonal_hats)
 		var/obj/item/new_hat = new hat_type(D)
 		D.equip_to_slot_or_del(new_hat, ITEM_SLOT_HEAD)
-	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
-	D.key = user.key
-	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of \a [src] in [AREACOORD(src)].")
-	log_game("[key_name(user)] has taken possession of \a [src] in [AREACOORD(src)].")
-	qdel(src)
+

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -258,11 +258,18 @@
 
 //Legion infested mobs
 
-/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf/equip(mob/living/carbon/human/H)
-	. = ..()
-	H.dna.add_mutation(DWARFISM)
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf/proc/special(datum/source, mob/living/new_spawn, name)
+	SIGNAL_HANDLER
 
-/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize(mapload)
+	if(ishuman(new_spawn))
+		var/mob/living/carbon/human/H
+		H.dna.add_mutation(DWARFISM)
+
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf/pre_configure()
+	..()
+	RegisterSignal(src, COMSIG_MOB_SPAWNER_DOSPECIAL, .proc/special)
+
+/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/pre_configure()
 	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,JOB_NAME_CLOWN = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4))
 	switch(type)
 		if("Miner")
@@ -362,4 +369,3 @@
 			l_pocket = /obj/item/melee/cultblade/dagger
 			glasses =  /obj/item/clothing/glasses/hud/health/night/cultblind
 			backpack_contents = list(/obj/item/reagent_containers/glass/beaker/unholywater = 1, /obj/item/cult_shift = 1, /obj/item/flashlight/flare/culttorch = 1, /obj/item/stack/sheet/runed_metal = 15)
-	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -20,7 +20,6 @@
 	del_on_death = TRUE
 	var/zombiejob = JOB_NAME_MEDICALDOCTOR
 	var/infection_chance = 0
-	var/obj/effect/mob_spawn/human/corpse/delayed/corpse
 	mobchatspan = "bartender"
 	discovery_points = 3000
 
@@ -42,10 +41,6 @@
 
 	var/icon/P = get_flat_human_icon("zombie_[zombiejob]", J , CS, "zombie", outfit_override = O)
 	icon = P
-	corpse = new(src)
-	corpse.outfit = O
-	corpse.mob_species = /datum/species/zombie
-	corpse.mob_name = name
 
 /mob/living/simple_animal/hostile/zombie/AttackingTarget()
 	. = ..()
@@ -54,5 +49,14 @@
 
 /mob/living/simple_animal/hostile/zombie/drop_loot()
 	. = ..()
+	var/mob/living/carbon/human/corpse = new(src)
+	var/datum/job/J = SSjob.GetJob(zombiejob)
+	var/datum/outfit/O
+	if(J.outfit)
+		O = new J.outfit
+		O.r_hand = null
+		O.l_hand = null
+	corpse.equipOutfit(O)
+	corpse.set_species(/datum/species/zombie)
+	corpse.name = name
 	corpse.forceMove(drop_location())
-	corpse.create()

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -116,7 +116,12 @@
 	assignedrole = "Lavaland Syndicate"
 	use_cooldown = TRUE
 
-/obj/effect/mob_spawn/human/lavaland_syndicate/special(mob/living/new_spawn)
+/obj/effect/mob_spawn/human/lavaland_syndicate/pre_configure()
+	RegisterSignal(src, COMSIG_MOB_SPAWNER_DOSPECIAL, .proc/special)
+
+/obj/effect/mob_spawn/human/lavaland_syndicate/proc/special(datum/source, mob/living/new_spawn, name)
+	SIGNAL_HANDLER
+
 	new_spawn.grant_language(/datum/language/codespeak)
 
 /datum/outfit/lavaland_syndicate

--- a/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
@@ -9,7 +9,7 @@
 
 /datum/xenoartifact_trait/minor/looped/on_item(obj/item/xenoartifact/X, atom/user, atom/item)
 	if(istype(item, /obj/item/multitool))
-		to_chat(user, "<span class='info'>The [item.name] displays a resistance reading of [X.charge_req*0.1].</span>") 
+		to_chat(user, "<span class='info'>The [item.name] displays a resistance reading of [X.charge_req*0.1].</span>")
 		return TRUE
 	return ..()
 
@@ -41,13 +41,13 @@
 		X.cooldown = -1000 SECONDS //This is better than making a unique interaction in xenoartifact.dm
 		return
 	charges = pick(0, 1, 2)
-	playsound(get_turf(X), 'sound/machines/capacitor_charge.ogg', 50, TRUE) 
+	playsound(get_turf(X), 'sound/machines/capacitor_charge.ogg', 50, TRUE)
 	X.cooldown = saved_cooldown
 	saved_cooldown = null
 
 /datum/xenoartifact_trait/minor/capacitive/on_item(obj/item/xenoartifact/X, atom/user, atom/item)
 	if(istype(item, /obj/item/multitool))
-		to_chat(user, "<span class='info'>The [item.name] displays an overcharge reading of [charges/3].</span>") 
+		to_chat(user, "<span class='info'>The [item.name] displays an overcharge reading of [charges/3].</span>")
 		return TRUE
 	return ..()
 
@@ -115,7 +115,7 @@
 	///he who lives inside
 	var/mob/living/simple_animal/shade/man
 	///His doorbell
-	var/obj/effect/mob_spawn/sentient_artifact/S
+	var/obj/effect/sentient_artifact_spawner/S
 
 /datum/xenoartifact_trait/minor/sentient/on_touch(obj/item/xenoartifact/X, mob/user)
 	to_chat(user, "<span class='warning'>The [X.name] whispers to you...</span>")
@@ -141,8 +141,8 @@
 
 /datum/xenoartifact_trait/minor/sentient/proc/setup_sentience(obj/item/xenoartifact/X, ckey)
 	if(!(SSzclear.get_free_z_level()))
-		playsound(get_turf(X), 'sound/machines/buzz-sigh.ogg', 50, TRUE) 
-		return	
+		playsound(get_turf(X), 'sound/machines/buzz-sigh.ogg', 50, TRUE)
+		return
 	man = new(get_turf(X))
 	man.name = pick(GLOB.xenoa_artifact_names)
 	man.real_name = "[man.name] - [X]"
@@ -191,23 +191,39 @@
 	QDEL_NULL(man) //Kill the inner person. Otherwise invisible runs around
 	QDEL_NULL(S)
 
-/obj/effect/mob_spawn/sentient_artifact
-	death = FALSE
+/obj/effect/sentient_artifact_spawner
 	name = "Sentient Xenoartifact"
-	short_desc = "You're a maleviolent sentience, possesing an ancient alien artifact."
-	flavour_text = "Return to your master..."
-	use_cooldown = TRUE
 	invisibility = 101
 	var/obj/item/xenoartifact/artifact
 
-/obj/effect/mob_spawn/sentient_artifact/Initialize(mapload, var/obj/item/xenoartifact/Z)
+/obj/effect/sentient_artifact_spawner/Initialize(mapload, var/obj/item/xenoartifact/Z)
 	if(!Z)
 		qdel(src)
 		return FALSE
 	artifact = Z
 	return ..()
 
-/obj/effect/mob_spawn/sentient_artifact/create(ckey, name)
+/obj/effect/sentient_artifact_spawner/attack_ghost(mob/dead/observer/user)
+	if(!SSticker.HasRoundStarted() || !loc)
+		return
+	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
+		to_chat(user, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
+		return
+	if(is_banned_from(user.key, ROLE_SENTIENCE))
+		to_chat(user, "<span class='warning'>You are jobanned!</span>")
+		return
+	if(QDELETED(src) || QDELETED(user))
+		return
+	if(user.client.next_ghost_role_tick > world.time)
+		to_chat(user, "<span class='warning'>You have died recently, you must wait [(user.client.next_ghost_role_tick - world.time)/10] seconds until you can use a ghost spawner.</span>")
+		return
+	var/ghost_role = alert("Become [name]? (Warning, You can no longer be cloned!)",,"Yes","No")
+	if(ghost_role == "No" || !loc)
+		return
+	log_game("[key_name(user)] became [name]")
+	create(user.ckey)
+
+/obj/effect/sentient_artifact_spawner/proc/create(ckey)
 	var/datum/xenoartifact_trait/minor/sentient/S = artifact.get_trait(/datum/xenoartifact_trait/minor/sentient)
 	S.setup_sentience(artifact, ckey)
 
@@ -232,7 +248,7 @@
 		X.visible_message("<span class='danger'>The [X.name] shatters!</span>", "<span class='danger'>The [X.name] shatters!</span>")
 		var/obj/effect/decal/cleanable/ash/A = new(get_turf(X))
 		A.color = X.material
-		playsound(get_turf(X), 'sound/effects/glassbr1.ogg', 50, TRUE) 
+		playsound(get_turf(X), 'sound/effects/glassbr1.ogg', 50, TRUE)
 		qdel(X)
 
 //============
@@ -280,7 +296,7 @@
 
 /datum/xenoartifact_trait/minor/wearable/on_init(obj/item/xenoartifact/X)
 	X.slot_flags = ITEM_SLOT_GLOVES
-	
+
 /datum/xenoartifact_trait/minor/wearable/activate(obj/item/xenoartifact/X, atom/user)
 	X.true_target |= list(user)
 


### PR DESCRIPTION
## About The Pull Request

Refactors `/obj/effect/mob_spawn` to be based on a component rather than locked into the `/obj/effect` type.

## Why It's Good For The Game

This allows for more dynamic usage of the mob spawning behavior on other types of objects and more re-usable code.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
refactor: Converted mob spawners to a component.
/:cl: