### PR TITLE
Ecto Sniffer yells over Science Comms now

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -40,7 +40,7 @@
 /obj/machinery/ecto_sniffer/proc/activate(mob/activator)
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
-	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrixes available!"
+	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrices available!"
 	radio.talk_into(src, msg, RADIO_CHANNEL_SCIENCE)
 	use_power(10)
 	if(activator?.ckey)

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -79,6 +79,7 @@
 
 /obj/machinery/ecto_sniffer/Destroy()
 	QDEL_NULL(wires)
+	QDEL_NULL(radio)
 	ectoplasmic_residues = null
 	. = ..()
 

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -21,7 +21,7 @@
 	radio = new(src)
 	radio.keyslot = new /obj/item/encryptionkey/headset_sci
 	radio.subspace_transmission = TRUE
-	radio.canhear_range = 9
+	radio.canhear_range = 0
 	radio.recalculateChannels()
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -13,10 +13,16 @@
 	var/sensor_enabled = TRUE
 	///List of ckeys containing players who have recently activated the device, players on this list are prohibited from activating the device untill their residue decays.
 	var/list/ectoplasmic_residues = list()
+	var/obj/item/radio/radio
 
 /obj/machinery/ecto_sniffer/Initialize()
 	. = ..()
 	wires = new/datum/wires/ecto_sniffer(src)
+	radio = new(src)
+	radio.keyslot = new /obj/item/encryptionkey/headset_sci
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 9
+	radio.recalculateChannels()
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)
 	if(!on || !sensor_enabled || !is_operational)
@@ -34,12 +40,13 @@
 /obj/machinery/ecto_sniffer/proc/activate(mob/activator)
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
-	visible_message("<span class='notice'>[src] beeps, detecting ectoplasm! There may be additional positronic brain matrixes available!</span>")
+	var/msg = "[src] beeps, detecting ectoplasm! There may be additional positronic brain matrixes available!"
+	radio.talk_into(src, msg, RADIO_CHANNEL_SCIENCE)
 	use_power(10)
 	if(activator?.ckey)
 		ectoplasmic_residues[activator.ckey] = TRUE
 		activator.log_message("activated an ecto sniffer", LOG_ATTACK)
-		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 30 SECONDS)
+		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 60 SECONDS)
 
 /obj/machinery/ecto_sniffer/attack_hand(mob/living/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the Ecto Sniffer to now send a message to Science Comms rather than just locally to whoever is in the room, if anyone is even in there. It's much more delayed than beforehand, now taking 60 seconds rather than 30, and can still be disabled by just anyone clicking on the thing if ghosts decide to abuse it.

## Why It's Good For The Game
Allows for ghosts to more noticeably beg for posi brains. When there isn't anyone in robotics, or if the Roboticist is new and doesn't notice/understand what the weird beeping messaging machine means, it can take quite a long while for a single posibrain to be printed, if ever. If the message is blared over Science Comms now, it'll make it easier for others to take notice and hopefully either print one themselves or inform the Roboticist what it means and all that.

## Testing Photographs and Procedure
Before
![before](https://user-images.githubusercontent.com/81683771/208327193-a29781ce-673b-4b93-8ee0-a752d4f32156.png)
After
![after](https://user-images.githubusercontent.com/81683771/208327207-15f61a11-9269-4a9d-8f92-24e08467d12f.png)

## Changelog
:cl:WhereAmO
tweak: Ecto Sniffer now sends a message over Science Comms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
