### PR TITLE
Replaces the advanced health analyzer with the ERT medibelt in the Debug outfit

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1320,7 +1320,7 @@
 		/obj/item/areaeditor/blueprints=1,\
 		/obj/item/card/emag=1,\
 		/obj/item/stack/spacecash/c1000=50,\
-		/obj/item/healthanalyzer/advanced=1,\
+		/obj/item/storage/belt/medical/ert=1,\
 		/obj/item/disk/tech_disk/debug=1,\
 		/obj/item/disk/surgery/debug=1,\
 		/obj/item/disk/data/debug=1,\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the advanced health analyzer for the Debug outfit with the ERT medical belt, which contains said analyzer, full set of advanced surgery tools, sterilizer spray and a medibeam.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having to click less buttons when testing surgeries gud, debug outfit having the tools needed to do debugging also good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/110184118/208942751-024fd68e-bfc0-4536-8083-232d31c35f56.png)

![image](https://user-images.githubusercontent.com/110184118/208942784-8fbcb0c7-171d-4ddf-a2ff-448e80687a6a.png)

![image](https://user-images.githubusercontent.com/110184118/208942809-6b94a6af-dbed-4e52-b75f-50c69a0d536c.png)

</details>

## Changelog
:cl:
tweak: Gave the Debug outfit an ERT medibelt instead of the advanced health analyzer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
