### PR TITLE
Exploration hardsuit's can now locate research disk, objectives and the exploration shuttle

### DIFF
--- a/code/datums/components/team_monitor.dm
+++ b/code/datums/components/team_monitor.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 
 /proc/get_all_beacons_on_frequency(frequency, base_frequency)
 	if(!frequency)
-		return list()
+		return GLOB.tracker_beacons["[base_frequency]-GLOB"]
 	var/list/found_beacons = list()
 	if(islist(GLOB.tracker_beacons[frequency]))
 		found_beacons.Add(GLOB.tracker_beacons[frequency])

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -76,6 +76,17 @@
 	else
 		soundloop.start(user)
 
+/obj/item/clothing/head/helmet/space/hardsuit/proc/toggle_hud(mob/user)
+	var/datum/component/team_monitor/monitor = GetComponent(/datum/component/team_monitor)
+	if(!monitor)
+		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
+		return
+	monitor.toggle_hud(!monitor.hud_visible, user)
+	if(monitor.hud_visible)
+		to_chat(user, "<span class='notice'>You toggle the heads up display of your suit.</span>")
+	else
+		to_chat(user, "<span class='warning'>You disable the heads up display of your suit.</span>")
+
 /obj/item/clothing/head/helmet/space/hardsuit/proc/display_visor_message(var/msg)
 	var/mob/wearer = loc
 	if(msg && ishuman(wearer))
@@ -105,6 +116,12 @@
 	. = ..()
 	display_visor_message("[severity > 1 ? "Light" : "Strong"] electromagnetic pulse detected!")
 
+/obj/item/clothing/head/helmet/space/hardsuit/ui_action_click(mob/user, datum/action)
+	switch(action.type)
+		if(/datum/action/item_action/toggle_beacon_hud)
+			toggle_hud(user)
+			return
+	. = ..()
 
 /obj/item/clothing/suit/space/hardsuit
 	name = "hardsuit"
@@ -174,6 +191,37 @@
 		for(var/X in jetpack.actions)
 			var/datum/action/A = X
 			A.Remove(user)
+
+/obj/item/clothing/suit/space/hardsuit/ui_action_click(mob/user, datum/actiontype)
+	switch(actiontype.type)
+		if(/datum/action/item_action/toggle_helmet)
+			ToggleHelmet()
+			return
+		if(/datum/action/item_action/toggle_beacon)
+			toggle_beacon(user)
+			return
+		if(/datum/action/item_action/toggle_beacon_frequency)
+			set_beacon_freq(user)
+			return
+	return ..()
+
+/obj/item/clothing/suit/space/hardsuit/proc/toggle_beacon(mob/user)
+	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
+	if(!beacon)
+		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
+		return
+	beacon.toggle_visibility(!beacon.visible)
+	if(beacon.visible)
+		to_chat(user, "<span class='notice'>You enable the tracking beacon on [src]. Anybody on the same frequency will now be able to track your location.</span>")
+	else
+		to_chat(user, "<span class='warning'>You disable the tracking beacon on [src].</span>")
+
+/obj/item/clothing/suit/space/hardsuit/proc/set_beacon_freq(mob/user)
+	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
+	if(!beacon)
+		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
+		return
+	beacon.change_frequency(user)
 
 /obj/item/clothing/suit/space/hardsuit/item_action_slot_check(slot)
 	if(slot == ITEM_SLOT_OCLOTHING) //we only give the mob the ability to toggle the helmet if he's wearing the hardsuit.
@@ -290,6 +338,14 @@
 	armor = list("melee" = 35, "bullet" = 15, "laser" = 20, "energy" = 10, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 75, "stamina" = 20)
 	light_range = 6
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator)
+	actions_types = list(
+		/datum/action/item_action/toggle_helmet_light,
+		/datum/action/item_action/toggle_beacon_hud
+		)
+
+/obj/item/clothing/head/helmet/space/hardsuit/exploration/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/team_monitor, "expl", null)
 
 /obj/item/clothing/suit/space/hardsuit/exploration
 	icon_state = "hardsuit-exploration"
@@ -301,6 +357,9 @@
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/bag/ore, /obj/item/pickaxe)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/exploration
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	actions_types = list(
+		/datum/action/item_action/toggle_helmet
+	)
 
 	//Cybersun Hardsuit
 	//A kind of side-grade to the explorer suit, sacrificing burn protection for brute. If you can kill the guy inside it, anyways.
@@ -362,19 +421,8 @@
 	switch(action.type)
 		if(/datum/action/item_action/toggle_helmet_mode)
 			attack_self(user)
-		if(/datum/action/item_action/toggle_beacon_hud)
-			toggle_hud(user)
-
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/proc/toggle_hud(mob/user)
-	var/datum/component/team_monitor/monitor = GetComponent(/datum/component/team_monitor)
-	if(!monitor)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	monitor.toggle_hud(!monitor.hud_visible, user)
-	if(monitor.hud_visible)
-		to_chat(user, "<span class='notice'>You toggle the heads up display of your suit.</span>")
-	else
-		to_chat(user, "<span class='warning'>You disable the heads up display of your suit.</span>")
+			return
+	..()
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/attack_self(mob/user) //Toggle Helmet
 	if(!isturf(user.loc))
@@ -450,33 +498,6 @@
 /obj/item/clothing/suit/space/hardsuit/syndi/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/anti_artifact, INFINITY, FALSE, 100)
-
-/obj/item/clothing/suit/space/hardsuit/syndi/ui_action_click(mob/user, datum/actiontype)
-	switch(actiontype.type)
-		if(/datum/action/item_action/toggle_helmet)
-			ToggleHelmet()
-		if(/datum/action/item_action/toggle_beacon)
-			toggle_beacon(user)
-		if(/datum/action/item_action/toggle_beacon_frequency)
-			set_beacon_freq(user)
-
-/obj/item/clothing/suit/space/hardsuit/syndi/proc/toggle_beacon(mob/user)
-	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
-	if(!beacon)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	beacon.toggle_visibility(!beacon.visible)
-	if(beacon.visible)
-		to_chat(user, "<span class='notice'>You enable the tracking beacon on [src]. Anybody on the same frequency will now be able to track your location.</span>")
-	else
-		to_chat(user, "<span class='warning'>You disable the tracking beacon on [src].</span>")
-
-/obj/item/clothing/suit/space/hardsuit/syndi/proc/set_beacon_freq(mob/user)
-	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
-	if(!beacon)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	beacon.change_frequency(user)
 
 /obj/item/clothing/suit/space/hardsuit/syndi/RemoveHelmet()
 	. = ..()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -345,7 +345,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/exploration/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/team_monitor, "expl", null)
+	AddComponent(/datum/component/team_monitor, "expl", -1)
 
 /obj/item/clothing/suit/space/hardsuit/exploration
 	icon_state = "hardsuit-exploration"
@@ -415,7 +415,7 @@
 		//Add the monitor (Default to null - No tracking)
 		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor, "synd", null, component_beacon)
 	else
-		AddComponent(/datum/component/team_monitor, "synd", null)
+		AddComponent(/datum/component/team_monitor, "synd", -1)
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/ui_action_click(mob/user, datum/action)
 	switch(action.type)
@@ -971,7 +971,7 @@
 		//Add the monitor (Default to null - No tracking)
 		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor, "synd", null, component_beacon)
 	else
-		AddComponent(/datum/component/team_monitor, "synd", null)
+		AddComponent(/datum/component/team_monitor, "synd", -1)
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi/ui_action_click(mob/user, datum/action)
 	switch(action.type)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -949,24 +949,6 @@
 		if(/datum/action/item_action/toggle_beacon_frequency)
 			set_beacon_freq(user)
 
-/obj/item/clothing/suit/space/hardsuit/shielded/syndi/proc/toggle_beacon(mob/user)
-	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
-	if(!beacon)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	beacon.toggle_visibility(!beacon.visible)
-	if(beacon.visible)
-		to_chat(user, "<span class='notice'>You enable the tracking beacon on [src]. Anybody on the same frequency will now be able to track your location.</span>")
-	else
-		to_chat(user, "<span class='warning'>You disable the tracking beacon on [src].</span>")
-
-/obj/item/clothing/suit/space/hardsuit/shielded/syndi/proc/set_beacon_freq(mob/user)
-	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
-	if(!beacon)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	beacon.change_frequency(user)
-
 //Helmet - With built in HUD
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi
@@ -997,17 +979,6 @@
 			toggle_helmlight()
 		if(/datum/action/item_action/toggle_beacon_hud)
 			toggle_hud(user)
-
-/obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi/proc/toggle_hud(mob/user)
-	var/datum/component/team_monitor/monitor = GetComponent(/datum/component/team_monitor)
-	if(!monitor)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	monitor.toggle_hud(!monitor.hud_visible, user)
-	if(monitor.hud_visible)
-		to_chat(user, "<span class='notice'>You toggle the heads up display of your suit.</span>")
-	else
-		to_chat(user, "<span class='warning'>You disable the heads up display of your suit.</span>")
 
 ///SWAT version
 /obj/item/clothing/suit/space/hardsuit/shielded/swat

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -198,17 +198,6 @@ Contains:
 		if(/datum/action/item_action/toggle_beacon_hud)
 			toggle_hud(user)
 
-/obj/item/clothing/head/helmet/space/hardsuit/ert/proc/toggle_hud(mob/user)
-	var/datum/component/team_monitor/monitor = GetComponent(/datum/component/team_monitor)
-	if(!monitor)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	monitor.toggle_hud(!monitor.hud_visible, user)
-	if(monitor.hud_visible)
-		to_chat(user, "<span class='notice'>You toggle the heads up display of your suit.</span>")
-	else
-		to_chat(user, "<span class='warning'>You disable the heads up display of your suit.</span>")
-
 /obj/item/clothing/suit/space/hardsuit/ert
 	name = "emergency response team commander hardsuit"
 	desc = "The standard issue hardsuit of the ERT, this one has blue highlights. Offers superb protection against environmental hazards."
@@ -236,24 +225,6 @@ Contains:
 			toggle_beacon(user)
 		if(/datum/action/item_action/toggle_beacon_frequency)
 			set_beacon_freq(user)
-
-/obj/item/clothing/suit/space/hardsuit/ert/proc/toggle_beacon(mob/user)
-	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
-	if(!beacon)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	beacon.toggle_visibility(!beacon.visible)
-	if(beacon.visible)
-		to_chat(user, "<span class='notice'>You enable the tracking beacon on [src]. Anybody on the same frequency will now be able to track your location.</span>")
-	else
-		to_chat(user, "<span class='warning'>You disable the tracking beacon on [src].</span>")
-
-/obj/item/clothing/suit/space/hardsuit/ert/proc/set_beacon_freq(mob/user)
-	var/datum/component/tracking_beacon/beacon = GetComponent(/datum/component/tracking_beacon)
-	if(!beacon)
-		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
-		return
-	beacon.change_frequency(user)
 
 	//ERT Security
 /obj/item/clothing/head/helmet/space/hardsuit/ert/sec

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -189,7 +189,7 @@ Contains:
 		//Add the monitor (Default to null - No tracking)
 		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor, "cent", null, component_beacon)
 	else
-		AddComponent(/datum/component/team_monitor, "cent", null)
+		AddComponent(/datum/component/team_monitor, "cent", -1)
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/ui_action_click(mob/user, datum/action)
 	switch(action.type)

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -153,10 +153,6 @@
 		W.suit = src
 		helmet = W
 
-/obj/item/clothing/suit/space/hardsuit/ui_action_click()
-	..()
-	ToggleHelmet()
-
 /obj/item/clothing/suit/space/hardsuit/equipped(mob/user, slot)
 	if(!helmettype)
 		return

--- a/code/modules/exploration_crew/exploration_shuttle.dm
+++ b/code/modules/exploration_crew/exploration_shuttle.dm
@@ -6,6 +6,12 @@
 	possible_destinations = "exploration_home"
 	req_access = list(ACCESS_EXPLORATION)
 
+/obj/machinery/computer/shuttle_flight/custom_shuttle/exploration/ComponentInitialize()
+	. = ..()
+	//For finding your way home
+	if (istype(get_area(src), /area/shuttle/exploration))
+		AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#63e769", TRUE, TRUE)
+
 /obj/machinery/computer/shuttle_flight/custom_shuttle/exploration/linkShuttle(new_id)
 	return
 

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -22,6 +22,7 @@
 /obj/item/alienartifact/objective/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/gps, "[scramble_message_replace_chars("#########", 100)]", TRUE)
+	AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#eb4d4d", TRUE, TRUE)
 
 /obj/item/alienartifact/Initialize(mapload)
 	. = ..()

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
@@ -10,6 +10,10 @@
 		var/datum/techweb_node/node = SSresearch.techweb_node_by_id(node_id)
 		name = "research disk ([node.display_name])"
 
+/obj/item/disk/tech_disk/research/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#e7a3e4", TRUE, TRUE)
+
 /obj/item/disk/tech_disk/research/Destroy()
 	SSorbits.research_disks -= src
 	. = ..()

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/research_disks.dm
@@ -13,6 +13,12 @@
 /obj/item/disk/tech_disk/research/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#e7a3e4", TRUE, TRUE)
+	//After 15 minutes the tracking beacon turns off
+	addtimer(CALLBACK(src, .proc/signal_decay), 15 MINUTES)
+
+/obj/item/disk/tech_disk/research/proc/signal_decay()
+	var/datum/component/tracking_beacon/component = GetComponent(/datum/component/tracking_beacon)
+	qdel(component)
 
 /obj/item/disk/tech_disk/research/Destroy()
 	SSorbits.research_disks -= src

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -41,6 +41,7 @@
 
 /obj/item/disk/nuclear/decommission/ComponentInitialize()
 	AddComponent(/datum/component/gps, "AUTH0", TRUE)
+	AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#f3d594", TRUE, TRUE)
 
 //==============
 //The bomb
@@ -57,6 +58,7 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 /obj/machinery/nuclearbomb/decomission/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/gps, "BOMB0", TRUE)
+	AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#df3737", TRUE, TRUE)
 
 /obj/machinery/nuclearbomb/decomission/Initialize(mapload)
 	. = ..()

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
@@ -36,6 +36,7 @@
 /obj/item/blackbox/objective/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/gps, "BLACKBOX #[rand(1000, 9999)]", TRUE)
+	AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#ecdf94", TRUE, TRUE)
 
 /obj/item/blackbox/objective/proc/setup_recover(linked_mission)
 	AddComponent(/datum/component/recoverable, linked_mission)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_traits.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_traits.dm
@@ -42,12 +42,12 @@
 ///Compile a blacklist of traits from a given flag/s
 /proc/compile_artifact_blacklist(var/flags)
 	var/list/output = list()
-	for(var/datum/xenoartifact_trait/T as() in GLOB.xenoa_all_traits)	
+	for(var/datum/xenoartifact_trait/T as() in GLOB.xenoa_all_traits)
 		if(!(initial(T.flags) & flags))
 			output += T
 	return output
 
-//Activator signal shenanignas 
+//Activator signal shenanignas
 ///Passes information into the activator datum to decide if, and how, the artifact activates
 /datum/xenoartifact_trait/activator/proc/pass_input(obj/item/xenoartifact/X)
 	return

--- a/code/modules/xenoarchaeology/xenoartifact.dm
+++ b/code/modules/xenoarchaeology/xenoartifact.dm
@@ -9,15 +9,15 @@
 
 	///How much input the artifact is getting from activator traits
 	var/charge = 0
-	///This isn't a requirement anymore. This just affects how effective the charge is 
-	var/charge_req 
+	///This isn't a requirement anymore. This just affects how effective the charge is
+	var/charge_req
 	///Processing type, used for tick
 	var/process_type
 	///List of targted entities for traits
-	var/list/true_target = list() 
+	var/list/true_target = list()
 
 	///Associated traits & colour
-	var/material 
+	var/material
 	///activation trait, minor 1, minor 2, minor 3, major, malfunction
 	var/list/traits = list()
 	///Internal list of unallowed traits
@@ -32,7 +32,7 @@
 	var/max_range = 1
 
 	//Used for signaler trait
-	var/code 
+	var/code
 	var/frequency
 	var/datum/radio_frequency/radio_connection
 
@@ -89,9 +89,9 @@
 		if(XENOA_URANIUM)
 			name = "uranium [name]"
 			blacklist_ref = GLOB.xenoa_uranium_blacklist
-			generate_traits(GLOB.xenoa_uranium_blacklist, TRUE) 
+			generate_traits(GLOB.xenoa_uranium_blacklist, TRUE)
 			if(!price)
-				price = pick(300, 500, 800) 
+				price = pick(300, 500, 800)
 			malfunction_mod = 5
 			extra_masks = pick(1)
 
@@ -163,7 +163,7 @@
 	..()
 
 /obj/item/xenoartifact/examine(mob/living/carbon/user)
-	. = ..()	
+	. = ..()
 	if(user.can_see_reagents()) //Not checking carbon throws a runtime concerning observers
 		. += "<span class='notice'>[special_desc]</span>"
 	if(isobserver(user))
@@ -182,7 +182,7 @@
 
 	if(isliving(loc) && touch_desc?.on_touch(src, user) && user.can_see_reagents())
 		balloon_alert(user, (initial(touch_desc.desc) ? initial(touch_desc.desc) : initial(touch_desc.label_name)), material)
-		
+
 	var/obj/item/clothing/gloves/artifact_pinchers/P = locate(/obj/item/clothing/gloves/artifact_pinchers) in user.contents
 	if(P?.safety && isliving(loc))
 		return
@@ -229,7 +229,7 @@
 		COOLDOWN_START(src, xenoa_cooldown, cooldown+cooldownmod)
 		if(prob(malfunction_chance) && traits.len < 7 + (material == XENOA_URANIUM ? 1 : 0)) //See if we pick up an malfunction
 			generate_malfunction_unique()
-			malfunction_chance = 0 //Lower chance after contracting 
+			malfunction_chance = 0 //Lower chance after contracting
 		else //otherwise increase chance.
 			malfunction_chance = min(malfunction_chance + malfunction_mod, 100)
 
@@ -252,9 +252,9 @@
 			if(!istype(M.get_item_by_slot(ITEM_SLOT_GLOVES), /obj/item/clothing/gloves/artifact_pinchers) && !istype(get_area(M), /area/science))
 				true_target |= list(M)
 		*/
-   
+
 		for(var/atom/M in true_target) //target loop, majors & malfunctions
-			if(get_dist(get_turf(src), get_turf(M)) <= max_range) 
+			if(get_dist(get_turf(src), get_turf(M)) <= max_range)
 				create_beam(M) //Indicator beam, points to target, M
 				for(var/datum/xenoartifact_trait/t as() in traits) //Major traits
 					if(!istype(t, /datum/xenoartifact_trait/minor))
@@ -309,7 +309,7 @@
 	new_trait = new new_trait //type converting doesn't work too well here but this should be fine.
 	blacklist += new_trait.blacklist_traits //Cant use initial() to access lists without bork'ing it
 	return new_trait
-	
+
 ///generates a malfunction respective to the artifact's type - don't use anywhere but for check_charge malfunctions
 /obj/item/xenoartifact/proc/generate_malfunction_unique(list/blacklist)
 	var/list/malfunctions = GLOB.xenoa_malfs.Copy()
@@ -342,7 +342,7 @@
 		if(H.wear_suit && H.head && isclothing(H.wear_suit) && isclothing(H.head))
 			if(H.anti_artifact_check())
 				to_chat(target, "<span class='warning'>The [name] was unable to target you!</span>")
-				playsound(get_turf(target), 'sound/weapons/deflect.ogg', 25, TRUE) 
+				playsound(get_turf(target), 'sound/weapons/deflect.ogg', 25, TRUE)
 				return
 
 	if(isliving(target)) //handle pulling
@@ -408,7 +408,7 @@
 				process_type = null
 				return PROCESS_KILL
 		if(PROCESS_TYPE_TICK) //Clock-ing
-			playsound(get_turf(src), 'sound/effects/clock_tick.ogg', 50, TRUE) 
+			playsound(get_turf(src), 'sound/effects/clock_tick.ogg', 50, TRUE)
 			visible_message("<span class='danger' size='10'>The [name] ticks.</span>")
 			true_target = get_target_in_proximity(min(max_range, 5))
 			default_activate(25, null, null)
@@ -452,6 +452,7 @@
 
 /obj/item/xenoartifact/objective/ComponentInitialize()
 	AddComponent(/datum/component/gps, "[scramble_message_replace_chars("#########", 100)]", TRUE)
+	AddComponent(/datum/component/tracking_beacon, "expl", null, null, TRUE, "#eb4d4d", TRUE, TRUE)
 	..()
 
 /obj/effect/ebeam/xenoa_ebeam //Beam code. This isn't mine. See beam.dm for better documentation.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The exploration hardsuit will now point towards research disks, objective items and the exploration shuttles. (See testing photographs)

## Why It's Good For The Game

Quality of life upgrade, no longer requiring to have a GPS device open on a second monitor (which is inconvenient if you only have 1 monitor). Also allows for easy locating of research disks, meaning explorers are much more likely to explore the ruins and collect the disks.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/209153693-dfa9fb91-8c38-4869-8be4-930e1116bc1f.png)

![image](https://user-images.githubusercontent.com/26465327/209154301-9f165dec-b801-4f42-b82b-1b6ce6904737.png)

![image](https://user-images.githubusercontent.com/26465327/209154348-aa0ecb6b-6243-43f5-af28-abaa31ac076f.png)


## Changelog
:cl:
add: Exploration hardsuits now have a HUD which points them towards research disks, objectives and the exploration shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
