### PR TITLE
Fixes a few issues with the Tablet PDAs

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -82,13 +82,13 @@
 	modularInterface.saved_identification = real_name || name
 	if(iscyborg(src))
 		modularInterface.saved_job = JOB_NAME_CYBORG
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/robot)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/pda/robot)
 	if(isAI(src))
 		modularInterface.saved_job = JOB_NAME_AI
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/pda/ai)
 	if(ispAI(src))
 		modularInterface.saved_job = JOB_NAME_PAI
-		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/ai)
+		modularInterface.install_component(new /obj/item/computer_hardware/hard_drive/small/pda/ai)
 
 /mob/living/silicon/robot/model/syndicate/create_modularInterface()
 	if(!modularInterface)

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -371,7 +371,7 @@
 
 /obj/item/modular_computer/tablet/pda/Initialize(mapload)
 	. = ..()
-	install_component(new /obj/item/computer_hardware/hard_drive/small)
+	install_component(new /obj/item/computer_hardware/hard_drive/small/pda)
 	install_component(new /obj/item/computer_hardware/processor_unit/small)
 	install_component(new /obj/item/computer_hardware/battery(src, /obj/item/stock_parts/cell/computer))
 	install_component(new /obj/item/computer_hardware/network_card)

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -4,7 +4,9 @@
 	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "generic"
 	extended_desc = "Jot down your work-safe thoughts and what not."
-	size = 2
+	size = 0
+	undeletable = TRUE // It comes by default in PDAs, can't be downloaded, takes no space and should obviously not be able to be deleted.
+	available_on_ntnet = FALSE
 	tgui_id = "NtosNotepad"
 	program_icon = "book"
 	usage_flags = PROGRAM_TABLET

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -9,6 +9,8 @@
 	extended_desc = "This program allows old-school communication with other modular devices."
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
+	requires_ntnet = TRUE
+	requires_ntnet_feature = NTNET_COMMUNICATION
 	available_on_ntnet = FALSE
 	usage_flags = PROGRAM_TABLET
 	ui_header = "ntnrc_idle.gif"

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -9,8 +9,6 @@
 	extended_desc = "This program allows old-school communication with other modular devices."
 	size = 0
 	undeletable = TRUE // It comes by default in tablets, can't be downloaded, takes no space and should obviously not be able to be deleted.
-	requires_ntnet = TRUE
-	requires_ntnet_feature = NTNET_COMMUNICATION
 	available_on_ntnet = FALSE
 	usage_flags = PROGRAM_TABLET
 	ui_header = "ntnrc_idle.gif"

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -33,7 +33,6 @@
 	store_file(new/datum/computer_file/program/ntnetdownload(src))		// NTNet Downloader Utility, allows users to download more software from NTNet repository
 	store_file(new/datum/computer_file/program/computerconfig(src)) 	// Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new/datum/computer_file/program/filemanager(src))		// File manager, allows text editor functions and basic file manipulation.
-	store_file(new/datum/computer_file/program/databank_uplink(src))	// Wiki Uplink, allows the user to access the Wiki from in-game!
 
 /obj/item/computer_hardware/hard_drive/examine(user)
 	. = ..()
@@ -174,12 +173,14 @@
 	w_class = WEIGHT_CLASS_TINY
 	custom_price = 15
 
-/obj/item/computer_hardware/hard_drive/small/install_default_programs()
+// PDA Version of the SSD, contains all the programs that PDAs have by default, however with the variables of the SSD.
+/obj/item/computer_hardware/hard_drive/small/pda/install_default_programs()
 	store_file(new /datum/computer_file/program/messenger(src))
 	store_file(new /datum/computer_file/program/notepad(src))
+	store_file(new/datum/computer_file/program/databank_uplink(src))	// Wiki Uplink, allows the user to access the Wiki from in-game!
 	..()
 
-/obj/item/computer_hardware/hard_drive/small/on_install(obj/item/modular_computer/install_into, mob/living/user = null)
+/obj/item/computer_hardware/hard_drive/small/pda/on_install(obj/item/modular_computer/install_into, mob/living/user = null)
 	. = ..()
 	if(!.)
 		return
@@ -190,12 +191,12 @@
 
 
 // For borg integrated tablets. No downloader.
-/obj/item/computer_hardware/hard_drive/small/ai/install_default_programs()
+/obj/item/computer_hardware/hard_drive/small/pda/ai/install_default_programs()
 	var/datum/computer_file/program/messenger/messenger = new(src)
 	messenger.is_silicon = TRUE
 	store_file(messenger)
 
-/obj/item/computer_hardware/hard_drive/small/robot/install_default_programs()
+/obj/item/computer_hardware/hard_drive/small/pda/robot/install_default_programs()
 	store_file(new /datum/computer_file/program/borg_self_monitor(src))
 	store_file(new /datum/computer_file/program/computerconfig(src)) // Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new /datum/computer_file/program/filemanager(src)) // File manager, allows text editor functions and basic file manipulation.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #7904

Also addresses some issues that were made in the PR-Discussion channel relating to the Wiki Uplink Program. 

What this PR does in detail: 
Makes the Notepad Program undeletable and removes it from existing on the NTNet for download.

Moves the default installed PDA programs from the SSD that's installed by default on EVERY tablet, into a sub-type version that's only installed on PDAs, pAI, AIs and Cyborgs by default. 

Also moves the Wiki Uplink Program to only being installed by default on the PDA, not absolutely everything. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/213990241-418ad059-b4da-4d84-a375-e7c1a433e955.mp4

</details>

## Changelog
:cl:
code: Changed the default installed PDA programs to only being installed on the PDA subtype instead of the default Tablet SSD.
code: Changes the size of the Notepad to 0 and makes it undeletable and unavailable on NTNet.
code: Moves the Wiki Uplink Program to only being installed by default on the PDAs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
