### PR TITLE
Reintroducing airborne viruses and increasing transmission cost

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -111,7 +111,7 @@
 	if(affected_mob.reagents.has_reagent(/datum/reagent/medicine/spaceacillin) || (affected_mob.satiety > 0 && prob(affected_mob.satiety/10)))
 		return
 
-	var/spread_range = 2
+	var/spread_range = 1
 
 	if(force_spread)
 		spread_range = force_spread

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -301,9 +301,12 @@
 			if(6 to 10)
 				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS
 				spread_text = "Fluids"
-			if(11 to INFINITY)
+			if(11 to 12)
 				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN
 				spread_text = "On contact"
+			if(13 to INFINITY)
+				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_AIRBORNE
+				spread_text = "Airborne"
 
 /datum/disease/advance/proc/SetDanger(level_sev)
 	switch(level_sev)

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -54,7 +54,7 @@ BONUS
 			power = 2
 	if(A.stage_rate >= 6) //cough more often
 		symptom_delay_max = 10
-	if(A.transmission >= 11) //spread virus
+	if(A.transmission >= 10) //spread virus
 		infective =TRUE
 
 /datum/symptom/cough/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -37,7 +37,7 @@ Bonus
 		return
 	if(A.stealth >= 4)
 		suppress_warning = TRUE
-	if(A.transmission >= 12)
+	if(A.transmission >= 11)
 		infective = TRUE
 
 /datum/symptom/sneeze/Activate(datum/disease/advance/A)


### PR DESCRIPTION
## About The Pull Request

In the PR "Removes airborne transmission from advanced diseases" [(#6619)](https://github.com/BeeStation/BeeStation-Hornet/pull/6619) advanced viruses with the airborne transmission have been removed from the game. 

The previous pull request, which removed the airborne spread mechanic, was received negatively and was almost closed. However, it was still merged. I remain convinced that the airborne spread mechanic is essential to the game and should be reinstated.

The previous argument to remove this feature was: "Airborne transmission has no counterplay". While it does take some understanding of virology, there are some clear counters for these viruses.
For example:
- Wearing masks + Internals
- Wearing a biosuit
- Isolating infected people

These are all named in the medical [Viral Outbreak Procedures](https://wiki.beestation13.com/view/Department_Standard_Operating_Procedure:_Medical#Viral_Outbreak_Procedures).

## Why It's Good For The Game

Airborne viruses have been part of the game for a long time. Adding them back into the game also adds a bit of realism.
Previously, airborne spread required transmission of 12 or above. In this PR I've rebalanced that to 13 or above.

The theoretical maximum transmission for a virus is 17. While it is possible to get a virus with 17 transmission it wouldn't be a very good virus. I've chosen to make the transmission of airborne viruses 13 to reduce the possibilities of very stealthy, infective and deadly viruses. 

While it is still possible to create a deadly virus that spreads via airborne transmission, it will be easier for medical personnel wearing a medical hud to see that there is a virus going around and create a cure for it.

## Testing Photographs and Procedure

During testing, I've also taken the time to show you a representation of the infective area around an infected person.
As shown in the attached screenshot there is a 5x5 grid around the player where someone could get infected. Players outside this range will not become infected. Using just internals you won't be infected either. You will, however, become infected when you get in contact with the infected person. This is where you would need to wear a biosuit to prevent these cases.

The test was conducted with the first commit. The second picture is the new updated 3x3 grid where a virus will spread.
<details>
![airbornevirustest](https://user-images.githubusercontent.com/45425020/209437858-6aaf1324-ea08-4629-8cda-d1eabe5edc3a.jpg) 
![airbornevirustest3](https://user-images.githubusercontent.com/45425020/209442524-e8048222-49df-4217-b37d-4eb392809fe1.jpg)
</details>

## Changelog
:cl:
add: Advanced diseases can spread via airborne spread
tweak: On contact viruses now range between 11 and 12
tweak: Coughing symptom can now spread at a threshold of 10 transmission
tweak: Sneezing symptom can now spread at a threshold of 11 transmission
tweak: Reducing the area the virus is spread from a 5x5 area to 3x3
balance: Airborne viruses need a transmission of 13+ (previously 12)
/:cl: