### PR TITLE
Orbit panel job icons

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -61,6 +61,16 @@
 				var/datum/mind/mind = M.mind
 				var/was_antagonist = FALSE
 
+				//If we have an ID, use that
+				var/obj/item/card/id/identification_card = M.get_idcard()
+				if (identification_card)
+					serialized["role_icon"] = "hud[ckey(identification_card.GetJobIcon())]"
+				else
+					//If we have no ID, use the mind job
+					var/datum/job/located_job = SSjob.GetJob(mind.assigned_role)
+					if (located_job)
+						serialized["role_icon"] = "hud[ckey(located_job.title)]"
+
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A
 					if (A.show_to_ghosts)
@@ -86,3 +96,16 @@
 /datum/orbit_menu/ui_assets()
 	. = ..() || list()
 	. += get_asset_datum(/datum/asset/simple/orbit)
+	. += get_asset_datum(/datum/asset/spritesheet/job_icons)
+
+/datum/asset/spritesheet/job_icons
+	name = "job-icon"
+
+/datum/asset/spritesheet/job_icons/register()
+	var/icon/I = icon('icons/mob/hud.dmi')
+	// Get the antag hud part
+	I.Crop(1, 17, 8, 24)
+	// Scale it up
+	I.Scale(16, 16)
+	InsertAll("job-icon", I)
+	..()

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -103,7 +103,7 @@
 
 /datum/asset/spritesheet/job_icons/register()
 	var/icon/I = icon('icons/mob/hud.dmi')
-	// Get the antag hud part
+	// Get the job hud part
 	I.Crop(1, 17, 8, 24)
 	// Scale it up
 	I.Scale(16, 16)

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -64,6 +64,12 @@ const OrbitedButton = (props, context) => {
       onClick={() => act("orbit", {
         ref: thing.ref,
       })}>
+      {job && (
+        <Box inline
+          ml={1}
+          style={{ "transform": "translateY(2.5px)" }}
+          className={`job-icon16x16 job-icon-${job}`} />
+      )}
       {thing.name}
       {thing.orbiters && (
         <Box inline ml={1}>
@@ -74,12 +80,6 @@ const OrbitedButton = (props, context) => {
             opacity={0.7} />
           {")"}
         </Box>
-      )}
-      {job && (
-        <Box inline
-          ml={1}
-          style={{ "transform": "translateY(2.5px)" }}
-          className={`job-icon16x16 job-icon-${job}`} />
       )}
     </Button>
   );

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -56,7 +56,7 @@ const BasicSection = (props, context) => {
 
 const OrbitedButton = (props, context) => {
   const { act } = useBackend(context);
-  const { color, thing } = props;
+  const { color, thing, job } = props;
 
   return (
     <Button
@@ -74,6 +74,12 @@ const OrbitedButton = (props, context) => {
             opacity={0.7} />
           {")"}
         </Box>
+      )}
+      {job && (
+        <Box inline
+          ml={1}
+          style={{ "transform": "translateY(2.5px)" }}
+          className={`job-icon16x16 job-icon-${job}`} />
       )}
     </Button>
   );
@@ -154,6 +160,7 @@ export const Orbit = (props, context) => {
                       key={antag.name}
                       color="bad"
                       thing={antag}
+                      job={antag.role_icon}
                     />
                   ))}
               </Section>
@@ -169,7 +176,8 @@ export const Orbit = (props, context) => {
               <OrbitedButton
                 key={thing.name}
                 color="good"
-                thing={thing} />
+                thing={thing}
+                job={thing.role_icon} />
             ))}
         </Section>
 

--- a/tgui/packages/tgui/interfaces/PlayerPanel.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.js
@@ -1049,7 +1049,7 @@ class PlayerTraitorPanelButton extends PureComponent {
         style={{
           "padding": "0px 2px",
         }}
-        content={<Box style={{ "transform": "translateY(2.5px)" }} className={`antag-hud16x16 antag-hud-${antag_hud}`} />}
+        content={<Box style={{ "transform": "translateY(2.5px)" }}  />}
         tooltip={has_mind ? "Open Traitor Panel" : "Initialize Mind"}
         onClick={() => act(has_mind ? 'open_traitor_panel' : 'init_mind', { who: ckey })}
       />

--- a/tgui/packages/tgui/interfaces/PlayerPanel.js
+++ b/tgui/packages/tgui/interfaces/PlayerPanel.js
@@ -1049,7 +1049,7 @@ class PlayerTraitorPanelButton extends PureComponent {
         style={{
           "padding": "0px 2px",
         }}
-        content={<Box style={{ "transform": "translateY(2.5px)" }}  />}
+        content={<Box style={{ "transform": "translateY(2.5px)" }} className={`antag-hud16x16 antag-hud-${antag_hud}`} />}
         tooltip={has_mind ? "Open Traitor Panel" : "Initialize Mind"}
         onClick={() => act(has_mind ? 'open_traitor_panel' : 'init_mind', { who: ckey })}
       />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in job icons to the orbit panel.
It will use the hud icon of the mob's ID, or the job assigned to the mind if the mob has no ID.

## Why It's Good For The Game

Trying to look for explorers or specific roles is a right pain in the orbit menu.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/209449116-50dbb7e6-0457-4ad4-bab3-3c8c0121a497.png)

![image](https://user-images.githubusercontent.com/26465327/209449141-ead2b45a-9795-45d5-b3d7-de16172dc37a.png)

![image](https://user-images.githubusercontent.com/26465327/209449153-3b6286e2-e439-4a4f-b460-d8188b4e130e.png)


## Changelog
:cl:
add: Adds in job icons to the orbit panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
