### PR TITLE
Fix Blob strain choices not rerolling

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -45,6 +45,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 	/// The list of strains the blob can reroll for.
 	var/list/strain_choices
+	var/need_reroll_strain = FALSE
 
 /mob/camera/blob/Initialize(mapload, starting_points = 60)
 	validate_location()

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -352,7 +352,7 @@
 
 /// Open the menu to reroll strains
 /mob/camera/blob/proc/open_reroll_menu()
-	if (!strain_choices)
+	if (!strain_choices || need_reroll_strain)
 		strain_choices = list()
 
 		var/list/new_strains = GLOB.valid_blobstrains.Copy()
@@ -372,6 +372,7 @@
 			choice.info = info_text
 
 			strain_choices[initial(strain.name)] = choice
+			need_reroll_strain = FALSE
 
 	var/strain_result = show_radial_menu(src, src, strain_choices, radius = BLOB_REROLL_RADIUS, tooltips = TRUE)
 	if (isnull(strain_result))
@@ -380,6 +381,7 @@
 	if (!free_strain_rerolls && !can_buy(BLOB_REROLL_COST))
 		return
 
+	need_reroll_strain = TRUE
 	for (var/_other_strain in GLOB.valid_blobstrains)
 		var/datum/blobstrain/other_strain = _other_strain
 		if (initial(other_strain.name) == strain_result)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/8227
Upon buying a new strain, Blob will have its next list of strains randomly chosen again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

It was always intended for the blob to be able to switch strains often in hopes of getting one better fitting their current needs, under RNG and for a hefty cost. This is now fixed, and allows terrible spawning strains to not be permanent choices.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Works before spawning, changes with both a free strain and a bought strain, can't reroll them by repeatedly opening and closing the radial strain choices menu.
https://streamable.com/nm6pmr

</details>

## Changelog
:cl:
fix: Blob strains now properly reroll a new list of strains after every strain change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
