### PR TITLE
Alcohol symptom runtime fix

### DIFF
--- a/code/datums/diseases/advance/symptoms/alcohol.dm
+++ b/code/datums/diseases/advance/symptoms/alcohol.dm
@@ -35,7 +35,7 @@
 	var/mob/living/carbon/M = A.affected_mob
 	var/list/warningstrings = list()
 	switch(A.stage + severity)
-		if(4 to 5)
+		if(-5 to 5)
 			warningstrings = list("You feel buzzed", "You feel a bit tipsy")
 		if(6 to 7)
 			warningstrings = list("You feel drunk", "You feel a bit woozy")

--- a/code/datums/diseases/advance/symptoms/alcohol.dm
+++ b/code/datums/diseases/advance/symptoms/alcohol.dm
@@ -35,12 +35,12 @@
 	var/mob/living/carbon/M = A.affected_mob
 	var/list/warningstrings = list()
 	switch(A.stage + severity)
-		if(-5 to 5)
-			warningstrings = list("You feel buzzed", "You feel a bit tipsy")
 		if(6 to 7)
 			warningstrings = list("You feel drunk", "You feel a bit woozy")
 		if(8 to INFINITY)
 			warningstrings = list("ahyguabngaghabyugbauwf", "You feel sick", "It feels like you drank too much", "You feel like doing something unwise")
+		else
+			warningstrings = list("You feel buzzed", "You feel a bit tipsy")
 	M.drunkenness = CLAMP(M.drunkenness + target * ((A.stage - 1) * 0.1), M.drunkenness, target)
 	if(prob(5 * A.stage))
 		to_chat(M, "<span class='warning'>[pick(warningstrings)]</span>")


### PR DESCRIPTION
## About The Pull Request

There is currently a runtime error when someone is getting the Autobrewery Syndrome symptom.
The symptom itself only has 1 severity, any virus that doesn't go above 3 severity will make this runtime error happen.

Basically what is happening:

It's checking A.stage + severity.
If it's 4 to 5, then it will say x
If it's 6 to 7, then it will say y
If it's 8 to Infinite then it will say z

But during the start, the sum will be 2. Which isn't in the switch.
This is where the change comes in.

(Note that `-INFINITY` does not work and crashes the compiler on boot)

## Why It's Good For The Game

Just another removal of a runtime error.

## Testing Photographs and Procedure

During the testing of symptoms, I noticed a runtime error.
I found the problem. After implementing this it works as intended.

## Changelog
:cl:
fix: Fixed a runtime I've found located in the alcohol.dm file
/:cl: