### PR TITLE
Ports TGUI for cryopod consoles

### DIFF
--- a/tgui/packages/tgui/interfaces/CryopodConsole.js
+++ b/tgui/packages/tgui/interfaces/CryopodConsole.js
@@ -1,0 +1,95 @@
+import { useBackend } from '../backend';
+import { Stack, Button, Section, NoticeBox, LabeledList, Collapsible } from '../components';
+import { Window } from '../layouts';
+
+export const CryopodConsole = (props, context) => {
+  const { data } = useBackend(context);
+  const { account_name, allow_items } = data;
+
+  const welcomeTitle = `Hello, ${account_name || '[REDACTED]'}!`;
+
+  return (
+    <Window title="Cryopod Console" width={400} height={480}>
+      <Window.Content>
+        <Stack vertical>
+          <Section title={welcomeTitle}>
+            This automated cryogenic freezing unit will safely store your
+            corporeal form until your next assignment.
+          </Section>
+          <CrewList />
+          {!!allow_items && <ItemList />}
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const CrewList = (props, context) => {
+  const { data } = useBackend(context);
+  const { frozen_crew } = data;
+
+  return (
+    <Collapsible title="Stored Crew">
+      {!frozen_crew.length ? (
+        <NoticeBox>No stored crew!</NoticeBox>
+      ) : (
+        <Section height={10} fill scrollable>
+          <LabeledList>
+            {frozen_crew.map((person) => (
+              <LabeledList.Item key={person} label={person.name}>
+                {person.job}
+              </LabeledList.Item>
+            ))}
+          </LabeledList>
+        </Section>
+      )}
+    </Collapsible>
+  );
+};
+
+const ItemList = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { frozen_items } = data;
+
+  const replaceItemName = (item) => {
+    let itemName = item.toString();
+    if (itemName.startsWith('the')) {
+      itemName = itemName.slice(4, itemName.length);
+    }
+    return itemName.replace(/^\w/, (c) => c.toUpperCase());
+  };
+
+  return (
+    <Collapsible title="Stored Items">
+      {!frozen_items.length ? (
+        <NoticeBox>No stored items!</NoticeBox>
+      ) : (
+        <>
+          <Section height={12} fill scrollable>
+            <LabeledList>
+              {frozen_items.map((item, index) => (
+                <LabeledList.Item
+                  key={item}
+                  label={replaceItemName(item)}
+                  buttons={
+                    <Button
+                      icon="arrow-down"
+                      content="Drop"
+                      mr={1}
+                      onClick={() => act('one_item', { item: index + 1 })}
+                    />
+                  }
+                />
+              ))}
+            </LabeledList>
+          </Section>
+          <Button
+            content="Drop All Items"
+            color="red"
+            onClick={() => act('all_items')}
+          />
+        </>
+      )}
+    </Collapsible>
+  );
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the TGUI interface for cryopod consoles from tgstation [#58025](https://github.com/tgstation/tgstation/pull/58025)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

TGUI good; the cryopod console interface no longer looks ancient and using it is easier

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/35978630/209750024-b9163715-2313-4564-98b1-98030e35c9e8.png)

</details>

The jobs for the final 3 show up as unassigned because they were spawned & given equipment - this should not be the case for any actual crew members, such as the captain on the top of the list. In addition, it displays the proper name of the user as long as they have an ID with an associated bank account - [REDACTED] is the fallback for those without a proper ID & account.

## Changelog
:cl:LemonLimeSoda, jlsnow301
add: The cryopod console now has a sleek tgui interface
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
