### PR TITLE
Removes blocks_air

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -73,9 +73,7 @@
 /area/ruin/powered/pride)
 "Y" = (
 /obj/machinery/door/airlock/diamond,
-/turf/open/floor/mineral/silver{
-	blocks_air = 1
-	},
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 
 (1,1,1) = {"

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -8,20 +8,17 @@
 "c" = (
 /obj/item/paper/fluff/stations/lavaland/sloth/note,
 /turf/open/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered)
 "d" = (
 /turf/open/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered)
 "e" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered)
@@ -29,7 +26,6 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
 /turf/open/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered)
@@ -37,7 +33,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/open/floor/sepia{
-	blocks_air = 0;
 	slowdown = 10
 	},
 /area/ruin/unpowered)

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/eng
 // break_if_found is a typecache of turf/area types to return false if found
 // Please keep this proc type agnostic. If you need to restrict it do it elsewhere or add an arg.
 /proc/detect_room(turf/origin, list/break_if_found)
-	if(origin.blocks_air)
+	if(isclosedturf(origin))
 		return list(origin)
 
 	. = list()
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/eng
 			if(break_if_found[checkT.type] || break_if_found[checkT.loc.type])
 				return FALSE
 			var/static/list/cardinal_cache = list("[NORTH]"=TRUE, "[EAST]"=TRUE, "[SOUTH]"=TRUE, "[WEST]"=TRUE)
-			if(!cardinal_cache["[dir]"] || checkT.blocks_air || !CANATMOSPASS(sourceT, checkT))
+			if(!cardinal_cache["[dir]"] || isclosedturf(checkT) || !CANATMOSPASS(sourceT, checkT))
 				continue
 			found_turfs += checkT // Since checkT is connected, add it to the list to be processed
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -523,7 +523,7 @@ SUBSYSTEM_DEF(air)
 
 	for(var/thing in turfs_to_init)
 		var/turf/T = thing
-		if (T.blocks_air)
+		if (isclosedturf(T))
 			continue
 		T.Initalize_Atmos(times_fired)
 		CHECK_TICK

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -323,7 +323,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 //////Assimilate Air//////
 /turf/open/proc/Assimilate_Air()
 	var/turf_count = LAZYLEN(atmos_adjacent_turfs)
-	if(blocks_air || !turf_count) //if there weren't any open turfs, no need to update.
+	if(isclosedturf(src) || !turf_count) //if there weren't any open turfs, no need to update.
 		return
 
 	var/datum/gas_mixture/total = new//Holders to assimilate air from nearby turfs

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -2,7 +2,6 @@
 	layer = CLOSED_TURF_LAYER
 	opacity = 1
 	density = TRUE
-	blocks_air = TRUE
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 	rad_insulation = RAD_MEDIUM_INSULATION
 	pass_flags_self = PASSCLOSEDTURF

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -145,15 +145,14 @@
 
 /turf/open/indestructible/airblock
 	icon_state = "bluespace"
-	blocks_air = TRUE
 	baseturfs = /turf/open/indestructible/airblock
+	CanAtmosPass = ATMOS_PASS_NO
 
 /turf/open/Initalize_Atmos(times_fired)
-	if(!blocks_air)
-		if(!istype(air,/datum/gas_mixture/turf))
-			air = new(2500,src)
-		air.copy_from_turf(src)
-		update_air_ref(planetary_atmos ? 1 : 2)
+	if(!istype(air, /datum/gas_mixture/turf))
+		air = new(2500,src)
+	air.copy_from_turf(src)
+	update_air_ref(planetary_atmos ? 1 : 2)
 
 	update_visuals()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -27,9 +27,6 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 	//If true, turf will allow users to float up and down in 0 grav.
 	var/allow_z_travel = FALSE
 
-	/// Whether the turf blocks atmos from passing through it or not
-	var/blocks_air = FALSE
-
 	flags_1 = CAN_BE_DIRTY_1
 
 	/// For the station blueprints, images of objects eg: pipes

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -801,9 +801,6 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 	var/datum/gas_mixture/GM = new
 	for(var/turf/open/F in view())
-		if(F.blocks_air)
-		//skip walls
-			continue
 		GM.parse_gas_string(F.initial_gas_mix)
 		F.copy_air(GM)
 		F.update_visuals()

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -22,7 +22,7 @@
 	. = TRUE
 	if(vertical && !(zAirOut(dir, T) && T.zAirIn(dir, src)))
 		. = FALSE
-	if(blocks_air || T.blocks_air)
+	if(isclosedturf(src) || isclosedturf(T))
 		. = FALSE
 	if (T == src)
 		return .
@@ -49,7 +49,7 @@
 		var/turf/T = get_step_multiz(src, direction)
 		if(!istype(T))
 			continue
-		if(isopenturf(T) && !(blocks_air || T.blocks_air) && ((direction & (UP|DOWN))? (canvpass && CANVERTICALATMOSPASS(T, src)) : (canpass && CANATMOSPASS(T, src))) )
+		if(isopenturf(T) && !(isclosedturf(src) || isclosedturf(T)) && ((direction & (UP|DOWN))? (canvpass && CANVERTICALATMOSPASS(T, src)) : (canpass && CANATMOSPASS(T, src))) )
 			LAZYINITLIST(atmos_adjacent_turfs)
 			LAZYINITLIST(T.atmos_adjacent_turfs)
 			atmos_adjacent_turfs[T] = 1
@@ -60,11 +60,11 @@
 			if (T.atmos_adjacent_turfs)
 				T.atmos_adjacent_turfs -= src
 			UNSETEMPTY(T.atmos_adjacent_turfs)
-			T.set_sleeping(T.blocks_air)
+			T.set_sleeping(isclosedturf(T))
 		T.__update_auxtools_turf_adjacency_info(isspaceturf(T.get_z_base_turf()), -1)
 	UNSETEMPTY(atmos_adjacent_turfs)
 	src.atmos_adjacent_turfs = atmos_adjacent_turfs
-	set_sleeping(blocks_air)
+	set_sleeping(isclosedturf(src))
 	__update_auxtools_turf_adjacency_info(isspaceturf(get_z_base_turf()))
 
 /turf/proc/ImmediateDisableAdjacency(disable_adjacent = TRUE)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -28,10 +28,9 @@
 	var/list/atmos_overlay_types //gas IDs of current active gas overlays
 
 /turf/open/Initialize(mapload)
-	if(!blocks_air)
-		air = new(2500,src)
-		air.copy_from_turf(src)
-		update_air_ref(planetary_atmos ? 1 : 2)
+	air = new(2500,src)
+	air.copy_from_turf(src)
+	update_air_ref(planetary_atmos ? 1 : 2)
 	. = ..()
 
 /turf/open/Destroy()

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -158,38 +158,27 @@
 		target_temperature = modeled_location.GetTemperature()
 		target_heat_capacity = modeled_location.GetHeatCapacity()
 
-		if(modeled_location.blocks_air)
 
-			if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))
-				var/delta_temperature = air.return_temperature() - target_temperature
+		var/delta_temperature = 0
+		var/sharer_heat_capacity = 0
 
-				var/heat = thermal_conductivity*delta_temperature* \
-					(partial_heat_capacity*target_heat_capacity/(partial_heat_capacity+target_heat_capacity))
+		delta_temperature = (air.return_temperature() - target_temperature)
+		sharer_heat_capacity = target_heat_capacity
 
-				air.set_temperature(air.return_temperature() - heat/total_heat_capacity)
-				modeled_location.TakeTemperature(heat/target_heat_capacity)
+		var/self_temperature_delta = 0
+		var/sharer_temperature_delta = 0
 
+		if((sharer_heat_capacity>0) && (partial_heat_capacity>0))
+			var/heat = thermal_conductivity*delta_temperature* \
+				(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
+
+			self_temperature_delta = -heat/total_heat_capacity
+			sharer_temperature_delta = heat/sharer_heat_capacity
 		else
-			var/delta_temperature = 0
-			var/sharer_heat_capacity = 0
+			return 1
 
-			delta_temperature = (air.return_temperature() - target_temperature)
-			sharer_heat_capacity = target_heat_capacity
-
-			var/self_temperature_delta = 0
-			var/sharer_temperature_delta = 0
-
-			if((sharer_heat_capacity>0) && (partial_heat_capacity>0))
-				var/heat = thermal_conductivity*delta_temperature* \
-					(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
-
-				self_temperature_delta = -heat/total_heat_capacity
-				sharer_temperature_delta = heat/sharer_heat_capacity
-			else
-				return 1
-
-			air.set_temperature(air.return_temperature() + self_temperature_delta)
-			modeled_location.TakeTemperature(sharer_temperature_delta)
+		air.set_temperature(air.return_temperature() + self_temperature_delta)
+		modeled_location.TakeTemperature(sharer_temperature_delta)
 
 
 	else

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -26,7 +26,7 @@
 
 	var/turf/T = loc
 	if(istype(T))
-		if(T.blocks_air)
+		if(isclosedturf(T))
 			environment_temperature = T.return_temperature()
 		else
 			var/turf/open/OT = T

--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -252,7 +252,7 @@
 /mob/living/simple_animal/bot/atmosbot/proc/return_nearest_breach()
 	var/turf/origin = get_turf(src)
 
-	if(origin.blocks_air)
+	if(isclosedturf(origin))
 		return null
 
 	var/room_limit = ATMOSBOT_MAX_AREA_SCAN

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -117,9 +117,7 @@ All ShuttleMove procs go here
 	return TRUE
 
 /turf/proc/lateShuttleMove(turf/oldT)
-	blocks_air = initial(blocks_air)
 	air_update_turf(TRUE)
-	oldT.blocks_air = initial(oldT.blocks_air)
 	oldT.air_update_turf(TRUE)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes blocks air, a variable used to differentiate closed and open turfs.
This may potentially fix the issues with atmos, but needs testing

## Why It's Good For The Game

This variable can cause open turfs to initialise without an air, which can cause runtimes in auxmos if the turfs are rebuilt.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/210117850-38bbe25f-279c-4db3-bb40-caabd600ad7e.png)
Here is a working supermatter setup
I z-cleared lavaland and spawned a 199 radius ruin too in order to check if the SM would break. It continued to function.

## Changelog
:cl:
code: Removes the internal blocks_air variable which can cause issues with atmos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
