### PR TITLE
Ghoul examine text is no longer visible with obscured eyes

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -918,8 +918,6 @@
 	var/obscured = H.check_obscured_slots()
 	if(!(obscured & ITEM_SLOT_EYES) && !H.glasses) //The examine text is only displayed if the ghoul's eyes are not obscured
 		return examine_text
-	else
-		return null
 
 /atom/movable/screen/alert/status_effect/ghoul
 	name = "Flesh Servant"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -910,16 +910,16 @@
 	id = "ghoul"
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = -1
-	tick_interval = 10
+	examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, catatonic like stare.</span>"
 	alert_type = /atom/movable/screen/alert/status_effect/ghoul
 
-/datum/status_effect/ghoul/tick()
+/datum/status_effect/ghoul/get_examine_text()
 	var/mob/living/carbon/human/H = owner
 	var obscured = H.check_obscured_slots()
 	if(!(obscured & ITEM_SLOT_EYES) && !H.glasses) //The examine text is only displayed if the ghoul's eyes are not obscured
-		examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, catatonic like stare.</span>"
+		return examine_text
 	else
-		examine_text = null
+		return null
 
 /atom/movable/screen/alert/status_effect/ghoul
 	name = "Flesh Servant"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -910,8 +910,16 @@
 	id = "ghoul"
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = -1
-	examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, catatonic like stare.</span>"
+	tick_interval = 10
 	alert_type = /atom/movable/screen/alert/status_effect/ghoul
+
+/datum/status_effect/ghoul/tick()
+	var/mob/living/carbon/human/H = owner
+	var obscured = H.check_obscured_slots()
+	if(!(obscured & ITEM_SLOT_EYES) && !H.glasses) //The examine text is only displayed if the ghoul's eyes are not obscured
+		examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, catatonic like stare.</span>"
+	else
+		examine_text = null
 
 /atom/movable/screen/alert/status_effect/ghoul
 	name = "Flesh Servant"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -915,7 +915,7 @@
 
 /datum/status_effect/ghoul/get_examine_text()
 	var/mob/living/carbon/human/H = owner
-	var obscured = H.check_obscured_slots()
+	var/obscured = H.check_obscured_slots()
 	if(!(obscured & ITEM_SLOT_EYES) && !H.glasses) //The examine text is only displayed if the ghoul's eyes are not obscured
 		return examine_text
 	else

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -71,6 +71,9 @@
 		return
 	duration = world.time + original_duration
 
+/datum/status_effect/proc/get_examine_text() //Called when the owner is examined
+	return examine_text
+
 //clickdelay/nextmove modifiers!
 /datum/status_effect/proc/nextmove_modifier()
 	return 1

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -377,8 +377,9 @@
 		pronoun_replacement = p_they(TRUE)
 	for(var/V in status_effects)
 		var/datum/status_effect/E = V
-		if(E.examine_text)
-			var/new_text = replacetext(E.examine_text, "SUBJECTPRONOUN", pronoun_replacement)
+		var/effect_text = E.get_examine_text()
+		if(effect_text)
+			var/new_text = replacetext(effect_text, "SUBJECTPRONOUN", pronoun_replacement)
 			new_text = replacetext(new_text, "[pronoun_replacement] is", "[pronoun_replacement] [p_are()]") //To make sure something become "They are" or "She is", not "They are" and "She are"
 			dat += "[new_text]\n" //dat.Join("\n") doesn't work here, for some reason
 	if(dat.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Heretic ghouls' examine text no longer appears if their eyes are obscured
Fixes #8263 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![ghoul10](https://user-images.githubusercontent.com/113535457/210136597-f1de652c-140a-44e1-919e-d84e1d9ce8fc.png)
![ghoul11](https://user-images.githubusercontent.com/113535457/210136601-c5da8db7-7310-4a9c-8361-61e234fddcab.png)
![ghoul12](https://user-images.githubusercontent.com/113535457/210136606-672f9981-b5a4-4d3c-8b5a-9bbdeabe6fa7.png)
![ghoul13](https://user-images.githubusercontent.com/113535457/210136610-e1136435-afda-4886-9599-130b001501e0.png)
![ghoul14](https://user-images.githubusercontent.com/113535457/210136629-48293c96-527c-426f-9304-70f1fd83ffd9.png)
![ghoul15](https://user-images.githubusercontent.com/113535457/210136630-ddb10aa3-00e9-4a1c-ab0e-828a8fbabf50.png)
![ghoul16](https://user-images.githubusercontent.com/113535457/210136632-478a8ac4-d7eb-4b2b-95a3-117569251a20.png)
![ghoul17](https://user-images.githubusercontent.com/113535457/210136634-14ecb332-26ac-424a-8d6c-1a8e11356d81.png)

</details>

## Changelog
:cl:
fix: Ghouls no longer appear to have a blank stare with their eyes obscured
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
