### PR TITLE
Adds logging and admin messaging to buying items from an uplink

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1457,7 +1457,7 @@
 /proc/log_uplink_purchase(mob/buyer, atom/object, type = "\improper uplink")
 	var/message = "has bought [object] from \a [type]"
 	buyer.log_message(message, LOG_GAME)
-	if(isnull(locate(/datum/antagonist) in buyer.mind.antag_datums))
+	if(isnull(locate(/datum/antagonist) in buyer.mind?.antag_datums))
 		message_admins("[ADMIN_LOOKUPFLW(user)] has bought [object] from \a [type] as a non-antagonist.")
 
 /atom/proc/add_filter(name,priority,list/params)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1447,6 +1447,20 @@
 		var/reverse_message = "has been [what_done] by [ssource][postfix]"
 		target.log_message(reverse_message, LOG_ATTACK, color="orange", log_globally=FALSE)
 
+/**
+  * Log for buying items from the uplink
+  *
+  * 1 argument is for the user that bought the item
+  * 2 argument is for the item that was purchased
+  * 3 argument is for the uplink type (traitor/contractor)
+ */
+/proc/log_uplink_purchase(atom/user, atom/object, type = "\improper uplink")
+	var/message = "has bought [object] from \a [type]"
+	user.log_message(message, LOG_GAME)
+	var/mob/buyer = user
+	if(isnull(locate(/datum/antagonist) in buyer.mind.antag_datums))
+		message_admins("[ADMIN_LOOKUPFLW(user)] has bought [object] from \a [type] as a non-antagonist.")
+
 /atom/proc/add_filter(name,priority,list/params)
 	LAZYINITLIST(filter_data)
 	var/list/p = params.Copy()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1458,7 +1458,7 @@
 	var/message = "has bought [object] from \a [type]"
 	buyer.log_message(message, LOG_GAME)
 	if(isnull(locate(/datum/antagonist) in buyer.mind?.antag_datums))
-		message_admins("[ADMIN_LOOKUPFLW(user)] has bought [object] from \a [type] as a non-antagonist.")
+		message_admins("[ADMIN_LOOKUPFLW(buyer)] has bought [object] from \a [type] as a non-antagonist.")
 
 /atom/proc/add_filter(name,priority,list/params)
 	LAZYINITLIST(filter_data)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1454,10 +1454,9 @@
   * 2 argument is for the item that was purchased
   * 3 argument is for the uplink type (traitor/contractor)
  */
-/proc/log_uplink_purchase(atom/user, atom/object, type = "\improper uplink")
+/proc/log_uplink_purchase(mob/buyer, atom/object, type = "\improper uplink")
 	var/message = "has bought [object] from \a [type]"
-	user.log_message(message, LOG_GAME)
-	var/mob/buyer = user
+	buyer.log_message(message, LOG_GAME)
 	if(isnull(locate(/datum/antagonist) in buyer.mind.antag_datums))
 		message_admins("[ADMIN_LOOKUPFLW(user)] has bought [object] from \a [type] as a non-antagonist.")
 

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -269,7 +269,7 @@
 			to_chat(user, "<span class='notice'>Your purchase materializes into your hands!</span>")
 		else
 			to_chat(user, "<span class='notice'>Your purchase materializes onto the floor.</span>")
-		log_uplink_purchase(user, item_to_create, "\improper contractor_tablet")
+		log_uplink_purchase(user, item_to_create, "\improper contractor tablet")
 		return item_to_create
 	return TRUE
 

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -269,7 +269,7 @@
 			to_chat(user, "<span class='notice'>Your purchase materializes into your hands!</span>")
 		else
 			to_chat(user, "<span class='notice'>Your purchase materializes onto the floor.</span>")
-
+		log_uplink_purchase(user, item_to_create, "\improper contractor_tablet")
 		return item_to_create
 	return TRUE
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -162,6 +162,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 				to_chat(H, "[A] materializes into your hands!")
 				return A
 	to_chat(user, "[A] materializes onto the floor.")
+	log_uplink_purchase(user, A)
 	return A
 
 //Discounts (dynamically filled above)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -160,6 +160,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			var/mob/living/carbon/human/H = user
 			if(H.put_in_hands(A))
 				to_chat(H, "[A] materializes into your hands!")
+				log_uplink_purchase(user, A)
 				return A
 	to_chat(user, "[A] materializes onto the floor.")
 	log_uplink_purchase(user, A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds logging and admin messaging to buying items from an uplink.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easier log diving for admins.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Buying a bundle of items from an uplink

![image](https://user-images.githubusercontent.com/110184118/210800491-d7109085-f1dc-482a-b7e5-7f819e7b6666.png)

Buying items from an uplink as a non-antag

![image](https://user-images.githubusercontent.com/110184118/210800866-2ab10de9-71e5-4da6-a5cf-717fce8006e2.png)

Buying an item from the contractor tablet

![image](https://user-images.githubusercontent.com/110184118/210805134-bdebdcbd-b3d8-4312-9b74-ba0a47c7d6d6.png)

</details>

## Changelog
:cl:
code: Added a log_uplink_purchase proc which logs buying items from an uplink
admin: Added a message for a player buying an item from an uplink as a non-antag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
