### PR TITLE
Removes speechmods from the obsessed trauma

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -37,7 +37,7 @@
 
 /datum/brain_trauma/special/obsessed/on_life()
 	if(!obsession || obsession.stat == DEAD)
-		viewing = FALSE//important, makes sure you no longer stutter when happy if you murdered them while viewing
+		viewing = FALSE
 		return
 	if(get_dist(get_turf(owner), get_turf(obsession)) > 7)
 		viewing = FALSE //they are further than our viewrange they are not viewing us
@@ -70,13 +70,6 @@
 	antagonist?.trauma = null
 	owner.mind.remove_antag_datum(/datum/antagonist/obsessed)
 
-/datum/brain_trauma/special/obsessed/handle_speech(datum/source, list/speech_args)
-	if(!viewing)
-		return
-	var/datum/component/mood/mood = owner.GetComponent(/datum/component/mood)
-	if(mood && mood.sanity >= SANITY_GREAT && social_interaction())
-		speech_args[SPEECH_MESSAGE] = ""
-
 /datum/brain_trauma/special/obsessed/on_hug(mob/living/hugger, mob/living/hugged)
 	if(hugged == obsession)
 		obsession_hug_count++
@@ -97,29 +90,6 @@
 	antagonist.forge_objectives(obsession.mind)
 	to_chat(owner, "<B>You don't know their connection, but The Voices compel you to stalk [obsession], forcing them into a state of constant paranoia.</B>")
 	owner.mind.announce_objectives()
-
-/datum/brain_trauma/special/obsessed/proc/social_interaction()
-	var/fail = FALSE //whether you can finish a sentence while doing it
-	owner.stuttering = max(3, owner.stuttering)
-	owner.blur_eyes(10)
-	switch(rand(1,4))
-		if(1)
-			shake_camera(owner, 15, 1)
-			owner.vomit()
-			fail = TRUE
-		if(2)
-			INVOKE_ASYNC(owner, /mob.proc/emote, "cough")
-			owner.dizziness += 10
-			fail = TRUE
-		if(3)
-			to_chat(owner, "<span class='userdanger'>You feel your heart lurching in your chest...</span>")
-			owner.Stun(20)
-			shake_camera(owner, 15, 1)
-		if(4)
-			to_chat(owner, "<span class='warning'>You faint.</span>")
-			owner.Unconscious(80)
-			fail = TRUE
-	return fail
 
 
 /datum/brain_trauma/special/obsessed/proc/find_obsession()

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -12,10 +12,10 @@
 /datum/antagonist/obsessed/admin_add(datum/mind/new_owner,mob/admin)
 	var/mob/living/carbon/C = new_owner.current
 	if(!istype(C))
-		to_chat(admin, "[roundend_category] come from a brain trauma, so they need to at least be a carbon!")
+		to_chat(admin, "[roundend_category] comes from a brain trauma, so they need to at least be a carbon!")
 		return
 	if(!C.getorgan(/obj/item/organ/brain)) // If only I had a brain
-		to_chat(admin, "[roundend_category] come from a brain trauma, so they need to HAVE A BRAIN.")
+		to_chat(admin, "[roundend_category] comes from a brain trauma, so they need to HAVE A BRAIN.")
 		return
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] into [name].")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] into [name].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This removes the RNG stuttering/vomiting/fainting from trying to talk near your target when you're obsessed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
In practice, this functionality prevented you from interacting with your target for any length of time and immediately flagged you as obsessed if you got bad RNG. That sort of thing tends to remove a lot of RP opportunities that could otherwise come from this antag. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/210886925-8669ccc4-f67c-4012-b8d6-c2067a2656db.png)

Everything compiles properly. I was having some issues getting multiple clients together on my computer, but since this is a removal it *shouldn't* break anything.
</details>

## Changelog
:cl:
tweak: Obsessed antags no longer stutter/vomit/faint while talking near their target.
spellcheck: Fixes a typo in some obsessed logging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
