### PR TITLE
Tweak the error message when compiling in OD

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -109,7 +109,7 @@
 #endif
 
 #if defined(OPENDREAM)
-#error Compiling BeeStation in OpenDream is unsupported, due to BeeStation's dependence on the auxtools DLL to function.
+#error Compiling BeeStation in OpenDream is unsupported due to BeeStation's dependence on the auxtools DLL to function.
 #elif !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(FASTDMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error Switch to VSCode and when prompted install the recommended extensions, you can then either use the UI or press Ctrl+Shift+B to build the codebase.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -108,7 +108,9 @@
 #define CBT
 #endif
 
-#if !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(FASTDMM)
+#if defined(OPENDREAM)
+#error Compiling BeeStation in OpenDream is unsupported, due to BeeStation's dependence on the auxtools DLL to function.
+#elif !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(FASTDMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error Switch to VSCode and when prompted install the recommended extensions, you can then either use the UI or press Ctrl+Shift+B to build the codebase.
 #endif


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If we ever drop auxtools I'll change the error to a warning that says they still need to run the TGUI build script manually.

## Changelog
:cl:
tweak: Attempting to compile BeeStation in OpenDream now gives a better error message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
