### PR TITLE
Fixes bad icon call with directional uranium glass

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -486,7 +486,7 @@
 /obj/structure/window/depleteduranium
 	name = "depleted uranium window"
 	desc = "A window made out of depleted uranium. It looks perfect for radiation shielding!"
-	icon_state = "du_window"
+	icon_state = "duwindow"
 	reinf = TRUE
 	heat_resistance = 50000
 	armor = list("melee" = 45, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "stamina" = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In:
- https://github.com/BeeStation/BeeStation-Hornet/pull/8123
Improper naming scheme was used when calling for the directional window, resulting in the NONAME sprite appearing rather than the correct one.

This fixes that.

I just deleted a character. It works now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![bruh4](https://user-images.githubusercontent.com/62388554/210924992-105f9148-69a5-412f-b8ed-bf33656cc890.PNG)
![bruh6](https://user-images.githubusercontent.com/62388554/210925000-aa86a226-9796-40e2-b8bf-fc3a64d856c0.PNG)
See the discrepancy? (underlined in red)


![gaminsdsd](https://user-images.githubusercontent.com/62388554/210924786-f98b4d55-be81-41b2-8046-3ecddeec0bc5.PNG)
Fixed
</details>

## Changelog
:cl: RKz
fix: Depleted Uranium directional windows will now appear correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
