### PR TITLE
Nerfs overall first aid kits, and compensates the nerfs with some touches

### DIFF
--- a/code/game/gamemodes/gangs/gang_items.dm
+++ b/code/game/gamemodes/gangs/gang_items.dm
@@ -114,7 +114,7 @@
 	if(gangtool?.free_pen)
 		return "(GET ONE FREE)"
 	return ..()
-	
+
 /datum/gang_item/essentials/reinforce
 	name = "Call Reinforcments"
 	id = "reinforce"
@@ -393,7 +393,7 @@
 /obj/item/storage/firstaid/shifty/hangover/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/storage/pill_bottle/charcoal = 1,
-		/obj/item/reagent_containers/syringe/antitoxin = 1,
+		/obj/item/reagent_containers/syringe/antitoxin_carth = 1,
 		/obj/item/reagent_containers/hypospray/medipen = 2,
 		/obj/item/reagent_containers/hypospray/medipen/dexalin = 2,
 		/obj/item/healthanalyzer = 1)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -36,7 +36,7 @@
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 1,
 		/obj/item/stack/medical/ointment = 1,
-		/obj/item/storage/pill_bottle/tricordrazine_first_aid = 1,
+		/obj/item/storage/pill_bottle/first_aid_tricordrazine = 1,
 		/obj/item/reagent_containers/hypospray/medipen = 3)
 	generate_items_inside(items_inside,src)
 
@@ -111,7 +111,7 @@
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 1,
 		/obj/item/stack/medical/ointment = 1,
-		/obj/item/storage/pill_bottle/tricordrazine_first_aid/medical_doctor = 1,
+		/obj/item/storage/pill_bottle/first_aid_tricordrazine/medical_doctor = 1,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/healthanalyzer = 1,
 		/obj/item/surgical_drapes = 1,
@@ -138,9 +138,9 @@
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 2,
 		/obj/item/stack/medical/bruise_pack = 2,
-		/obj/item/storage/pill_bottle/bicaridine = 1,
+		/obj/item/storage/pill_bottle/brute_treatment = 1,
 		/obj/item/stack/medical/ointment= 2,
-		/obj/item/storage/pill_bottle/kelotane = 1)
+		/obj/item/storage/pill_bottle/burn_treatment = 1)
 	generate_items_inside(items_inside,src)
 
 
@@ -165,7 +165,7 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/silver_sulf = 4,
-		/obj/item/storage/pill_bottle/kelotane = 1,
+		/obj/item/storage/pill_bottle/burn_treatment = 1,
 		/obj/item/stack/medical/ointment = 2)
 	generate_items_inside(items_inside,src)
 
@@ -266,7 +266,7 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/styptic = 4,
-		/obj/item/storage/pill_bottle/bicaridine = 1,
+		/obj/item/storage/pill_bottle/brute_treatment = 1,
 		/obj/item/stack/medical/bruise_pack = 1,
 		/obj/item/stack/medical/gauze = 1)
 	generate_items_inside(items_inside,src)
@@ -326,7 +326,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/atropine,
 		/obj/item/storage/pill_bottle/penacid,
 		/obj/item/reagent_containers/pill/patch/styptic,
-		/obj/item/storage/pill_bottle/bicaridine,
+		/obj/item/storage/pill_bottle/brute_treatment,
 		/obj/item/reagent_containers/pill/salbutamol,
 		/obj/item/reagent_containers/hypospray/medipen/dexalin,
 		/obj/item/reagent_containers/pill/mutadone,
@@ -336,7 +336,7 @@
 		/obj/item/reagent_containers/syringe/diphenhydramine,
 		/obj/item/storage/pill_bottle/charcoal,
 		/obj/item/reagent_containers/pill/patch/silver_sulf,
-		/obj/item/storage/pill_bottle/kelotane)
+		/obj/item/storage/pill_bottle/burn_treatment)
 	for(var/i in 1 to 6)
 		var/selected_type = pick(supplies)
 		new selected_type(src)
@@ -435,36 +435,36 @@
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/charcoal(src)
 
-/obj/item/storage/pill_bottle/bicaridine
-	name = "bottle of bicaridine pills"
-	desc = "Contains pills used to treat moderate to small brute injuries."
+/obj/item/storage/pill_bottle/brute_treatment
+	name = "bottle of brute-treatment pills"
+	desc = "Contains pills used to treat moderate to small brute injuries. The label on it says: 'Total contents: 7 pills of Bicaridine 15u + Salicyclic Acid 2u.'"
 
-/obj/item/storage/pill_bottle/bicaridine/PopulateContents()
+/obj/item/storage/pill_bottle/brute_treatment/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/pill/bicaridine(src)
+		new /obj/item/reagent_containers/pill/brute_treatment(src)
 
-/obj/item/storage/pill_bottle/kelotane
-	name = "bottle of kelotane pills"
-	desc = "Contains pills used to treat moderate to small burns."
+/obj/item/storage/pill_bottle/burn_treatment
+	name = "bottle of burn-treatment pills"
+	desc = "Contains pills used to treat moderate to small burns. The label on it says: 'Total contents: 7 pills of Kelotane 15u + Oxandrolone 2u.'"
 
-/obj/item/storage/pill_bottle/kelotane/PopulateContents()
+/obj/item/storage/pill_bottle/burn_treatment/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/pill/kelotane(src)
+		new /obj/item/reagent_containers/pill/burn_treatment(src)
 
-/obj/item/storage/pill_bottle/tricordrazine_first_aid
+/obj/item/storage/pill_bottle/first_aid_tricordrazine
 	name = "bottle of Pain Relief pills"
 	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x3. WARNING: Do NOT take more than one pill.'"
 
-/obj/item/storage/pill_bottle/tricordrazine_first_aid/PopulateContents()
+/obj/item/storage/pill_bottle/first_aid_tricordrazine/PopulateContents()
 	for(var/i in 1 to 3)
-		new /obj/item/reagent_containers/pill/tricordrazine_first_aid(src)
+		new /obj/item/reagent_containers/pill/first_aid_tricordrazine(src)
 
-/obj/item/storage/pill_bottle/tricordrazine_first_aid/medical_doctor
+/obj/item/storage/pill_bottle/first_aid_tricordrazine/medical_doctor
 	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x7. WARNING: Do NOT take more than one pill.'"
 
-/obj/item/storage/pill_bottle/tricordrazine_first_aid/medical_doctor/PopulateContents()
+/obj/item/storage/pill_bottle/first_aid_tricordrazine/medical_doctor/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/pill/tricordrazine_first_aid(src)
+		new /obj/item/reagent_containers/pill/first_aid_tricordrazine(src)
 
 /obj/item/storage/pill_bottle/antirad
 	name = "bottle of anti-radiation pills"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -437,7 +437,7 @@
 
 /obj/item/storage/pill_bottle/brute_treatment
 	name = "bottle of brute-treatment pills"
-	desc = "Contains pills used to treat moderate to small brute injuries. The label on it says: 'Total contents: 7 pills of Bicaridine 15u + Salicyclic Acid 2u.'"
+	desc = "Contains pills used to treat moderate to small brute injuries. The label on it says: 'Total contents: 7 pills of Bicaridine 10u + Salicyclic Acid 2u.'"
 
 /obj/item/storage/pill_bottle/brute_treatment/PopulateContents()
 	for(var/i in 1 to 7)
@@ -445,7 +445,7 @@
 
 /obj/item/storage/pill_bottle/burn_treatment
 	name = "bottle of burn-treatment pills"
-	desc = "Contains pills used to treat moderate to small burns. The label on it says: 'Total contents: 7 pills of Kelotane 15u + Oxandrolone 2u.'"
+	desc = "Contains pills used to treat moderate to small burns. The label on it says: 'Total contents: 7 pills of Kelotane 10u + Oxandrolone 2u.'"
 
 /obj/item/storage/pill_bottle/burn_treatment/PopulateContents()
 	for(var/i in 1 to 7)
@@ -453,7 +453,7 @@
 
 /obj/item/storage/pill_bottle/first_aid_tricordrazine
 	name = "bottle of Pain Relief pills"
-	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x3. WARNING: Do NOT take more than one pill.'"
+	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x4. WARNING: Do NOT take more than one pill.'"
 
 /obj/item/storage/pill_bottle/first_aid_tricordrazine/PopulateContents()
 	for(var/i in 1 to 4)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -34,9 +34,10 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
-		/obj/item/stack/medical/bruise_pack = 2,
-		/obj/item/stack/medical/ointment = 2,
-		/obj/item/reagent_containers/hypospray/medipen = 2)
+		/obj/item/stack/medical/bruise_pack = 1,
+		/obj/item/stack/medical/ointment = 1,
+		/obj/item/storage/pill_bottle/tricordrazine_first_aid = 1,
+		/obj/item/reagent_containers/hypospray/medipen = 3)
 	generate_items_inside(items_inside,src)
 
 
@@ -108,13 +109,15 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
-		/obj/item/stack/medical/bruise_pack = 2,
-		/obj/item/stack/medical/ointment = 2,
+		/obj/item/stack/medical/bruise_pack = 1,
+		/obj/item/stack/medical/ointment = 1,
+		/obj/item/storage/pill_bottle/tricordrazine_first_aid/medical_doctor = 1,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/healthanalyzer = 1,
 		/obj/item/surgical_drapes = 1,
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,
+		/obj/item/retractor = 1,
 		/obj/item/cautery = 1)
 	generate_items_inside(items_inside,src)
 
@@ -134,8 +137,10 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 2,
-		/obj/item/stack/medical/bruise_pack = 3,
-		/obj/item/stack/medical/ointment= 3)
+		/obj/item/stack/medical/bruise_pack = 2,
+		/obj/item/storage/pill_bottle/bicaridine = 1,
+		/obj/item/stack/medical/ointment= 2,
+		/obj/item/storage/pill_bottle/kelotane = 1)
 	generate_items_inside(items_inside,src)
 
 
@@ -185,7 +190,7 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/syringe/antitoxin = 4,
+		/obj/item/reagent_containers/syringe/antitoxin_carth = 4,
 		/obj/item/reagent_containers/syringe/calomel = 1,
 		/obj/item/reagent_containers/syringe/diphenhydramine = 1,
 		/obj/item/storage/pill_bottle/charcoal = 1)
@@ -326,7 +331,7 @@
 		/obj/item/reagent_containers/hypospray/medipen/dexalin,
 		/obj/item/reagent_containers/pill/mutadone,
 		/obj/item/reagent_containers/pill/antirad,
-		/obj/item/reagent_containers/syringe/antitoxin,
+		/obj/item/reagent_containers/syringe/antitoxin_carth,
 		/obj/item/reagent_containers/syringe/calomel,
 		/obj/item/reagent_containers/syringe/diphenhydramine,
 		/obj/item/storage/pill_bottle/charcoal,
@@ -445,6 +450,18 @@
 /obj/item/storage/pill_bottle/kelotane/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/kelotane(src)
+
+/obj/item/storage/pill_bottle/tricordrazine_first_aid
+	name = "bottle of Washes Pain Away pills"
+	desc = "A pill bottle that contains pills that tend all small damages. Its label says: 'Supplement Facts: Tricordrazine 36u. WARN: Do NOT eat more than one pill.'"
+
+/obj/item/storage/pill_bottle/tricordrazine_first_aid/PopulateContents()
+	for(var/i in 1 to 3)
+		new /obj/item/reagent_containers/pill/tricordrazine_first_aid(src)
+
+/obj/item/storage/pill_bottle/tricordrazine_first_aid/medical_doctor/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/tricordrazine_first_aid(src)
 
 /obj/item/storage/pill_bottle/antirad
 	name = "bottle of anti-radiation pills"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -452,8 +452,8 @@
 		new /obj/item/reagent_containers/pill/kelotane(src)
 
 /obj/item/storage/pill_bottle/tricordrazine_first_aid
-	name = "bottle of Washes Pain Away pills"
-	desc = "A pill bottle that contains pills that tend all small damages. Its label says: 'Supplement Facts: Tricordrazine 36u. WARN: Do NOT eat more than one pill.'"
+	name = "bottle of Pain Relief pills"
+	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x7. WARNING: Do NOT take more than one pill.'"
 
 /obj/item/storage/pill_bottle/tricordrazine_first_aid/PopulateContents()
 	for(var/i in 1 to 3)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -453,11 +453,14 @@
 
 /obj/item/storage/pill_bottle/tricordrazine_first_aid
 	name = "bottle of Pain Relief pills"
-	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x7. WARNING: Do NOT take more than one pill.'"
+	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x3. WARNING: Do NOT take more than one pill.'"
 
 /obj/item/storage/pill_bottle/tricordrazine_first_aid/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/pill/tricordrazine_first_aid(src)
+
+/obj/item/storage/pill_bottle/tricordrazine_first_aid/medical_doctor
+	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x7. WARNING: Do NOT take more than one pill.'"
 
 /obj/item/storage/pill_bottle/tricordrazine_first_aid/medical_doctor/PopulateContents()
 	for(var/i in 1 to 7)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -456,7 +456,7 @@
 	desc = "A pill bottle containing basic healing medicine. The label on it says: 'Total contents: Tricordrazine 36u x3. WARNING: Do NOT take more than one pill.'"
 
 /obj/item/storage/pill_bottle/first_aid_tricordrazine/PopulateContents()
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 4)
 		new /obj/item/reagent_containers/pill/first_aid_tricordrazine(src)
 
 /obj/item/storage/pill_bottle/first_aid_tricordrazine/medical_doctor

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -152,7 +152,7 @@
 	name = "brute-treatment pill"
 	desc = "Used to stimulate the healing of small brute injuries."
 	icon_state = "pill9"
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 15,
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 10,
 						/datum/reagent/medicine/sal_acid = 2) // enough to heal 30 brute damage (2u / 0.2 = 10 ticks * 3 heal = 30 damage)
 	rename_with_volume = FALSE
 
@@ -160,7 +160,7 @@
 	name = "burn-treatment pill"
 	desc = "Used to stimulate the healing of small burns."
 	icon_state = "pill11"
-	list_reagents = list(/datum/reagent/medicine/kelotane = 15,
+	list_reagents = list(/datum/reagent/medicine/kelotane = 10,
 						/datum/reagent/medicine/oxandrolone = 2) // enough to heal 30 burn damage (2u / 0.2 = 10 ticks * 3 heal = 30 damage)
 	rename_with_volume = FALSE
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -162,6 +162,13 @@
 	list_reagents = list(/datum/reagent/medicine/kelotane = 15)
 	rename_with_volume = TRUE
 
+/obj/item/reagent_containers/pill/tricordrazine_first_aid
+	name = "Washes Pain Away pill"
+	desc = "A simple pill that tends all small damages. You might need to read an drug instruction in the pill bottle..."
+	icon_state = "pill_happy"
+	list_reagents = list(/datum/reagent/medicine/tricordrazine = 36)
+	rename_with_volume = FALSE
+
 /obj/item/reagent_containers/pill/salicyclic
 	name = "salicylic acid pill"
 	desc = "Used to dull pain."

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -148,21 +148,23 @@
 	list_reagents = list(/datum/reagent/medicine/mutadone = 50)
 	rename_with_volume = TRUE
 
-/obj/item/reagent_containers/pill/bicaridine
-	name = "bicaridine pill"
+/obj/item/reagent_containers/pill/brute_treatment
+	name = "brute-treatment pill"
 	desc = "Used to stimulate the healing of small brute injuries."
 	icon_state = "pill9"
-	list_reagents = list(/datum/reagent/medicine/bicaridine = 15)
-	rename_with_volume = TRUE
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 15,
+						/datum/reagent/medicine/sal_acid = 2) // enough to heal 30 brute damage (2u / 0.2 = 10 ticks * 3 heal = 30 damage)
+	rename_with_volume = FALSE
 
-/obj/item/reagent_containers/pill/kelotane
-	name = "kelotane pill"
+/obj/item/reagent_containers/pill/burn_treatment
+	name = "burn-treatment pill"
 	desc = "Used to stimulate the healing of small burns."
 	icon_state = "pill11"
-	list_reagents = list(/datum/reagent/medicine/kelotane = 15)
-	rename_with_volume = TRUE
+	list_reagents = list(/datum/reagent/medicine/kelotane = 15,
+						/datum/reagent/medicine/oxandrolone = 2) // enough to heal 30 burn damage (2u / 0.2 = 10 ticks * 3 heal = 30 damage)
+	rename_with_volume = FALSE
 
-/obj/item/reagent_containers/pill/tricordrazine_first_aid
+/obj/item/reagent_containers/pill/first_aid_tricordrazine
 	name = "Pain Relief pill"
 	desc = "A pill that cures basic ailments. You feel like you should read the instructions on the pill bottle again..."
 	icon_state = "pill_happy"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -163,8 +163,8 @@
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/tricordrazine_first_aid
-	name = "Washes Pain Away pill"
-	desc = "A simple pill that tends all small damages. You might need to read an drug instruction in the pill bottle..."
+	name = "Pain Relief pill"
+	desc = "A pill that cures basic ailments. You feel like you should read the instructions on the pill bottle again..."
 	icon_state = "pill_happy"
 	list_reagents = list(/datum/reagent/medicine/tricordrazine = 36)
 	rename_with_volume = FALSE

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -243,10 +243,11 @@
 	desc = "Contains charcoal."
 	list_reagents = list(/datum/reagent/medicine/charcoal = 15)
 
-/obj/item/reagent_containers/syringe/antitoxin
-	name = "syringe (antitoxin)"
-	desc = "Contains antitoxin."
-	list_reagents = list(/datum/reagent/medicine/antitoxin = 15)
+/obj/item/reagent_containers/syringe/antitoxin_carth
+	name = "syringe (antitoxin + carthatoline)"
+	desc = "Contains antitoxin 10.5u and carthatoline 4.5u."
+	list_reagents = list(/datum/reagent/medicine/antitoxin = 10.5, // 3.5u per use
+						/datum/reagent/medicine/carthatoline = 4.5) // 1.5u per use
 
 /obj/item/reagent_containers/syringe/diphenhydramine
 	name = "syringe (diphenhydramine)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
follow-up PR with https://github.com/BeeStation/BeeStation-Hornet/pull/7936
* adds tricordrazine pills to first aid kits
* adjust medical basic kits
* compensates some toxin cases for the medbay since it'd be difficult to manage with default ones. (antitoxin syringe is currently awful for this state, so buff it a bit)
* retractor is now default to the doctor's box. That's because I removed one brute pack and one ointment!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
first aid kits are too strong. let's make it less-powergamy with awfully nerfed medicine pills.

basic medical kit with 'basic medicine' will be nightmare for right now, so lets buff it a little.
2u of advanced chem is enough to heal 30 damage

there are a few compensation since the nerf is a bit impactful.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![image](https://user-images.githubusercontent.com/87972842/211189076-5a6096d4-902b-47bf-b129-6093a65cf9e7.png)

![image](https://user-images.githubusercontent.com/87972842/211189237-95da23d1-9dac-411f-a32f-fbf38a387479.png)

-------------

![image](https://user-images.githubusercontent.com/87972842/211189263-b98dd376-041c-400d-8f38-c7e629db6dd6.png)

![image](https://user-images.githubusercontent.com/87972842/211189325-8ecbb2db-d6c8-44e0-b657-a058af6ce915.png)

first aid one only has 4 pills. (increased 3 to 4 later)

------------

![image](https://user-images.githubusercontent.com/87972842/211189270-d6d4ded2-f017-44e4-8f37-dff1b111440a.png)

----------

![image](https://user-images.githubusercontent.com/87972842/211285389-581850e5-945b-4ec4-ad26-06aa8cbfb060.png)

</details>

## Changelog
:cl:
add: a pre-made pill 'Pain Relief' that has 36u of tricordrazine, and its pill bottle. (Note: Tricordrazine effect was changed.)
add: a pre-made pill 'brute-treatment' that has bicaridine 10u + salicyclic acid 2u.
add: a pre-made pill 'burn-treatment' that has which contains kelotane 10u + oxandrolon 2u.
balance: medical roundstart brute kit's pill bottle is now filled with 7 of 'brute-treatment' pills
balance: medical roundstart burn kit's pill bottle is now filled with 7 of 'burn-treatment' pills
balance: medical roundstart toxin kit's antitoxin syringe is now filled with antitoxin(10.5u) + carthatoline(4.5u).
balance: all types of first aid kits have one less bruise pack and one less ointment than before, and these will get a pill bottle of 'Pain Relief' pills, and one additional epipen instead. (ancient first aid kit takes bicaridine/kelotane pill bottle instead)
tweak: doctors will have a retractor in their roundstart medikit (since they have less brute pack and ointment)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
