### PR TITLE
Areas now use correct \improper usage in naming

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1175,7 +1175,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "checkpoint_sci"
 
 /area/security/checkpoint/science/research
-	name = \improper "Security Post - Research Division"
+	name = "\improper Security Post - Research Division"
 	icon_state = "checkpoint_res"
 
 /area/security/checkpoint/customs
@@ -1409,11 +1409,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/storage/tools
-	name = "\improperAuxiliary Tool Storage"
+	name = "\improper Auxiliary Tool Storage"
 	icon_state = "tool_storage"
 
 /area/storage/primary
-	name = "\improperPrimary Tool Storage"
+	name = "\improper Primary Tool Storage"
 	icon_state = "primarystorage"
 
 /area/storage/art

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -57,7 +57,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //EXTRA
 
 /area/asteroid
-	name = "Asteroid"
+	name = "\improper Asteroid"
 	icon_state = "asteroid"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
@@ -73,7 +73,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	area_flags = UNIQUE_AREA | BLOBS_ALLOWED
 
 /area/asteroid/nearstation/bomb_site
-	name = "Bomb Testing Asteroid"
+	name = "\improper Bomb Testing Asteroid"
 
 //STATION13
 
@@ -87,28 +87,28 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_bulb = "#1c748a"
 
 /area/docking/arrival
-	name = "Arrival Docking Area"
+	name = "\improper Arrivals Docking Area"
 	icon_state = "arrivaldockarea"
 
 /area/docking/arrivalaux
-	name = "Auxiliary Arrival Docking Area"
+	name = "\improper Auxiliary Arrivals Docking Area"
 	icon_state = "arrivalauxdockarea"
 
 /area/docking/bridge
-	name = "Bridge Docking Area"
+	name = "\improper Bridge Docking Area"
 	icon_state = "bridgedockarea"
 
 //Dry Dock
 
 /area/drydock
-	name = "Shuttle drydock"
+	name = "\improper Shuttle Drydock"
 	icon_state = "drydock"
 	ambience_index = AMBIENCE_MAINT
 	lighting_colour_tube = "#1c748a"
 	lighting_colour_bulb = "#1c748a"
 
 /area/drydock/security
-	name = "Security Shuttle drydock"
+	name = "\improper Security Shuttle Drydock"
 	icon_state = "drydock_sec"
 
 //Maintenance
@@ -206,141 +206,141 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Maintenance - Generic
 
 /area/maintenance/aft
-	name = "Aft Maintenance"
+	name = "\improper Aft Maintenance"
 	icon_state = "aftmaint"
 
 /area/maintenance/aft/secondary
-	name = "Aft Maintenance"
+	name = "\improper Aft Maintenance"
 	icon_state = "aftmaint"
 
 /area/maintenance/central
-	name = "Central Maintenance"
+	name = "\improper Central Maintenance"
 	icon_state = "centralmaint"
 
 /area/maintenance/central/secondary
-	name = "Central Maintenance"
+	name = "\improper Central Maintenance"
 	icon_state = "centralmaint"
 
 /area/maintenance/fore
-	name = "Fore Maintenance"
+	name = "\improper Fore Maintenance"
 	icon_state = "foremaint"
 
 /area/maintenance/fore/secondary
-	name = "Fore Maintenance"
+	name = "\improper Fore Maintenance"
 	icon_state = "foremaint"
 
 /area/maintenance/starboard
-	name = "Starboard Maintenance"
+	name = "\improper Starboard Maintenance"
 	icon_state = "starboardmaint"
 
 /area/maintenance/starboard/central
-	name = "Central Starboard Maintenance"
+	name = "\improper Central Starboard Maintenance"
 	icon_state = "starboardmaint"
 
 /area/maintenance/starboard/secondary
-	name = "Secondary Starboard Maintenance"
+	name = "\improper Secondary Starboard Maintenance"
 	icon_state = "starboardmaint"
 
 /area/maintenance/starboard/aft
-	name = "Starboard Quarter Maintenance"
+	name = "\improper Starboard Quarter Maintenance"
 	icon_state = "asmaint"
 
 /area/maintenance/starboard/aft/secondary
-	name = "Secondary Starboard Quarter Maintenance"
+	name = "\improper Secondary Starboard Quarter Maintenance"
 	icon_state = "asmaint"
 
 /area/maintenance/starboard/fore
-	name = "Starboard Bow Maintenance"
+	name = "\improper Starboard Bow Maintenance"
 	icon_state = "fsmaint"
 
 /area/maintenance/port
-	name = "Port Maintenance"
+	name = "\improper Port Maintenance"
 	icon_state = "portmaint"
 
 /area/maintenance/port/central
-	name = "Central Port Maintenance"
+	name = "\improper Central Port Maintenance"
 	icon_state = "centralmaint"
 
 /area/maintenance/port/aft
-	name = "Port Quarter Maintenance"
+	name = "\improper Port Quarter Maintenance"
 	icon_state = "apmaint"
 
 /area/maintenance/port/fore
-	name = "Port Bow Maintenance"
+	name = "\improper Port Bow Maintenance"
 	icon_state = "fpmaint"
 
 /area/maintenance/disposal
-	name = "Waste Disposal"
+	name = "\improper Waste Disposal"
 	icon_state = "disposal"
 
 /area/maintenance/disposal/incinerator
-	name = "Incinerator"
+	name = "\improper Incinerator"
 	icon_state = "incinerator"
 
 //Maintenance - Upper
 
 /area/maintenance/upper/aft
-	name = "Upper Aft Maintenance"
+	name = "\improper Upper Aft Maintenance"
 	icon_state = "aftmaint"
 
 /area/maintenance/upper/aft/secondary
-	name = "Upper Aft Maintenance"
+	name = "\improper Upper Aft Maintenance"
 	icon_state = "aftmaint"
 
 /area/maintenance/upper/central
-	name = "Upper Central Maintenance"
+	name = "\improper Upper Central Maintenance"
 	icon_state = "centralmaint"
 
 /area/maintenance/upper/central/secondary
-	name = "Upper Central Maintenance"
+	name = "\improper Upper Central Maintenance"
 	icon_state = "centralmaint"
 
 /area/maintenance/upper/fore
-	name = "Upper Fore Maintenance"
+	name = "\improper Upper Fore Maintenance"
 	icon_state = "foremaint"
 
 /area/maintenance/upper/fore/secondary
-	name = "Upper Fore Maintenance"
+	name = "\improper Upper Fore Maintenance"
 	icon_state = "foremaint"
 
 /area/maintenance/upper/starboard
-	name = "Upper Starboard Maintenance"
+	name = "\improper Upper Starboard Maintenance"
 	icon_state = "starboardmaint"
 
 /area/maintenance/upper/starboard/central
-	name = "Upper Central Starboard Maintenance"
+	name = "\improper Upper Central Starboard Maintenance"
 	icon_state = "starboardmaint"
 
 /area/maintenance/upper/starboard/secondary
-	name = "Upper Secondary Starboard Maintenance"
+	name = "\improper Upper Secondary Starboard Maintenance"
 	icon_state = "starboardmaint"
 
 /area/maintenance/upper/starboard/aft
-	name = "Upper Starboard Quarter Maintenance"
+	name = "\improper Upper Starboard Quarter Maintenance"
 	icon_state = "asmaint"
 
 /area/maintenance/upper/starboard/aft/secondary
-	name = "Upper Secondary Starboard Quarter Maintenance"
+	name = "\improper Upper Secondary Starboard Quarter Maintenance"
 	icon_state = "asmaint"
 
 /area/maintenance/upper/starboard/fore
-	name = "Upper Starboard Bow Maintenance"
+	name = "\improper Upper Starboard Bow Maintenance"
 	icon_state = "fsmaint"
 
 /area/maintenance/upper/port
-	name = "Upper Port Maintenance"
+	name = "\improper Upper Port Maintenance"
 	icon_state = "pmaint"
 
 /area/maintenance/upper/port/central
-	name = "Upper Central Port Maintenance"
+	name = "\improper Upper Central Port Maintenance"
 	icon_state = "centralmaint"
 
 /area/maintenance/upper/port/aft
-	name = "Upper Port Quarter Maintenance"
+	name = "\improper Upper Port Quarter Maintenance"
 	icon_state = "apmaint"
 
 /area/maintenance/upper/port/fore
-	name = "Upper Port Bow Maintenance"
+	name = "\improper Upper Port Bow Maintenance"
 	icon_state = "fpmaint"
 
 
@@ -354,108 +354,108 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_brightness_tube = 8
 
 /area/hallway/primary
-	name = "Primary Hallway"
+	name = "\improper Primary Hallway"
 
 /area/hallway/primary/aft
-	name = "Aft Primary Hallway"
+	name = "\improper Aft Primary Hallway"
 	icon_state = "hallA"
 
 /area/hallway/primary/fore
-	name = "Fore Primary Hallway"
+	name = "\improper Fore Primary Hallway"
 	icon_state = "hallF"
 
 /area/hallway/primary/starboard
-	name = "Starboard Primary Hallway"
+	name = "\improper Starboard Primary Hallway"
 	icon_state = "hallS"
 
 /area/hallway/primary/port
-	name = "Port Primary Hallway"
+	name = "\improper Port Primary Hallway"
 	icon_state = "hallP"
 
 /area/hallway/primary/central
-	name = "Central Primary Hallway"
+	name = "\improper Central Primary Hallway"
 	icon_state = "hallC"
 
 /area/hallway/secondary/command
-	name = "Command Hallway"
+	name = "\improper Command Hallway"
 	icon_state = "bridge_hallway"
 
 /area/hallway/secondary/construction
-	name = "Construction Area"
+	name = "\improper Construction Area"
 	icon_state = "construction"
 
 /area/hallway/secondary/exit
-	name = "Escape Shuttle Hallway"
+	name = "\improper Escape Shuttle Hallway"
 	icon_state = "escape"
 
 /area/hallway/secondary/exit/departure_lounge
-	name = "Departure Lounge"
+	name = "\improper Departure Lounge"
 	icon_state = "escape_lounge"
 
 /area/hallway/secondary/entry
-	name = "Arrival Shuttle Hallway"
+	name = "\improper Arrival Shuttle Hallway"
 	icon_state = "entry"
 
 /area/hallway/secondary/service
-	name = "Service Hallway"
+	name = "\improper Service Hallway"
 	icon_state = "hall_service"
 
 /area/hallway/secondary/law
-	name = "Law Hallway"
+	name = "\improper Law Hallway"
 	icon_state = "security"
 
 /area/hallway/secondary/asteroid
-	name = "Asteroid Hallway"
+	name = "\improper Asteroid Hallway"
 	icon_state = "construction"
 
 /area/hallway/upper/primary/aft
-	name = "Upper Aft Primary Hallway"
+	name = "\improper Upper Aft Primary Hallway"
 	icon_state = "hallA"
 
 /area/hallway/upper/primary/fore
-	name = "Upper Fore Primary Hallway"
+	name = "\improper Upper Fore Primary Hallway"
 	icon_state = "hallF"
 
 /area/hallway/upper/primary/starboard
-	name = "Upper Starboard Primary Hallway"
+	name = "\improper Upper Starboard Primary Hallway"
 	icon_state = "hallS"
 
 /area/hallway/upper/primary/port
-	name = "Upper Port Primary Hallway"
+	name = "\improper Upper Port Primary Hallway"
 	icon_state = "hallP"
 
 /area/hallway/upper/primary/central
-	name = "Upper Central Primary Hallway"
+	name = "\improper Upper Central Primary Hallway"
 	icon_state = "hallC"
 
 /area/hallway/upper/secondary/command
-	name = "Upper Command Hallway"
+	name = "\improper Upper Command Hallway"
 	icon_state = "bridge_hallway"
 
 /area/hallway/upper/secondary/construction
-	name = "Upper Construction Area"
+	name = "\improper Upper Construction Area"
 	icon_state = "construction"
 
 /area/hallway/upper/secondary/exit
-	name = "Upper Escape Shuttle Hallway"
+	name = "\improper Upper Escape Shuttle Hallway"
 	icon_state = "escape"
 
 /area/hallway/upper/secondary/exit/departure_lounge
-	name = "Upper Departure Lounge"
+	name = "\improper Upper Departure Lounge"
 	icon_state = "escape_lounge"
 
 /area/hallway/upper/secondary/entry
-	name = "Upper Arrival Shuttle Hallway"
+	name = "\improper Upper Arrival Shuttle Hallway"
 	icon_state = "entry"
 
 /area/hallway/upper/secondary/service
-	name = "Upper Service Hallway"
+	name = "\improper Upper Service Hallway"
 	icon_state = "hall_service"
 
 //Command
 
 /area/bridge
-	name = "Bridge"
+	name = "\improper Bridge"
 	icon_state = "bridge"
 	ambientsounds = list('sound/ambience/signal.ogg')
 
@@ -467,59 +467,59 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/bridge/meeting_room
-	name = "Heads of Staff Meeting Room"
+	name = "\improper Heads of Staff Meeting Room"
 	icon_state = "meeting"
 	sound_environment = SOUND_AREA_MEDIUM_SOFTFLOOR
 
 /area/bridge/meeting_room/council
-	name = "Council Chamber"
+	name = "\improper Council Chamber"
 	icon_state = "meeting"
 	sound_environment = SOUND_AREA_MEDIUM_SOFTFLOOR
 
 /area/bridge/showroom/corporate
-	name = "Corporate Showroom"
+	name = "\improper Corporate Showroom"
 	icon_state = "showroom"
 	sound_environment = SOUND_AREA_MEDIUM_SOFTFLOOR
 
 /area/crew_quarters/heads/captain
-	name = "Captain's Office"
+	name = "\improper Captain's Office"
 	icon_state = "captain"
 	sound_environment = SOUND_AREA_WOODFLOOR
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/crew_quarters/heads/captain/private
-	name = "Captain's Quarters"
+	name = "\improper Captain's Quarters"
 	icon_state = "captain_private"
 	sound_environment = SOUND_AREA_WOODFLOOR
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/crew_quarters/heads/chief
-	name = "Chief Engineer's Office"
+	name = "\improper Chief Engineer's Office"
 	icon_state = "ce_office"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/cmo
-	name = "Chief Medical Officer's Office"
+	name = "\improper Chief Medical Officer's Office"
 	icon_state = "cmo_office"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/hop
-	name = "Head of Personnel's Office"
+	name = "\improper Head of Personnel's Office"
 	icon_state = "hop_office"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/hos
-	name = "Head of Security's Office"
+	name = "\improper Head of Security's Office"
 	icon_state = "hos_office"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/crew_quarters/heads/hor
-	name = "Research Director's Office"
+	name = "\improper Research Director's Office"
 	icon_state = "rd_office"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/comms
-	name = "Communications Relay"
+	name = "\improper Communications Relay"
 	icon_state = "tcom_sat_cham"
 	lighting_colour_tube = "#e2feff"
 	lighting_colour_bulb = "#d5fcff"
@@ -527,7 +527,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/server
-	name = "Messaging Server Room"
+	name = "\improper Messaging Server Room"
 	icon_state = "server"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
@@ -541,104 +541,104 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_STANDARD_STATION
 
 /area/crew_quarters/dorms
-	name = "Dormitories"
+	name = "\improper Dormitories"
 	icon_state = "dorms"
 	area_flags = VALID_TERRITORY | BLOBS_ALLOWED | UNIQUE_AREA
 	mood_bonus = 3
 	mood_message = "<span class='nicegreen'>There's no place like the dorms!\n</span>"
 
 /area/commons/dorms/barracks
-	name = "Sleep Barracks"
+	name = "\improper Sleep Barracks"
 
 /area/commons/dorms/barracks/male
-	name = "Male Sleep Barracks"
+	name = "\improper Male Sleep Barracks"
 	icon_state = "dorms_male"
 
 /area/commons/dorms/barracks/female
-	name = "Female Sleep Barracks"
+	name = "\improper Female Sleep Barracks"
 	icon_state = "dorms_female"
 
 /area/commons/dorms/laundry
-	name = "Laundry Room"
+	name = "\improper Laundry Room"
 	icon_state = "laundry_room"
 
 /area/crew_quarters/dorms/upper
-	name = "Upper Dorms"
+	name = "\improper Upper Dorms"
 
 /area/crew_quarters/cryopods
-	name = "Cryopod Room"
+	name = "\improper Cryopod Room"
 	icon_state = "cryopod"
 	lighting_colour_tube = "#e3ffff"
 	lighting_colour_bulb = "#d5ffff"
 
 /area/crew_quarters/toilet
-	name = "Dormitory Toilets"
+	name = "\improper Dormitory Toilets"
 	icon_state = "toilet"
 	lighting_colour_tube = "#e3ffff"
 	lighting_colour_bulb = "#d5ffff"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/crew_quarters/toilet/auxiliary
-	name = "Auxiliary Restrooms"
+	name = "\improper Auxiliary Restrooms"
 	icon_state = "toilet"
 
 /area/crew_quarters/toilet/locker
-	name = "Locker Toilets"
+	name = "\improper Locker Toilets"
 	icon_state = "toilet"
 
 /area/crew_quarters/toilet/restrooms
-	name = "Restrooms"
+	name = "\improper Restrooms"
 	icon_state = "toilet"
 
 /area/crew_quarters/locker
-	name = "Locker Room"
+	name = "\improper Locker Room"
 	icon_state = "locker"
 
 /area/crew_quarters/lounge
-	name = "Lounge"
+	name = "\improper Lounge"
 	icon_state = "yellow"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 
 /area/crew_quarters/fitness
-	name = "Fitness Room"
+	name = "\improper Fitness Room"
 	icon_state = "fitness"
 
 /area/crew_quarters/fitness/locker_room
-	name = "Unisex Locker Room"
+	name = "\improper Unisex Locker Room"
 	icon_state = "fitness"
 
 /area/crew_quarters/fitness/recreation
-	name = "Recreation Area"
+	name = "\improper Recreation Area"
 	icon_state = "fitness"
 
 /area/crew_quarters/fitness/recreation/upper
-	name = "Upper Recreation Area"
+	name = "\improper Upper Recreation Area"
 	icon_state = "fitness"
 
 /area/crew_quarters/park
-	name = "Recrational Park"
+	name = "\improper Recreational Park"
 	icon_state = "fitness"
 	lighting_colour_bulb = "#80aae9"
 	lighting_colour_tube = "#80aae9"
 	lighting_brightness_bulb = 9
 
 /area/crew_quarters/cafeteria
-	name = "Cafeteria"
+	name = "\improper Cafeteria"
 	icon_state = "cafeteria"
 
 /area/crew_quarters/kitchen
-	name = "Kitchen"
+	name = "\improper Kitchen"
 	icon_state = "kitchen"
 	lighting_colour_tube = "#e3ffff"
 	lighting_colour_bulb = "#d5ffff"
 
 /area/crew_quarters/kitchen/coldroom
-	name = "Kitchen Cold Room"
+	name = "\improper Kitchen Cold Room"
 	icon_state = "kitchen_cold"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/crew_quarters/bar
-	name = "Bar"
+	name = "\improper Bar"
 	icon_state = "bar"
 	mood_bonus = 5
 	mood_message = "<span class='nicegreen'>I love being in the bar!\n</span>"
@@ -653,7 +653,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	return ..()
 
 /area/crew_quarters/bar/lounge
-	name = "Bar lounge"
+	name = "\improper Bar lounge"
 	icon_state = "lounge"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 
@@ -666,37 +666,37 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	GLOB.bar_areas += src
 
 /area/crew_quarters/bar/atrium
-	name = "Atrium"
+	name = "\improper Atrium"
 	icon_state = "bar"
 	sound_environment = SOUND_AREA_WOODFLOOR
 
 /area/crew_quarters/electronic_marketing_den
-	name = "Electronic Marketing Den"
+	name = "\improper Electronic Marketing Den"
 	icon_state = "bar"
 
 /area/crew_quarters/abandoned_gambling_den
-	name = "Abandoned Gambling Den"
+	name = "\improper Abandoned Gambling Den"
 	icon_state = "abandoned_g_den"
 
 /area/crew_quarters/abandoned_gambling_den/secondary
 	icon_state = "abandoned_g_den_2"
 
 /area/crew_quarters/theatre
-	name = "Theatre"
+	name = "\improper Theatre"
 	icon_state = "theatre"
 	sound_environment = SOUND_AREA_WOODFLOOR
 
 /area/crew_quarters/theatre/backstage
-	name = "Backstage"
+	name = "\improper Backstage"
 	icon_state = "theatre_back"
 	sound_environment = SOUND_AREA_WOODFLOOR
 
 /area/crew_quarters/theatre/abandoned
-	name = "Abandoned Theatre"
+	name = "\improper Abandoned Theatre"
 	icon_state = "theatre"
 
 /area/library
-	name = "Library"
+	name = "\improper Library"
 	icon_state = "library"
 	flags_1 = NONE
 
@@ -706,12 +706,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/library/lounge
-	name = "Library Lounge"
+	name = "\improper Library Lounge"
 	sound_environment = SOUND_AREA_LARGE_SOFTFLOOR
 	icon_state = "library"
 
 /area/library/abandoned
-	name = "Abandoned Library"
+	name = "\improper Abandoned Library"
 	icon_state = "library"
 	flags_1 = NONE
 
@@ -725,29 +725,29 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/chapel/main
-	name = "Chapel"
+	name = "\improper Chapel"
 
 /area/chapel/main/monastery
-	name = "Monastery"
+	name = "\improper Monastery"
 
 /area/chapel/office
-	name = "Chapel Office"
+	name = "\improper Chapel Office"
 	icon_state = "chapeloffice"
 
 /area/chapel/asteroid
-	name = "Chapel Asteroid"
+	name = "\improper Chapel Asteroid"
 	icon_state = "explored"
 	sound_environment = SOUND_AREA_ASTEROID
 
 /area/chapel/asteroid/monastery
-	name = "Monastery Asteroid"
+	name = "\improper Monastery Asteroid"
 
 /area/chapel/dock
-	name = "Chapel Dock"
+	name = "\improper Chapel Dock"
 	icon_state = "construction"
 
 /area/lawoffice
-	name = "Law Office"
+	name = "\improper Law Office"
 	icon_state = "law"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
@@ -763,7 +763,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/engine/engine_smes
-	name = "Engineering SMES"
+	name = "\improper Engineering SMES"
 	icon_state = "engine_smes"
 
 /area/engine/engineering
@@ -771,7 +771,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "engine"
 
 /area/engineering/hallway
-	name = "Engineering Hallway"
+	name = "\improper Engineering Hallway"
 	icon_state = "engine_hallway"
 
 /area/engine/atmos
@@ -780,37 +780,37 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	flags_1 = NONE
 
 /area/engine/atmospherics_engine
-	name = "Atmospherics Engine"
+	name = "\improper Atmospherics Engine"
 	icon_state = "atmos_engine"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/engine/engine_room //donut station specific
-	name = "Engine Room"
+	name = "\improper Engine Room"
 	icon_state = "engine_sm"
 
 /area/engine/engine_room/external
-	name = "Supermatter External Access"
+	name = "\improper Supermatter External Access"
 	icon_state = "engine_foyer"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/engine/supermatter
-	name = "Supermatter Engine"
+	name = "\improper Supermatter Engine"
 	icon_state = "engine_sm_room"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/engine/break_room
-	name = "Engineering Foyer"
+	name = "\improper Engineering Foyer"
 	icon_state = "engine_foyer"
 	mood_bonus = 2
 	mood_message = "<span class='nicegreen'>Ahhh, time to take a break.\n</span>"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/engine/gravity_generator
-	name = "Gravity Generator Room"
+	name = "\improper Gravity Generator Room"
 	icon_state = "grav_gen"
 	clockwork_warp_allowed = FALSE
 	clockwork_warp_fail = "The gravitons generated here could throw off your warp's destination and possibly throw you into deep space."
@@ -826,7 +826,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "engine_storage_shared"
 
 /area/engine/transit_tube
-	name = "Transit Tube"
+	name = "\improper Transit Tube"
 	icon_state = "transit_tube"
 
 
@@ -841,44 +841,44 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_SPACE
 
 /area/solar/fore
-	name = "Fore Solar Array"
+	name = "\improper Fore Solar Array"
 	icon_state = "yellow"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 
 /area/solar/aft
-	name = "Aft Solar Array"
+	name = "\improper Aft Solar Array"
 	icon_state = "yellow"
 
 /area/solar/aux/port
-	name = "Port Bow Auxiliary Solar Array"
+	name = "\improper Port Bow Auxiliary Solar Array"
 	icon_state = "panelsA"
 
 /area/solar/aux/starboard
-	name = "Starboard Bow Auxiliary Solar Array"
+	name = "\improper Starboard Bow Auxiliary Solar Array"
 	icon_state = "panelsA"
 
 /area/solar/starboard
-	name = "Starboard Solar Array"
+	name = "\improper Starboard Solar Array"
 	icon_state = "panelsS"
 
 /area/solar/starboard/aft
-	name = "Starboard Quarter Solar Array"
+	name = "\improper Starboard Quarter Solar Array"
 	icon_state = "panelsAS"
 
 /area/solar/starboard/fore
-	name = "Starboard Bow Solar Array"
+	name = "\improper Starboard Bow Solar Array"
 	icon_state = "panelsFS"
 
 /area/solar/port
-	name = "Port Solar Array"
+	name = "\improper Port Solar Array"
 	icon_state = "panelsP"
 
 /area/solar/port/aft
-	name = "Port Quarter Solar Array"
+	name = "\improper Port Quarter Solar Array"
 	icon_state = "panelsAP"
 
 /area/solar/port/fore
-	name = "Port Bow Solar Array"
+	name = "\improper Port Bow Solar Array"
 	icon_state = "panelsFP"
 
 
@@ -916,13 +916,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Teleporter
 
 /area/teleporter
-	name = "Teleporter Room"
+	name = "\improper Teleporter Room"
 	icon_state = "teleporter"
 	ambience_index = AMBIENCE_ENGI
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/gateway
-	name = "Gateway"
+	name = "\improper Gateway"
 	icon_state = "gateway"
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_STANDARD_STATION
@@ -942,31 +942,31 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/medical/medbay/zone2
-	name = "Medbay"
+	name = "\improper Medbay"
 	icon_state = "medbay2"
 
 /area/medical/abandoned
-	name = "Abandoned Medbay"
+	name = "\improper Abandoned Medbay"
 	icon_state = "abandoned_medbay"
 	ambientsounds = list('sound/ambience/signal.ogg')
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/medical/medbay/balcony
-	name = "Medbay Balcony"
+	name = "\improper Medbay Balcony"
 	icon_state = "medbay"
 
 /area/medical/medbay/central
-	name = "Medbay Central"
+	name = "\improper Medbay Central"
 	icon_state = "med_central"
 
 /area/medical/medbay/lobby
-	name = "Medbay Lobby"
+	name = "\improper Medbay Lobby"
 	icon_state = "med_lobby"
 
 	//Medbay is a large area, these additional areas help level out APC load.
 
 /area/medical/medbay/aft
-	name = "Medbay Aft"
+	name = "\improper Medbay Aft"
 	icon_state = "med_aft"
 
 /area/medical/storage
@@ -974,11 +974,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "med_storage"
 
 /area/medical/office
-	name = "Medical Office"
+	name = "\improper Medical Office"
 	icon_state = "med_office"
 
 /area/medical/break_room
-	name = "Medical Break Room"
+	name = "\improper Medical Break Room"
 	icon_state = "med_break"
 
 /area/medical/patients_rooms
@@ -1005,7 +1005,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/medical/morgue
-	name = "Morgue"
+	name = "\improper Morgue"
 	icon_state = "morgue"
 	ambience_index = AMBIENCE_SPOOKY
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
@@ -1040,20 +1040,20 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "cryo"
 
 /area/medical/exam_room
-	name = "Exam Room"
+	name = "\improper Exam Room"
 	icon_state = "exam_room"
 
 /area/medical/genetics
-	name = "Genetics Lab"
+	name = "\improper Genetics Lab"
 	icon_state = "genetics"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/medical/genetics/cloning
-	name = "Cloning Lab"
+	name = "\improper Cloning Lab"
 	icon_state = "cloning"
 
 /area/medical/sleeper
-	name = "Medbay Treatment Center"
+	name = "\improper Medbay Treatment Center"
 	icon_state = "exam_room"
 
 
@@ -1069,11 +1069,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/security/main
-	name = "Security Office"
+	name = "\improper Security Office"
 	icon_state = "security"
 
 /area/security/brig
-	name = "Brig"
+	name = "\improper Brig"
 	icon_state = "brig"
 	mood_bonus = -3
 	mood_job_allowed = list(JOB_NAME_HEADOFSECURITY,JOB_NAME_WARDEN,JOB_NAME_SECURITYOFFICER,JOB_NAME_BRIGPHYSICIAN,JOB_NAME_DETECTIVE)
@@ -1082,13 +1082,13 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_message = "<span class='warning'>I hate cramped brig cells.\n</span>"
 
 /area/security/courtroom
-	name = "Courtroom"
+	name = "\improper Courtroom"
 	icon_state = "courtroom"
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/security/prison
-	name = "Prison Wing"
+	name = "\improper Prison Wing"
 	icon_state = "sec_prison"
 	mood_bonus = -4
 	mood_job_allowed = list(JOB_NAME_HEADOFSECURITY,JOB_NAME_WARDEN, JOB_NAME_SECURITYOFFICER)  // JUSTICE!
@@ -1096,35 +1096,35 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_message = "<span class='warning'>I'm trapped here with little hope of escape!\n</span>"
 
 /area/security/prison/shielded
-	name = "Prison Wing Shielded area"
+	name = "\improper Prison Wing Shielded area"
 	icon_state = "sec_prison"
 
 /area/security/processing
-	name = "Labor Shuttle Dock"
+	name = "\improper Labor Shuttle Dock"
 	icon_state = "sec_prison"
 
 /area/security/processing/cremation
-	name = "Security Crematorium"
+	name = "\improper Security Crematorium"
 	icon_state = "sec_prison"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/security/warden
-	name = "Brig Control"
+	name = "\improper Brig Control"
 	icon_state = "Warden"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 
 /area/security/detectives_office
-	name = "Detective's Office"
+	name = "\improper Detective's Office"
 	icon_state = "detective"
 	ambientsounds = list('sound/ambience/ambidet1.ogg','sound/ambience/ambidet2.ogg','sound/ambience/ambidet3.ogg','sound/ambience/ambidet4.ogg')
 
 /area/security/detectives_office/private_investigators_office
-	name = "Private Investigator's Office"
+	name = "\improper Private Investigator's Office"
 	icon_state = "detective"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 
 /area/security/range
-	name = "Firing Range"
+	name = "\improper Firing Range"
 	icon_state = "firingrange"
 
 /area/security/execution
@@ -1133,23 +1133,23 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_message = "<span class='warning'>I feel a sense of impending doom.\n</span>"
 
 /area/security/execution/transfer
-	name = "Transfer Centre"
+	name = "\improper Transfer Centre"
 
 /area/security/execution/education
-	name = "Prisoner Education Chamber"
+	name = "\improper Prisoner Education Chamber"
 
 /area/security/nuke_storage
-	name = "Vault"
+	name = "\improper Vault"
 	icon_state = "nuke_storage"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/ai_monitored/nuke_storage
-	name = "Vault"
+	name = "\improper Vault"
 	icon_state = "nuke_storage"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
 /area/security/checkpoint
-	name = "Security Checkpoint"
+	name = "\improper Security Checkpoint"
 	icon_state = "checkpoint"
 
 /area/security/checkpoint/auxiliary
@@ -1159,23 +1159,23 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "checkpoint_esc"
 
 /area/security/checkpoint/supply
-	name = "Security Post - Cargo Bay"
+	name = "\improper Security Post - Cargo Bay"
 	icon_state = "checkpoint_supp"
 
 /area/security/checkpoint/engineering
-	name = "Security Post - Engineering"
+	name = "\improper Security Post - Engineering"
 	icon_state = "checkpoint_engi"
 
 /area/security/checkpoint/medical
-	name = "Security Post - Medbay"
+	name = "\improper Security Post - Medbay"
 	icon_state = "checkpoint_med"
 
 /area/security/checkpoint/science
-	name = "Security Post - Science"
+	name = "\improper Security Post - Science"
 	icon_state = "checkpoint_sci"
 
 /area/security/checkpoint/science/research
-	name = "Security Post - Research Division"
+	name = \improper "Security Post - Research Division"
 	icon_state = "checkpoint_res"
 
 /area/security/checkpoint/customs
@@ -1186,29 +1186,29 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "customs_point_aux"
 
 /area/security/prison/vip
-	name = "VIP Prison Wing"
+	name = "\improper VIP Prison Wing"
 	icon_state = "sec_prison"
 
 /area/security/prison/asteroid
-	name = "Outer Asteroid Prison Wing"
+	name = "\improper Outer Asteroid Prison Wing"
 	icon_state = "sec_prison"
 
 /area/security/prison/asteroid/service
-	name = "Outer Asteroid Prison Wing Services"
+	name = "\improper Outer Asteroid Prison Wing Services"
 	icon_state = "sec_prison"
 
 /area/security/prison/asteroid/arrival
-	name = "Outer Asteroid Prison Wing Arrival"
+	name = "\improper Outer Asteroid Prison Wing Arrival"
 	icon_state = "sec_prison"
 
 /area/security/prison/asteroid/abbandoned
-	name = "Outer Asteroid Prison Wing Abbandoned maintenance"
+	name = "\improper Outer Asteroid Prison Wing Abandoned maintenance"
 	icon_state = "sec_prison"
 	mood_bonus = -2
 	mood_message = "<span class='warning'>This place gives me the creeps...\n</span>"
 
 /area/security/prison/asteroid/shielded
-	name = "Outer Asteroid Prison Wing Shielded area"
+	name = "\improper Outer Asteroid Prison Wing Shielded area"
 	icon_state = "sec_prison"
 
 //Cargo
@@ -1222,21 +1222,21 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/quartermaster/sorting
-	name = "Delivery Office"
+	name = "\improper Delivery Office"
 	icon_state = "cargo_delivery"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 
 /area/quartermaster/warehouse
-	name = "Warehouse"
+	name = "\improper Warehouse"
 	icon_state = "cargo_warehouse"
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 
 /area/quartermaster/office
-	name = "Cargo Office"
+	name = "\improper Cargo Office"
 	icon_state = "cargo_office"
 
 /area/quartermaster/storage
-	name = "Cargo Bay"
+	name = "\improper Cargo Bay"
 	icon_state = "cargo_bay"
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 
@@ -1246,37 +1246,37 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/quartermaster/qm
-	name = "Quartermaster's Office"
+	name = "\improper Quartermaster's Office"
 	icon_state = "quart_office"
 
 /area/quartermaster/qm_bedroom
-	name = "Quartermaster's Bedroom"
+	name = "\improper Quartermaster's Bedroom"
 	icon_state = "quart_private"
 
 /area/quartermaster/miningdock
-	name = "Mining Dock"
+	name = "\improper Mining Dock"
 	icon_state = "mining_dock"
 
 /area/quartermaster/miningoffice
-	name = "Mining Office"
+	name = "\improper Mining Office"
 	icon_state = "mining"
 
 /area/quartermaster/meeting_room
-	name = "Supply Meeting Room"
+	name = "\improper Supply Meeting Room"
 	icon_state = "quart_perch"
 
 /area/quartermaster/exploration_prep
-	name = "Exploration Preparation Room"
+	name = "\improper Exploration Preparation Room"
 	icon_state = "mining"
 
 /area/quartermaster/exploration_dock
-	name = "Exploration Dock"
+	name = "\improper Exploration Dock"
 	icon_state = "mining"
 
 //Service
 
 /area/janitor
-	name = "Custodial Closet"
+	name = "\improper Custodial Closet"
 	icon_state = "janitor"
 	flags_1 = NONE
 	mood_bonus = -1
@@ -1291,18 +1291,18 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/hydroponics/garden
-	name = "Garden"
+	name = "\improper Garden"
 	icon_state = "garden"
 	mood_bonus = 2
 	mood_message = "<span class='nicegreen'>It's so peaceful in here!\n</span>"
 
 /area/hydroponics/garden/abandoned
-	name = "Abandoned Garden"
+	name = "\improper Abandoned Garden"
 	icon_state = "abandoned_garden"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/hydroponics/garden/monastery
-	name = "Monastery Garden"
+	name = "\improper Monastery Garden"
 	icon_state = "hydro"
 
 
@@ -1329,7 +1329,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "research"
 
 /area/science/xenobiology
-	name = "Xenobiology Lab"
+	name = "\improper Xenobiology Lab"
 	icon_state = "xenobio"
 
 /area/science/shuttle
@@ -1343,35 +1343,35 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/science/test_area
-	name = "Toxins Test Area"
+	name = "\improper Toxins Test Area"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	icon_state = "tox_test"
 
 /area/science/mixing
-	name = "Toxins Mixing Lab"
+	name = "\improper Toxins Mixing Lab"
 	icon_state = "tox_mix"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/science/mixing/chamber
-	name = "Toxins Mixing Chamber"
+	name = "\improper Toxins Mixing Chamber"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	icon_state = "tox_mix_chamber"
 
 /area/science/misc_lab
-	name = "Testing Lab"
+	name = "\improper Testing Lab"
 	icon_state = "tox_misc"
 
 /area/science/misc_lab/range
-	name = "Research Testing Range"
+	name = "\improper Research Testing Range"
 	icon_state = "tox_range"
 
 /area/science/server
-	name = "Research Division Server Room"
+	name = "\improper Research Division Server Room"
 	icon_state = "server"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/science/explab
-	name = "Experimentation Lab"
+	name = "\improper Experimentation Lab"
 	icon_state = "exp_lab"
 
 /area/science/robotics
@@ -1379,28 +1379,28 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "robotics"
 
 /area/science/robotics/mechbay
-	name = "Mech Bay"
+	name = "\improper Mech Bay"
 	icon_state = "mechbay"
 
 /area/science/robotics/lab
-	name = "Robotics Lab"
+	name = "\improper Robotics Lab"
 	icon_state = "ass_line"
 
 /area/science/research
-	name = "Research Division"
+	name = "\improper Research Division"
 	icon_state = "science"
 
 /area/science/research/abandoned
-	name = "Abandoned Research Lab"
+	name = "\improper Abandoned Research Lab"
 	icon_state = "abandoned_sci"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/science/nanite
-	name = "Nanite Lab"
+	name = "\improper Nanite Lab"
 	icon_state = "nanite_lab"
 
 /area/science/shuttledock
-	name = "Science Shuttle Dock"
+	name = "\improper Science Shuttle Dock"
 	icon_state = "sci_dock"
 
 //Storage
@@ -1409,11 +1409,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/storage/tools
-	name = "Auxiliary Tool Storage"
+	name = "\improperAuxiliary Tool Storage"
 	icon_state = "tool_storage"
 
 /area/storage/primary
-	name = "Primary Tool Storage"
+	name = "\improperPrimary Tool Storage"
 	icon_state = "primarystorage"
 
 /area/storage/art
@@ -1445,50 +1445,50 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Construction
 
 /area/construction
-	name = "Construction Area"
+	name = "\improper Construction Area"
 	icon_state = "yellow"
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/construction/mining/aux_base
-	name = "Auxiliary Base Construction"
+	name = "\improper Auxiliary Base Construction"
 	icon_state = "aux_base_construction"
 	sound_environment = SOUND_AREA_MEDIUM_SOFTFLOOR
 
 /area/construction/storage_wing
-	name = "Storage Wing"
+	name = "\improper Storage Wing"
 	icon_state = "storage_wing"
 
 // Vacant Rooms
 /area/vacant_room
-	name = "Vacant Room"
+	name = "\improper Vacant Room"
 	icon_state = "yellow"
 	ambience_index = AMBIENCE_MAINT
 	icon_state = "vacant_room"
 
 /area/vacant_room/office
-	name = "Vacant Office"
+	name = "\improper Vacant Office"
 	icon_state = "vacant_office"
 
 /area/vacant_room/commissary
-	name = "Vacant Commissary"
+	name = "\improper Vacant Commissary"
 	icon_state = "vacant_commissary"
 
 /area/vacant_room/commissary/commissary1
-	name = "Vacant Commissary #1"
+	name = "\improper Vacant Commissary #1"
 	icon_state = "vacant_commissary"
 
 /area/vacant_room/commissary/commissary2
-	name = "Vacant Commissary #2"
+	name = "\improper Vacant Commissary #2"
 	icon_state = "vacant_commissary"
 
 /area/vacant_room/commissary/commissaryFood
-	name = "Vacant Food Stall Commissary"
+	name = "\improper Vacant Food Stall Commissary"
 	icon_state = "vacant_commissary"
 
 /area/vacant_room/commissary/commissaryRandom
-	name = "Unique Commissary"
+	name = "\improper Unique Commissary"
 	icon_state = "vacant_commissary"
 
 //AI
@@ -1498,7 +1498,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/ai_monitored/security/armory
-	name = "Armory"
+	name = "\improper Armory"
 	icon_state = "armory"
 	ambience_index = AMBIENCE_DANGER
 	mood_job_allowed = list(JOB_NAME_WARDEN)
@@ -1521,7 +1521,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	ambientsounds = list('sound/ambience/ambimalf.ogg', 'sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
 
 /area/ai_monitored/turret_protected/ai_upload
-	name = "AI Upload Chamber"
+	name = "\improper AI Upload Chamber"
 	icon_state = "ai_upload"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 	mood_job_allowed = list(JOB_NAME_RESEARCHDIRECTOR, JOB_NAME_CAPTAIN)
@@ -1529,54 +1529,54 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_message = "<span class='nicegreen'>The AI will bend to my will!\n</span>"
 
 /area/ai_monitored/turret_protected/ai_upload_foyer
-	name = "AI Upload Access"
+	name = "\improper AI Upload Access"
 	icon_state = "ai_upload_foyer"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/ai_monitored/turret_protected/ai
-	name = "AI Chamber"
+	name = "\improper AI Chamber"
 	icon_state = "ai_chamber"
 
 /area/ai_monitored/turret_protected/aisat
-	name = "AI Satellite"
+	name = "\improper AI Satellite"
 	icon_state = "ai"
 	sound_environment = SOUND_ENVIRONMENT_ROOM
 
 /area/ai_monitored/turret_protected/aisat/atmos
-	name = "AI Satellite Atmos"
+	name = "\improper AI Satellite Atmos"
 	icon_state = "ai"
 
 /area/ai_monitored/turret_protected/aisat/foyer
-	name = "AI Satellite Foyer"
+	name = "\improper AI Satellite Foyer"
 	icon_state = "ai_foyer"
 
 /area/ai_monitored/turret_protected/aisat/service
-	name = "AI Satellite Service"
+	name = "\improper AI Satellite Service"
 	icon_state = "ai"
 
 /area/ai_monitored/turret_protected/aisat/hallway
-	name = "AI Satellite Hallway"
+	name = "\improper AI Satellite Hallway"
 	icon_state = "ai"
 
 /area/aisat
-	name = "AI Satellite Exterior"
+	name = "\improper AI Satellite Exterior"
 	icon_state = "yellow"
 
 /area/ai_monitored/turret_protected/aisat/maint
-	name = "AI Satellite Maintenance"
+	name = "\improper AI Satellite Maintenance"
 	icon_state = "ai_maint"
 
 /area/ai_monitored/turret_protected/aisat_interior
-	name = "AI Satellite Antechamber"
+	name = "\improper AI Satellite Antechamber"
 	icon_state = "ai_interior"
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 
 /area/ai_monitored/turret_protected/AIsatextAS
-	name = "AI Sat Ext"
+	name = "\improper AI Sat Ext"
 	icon_state = "ai_sat_east"
 
 /area/ai_monitored/turret_protected/AIsatextAP
-	name = "AI Sat Ext"
+	name = "\improper AI Sat Ext"
 	icon_state = "ai_sat_west"
 
 
@@ -1591,7 +1591,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ELITE
 
 /area/tcommsat/computer
-	name = "Telecomms Control Room"
+	name = "\improper Telecomms Control Room"
 	icon_state = "tcom_sat_comp"
 	sound_environment = SOUND_AREA_MEDIUM_SOFTFLOOR
 	mood_job_allowed = list(JOB_NAME_CHIEFENGINEER, JOB_NAME_STATIONENGINEER)
@@ -1599,9 +1599,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_message = "<span class='nicegreen'>It's good to see these in working order.\n</span>"
 
 /area/tcommsat/server
-	name = "Telecomms Server Room"
+	name = "\improper Telecomms Server Room"
 	icon_state = "tcom_sat_cham"
 
 /area/tcommsat/relay
-	name = "Telecommunications Relay"
+	name = "\improper Telecommunications Relay"
 	icon_state = "tcom_sat_cham"

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -1,5 +1,5 @@
 /area/ai_monitored
-	name = "AI Monitored Area"
+	name = "\improper AI Monitored Area"
 	clockwork_warp_allowed = FALSE
 	var/list/obj/machinery/camera/motioncameras = list()
 	var/list/datum/weakref/motionTargets = list()

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -4,7 +4,7 @@
 	icon_state = "dk_yellow"
 
 /area/ruin/powered/clownplanet
-	name = "Clown Planet"
+	name = "\improper Clown Planet"
 	icon_state = "dk_yellow"
 	ambientsounds = list('sound/ambience/clown.ogg')
 
@@ -18,14 +18,14 @@
 	icon_state = "dk_yellow"
 
 /area/ruin/powered/golem_ship
-	name = "Free Golem Ship"
+	name = "\improper Free Golem Ship"
 	icon_state = "dk_yellow"
 
 /area/ruin/powered/greed
 	icon_state = "dk_yellow"
 
 /area/ruin/unpowered/hierophant
-	name = "Hierophant's Arena"
+	name = "\improper Hierophant's Arena"
 	icon_state = "dk_yellow"
 
 /area/ruin/powered/pride
@@ -35,27 +35,27 @@
 	icon_state = "dk_yellow"
 
 /area/ruin/unpowered/syndicate_lava_base
-	name = "Secret Base"
+	name = "\improper Secret Base"
 	icon_state = "dk_yellow"
 	ambience_index = AMBIENCE_DANGER
 
 /area/ruin/unpowered/syndicate_lava_base/engineering
-	name = "Syndicate Lavaland Engineering"
+	name = "\improper Syndicate Lavaland Engineering"
 
 /area/ruin/unpowered/syndicate_lava_base/medbay
-	name = "Syndicate Lavaland Medbay"
+	name = "\improper Syndicate Lavaland Medbay"
 
 /area/ruin/unpowered/syndicate_lava_base/arrivals
 	name = "Syndicate Lavaland Arrivals"
 
 /area/ruin/unpowered/syndicate_lava_base/bar
-	name = "Syndicate Lavaland Bar"
+	name = "\improper Syndicate Lavaland Bar"
 
 /area/ruin/unpowered/syndicate_lava_base/main
-	name = "Syndicate Lavaland Primary Hallway"
+	name = "\improper Syndicate Lavaland Primary Hallway"
 
 /area/ruin/unpowered/syndicate_lava_base/cargo
-	name = "Syndicate Lavaland Cargo Bay"
+	name = "\improper Syndicate Lavaland Cargo Bay"
 
 /area/ruin/unpowered/syndicate_lava_base/chemistry
 	name = "Syndicate Lavaland Chemistry"
@@ -64,13 +64,13 @@
 	name = "Syndicate Lavaland Virology"
 
 /area/ruin/unpowered/syndicate_lava_base/testlab
-	name = "Syndicate Lavaland Experimentation Lab"
+	name = "\improper Syndicate Lavaland Experimentation Lab"
 
 /area/ruin/unpowered/syndicate_lava_base/dormitories
-	name = "Syndicate Lavaland Dormitories"
+	name = "\improper Syndicate Lavaland Dormitories"
 
 /area/ruin/unpowered/syndicate_lava_base/telecomms
-	name = "Syndicate Lavaland Telecommunications"
+	name = "\improper Syndicate Lavaland Telecommunications"
 
 /area/ruin/unpowered/standruin
 	name = "Forgotten Ruin"

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -20,19 +20,19 @@
 // Ruins of "onehalf" ship
 
 /area/ruin/space/has_grav/onehalf/hallway
-	name = "Hallway"
+	name = "\improper Hallway"
 	icon_state = "hallC"
 
 /area/ruin/space/has_grav/onehalf/drone_bay
-	name = "Mining Drone Bay"
+	name = "\improper Mining Drone Bay"
 	icon_state = "engine"
 
 /area/ruin/space/has_grav/onehalf/dorms_med
-	name = "Crew Quarters"
+	name = "\improper Crew Quarters"
 	icon_state = "Sleep"
 
 /area/ruin/space/has_grav/onehalf/bridge
-	name = "Bridge"
+	name = "\improper Bridge"
 	icon_state = "bridge"
 
 
@@ -41,10 +41,10 @@
 	name = "Dinner for Two"
 
 /area/ruin/space/has_grav/powered/cat_man
-	name = "Kitty Den"
+	name = "\improper Kitty Den"
 
 /area/ruin/space/has_grav/powered/authorship
-	name = "Authorship"
+	name = "\improper Authorship"
 
 /area/ruin/space/has_grav/powered/aesthetic
 	name = "Aesthetic"
@@ -54,65 +54,65 @@
 //Ruin of Hotel
 
 /area/ruin/space/has_grav/hotel
-	name = "Hotel"
+	name = "\improper Hotel"
 
 /area/ruin/space/has_grav/hotel/guestroom
-	name = "Hotel Guest Room"
+	name = "\improper Hotel Guest Room"
 	icon_state = "Sleep"
 
 /area/ruin/space/has_grav/hotel/guestroom/room_1
-	name = "Hotel Guest Room 1"
+	name = "\improper Hotel Guest Room 1"
 
 /area/ruin/space/has_grav/hotel/guestroom/room_2
-	name = "Hotel Guest Room 2"
+	name = "\improper Hotel Guest Room 2"
 
 /area/ruin/space/has_grav/hotel/guestroom/room_3
-	name = "Hotel Guest Room 3"
+	name = "\improper Hotel Guest Room 3"
 
 /area/ruin/space/has_grav/hotel/guestroom/room_4
-	name = "Hotel Guest Room 4"
+	name = "\improper Hotel Guest Room 4"
 
 /area/ruin/space/has_grav/hotel/guestroom/room_5
-	name = "Hotel Guest Room 5"
+	name = "\improper Hotel Guest Room 5"
 
 /area/ruin/space/has_grav/hotel/guestroom/room_6
-	name = "Hotel Guest Room 6"
+	name = "\improper Hotel Guest Room 6"
 
 /area/ruin/space/has_grav/hotel/security
-	name = "Hotel Security Post"
+	name = "\improper Hotel Security Post"
 	icon_state = "security"
 
 /area/ruin/space/has_grav/hotel/pool
-	name = "Hotel Pool Room"
+	name = "\improper Hotel Pool Room"
 	icon_state = "fitness"
 
 /area/ruin/space/has_grav/hotel/bar
-	name = "Hotel Bar"
+	name = "\improper Hotel Bar"
 	icon_state = "cafeteria"
 
 /area/ruin/space/has_grav/hotel/power
-	name = "Hotel Power Room"
+	name = "\improper Hotel Power Room"
 	icon_state = "engine_smes"
 
 /area/ruin/space/has_grav/hotel/custodial
-	name = "Hotel Custodial Closet"
+	name = "\improper Hotel Custodial Closet"
 	icon_state = "janitor"
 
 /area/ruin/space/has_grav/hotel/shuttle
-	name = "Hotel Shuttle"
+	name = "\improper Hotel Shuttle"
 	icon_state = "shuttle"
 	requires_power = FALSE
 
 /area/ruin/space/has_grav/hotel/dock
-	name = "Hotel Shuttle Dock"
+	name = "\improper Hotel Shuttle Dock"
 	icon_state = "start"
 
 /area/ruin/space/has_grav/hotel/workroom
-	name = "Hotel Staff Room"
+	name = "\improper Hotel Staff Room"
 	icon_state = "crew_quarters"
 
 /area/ruin/space/has_grav/hotel/secondary_solars
-	name = "Hotel Secondary Solar Control"
+	name = "\improper Hotel Secondary Solar Control"
 	icon_state = "engine_smes"
 
 
@@ -121,43 +121,43 @@
 //Ruin of Derelict Oupost
 
 /area/ruin/space/has_grav/derelictoutpost
-	name = "Derelict Outpost"
+	name = "\improper Derelict Outpost"
 	icon_state = "green"
 
 /area/ruin/space/has_grav/derelictoutpost/cargostorage
-	name = "Derelict Outpost Cargo Storage"
+	name = "\improper Derelict Outpost Cargo Storage"
 	icon_state = "storage"
 
 /area/ruin/space/has_grav/derelictoutpost/cargobay
-	name = "Derelict Outpost Cargo Bay"
+	name = "\improper Derelict Outpost Cargo Bay"
 	icon_state = "quartstorage"
 
 /area/ruin/space/has_grav/derelictoutpost/powerstorage
-	name = "Derelict Outpost Power Storage"
+	name = "\improper Derelict Outpost Power Storage"
 	icon_state = "engine_smes"
 
 /area/ruin/space/has_grav/derelictoutpost/dockedship
-	name = "Derelict Outpost Docked Ship"
+	name = "\improper Derelict Outpost Docked Ship"
 	icon_state = "red"
 
 //Ruin of turretedoutpost
 
 /area/ruin/space/has_grav/turretedoutpost
-	name = "Turreted Outpost"
+	name = "\improper Turreted Outpost"
 	icon_state = "red"
 
 
 //Ruin of old teleporter
 
 /area/ruin/space/oldteleporter
-	name = "Old Teleporter"
+	name = "\improper Old Teleporter"
 	icon_state = "teleporter"
 
 
 //Ruin of mech transport
 
 /area/ruin/space/has_grav/powered/mechtransport
-	name = "Mech Transport"
+	name = "\improper Mech Transport"
 	icon_state = "green"
 
 
@@ -170,46 +170,46 @@
 //Ruin of Deep Storage
 
 /area/ruin/space/has_grav/deepstorage
-	name = "Deep Storage"
+	name = "\improper Deep Storage"
 	icon_state = "storage"
 
 /area/ruin/space/has_grav/deepstorage/airlock
-	name = "Deep Storage Airlock"
+	name = "\improper Deep Storage Airlock"
 	icon_state = "quart"
 
 /area/ruin/space/has_grav/deepstorage/power
-	name = "Deep Storage Power and Atmospherics Room"
+	name = "\improper Deep Storage Power and Atmospherics Room"
 	icon_state = "engi_storage"
 
 /area/ruin/space/has_grav/deepstorage/hydroponics
-	name = "Deep Storage Hydroponics"
+	name = "\improper Deep Storage Hydroponics"
 	icon_state = "garden"
 
 /area/ruin/space/has_grav/deepstorage/armory
-	name = "Deep Storage Secure Storage"
+	name = "\improper Deep Storage Secure Storage"
 	icon_state = "armory"
 
 /area/ruin/space/has_grav/deepstorage/storage
-	name = "Deep Storage Storage"
+	name = "\improper Deep Storage Storage"
 	icon_state = "storage_wing"
 
 /area/ruin/space/has_grav/deepstorage/dorm
-	name = "Deep Storage Dormitory"
+	name = "\improper Deep Storage Dormitory"
 	icon_state = "crew_quarters"
 
 /area/ruin/space/has_grav/deepstorage/kitchen
-	name = "Deep Storage Kitchen"
+	name = "\improper Deep Storage Kitchen"
 	icon_state = "kitchen"
 
 /area/ruin/space/has_grav/deepstorage/crusher
-	name = "Deep Storage Recycler"
+	name = "\improper Deep Storage Recycler"
 	icon_state = "storage"
 
 
 //Ruin of Abandoned Zoo
 
 /area/ruin/space/has_grav/abandonedzoo
-	name = "Abandoned Zoo"
+	name = "\improper Abandoned Zoo"
 	icon_state = "green"
 
 
@@ -253,11 +253,11 @@
 	icon_state = "captain"
 
 /area/ruin/space/has_grav/ancientstation/hydroponics
-	name = "Charlie Station Hydroponics"
+	name = "\improper Charlie Station Hydroponics"
 	icon_state = "garden"
 
 /area/ruin/space/has_grav/ancientstation/kitchen
-	name = "Charlie Station Kitchen"
+	name = "\improper Charlie Station Kitchen"
 	icon_state = "kitchen"
 
 /area/ruin/space/has_grav/ancientstation/sec
@@ -269,7 +269,7 @@
 	icon_state = "green"
 
 /area/ruin/space/has_grav/ancientstation/proto
-	name = "Delta Station Prototype Lab"
+	name = "\improper Delta Station Prototype Lab"
 	icon_state = "toxlab"
 
 /area/ruin/space/has_grav/ancientstation/rnd
@@ -283,70 +283,70 @@
 //DERELICT
 
 /area/ruin/space/derelict
-	name = "Derelict Station"
+	name = "\improper Derelict Station"
 	icon_state = "storage"
 
 /area/ruin/space/derelict/hallway/primary
-	name = "Derelict Primary Hallway"
+	name = "\improper Derelict Primary Hallway"
 	icon_state = "hallP"
 
 /area/ruin/space/derelict/hallway/secondary
-	name = "Derelict Secondary Hallway"
+	name = "\improper Derelict Secondary Hallway"
 	icon_state = "hallS"
 
 /area/ruin/space/derelict/hallway/primary/port
-	name = "Derelict Port Hallway"
+	name = "\improper Derelict Port Hallway"
 	icon_state = "hallFP"
 
 /area/ruin/space/derelict/arrival
-	name = "Derelict Arrival Centre"
+	name = "\improper Derelict Arrival Centre"
 	icon_state = "yellow"
 
 /area/ruin/space/derelict/storage/equipment
-	name = "Derelict Equipment Storage"
+	name = "\improper Derelict Equipment Storage"
 
 /area/ruin/space/derelict/bridge
-	name = "Derelict Control Room"
+	name = "\improper Derelict Control Room"
 	icon_state = "bridge"
 
 /area/ruin/space/derelict/bridge/access
-	name = "Derelict Control Room Access"
+	name = "\improper Derelict Control Room Access"
 	icon_state = "auxstorage"
 
 /area/ruin/space/derelict/bridge/ai_upload
-	name = "Derelict Computer Core"
+	name = "\improper Derelict Computer Core"
 	icon_state = "ai"
 
 /area/ruin/space/derelict/solar_control
-	name = "Derelict Solar Control"
+	name = "\improper Derelict Solar Control"
 	icon_state = "engine"
 
 /area/ruin/space/derelict/se_solar
-	name = "South East Solars"
+	name = "\improper South East Solars"
 	icon_state = "engine"
 
 /area/ruin/space/derelict/medical
-	name = "Derelict Medbay"
+	name = "\improper Derelict Medbay"
 	icon_state = "medbay"
 
 /area/ruin/space/derelict/medical/chapel
-	name = "Derelict Chapel"
+	name = "\improper Derelict Chapel"
 	icon_state = "chapel"
 
 /area/solar/derelict_starboard
-	name = "Derelict Starboard Solar Array"
+	name = "\improper Derelict Starboard Solar Array"
 	icon_state = "panelsS"
 
 /area/solar/derelict_aft
-	name = "Derelict Aft Solar Array"
+	name = "\improper Derelict Aft Solar Array"
 	icon_state = "yellow"
 
 /area/ruin/space/derelict/singularity_engine
-	name = "Derelict Singularity Engine"
+	name = "\improper Derelict Singularity Engine"
 	icon_state = "engine"
 
 /area/ruin/space/derelict/gravity_generator
-	name = "Derelict Gravity Generator Room"
+	name = "\improper Derelict Gravity Generator Room"
 	icon_state = "red"
 
 /area/ruin/space/derelict/atmospherics
@@ -356,12 +356,12 @@
 //DJSTATION
 
 /area/ruin/space/djstation
-	name = "Ruskie DJ Station"
+	name = "\improper Ruskie DJ Station"
 	icon_state = "DJ"
 	has_gravity = STANDARD_GRAVITY
 
 /area/ruin/space/djstation/solars
-	name = "DJ Station Solars"
+	name = "\improper DJ Station Solars"
 	icon_state = "DJ"
 	has_gravity = STANDARD_GRAVITY
 
@@ -369,36 +369,36 @@
 //ABANDONED TELEPORTER
 
 /area/ruin/space/abandoned_tele
-	name = "Abandoned Teleporter"
+	name = "\improper Abandoned Teleporter"
 	icon_state = "teleporter"
 	ambientsounds = list('sound/ambience/ambimalf.ogg', 'sound/ambience/signal.ogg')
 
 //OLD AI SAT
 
 /area/tcommsat/oldaisat
-	name = "Abandoned Satellite"
+	name = "\improper Abandoned Satellite"
 	icon_state = "tcomsatcham"
 
 //ABANDONED BOX WHITESHIP
 
 /area/ruin/space/has_grav/whiteship/box
 
-	name = "Abandoned Ship"
+	name = "\improper Abandoned Ship"
 	icon_state = "red"
 
 
 //SYNDICATE LISTENING POST STATION
 
 /area/ruin/space/has_grav/listeningstation
-	name = "Listening Post"
+	name = "\improper Listening Post"
 	icon_state = "yellow"
 
 /area/ruin/space/has_grav/powered/ancient_shuttle
-	name = "Ancient Shuttle"
+	name = "\improper Ancient Shuttle"
 	icon_state = "yellow"
 
 /area/ruin/space/has_grav/powered/macspace
-	name = "Mac Space Restaurant"
+	name = "\improper Mac Space Restaurant"
 	icon_state = "yellow"
 
 //POWER PUZLE

--- a/code/game/area/areas/ruins/templates.dm
+++ b/code/game/area/areas/ruins/templates.dm
@@ -1,7 +1,7 @@
 //Template ruin areas
 
 /area/ruin/powered/shuttle
-	name = "Shuttle"
+	name = "\improper Shuttle"
 
 /area/ruin/powered/shuttle/medium_1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I basically looked through all code /area/ with a name ="" and added an \improper where I thought it would make grammatical sense.

For example, "Bar" will now be "the Bar", "the Vault", "the AI Satellite Exterior".

I left it out of a few choices names, including departmental names, anything that went "[Name] Storage" or stuff that just didnt sound right.

"Science" is not "the Science", but there is "the Research and Development Lab". 
"Medical" is not "the Medical", but there is "the Medbay".

Make sense?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Grammatical sense matters when an area is called by an announcement or whatever. It kinda irked me and this should make more sense.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: RKz
spellcheck: area names now use the correct \improper usage ('the Bar' instead of 'Bar')
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
