### PR TITLE
Tweaks plasma canister coloring

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -137,7 +137,7 @@
 	desc = "Plasma gas. The reason YOU are here. Highly toxic."
 	gas_type = GAS_PLASMA
 	greyscale_config = /datum/greyscale_config/canister/hazard
-	greyscale_colors = "#f64100#000000"
+	greyscale_colors = "#f64300#000000"
 
 /obj/machinery/portable_atmospherics/canister/tritium
 	name = "tritium canister"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -137,7 +137,7 @@
 	desc = "Plasma gas. The reason YOU are here. Highly toxic."
 	gas_type = GAS_PLASMA
 	greyscale_config = /datum/greyscale_config/canister/hazard
-	greyscale_colors = "#f62800#000000"
+	greyscale_colors = "#f64100#000000"
 
 /obj/machinery/portable_atmospherics/canister/tritium
 	name = "tritium canister"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When #6204 was made and the icons replaced with greyscale, the wrong color hexcode was used to represent the plasma can, the red #f62800. This color hexcode is very visually similiar to the other red canister we have, Nitrogen, and has led to some confusion for returning or new players.

This PR seeks to add some more visual contrast to try to bring it back to pre-GAGS level of differentiation. 



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This irks me personally, and I think this is an overall fix to a mistake made when GAGS canisters were ported here.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->


The current red(#f62800)
![cringe red](https://user-images.githubusercontent.com/62388554/212644709-ed09e1e5-953c-4991-80fc-e1080f7eabdc.PNG)


The replacement orange (#ff
![asdfasd](https://user-images.githubusercontent.com/62388554/212647789-eb401320-2983-427a-a8f8-e40b4fc9a338.PNG)
64300)


It obviously doesnt look very different above, but ingame it is much more apparent
![yuhgrey](https://user-images.githubusercontent.com/62388554/212647436-89bbdb58-e535-484d-b5c7-ddc96c6859ea.PNG)
![yuhblack](https://user-images.githubusercontent.com/62388554/212647445-15101bf6-585c-4d99-a47c-4581e01cc3e6.PNG)




## Changelog
:cl: RKz
tweak: edited the Plasma canister sprite to be more orange, to differentiate it from the Nitrogen canister color
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
