### PR TITLE
Adds an Alt+Click Interaction to Plasma Refineries

### DIFF
--- a/code/modules/shuttle/super_cruise/shuttle_components/plasma_refiner.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/plasma_refiner.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/components/unary/plasma_refiner
 	name = "plasma refinery"
-	desc = "A refinery that burns plasma sheets into plasma gas."
+	desc = "A refinery that burns plasma sheets into plasma gas. Can also create plasma sheets, albeit inefficiently."
 	icon_state = "plasma_refinery"
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/plasma_refiner
@@ -31,6 +31,19 @@
 	if(default_deconstruction_crowbar(W))
 		return
 
+	. = ..()
+
+/obj/machinery/atmospherics/components/unary/plasma_refiner/AltClick(mob/living/user)
+	var/datum/gas_mixture/air_contents = airs[1]
+	var/plasmoles = air_contents.get_moles(GAS_PLASMA)
+	if(!air_contents)
+		return
+	if(plasmoles >= 100)
+		var/obj/item/stack/sheet/mineral/plasma/P = new(src.loc, 1)
+		air_contents.adjust_moles(GAS_PLASMA, -100)
+		say("100 moles of plasma consumed. 1 Plasma sheet created.")
+	else
+		say("Insufficient plasma. At least 100 moles of plasma are required. There are currently [plasmoles] moles of plasma.")
 	. = ..()
 
 /obj/machinery/atmospherics/components/unary/plasma_refiner/RefreshParts()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an Alt+Click Interaction to the Plasma Refinery that creates a plasma sheet for the cost of 100 moles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows exploration crew to create PACMAN fuel if needed when stranded, this is incredibly inefficient and meant as a last resort.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Insufficient plasma](https://user-images.githubusercontent.com/68963748/212765763-35df6e2f-76af-4717-8735-846c207973df.png)

Insufficient Plasma

![Before Creation](https://user-images.githubusercontent.com/68963748/212765800-42e09a35-1625-4245-8dfb-ae1f1a37e171.png)

Before creation with sufficient Plasma

![Creation](https://user-images.githubusercontent.com/68963748/212765843-776b0ee4-3a82-4ff0-951e-ca708dda73cc.png)

Sheet created

![After Creation](https://user-images.githubusercontent.com/68963748/212765863-bf7c481b-f8bd-4ef6-8ca0-4685565b69cf.png)

After creation analysis of plasma system shows that there were moles consumed.

</details>

## Changelog
:cl: DatBoiTim
add: Added an Alt+Click Interaction to the Plasma Refinery which creates plasma sheets for the cost of 100 moles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
