### PR TITLE
Makes the bears spawned by xenoarch artifacts weaker

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -71,7 +71,7 @@
 
 /mob/living/simple_animal/hostile/bear/malnourished
 	name = "starving space bear"
-	desc = "You can practically seen its ribcage through its thinning layer of fur. Looks like it hasn't eaten anything in a long while."
+	desc = "You can practically see its ribcage through its thinning layer of fur. Looks like it hasn't eaten anything in a long while."
 	maxHealth = 60
 	health = 40
 	obj_damage = 30

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -69,6 +69,14 @@
 	maxHealth = 120
 	armored = TRUE
 
+/mob/living/simple_animal/hostile/bear/malnourished
+	name = "starving space bear"
+	desc = "You can practically seen its ribcage through its thinning layer of fur. Looks like it hasn't eaten anything in a long while."
+	maxHealth = 60
+	health = 40
+	obj_damage = 30
+	melee_damage = 10
+
 /mob/living/simple_animal/hostile/bear/update_icons()
 	..()
 	if(armored)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_malfunctions.dm
@@ -3,7 +3,7 @@
 // Bear, produces a bear until it reaches its upper limit
 //============
 /datum/xenoartifact_trait/malfunction/bear
-	label_name = "P.B.R." 
+	label_name = "P.B.R."
 	label_desc = "Parallel Bearspace Retrieval: A strange malfunction causes the Artifact to open a gateway to deep bearspace."
 	weight = 15
 	flags = URANIUM_TRAIT
@@ -13,11 +13,11 @@
 	if(length(bears) >= XENOA_MAX_BEARS)
 		return
 	var/turf/T = get_turf(X)
-	var/mob/living/simple_animal/hostile/bear/new_bear = new(T)
+	var/mob/living/simple_animal/hostile/bear/malnourished/new_bear = new(T)
 	new_bear.name = pick("Freddy", "Bearington", "Smokey", "Beorn", "Pooh", "Winnie", "Baloo", "Rupert", "Yogi", "Fozzie", "Boo") //Why not?
 	bears += new_bear
 	RegisterSignal(new_bear, COMSIG_MOB_DEATH, .proc/handle_death)
-	log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear) at [world.time]. [X] located at [AREACOORD(X)]")
+	log_game("[X] spawned a (/mob/living/simple_animal/hostile/bear/malnourished) at [world.time]. [X] located at [AREACOORD(X)]")
 	X.cooldown += 20 SECONDS
 
 /datum/xenoartifact_trait/malfunction/bear/proc/handle_death(datum/source)
@@ -92,14 +92,14 @@
 // Heated, causes artifact explode in flames
 //============
 /datum/xenoartifact_trait/malfunction/heated
-	label_name = "Combustible" 
+	label_name = "Combustible"
 	label_desc = "Combustible: A strange malfunction that causes the Artifact to violently combust."
 	weight = 15
 	flags = URANIUM_TRAIT
 
 /datum/xenoartifact_trait/malfunction/heated/activate(obj/item/xenoartifact/X, atom/target, atom/user)
 	var/turf/T = get_turf(X)
-	playsound(T, 'sound/effects/bamf.ogg', 50, TRUE) 
+	playsound(T, 'sound/effects/bamf.ogg', 50, TRUE)
 	for(var/turf/open/turf in RANGE_TURFS(max(1, 4*((X.charge*1.5)/100)), T))
 		if(!locate(/obj/effect/safe_fire) in turf)
 			new /obj/effect/safe_fire(turf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new malnourished bear type and makes the xenoarch artifacts spawn those. They deal less damage and have less health.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The bears spawned by the malfunction are rather strong. Too strong when they appear in groups, to the point of being able to wipe out several unsuspecting scientists. This, in my opinion, is too much. So this weakens the bears.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Health after a single bear attack :

![image](https://user-images.githubusercontent.com/110184118/212927117-e6b9fa58-5c6e-49f2-ace2-85616e2903b0.png)

Bear inspect image :

![image](https://user-images.githubusercontent.com/110184118/212927250-6cec4b40-fdf5-4db4-b499-03da1d4c86de.png)


</details>

## Changelog
:cl:
add: Added a new malnourished bear type which is overall weaker than the normal one
tweak: Tweaked the bear malfunction of artifacts to spawn malnourished bears
/:cl:
