### PR TITLE
Some custom shuttle related bugfixes

### DIFF
--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -13,6 +13,9 @@
 
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
 
+	untowable = TRUE
+	undockable = TRUE
+
 	var/damaged	//too damaged to undock?
 	var/list/areas	//areas in our shuttle
 	var/list/queued_announces	//people coming in that we have to announce

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -94,7 +94,7 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 		mat1.f
 		)
 
-//returns the dwidth, dheight, width, and height in the order of the union bounds of all shuttles relative to our shuttle.
+//returns the dwidth, dheight, width, and height in that order of the union bounds of all shuttles relative to our shuttle.
 /obj/docking_port/proc/return_union_bounds(var/list/obj/docking_port/others)
 	var/list/coords =  return_union_coords(others, 0, 0, NORTH)
 	var/X0 = min(coords[1],coords[3]) //This will be the negative dwidth of the combined bounds
@@ -353,6 +353,9 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	//If the shuttle is unable to be moved by non-untowable shuttles.
 	//Stops interference with the arrival and escape shuttle. Use this sparingly.
 	var/untowable = FALSE
+	//If docking on this shuttle is not allowed.
+	//For important shuttles such as the arrivals shuttle where access to its shuttle area type is needed at any moment
+	var/undockable = FALSE
 
 	//The designated virtual Z-Value of this shuttle
 	var/virtual_z

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	//During designation
 	var/overwritten_area = /area/space
 	var/list/loggedTurfs = list()
-	var/area/loggedOldArea
+	var/list/loggedOldArea = list() //<-- Fix this so airlocks/firedoors are good and not bad (and fix the airlock shuttle creator power)
 	var/area/shuttle/recorded_shuttle_area
 	var/datum/shuttle_creator_overlay_holder/overlay_holder
 	//After designation
@@ -257,7 +257,11 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	port.linkup(new_shuttle, stationary_port)
 
 	//Update doors
-	var/list/firedoors = loggedOldArea.firedoors
+	var/list/firedoors = list()
+	for(var/area/oldArea in loggedOldArea)
+		if(!islist(oldArea.firedoors))
+			continue
+		firedoors |= oldArea.firedoors
 	for(var/door in firedoors)
 		var/obj/machinery/door/firedoor/FD = door
 		FD.CalculateAffectingAreas()
@@ -364,7 +368,11 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 			continue
 		port.add_turf(T, recorded_shuttle_area)
 
-	var/list/firedoors = loggedOldArea.firedoors
+	var/list/firedoors = list()
+	for(var/area/oldArea in loggedOldArea)
+		if(!islist(oldArea.firedoors))
+			continue
+		firedoors |= oldArea.firedoors
 	for(var/door in firedoors)
 		var/obj/machinery/door/firedoor/FD = door
 		FD.CalculateAffectingAreas()
@@ -410,6 +418,9 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 			continue
 		if(towed_shuttles && istype(place) && towed_shuttles[place.mobile_port]) //prevent recursive stacking
 			to_chat(usr, "<span class='warning'>Warning, shuttle must not use any material connected to a docked shuttle. Your shuttle is currenly overlapping with [place.mobile_port.name].</span>")
+			return FALSE
+		if(istype(place) && place.mobile_port?.undockable) //Can't make a shuttle on something we can't dock on
+			to_chat(usr, "<span class='warning'>Warning, [place.mobile_port.name] is preventing designation in this region.</span>")
 			return FALSE
 		if(!istype(t,/turf/open/floor/dock/drydock)) //Drydocks bypass the area check, but not the recursion check
 			var/static/list/drydock_types = typesof(/turf/open/floor/dock/drydock)
@@ -467,7 +478,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	if(!check_area(list(T)))
 		return FALSE
 	loggedTurfs |= T
-	loggedOldArea = get_area(T)
+	loggedOldArea |= get_area(T)
 	overlay_holder.highlight_turf(T)
 
 /obj/item/shuttle_creator/proc/add_saved_area(mob/user)
@@ -477,7 +488,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	var/list/turfs = detect_room(get_turf(user), area_or_turf_fail_types)
 	if(!check_area(turfs))
 		return FALSE
-	loggedOldArea = get_area(get_turf(user))
+	loggedOldArea |= get_area(get_turf(user)) //This is disgusting and I hate it
 	loggedTurfs |= turfs
 	overlay_holder.highlight_area(turfs)
 	//TODO READD THIS SHIT: icon_state = "rsd_used"
@@ -491,16 +502,22 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 		to_chat(usr, "<span class='warning'>You cannot undesignate the exterior airlock.</span>")
 		return
 	loggedTurfs -= T
-	if(are_turfs_connected())
-		loggedOldArea = get_area(T)
-		overlay_holder.unhighlight_turf(T)
-	else
+	if(!are_turfs_connected())
 		to_chat(usr, "<span class='warning'>Caution, removing this turf would split the shuttle.</span>")
 		loggedTurfs |= T
+		return
+	var/new_area
+	if(linkedShuttleId)
+		var/obj/docking_port/mobile/port = SSshuttle.getShuttle(linkedShuttleId)
+		new_area = port.underlying_turf_area[T]
+	if(new_area)
+		loggedOldArea |= new_area
+	overlay_holder.unhighlight_turf(T)
 
 /obj/item/shuttle_creator/proc/reset_saved_area(loud = TRUE)
 	overlay_holder.clear_highlights()
 	loggedTurfs.Cut()
+	loggedOldArea.Cut()
 
 	//Rebuild the highlights on our shuttle
 	var/obj/docking_port/mobile/port
@@ -510,6 +527,8 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 		for(var/turf/T in port.underlying_turf_area)
 			loggedTurfs |= T
 			overlay_holder.create_hightlight(T, T == recorded_origin)
+		for(var/area/A in port.shuttle_areas)
+			loggedOldArea |= A //Can't directly
 	if(loud)
 		to_chat(usr, "<span class='notice'>You reset the area buffer on the [src].</span>")
 

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	//During designation
 	var/overwritten_area = /area/space
 	var/list/loggedTurfs = list()
-	var/list/loggedOldArea = list() //<-- Fix this so airlocks/firedoors are good and not bad (and fix the airlock shuttle creator power)
+	var/list/loggedOldArea = list()
 	var/area/shuttle/recorded_shuttle_area
 	var/datum/shuttle_creator_overlay_holder/overlay_holder
 	//After designation

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator_actions.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator_actions.dm
@@ -81,7 +81,7 @@
 		return
 	var/turf/T = get_turf(remote_eye)
 	for(var/obj/machinery/door/airlock/A in T)
-		if(get_area(A) != shuttle_creator.loggedOldArea)
+		if(!(T in shuttle_creator.loggedTurfs))
 			to_chat(C, "<span class='warning'>Caution, airlock must be on the shuttle to function as a dock.</span>")
 			return
 		if(shuttle_creator.linkedShuttleId)

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
@@ -281,6 +281,9 @@
 
 	// Checking for overlapping dock boundaries
 	for(var/i in 1 to overlappers.len)
+		var/obj/docking_port/mobile/shuttle = overlappers[i]
+		if(istype(shuttle) && shuttle.undockable)
+			return SHUTTLE_DOCKER_BLOCKED
 		var/obj/docking_port/stationary/port = overlappers[i]
 		if(port == my_port)
 			continue

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	dwidth = 5
 	height = 7
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
+	undockable = TRUE
 
 
 	//Export categories for this run, this is set by console sending the shuttle.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a few issues with shuttles. This PR updates the usage of the rapid shuttle designator's  loggedOldArea var, making its firedoor area updates more accurate, and removing a bug that prevented creating a shuttle if the airlock port in another area than the most recently designated turf.
Also, this PR adds a new var for mobile docking ports called "undockable" that prevents any other shuttles from docking on top of them. This is currently only given to the arrivals shuttle and cargo shuttle, arrivals to prevent nested shuttles causing bad things to it, such as keeping it perma-docked at the station, giving false positives for arrival shuttle damage, and potentially removing all turfs available for late spawn by completely covering the arrivals shuttle. I considered also applying this to the escape shuttle, but through testing it seems that the escape shuttle doesn't seem to care if its bounds are arbitrarily changed by a shuttle landing on top of it, and will complete its trip to centcomm just fine. The cargo shuttle is made undockable so that you can't stand on a docked nested shuttle to make the cargo shuttle think you're not on it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ironing out some annoying bugs with the designator will make it easier to use.
Removing griefing potential for the arrivals shuttle prevents griefing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/51838176/213061776-e33174d4-326b-463c-884c-a7b8125295a1.mp4


Shows prevention of shuttle designation on the arrivals shuttle, proper tracking of multiple areas for loggedOldAreas and designating over multiple areas, and prevention of docking on top of the arrivals shuttle in that order.

</details>

## Changelog
:cl:
fix: It's now impossible to land shuttles ontop of the arrival shuttle to prevent spawning or the arrivals shuttle from leaving
fix: It's also impossible now to land another shuttle on the cargo shuttle to stowaway on it. 
fix: Fixes improper firedoor updates and potential failure to create shuttles with the rapid shuttle designator when designating in multiple areas at the same time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
