### PR TITLE
Adds text that appears after cloning/replica pod cloning

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -335,6 +335,7 @@
 #include "code\controllers\configuration\entries\general.dm"
 #include "code\controllers\configuration\entries\interview.dm"
 #include "code\controllers\configuration\entries\performance.dm"
+#include "code\controllers\configuration\entries\policies.dm"
 #include "code\controllers\configuration\entries\resources.dm"
 #include "code\controllers\subsystem\achievements.dm"
 #include "code\controllers\subsystem\acid.dm"

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -102,7 +102,7 @@
 #define STICKYBAN_ROGUE_CHECK_TIME 5
 
 
-#define POLICY_POLYMORPH "polymorph" //Shown to vicitm of staff of change and related effects.
+#define POLICY_POLYMORPH "policy_polymorph" //Shown to vicitm of staff of change and related effects.
 #define POLICY_VERB_HEADER "policy_verb_header" //Shown on top of policy verb window
 
 // allowed ghost roles this round, starts as everything allowed

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -102,7 +102,7 @@
 #define STICKYBAN_ROGUE_CHECK_TIME 5
 
 
-#define POLICY_POLYMORPH "policy_polymorph" //Shown to vicitm of staff of change and related effects.
+#define POLICY_POLYMORPH "polymorph" //Shown to victim of staff of change and related effects.
 #define POLICY_VERB_HEADER "policy_verb_header" //Shown on top of policy verb window
 
 // allowed ghost roles this round, starts as everything allowed

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -242,6 +242,8 @@
 
 /datum/config_entry/flag/revival_cloning
 
+/datum/config_entry/flag/post_revival_message
+
 /datum/config_entry/number/revival_brain_life
 	config_entry_value = -1
 	integer = FALSE

--- a/code/controllers/configuration/entries/policies.dm
+++ b/code/controllers/configuration/entries/policies.dm
@@ -1,0 +1,2 @@
+/datum/config_entry/string/policy_postclonetext
+	config_entry_value = "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -515,8 +515,9 @@
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-		if(CONFIG_GET(flag/post_revival_message))
-			to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
+		var/postclonemessage = CONFIG_GET(string/policy_postclonetext)
+		if(postclonemessage)
+			to_chat(occupant, postclonemessage)
 		mob_occupant.flash_act()
 
 	if(move)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -515,6 +515,7 @@
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
+		to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the ten minutes leading up to your death!</span>")
 		mob_occupant.flash_act()
 
 	if(move)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -515,7 +515,8 @@
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-		to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the ten minutes leading up to your death!</span>")
+		if(CONFIG_GET(flag/post_revival_message))
+			to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
 		mob_occupant.flash_act()
 
 	if(move)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -515,7 +515,7 @@
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-		if(!experimental && !experimental_pod)
+		if(!experimental_pod && !connected?.experimental) // connected computer can be null, so put '?' here. Let's not make this message to be seen by experimental clones.
 			to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
 		mob_occupant.flash_act()
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -515,7 +515,8 @@
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-		to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
+		if(!experimental && !experimental_pod)
+			to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
 		mob_occupant.flash_act()
 
 	if(move)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -515,7 +515,7 @@
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		mob_occupant.grab_ghost()
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-		to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the ten minutes leading up to your death!</span>")
+		to_chat(occupant, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
 		mob_occupant.flash_act()
 
 	if(move)

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -156,7 +156,7 @@
 	podman.set_cloned_appearance()
 	// On harvest
 	to_chat(podman, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-	to_chat(podman, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as everything that happened after you had the blood sample taken from you!</span>")
+	to_chat(podman, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
 	podman.flash_act()
 	log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -156,8 +156,9 @@
 	podman.set_cloned_appearance()
 	// On harvest
 	to_chat(podman, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-	if(CONFIG_GET(flag/post_revival_message))
-		to_chat(podman, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
+	var/postclonemessage = CONFIG_GET(string/policy_postclonetext)
+	if(postclonemessage)
+		to_chat(podman, postclonemessage)
 	podman.flash_act()
 	log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -156,7 +156,8 @@
 	podman.set_cloned_appearance()
 	// On harvest
 	to_chat(podman, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
-	to_chat(podman, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as everything that happened after you had the blood sample taken from you!</span>")
+	if(CONFIG_GET(flag/post_revival_message))
+		to_chat(podman, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>")
 	podman.flash_act()
 	log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -156,6 +156,7 @@
 	podman.set_cloned_appearance()
 	// On harvest
 	to_chat(podman, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
+	to_chat(podman, "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as everything that happened after you had the blood sample taken from you!</span>")
 	podman.flash_act()
 	log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -14,6 +14,9 @@ REVIVAL_CLONING
 ## amount of time (in hundredths of seconds) for which a brain retains the "spark of life" after the person's death (set to -1 for infinite)
 REVIVAL_BRAIN_LIFE -1
 
+## whether there is text displayed for people who just got cloned
+POST_REVIVAL_MESSAGE
+
 ## OOC DURING ROUND ###
 ## Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
 #OOC_DURING_ROUND

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -14,9 +14,6 @@ REVIVAL_CLONING
 ## amount of time (in hundredths of seconds) for which a brain retains the "spark of life" after the person's death (set to -1 for infinite)
 REVIVAL_BRAIN_LIFE -1
 
-## whether there is text displayed for people who just got cloned
-POST_REVIVAL_MESSAGE
-
 ## OOC DURING ROUND ###
 ## Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
 #OOC_DURING_ROUND

--- a/config/policies.txt
+++ b/config/policies.txt
@@ -3,3 +3,4 @@
 
 # When a mob is polymorphed
 POLYMORPH <span class='danger'>Note that you are allowed to act as an antagonist while transformed into a hostile mob, unless you volunteered for or sought out transformation.</span>
+POSTCLONETEXT "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds text that appears after cloning/replica pod cloning
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its kind of an unwritten rule that you forget some of your life that happened if you get cloned. But player confusion still happens. This PR aims to rectify that by directly saying it to the player that got cloned.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Medbay cloning text : 
![image](https://user-images.githubusercontent.com/110184118/213238849-fdf53539-ef18-4ae8-8dc2-39b4b34980c7.png)

</details>

## Changelog
:cl:
add: Added text that appears to the person got cloned, stating they forgot some of their previous life
config: Added a config option to show text that appears to the person got cloned, stating they forgot five minutes of their previous life
spellcheck: Fixed a typo in a comment about the polymorph staff policy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
