### PR TITLE
Fixes title screens wtih a new approach

### DIFF
--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -30,27 +30,28 @@ SUBSYSTEM_DEF(title)
 	ASSERT(fexists(file_path))
 
 	icon = new(fcopy_rsc(file_path))
-	var/icon/single_frame = new(icon, frame=1)
 
 	//Calculate the screen size
-	var/width = round(single_frame.Width() / world.icon_size)
-	var/height = round(single_frame.Height() / world.icon_size)
-	lobby_screen_size = "[width]x[height]"
+	var/regex/size_regex = new("(\\d+)x(\\d+)\.\\w*$")
+	if (size_regex.match(file_path))
+		var/width = text2num(size_regex.group[1])
+		var/height = text2num(size_regex.group[2])
+		lobby_screen_size = "[width]x[height]"
 
-	//Update the new player start (views are centered)
-	var/new_player_x = splash_turf.x + FLOOR(width / 2, 1)
-	var/new_player_y = splash_turf.y + FLOOR(height / 2, 1)
-	newplayer_start_loc = locate(new_player_x, new_player_y, splash_turf.z)
-	for(var/atom/movable/new_player_start in GLOB.newplayer_start)
-		new_player_start.forceMove(newplayer_start_loc)
+		//Update the new player start (views are centered)
+		var/new_player_x = splash_turf.x + FLOOR(width / 2, 1)
+		var/new_player_y = splash_turf.y + FLOOR(height / 2, 1)
+		newplayer_start_loc = locate(new_player_x, new_player_y, splash_turf.z)
+		for(var/atom/movable/new_player_start in GLOB.newplayer_start)
+			new_player_start.forceMove(newplayer_start_loc)
 
-	//Update fast joiners
-	for (var/mob/dead/new_player/fast_joiner in GLOB.new_player_list)
-		if(isnull(fast_joiner.client?.view_size))
-			fast_joiner.client?.change_view(getScreenSize(fast_joiner))
-		else
-			fast_joiner.client?.view_size.resetToDefault(getScreenSize(fast_joiner))
-		fast_joiner.forceMove(newplayer_start_loc)
+		//Update fast joiners
+		for (var/mob/dead/new_player/fast_joiner in GLOB.new_player_list)
+			if(isnull(fast_joiner.client?.view_size))
+				fast_joiner.client?.change_view(getScreenSize(fast_joiner))
+			else
+				fast_joiner.client?.view_size.resetToDefault(getScreenSize(fast_joiner))
+			fast_joiner.forceMove(newplayer_start_loc)
 
 	if(splash_turf)
 		splash_turf.icon = icon

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -32,8 +32,8 @@ SUBSYSTEM_DEF(title)
 	icon = new(fcopy_rsc(file_path))
 
 	//Calculate the screen size
-	var/regex/size_regex = new("(\\d+)x(\\d+)\.\\w*$")
-	if (size_regex.match(file_path))
+	var/regex/size_regex = new("(\\d+)x(\\d+)\\.\\w*$")
+	if (size_regex.Find(file_path))
 		var/width = text2num(size_regex.group[1])
 		var/height = text2num(size_regex.group[2])
 		lobby_screen_size = "[width]x[height]"

--- a/config/title_screens/README.txt
+++ b/config/title_screens/README.txt
@@ -23,8 +23,8 @@ Common titles are in the rotation to be displayed all the time. Any name that do
 
 An example of a common title name is "clown".
 
-The common title screen named "default" is special. It is only used if no other titles are available. You can overwrite "default" safely, but you 
-should have a title named "default" somewhere in your DMI file if you don't have any other common titles. Because default only runs in the 
+The common title screen named "default" is special. It is only used if no other titles are available. You can overwrite "default" safely, but you
+should have a title named "default" somewhere in your DMI file if you don't have any other common titles. Because default only runs in the
 absence of other titles, if you want it to also appear in the general rotation you must rename it.
 
 The common title screen named "blank.png" is also special. It is only used to fill space while the real title screen loads. You should leave this file alone.
@@ -34,7 +34,7 @@ Map Titles:
 
 Map titles are tied to a specific in game map. To make a map title you format the name like this "(name of a map)+(name of your title)"
 
-The spelling of the map name is important. It must match exactly the define MAP_NAME found in the relevant .DM file in the /_maps folder in 
+The spelling of the map name is important. It must match exactly the define MAP_NAME found in the relevant .DM file in the /_maps folder in
 the root directory. It can also be seen in game in the status menu. Note that there are no spaces between the two names.
 
 It is absolutely fine to have more than one title tied to the same map.
@@ -48,3 +48,10 @@ Rare titles are a just for fun feature where they will only have a 1% chance of 
 Add the phrase "rare+" to the beginning of the name. Again note there are no spaces. A title cannot be rare title and a map title at the same time.
 
 An example of a rare title name is "rare+explosion"
+
+
+Custom viewport sizes:
+
+Custom viewport sizes can be done by adding the viewport size at the end of the image.
+
+An example is: "titlescreen17x15" and "rare+explosion17x15"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since byond icon frame=1 randomly doesn't work, we will just use the title screen name instead.
If a title screen ends with [width]x[height] before the extension, that will be used as the icon's height.

for example
title15x20.dmi

Be careful not to name something like
1414x182562895.dmi since that will be considered the size to use.

## Why It's Good For The Game

We can have custom sized title screens without the bugs.

## Testing Photographs and Procedure

I tested this and it worked fine by renaming the file to singularity36x24.dmi
I lost the screenshot due to clipboard though.

## Changelog
:cl:
fix: Fixes title screens being bugged when animated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
