### PR TITLE
Dynamic 2023

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -71,7 +71,7 @@
 	restricted_roles = list(JOB_NAME_AI,JOB_NAME_CYBORG)
 	required_candidates = 1
 	weight = 7
-	cost = 5
+	cost = 8
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	repeatable = TRUE
 	blocking_rules = list(
@@ -101,7 +101,7 @@
 	required_candidates = 1
 	weight = 2
 	delay = 1 MINUTES // Prevents rule start while head is offstation.
-	cost = 10
+	cost = 13
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
@@ -174,7 +174,7 @@
 	restricted_roles = list(JOB_NAME_AI,JOB_NAME_CYBORG)
 	required_candidates = 1
 	weight = 4
-	cost = 7
+	cost = 10
 	requirements = list(101,101,101,10,10,10,10,10,10,10)
 	repeatable = TRUE
 	blocking_rules = list(

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -97,6 +97,9 @@
 		log_game("DYNAMIC: FAIL: [src] is not ready, because there are not enough enemies: [required_enemies[threat]] needed, [job_check] found")
 		return FALSE
 
+	if (mode.check_lowpop_lowimpact_injection())
+		return FALSE
+
 	return TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/execute()
@@ -189,9 +192,9 @@
 	protected_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
 	restricted_roles = list(JOB_NAME_CYBORG, JOB_NAME_AI, "Positronic Brain")
 	required_candidates = 1
-	weight = 35
-	cost = 3
-	requirements = list(3,3,3,3,3,3,3,3,3,3)
+	weight = 20
+	cost = 8
+	requirements = list(8,8,8,8,8,8,8,8,8,8)
 	repeatable = TRUE
 	blocking_rules = list(
 		/datum/dynamic_ruleset/roundstart/bloodcult,
@@ -220,8 +223,6 @@
 	if (required_candidates > candidates_amt)
 		log_game("DYNAMIC: FAIL: [src] does not have enough candidates ([required_candidates] needed, [candidates_amt] found)")
 		return FALSE
-	if (mode.check_lowpop_lowimpact_injection())
-		return FALSE
 	return ..()
 
 /datum/dynamic_ruleset/midround/autotraitor/execute()
@@ -245,13 +246,14 @@
 	antag_flag = ROLE_MALF
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_WARDEN, JOB_NAME_DETECTIVE, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN, JOB_NAME_SCIENTIST, JOB_NAME_CHEMIST, JOB_NAME_RESEARCHDIRECTOR, JOB_NAME_CHIEFENGINEER)
 	exclusive_roles = list(JOB_NAME_AI)
-	required_enemies = list(4,4,4,4,4,4,2,2,2,0)
+	required_enemies = list(3,3,2,2,2,1,1,1,1,0)
 	required_candidates = 1
 	minimum_players = 25
 	weight = 2
-	cost = 10
+	cost = 13
 	required_type = /mob/living/silicon/ai
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/nuclear)
+	flags = HIGH_IMPACT_RULESET
 	var/ion_announce = 33
 	var/removeDontImproveChance = 10
 
@@ -302,7 +304,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 1
-	cost = 10
+	cost = 15
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	flags = HIGH_IMPACT_RULESET
 
@@ -331,10 +333,10 @@
 	antag_flag = ROLE_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop
 	enemy_roles = list(JOB_NAME_AI, JOB_NAME_CYBORG, JOB_NAME_SECURITYOFFICER, JOB_NAME_WARDEN, JOB_NAME_DETECTIVE, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
-	required_enemies = list(3,3,3,3,3,2,1,1,0,0)
+	required_enemies = list(3,3,2,2,2,2,1,1,0,0)
 	required_candidates = 5
 	weight = 5
-	cost = 7
+	cost = 15
 	minimum_round_time = 70 MINUTES
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
@@ -379,9 +381,9 @@
 	required_candidates = 1
 	minimum_round_time = 35 MINUTES
 	weight = 3
-	cost = 8
+	cost = 12
 	minimum_players = 25
-	repeatable = TRUE
+	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
 	var/body = applicant.become_overmind()
@@ -403,9 +405,9 @@
 	required_candidates = 1
 	minimum_round_time = 40 MINUTES
 	weight = 3
-	cost = 10
+	cost = 12
 	minimum_players = 25
-	repeatable = TRUE
+	flags = HIGH_IMPACT_RULESET
 	var/list/vents = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph/execute()
@@ -448,11 +450,11 @@
 	antag_flag = "Nightmare"
 	antag_flag_override = ROLE_ALIEN
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(1,1,1,1,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 3
-	cost = 5
-	minimum_players = 15
+	weight = 5
+	cost = 6
+	minimum_players = 12
 	repeatable = TRUE
 	var/list/spawn_locs = list()
 
@@ -495,7 +497,7 @@
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
 	antag_flag = ROLE_ABDUCTOR
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(2,2,1,1,1,1,0,0,0,0)
 	required_candidates = 2
 	required_applicants = 2
 	weight = 4
@@ -534,13 +536,13 @@
 	antag_flag = "Revenant"
 	antag_flag_override = ROLE_REVENANT
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(1,1,1,1,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 4
+	weight = 5
 	cost = 5
-	minimum_players = 15
+	minimum_players = 12
 	repeatable = TRUE
-	var/dead_mobs_required = 20
+	var/dead_mobs_required = 15
 	var/need_extra_spawns_value = 15
 	var/list/spawn_locs = list()
 
@@ -586,7 +588,7 @@
 	antag_flag = "Space Pirates"
 	required_type = /mob/dead/observer
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(2,2,2,1,1,1,1,0,0,0)
 	required_candidates = 0
 	weight = 4
 	cost = 8
@@ -610,10 +612,10 @@
 	antag_flag = ROLE_OBSESSED
 	restricted_roles = list(JOB_NAME_AI, JOB_NAME_CYBORG, "Positronic Brain")
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(1,1,1,1,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 4
-	cost = 3 // Doesn't have the same impact on rounds as revenants, dragons, sentient disease (10) or syndicate infiltrators (5).
+	weight = 3
+	cost = 5
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/obsessed/trim_candidates()
@@ -632,8 +634,6 @@
 
 /datum/dynamic_ruleset/midround/obsessed/ready(forced = FALSE)
 	if(!check_candidates())
-		return FALSE
-	if(mode.check_lowpop_lowimpact_injection())
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Attempts to resolve various issues with dynamic.

Currently, Dynamic is on average creating too many midrounds and also triggering combinations like Xenos+Blob when it really shouldn't. It's also having an incredibly boring and low variety on lowpop due to high security requirements for antags that really do not require much security (Revenant for example)

Costs are also across the board too low for midrounds, especially traitors which it still tends to overdo when there are plenty of interesting OTHER low impact antagonists like Nightmare, Revenant, Abductors, and Obsessed.

The above is addressed by doing the following:

### Raised Dynamic costs for most midround antagonists to better represent their impact.

This should prevent too many antagonists overall spawning on average by making more threat be consumed, and thus less available for more midrounds.

### Added HIGH_IMPACT flags to Blob and Xenos, meaning they typically will not coincide in the same round.

This will resolve the bad interaction that has been pointed out in all but the highest threat rounds (90+) in which the high impact system is disabled, leaving this bad interaction of two round-ending antagonists as an actual rarity.

### Added living antagonist percentage checks to all midround injections, scaling with population. This means if there are too many currently active antagonists, Dynamic will not inject any midrounds.

This should allow Dynamic to more accurately assess the state of the round and not inject antagonists when there is already a high percentage, allowing the crew to attempt to deal with their currently problems before adding to the pile while still taking population into account.

### Lowered dynamic security requirements across the board, to allow for a better variety of antagonists on lowpop rather than defaulting to excessive amounts of traitors.

This one I am less sure about, but it's worth trying. Typically on lowpop, the only thing you will find spawning is traitors, which can get extremely boring. Having a revenant or two could suit to make more variety in lowpop.

## Other Problems (Not Addressed)

Currently midround variety is still quite low. We need to add more midround options as well as port some of the Random Event antagonists over to Dynamic, such as:

- Space Dragon (#7500)
- Sentient Spiders (#7870)
- Swarmers (#8341)
- Space Ninja (needs a rework first)
- Fugitives (#8395)
- Morph (#8341)
- Slaughter Demon

## Why It's Good For The Game

Currently Dynamic is a point of tension due to the unfun situations it tends to create. This attempts to ease that.

## Testing Photographs and Procedure

This will need testmerging, however the game does run the dynamic gamemode just fine.

<details>
<summary>
Click to expand
</summary>

![image](https://user-images.githubusercontent.com/10366817/213802026-75ee0e76-9d1f-47a1-a400-49ec42209e60.png)

</details>

## Changelog
:cl:
tweak: Raised Dynamic costs for most midround antagonists to better represent their impact.
tweak: Added HIGH_IMPACT flags to Blob and Xenos, meaning they typically will not coincide in the same round.
tweak: Added living antagonist percentage checks to all midround injections, scaling with population. This means if there are too many currently active antagonists, Dynamic will not inject any midrounds.
tweak: Lowered dynamic security requirements across the board, to allow for a better variety of antagonists on lowpop rather than defaulting to excessive amounts of traitors.
/:cl:
