### PR TITLE
Dynamic: Count unreadied players as 1/2 for roundstart rulesets

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -435,10 +435,14 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/player = i
-		if(player.ready == PLAYER_READY_TO_PLAY && player.mind)
+		if(!player.mind || player.ready == PLAYER_READY_TO_OBSERVE)
+			continue
+		if(player.ready == PLAYER_READY_TO_PLAY)
 			roundstart_pop_ready++
 			candidates.Add(player)
-
+		else
+			roundstart_pop_ready += 0.5
+	roundstart_pop_ready = round(roundstart_pop_ready, 1)
 	setup_parameters()
 	setup_hijacking()
 	setup_rulesets()


### PR DESCRIPTION
## About The Pull Request

Many dynamic roundstart rulesets depend on the readied player count to determine how many players will be in the round, thus determining if things like Cult should run.

However, there is a large share of our current playerbase that prefers to be unreadied and then latejoin to see what jobs are open. This attempts to accommodate for that by counting half of all unreadied players. It rounds up

## Why It's Good For The Game

Having more players counted is more accurate to the actual round population and also allows for more variety in gameplay, as many more interesting gamemodes depend on higher populations, which they erroneously do not catch on to.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Hard to test, but it counted me (Unready) as 0.5, then rounded up to 1

![image](https://user-images.githubusercontent.com/10366817/213895924-d043fda8-e8bb-4e5a-b0af-c0167962e52d.png)

</details>

## Changelog
:cl:
tweak: Dynamic will now count unreadied players as half a player (round up) for ruleset selection purposes, allowing rulesets to get a more accurate depiction of the roundstart population.
/:cl:
