### PR TITLE
Make railings take time to deconstruct

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -39,11 +39,14 @@
 
 /obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
+	if(flags_1 & NODECONSTRUCT_1)
+		return
 	if(!anchored)
-		to_chat(user, "<span class='warning'>You cut apart the railing.</span>")
-		I.play_tool_sound(src, 100)
-		deconstruct()
-		return TRUE
+		to_chat(user, "<span class='warning'>You begin to cut apart [src]...</span>")
+		// Insta-disassemble is bad
+		if(I.use_tool(src, user, 2.5 SECONDS))
+			deconstruct()
+			return TRUE
 
 /obj/structure/railing/deconstruct(disassembled)
 	if(!(flags_1 & NODECONSTRUCT_1))
@@ -57,7 +60,7 @@
 	if(flags_1&NODECONSTRUCT_1)
 		return
 	to_chat(user, "<span class='notice'>You begin to [anchored ? "unfasten the railing from":"fasten the railing to"] the floor...</span>")
-	if(I.use_tool(src, user, volume = 75, extra_checks = CALLBACK(src, .proc/check_anchored, anchored)))
+	if(I.use_tool(src, user, 1 SECONDS, volume = 75, extra_checks = CALLBACK(src, .proc/check_anchored, anchored)))
 		setAnchored(!anchored)
 		to_chat(user, "<span class='notice'>You [anchored ? "fasten the railing to":"unfasten the railing from"] the floor.</span>")
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Currently they can be disassembled as fast as you can click, which is HIGHLY abusable on multiz maps with lots of railings, creating a workplace safety hazard with 0 effort. They should take at least as long as they take to construct to deconstruct.

## Why It's Good For The Game

As funny as the "railing bandit" is, it should require more effort than speed clicking all the railings.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/213961193-da127dda-22a4-4b07-9e82-639d201dfe3a.png)

![image](https://user-images.githubusercontent.com/10366817/213961203-7f77d849-5ced-4634-a332-6463597ded50.png)

![image](https://user-images.githubusercontent.com/10366817/213961212-f80704aa-cb3f-4d70-b05f-2af2b55a7c95.png)

</details>

## Changelog
:cl:
tweak: Railing deconstruction is no longer instant- 3.5 seconds total between two steps, slightly longer than construction (3 seconds).
/:cl:
