### PR TITLE
Fixes a few Custom Say Issues

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -317,8 +317,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	var/message = "<span class='big'>You can add emphasis to your text by surrounding words or sentences in certain characters.</span>\n \
 		**bold**, and _italics_ are supported.\n\n \
-		<span class='big'>You can made custom saymods by doing <i>say 'screams\\\ \\ HELP IM DYING!'</i>. This works over the radio, and can be used to emote over the radio.</span>\n \
-		Example: say ';laughs maniacally!\\\ \\' >> \[Common] Joe Schmoe laughs maniacally!"
+		<span class='big'>You can made custom saymods by doing <i>say 'screams| HELP IM DYING!'</i>. This works over the radio, and can be used to emote over the radio.</span>\n \
+		Example: say ';laughs maniacally!|' >> \[Common] Joe Schmoe laughs maniacally!"
 
 
 	to_chat(usr, "<span class='notice'>[message]</span>")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -317,8 +317,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	var/message = "<span class='big'>You can add emphasis to your text by surrounding words or sentences in certain characters.</span>\n \
 		**bold**, and _italics_ are supported.\n\n \
-		<span class='big'>You can made custom saymods by doing <i>say 'screams- HELP IM DYING!'</i>. This works over the radio, and can be used to emote over the radio.</span>\n \
-		Example: say ';laughs maniacally!-' >> \[Common] Joe Schmoe laughs maniacally!"
+		<span class='big'>You can made custom saymods by doing <i>say 'screams/ HELP IM DYING!'</i>. This works over the radio, and can be used to emote over the radio.</span>\n \
+		Example: say ';laughs maniacally!/' >> \[Common] Joe Schmoe laughs maniacally!"
 
 
 	to_chat(usr, "<span class='notice'>[message]</span>")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -317,8 +317,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	var/message = "<span class='big'>You can add emphasis to your text by surrounding words or sentences in certain characters.</span>\n \
 		**bold**, and _italics_ are supported.\n\n \
-		<span class='big'>You can made custom saymods by doing <i>say 'screams/ HELP IM DYING!'</i>. This works over the radio, and can be used to emote over the radio.</span>\n \
-		Example: say ';laughs maniacally!/' >> \[Common] Joe Schmoe laughs maniacally!"
+		<span class='big'>You can made custom saymods by doing <i>say 'screams\\\ \\ HELP IM DYING!'</i>. This works over the radio, and can be used to emote over the radio.</span>\n \
+		Example: say ';laughs maniacally!\\\ \\' >> \[Common] Joe Schmoe laughs maniacally!"
 
 
 	to_chat(usr, "<span class='notice'>[message]</span>")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -98,10 +98,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	message = get_message_mods(message, message_mods)
 	var/datum/saymode/saymode = SSradio.saymodes[message_mods[RADIO_KEY]]
 	var/in_critical = InCritical()
-	message = check_for_custom_say_emote(message, message_mods)
 
 	if(!message)
 		return
+
+	message = check_for_custom_say_emote(message, message_mods)
 
 	if(stat == DEAD)
 		say_dead(original_message)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -103,18 +103,18 @@
 
 /**
  * Checks the inputted message for a custom say emote
- * Basically it checks every message for "\\"
- * If a message contains it then it will mark everything that came before "\\" as a custom say emote, IE: "stammers\\", "cackles\\", "screams\\", "yells\\", and everything after as the message
- * If a message contains "\\" but nothing after it then it will convert everything that came before "\\" into an emote
- * If a message doesn't contain "\\" then it will simply return the input as a message
+ * Basically it checks every message for "|"
+ * If a message contains it then it will mark everything that came before "|" as a custom say emote, IE: "stammers|", "cackles|", "screams|", "yells|", and everything after as the message
+ * If a message contains "|" but nothing after it then it will convert everything that came before "|" into an emote
+ * If a message doesn't contain "|" then it will simply return the input as a message
  *
  * Example
- * * "mutters\\ hello" will be marked as a custom say emote of "mutters" and the message will be "hello"
+ * * "mutters| hello" will be marked as a custom say emote of "mutters" and the message will be "hello"
  * * and it will appear as Joe Average mutters, "hello"
- * * "screams\\" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams
+ * * "screams|" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams
  */
 /mob/proc/check_for_custom_say_emote(message, list/mods)
-	var/customsaypos = findtext(message, "\\")
+	var/customsaypos = findtext(message, "|")
 	var/messagetextpos = 1
 	if(!customsaypos)
 		return message

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -103,18 +103,18 @@
 
 /**
  * Checks the inputted message for a custom say emote
- * Basically it checks every message for "/"
- * If a message contains it then it will mark everything that came before "/" as a custom say emote, IE: "stammers/", "cackles/", "screams/", "yells/", and everything after as the message
- * If a message contains "/" but nothing after it then it will convert everything that came before "/" into an emote
- * If a message doesn't contain "/" then it will simply return the input as a message
+ * Basically it checks every message for "\\"
+ * If a message contains it then it will mark everything that came before "\\" as a custom say emote, IE: "stammers\\", "cackles\\", "screams\\", "yells\\", and everything after as the message
+ * If a message contains "\\" but nothing after it then it will convert everything that came before "\\" into an emote
+ * If a message doesn't contain "\\" then it will simply return the input as a message
  *
  * Example
- * * "mutters/ hello" will be marked as a custom say emote of "mutters" and the message will be "hello"
+ * * "mutters\\ hello" will be marked as a custom say emote of "mutters" and the message will be "hello"
  * * and it will appear as Joe Average mutters, "hello"
- * * "screams/" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams
+ * * "screams\\" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams
  */
 /mob/proc/check_for_custom_say_emote(message, list/mods)
-	var/customsaypos = findtext(message, "/")
+	var/customsaypos = findtext(message, "\\")
 	var/messagetextpos = 1
 	if(!customsaypos)
 		return message

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -103,18 +103,18 @@
 
 /**
  * Checks the inputted message for a custom say emote
- * Basically it checks every message for "-"
- * If a message contains it then it will mark everything that came before "-" as a custom say emote, IE: "stammers-", "cackles-", "screams-", "yells-", and everything after as the message
- * If a message contains "-" but nothing after it then it will convert everything that came before "-" into an emote
- * If a message doesn't contain "-" then it will simply return the input as a message
+ * Basically it checks every message for "/"
+ * If a message contains it then it will mark everything that came before "/" as a custom say emote, IE: "stammers/", "cackles/", "screams/", "yells/", and everything after as the message
+ * If a message contains "/" but nothing after it then it will convert everything that came before "/" into an emote
+ * If a message doesn't contain "/" then it will simply return the input as a message
  *
  * Example
- * * "mutters- hello" will be marked as a custom say emote of "mutters" and the message will be "hello"
+ * * "mutters/ hello" will be marked as a custom say emote of "mutters" and the message will be "hello"
  * * and it will appear as Joe Average mutters, "hello"
- * * "screams-" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams
+ * * "screams/" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams
  */
 /mob/proc/check_for_custom_say_emote(message, list/mods)
-	var/customsaypos = findtext(message, "-")
+	var/customsaypos = findtext(message, "/")
 	var/messagetextpos = 1
 	if(!customsaypos)
 		return message
@@ -126,7 +126,7 @@
 	message = copytext(message, customsaypos + messagetextpos)
 	if(!message)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
-		stack_trace("check_for_custom_say_emote failed to find a message for [key]")
+		message = ""
 	return message
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a few issues that were created by
* https://github.com/BeeStation/BeeStation-Hornet/pull/8136

Also changes the custom say trigger character from `-` to `|`
Also removes the stack_trace as that would potentially become rapidly annoying for anyone trying to find runtime errors as it would apparently trigger every single time someone sent a custom say emote without any message afterwards, so for example:
"screams|" would produce a stack_trace. 

Instead the message is now returned as an empty string.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes. 
Allows for people to cut off sentences without turning it into a custom say emote
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/214043773-5c29efb1-e912-4902-b726-71952d21a500.mp4

https://user-images.githubusercontent.com/59128051/214043784-8bfd2d3f-6b72-4186-a295-efda17d800bb.mp4

</details>

## Changelog
:cl:
fix: Fixed an issue that was being caused by custom say that was clashing with roleplaying by changing the trigger letter to |
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
