### PR TITLE
Give emote

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -57,6 +57,10 @@
 	message = "mumbles"
 	emote_type = EMOTE_AUDIBLE
 
+/datum/emote/living/carbon/human/givesItem
+	key = "gives"
+	message = "Holds out hand, offering it to you"
+
 /datum/emote/living/carbon/human/moth
 	// allow mothroach as well as human base mob - species check is done in can_run_emote
 	mob_type_allowed_typecache = list(/mob/living/carbon/human,/mob/living/simple_animal/mothroach)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -58,8 +58,8 @@
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/givesItem
-	key = "gives"
-	message = "Holds out hand, offering it to you"
+	key = "givesitem"
+	message = "Offers you the item"
 
 /datum/emote/living/carbon/human/moth
 	// allow mothroach as well as human base mob - species check is done in can_run_emote

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -59,7 +59,7 @@
 
 /datum/emote/living/carbon/human/givesItem
 	key = "givesitem"
-	message = "offers you the item"
+	message = "offers an item"
 
 /datum/emote/living/carbon/human/moth
 	// allow mothroach as well as human base mob - species check is done in can_run_emote

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -59,7 +59,7 @@
 
 /datum/emote/living/carbon/human/givesItem
 	key = "givesitem"
-	message = "Offers you the item"
+	message = "offers you the item"
 
 /datum/emote/living/carbon/human/moth
 	// allow mothroach as well as human base mob - species check is done in can_run_emote

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -57,8 +57,8 @@
 	message = "mumbles"
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/carbon/human/givesItem
-	key = "givesitem"
+/datum/emote/living/carbon/human/offer
+	key = "offer"
 	message = "offers an item"
 
 /datum/emote/living/carbon/human/moth

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -168,7 +168,7 @@
 	visible_message("<span class='notice'>[src] is offering [offered_item].</span>", \
 					"<span class='notice'>You offer [offered_item].</span>", null, 2)
 
-	message = "Holds out hand, offering it to you"
+	INVOKE_ASYNC(src, .proc/emote, "givesitem")
 
 	apply_status_effect(STATUS_EFFECT_OFFERING, offered_item)
 

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -168,6 +168,8 @@
 	visible_message("<span class='notice'>[src] is offering [offered_item].</span>", \
 					"<span class='notice'>You offer [offered_item].</span>", null, 2)
 
+	message = "Holds out hand, offering it to you"
+
 	apply_status_effect(STATUS_EFFECT_OFFERING, offered_item)
 
 /**

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -168,7 +168,7 @@
 	visible_message("<span class='notice'>[src] is offering [offered_item].</span>", \
 					"<span class='notice'>You offer [offered_item].</span>", null, 2)
 
-	INVOKE_ASYNC(src, .proc/emote, "givesitem")
+	INVOKE_ASYNC(src, .proc/emote, "offer")
 
 	apply_status_effect(STATUS_EFFECT_OFFERING, offered_item)
 


### PR DESCRIPTION
## About The Pull Request

Adds a rune text emote that triggers on offering a item.

## Why It's Good For The Game

Many people miss the small moodlet in the top right leaving you hanging around for them to see it. This simple edit hopes to alleviate that by drawing attention to it.

## Testing Photographs and Procedure

![scrnshot1](https://user-images.githubusercontent.com/107176252/214141707-4bc659f4-fcb6-4b2a-a186-79953fdb5563.png)


## Changelog
:cl:
add: Added new "givesitem" emote. Added trigger to inventory.dm to call it.
/:cl:
