### PR TITLE
Fix blob being able to place core on nonspace but still disallowed tiles

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /mob/camera/blob/proc/is_valid_turf(turf/T)
 	var/area/A = get_area(T)
-	if((A && !(A.area_flags & BLOBS_ALLOWED)) || !T || !is_station_level(T.z) || isspaceturf(T))
+	if((A && !(A.area_flags & BLOBS_ALLOWED)) || !T || !is_station_level(T.z) || isspaceturf(T) || istype(T, /turf/open/openspace))
 		return FALSE
 	return TRUE
 
@@ -282,13 +282,13 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		if(B)
 			forceMove(NewLoc)
 		else
-			return 0
+			return FALSE
 	else
-		var/area/A = get_area(NewLoc)
-		if(isspaceturf(NewLoc) || istype(A, /area/shuttle)) //if unplaced, can't go on shuttles or space tiles
-			return 0
+		var/turf/T = get_turf(NewLoc)
+		if(!is_valid_turf(T)) //if unplaced, can't go out of placeable area
+			return FALSE
 		forceMove(NewLoc)
-		return 1
+		return TRUE
 
 /mob/camera/blob/mind_initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Blocks blob from moving into disallowed tiles during the placement phase, as it appears was intended. Also adds proper and consistent checks between all core placement sources.

## Why It's Good For The Game

Blobs should not be placing cores places they were not intended to.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Cannot move out further into openspace, cannot move onto ground tiles, etc.

![image](https://user-images.githubusercontent.com/10366817/214718892-824ed2b9-d872-4265-978a-e50a719759d2.png)

</details>

## Changelog
:cl:
fix: Fixed blobs being able to place their core and move onto disallowed tiles that were not in space.
/:cl:
