### PR TITLE
Fixes cultists being unable to use their spells

### DIFF
--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -250,7 +250,7 @@
 	button_icon_state = "wavespeak"
 	check_flags = AB_CHECK_CONSCIOUS
 
-/datum/action/innate/cult/IsAvailable()
+/datum/action/innate/wavespeak/IsAvailable()
 	if(!("carp" in owner.faction))
 		return FALSE
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug with the space dragon update which broke cultist spells.

## Why It's Good For The Game

Cultists shouldn't require the carp faction in order to use their spells. Fixes a bad copy-paste.

## Testing Photographs and Procedure

Please see https://github.com/BeeStation/BeeStation-Hornet/pull/7500 for evidence that this spell works. Cult spell should be returning to prior behaviour and should function as previous.

## Changelog
:cl:
fix: Fixes cultists requiring the carp faction to use their spells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
