### PR TITLE
Tweaks pierced realities

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -136,7 +136,7 @@
 		smashes++
 
 /obj/effect/broken_illusion
-	name = "pierced reality"
+	name = "???"
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "pierced_illusion"
 	anchored = TRUE
@@ -160,15 +160,15 @@
 	I.alpha = 255
 	I.appearance_flags = RESET_ALPHA
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/heretics,"pierced_reality_heretics",I)
-	addtimer(CALLBACK(src,.proc/dissipate),15 MINUTES)
+	addtimer(CALLBACK(src,.proc/dissipate),40 SECONDS)
 
 ///Makes this obj appear out of nothing
 /obj/effect/broken_illusion/proc/show_presence()
 	animate(src,alpha = 255,time = 15 SECONDS)
 
 /obj/effect/broken_illusion/proc/dissipate()
-	animate(src,alpha = 0,time = 2 MINUTES)
-	QDEL_IN(src, 2 MINUTES)
+	animate(src,alpha = 0,time = 15 SECONDS)
+	QDEL_IN(src, 15 SECONDS)
 
 /obj/effect/broken_illusion/attack_hand(mob/living/user)
 	if(!ishuman(user))
@@ -234,8 +234,7 @@
 ///Custom effect that happens on destruction
 /obj/effect/reality_smash/proc/on_destroy()
 	GLOB.reality_smash_track.smashes--
-	var/obj/effect/broken_illusion/illusion = new /obj/effect/broken_illusion(drop_location())
-	illusion.name = pick("Researched","Siphoned","Analyzed","Emptied","Drained") + " " + name
+	new /obj/effect/broken_illusion(drop_location())
 
 ///Generates random name
 /obj/effect/reality_smash/proc/generate_name()

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -136,7 +136,7 @@
 		smashes++
 
 /obj/effect/broken_illusion
-	name = "???"
+	name = "pierced reality"
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "pierced_illusion"
 	anchored = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1) Dramatically reduces the lifetime of pierced realities 
2) Changes their in-game name to ??? since they are supposed to be incomprehensible phenomena to non-heretics.

Timeline:
* Invisible to non-heretics for first 15 seconds, just like current iteration
* Fade in to being fully visible over 15 seconds
* Fully visible for 10 seconds (30-40 seconds into its total lifetime)
* Fade to nothingness over 15 seconds
* qdel itself after a grand total of 55 seconds

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Heretical players aren't outed almost immediately, enabling a longer period of intrigue and more gradual prep instead of rushing. 

Heretics leave *more than ample* evidence behind in so many ways that the persistence of pierced realities are not a necessary part of counterbalancing them and only serve to worsen the experience of heretic rounds by rapidly accelerating security into a state of bag-searching every dweller on the station. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Not really much to show exactly. Here's proof of the reality fading.

![image](https://user-images.githubusercontent.com/9547572/215003267-f0da3f39-03e4-427d-8c6f-8c113f12eebb.png)

</details>

## Changelog
:cl:
tweak: Pierced realities are more incomprehensible to the fragile minds of the average space station worker, and also fade from existence much quicker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
