### PR TITLE
[PORT] Moves Dejavu component out of crossbreeding

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -538,6 +538,7 @@
 #include "code\datums\components\conveyor_movement.dm"
 #include "code\datums\components\cult_ritual_item.dm"
 #include "code\datums\components\deadchat_control.dm"
+#include "code\datums\components\dejavu.dm"
 #include "code\datums\components\drift.dm"
 #include "code\datums\components\edit_complainer.dm"
 #include "code\datums\components\effect_remover.dm"

--- a/code/datums/components/dejavu.dm
+++ b/code/datums/components/dejavu.dm
@@ -1,0 +1,107 @@
+/**
+ * A component to reset the parent to its previous state after some time passes
+ */
+/datum/component/dejavu
+	/// The turf the parent was on when this components was applied, they get moved back here after the duration
+	var/turf/starting_turf
+	/// Determined by the type of the parent so different behaviours can happen per type
+	var/rewind_type
+	/// How many rewinds will happen before the effect ends
+	var/rewinds_remaining
+	/// How long to wait between each rewind
+	var/rewind_interval
+
+	/// The starting value of clone loss at the beginning of the effect
+	var/clone_loss = 0
+	/// The starting value of toxin loss at the beginning of the effect
+	var/tox_loss = 0
+	/// The starting value of oxygen loss at the beginning of the effect
+	var/oxy_loss = 0
+	/// The starting value of brain loss at the beginning of the effect
+	var/brain_loss = 0
+	/// The starting value of brute loss at the beginning of the effect
+	/// This only applies to simple animals
+	var/brute_loss
+	/// The starting value of integrity at the beginning of the effect
+	/// This only applies to objects
+	var/integrity
+	/// A list of body parts saved at the beginning of the effect
+	var/list/datum/saved_bodypart/saved_bodyparts
+
+/datum/component/dejavu/Initialize(rewinds = 1, interval = 10 SECONDS)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	starting_turf = get_turf(parent)
+	rewinds_remaining = rewinds
+	rewind_interval = interval
+
+	if(isliving(parent))
+		var/mob/living/L = parent
+		clone_loss = L.getCloneLoss()
+		tox_loss = L.getToxLoss()
+		oxy_loss = L.getOxyLoss()
+		brain_loss = L.getOrganLoss(ORGAN_SLOT_BRAIN)
+		rewind_type = .proc/rewind_living
+
+	if(iscarbon(parent))
+		var/mob/living/carbon/C = parent
+		saved_bodyparts = C.save_bodyparts()
+		rewind_type = .proc/rewind_carbon
+
+	else if(isanimal(parent))
+		var/mob/living/simple_animal/M = parent
+		brute_loss = M.bruteloss
+		rewind_type = .proc/rewind_animal
+
+	else if(isobj(parent))
+		var/obj/O = parent
+		integrity = O.obj_integrity
+		rewind_type = .proc/rewind_obj
+
+	addtimer(CALLBACK(src, rewind_type), rewind_interval)
+
+/datum/component/dejavu/Destroy()
+	starting_turf = null
+	saved_bodyparts = null
+	return ..()
+
+/datum/component/dejavu/proc/rewind()
+	to_chat(parent, "<span class=notice>You remember a time not so long ago...</span>")
+
+	//comes after healing so new limbs comically drop to the floor
+	if(starting_turf)
+		var/atom/movable/master = parent
+		master.forceMove(starting_turf)
+
+	rewinds_remaining --
+	if(rewinds_remaining)
+		addtimer(CALLBACK(src, rewind_type), rewind_interval)
+	else
+		to_chat(parent, "<span class=notice>But the memory falls out of your reach.</span>")
+		qdel(src)
+
+/datum/component/dejavu/proc/rewind_living()
+	var/mob/living/master = parent
+	master.setCloneLoss(clone_loss)
+	master.setToxLoss(tox_loss)
+	master.setOxyLoss(oxy_loss)
+	master.setOrganLoss(ORGAN_SLOT_BRAIN, brain_loss)
+	rewind()
+
+/datum/component/dejavu/proc/rewind_carbon()
+	if(saved_bodyparts)
+		var/mob/living/carbon/master = parent
+		master.apply_saved_bodyparts(saved_bodyparts)
+	rewind_living()
+
+/datum/component/dejavu/proc/rewind_animal()
+	var/mob/living/simple_animal/master = parent
+	master.bruteloss = brute_loss
+	master.updatehealth()
+	rewind_living()
+
+/datum/component/dejavu/proc/rewind_obj()
+	var/obj/master = parent
+	master.obj_integrity = integrity
+	rewind()

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -4,8 +4,6 @@ Slimecrossing Items
 	Collected here for clarity.
 */
 
-#define DEJAVU_REWIND_INTERVAL (10 SECONDS)
-
 //Rewind camera - I'm already Burning Sepia
 /obj/item/camera/rewind
 	name = "sepia-tinted camera"
@@ -55,81 +53,6 @@ Slimecrossing Items
 
 		ret[part.body_zone] = saved_part
 	return ret
-
-
-
-/datum/component/dejavu
-	var/integrity	//for objects
-	var/brute_loss //for simple animals
-	var/list/datum/saved_bodypart/saved_bodyparts //maps bodypart slots to health
-	var/clone_loss = 0
-	var/tox_loss = 0
-	var/oxy_loss = 0
-	var/brain_loss = 0
-	var/x
-	var/y
-	var/z
-	var/rewinds_remaining
-
-/datum/component/dejavu/Initialize(rewinds = 1)
-	rewinds_remaining = rewinds
-	var/turf/T = get_turf(parent)
-	if(T)
-		x = T.x
-		y = T.y
-		z = T.z
-	if(isliving(parent))
-		var/mob/living/L = parent
-		clone_loss = L.getCloneLoss()
-		tox_loss = L.getToxLoss()
-		oxy_loss = L.getOxyLoss()
-		brain_loss = L.getOrganLoss(ORGAN_SLOT_BRAIN)
-	if(iscarbon(parent))
-		var/mob/living/carbon/C = parent
-		saved_bodyparts = C.save_bodyparts()
-	else if(isanimal(parent))
-		var/mob/living/simple_animal/M = parent
-		brute_loss = M.bruteloss
-	else if(isobj(parent))
-		var/obj/O = parent
-		integrity = O.obj_integrity
-	addtimer(CALLBACK(src, .proc/rewind), DEJAVU_REWIND_INTERVAL)
-
-/datum/component/dejavu/proc/rewind()
-	to_chat(parent, "<span class=notice>You remember a time not so long ago...</span>")
-
-	if(isliving(parent))
-		var/mob/living/L = parent
-		L.setCloneLoss(clone_loss)
-		L.setToxLoss(tox_loss)
-		L.setOxyLoss(oxy_loss)
-		L.setOrganLoss(ORGAN_SLOT_BRAIN, brain_loss)
-
-	if(iscarbon(parent))
-		if(saved_bodyparts)
-			var/mob/living/carbon/C = parent
-			C.apply_saved_bodyparts(saved_bodyparts)
-	else if(isanimal(parent))
-		var/mob/living/simple_animal/M = parent
-		M.bruteloss = brute_loss
-		M.updatehealth()
-	else if(isobj(parent))
-		var/obj/O = parent
-		O.obj_integrity = integrity
-
-	//comes after healing so new limbs comically drop to the floor
-	if(!isnull(x) && istype(parent, /atom/movable))
-		var/atom/movable/AM = parent
-		var/turf/T = locate(x,y,z)
-		AM.forceMove(T)
-
-	rewinds_remaining --
-	if(rewinds_remaining)
-		addtimer(CALLBACK(src, .proc/rewind), DEJAVU_REWIND_INTERVAL)
-	else
-		to_chat(parent, "<span class=notice>But the memory falls out of your reach.</span>")
-
-
 
 /obj/item/camera/rewind/afterattack(atom/target, mob/user, flag)
 	if(!on || !pictures_left || !isturf(target.loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports the following PR from TG:
* https://github.com/tgstation/tgstation/pull/46935

What that PR does is it moves the dejavu component out of the crossbreeding _misc file and into a Component file in the component folder while adding some documentations.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Moves the component from a location where it's no doubt not supposed to be, to an actual component file for easier method of locating it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/59128051/215032334-d11f1f06-a989-4e69-b76e-91e50a3185dd.mp4

</details>

## Changelog
:cl:Bobbanz1, ninjanomnom
code: Moves the dejavu component out of the crossbreeding file and into a file in the component folder
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
