### PR TITLE
Suit storage adjustments.

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -44,7 +44,7 @@
 	///how strong is the burn damage during cook(), decreases with micro laser tier
 	var/laser_strength = 10
 	///how strong is the burn damage if hacked/emagged during cook(), increases with micro laser tier
-	var/laser_strength_hacked =  20
+	var/laser_strength_hacked = 20
 	var/uv_super = FALSE
 	/// For managing the messages sent back when the machine was hacked
 	var/toasted = FALSE
@@ -211,10 +211,7 @@
 	occupant = null
 
 /obj/machinery/suit_storage_unit/proc/is_empty()
-	var empty = FALSE
-	if(isnull(helmet) && isnull(suit) && isnull(mask) && isnull(storage) && isnull(occupant))
-		empty = TRUE
-	return empty
+	return isnull(helmet) && isnull(suit) && isnull(mask) && isnull(storage) && isnull(occupant)
 
 /obj/machinery/suit_storage_unit/emp_act()
 	. = ..()
@@ -278,9 +275,7 @@
 */
 /obj/machinery/suit_storage_unit/proc/cook()
 	var/mob/living/mob_occupant = occupant
-	var/burn_damage = laser_strength
-	if(uv_super || (obj_flags & EMAGGED))
-		burn_damage = laser_strength_hacked
+	var/burn_damage = uv_super || (obj_flags & EMAGGED) ? laser_strength_hacked : laser_strength
 	if(uv_cycles)
 		uv_cycles--
 		uv = TRUE

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -9,7 +9,7 @@
 	power_channel = AREA_USAGE_EQUIP
 	density = TRUE
 	max_integrity = 250
-
+	circuit = /obj/item/circuitboard/machine/suit_storage_unit
 
 
 	var/obj/item/clothing/suit/space/suit = null
@@ -144,6 +144,7 @@
 
 /obj/machinery/suit_storage_unit/Initialize(mapload)
 	. = ..()
+	//circuit.apply_default_parts(src)
 	wires = new /datum/wires/suit_storage_unit(src)
 	if(suit_type)
 		suit = new suit_type(src)
@@ -199,6 +200,12 @@
 	storage = null
 	occupant = null
 
+/obj/machinery/suit_storage_unit/proc/is_empty()
+	var empty = FALSE
+	if(isnull(helmet) && isnull(suit) && isnull(mask) && isnull(storage) && isnull(occupant))
+		empty = TRUE
+	return empty
+
 /obj/machinery/suit_storage_unit/emp_act()
 	. = ..()
 	uv_super = !uv_super
@@ -213,7 +220,10 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		open_machine()
 		dump_contents()
-		new /obj/item/stack/sheet/iron (loc, 2)
+		spawn_frame(disassembled)
+		for(var/obj/item/I in component_parts)
+			I.forceMove(loc)
+			component_parts.Cut()
 	qdel(src)
 
 /obj/machinery/suit_storage_unit/MouseDrop_T(atom/A, mob/living/user)
@@ -417,6 +427,9 @@
 		if(default_deconstruction_screwdriver(user, "panel", "close", I))
 			ui_update() // Wires might've changed availability of decontaminate button
 			return
+		if(is_empty())
+			if(default_deconstruction_crowbar(I))
+				return
 	if(default_pry_open(I))
 		dump_contents()
 		return

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -11,7 +11,6 @@
 	max_integrity = 250
 	circuit = /obj/item/circuitboard/machine/suit_storage_unit
 
-
 	var/obj/item/clothing/suit/space/suit = null
 	var/obj/item/clothing/head/helmet/space/helmet = null
 	var/obj/item/clothing/mask/mask = null
@@ -42,6 +41,10 @@
 	* * If FALSE, decontamination sequence will clear radiation for all atoms (and their contents) contained inside the unit, and burn any mobs inside.
 	* * If TRUE, decontamination sequence will burn and decontaminate all items contained within, and if occupied by a mob, intensifies burn damage delt. All wires will be cut at the end.
 	*/
+	///how strong is the burn damage during cook(), decreases with micro laser tier
+	var/laser_strength = 10
+	///how strong is the burn damage if hacked/emagged during cook(), increases with micro laser tier
+	var/laser_strength_hacked =  20
 	var/uv_super = FALSE
 	/// For managing the messages sent back when the machine was hacked
 	var/toasted = FALSE
@@ -144,7 +147,6 @@
 
 /obj/machinery/suit_storage_unit/Initialize(mapload)
 	. = ..()
-	//circuit.apply_default_parts(src)
 	wires = new /datum/wires/suit_storage_unit(src)
 	if(suit_type)
 		suit = new suit_type(src)
@@ -154,6 +156,7 @@
 		mask = new mask_type(src)
 	if(storage_type)
 		storage = new storage_type(src)
+	RefreshParts()
 	update_icon()
 
 /obj/machinery/suit_storage_unit/Destroy()
@@ -191,6 +194,13 @@
 		open_machine()
 		dump_contents()
 	update_icon()
+
+/obj/machinery/suit_storage_unit/RefreshParts()
+	var/calculated_laser_rating = 0
+	for(var/obj/item/stock_parts/micro_laser/laser in component_parts)
+		calculated_laser_rating += laser.rating
+	laser_strength_hacked = 15 + (5 * (calculated_laser_rating)) //20 on T1, 35 on T4
+	laser_strength = 12 - (2 * (calculated_laser_rating)) //10 on T1, 4 on T4
 
 /obj/machinery/suit_storage_unit/proc/dump_contents()
 	dropContents()
@@ -268,16 +278,16 @@
 */
 /obj/machinery/suit_storage_unit/proc/cook()
 	var/mob/living/mob_occupant = occupant
+	var/burn_damage = laser_strength
+	if(uv_super || (obj_flags & EMAGGED))
+		burn_damage = laser_strength_hacked
 	if(uv_cycles)
 		uv_cycles--
 		uv = TRUE
 		locked = TRUE
 		update_icon()
 		if(occupant)
-			if(uv_super || (obj_flags & EMAGGED))
-				mob_occupant.adjustFireLoss(rand(20, 36))
-			else
-				mob_occupant.adjustFireLoss(rand(10, 16))
+			mob_occupant.adjustFireLoss(rand(burn_damage, burn_damage * 1.5))
 			mob_occupant.emote("scream")
 		addtimer(CALLBACK(src, .proc/cook), 50)
 	else
@@ -292,13 +302,13 @@
 				visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A cloud of foul black smoke escapes from its chamber.</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 50, TRUE)
 			if(helmet)
-				helmet.take_damage(100,BURN,"fire")
+				helmet.take_damage(burn_damage * 10,BURN,"fire")
 			if(suit)
-				suit.take_damage(100,BURN,"fire")
+				suit.take_damage(burn_damage * 10,BURN,"fire")
 			if(mask)
-				mask.take_damage(100,BURN,"fire")
+				mask.take_damage(burn_damage * 10,BURN,"fire")
 			if(storage)
-				storage.take_damage(100,BURN,"fire")
+				storage.take_damage(burn_damage * 10,BURN,"fire")
 			// The wires get damaged too.
 			wires.cut_all()
 		if(!toasted) //Special toast check to prevent a double finishing message.
@@ -385,10 +395,27 @@
 		open_machine()
 
 /obj/machinery/suit_storage_unit/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_CROWBAR && user.a_intent == INTENT_HARM && !panel_open && machine_stat & NOPOWER)
+		if(locked)
+			to_chat(user, "<span class='warning'>[src]'s door won't budge!</span>")
+			return
+		if(!state_open)
+			visible_message("<span class='notice'>[user] starts prying open the doors of [src]!</span>", "<span class='notice'>You start prying open the doors of [src]!</span>")
+			I.play_tool_sound(src, 50)
+			if(do_after(user, 20, target=src))
+				playsound(src, 'sound/effects/bin_open.ogg', 50, TRUE)
+				open_machine(0)
+				return
+		else
+			I.play_tool_sound(src, 50)
+			visible_message("<span class='notice'>[user] pulls out the contents of [src] outside!</span>", "<span class='notice'>You pull [src]'s contents outside!</span>")
+			dump_contents()
+			update_icon()
+			return
 	if(state_open && is_operational)
 		if(istype(I, /obj/item/clothing/suit))
 			if(suit)
-				to_chat(user, "<span class='warning'>The unit already contains a suit!.</span>")
+				to_chat(user, "<span class='warning'>The unit already contains a suit!</span>")
 				return
 			if(!user.transferItemToLoc(I, src))
 				return

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -298,6 +298,7 @@
 			toasted = TRUE
 			if(occupant)
 				visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A foul stench and a cloud of smoke exit the chamber.</span>")
+				mob_occupant.radiation = 0 //The guy inside is toasted to a crisp, no need to leave him with the rads
 			else
 				visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A cloud of foul black smoke escapes from its chamber.</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 50, TRUE)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -403,8 +403,8 @@
 	icon_state = "generic"
 	build_path = /obj/machinery/suit_storage_unit/
 	req_components = list(
-		/obj/item/assembly/igniter = 1,
-		/obj/item/stack/cable_coil = 2)
+		/obj/item/stock_parts/matter_bin = 1,
+		/obj/item/stock_parts/micro_laser = 1)
 
 //Generic
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -607,6 +607,14 @@
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/vending_refill/donksoft = 1)
 
+/obj/item/circuitboard/machine/suit_storage_unit
+	name = "Suit Storage Unit (Machine Board)"
+	icon_state = "generic"
+	build_path = /obj/machinery/suit_storage_unit/
+	req_components = list(
+		/obj/item/assembly/igniter = 1,
+		/obj/item/stack/cable_coil = 2)
+
 
 //Medical
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -398,6 +398,14 @@
 	. = ..()
 	. += "<span class='notice'>It is set to layer [pipe_layer].</span>"
 
+/obj/item/circuitboard/machine/suit_storage_unit
+	name = "Suit Storage Unit (Machine Board)"
+	icon_state = "generic"
+	build_path = /obj/machinery/suit_storage_unit/
+	req_components = list(
+		/obj/item/assembly/igniter = 1,
+		/obj/item/stack/cable_coil = 2)
+
 //Generic
 
 
@@ -607,13 +615,6 @@
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/vending_refill/donksoft = 1)
 
-/obj/item/circuitboard/machine/suit_storage_unit
-	name = "Suit Storage Unit (Machine Board)"
-	icon_state = "generic"
-	build_path = /obj/machinery/suit_storage_unit/
-	req_components = list(
-		/obj/item/assembly/igniter = 1,
-		/obj/item/stack/cable_coil = 2)
 
 
 //Medical

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -683,3 +683,11 @@
 	build_path = /obj/item/circuitboard/machine/chem_dispenser/botany
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 	category = list ("Hydroponics Machinery")
+
+/datum/design/board/suit_storage_unit
+	name = "Machine Design (Suit Storage Unit)"
+	desc = "The circuit board for a suit storage unit."
+	id = "suit_storage_unit"
+	build_path = /obj/item/circuitboard/machine/suit_storage_unit
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	category = list ("Misc. Machinery")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -158,8 +158,8 @@
 	description = "A refresher course on modern engineering technology."
 	prereq_ids = list("base")
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
-	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "machine_igniter", "mass_driver", "tesla_coil", "grounding_rod",
-	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "aac_electronics", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine",
+	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "suit_storage_unit", "thermomachine", "rad_collector", "machine_igniter", "mass_driver", "tesla_coil", "grounding_rod",
+	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "aac_electronics", "airalarm_electronics", "firealarm_electronics", "stack_console", "stack_machine",
 	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "plasmaman_tank", "antivirus2", "researchdisk_locator")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Suit Storage Unit circuitboards researchable, adds stock parts to the Suit Storage Unit. Makes the burn damage of the decontamination process scale with the tier of the micro laser. Also adds the ablity to crowbar open depowered suit storage units.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's nice to have more roundstart machinery that's replicable, and that also that uses machine parts. Also getting your items out of a depowered suit storage unit is a pain since you need to smash it apart, which takes a long while. This PR remedies that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Suit Storage Unit research : 

![image](https://user-images.githubusercontent.com/110184118/215284887-5508e0bc-8df0-46e7-8567-ca68d851450e.png)

![image](https://user-images.githubusercontent.com/110184118/215285036-5cb6b066-7440-4985-a0a4-8fde8f9acd53.png)

Prying open a depowered suit storage and prying its contents out :

https://user-images.githubusercontent.com/110184118/215284643-e438fb36-1d22-4bbf-84e4-5f6edabf4da8.mp4

Non-hacked decontamination damage with stock parts : 
![image](https://user-images.githubusercontent.com/110184118/215284383-4b55b26b-8492-44be-bfdb-75a1c60b18c7.png)

With t4 parts :
![image](https://user-images.githubusercontent.com/110184118/215284399-bf867631-cb8e-48ac-a7ad-bf712853950f.png)

Hacked/emagged decontamination damage with stock parts :

![image](https://user-images.githubusercontent.com/110184118/215284479-e9bce601-b360-4c33-8c53-d79f9fc971a8.png)

With t4 parts :

![image](https://user-images.githubusercontent.com/110184118/215284505-43bf9100-c9c5-4674-847c-f012291b2223.png)


</details>

## Changelog
:cl:
add: Added research for a Suit Storage Unit circuit board
add: Added the ability to build and deconstruct Suit Storage Units
add: Added machine parts to the Suit Storage Unit
add: Added the ability to crowbar open and pry the items out of a depowered Suit Storage Unit on harm intent
balance: Suit storage unit's decontamination damage is lower by default when unhacked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
