### PR TITLE
Prevent duplicate Space Pirate spawns

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -637,15 +637,18 @@
 	weight = 4
 	cost = 8
 	minimum_players = 27
-	repeatable = TRUE
+	repeatable = FALSE
 
 /datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
 	if (!SSmapping.empty_space)
 		return FALSE
+	if(GLOB.pirates_spawned)
+		return FALSE
 	return ..()
 
 /datum/dynamic_ruleset/midround/pirates/execute()
-	send_pirate_threat()
+	if(!GLOB.pirates_spawned)
+		send_pirate_threat()
 	return ..()
 
 /// Obsessed ruleset

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -1,3 +1,5 @@
+GLOBAL_VAR_INIT(pirates_spawned, FALSE)
+
 /datum/round_event_control/pirates
 	name = "Space Pirates"
 	typepath = /datum/round_event/pirates
@@ -14,9 +16,11 @@
 	return ..()
 
 /datum/round_event/pirates/start()
-	send_pirate_threat()
+	if(!GLOB.pirates_spawned)
+		send_pirate_threat()
 
 /proc/send_pirate_threat()
+	GLOB.pirates_spawned = TRUE
 	var/ship_name = "Space Privateers Association"
 	var/payoff_min = 20000
 	var/payoff = 0


### PR DESCRIPTION
## About The Pull Request

Blocks more than one pirate threat from being sent.

## Why It's Good For The Game

Spawning more than one Space Pirate shuttle causes the shuttle flight to completely break for one of them, and it also is generally just not great for the round.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/215471636-c5b8ef23-5f96-45a1-ad3d-a7bf298380f7.png)

</details>

## Changelog
:cl:
tweak: Prevented multiple Space Pirates spawning in a round.
/:cl:
