### PR TITLE
Happiness fakes your health-diagnosis UI

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -445,7 +445,7 @@
 	. = 1
 
 /datum/reagent/drug/happiness/overdose_process(mob/living/M)
-	var/mob/living/carbon/C = L
+	var/mob/living/carbon/C = M
 	if(prob(30))
 		var/reaction = rand(1,3)
 		switch(reaction)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -422,10 +422,16 @@
 
 /datum/reagent/drug/happiness/on_mob_metabolize(mob/living/L)
 	..()
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		C.hal_screwyhud = SCREWYHUD_HEALTHY // I AM TOTALLY FINE!!
 	ADD_TRAIT(L, TRAIT_FEARLESS, type)
 	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "happiness_drug", /datum/mood_event/happiness_drug)
 
 /datum/reagent/drug/happiness/on_mob_delete(mob/living/L)
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		C.hal_screwyhud = 0 // okay, I wasn't really fine
 	REMOVE_TRAIT(L, TRAIT_FEARLESS, type)
 	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "happiness_drug")
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -445,18 +445,22 @@
 	. = 1
 
 /datum/reagent/drug/happiness/overdose_process(mob/living/M)
+	var/mob/living/carbon/C = L
 	if(prob(30))
 		var/reaction = rand(1,3)
 		switch(reaction)
 			if(1)
 				M.emote("laugh")
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "happiness_drug", /datum/mood_event/happiness_drug_good_od)
+				C.hal_screwyhud = SCREWYHUD_HEALTHY
 			if(2)
 				M.emote("sway")
 				M.Dizzy(25)
+				C.hal_screwyhud = 0
 			if(3)
 				M.emote("frown")
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "happiness_drug", /datum/mood_event/happiness_drug_bad_od)
+				C.hal_screwyhud = 0
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5)
 	..()
 	. = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Happiness chem fakes your health-diagnosis UI - you'll believe you're fully healed once you eat it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
because you should be happy with a single pill
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/215568251-e4fa4490-4804-4f2c-bf84-f6455077017c.png)

before taking it

----------

![image](https://user-images.githubusercontent.com/87972842/215568289-14d0300d-483c-45ec-a4b9-8429a2db0d23.png)

oh, god, I am fully fine!!

forgot to capture, medhud health bar says they're hurt.
so, it only fakes your personal health UI


</details>

## Changelog
:cl:
tweak: Happiness chem fakes your health-diagnosis UI - you'll believe you're fully healed once you eat it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
