### PR TITLE
Easily replaceable power cells in machines (mainly dispensers related)

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -538,7 +538,6 @@ Class Procs:
 // Power cell in hand replacement
 /obj/machinery/attackby(obj/item/C, mob/user)
 	if(istype(C, /obj/item/stock_parts/cell) && panel_open)
-		locate(/obj/item/circuitboard/machine) in component_parts
 		for(var/obj/item/P in component_parts)
 			if(istype(P,/obj/item/stock_parts/cell))
 				if(user.transferItemToLoc(C, src))

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -547,7 +547,7 @@ Class Procs:
 					component_parts-=P
 					RefreshParts()
 					playsound(src, 'sound/surgery/taperecorder_close.ogg', 50, FALSE)
-					to_chat(user, "<span class='notice'>you replaced [capitalize(P.name)]  with [C.name] via power cell socket.</span>")
+					to_chat(user, "<span class='notice'>You replace [P.name] with [C.name].</span>")
 					break
 	else
 		..()

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -535,6 +535,23 @@ Class Procs:
 		return FALSE
 	return TRUE
 
+// Power cell in hand replacement
+/obj/machinery/attackby(obj/item/C, mob/user)
+	if(istype(C, /obj/item/stock_parts/cell) && panel_open)
+		locate(/obj/item/circuitboard/machine) in component_parts
+		for(var/obj/item/P in component_parts)
+			if(istype(P,/obj/item/stock_parts/cell))
+				if(user.transferItemToLoc(C, src))
+					user.put_in_active_hand(P)
+					component_parts+=C
+					component_parts-=P
+					RefreshParts()
+					playsound(src, 'sound/surgery/taperecorder_close.ogg', 50, FALSE)
+					to_chat(user, "<span class='notice'>you replaced [capitalize(P.name)]  with [C.name] via power cell socket.</span>")
+					break
+	else
+		..()
+
 /obj/machinery/proc/exchange_parts(mob/user, obj/item/storage/part_replacer/W)
 	if(!istype(W))
 		return FALSE

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -548,9 +548,8 @@ Class Procs:
 					RefreshParts()
 					playsound(src, 'sound/surgery/taperecorder_close.ogg', 50, FALSE)
 					to_chat(user, "<span class='notice'>You replace [P.name] with [C.name].</span>")
-					break
-	else
-		..()
+					return
+	..()
 
 /obj/machinery/proc/exchange_parts(mob/user, obj/item/storage/part_replacer/W)
 	if(!istype(W))

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -343,7 +343,7 @@
 		to_chat(user, "<span class='notice'>You add [B] to [src].</span>")
 		updateUsrDialog()
 		update_icon()
-	else if(user.a_intent != INTENT_HARM && !istype(I, /obj/item/card/emag))
+	else if(user.a_intent != INTENT_HARM && !istype(I, /obj/item/card/emag) && !istype(I, /obj/item/stock_parts/cell))
 		to_chat(user, "<span class='warning'>You can't load [I] into [src]!</span>")
 		return ..()
 	else

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -5,6 +5,7 @@
 	icon_state = "nanite_cloud_controller"
 	circuit = /obj/item/circuitboard/computer/nanite_cloud_controller
 
+	req_access = list(ACCESS_RESEARCH)
 
 
 	var/obj/item/disk/nanite_program/disk
@@ -66,6 +67,10 @@
 	return GLOB.default_state
 
 /obj/machinery/computer/nanite_cloud_controller/ui_interact(mob/user, datum/tgui/ui)
+	if(!allowed(user))
+		to_chat(user, "<span class='warning'>Missing required access!</span>")
+		return
+	..()
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "NaniteCloudControl")
@@ -256,3 +261,8 @@
 	storage.cloud_backups -= src
 	SSnanites.cloud_backups -= src
 	return ..()
+
+/obj/machinery/computer/nanite_cloud_controller/on_emag(mob/user)
+	..()
+	req_access = list()
+	to_chat(user, "<span class='warning'>You bypass [src]'s access requirements.</span>")

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -5,7 +5,6 @@
 	icon_state = "nanite_cloud_controller"
 	circuit = /obj/item/circuitboard/computer/nanite_cloud_controller
 
-	req_access = list(ACCESS_RESEARCH)
 
 
 	var/obj/item/disk/nanite_program/disk
@@ -67,10 +66,6 @@
 	return GLOB.default_state
 
 /obj/machinery/computer/nanite_cloud_controller/ui_interact(mob/user, datum/tgui/ui)
-	if(!allowed(user))
-		to_chat(user, "<span class='warning'>Missing required access!</span>")
-		return
-	..()
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "NaniteCloudControl")
@@ -261,8 +256,3 @@
 	storage.cloud_backups -= src
 	SSnanites.cloud_backups -= src
 	return ..()
-
-/obj/machinery/computer/nanite_cloud_controller/on_emag(mob/user)
-	..()
-	req_access = list()
-	to_chat(user, "<span class='warning'>You bypass [src]'s access requirements.</span>")


### PR DESCRIPTION
## About The Pull Request

Just what the title says, being able to replace power cell in a machine without actually breaking it. 

## Why It's Good For The Game
 It feels bad that you have to disassemble whole machine apart to replace a power cell. Power cell should be considered an easily replaceable part, its replacement should be less complicated.
This will lessen needs for tools for other departments such as botany/chemistry/bar and make their life's easier.
Power cells could be replaced by clicking on a machine with a battery in hand with  its maintenance hatch open.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/58709092/215908458-7b88b96b-652d-49e1-99b2-ebe1e1ed63cc.mp4



https://user-images.githubusercontent.com/58709092/215908777-21b6d966-b545-43c4-a085-7d0b2fc3d822.mp4



https://user-images.githubusercontent.com/58709092/215909336-823f490a-e183-4fc8-99b1-679170a3180f.mp4



</details>

## Changelog
:cl:
add: Added Power Cell swapping.
/:cl:
