### PR TITLE
Fixes lavaland swarmer runtime

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -469,7 +469,7 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/swarmer/proc/add_to_total_resources_eaten(var/gains)
-	var/datum/antagonist/swarmer/S = mind.has_antag_datum(/datum/antagonist/swarmer)
+	var/datum/antagonist/swarmer/S = mind?.has_antag_datum(/datum/antagonist/swarmer)
 	if(S)
 		S.swarm.total_resources_eaten += gains
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Encountered this runtime while testing spider AI changes by accidentally loading full server with lavaland. Lavaland had swarmers and kept firing off runtimes unrelated to what I was testing and made me angry. 

The only thing changed is the addition of a single `?`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtimes bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/216185624-b80c229c-af13-42ba-b270-2b20cb534cb6.png)

</details>

## Changelog
:cl:
fix: fixed a runtime caused by lavaland swarmers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
