### PR TITLE
Station traits are chosen with more equalised randomness

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -43,10 +43,19 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	var/neutral_trait_count = pick(10;0, 10;1, 3;2)
 	var/negative_trait_count = pick(20;0, 5;1, 1;2)
 
-	pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
-	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
-	pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
-	adds_exclusive_traits()
+	var/possible_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE, STATION_TRAIT_EXCLUSIVE)
+	while(length(possible_types))
+		var/picked = pick(possible_types)
+		switch(picked)
+			if(STATION_TRAIT_POSITIVE)
+				pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
+			if(STATION_TRAIT_NEUTRAL)
+				pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
+			if(STATION_TRAIT_NEGATIVE)
+				pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
+			if(STATION_TRAIT_EXCLUSIVE)
+				adds_exclusive_traits()
+		possible_types -= picked
 
 ///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them and adds them to the list of traits.
 /datum/controller/subsystem/processing/station/proc/pick_traits(trait_type, amount)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -45,7 +45,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 	var/possible_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE, STATION_TRAIT_EXCLUSIVE)
 	while(length(possible_types))
-		var/picked = pick(possible_types)
+		var/picked = pick_n_take(possible_types)
 		switch(picked)
 			if(STATION_TRAIT_POSITIVE)
 				pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
@@ -55,7 +55,6 @@ PROCESSING_SUBSYSTEM_DEF(station)
 				pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
 			if(STATION_TRAIT_EXCLUSIVE)
 				adds_exclusive_traits()
-		possible_types -= picked
 
 ///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them and adds them to the list of traits.
 /datum/controller/subsystem/processing/station/proc/pick_traits(trait_type, amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Station traits are chosen with more equalised randomness
Positive station traits are always chosen first, and it blacklists the traits that'll come up later.
This means the traits that come up later will not be chosen, and it's against the nature of randomness.

as a result of this PR, the chance of some neg station traits will appear slightly more than before,
while some neg traits that are not affected by blacklist will have lower chance to appear than before.

i.e.) intern announcer will appear slightly more than before, because it was blacklisted by neutral traited announcers
i.e.2.) united budget will appear slightly less than before, because intern will not be blacklisted when neg traits are chosen

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
more equalised randomness good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
It's hard to tell the difference as a screenshot.
local test has been done with no runtime error, and I checked it through `world.log << picked`

## Changelog
:cl:
tweak: Station traits are now chosen with more equalised randomness.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
