### PR TITLE
Fixes remained quirk point at positive value resets your quirk pref

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -47,7 +47,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		else
 			stack_trace("Invalid quirk \"[V]\" in client [cli.ckey] preferences. the game has reset their quirks automatically.")
 			bad_quirks += V
-	if(bad_quirk_checker || length(bad_quirks)) // negative & zero value = calculation good / positive quirk value = something's wrong
+	if(!bad_quirk_checker || length(bad_quirks)) // positive & zero value = calculation good / negative quirk value = something's wrong
 		cli.prefs.active_character.all_quirks = list()
 		cli.prefs.active_character.save(cli)
 		client_alert(cli, "You have one or more outdated quirks[length(bad_quirks) ? ": [english_list(bad_quirks)]" : ""]. Your eligible quirks are kept at this round, but your character preference has been reset. Please review them at any time.", "Oh, no!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Fixes remained quirk point at positive value resets your quirk pref

bug is caused by https://github.com/BeeStation/BeeStation-Hornet/pull/8143
I reversed the condition check...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fuck me

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/216275657-30e4a77b-292a-4412-9c47-e990ebeb666c.png)

</details>

## Changelog
:cl:
Fix: remained quirk point being positive value (i.e. has only neg quirks) no longer resets your quirk pref
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
