### PR TITLE
Fixes missing cyborg welder icon introduced in #8254

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -349,6 +349,7 @@
 /obj/item/weldingtool/cyborg/mini
 	name = "integrated emergency welding tool"
 	desc = "A miniature integrated welder used during emergencies."
+	icon = 'icons/obj/tools.dmi'
 	icon_state = "miniwelder"
 	max_fuel = 10
 	w_class = WEIGHT_CLASS_TINY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#8254 refactored cyborg welders, and introduced a new type of welder for use by mining cyborgs that didn't have a working icon. I then gave that welder to all the rest of the cyborgs in #8412 and have now realized that item didn't have a working icon. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Missing icons bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Cyborg mini-welder icon was missing:
![image](https://user-images.githubusercontent.com/9547572/216523400-dcf24c7c-a9c7-41e4-b26d-bbfa85fa653b.png)

Now it isn't:
![image](https://user-images.githubusercontent.com/9547572/216523382-7bd40fc1-0b03-4128-9134-76433aa3c294.png)

</details>

## Changelog
:cl:
fix: Fixes cyborg mini-welder icon. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
