### PR TITLE
Nightmare's Lighteater now smashes the lamp of the plamsaman helmets instead of dusting them.

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -108,7 +108,7 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/attackby(obj/item/item, mob/living/user)
 	. = ..()
-	if(istype(item, /obj/item/flashlight) && !lamp_functional)
+	if(istype(item, /obj/item/light/bulb) && !lamp_functional)
 		lamp_functional = TRUE
 		qdel(item)
 		to_chat(user, "<span class='notice'>You repair the broken headlamp!</span>")

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -201,7 +201,7 @@
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	helmet_on = !helmet_on
 	if(!lamp_functional)
-		to_chat(user, "<span class='notice'>Your helmet's torch is broken!</span>")
+		to_chat(user, "<span class='notice'>Your helmet's torch is broken! You'll have to repair it with a lightbulb!</span>")
 		set_light_on(FALSE)
 		helmet_on = FALSE
 		return

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -58,6 +58,7 @@
 	var/smile_color = "#FF0000"
 	var/smile_state = "envirohelm_smile"
 	var/visor_state = "enviro_visor"
+	var/lamp_functional = TRUE
 	var/obj/item/clothing/head/attached_hat
 	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen/plasmaman)
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
@@ -107,6 +108,10 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/attackby(obj/item/item, mob/living/user)
 	. = ..()
+	if(istype(item, /obj/item/flashlight) && !lamp_functional)
+		lamp_functional = TRUE
+		qdel(item)
+		to_chat(user, "<span class='notice'>You repair the broken headlamp!</span>")
 	if(istype(item, /obj/item/toy/crayon))
 		if(smile)
 			to_chat(user, "<span class='notice'>Seems like someone already drew something on the helmet's visor.</span>")
@@ -195,7 +200,11 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	helmet_on = !helmet_on
-
+	if(!lamp_functional)
+		to_chat(user, "<span class='notice'>Your helmet's torch is broken!</span>")
+		set_light_on(FALSE)
+		helmet_on = FALSE
+		return
 	if(helmet_on)
 		if(!up)
 			to_chat(user, "<span class='notice'>Your helmet's torch can't pass through your welding visor!</span>")
@@ -209,6 +218,20 @@
 	update_icon()
 	user.update_inv_head() //So the mob overlay updates
 	update_button_icons(user)
+
+/obj/item/clothing/head/helmet/space/plasmaman/proc/smash_headlamp()
+	if(!lamp_functional)
+		return
+	if(!helmet_on)
+		return
+	set_light_on(FALSE)
+	helmet_on = FALSE
+	playsound(src, 'sound/effects/glass_step.ogg', 100)
+	to_chat(usr, "<span class='danger'>The [src]'s headlamp is smashed to pieces!</span>")
+	lamp_functional = FALSE
+	update_icon()
+	usr.update_inv_head() //So the mob overlay updates
+	update_button_icons(usr)
 
 /obj/item/clothing/head/helmet/space/plasmaman/update_overlays()
 	cut_overlays()

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -252,6 +252,13 @@
 	playsound(src, 'sound/items/welder.ogg', 50, 1)
 	..()
 
+/obj/item/clothing/head/helmet/space/plasmaman/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
+	if(!lamp_functional)
+		return
+	if(helmet_on)
+		smash_headlamp()
+	..()
+
 /turf/open/floor/light/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	. = ..()
 	if(!light_range || !light_power || !light_on)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Nightmare's Lighteater destroy the lamp of the plasmaman helmet if it's on, instead of dusting the helmet outright.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Kinda sucks to get jumpscared by a Nightmare and loose your only helmet while playing as a plasmaman, which odds are will end up with you husked.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/110184118/216715321-c7e39683-9a61-430b-b582-581d22b80952.mp4

</details>

## Changelog
:cl:
tweak: Instead of being dusted, plasmaman helmets now have their lamps broken when hit with the Light Eater
add: Added the ability to repair broken plasmaman helmet lamps with light bulbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
