### PR TITLE
Fixes phobia fainting loop

### DIFF
--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -111,7 +111,7 @@
 				to_chat(owner, "<span class ='notice'>you manage to calm down a little.</span>")
 			if(fear_state == PHOBIA_STATE_CALM)
 				fear_state = PHOBIA_STATE_EDGY
-				if(prob(stress * 10))
+				if(prob(stress * 5))
 					fearscore = 9
 		if(9 to 16)
 			if(fear_state >= PHOBIA_STATE_FIGHTORFLIGHT)
@@ -122,7 +122,7 @@
 				fear_state = PHOBIA_STATE_UNEASY
 				owner.add_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE, 100, override=TRUE, multiplicative_slowdown = 1)
 				owner.Jitter(5)
-				if(prob(stress * 10))
+				if(prob(stress * 5))
 					fearscore = 17
 		if(17 to 28)
 			if(fear_state >= PHOBIA_STATE_TERROR) //we don't get an adrenaline rush when calming down
@@ -134,8 +134,8 @@
 				to_chat(owner, "<span class ='userdanger'>YOU HAVE TO GET OUT OF HERE! IT'S DANGEROUS!</span>")
 				owner.add_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE, 100, override=TRUE, multiplicative_slowdown = -0.4)//while terrified, get a speed boost
 				owner.emote("scream")
-				if(prob(stress * 10))
-					fearscore = 27 //we don't get the adrenaline rush, and keel over like a baby immediately
+				if(prob(stress * 5))
+					fearscore = 29 //we don't get the adrenaline rush, and keel over like a baby immediately
 				owner.adjustStaminaLoss(-75)
 				owner.SetStun(0)
 				owner.SetKnockdown(0)
@@ -156,14 +156,15 @@
 				owner.Paralyze(80)
 				owner.Jitter(8)
 				stress++
-				if(prob(stress * 10))
+				if(prob(stress * 5))
 					fearscore = 36 //we immediately keel over and faint
 		if(36 to INFINITY)
 			if(fear_state <= PHOBIA_STATE_TERROR)
 				fear_state = PHOBIA_STATE_FAINT
 				owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE) //in the case that we get so scared by enough bullshit nearby we skip the last stage
+				fearscore = 9
+				owner.visible_message("<span class ='danger'>[owner] faints in fear!</span>", "<span class ='userdanger'>It's too much! You faint!</span>")
 				owner.Sleeping(300)
-				owner.visible_message("<span class ='danger'>[owner] faints in fear!</span>", "<span class ='userdanger'>It's too much! you faint!</span>")
 				if(prob(stress * 3))
 					owner.set_heartattack(TRUE)
 					to_chat(owner, "<span class='userdanger'>Your heart stops!</span>")
@@ -244,7 +245,11 @@
 			owner.Jitter(3)
 		if(PHOBIA_STATE_FAINT)
 			if(!owner.stat)
-				owner.Sleeping(300)
+				if(fearscore>=36)  //Checks for fearscore so you wont be instantly fainting right after waking up from a faint and seeing the reason again
+					owner.Sleeping(300)
+					fear_state = PHOBIA_STATE_FIGHTORFLIGHT
+					fearscore = 9
+
 
 /datum/brain_trauma/mild/phobia/on_lose()
 	owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remake of #8426 because that one was pushed from my main branch. Now I understand how branches work.
Buffed fainting from phobias by fixing instantly fainting right after waking up. After fainting, you'll be bumped back to an Uneasy level instead of leaving you on Fainting.
Decreased the snowball effect from stress build-up by half as well. Necessary as being looped back to a lower level gives you more stress as you build up to a fainting level again. This leads to faster heartattack however, since each fainting adds +3 to stress.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently having a phobia and fainting once puts you into a fainting loop with only a very little time to get away or say something after waking up. This should make you be able to get away or at least ask someone to pull you away from your fears.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<summary>Screenshots&Videos</summary>

https://www.youtube.com/watch?v=Xvwl8x1hUpM

</details>

## Changelog
:cl:
balance: Decreased the snowball effect of fear build-up from (stress x10)% to (stress x5)%. Your stress levels build up faster with each fainting now, which leads to a higher chance of a heartattack
fix: You wont faint immediately after waking up from a faint caused by a phobia
fix: The message for fainting from a phobia will actually be visible for the one fainting now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
