### PR TITLE
Cyborg emissive lights work again!

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -679,7 +679,7 @@
 		else
 			eye_lights.icon_state = "[module.special_light_key ? "[module.special_light_key]":"[module.cyborg_base_icon]"]_e[ratvar ? "_r" : ""]"
 			eye_lights.color = COLOR_WHITE
-			eye_lights.plane = OBJ_LAYER
+			eye_lights.plane = ABOVE_LIGHTING_PLANE //still glowy, but don't emit actual light
 		eye_lights.icon = icon
 		add_overlay(eye_lights)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cyborgs look dead even when they aren't:

![image](https://user-images.githubusercontent.com/9547572/216756246-5241e7bc-fd80-4592-9d4c-a1201086c290.png)

Their passive lights (not the flashlight) don't come on when they are powered up. This PR fixes them

![image](https://user-images.githubusercontent.com/9547572/216756250-956607d4-6757-461d-b519-54aa21296d6a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Things working is generally better than things not working

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/216756270-6a5d14dc-491a-4785-ad6e-672377adf45d.png)

![image](https://user-images.githubusercontent.com/9547572/216756275-b27e88cf-5bd0-4a08-b021-c5afde59df13.png)
</details>

## Changelog
:cl:
fix: Cyborgs now have properly functioning emissive lights again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
