### PR TITLE
Corrects the potentialRandomZlevels filename attribute

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -1,5 +1,5 @@
 // How much "space" we give the edge of the map
-GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "[global.config.directory]/awaymissionconfig.txt"))
+GLOBAL_LIST_INIT(potentialRandomZlevels, generateMapList(filename = "awaymissionconfig.txt"))
 
 /proc/createRandomZlevel()
 	if(GLOB.awaydestinations.len)	//crude, but it saves another var!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The potentialRandomZlevels list was broken following pr #5695. This removes the vestigial config location portion of the filename from the global variable.

## Why It's Good For The Game

Away missions are largely depreciated, but, someone brought it up in Discord and this is a minor patch; might as well fix it.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26130695/216791897-dbc7a59a-d947-4fc9-af87-4eba57c92cf2.png)


## Changelog
:cl:
fix: The away mission map list correctly populates again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
