### PR TITLE
Adds a cooldown to farting

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -210,6 +210,24 @@
 		return
 	return 'sound/misc/fart1.ogg'
 
+/datum/emote/living/carbon/human/fart/run_emote(mob/user, params, type_override, intentional)
+	if(ishuman(user))
+		var/mob/living/carbon/human/fartee = user
+		if(COOLDOWN_FINISHED(fartee, fart_cooldown))
+			..()
+			COOLDOWN_START(fartee, fart_cooldown, 2 MINUTES)
+		else
+			if(prob(20) && HAS_TRAIT(fartee, TRAIT_CLUMSY))
+				var/turf/T = get_turf(fartee)
+				fartee.spew_organ(0, 1)
+				fartee.add_splatter_floor(T)
+				playsound(T, 'sound/effects/splat.ogg', 50, 1)
+				fartee.visible_message("[fartee] sprays a bloody mess out of their rear!", "<span class='notice'>You manage to strain out more than just a fart!</span>")
+				..()
+			else
+				to_chat(user, "<span class='warning'>You strain, but can't seem to fart again just yet.</span>")
+		return TRUE
+		
 // Robotic Tongue emotes. Beep!
 
 /datum/emote/living/carbon/human/robot_tongue/can_run_emote(mob/user, status_check = TRUE , intentional)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -213,19 +213,11 @@
 /datum/emote/living/carbon/human/fart/run_emote(mob/user, params, type_override, intentional)
 	if(ishuman(user))
 		var/mob/living/carbon/human/fartee = user
-		if(COOLDOWN_FINISHED(fartee, fart_cooldown))
+		if(COOLDOWN_FINISHED(fartee, special_emote_cooldown))
 			..()
-			COOLDOWN_START(fartee, fart_cooldown, 20 SECONDS)
+			COOLDOWN_START(fartee, special_emote_cooldown, 20 SECONDS)
 		else
-			if(prob(5) && HAS_TRAIT(fartee, TRAIT_CLUMSY))
-				var/turf/T = get_turf(fartee)
-				fartee.spew_organ(0, 1)
-				fartee.add_splatter_floor(T)
-				playsound(T, 'sound/effects/splat.ogg', 50, 1)
-				fartee.visible_message("<span class='warning'>[fartee] sprays a bloody mess out of their rear!</span>", "<span class='warning'>You manage to strain out more than just a fart!</span>")
-				..()
-			else
-				to_chat(user, "<span class='warning'>You strain, but can't seem to fart again just yet.</span>")
+			to_chat(user, "<span class='warning'>You strain, but can't seem to fart again just yet.</span>")
 		return TRUE
 
 // Robotic Tongue emotes. Beep!

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -215,7 +215,7 @@
 		var/mob/living/carbon/human/fartee = user
 		if(COOLDOWN_FINISHED(fartee, fart_cooldown))
 			..()
-			COOLDOWN_START(fartee, fart_cooldown, 2 MINUTES)
+			COOLDOWN_START(fartee, fart_cooldown, 20 SECONDS)
 		else
 			if(prob(20) && HAS_TRAIT(fartee, TRAIT_CLUMSY))
 				var/turf/T = get_turf(fartee)
@@ -227,7 +227,7 @@
 			else
 				to_chat(user, "<span class='warning'>You strain, but can't seem to fart again just yet.</span>")
 		return TRUE
-		
+
 // Robotic Tongue emotes. Beep!
 
 /datum/emote/living/carbon/human/robot_tongue/can_run_emote(mob/user, status_check = TRUE , intentional)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -217,12 +217,12 @@
 			..()
 			COOLDOWN_START(fartee, fart_cooldown, 20 SECONDS)
 		else
-			if(prob(20) && HAS_TRAIT(fartee, TRAIT_CLUMSY))
+			if(prob(5) && HAS_TRAIT(fartee, TRAIT_CLUMSY))
 				var/turf/T = get_turf(fartee)
 				fartee.spew_organ(0, 1)
 				fartee.add_splatter_floor(T)
 				playsound(T, 'sound/effects/splat.ogg', 50, 1)
-				fartee.visible_message("[fartee] sprays a bloody mess out of their rear!", "<span class='notice'>You manage to strain out more than just a fart!</span>")
+				fartee.visible_message("<span class='warning'>[fartee] sprays a bloody mess out of their rear!</span>", "<span class='warning'>You manage to strain out more than just a fart!</span>")
 				..()
 			else
 				to_chat(user, "<span class='warning'>You strain, but can't seem to fart again just yet.</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/mob/human.dmi'
 	icon_state = ""
 	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
-	COOLDOWN_DECLARE(fart_cooldown)
+	COOLDOWN_DECLARE(special_emote_cooldown)
 
 /mob/living/carbon/human/Initialize(mapload)
 	add_verb(/mob/living/proc/mob_sleep)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/mob/human.dmi'
 	icon_state = ""
 	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
+	COOLDOWN_DECLARE(fart_cooldown)
 
 /mob/living/carbon/human/Initialize(mapload)
 	add_verb(/mob/living/proc/mob_sleep)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Adds a ~~two minute~~ 20 second cooldown to farting
* Attempting to fart again while this cooldown is active gives an appropriate error message
* ~~Attempting to fart while this is on cooldown *with the clumsy trait* has a 5% chance to succeed at the cost of shitting out an organ. Honk.~~

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Spamming fart is LRP behavior and doesn't generally belong on the server. 
~~Clowns deserve better than just a cooldown on their farts, however.~~

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

As a clown
![image](https://user-images.githubusercontent.com/9547572/217232269-b1fd9d95-95c2-4cf2-b4d9-3750e57b30ce.png)
![image](https://user-images.githubusercontent.com/9547572/217232081-d6e43075-e2c1-4fd5-ba02-b339a3c149f1.png)
![image](https://user-images.githubusercontent.com/9547572/217232178-7d39b1fc-ece0-45f9-9170-bf0ff73f71de.png)

Meanwhile as a non-clown:
![image](https://user-images.githubusercontent.com/9547572/217232333-ce63294e-2cf9-4e31-b29e-b69c8330cae6.png)
![image](https://user-images.githubusercontent.com/9547572/217232359-0e59a078-e1a7-46fd-b43b-fc86b32dd38a.png)
</details>

## Changelog
:cl:
tweak: Farting now has a cooldown. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
