### PR TITLE
Changes the MK-2 Ripley's speed to be quicker

### DIFF
--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -1,12 +1,10 @@
 /obj/mecha/proc/get_armour_facing(relative_dir)
-	switch(relative_dir)
-		if(0) // BACKSTAB!
+	switch(abs(relative_dir))
+		if(180) // BACKSTAB!
 			return facing_modifiers[MECHA_BACK_ARMOUR]
-		if(45, 90, 270, 315)
-			return facing_modifiers[MECHA_SIDE_ARMOUR]
-		if(225, 180, 135)
+		if(0, 45)
 			return facing_modifiers[MECHA_FRONT_ARMOUR]
-	return 1 //always return non-0
+	return facing_modifiers[MECHA_SIDE_ARMOUR] //always return non-0
 
 /obj/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
@@ -43,7 +41,7 @@
 				break
 
 	if(attack_dir)
-		var/facing_modifier = get_armour_facing(dir2angle(attack_dir) - dir2angle(src))
+		var/facing_modifier = get_armour_facing(dir2angle(attack_dir) - dir2angle(dir))
 		booster_damage_modifier /= facing_modifier
 		booster_deflection_modifier *= facing_modifier
 	if(prob(deflect_chance * booster_deflection_modifier))

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -78,9 +78,9 @@
 	name = "\improper APLU MK-II \"Ripley\""
 	icon_state = "ripleymkii"
 	base_icon_state = "ripleymkii"
-	fast_pressure_step_in = 2 //step_in while in low pressure conditions
-	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
-	step_in = 4
+	fast_pressure_step_in = 1.75 //step_in while in low pressure conditions
+	slow_pressure_step_in = 3 //step_in while in normal pressure conditions
+	step_in = 3
 	armor = list("melee" = 40, "bullet" = 20, "laser" = 10, "energy" = 20, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100, "stamina" = 0)
 	wreckage = /obj/structure/mecha_wreckage/ripley/mkii
 	enclosed = TRUE


### PR DESCRIPTION
## About The Pull Request

Very simply, changes the MK-II's (NOT the firefighter's) walking speed to 3 in atmos, 1.75 out of atmos, from 4 & 2, respectively.

## Why It's Good For The Game

There's no incentive to build a MK-II outside of cargo bounties as the Firefighter is simply better in almost every way, it's radproof, more fire resistant, has more health & more armor. Instead of making the Firefighter slower, which.. would make it very unpopular, this increases the MK-II's speed to be on-par with a Gygax, so it's a lot more usable indoors. (Why would such a  weak mech even be as slow as the Durand.)

## Testing Photographs and Procedure

WebEdit of existing variables that affect balance.

</details>

## Changelog
:cl:
balance: The MK-II Ripley isn't completely inferior compared to the Firefighter - there's a reason to make it now! You should see more MK-II's after if this change goes through which is (probably?) good.
/:cl:

