### PR TITLE
Fixes Snow rock icon states

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -201,7 +201,7 @@
 	name = "ice cavern rock"
 	icon = 'icons/turf/mining.dmi'
 	smooth_icon = 'icons/turf/walls/icerock_wall.dmi'
-	icon_state = "icerock"
+	icon_state = "icerock_wall"
 	base_icon_state = "icerock_wall"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
 	baseturfs = /turf/open/floor/plating/asteroid/basalt/iceland_surface
@@ -413,7 +413,7 @@
 	name = "snowy mountainside"
 	icon = 'icons/turf/mining.dmi'
 	smooth_icon = 'icons/turf/walls/mountain_wall.dmi'
-	icon_state = "mountain_wall-0"
+	icon_state = "mountain_wall"
 	base_icon_state = "mountain_wall"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
 	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS)
@@ -427,7 +427,7 @@
 	name = "ice cavern rock"
 	icon = 'icons/turf/mining.dmi'
 	smooth_icon = 'icons/turf/walls/icerock_wall.dmi'
-	icon_state = "icerock_wall-0"
+	icon_state = "icerock_wall"
 	base_icon_state = "icerock_wall"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
 	baseturfs = /turf/open/floor/plating/asteroid/basalt/iceland_surface


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
currently, these three have the wrong icon_state:
/turf/closed/mineral/random/snowmountain/cavern
/turf/closed/mineral/snowmountain
/turf/closed/mineral/snowmountain/cavern

----

This causes them to load with the error marker, instead of their icon in the map editor, which is incredibly annoying

/turf/closed/mineral/random/snowmountain/cavern is a subtype of a non-existent turf, but that's a can of worms I do not want to open
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it being pink and black squares make mapping with them tedious, and annoying. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

for whatever reason, /turf/closed/mineral/snowmountain+cavern uses "Mountain_wall-o" as its icon state (it doesn't exist)

![image](https://user-images.githubusercontent.com/79304582/217236045-af7d7aa4-8c50-4b34-8070-344cc1d97c23.png)

/turf/closed/mineral/random/snowmountain/cavern uses "icerock" instead of the right one "icerock_wall"

![image](https://user-images.githubusercontent.com/79304582/217236128-e183e9a3-2975-49fc-a5cd-29db037e20fd.png)

they look right now!

![image](https://user-images.githubusercontent.com/79304582/217236509-b2b11fa4-5994-4aff-a051-84674a20dc0f.png)

</details>

## Changelog
:cl:
fix: fixed /turf/closed/mineral/random/snowmountain/cavern
fix: fixed /turf/closed/mineral/snowmountain
fix: fixed /turf/closed/mineral/snowmountain/cavern
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
