### PR TITLE
Conveyor QOL

### DIFF
--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -425,7 +425,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		if(1)
 			oneway = -1
 			newdirtext = "reverse one-way"
-	to_chat(user, "<span class='notice'>You set the conveyor switch to [newdirtext] mode.")
+	to_chat(user, "<span class='notice'>You set the conveyor switch to [newdirtext] mode.</span>")
 	return TRUE
 
 /obj/machinery/conveyor_switch/oneway

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -251,6 +251,20 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	else
 		return ..()
 
+/obj/machinery/conveyor/multitool_act(mob/living/user, obj/item/multitool/tool)
+	if(!multitool_check_buffer(user, tool)) //make sure it has a data buffer
+		return TRUE
+	var/obj/machinery/conveyor_switch/cswitch = tool.buffer
+	if(!cswitch || !istype(cswitch))
+		return TRUE
+
+	// Set up the conveyor with our new ID
+	LAZYREMOVE(GLOB.conveyors_by_id[id], src)
+	id = cswitch.id
+	LAZYADD(GLOB.conveyors_by_id[id], src)
+	to_chat(user, "<span class='notice'>You link [src] to [cswitch].</span>")
+	return TRUE
+
 // attack with hand, move pulled object onto conveyor
 /obj/machinery/conveyor/attack_hand(mob/user)
 	. = ..()
@@ -384,13 +398,35 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	update_linked_switches()
 
 
-/obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_CROWBAR)
-		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
-		C.id = id
-		transfer_fingerprints_to(C)
-		to_chat(user, "<span class='notice'>You detach the conveyor switch.</span>")
-		qdel(src)
+/obj/machinery/conveyor_switch/crowbar_act(mob/living/user, obj/item/I)
+	var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
+	C.id = id
+	transfer_fingerprints_to(C)
+	to_chat(user, "<span class='notice'>You detach the conveyor switch.</span>")
+	qdel(src)
+	return TRUE
+
+/obj/machinery/conveyor_switch/multitool_act(mob/living/user, obj/item/multitool/tool)
+	if(!istype(tool))
+		return
+	tool.buffer = src
+	to_chat(user, "<span class='notice'>You store [src] in [tool]'s buffer.</span>")
+	return TRUE
+
+/obj/machinery/conveyor_switch/screwdriver_act(mob/living/user, obj/item/I)
+	var/newdirtext = ""
+	switch(oneway)
+		if(-1)
+			oneway = 0
+			newdirtext = "two-way"
+		if(0)
+			oneway = 1
+			newdirtext = "one-way"
+		if(1)
+			oneway = -1
+			newdirtext = "reverse one-way"
+	to_chat(user, "<span class='notice'>You set the conveyor switch to [newdirtext] mode.")
+	return TRUE
 
 /obj/machinery/conveyor_switch/oneway
 	icon_state = "conveyor_switch_oneway"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This adds multitool-based conveyor linking functionality to conveyors. It also lets you use a screwdriver to change conveyor switches from two-way to one-way mode for both directions.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This should hopefully make conveyor construction less tedious, especially if you forget to link your switch before-hand.
This also means you can make one-way switches in-game, instead of having them be mapping-only.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/9423435/217419616-b460c9e3-6f20-47f9-bf5f-e576d5a3fc5f.mp4



</details>

## Changelog
:cl:
add: Conveyors may now be linked to conveyor switches using a multitool.
add: Using a screwdriver on a conveyor switch will now toggle it between one-way and two-way mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
