### PR TITLE
Fixes an APC icon issue

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1,10 +1,11 @@
 //update_state
-#define UPSTATE_CELL_IN		(1<<0)
+//Shifts 0/1/2 are used by UPSTATE_OPENED1 and UPSTATE_OPENED2 with a base shift of 0 (see _DEFINES/apc.dm)
 #define UPSTATE_MAINT		(1<<3)
 #define UPSTATE_BROKE		(1<<4)
 #define UPSTATE_BLUESCREEN	(1<<5)
 #define UPSTATE_WIREEXP		(1<<6)
 #define UPSTATE_ALLGOOD		(1<<7)
+#define UPSTATE_CELL_IN		(1<<8)
 
 #define APC_RESET_EMP "emp"
 
@@ -341,7 +342,7 @@
 		icon_state = "apc0"
 		return ..()
 	if(update_state & (UPSTATE_OPENED1|UPSTATE_OPENED2))
-		var/basestate = "apc[cell ? 2 : 1]"
+		var/basestate = "apc[update_state & UPSTATE_CELL_IN ? 2 : 1]"
 		if(update_state & UPSTATE_OPENED1)
 			icon_state = (update_state & (UPSTATE_MAINT|UPSTATE_BROKE)) ? "apcmaint" : basestate
 		else if(update_state & UPSTATE_OPENED2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes UPSTATE_CELL_IN breaking APC icon states. Originally this define's bitshift would interfere with UPSTATE_OPENED1 and UPSTATE_OPENED2, which skipped the rest of update_icon_state if a cell was inside.

APCs also use UPSTATE_CELL_IN instead of checking the cell var when updating their icons now, which is consistent with the rest of update_icon_state.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
An APC looking like its open when its fully broken is pretty confusing. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/217618746-7d0eb95a-e6a4-4520-b591-4bd75d656a14.png)

![image](https://user-images.githubusercontent.com/9423435/217619220-83f87ba7-d850-451d-b970-d57dcb09ce30.png)

![image](https://user-images.githubusercontent.com/9423435/217619359-1cee9752-93a6-498e-8736-daeebbd0e8c0.png)


</details>

## Changelog
:cl:
fix: APC icon states now update properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
