### PR TITLE
Single Recipe Deletion for chem dispensers

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -306,13 +306,9 @@
 			recording_recipe = list()
 			. = TRUE
 		if("delete_recipe")
-			var/deletion_target = stripped_input(usr,"Name","please type the recipe you wish to delete", "Recipe", MAX_NAME_LEN)
+			//open a dialogue box to choose what recipe to delete
+			var/deletion_target = input("Select recipe to delete." , "Recipe Deletion") as null|anything in saved_recipes
 			if(!usr.canUseTopic(src, !issilicon(usr)))
-				return
-			if(!saved_recipes.Find(deletion_target))
-				say("No recipe by that name!")
-				return
-			if(saved_recipes[deletion_target] && alert("\"[deletion_target]\" exists, do you want to Delete it?",, "Yes", "No") == "No")
 				return
 			if(deletion_target)
 				saved_recipes.Remove(deletion_target)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -305,6 +305,18 @@
 		if("record_recipe")
 			recording_recipe = list()
 			. = TRUE
+		if("delete_recipe")
+			var/deletion_target = stripped_input(usr,"Name","please type the recipe you wish to delete", "Recipe", MAX_NAME_LEN)
+			if(!usr.canUseTopic(src, !issilicon(usr)))
+				return
+			if(!saved_recipes.Find(deletion_target))
+				say("No recipe by that name!")
+				return
+			if(saved_recipes[deletion_target] && alert("\"[deletion_target]\" exists, do you want to Delete it?",, "Yes", "No") == "No")
+				return
+			if(deletion_target)
+				saved_recipes.Remove(deletion_target)
+				. = TRUE
 		if("save_recording")
 			var/name = stripped_input(usr,"Name","What do you want to name this recipe?", "Recipe", MAX_NAME_LEN)
 			if(!usr.canUseTopic(src, !issilicon(usr)))

--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -65,6 +65,13 @@ export const ChemDispenser = (props, context) => {
                   content="Record"
                   onClick={() => act('record_recipe')} />
               )}
+              {!recording && (
+                <Button
+                  icon="ban"
+                  disabled={recipes.map===[]}
+                  content="Delete"
+                  onClick={() => act('delete_recipe')} />
+              )}
               {recording && (
                 <Button
                   icon="ban"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a button to chem dispensers that allows the user to delete a single, specific recipe.
Designed with multiple checks to avoid accidental deletion, including the user having to type out the recipe in question, and a Yes/No prompt to make doubly sure. No chance of accidentally griefing yourself by clicking the wrong recipe in a rush.

## Why It's Good For The Game

It allows more granular deletion of chem dispenser macros than the current fairly limited overwrite and delete-all functionality.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

- Here's the button (thanks to Babel Finger for the helpful circle and arrows)
![image](https://user-images.githubusercontent.com/39484008/217936576-3db9f2f2-68f4-4b25-afb1-26808193ea2c.png)

- Checking the recipe buttons still work (they do!)
![image](https://user-images.githubusercontent.com/39484008/217936400-fc54fbd4-8f13-4ace-a76d-aecc2df94856.png)

- Tested Making and using multiple recipes, in a make-test-make-test-make-make-test-test pattern. all seems to be working nicely
![image](https://user-images.githubusercontent.com/39484008/217937489-d82078b9-53c8-4e58-a1c6-ec395e5fb5da.png)

- Tested overwriting, that still works.
- tested specific deletion:
![image](https://user-images.githubusercontent.com/39484008/217937602-bedc2e6e-372f-4cf7-946f-21b45113044e.png)
![image](https://user-images.githubusercontent.com/39484008/217937630-77f73a81-f67b-4176-8856-1274fed1e349.png)
![image](https://user-images.githubusercontent.com/39484008/217937675-32eb1623-559d-4119-8644-ba0f38eb1901.png)
![image](https://user-images.githubusercontent.com/39484008/217937783-bd2d3444-5383-4c0b-addf-94176c566202.png)
Presto.

- Tested the clear recipes button:
![image](https://user-images.githubusercontent.com/39484008/217937884-5e2d7ec3-4259-4b5a-83ec-8327d246b167.png)
![image](https://user-images.githubusercontent.com/39484008/217937969-8ad6160b-8142-4f30-880c-3f73845bccfc.png)
That works too.

</details>

## Changelog
:cl:colonelorion
add: Added Delete button to the chem dispenser
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
