### PR TITLE
Adds map to metric tracking

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -112,6 +112,12 @@ SUBSYSTEM_DEF(mapping)
 	initialize_reserved_level(transit.z_value)
 	return ..()
 
+/datum/controller/subsystem/mapping/get_metrics()
+	. = ..()
+	var/list/custom = list()
+	custom["map"] = config.map_name
+	.["custom"] = custom
+
 /datum/controller/subsystem/mapping/proc/wipe_reservations(wipe_safety_delay = 100)
 	if(clearing_reserved_turfs || !initialized)			//in either case this is just not needed.
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds the current map as a thing to be tracked in SSmetrics. This allows us to take a look at the impact of the current map on maptick, time dilation and other subsystem costs.
This is allows us to actually verify claims that a particular map is very laggy over long periods of time, meaning that if we need to disable a map for lag reasons we have evidence for it rather than basing it off a gut feeling.

## Why It's Good For The Game

See above.

## Testing Photographs and Procedure

I don't have metrics setup locally, however have other implementations of metric to show that this works.

![image](https://user-images.githubusercontent.com/26465327/217940463-eaa7ec8d-57ea-4a20-a3c2-221dffc056c2.png)
![image](https://user-images.githubusercontent.com/26465327/217940484-f14adc95-aa88-498a-8adf-4130a1c5c893.png)


## Changelog
:cl:
code: Adds current map to metric tracking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
