### PR TITLE
Two for one feeding fixes for spiders

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -196,7 +196,7 @@
 					var/mob/living/L = cocoon_target
 					if(L.stat != DEAD)
 						L.death() //If it's not already dead, we want it dead regardless of nourishment
-					if(L.blood_volume && !isipc(L)) //IPCs and bloodless mobs are not nourishing.
+					if(L.blood_volume >= BLOOD_VOLUME_BAD && !isipc(L)) //IPCs and drained mobs are not nourishing.
 						L.blood_volume = 0 //Remove all fluids from this mob so they are no longer nourishing.
 						health = maxHealth //heal up from feeding.
 						if(istype(L,/mob/living/carbon/human)) 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -194,29 +194,20 @@
 				var/obj/structure/spider/cocoon/Coc = new(cocoon_target.loc)
 				if(isliving(cocoon_target))
 					var/mob/living/L = cocoon_target
-					if(L.blood_volume && !isipc(L) && !HAS_TRAIT(L, TRAIT_HUSK)) //If any of these fail there is no nourishment
-						if(iscarbon(L)) 
-							var/mob/living/carbon/C = L
-							C.death()
-							C.Drain() //drains blood and husks target to prevent repeated feeding
-							if(istype(C,/mob/living/carbon/human))
-								enriched_fed++ //it is a humanoid
-							else
-								fed++ //it is a monkey or equivalent to a monkey
-						else
-							fed++ //it is neither human nor monkey, but it still has blood so we will eat it.
-							L.death()
-							L.blood_volume = 0 //And now it does not have blood so no broodmother can eat it again
-
-						//At this point, regardless of what it was we have fed on it, cannot feed on it again without significant outside intervention, and it is dead. 
+					if(L.stat != DEAD)
+						L.death() //If it's not already dead, we want it dead regardless of nourishment
+					if(L.blood_volume && !isipc(L)) //IPCs and bloodless mobs are not nourishing.
+						L.blood_volume = 0 //Remove all fluids from this mob so they are no longer nourishing.
 						health = maxHealth //heal up from feeding.
+						if(istype(L,/mob/living/carbon/human)) 
+							enriched_fed++ //it is a humanoid, and is very nourishing
+						else
+							fed++ //it is not a humanoid, but still has nourishment
 						if(lay_eggs)
 							lay_eggs.UpdateButtonIcon(TRUE)
 						visible_message("<span class='danger'>[src] sticks a proboscis into [L] and sucks a viscous substance out.</span>","<span class='notice'>You suck the nutriment out of [L], feeding you enough to lay a cluster of eggs.</span>")
 					else
 						to_chat(src, "<span class='warning'>[L] cannot sate your hunger!</span>")
-						if(L.stat != DEAD)
-							L.death() //Even if it is not nourishing, it is still killed by our attempt to feed
 				cocoon_target.forceMove(Coc)
 
 				if(cocoon_target.density || ismob(cocoon_target))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -191,7 +191,7 @@
 		SSmove_manager.stop_looping(src)
 		if(do_after(src, 50, target = cocoon_target))
 			if(busy == SPINNING_COCOON)
-				var/obj/structure/spider/cocoon/Coc = new(cocoon_target.loc)
+				var/obj/structure/spider/cocoon/C = new(cocoon_target.loc)
 				if(isliving(cocoon_target))
 					var/mob/living/L = cocoon_target
 					if(L.stat != DEAD)
@@ -208,10 +208,10 @@
 						visible_message("<span class='danger'>[src] sticks a proboscis into [L] and sucks a viscous substance out.</span>","<span class='notice'>You suck the nutriment out of [L], feeding you enough to lay a cluster of eggs.</span>")
 					else
 						to_chat(src, "<span class='warning'>[L] cannot sate your hunger!</span>")
-				cocoon_target.forceMove(Coc)
+				cocoon_target.forceMove(C)
 
 				if(cocoon_target.density || ismob(cocoon_target))
-					Coc.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
+					C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
 	cocoon_target = null
 	busy = SPIDER_IDLE
 	stop_automated_movement = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Fixes an exploit that allows broodmothers to feed multiple times on the same corpse when they shouldn't. 
* Accomplishes this by draining all blood from victims, which will make them substantially harder to revive. 
* Simplemobs that do not provide nourishment now properly die when wrapped

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exploit bad
Spiders actually killing all the things they try to eat is good. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Did not screenshot, but re-tested on all three types of mob: Human, monkey and Simplemob that has blood for some reason. Verified I couldn't feed a second time on the same corpse as well. 

</details>

## Changelog
:cl:
fix: fixed a bug where broodmothers did not kill certain mobs when feeding on them
fix: fixed an exploit that allowed broodmothers to feed on the same target multiple times
tweak: Broodmothers now drain all blood from their victims when feeding. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
