### PR TITLE
Adds package junctions to RPDs

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -55,6 +55,7 @@ GLOBAL_LIST_INIT(disposal_pipe_recipes, list(
 		new /datum/pipe_info/disposal("Junction",		/obj/structure/disposalpipe/junction, PIPE_TRIN_M),
 		new /datum/pipe_info/disposal("Y-Junction",		/obj/structure/disposalpipe/junction/yjunction),
 		new /datum/pipe_info/disposal("Sort Junction",	/obj/structure/disposalpipe/sorting/mail, PIPE_TRIN_M),
+		new /datum/pipe_info/disposal("Package Junction",	/obj/structure/disposalpipe/sorting/wrap, PIPE_TRIN_M),
 		new /datum/pipe_info/disposal("Trunk",			/obj/structure/disposalpipe/trunk),
 		new /datum/pipe_info/disposal("Bin",			/obj/machinery/disposal/bin, PIPE_ONEDIR),
 		new /datum/pipe_info/disposal("Outlet",			/obj/structure/disposaloutlet),

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -23,6 +23,7 @@
 
 // Mail sorting junction, uses package tags to sort objects.
 /obj/structure/disposalpipe/sorting/mail
+	desc = "An underfloor disposal pipe that sorts wrapped objects based on their destination tags."
 	flip_type = /obj/structure/disposalpipe/sorting/mail/flip
 	var/sortType = 0
 	// sortType is to be set in map editor.
@@ -51,11 +52,11 @@
 /obj/structure/disposalpipe/sorting/mail/examine(mob/user)
 	. = ..()
 	if(sortTypes.len)
-		. += "It is tagged with the following tags:"
+		. += "<span class='notice'>It is tagged with the following tags:</span>"
 		for(var/t in sortTypes)
-			. += "\t[GLOB.TAGGERLOCATIONS[t]]."
+			. += "<span class='notice'>\t[GLOB.TAGGERLOCATIONS[t]]</span>."
 	else
-		. += "It has no sorting tags set."
+		. += "<span class='notice'>It has no sorting tags set. You can use a destination tagger on it to set its sorting tags.</span>"
 
 /obj/structure/disposalpipe/sorting/mail/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/dest_tagger))
@@ -80,6 +81,7 @@
 
 // Wrap sorting junction, sorts objects destined for the mail office mail table (tomail = 1)
 /obj/structure/disposalpipe/sorting/wrap
+	name = "package sorting disposal pipe"
 	desc = "An underfloor disposal pipe which sorts wrapped and unwrapped objects."
 	flip_type = /obj/structure/disposalpipe/sorting/wrap/flip
 	initialize_dirs = DISP_DIR_RIGHT | DISP_DIR_FLIP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This adds the sorting/wrap disposal junction to RPDs and disposals dispensers. These are similar to sorting junctions, but they will only sort between wrapped and unwrapped packages. They're called package junctions in the dispenser interface, which should help people differentiate between them and regular sorting disposals pipes

I also updated the descriptions on both types of sorting pipes to make it clearer what they do.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
These exist in some places, and having irreplaceable disposals pipes is bad. They'd also be useful for certain types of disposals setups, since they don't need destination tags to sort things.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/218298852-dafff478-3186-4ed4-9788-ef75327d5a26.png)

</details>

## Changelog
:cl:
add: Adds package sorting disposals pipes to RPDs and disposals dispensers. These sort wrapped and unwrapped objects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
