### PR TITLE
Revenant blight is actually worth using now

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -246,6 +246,9 @@
 	name = "spooky lights"
 	icon_state = "purplesparkles"
 
+/obj/effect/temp_visual/revenant/blightcure
+	icon_state = "blessed"
+
 /obj/effect/temp_visual/blightdisease
 	name = "spreadingsickness"
 	icon_state = "greenshatter"

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -65,7 +65,7 @@
 				if(90 to INFINITY)
 					to_chat(src, "<span class='revenbignotice'>Ah, the perfect soul. [target] will yield massive amounts of essence to you.</span>")
 			if(do_after(src, rand(15, 25), 0, target)) //how about now
-				if(!target.stat)
+				if(!target.stat && !target.stam_paralyzed)
 					to_chat(src, "<span class='revenwarning'>[target.p_theyre(TRUE)] now powerful enough to fight off your draining.</span>")
 					to_chat(target, "<span class='boldannounce'>You feel something tugging across your body before subsiding.</span>")
 					draining = 0

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -37,7 +37,7 @@
 	if(orbiting)
 		to_chat(src, "<span class='revenwarning'>You can't siphon essence during orbiting!</span>")
 		return
-	if(!target.stat)
+	if(!target.stat && !target.stam_paralyzed)
 		to_chat(src, "<span class='revennotice'>[target.p_their(TRUE)] soul is too strong to harvest.</span>")
 		if(prob(10))
 			to_chat(target, "You feel as if you are being watched.")

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -14,6 +14,7 @@
 	danger = DISEASE_HARMFUL
 	var/finalstage = 0 //Ensures the final stage effects that should only happen once do not happen repeatedly.
 	var/startresting
+	var/turf/restingat
 
 /datum/disease/revblight/cure()
 	if(affected_mob)
@@ -31,8 +32,9 @@
 	if(!(affected_mob.mobility_flags & MOBILITY_STAND))
 		if(affected_mob.stam_paralyzed && !finalstage)
 			stage = 5 
-		if(!startresting)
+		if(!startresting || restingat != get_turf(affected_mob))
 			startresting = world.time
+			restingat = get_turf(affected_mob)
 		else if(world.time - startresting >= 30 SECONDS) //Ensures nobody is left in permanent stamcrit, and also enables players to rest in a safe location to cure themselves
 			cure()
 	else

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -1,7 +1,7 @@
 /datum/disease/revblight
 	name = "Unnatural Wasting"
 	max_stages = 5
-	stage_prob = 10
+	stage_prob = 2
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	cure_text = "Holy water or extensive rest."
 	spread_text = "A burst of unholy energy"
@@ -12,8 +12,8 @@
 	disease_flags = CURABLE
 	permeability_mod = 1
 	danger = DISEASE_HARMFUL
-	var/stagedamage = 0 //Highest stage reached.
-	var/finalstage = 0 //Because we're spawning off the cure in the final stage, we need to check if we've done the final stage's effects.
+	var/finalstage = 0 //Ensures the final stage effects that should only happen once do not happen repeatedly.
+	var/startresting
 
 /datum/disease/revblight/cure()
 	if(affected_mob)
@@ -21,47 +21,46 @@
 		if(affected_mob.dna && affected_mob.dna.species)
 			affected_mob.dna.species.handle_mutant_bodyparts(affected_mob)
 			affected_mob.dna.species.handle_hair(affected_mob)
+		new /obj/effect/temp_visual/revenant/blightcure(affected_mob.loc)
 		to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 	..()
 
 /datum/disease/revblight/stage_act()
-	if(!finalstage)
-		if(!(affected_mob.mobility_flags & MOBILITY_STAND) && prob(stage*6))
+	..()
+	affected_mob.adjustStaminaLoss(1) //Provides very gradual exhaustion, mostly prevents stamina regen
+	if(!(affected_mob.mobility_flags & MOBILITY_STAND))
+		if(affected_mob.stam_paralyzed && !finalstage)
+			stage = 5 
+		if(!startresting)
+			startresting = world.time
+		else if(world.time - startresting >= 30 SECONDS) //Ensures nobody is left in permanent stamcrit, and also enables players to rest in a safe location to cure themselves
 			cure()
-			return
-		if(prob(stage*3))
-			to_chat(affected_mob, "<span class='revennotice'>You suddenly feel [pick("sick and tired", "disoriented", "tired and confused", "nauseated", "faint", "dizzy")]...</span>")
-			affected_mob.confused += 8
-			affected_mob.adjustStaminaLoss(20)
-			new /obj/effect/temp_visual/revenant(affected_mob.loc)
-		if(stagedamage < stage)
-			stagedamage++
-			affected_mob.adjustToxLoss(stage*2) //should, normally, do about 30 toxin damage.
-			new /obj/effect/temp_visual/revenant(affected_mob.loc)
-		if(prob(45))
-			affected_mob.adjustStaminaLoss(stage)
-	..() //So we don't increase a stage before applying the stage damage.
+	else
+		startresting = null
+	if(prob(stage*3) && !finalstage && affected_mob.staminaloss <= stage * 25) //no more lesser flavor messages and sparkles after stage 5
+		to_chat(affected_mob, "<span class='revennotice'>You suddenly feel [pick("like you need to rest", "disoriented", "tired and confused", "nauseated", "faint", "dizzy")]...</span>")
+		affected_mob.confused += 8
+		affected_mob.adjustStaminaLoss(15) //Where the real exhaustion builds up.
+		new /obj/effect/temp_visual/revenant(affected_mob.loc)
+
 	switch(stage)
-		if(2)
-			if(prob(5))
-				affected_mob.emote("pale")
 		if(3)
-			if(prob(10))
+			if(prob(5))
 				affected_mob.emote(pick("pale","shiver"))
 		if(4)
-			if(prob(15))
+			if(prob(10))
 				affected_mob.emote(pick("pale","shiver","cries"))
 		if(5)
+			if(affected_mob.staminaloss <= 200) //check required to prevent randomly screaming from limbs being crippled at extreme stamina
+				affected_mob.adjustStaminaLoss(15) //No longer realistically possible to counteract with stimulants
 			if(!finalstage)
 				finalstage = TRUE
-				to_chat(affected_mob, "<span class='revenbignotice'>You feel like [pick("nothing's worth it anymore", "nobody ever needed your help", "nothing you did mattered", "everything you tried to do was worthless")].</span>")
-				affected_mob.adjustStaminaLoss(45)
+				to_chat(affected_mob, "<span class='revenbignotice'>You feel like [pick("you just can't go on", "you should just give up", "there's nothing you can do", "everything is hopeless")].</span>")
 				new /obj/effect/temp_visual/revenant(affected_mob.loc)
 				if(affected_mob.dna?.species)
 					affected_mob.dna.species.handle_mutant_bodyparts(affected_mob,"#1d2953")
 					affected_mob.dna.species.handle_hair(affected_mob,"#1d2953")
 				affected_mob.visible_message("<span class='warning'>[affected_mob] looks terrifyingly gaunt...</span>", "<span class='revennotice'>You suddenly feel like your skin is <i>wrong</i>...</span>")
 				affected_mob.add_atom_colour("#1d2953", TEMPORARY_COLOUR_PRIORITY)
-				addtimer(CALLBACK(src, .proc/cure), 100)
 		else
 			return

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -27,7 +27,7 @@
 
 /datum/disease/revblight/stage_act()
 	..()
-	affected_mob.adjustStaminaLoss(1) //Provides very gradual exhaustion, mostly prevents stamina regen
+	affected_mob.adjustStaminaLoss(1) //Provides gradual exhaustion, but mostly to prevent regeneration and set an upper limit on disease duration to about five minutes
 	if(!(affected_mob.mobility_flags & MOBILITY_STAND))
 		if(affected_mob.stam_paralyzed && !finalstage)
 			stage = 5 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Blight now deals exclusively stamina damage instead of almost negligible toxin damage
* Blight being set to self-cure 10 seconds after it reaches its final stage has been removed (it still self-cures though)
* Revenants can now harvest the souls of people who are exhausted
* Changed the resting logic for blight so that it takes time instead of RNG, and players may not move while resting.
  * Stamcrit activates this logic, so stamcrit will cure in the same amount of time as willingly laying down: 30 seconds. 

Minor tweaks:
* Blight no longer sends what strikingly similar-to-suicidal thoughts, these messages have been shifted more towards being so exhausted you feel like giving up (and will trigger either just before or immediately after stamcrit)
* One of the random messages players can receive (You suddenly feel sick and tired) has been changed to "You feel like you need to rest", to give players a hint at needing to... *rest*.
* Adds a small visual cue that the blight has been cured. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Blight has always been so laughably weak that it was never worth using at all. Before these changes it did a maximum of 30 toxin damage over its entire duration, and occasionally spiked stamina damage to just below stamina slowdown... meaning players would likely never even feel the effects of the stamina damage unless they rolled some colossally poor RNG. 

Also doing this shit was just awful for immersion:
* You feel like nothing's worth it anymore
* You feel like nobody ever needed your help
* You feel like nothing you did mattered
* You feel like everything you tried to do was worthless
* **10 seconds pass**
* You feel better. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Demonstrates the duration of blight before stamcrit on a sample size of 100 humans. The first falls at about 80 seconds, and the last falls at about 260 seconds. The duration follows a somewhat broad bell curve. 
![ezgif-5-7564fa18f0](https://user-images.githubusercontent.com/9547572/218345313-deafa568-fb3f-4895-a1a5-e1e6399c55f2.gif)

</details>

## Changelog
:cl:
Balance: Revenants will find that their blight ability is now potentially worth using! Blight now prevents natural stamina regeneration and gradually builds exhaustion in its victims until they fall over. Laying down for a while, whether forced by the blight or not, still cures it and so does holy water. 
Tweak: Revenants can now harvest the souls of exhausted victims
Tweak: Added a small visual cue to blight so it is a tad easier to tell when it has been cured. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
