### PR TITLE
Fix MultiZ movement exploit

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -210,9 +210,11 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		if("Cancel")
 			return
 		if("Up")
-			travel_z(user, above, UP)
+			if(user.zMove(UP, TRUE))
+				to_chat(user, "<span class='notice'>You move upwards.</span>")
 		if("Down")
-			travel_z(user, below, DOWN)
+			if(user.zMove(DOWN, TRUE))
+				to_chat(user, "<span class='notice'>You move down.</span>")
 
 /turf/proc/travel_z(mob/user, turf/target, dir)
 	var/mob/living/L = user


### PR DESCRIPTION
## About The Pull Request

If you click on your current turf while flying or in zero g, it opens a movement HUD, which doesn't check if you are actually allowed to move and phases you through the floor. This adds the proper checks.

## Why It's Good For The Game

Exploits are bad

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

It works (source: trust me bro, also I closed the testing window before taking a picture)

</details>

## Changelog
:cl:
fix: Fixed multiz movement exploit.
/:cl: