### PR TITLE
Fixes motorized wheelchair power drain bug

### DIFF
--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -11,6 +11,7 @@
 							/obj/item/stock_parts/manipulator,
 							/obj/item/stock_parts/capacitor)
 	var/obj/item/stock_parts/cell/power_cell
+	var/low_power_alerted = FALSE
 
 /obj/vehicle/ridden/wheelchair/motorized/CheckParts(list/parts_list)
 	..()
@@ -57,8 +58,15 @@
 			canmove = FALSE
 			addtimer(VARSET_CALLBACK(src, canmove, TRUE), 20)
 			return FALSE
-		power_cell.use(power_usage / max(power_efficiency, 1))
 	return ..()
+
+/obj/vehicle/ridden/wheelchair/motorized/Moved()
+	. = ..()
+	power_cell.use(power_usage / max(power_efficiency, 1))
+	if(!low_power_alerted && power_cell.charge <= (power_cell.maxcharge / 4))
+		playsound(src, 'sound/machines/twobeep.ogg', 30, 1)
+		say("Warning: Power low!")
+		low_power_alerted = TRUE
 
 /obj/vehicle/ridden/wheelchair/motorized/set_move_delay(mob/living/user)
 	return
@@ -77,6 +85,7 @@
 		user.put_in_hands(power_cell)
 		power_cell = null
 		to_chat(user, "<span class='notice'>You remove the power cell from [src].</span>")
+		low_power_alerted = FALSE
 		return
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Motorized wheelchairs drain the ever loving soul out of batteries because they are set to drain the power cell every time the game checks if you are trying to move, rather than only when you actually make a movement. This PR fixes that. 
* Additionally adds a low-power alert when wheelchair power cells reach 25% or less - this alert can only occur once per battery installation, so that in the case of self-charging cells it does not spam alerts. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Motorized wheelchairs are actually practical to use now, and can make pretty good use of the lower tier slime cells if they're available. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Example of the bug before the fix:
![dreamseeker_MblG9kHzM3](https://user-images.githubusercontent.com/9547572/218391510-4d977cf7-fd57-40c7-871c-c87a2f8e5c2c.gif)


Low power alert working:
![dreamseeker_TbgspRh9NQ](https://user-images.githubusercontent.com/9547572/218391526-85709fbc-460e-47a9-9e7b-9cb9069d26df.gif)


</details>

## Changelog
:cl:
fix: Motorized wheelchairs now drain power cells as intended instead of dozens of times per second when a directional key is held down.
add: Motorized wheelchairs now play a soft beep and alert when the installed power cell reaches 25% charge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
