### PR TITLE
Corrects spelling in porta-turret perp assessment

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -512,15 +512,15 @@
 	if((stun_all || attacked) && !allowed(perp))
 		if(!allowed(perp))
 			return 10
-	//Check for judgement
-	var/judgement = NONE
+	//Check for judgment
+	var/judgment = NONE
 	if(obj_flags & EMAGGED)
-		judgement |= JUDGE_EMAGGED
+		judgment |= JUDGE_EMAGGED
 	if(auth_weapons)
-		judgement |= JUDGE_WEAPONCHECK
+		judgment |= JUDGE_WEAPONCHECK
 	if(check_records)
-		judgement |= JUDGE_RECORDCHECK
-	. = perp.assess_threat(judgement, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
+		judgment |= JUDGE_RECORDCHECK
+	. = perp.assess_threat(judgment, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 	if(shoot_unloyal)
 		if (!perp.has_mindshield_hud_icon())
 			. += 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Proc and variable were named with incorrect spelling, which has been rectified.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Spelling mistakes bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

It's a spelling PR.

</details>

## Changelog
:cl:
spellcheck: Porta-Turret proc spelling has been corrected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
