### PR TITLE
Moves some ghost role checks to client/

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -495,17 +495,3 @@
 			return TRUE
 
 	return FALSE
-
-/mob/proc/canGhostRole(role, use_cooldown = FALSE)
-	if(!SSticker.HasRoundStarted())
-		return FALSE
-	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
-		to_chat(src, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
-		return FALSE
-	if(role && is_banned_from(key, role)) //role can be null, no reason to check for a roleban if there is no special role assigned
-		to_chat(src, "<span class='warning'>You are jobanned!</span>")
-		return FALSE
-	if(use_cooldown && client.next_ghost_role_tick > world.time)
-		to_chat(src, "<span class='warning'>You have died recently, you must wait [(client.next_ghost_role_tick - world.time)/10] seconds until you can use a ghost spawner.</span>")
-		return FALSE
-	return TRUE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -495,3 +495,17 @@
 			return TRUE
 
 	return FALSE
+
+/mob/proc/canGhostRole(role, use_cooldown = FALSE)
+	if(!SSticker.HasRoundStarted())
+		return FALSE
+	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
+		to_chat(src, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
+		return FALSE
+	if(is_banned_from(key, role))
+		to_chat(src, "<span class='warning'>You are jobanned!</span>")
+		return FALSE
+	if(use_cooldown && client.next_ghost_role_tick > world.time)
+		to_chat(src, "<span class='warning'>You have died recently, you must wait [(client.next_ghost_role_tick - world.time)/10] seconds until you can use a ghost spawner.</span>")
+		return FALSE
+	return TRUE

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -502,7 +502,7 @@
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
 		to_chat(src, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
 		return FALSE
-	if(is_banned_from(key, role))
+	if(role && is_banned_from(key, role)) //role can be null, no reason to check for a roleban if there is no special role assigned
 		to_chat(src, "<span class='warning'>You are jobanned!</span>")
 		return FALSE
 	if(use_cooldown && client.next_ghost_role_tick > world.time)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -105,7 +105,7 @@
 
 /obj/structure/spider/eggcluster/attack_ghost(mob/user)
 	. = ..()
-	if(!user.canGhostRole(ROLE_SPIDER, TRUE))
+	if(!user?.client.canGhostRole(ROLE_SPIDER, TRUE, src))
 		return
 	if(ghost_ready)
 		make_spider(user)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -105,6 +105,8 @@
 
 /obj/structure/spider/eggcluster/attack_ghost(mob/user)
 	. = ..()
+	if(!user.canGhostRole(ROLE_SPIDER, TRUE))
+		return
 	if(ghost_ready)
 		make_spider(user)
 	else

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -105,7 +105,7 @@
 
 /obj/structure/spider/eggcluster/attack_ghost(mob/user)
 	. = ..()
-	if(!user?.client.canGhostRole(ROLE_SPIDER, TRUE, src))
+	if(!user?.client.canGhostRole(ROLE_SPIDER, TRUE, flags_1))
 		return
 	if(ghost_ready)
 		make_spider(user)

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -163,6 +163,7 @@
 	H.update_hair()
 	H.forceMove(src)
 	oldguy = H
+	role = ROLE_BLOB
 	update_icons()
 	visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
 	if(!key)

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -143,7 +143,8 @@
 
 /obj/structure/carp_rift/attack_ghost(mob/user)
 	. = ..()
-	summon_carp(user)
+	if(user.canGhostRole(ROLE_SPACE_DRAGON, TRUE))
+		summon_carp(user)
 
 /**
  * Does a series of checks based on the portal's status.

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -143,7 +143,7 @@
 
 /obj/structure/carp_rift/attack_ghost(mob/user)
 	. = ..()
-	if(user?.client.canGhostRole(ROLE_SPACE_DRAGON, TRUE, src))
+	if(user?.client.canGhostRole(ROLE_SPACE_DRAGON, TRUE, flags_1))
 		summon_carp(user)
 
 /**

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -143,7 +143,7 @@
 
 /obj/structure/carp_rift/attack_ghost(mob/user)
 	. = ..()
-	if(user.canGhostRole(ROLE_SPACE_DRAGON, TRUE))
+	if(user?.client.canGhostRole(ROLE_SPACE_DRAGON, TRUE, src))
 		summon_carp(user)
 
 /**

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -34,22 +34,15 @@
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/attack_ghost(mob/user)
-	if(!SSticker.HasRoundStarted() || !loc || !ghost_usable)
-		return
-	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
-		to_chat(user, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
+	if(!loc || !ghost_usable)
 		return
 	if(!uses)
 		to_chat(user, "<span class='warning'>This spawner is out of charges!</span>")
 		return
-	if(is_banned_from(user.key, banType))
-		to_chat(user, "<span class='warning'>You are jobanned!</span>")
+	if(!user.canGhostRole(banType, use_cooldown))
 		return
 	if(QDELETED(src) || QDELETED(user))
-		return
-	if(use_cooldown && user.client.next_ghost_role_tick > world.time)
-		to_chat(user, "<span class='warning'>You have died recently, you must wait [(user.client.next_ghost_role_tick - world.time)/10] seconds until you can use a ghost spawner.</span>")
-		return
+		return	
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role != "Yes" || !loc)
 		return

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -39,7 +39,7 @@
 	if(!uses)
 		to_chat(user, "<span class='warning'>This spawner is out of charges!</span>")
 		return
-	if(!user?.client.canGhostRole(banType, use_cooldown, src))
+	if(!user?.client.canGhostRole(banType, use_cooldown, flags_1))
 		return
 	if(QDELETED(src) || QDELETED(user))
 		return	

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -39,7 +39,7 @@
 	if(!uses)
 		to_chat(user, "<span class='warning'>This spawner is out of charges!</span>")
 		return
-	if(!user.canGhostRole(banType, use_cooldown))
+	if(!user?.client.canGhostRole(banType, use_cooldown, src))
 		return
 	if(QDELETED(src) || QDELETED(user))
 		return	

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -922,6 +922,20 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	..()
 
+/client/proc/canGhostRole(role, use_cooldown = FALSE, atom/callsource)
+	if(!SSticker.HasRoundStarted())
+		return FALSE
+	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(callsource.flags_1 & ADMIN_SPAWNED_1))
+		to_chat(src, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
+		return FALSE
+	if(role && is_banned_from(key, role)) //role can be null, no reason to check for a roleban if there is no special role assigned
+		to_chat(src, "<span class='warning'>You are jobanned!</span>")
+		return FALSE
+	if(use_cooldown && next_ghost_role_tick > world.time)
+		to_chat(src, "<span class='warning'>You have died recently, you must wait [(next_ghost_role_tick - world.time)/10] seconds until you can use a ghost spawner.</span>")
+		return FALSE
+	return TRUE
+
 /client/proc/add_verbs_from_config()
 	if (interviewee)
 		return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -922,10 +922,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	..()
 
-/client/proc/canGhostRole(role, use_cooldown = FALSE, atom/callsource)
+/client/proc/canGhostRole(role, use_cooldown = FALSE, spawned_by_admin)
 	if(!SSticker.HasRoundStarted())
 		return FALSE
-	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(callsource.flags_1 & ADMIN_SPAWNED_1))
+	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(spawned_by_admin & ADMIN_SPAWNED_1))
 		to_chat(src, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
 		return FALSE
 	if(role && is_banned_from(key, role)) //role can be null, no reason to check for a roleban if there is no special role assigned

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -135,3 +135,4 @@
 	//is mob player controllable
 	var/playable = FALSE
 	var/flavor_text = FLAVOR_TEXT_NONE
+	var/role //Used for determining whether a player is banned from taking control of a given mob, if it is assigned to a category.

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -34,7 +34,7 @@
 	if(key)
 		to_chat(user, "<span class='notice'>Someone else already took [name].</span>")
 		return TRUE
-	if(!user?.client.canGhostRole(role, TRUE, src))
+	if(!user?.client.canGhostRole(role, TRUE, flags_1))
 		return
 	key = user.key
 	log_game("[key_name(src)] took control of [name].")

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -34,6 +34,8 @@
 	if(key)
 		to_chat(user, "<span class='notice'>Someone else already took [name].</span>")
 		return TRUE
+	if(!user.canGhostRole(role, TRUE))
+		return
 	key = user.key
 	log_game("[key_name(src)] took control of [name].")
 	remove_from_spawner_menu()

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -34,7 +34,7 @@
 	if(key)
 		to_chat(user, "<span class='notice'>Someone else already took [name].</span>")
 		return TRUE
-	if(!user.canGhostRole(role, TRUE))
+	if(!user?.client.canGhostRole(role, TRUE, src))
 		return
 	key = user.key
 	log_game("[key_name(src)] took control of [name].")

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -65,6 +65,7 @@
 	var/enriched_fed = 0
 	var/datum/action/innate/spider/lay_eggs/lay_eggs //the ability to lay eggs, granted to broodmothers
 	var/datum/team/spiders/spider_team = null //utilized by AI controlled broodmothers to pass antag team info onto their eggs without a mind
+	role = ROLE_SPIDER
 
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -5,6 +5,7 @@
 	var/monkey_bonus_damage = 2
 	var/attack_cooldown = 0
 	var/attack_cooldown_time = 20 //How long, in deciseconds, the cooldown of attacks is
+	role = ROLE_SENTIENCE
 
 /mob/living/simple_animal/slime/Life()
 	set invisibility = 0

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -35,6 +35,7 @@
 /datum/orbital_objective/assassination/generate_objective_stuff(turf/chosen_turf)
 	var/mob/living/carbon/human/created_human = new(chosen_turf)
 	//Maybe polling ghosts would be better than the shintience code
+	created_human.role = ROLE_TRAITOR
 	created_human.set_playable()
 	created_human.mind_initialize()
 	//Remove nearby dangers


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #8496 

Shuffles a set of checks out of `/obj/effect/mob_spawn/attack_ghost(mob/user)` 
and places it into a new proc: `/client/proc/canGhostRole(role, use_cooldown = FALSE, atom/callsource)

Additionally applies this check to:
* Spider eggs
* Carp Portals
* All instances where set_playable() is called

Adds a variable for role directly to living defines, for use with antagonistic mobs that are set_playable()
* Slimes of all varieties have ROLE_SENTIENCE, including pyroclastic
* Spiders all have ROLE_SPIDER
* Assassination targets for explorers have ROLE_TRAITOR because it is the most relevant role available and adding an entirely new ban type specifically for assassination targets doesn't seem worthwhile for this mob. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghost roles should properly obey bans, server settings and admin toggles. 

Tying the relocated checks to the ghost client trying to take a spawn instead of individual spawners makes it **much** easier to implement and maintain proper checks on ghost role spawns. This is also why roles are assigned directly to relevant mobs in this PR. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

There is very little I can show to prove that what I have done works. 
![image](https://user-images.githubusercontent.com/9547572/218608347-10a089d0-3550-4ff9-9d92-dcd0638702dc.png)

Mass sentience verb used (set_playable() called on all station mobs)
![image](https://user-images.githubusercontent.com/9547572/218618964-92e6eb13-8247-4043-99ef-1221adff5a33.png)

Tested with a few spawners and spiders with the debugger set to breakpoint on various checks, but since I have no database I can't 100% verify that this works as it appears to and/or should.
</details>

## Changelog
:cl:
code: Checks for role bans, ghost role toggles and ghost role cooldowns have been moved from spawners to client code for easier use in determining ghost role eligibility
fix: Spider eggs, carp portals and other playable mobs now respect role bans, ghost role toggles and ghost role cooldowns. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
