### PR TITLE
Minor atmos fix to glow

### DIFF
--- a/_maps/map_files/GlowStation/GlowStation.dmm
+++ b/_maps/map_files/GlowStation/GlowStation.dmm
@@ -24187,11 +24187,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "fjG" = (
@@ -49550,6 +49550,20 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/exploration_prep)
+"kuE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2O to Pure"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "kuF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -51000,15 +51014,14 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
 "kLg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "co2 to Pure"
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/lava/smooth/cold,
 /area/engine/atmos)
 "kLp" = (
@@ -55068,12 +55081,11 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/medical/morgue)
 "lCA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2O to Pure"
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/lava/smooth/cold,
 /area/engine/atmos)
 "lCC" = (
@@ -61255,9 +61267,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mQc" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -61270,6 +61279,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "co2 to Pure"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -65607,10 +65620,6 @@
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main/monastery)
 "nOa" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Plasma to Pure"
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
 	dir = 8
@@ -65619,6 +65628,9 @@
 	dir = 1
 	},
 /obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/lava/smooth/cold,
 /area/engine/atmos)
 "nOe" = (
@@ -81962,6 +81974,20 @@
 	dir = 1
 	},
 /turf/open/floor/engine/air/light,
+/area/engine/atmos)
+"rhb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Plasma to Pure"
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "rho" = (
 /obj/structure/chair/wood{
@@ -154736,11 +154762,11 @@ bFq
 ifa
 kjd
 qgC
-dWB
+kuE
 nYd
 sQR
 nYd
-dWB
+rhb
 nYd
 sQR
 nYd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes a minor accident made on GlowStation, where the gaspumps were put outside atmos, rather than inside. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Simplifies gas extraction. Fixes minor oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/62388554/218823421-2c3c8cdb-d547-4061-8f81-fd517d720f0e.png)
Permission from map maker

![gaspumps](https://user-images.githubusercontent.com/62388554/218823483-ef25407f-3850-42a2-a63b-4a74ccc20da7.png)
Result

</details>

## Changelog
:cl: RKz
tweak: Fixes minor oversight in GlowStation atmos. Gas miner pumps are now in Atmospherics, rather than outside on the planet's surface
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
