### PR TITLE
Fixing the root of #8221 without causing side effects

### DIFF
--- a/code/modules/client/preferences2/character_save.dm
+++ b/code/modules/client/preferences2/character_save.dm
@@ -476,8 +476,9 @@
 		pref_species = new /datum/species/human
 		save(usr.client, async = FALSE) // This entire proc is called a lot at roundstart, and we dont want to lag that
 
-	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
+
 	character.dna.features = features.Copy()
+	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 
 	//Because of how set_species replaces all bodyparts with new ones, hair needs to be set AFTER species.
 	character.dna.real_name = character.real_name

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -229,6 +229,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		QDEL_NULL(tail)
 	if(should_have_tail && !tail)
 		tail = new mutanttail()
+		if(islizard(C))
+			tail.tail_type = C.dna.features["tail_lizard"]
+			tail.spines = C.dna.features["spines"]
 		tail.Insert(C)
 
 	if(wings && (!should_have_wings || replace_current))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -230,8 +230,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(should_have_tail && !tail)
 		tail = new mutanttail()
 		if(islizard(C))
-			tail.tail_type = C.dna.features["tail_lizard"]
-			tail.spines = C.dna.features["spines"]
+			var/obj/item/organ/tail/lizard/lizard_tail = tail
+			lizard_tail.tail_type = C.dna.features["tail_lizard"]
+			lizard_tail.spines = C.dna.features["spines"]
+			tail = lizard_tail
 		tail.Insert(C)
 
 	if(wings && (!should_have_wings || replace_current))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It accomplishes #8221 without causing any of the issues it brought mentioned in #8413.
It also solves it without repeating the same code twice like #8403 suggested doing. 

In short, it allows character customization of lizards to properly be seen once again in the preview pane during character setup. The original issue #8221 seemed to mention moth wings also having the same issue, and seems to have been resolved by #8134, which I took as inspiration for the code to commit.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![video](https://user-images.githubusercontent.com/22382345/219004480-6c6bd9b6-1ee9-4b4c-b50c-49328c6abf93.mp4)

</details>

## Changelog
:cl:
fix: Lizard tails no longer ignore dna when regenerating organs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
