### PR TITLE
Fixes a typo that causes explo team doesn't get explo points

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
@@ -49,7 +49,7 @@
 	completed = TRUE
 	//Handle payout
 	SSeconomy.distribute_funds(payout)
-	bound_bank_account.adjust_currency(ACCOUNT_CURRENCY_MINING, payout)
+	bound_bank_account.adjust_currency(ACCOUNT_CURRENCY_EXPLO, payout)
 	//Announcement
 	priority_announce("Central Command priority objective completed. [payout] credits have been \
 		distributed across departmental budgets. [payout] points have been distributed to exploration vendors.", "Central Command Report", SSstation.announcer.get_rand_report_sound())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Fixes a typo that causes explo team doesn't get explo points
* caused by https://github.com/BeeStation/BeeStation-Hornet/pull/8370
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
It's just typo fix

## Changelog
:cl:
fix: science budget card will properly get exploration points instead of the wrong type - mining points when exploration team completed their mission.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
