### PR TITLE
Fixes AI shell being instantly converted when using Twisted Construction

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -591,13 +591,14 @@
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else if(istype(target,/mob/living/silicon/robot))
 			var/mob/living/silicon/robot/candidate = target
-			if(candidate.mmi)
+			if(candidate.mmi || candidate.shell)
 				channeling = TRUE
 				user.visible_message("<span class='danger'>A dark cloud emanates from [user]'s hand and swirls around [candidate]!</span>")
 				playsound(T, 'sound/machines/airlock_alien_prying.ogg', 80, 1)
 				var/prev_color = candidate.color
 				candidate.color = "black"
 				if(do_after(user, 90, target = candidate))
+					candidate.undeploy()
 					candidate.emp_act(EMP_HEAVY)
 					var/construct_class = alert(user, "Please choose which type of construct you wish to create.",,"Juggernaut","Wraith","Artificer")
 					if(QDELETED(candidate))


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/63231

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When using twisted construction, it will use an if statement to check if the candidate is currently inhabitated by an MMI. If this check does come up with an MMI, the conversion is delayed and the candidate must be still to be converted into a cult mob.

This if does not however, check if an AI is currently using the shell, which will lead to the ability instantly kicking the AI out, and converting the shell as if nothing was inhabitating it.

This PR forces the if statement to check the candidate both for MMI or if its a shell.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instant fuck you button to AI isnt fun. I'm porting this because it fucked up my valentine's cult round and im salty. Should reduce the jankiness of the gamemode in general.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I cant test this using local means. Heres the startup confirmed working.
![image](https://user-images.githubusercontent.com/62388554/219563910-023ecfdf-9ce1-4a30-b38b-fc57a6e1c39d.png)
If you know of a way I can test this, let me know please.

</details>

## Changelog
:cl: RKz, AnturK
fix: AI shells are no longer instantly converted by Twisted Construction cult spell
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
