### PR TITLE
Improves reliability of wormhole jaunter

### DIFF
--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -75,7 +75,7 @@
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
 	if(user.get_item_by_slot(ITEM_SLOT_BELT) == src)
-		user.visible_message("<span class='notice'>[user.name] is saved by their [src]!</span>", "<span class='warning'>Your [src] activates, saving you from the chasm!</span>")
+		user.visible_message("<span class='notice'>[user] is saved by their [src]!</span>", "<span class='warning'>Your [src] activates, saving you from the chasm!</span>")
 		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
 		INVOKE_ASYNC(user.client, /client.proc/give_award, /datum/award/achievement/misc/chasmjaunt, user)
 		activate(user, FALSE)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -1,7 +1,7 @@
 /**********************Jaunter**********************/
 /obj/item/wormhole_jaunter
 	name = "wormhole jaunter"
-	desc = "A single use device harnessing outdated wormhole technology, Nanotrasen has since turned its eyes to bluespace for more accurate teleportation. The wormholes it creates are unpleasant to travel through, to say the least.\nThanks to modifications provided by the Free Golems, this jaunter can be worn on the belt to provide protection from chasms."
+	desc = "A single use device harnessing outdated wormhole technology, Nanotrasen has since turned its eyes to bluespace for more accurate teleportation. The wormholes it creates are unpleasant to travel through, to say the least.\nThis jaunter can be worn on the belt to provide protection from chasms."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "Jaunter"
 	item_state = "electronic"
@@ -14,7 +14,7 @@
 	slot_flags = ITEM_SLOT_BELT
 
 /obj/item/wormhole_jaunter/attack_self(mob/user)
-	user.visible_message("<span class='notice'>[user.name] activates the [src.name]!</span>")
+	user.visible_message("<span class='notice'>[user.name] activates the [src]!</span>", "<span class='notice'>You activate the [src]!</span>")
 	SSblackbox.record_feedback("tally", "jaunter", 1, "User") // user activated
 	activate(user, TRUE)
 
@@ -30,12 +30,12 @@
 
 	for(var/obj/item/beacon/B in GLOB.teleportbeacons)
 		var/turf/T = get_turf(B)
-		if(is_station_level(T.z))
+		if(is_station_level(T.z) && !isspaceturf(T))
 			destinations += B
 
 	return destinations
 
-/obj/item/wormhole_jaunter/proc/activate(mob/user, adjacent)
+/obj/item/wormhole_jaunter/proc/activate(mob/living/user, adjacent)
 	if(!turf_check(user))
 		return
 
@@ -47,6 +47,10 @@
 	var/obj/effect/portal/jaunt_tunnel/J = new (get_turf(src), src, 100, null, FALSE, get_turf(chosen_beacon))
 	if(adjacent)
 		try_move_adjacent(J)
+	else
+		user.Paralyze(2 SECONDS, TRUE, TRUE) //Ignore stun immunity here, for their own good
+		user.setMovetype(user.movement_type | FLOATING) //Prevents falling into chasm during delay, automatically removed upon movement
+		addtimer(CALLBACK(J, /atom/proc/attackby, null, user), 1 SECONDS) //Forcibly teleport them away from the chasm after a brief dramatic delay
 	playsound(src,'sound/effects/sparks4.ogg',50,1)
 	qdel(src)
 
@@ -71,7 +75,7 @@
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
 	if(user.get_item_by_slot(ITEM_SLOT_BELT) == src)
-		to_chat(user, "Your [name] activates, saving you from the chasm!</span>")
+		user.visible_message("<span class='notice'>[user.name] is saved by their [src]!</span>", "<span class='warning'>Your [src] activates, saving you from the chasm!</span>")
 		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
 		INVOKE_ASYNC(user.client, /client.proc/give_award, /datum/award/achievement/misc/chasmjaunt, user)
 		activate(user, FALSE)
@@ -97,4 +101,4 @@
 			L.Paralyze(60)
 			if(ishuman(L))
 				shake_camera(L, 20, 1)
-				addtimer(CALLBACK(L, /mob/living/carbon.proc/vomit), 20)
+				addtimer(CALLBACK(L, /mob/living/carbon.proc/vomit), 40)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When a wormhole jaunter automatically activates after stepping into a chasm, it also automatically drops the player into the portal it opens instead of requiring high reaction speeds that likely aren't present if you accidentally stepped into a chasm.

Additionally adds a check to prevent the jaunter from dumping players out into *most* of space. With bad enough luck they can still be dumped into space, but it will always be as a part of a defined area (such as solars), meaning the player will be at least adjacent to the station and able to work their way into an airlock if they're lucky/fast enough.

Adds missing text that should be displaying when someone uses a jaunter, whether automatically or manually. (Player using jaunter did not get a message for it in either case before now)

Slightly tweaks the delay on vomiting after transport, and also utilizes the same "dramatic delay" as I did in my explosive ducky PR because instant teleporting just isn't as good. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wormhole jaunters are already very rarely utilized and even more rarely are they actually useful for their intended purpose of saving miners from chasms. Most often when a miner falls into a chasm it's because they were lagging, or otherwise unable to appropriately respond to a situation - expecting them to have the reaction and/or connection speed required to click on the portal before all hope is lost is pretty dumb.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

## Below is the current iteration
https://user-images.githubusercontent.com/9547572/219979112-7ae223ca-c345-4361-9c1b-1aba5b076cde.mp4


## And the below moth is an example without the dramatic delay.
https://user-images.githubusercontent.com/9547572/219979749-19fdd249-da1a-4fbd-aeff-60e917283b67.mp4

It seems much more disorienting and just isn't nearly as good of a user experience in my opinion. 

</details>

## Changelog
:cl:
tweak: Wormhole jaunter now automatically saves players who step into chasms, instead of simply making their portal and letting players fall into the chasm anyway if they don't click the portal underneath them fast enough
tweak: Jaunter portals are less likely (but still able) to dump you in space. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
