### PR TITLE
Fixes revenants randomly being unable to Z-travel (By preventing them from resting)

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -434,6 +434,10 @@
 /mob/living/simple_animal/revenant/get_photo_description(obj/item/camera/camera)
 	return "You can also see a g-g-g-g-ghooooost of malice!"
 
+/mob/living/simple_animal/revenant/set_resting(rest, silent = TRUE)
+	to_chat(src, "<span class='warning'>You are too restless to rest now!</span>")
+	return FALSE
+
 //reforming
 /obj/item/ectoplasm/revenant
 	name = "glimmering residue"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Revenants sometimes lose their ability to travel between Z-levels. This seemingly happens inexplicably and without reason because V is a hotkey for resting, and it is very easy to fat-finger V when you're trying to press C instead. Revenants have no reason to rest whatsoever, so this PR disables their ability to rest in a flavorful way. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
**Admin please help, I can't change Z-levels anymore. Why is this broken.**
What? No I didn't do anything, it just stopped working on its own!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/219998739-8d57018a-e653-4876-8dd2-98f1f5a0c583.png)

</details>

## Changelog
:cl:
fix: Revenants can no longer rest because it is pointless to do so as a revenant. Coincidentally revenants will no longer be able to accidentally turn off their ability to travel between Z-levels on glowstation because this is how they were doing that. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
