### PR TITLE
Small Pubbystation fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27171,14 +27171,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/medical/virology)
-"gvf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/hallway/secondary/exit/departure_lounge)
 "gvG" = (
 /obj/structure/chair/fancy/comfy{
 	dir = 4
@@ -36477,9 +36469,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "lxE" = (
 /obj/structure/cable/yellow{
@@ -40848,9 +40838,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "nSE" = (
 /obj/structure/closet/emcloset,
@@ -49284,9 +49272,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "sol" = (
 /obj/machinery/door/airlock/maintenance{
@@ -51335,7 +51321,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "tvj" = (
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/library/lounge)
 "tvm" = (
@@ -56285,9 +56271,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wDl" = (
 /obj/structure/cable/yellow{
@@ -56477,9 +56461,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wHm" = (
 /obj/effect/turf_decal/loading_area{
@@ -79721,7 +79703,7 @@ vKV
 aiu
 imI
 gMy
-gvf
+aWE
 tKj
 aOk
 aWE

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -180,9 +180,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "ack" = (
 /obj/machinery/power/smes{
@@ -269,9 +267,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "acJ" = (
 /obj/structure/cable/yellow{
@@ -27247,17 +27243,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"gyS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/maintenance/department/science)
 "gzb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -27870,12 +27855,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"gPf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/maintenance/department/science)
 "gPH" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/cable/yellow{
@@ -30755,11 +30734,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"izF" = (
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/maintenance/department/science)
 "izR" = (
 /obj/effect/landmark/start/exploration,
 /obj/structure/cable/yellow{
@@ -37013,21 +36987,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"lNl" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	luminosity = 2
-	},
-/area/maintenance/department/science)
 "lNu" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -38530,6 +38489,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"mDx" = (
+/turf/open/floor/plating{
+	luminosity = 2
+	},
+/area/science/shuttledock)
 "mEH" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1
@@ -42728,9 +42692,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "oNN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48128,9 +48090,7 @@
 /obj/item/stack/sheet/mineral/copper{
 	amount = 5
 	},
-/turf/open/floor/plating{
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "rKY" = (
 /obj/structure/disposalpipe/segment,
@@ -56433,9 +56393,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "wGw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -105448,7 +105406,7 @@ bwm
 bwm
 huJ
 uek
-izF
+lWy
 bwm
 lWy
 lWy
@@ -105704,8 +105662,8 @@ lWy
 cBs
 dWk
 oNl
-gPf
-gPf
+ggq
+ggq
 pBd
 ggq
 xqd
@@ -105960,9 +105918,9 @@ lWy
 lWy
 lWy
 bwm
-gyS
+huJ
 tSL
-izF
+lWy
 bwm
 lWy
 lWy
@@ -106217,7 +106175,7 @@ lWy
 lWy
 lWy
 bwm
-gyS
+huJ
 bwm
 rNB
 bwm
@@ -106474,7 +106432,7 @@ bwm
 bwm
 bwm
 bwm
-gyS
+huJ
 bwm
 aht
 bwm
@@ -106731,7 +106689,7 @@ lWy
 lWy
 wiT
 bwm
-lNl
+gbY
 bwm
 aht
 aaa
@@ -109045,7 +109003,7 @@ vuQ
 vuQ
 vuQ
 dPS
-vuQ
+mDx
 vuQ
 vuQ
 vuQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes a few small things
the first are the library and chapel maints windows spawning without girders
the second is some plasteel and white tiles spawning with 1e+006 Heat capacity at random. 
The third is some maintenance tiles spawning with Luminocity set to 2. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mapping errors = bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/79304582/220336910-233d7c7c-5790-4136-8c11-1cdf2e955dd4.png)

![image](https://user-images.githubusercontent.com/79304582/220336942-46957962-df42-46f4-a19f-d4ac0aa5fb30.png)

</details>

## Changelog
:cl:
fix: fixed pubbystation chapel windows
fix: fixed random pubbystation tiles having 1e+006 Heat capacity
fix: fixed random pubbystation maintenance tiles having luminosity set to 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
