### PR TITLE
Changes preferred clothing style spawning behaviours.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -212,7 +212,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Socks:</b><BR><a href ='?_src_=prefs;preference=socks;task=input'>[active_character.socks]</a><BR>"
 			dat += "<b>Backpack:</b><BR><a href ='?_src_=prefs;preference=bag;task=input'>[active_character.backbag]</a><BR>"
 			var/preferred_clothing_style = "<a href ='?_src_=prefs;preference=suit;task=input'>[active_character.jumpsuit_style]</a>"
-			dat += "<b>Preferred Clothing Style:</b><BR>[TOOLTIP_WRAPPER(preferred_clothing_style, 400, "Preferred style of uniform (If available).")]<BR>"
+			dat += "<b>Preferred Clothing Style:</b><BR>[TOOLTIP_WRAPPER(preferred_clothing_style, 200, "Preferred style of uniform (If available).")]<BR>"
 			dat += "<b>Uplink Spawn Location:</b><BR><a href ='?_src_=prefs;preference=uplink_loc;task=input'>[active_character.uplink_spawn_loc == UPLINK_IMPLANT ? UPLINK_IMPLANT_WITH_PRICE : active_character.uplink_spawn_loc]</a><BR></td>"
 
 			var/use_skintones = active_character.pref_species.use_skintones

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -211,7 +211,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Undershirt:</b><BR><a href ='?_src_=prefs;preference=undershirt;task=input'>[active_character.undershirt]</a><BR>"
 			dat += "<b>Socks:</b><BR><a href ='?_src_=prefs;preference=socks;task=input'>[active_character.socks]</a><BR>"
 			dat += "<b>Backpack:</b><BR><a href ='?_src_=prefs;preference=bag;task=input'>[active_character.backbag]</a><BR>"
-			dat += "<b>Jumpsuit:</b><BR><a href ='?_src_=prefs;preference=suit;task=input'>[active_character.jumpsuit_style]</a><BR>"
+			var/preferred_clothing_style = "<a href ='?_src_=prefs;preference=suit;task=input'>[active_character.jumpsuit_style]</a>"
+			dat += "<b>Preferred Clothing Style:</b><BR>[TOOLTIP_WRAPPER(preferred_clothing_style, 400, "Preferred style of uniform (If available).")]<BR>"
 			dat += "<b>Uplink Spawn Location:</b><BR><a href ='?_src_=prefs;preference=uplink_loc;task=input'>[active_character.uplink_spawn_loc == UPLINK_IMPLANT ? UPLINK_IMPLANT_WITH_PRICE : active_character.uplink_spawn_loc]</a><BR></td>"
 
 			var/use_skintones = active_character.pref_species.use_skintones

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -309,13 +309,10 @@
 			back = backpack //Department backpack
 
 	//converts the uniform string into the path we'll wear, whether it's the skirt or regular variant
-	var/holder
-	if(H.jumpsuit_style == PREF_SKIRT)
-		holder = skirt_uniform
+	if(H.jumpsuit_style == PREF_SKIRT && skirt_uniform)
+		uniform = skirt_uniform
 	else
-		holder = uniform
-	uniform = text2path(holder)
-
+		uniform = initial(uniform)
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -282,6 +282,9 @@
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	box = /obj/item/storage/box/survival
 
+	/// The skirt uniform, if one is provided
+	var/skirt_uniform
+
 	var/backpack = /obj/item/storage/backpack
 	var/satchel  = /obj/item/storage/backpack/satchel
 	var/duffelbag = /obj/item/storage/backpack/duffelbag
@@ -308,11 +311,9 @@
 	//converts the uniform string into the path we'll wear, whether it's the skirt or regular variant
 	var/holder
 	if(H.jumpsuit_style == PREF_SKIRT)
-		holder = "[uniform]/skirt"
-		if(!text2path(holder))
-			holder = "[uniform]"
+		holder = skirt_uniform
 	else
-		holder = "[uniform]"
+		holder = uniform
 	uniform = text2path(holder)
 
 

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -34,6 +34,8 @@
 	belt = /obj/item/modular_computer/tablet/pda/bartender
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/bartender
+	skirt_uniform = /obj/item/clothing/under/rank/civilian/bartender/skirt
+
 	suit = /obj/item/clothing/suit/armor/vest
 	backpack_contents = list(/obj/item/storage/box/beanbag=1)
 	shoes = /obj/item/clothing/shoes/laceup

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -33,6 +33,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/service
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/hydroponics
+	skirt_uniform = /obj/item/clothing/under/rank/civilian/hydroponics/skirt
 	suit = /obj/item/clothing/suit/apron
 	gloves = /obj/item/clothing/gloves/botanic_leather
 	suit_store = /obj/item/plant_analyzer

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -35,5 +35,6 @@
 	belt = /obj/item/modular_computer/tablet/pda/cargo_technician
 	ears = /obj/item/radio/headset/headset_cargo
 	uniform = /obj/item/clothing/under/rank/cargo/tech
+	uniform = /obj/item/clothing/under/rank/cargo/tech/skirt
 	l_hand = /obj/item/export_scanner
 

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -119,6 +119,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/chaplain
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/chaplain
+	skirt_uniform = /obj/item/clothing/under/rank/civilian/chaplain/skirt
 	backpack_contents = list(
 		/obj/item/nullrod = 1,
 		/obj/item/choice_beacon/holy = 1,

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -37,6 +37,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/chemist
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/medical/chemist
+	skirt_uniform = /obj/item/clothing/under/rank/medical/chemist/skirt
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	suit =  /obj/item/clothing/suit/toggle/labcoat/chemist
 	backpack = /obj/item/storage/backpack/chemistry

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -35,6 +35,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/cook
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/chef
+	skirt_uniform = /obj/item/clothing/under/rank/civilian/chef/skirt
 	suit = /obj/item/clothing/suit/toggle/chef
 	head = /obj/item/clothing/head/chefhat
 	mask = /obj/item/clothing/mask/fakemoustache/italian

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -36,6 +36,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/curator
 	ears = /obj/item/radio/headset/headset_curator
 	uniform = /obj/item/clothing/under/rank/civilian/curator
+	skirt_uniform = /obj/item/clothing/under/rank/civilian/curator/skirt
 	l_hand = /obj/item/storage/bag/books
 	r_pocket = /obj/item/key/displaycase
 	l_pocket = /obj/item/laser_pointer

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -38,6 +38,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/geneticist
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/medical/geneticist
+	skirt_uniform = /obj/item/clothing/under/rank/medical/geneticist/skirt
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	suit =  /obj/item/clothing/suit/toggle/labcoat/genetics
 	suit_store =  /obj/item/flashlight/pen

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -54,6 +54,7 @@
 	l_hand = /obj/item/storage/wallet
 	l_pocket = /obj/item/razor/straightrazor
 	can_be_admin_equipped = TRUE
+
 /datum/job/gimmick/stage_magician
 	title = JOB_NAME_STAGEMAGICIAN
 	flag = MAGICIAN

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -34,6 +34,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/janitor
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/janitor
+	skirt_uniform = /obj/item/clothing/under/rank/civilian/janitor/skirt
 
 /datum/outfit/job/janitor/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -37,6 +37,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/mime
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/mime
+	skirt_uniform = /obj/item/clothing/under/rank/civilian/mime/skirt
 	mask = /obj/item/clothing/mask/gas/mime
 	gloves = /obj/item/clothing/gloves/color/white
 	head = /obj/item/clothing/head/frenchberet

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -36,6 +36,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/quartermaster
 	ears = /obj/item/radio/headset/headset_quartermaster
 	uniform = /obj/item/clothing/under/rank/cargo/quartermaster
+	uniform = /obj/item/clothing/under/rank/cargo/quartermaster/skirt
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	glasses = /obj/item/clothing/glasses/sunglasses/advanced
 	l_hand = /obj/item/clipboard

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -38,6 +38,7 @@
 	l_pocket = /obj/item/modular_computer/tablet/pda/roboticist
 	ears = /obj/item/radio/headset/headset_sci
 	uniform = /obj/item/clothing/under/rank/rnd/roboticist
+	skirt_uniform = /obj/item/clothing/under/rank/rnd/roboticist/skirt
 	suit = /obj/item/clothing/suit/toggle/labcoat
 
 	backpack = /obj/item/storage/backpack/science

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -38,6 +38,7 @@
 	belt = /obj/item/modular_computer/tablet/pda/science
 	ears = /obj/item/radio/headset/headset_sci
 	uniform = /obj/item/clothing/under/rank/rnd/scientist
+	skirt_uniform = /obj/item/clothing/under/rank/rnd/scientist/skirt
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	suit = /obj/item/clothing/suit/toggle/labcoat/science
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

closes #8537 

## About The Pull Request

Changes the behaviours of preferred clothing style, jobs that don't make sense to be wearing skirts will not have their official spawn uniform as a skirt style.
Members of these job roles are free to get skirts and wear them from the vendors, the same way they are free to wear a hoodie on the job, however the starting (official) work gear will not be a skirt unless it makes sense to be so.

This gives us the best of both worlds of allowing players to choose to wear informal clothing on the job, but having the official clothing as sensible and practical.

Jobs that include skirts are:
- All service jobs excluding the Head of Personnel
- All science jobs excluding the Research Director

## Why It's Good For The Game

Job roles that shouldn't have a skirt as their official uniform won't have a skirt as their official uniform. Ideally, any casual uniforms shouldn't be default spawn for job roles that have their uniform defined due to the work they are performing.

This is especially important for critical job roles, such as the captain, where ideally we want them to be playing a certain style of character (Powerful, authoritative) as oppossed to a cute kawaii catgirl.

Removes the shitcode of the previous method

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/220450156-6a9a1431-bf30-44dc-9ea3-af4930a67052.png)

![image](https://user-images.githubusercontent.com/26465327/220451003-c7ea7aa4-8836-40b2-956e-bf2124a7d7d2.png)

![image](https://user-images.githubusercontent.com/26465327/220451036-ad9bc501-361d-4582-83c2-8c9396f2ccc8.png)


## Changelog
:cl:
tweak: Preferred uniform style will no longer spawn crewmembers in their informal wear on the job (Job roles will not spawn with skirts when it makes no sense to do so).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
