### PR TITLE
Fixes being unable to send ellipses at the beginning of sentences correctly

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -145,10 +145,6 @@
   */
 /mob/proc/get_message_mods(message, list/mods)
 	for(var/I in 1 to MESSAGE_MODS_LENGTH)
-		// Prevents "...text" from being read as a radio message
-		if (length(message) > 1 && message[2] == message[1])
-			continue
-
 		var/key = message[1]
 		var/chop_to = 2 //By default we just take off the first char
 		if(key == "#" && !mods[WHISPER_MODE])
@@ -158,9 +154,15 @@
 		else if(key == ";" && !mods[MODE_HEADSET] && stat == CONSCIOUS)
 			mods[MODE_HEADSET] = TRUE
 		else if((key in GLOB.department_radio_prefixes) && length(message) > length(key) + 1 && !mods[RADIO_EXTENSION])
-			mods[RADIO_KEY] = lowertext(message[1 + length(key)])
-			mods[RADIO_EXTENSION] = GLOB.department_radio_keys[mods[RADIO_KEY]]
-			chop_to = length(key) + 2
+			key = lowertext(message[1 + length(key)])
+			var/valid_extension = GLOB.department_radio_keys[key]
+			var/valid_say_mode = SSradio.saymodes[key]
+			if(valid_extension || valid_say_mode)
+				mods[RADIO_KEY] = key
+				mods[RADIO_EXTENSION] = GLOB.department_radio_keys[key]
+				chop_to = length(key) + 2
+			else
+				continue
 		else if(key == "," && !mods[LANGUAGE_EXTENSION])
 			for(var/ld in GLOB.all_languages)
 				var/datum/language/LD = ld

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -145,6 +145,10 @@
   */
 /mob/proc/get_message_mods(message, list/mods)
 	for(var/I in 1 to MESSAGE_MODS_LENGTH)
+		// Prevents "...text" from being read as a radio message
+		if (length(message) > 1 && message[2] == message[1])
+			continue
+
 		var/key = message[1]
 		var/chop_to = 2 //By default we just take off the first char
 		if(key == "#" && !mods[WHISPER_MODE])

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -162,7 +162,7 @@
 				mods[RADIO_EXTENSION] = GLOB.department_radio_keys[key]
 				chop_to = length(key) + 2
 			else
-				continue
+				return message
 		else if(key == "," && !mods[LANGUAGE_EXTENSION])
 			for(var/ld in GLOB.all_languages)
 				var/datum/language/LD = ld


### PR DESCRIPTION
## About The Pull Request

Allows people to send multiple periods in a row at the beginning of messages, previously this would be incorrectly interpreted as a radio message

## Why It's Good For The Game

Having "...sure." be turned into [Security] "Ure." is incredibly annoying

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

forgive me for the horrific compression at the beginning

https://user-images.githubusercontent.com/39193182/222841032-8f12765c-6bb1-4368-a3b7-3be04a67f9b4.mp4

</details>

## Changelog
:cl: tonty
tweak: you can now put an ellipses at the beginning of your sentences
/:cl: