### PR TITLE
Buffs the sniper rifle

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -294,7 +294,7 @@
 
 /obj/item/gun/ballistic/automatic/sniper_rifle
 	name = "sniper rifle"
-	desc = "A long ranged weapon that does significant damage. No, you can't quickscope."
+	desc = "A long ranged semi-automatic marksman rifle that does significant damage. No, you can't quickscope."
 	icon_state = "sniper"
 	item_state = "sniper"
 	fire_sound = "sound/weapons/sniper_shot.ogg"
@@ -304,7 +304,7 @@
 	recoil = 2
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
-	fire_delay = 40
+	fire_delay = 7
 	burst_size = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	zoomable = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -316,7 +316,7 @@
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
-	desc = "An illegally modified .50 cal sniper rifle with suppression compatibility. Quickscoping still doesn't work."
+	desc = "An illegally modified .50 cal marksman rifle with suppression compatibility. Quickscoping still doesn't work."
 	can_suppress = TRUE
 	can_unsuppress = TRUE
 	pin = /obj/item/firing_pin/implant/pindicate

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -4,7 +4,8 @@
 	name =".50 bullet"
 	speed = 0.4
 	damage = 45
-	paralyze = 100
+	paralyze = 10
+	knockdown = 30
 	dismemberment = 50
 	armour_penetration = 50
 	var/breakthings = TRUE
@@ -21,6 +22,7 @@
 	damage = 25
 	dismemberment = 0
 	paralyze = 0
+	knockdown = 0
 	breakthings = FALSE
 
 /obj/item/projectile/bullet/p50/soporific/on_hit(atom/target, blocked = FALSE)
@@ -37,6 +39,7 @@
 	projectile_phasing = (ALL & (~PASSMOB))
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
+	knockdown = 0
 	breakthings = FALSE
 
 /obj/item/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -3,7 +3,7 @@
 /obj/item/projectile/bullet/p50
 	name =".50 bullet"
 	speed = 0.4
-	damage = 70
+	damage = 45
 	paralyze = 100
 	dismemberment = 50
 	armour_penetration = 50
@@ -17,8 +17,8 @@
 
 /obj/item/projectile/bullet/p50/soporific
 	name =".50 soporific bullet"
-	armour_penetration = 0
-	damage = 0
+	armour_penetration = 20
+	damage = 25
 	dismemberment = 0
 	paralyze = 0
 	breakthings = FALSE
@@ -32,7 +32,7 @@
 /obj/item/projectile/bullet/p50/penetrator
 	name =".50 penetrator bullet"
 	icon_state = "gauss"
-	damage = 60
+	damage = 40
 	projectile_piercing = PASSMOB
 	projectile_phasing = (ALL & (~PASSMOB))
 	dismemberment = 0 //It goes through you cleanly.

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -4,7 +4,6 @@
 	name =".50 bullet"
 	speed = 0.4
 	damage = 45
-	paralyze = 10
 	knockdown = 30
 	dismemberment = 50
 	armour_penetration = 50
@@ -21,7 +20,6 @@
 	armour_penetration = 20
 	damage = 25
 	dismemberment = 0
-	paralyze = 0
 	knockdown = 0
 	breakthings = FALSE
 
@@ -38,7 +36,6 @@
 	projectile_piercing = PASSMOB
 	projectile_phasing = (ALL & (~PASSMOB))
 	dismemberment = 0 //It goes through you cleanly.
-	paralyze = 0
 	knockdown = 0
 	breakthings = FALSE
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -622,7 +622,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/dangerous/sniper
 	name = "Sniper Rifle"
-	desc = "Ranged fury, Syndicate style. Guaranteed to cause shock and awe or your TC back!"
+	desc = "Ranged fury, Syndicate style. A semi-automatic marksman rifle that is guaranteed to cause \
+		shock and awe or your TC back!"
 	item = /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
 	cost = 16
 	surplus = 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs the sniper rifle:
- Firerate decreased from 4 seconds to 0.7 seconds
- Damage decreased from 70 to 45
- Paralysis decreased from 10 seconds to 1 seconds
- Knockdown added for 4 seconds

## Why It's Good For The Game

The sniper rifle is currently a very weak weapon, due having an insane 4 seconds shot delay which makes it almost unusable, combined with a low ammo count.
This reduces the sniper rifle's damage, making it more effective at combat ranges.
It's role now serves as a slow firing, high damage, armour penetrating weapon will is very effective against alone, armoured targets.

This makes the sniper rifle incredibly powerful and a weapon that you want to be careful when approaching, rather than a weapon that is almost entirely useless.
I get that its a sniper rifle, but in SS13 combat terms some kind of DMR/marksman rifle makes more balancing sense.

## Testing Photographs and Procedure

https://user-images.githubusercontent.com/26465327/221035008-38c06549-c1ab-4553-8e10-47ea80410d91.mp4

## Changelog
:cl:
balance: Sniper rifle firerate decreased from 4 seconds to 0.7 seconds
balance: Sniper rifle damage decreased from 70 to 45
balance: Removes sniper rifle paralysis
balance: Sniper rifle knockdown added for 4 seconds
balance: Sniper rifle soporific bullets now deal 25 damage instead of 0
balance: Sniper rifle penetrator rounds now deal 40 damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
