### PR TITLE
Revert "Supercruise now runs using continuous time, orbital map uses …

### DIFF
--- a/code/controllers/subsystem/processing/orbits.dm
+++ b/code/controllers/subsystem/processing/orbits.dm
@@ -230,6 +230,5 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 				"radius" = object.radius,
 				"render_mode" = object.render_mode,
 				"priority" = object.priority,
-				"vel_mult" = object.velocity_multiplier,
 			))
 	return data

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -10,8 +10,6 @@ SUBSYSTEM_DEF(processing)
 	var/list/processing = list()
 	var/list/currentrun = list()
 
-	var/last_time_fired = 0
-
 /datum/controller/subsystem/processing/stat_entry()
 	. = ..("[stat_tag]:[processing.len]")
 
@@ -24,10 +22,6 @@ SUBSYSTEM_DEF(processing)
 /datum/controller/subsystem/processing/fire(resumed = 0)
 	if (!resumed)
 		currentrun = processing.Copy()
-
-	var/continuous_delta_time = last_time_fired == 0 ? wait : world.timeofday - last_time_fired
-	last_time_fired = world.timeofday
-
 	//cache for sanic speed (lists are references anyways)
 	var/list/current_run = currentrun
 
@@ -36,7 +30,7 @@ SUBSYSTEM_DEF(processing)
 		current_run.len--
 		if(QDELETED(thing))
 			processing -= thing
-		else if(thing.process(((flags & SS_KEEP_TIMING) ? continuous_delta_time : wait) * 0.1) == PROCESS_KILL)
+		else if(thing.process(wait * 0.1) == PROCESS_KILL)
 			// fully stop so that a future START_PROCESSING will work
 			STOP_PROCESSING(src, thing)
 		if (MC_TICK_CHECK)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_object.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_object.dm
@@ -95,11 +95,18 @@
 	return
 
 //Process orbital objects, calculate gravity
-/datum/orbital_object/process(delta_time)
+/datum/orbital_object/process()
 	//Dont process updates for static objects.
 	if(static_object)
 		return PROCESS_KILL
 
+	//NOTE TO SELF: This does nothing because world.time is in ticks not realtime.
+	var/delta_time = 0
+	if(last_update_tick)
+		//Don't go too crazy.
+		delta_time = CLAMP(world.time - last_update_tick, 10, 50) * 0.1
+	else
+		delta_time = 1
 	last_update_tick = world.time
 
 	var/datum/orbital_map/parent_map = SSorbits.orbital_maps[orbital_map_index]

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/custom_shuttle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/custom_shuttle.dm
@@ -7,10 +7,10 @@
 	attached_console = null
 	. = ..()
 
-/datum/orbital_object/shuttle/custom_shuttle/process(delta_time)
+/datum/orbital_object/shuttle/custom_shuttle/process()
 	if(!attached_console)
 		return
-	attached_console.consume_fuel(ORBITAL_UPDATE_RATE_SECONDS * fuel_consumption_rate * delta_time * thrust / 100)
+	attached_console.consume_fuel(ORBITAL_UPDATE_RATE_SECONDS * fuel_consumption_rate * thrust / 100)
 	if(attached_console.check_stranded())
 		return
 	max_thrust = (5 * arctan(attached_console.calculated_acceleration / 20)) / 90

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -16,9 +16,8 @@
 
 /datum/orbital_object/meteor/New()
 	. = ..()
-	//Use continuous time for smoother meteors
-	start_tick = SSorbits.times_fired
-	end_tick = SSorbits.times_fired + (10 MINUTES / SSorbits.wait)
+	start_tick = world.time
+	end_tick = world.time + 10 MINUTES
 	radius = rand(10, 50)
 
 /datum/orbital_object/meteor/Destroy()
@@ -26,11 +25,12 @@
 	meteor_types = null
 	. = ..()
 
-/datum/orbital_object/meteor/process(delta_time)
+/datum/orbital_object/meteor/process()
+	. = ..()
 	if(!QDELETED(target))
 		end_x = target.position.x
 		end_y = target.position.y
-	var/current_tick = SSorbits.times_fired
+	var/current_tick = world.time
 	var/tick_proportion = min((current_tick - start_tick) / (end_tick - start_tick), 1)
 	//stop when reached the target
 	if(tick_proportion == 1)
@@ -38,10 +38,6 @@
 		velocity.y = 0
 	var/current_x = (end_x * tick_proportion) + (start_x * (1 - tick_proportion))
 	var/current_y = (end_y * tick_proportion) + (start_y * (1 - tick_proportion))
-	//Set the velocity for better rendering
-	velocity.x = current_x - position.x
-	velocity.y = current_y - position.y
-	. = ..()
 	MOVE_ORBITAL_BODY(src, current_x, current_y)
 	if(abs(position.x) > 10000 || abs(position.y) > 10000)
 		qdel(src)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/shuttle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/shuttle.dm
@@ -70,7 +70,7 @@
 		port.jumpToNullSpace()
 	qdel(src)
 
-/datum/orbital_object/shuttle/process(delta_time)
+/datum/orbital_object/shuttle/process()
 	if(check_stuck())
 		return
 
@@ -99,7 +99,7 @@
 	var/thrust_amount = thrust * max_thrust / 100
 	var/thrust_x = cos(angle) * thrust_amount
 	var/thrust_y = sin(angle) * thrust_amount
-	accelerate_towards(new /datum/orbital_vector(thrust_x, thrust_y), ORBITAL_UPDATE_RATE_SECONDS * delta_time)
+	accelerate_towards(new /datum/orbital_vector(thrust_x, thrust_y), ORBITAL_UPDATE_RATE_SECONDS)
 	//Do gravity and movement
 	can_dock_with = null
 	. = ..()

--- a/tgui/packages/tgui/components/OrbitalMapSvg.js
+++ b/tgui/packages/tgui/components/OrbitalMapSvg.js
@@ -66,7 +66,6 @@ export class OrbitalMapSvg extends Component {
         mapObject.velocity_x,
         mapObject.velocity_y,
         mapObject.radius,
-        mapObject.vel_mult,
         mapObject.created_at,
       );
     });
@@ -282,11 +281,11 @@ export class OrbitalMapSvg extends Component {
             <line
               x1={Math.max(Math.min((ourRenderableObject.position_x
                 + xOffset
-                + ourRenderableObject.velocity_x * elapsed * ourRenderableObject.vel_mult)
+                + ourRenderableObject.velocity_x * elapsed)
                 * zoomScale * mapDistanceScale, 250), -250)}
               y1={Math.max(Math.min((ourRenderableObject.position_y
                 + yOffset
-                + ourRenderableObject.velocity_y * elapsed * ourRenderableObject.vel_mult)
+                + ourRenderableObject.velocity_y * elapsed)
                 * zoomScale * mapDistanceScale, 250), -250)}
               x2={Math.max(Math.min((shuttleTargetX
                 + xOffset)
@@ -301,11 +300,11 @@ export class OrbitalMapSvg extends Component {
           <circle
             cx={(ourRenderableObject.position_x
               + xOffset
-              + ourRenderableObject.velocity_x * elapsed * ourRenderableObject.vel_mult)
+              + ourRenderableObject.velocity_x * elapsed)
               * zoomScale * mapDistanceScale}
             cy={(ourRenderableObject.position_y
               + yOffset
-              + ourRenderableObject.velocity_y * elapsed * ourRenderableObject.vel_mult)
+              + ourRenderableObject.velocity_y * elapsed)
               * zoomScale * mapDistanceScale}
             r={Math.max(5 * zoomScale, interdiction_range
               * zoomScale)}
@@ -353,7 +352,7 @@ class RenderableObjectType {
   // Called every second
   // Updates the data
   onTick(name, position_x, position_y, velocity_x, velocity_y, radius,
-    vel_mult, created_at)
+    created_at)
   {
     this.name = name;
     this.position_x = position_x;
@@ -362,7 +361,6 @@ class RenderableObjectType {
     this.velocity_y = velocity_y;
     this.radius = radius;
     this.created_at = created_at;
-    this.vel_mult = vel_mult;
   }
 
   // Called on render()
@@ -380,11 +378,11 @@ class RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed * this.vel_mult)
+      + this.velocity_x * elapsed)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed * this.vel_mult)
+      + this.velocity_y * elapsed)
       * zoomScale * mapDistanceScale;
     let outputRadius = this.radius * zoomScale;
 
@@ -491,11 +489,11 @@ class Beacon extends RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed * this.vel_mult)
+      + this.velocity_x * elapsed)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed * this.vel_mult)
+      + this.velocity_y * elapsed)
       * zoomScale * mapDistanceScale;
 
     let beaconTimer = ((elapsed + this.random_offset) % 1);
@@ -568,12 +566,12 @@ class Shuttle extends RenderableObjectType {
   // Called every updateTick
   // Record the path and update variables.
   onTick(name, position_x, position_y, velocity_x, velocity_y, radius,
-    vel_mult, created_at)
+    created_at)
   {
     // wtf is this
     RenderableObjectType.prototype.onTick.call(
       this, name, position_x, position_y, velocity_x, velocity_y, radius,
-      vel_mult, created_at);
+      created_at);
     // Set the position
     this.recordedTrack[this.recordedTrackLastIndex] = {
       x: this.position_x,
@@ -613,11 +611,11 @@ class Shuttle extends RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed * this.vel_mult)
+      + this.velocity_x * elapsed)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed * this.vel_mult)
+      + this.velocity_y * elapsed)
       * zoomScale * mapDistanceScale;
     let outputRadius = this.radius * zoomScale;
 
@@ -754,12 +752,13 @@ class Projectile extends RenderableObjectType {
 
     let outputXPosition = (this.position_x
       + xOffset
-      + this.velocity_x * elapsed * this.vel_mult)
+      + this.velocity_x * elapsed)
       * zoomScale * mapDistanceScale;
     let outputYPosition = (this.position_y
       + yOffset
-      + this.velocity_y * elapsed * this.vel_mult)
+      + this.velocity_y * elapsed)
       * zoomScale * mapDistanceScale;
+    let outputRadius = this.radius * zoomScale;
 
     this.inBounds = outputXPosition < 250 && outputYPosition < 250
       && outputXPosition > -250 && outputYPosition > -250;


### PR DESCRIPTION
…velocity multiplier to predict smoother shuttle movement (#8194)"

## About The Pull Request

This reverts commit c2dbb11a4311ff94187a0efe4c27b1ba55c94204 of PR #8194 

## Why It's Good For The Game

This PR has caused a bug where the orbital map drifts apart and completely breaks navigation randomly. It should probably be reverted until a fix can be made.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/221075346-1d1bccc5-e732-4edf-aa47-de70317c93ec.png)

</details>

## Changelog
:cl:
del: Removed continous-time supercruise orbit calculations.
fix: Fixed orbital map objects getting way too far apart randomly. 
/:cl:
