### PR TITLE
Clamps processing subsystems delta time

### DIFF
--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -25,7 +25,7 @@ SUBSYSTEM_DEF(processing)
 	if (!resumed)
 		currentrun = processing.Copy()
 
-	var/continuous_delta_time = last_time_fired == 0 ? wait : world.timeofday - last_time_fired
+	var/continuous_delta_time = last_time_fired == 0 ? wait : CLAMP(world.timeofday - last_time_fired, 0.1, 2)
 	last_time_fired = world.timeofday
 
 	//cache for sanic speed (lists are references anyways)

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -25,7 +25,11 @@ SUBSYSTEM_DEF(processing)
 	if (!resumed)
 		currentrun = processing.Copy()
 
-	var/continuous_delta_time = last_time_fired == 0 ? wait : CLAMP(world.timeofday - last_time_fired, 0.1, 2)
+	var/continuous_delta_time = last_time_fired == 0
+		// Give the raw wait time
+		? wait
+		// Give the actual time since the last fire, but clamp it to a reasonable value
+		: (CLAMP(world.timeofday - last_time_fired, 0.5 * wait, 2 * wait))
 	last_time_fired = world.timeofday
 
 	//cache for sanic speed (lists are references anyways)

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -25,11 +25,7 @@ SUBSYSTEM_DEF(processing)
 	if (!resumed)
 		currentrun = processing.Copy()
 
-	var/continuous_delta_time = last_time_fired == 0
-		// Give the raw wait time
-		? wait
-		// Give the actual time since the last fire, but clamp it to a reasonable value
-		: (CLAMP(world.timeofday - last_time_fired, 0.5 * wait, 2 * wait))
+	var/continuous_delta_time = last_time_fired == 0 ? wait : (CLAMP(world.timeofday - last_time_fired, 0.5 * wait, 2 * wait))
 	last_time_fired = world.timeofday
 
 	//cache for sanic speed (lists are references anyways)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a clamp to continuous delta time, so that it can never exceed 2 * wait or 0.5 * wait.
This means that if the game pauses for 8 hours, delta_time will be 2 instead of 4,800.

## Why It's Good For The Game

Continous processing implies that something is going to be updated frequently, if an anomalously long wait time comes in then we don't want to reduce the accuracy of our simulation by trying to perform an anomalously long tick.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/221237520-13237ec6-5e63-49ba-8232-a49b2337a289.png)
Difficult to test.

## Changelog
:cl:
fix: Fixes continuous subsystems being affected by anomalously long wait times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
