### PR TITLE
Fixes monkey hat and mask offset

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkey.dm
@@ -5,6 +5,10 @@
 	id = SPECIES_MONKEY
 	skinned_type = /obj/item/stack/sheet/animalhide/
 	changesource_flags = MIRROR_BADMIN
+	offset_features = list(
+	OFFSET_HEAD = list(0,-3),
+	OFFSET_FACEMASK = list(0,-3)
+	)
 
 	species_chest = /obj/item/bodypart/chest/monkey
 	species_head = /obj/item/bodypart/head/monkey


### PR DESCRIPTION
## About The Pull Request

Offsets all hats and facemasks down 3 pixels on monkeys, fixes (partially) https://github.com/BeeStation/BeeStation-Hornet/issues/8573, monkey hats and masks seem to still be messed up (i.e fake facehugger, wig and certainly many more)

## Why It's Good For The Game

Fix

## Testing Photographs and Procedure

Tried on some hats and facemasks, everything seems to line up

Before:
![beforemask](https://user-images.githubusercontent.com/81387903/222884486-3843a48f-ba40-40b2-919c-134a17c4a719.png)
![beforehat](https://user-images.githubusercontent.com/81387903/222884488-3c5f4633-8580-48b2-afce-83a7cd503f88.png)

After
![aftermask](https://user-images.githubusercontent.com/81387903/222884494-2ed4d1fe-3908-47d1-b256-a4873252df12.png)
![afterhead](https://user-images.githubusercontent.com/81387903/222884495-35278406-590e-4298-8112-efdf793b6795.png)


## Changelog
:cl:
fix:monkey hats and facemasks will now be lined up with their head
/:cl: