### PR TITLE
Various spider fixes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -328,7 +328,7 @@
 //Sentience types, to prevent things like sentience potions from giving bosses sentience
 #define SENTIENCE_ORGANIC 1
 #define SENTIENCE_ARTIFICIAL 2
-// #define SENTIENCE_OTHER 3 unused
+#define SENTIENCE_OTHER 3
 #define SENTIENCE_MINEBOT 4
 #define SENTIENCE_BOSS 5
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -726,6 +726,7 @@
 	spider.key = applicant.key
 	if(fed)
 		spider.fed += 3
+		spider.lay_eggs.UpdateButtonIcon()
 		fed--
 	message_admins("[ADMIN_LOOKUPFLW(spider)] has been made into a spider by the midround ruleset.")
 	log_game("DYNAMIC: [key_name(spider)] was spawned as a spider by the midround ruleset.")

--- a/code/modules/antagonists/spider/spider.dm
+++ b/code/modules/antagonists/spider/spider.dm
@@ -24,6 +24,7 @@
 	for(var/datum/antagonist/spider/spider in spiders)
 		to_chat(spider.owner, "<span class='spiderlarge'>Your directives have been updated!</span>")
 		to_chat(spider.owner, "<span class='spiderlarge'>New directive: [directive]</span>")
+		spider.owner.store_memory("<b>Directive: [directive]</b>")
 
 /datum/team/spiders/proc/handle_master_qdel()
 	SIGNAL_HANDLER
@@ -69,8 +70,8 @@
 
 	// Alert our spider to its directives
 	if(spider_team.directive)
-		to_chat(owner, "<span class='spider'>You were left a directive! Follow it at all costs.</span>")
-		to_chat(owner, "<span class='spider'><b>[spider_team.directive]</b></span>")
+		to_chat(owner, "<span class='spiderlarge'>You were left a directive! Follow it at all costs.</span>")
+		to_chat(owner, "<span class='spiderlarge'><b>[spider_team.directive]</b></span>")
 		owner.store_memory("<b>Directive: [spider_team.directive]</b>")
 	else
 		to_chat(owner, "<span class='spider'>You do not have a directive. You'll need to set one before laying eggs.</span>")

--- a/code/modules/antagonists/spider/spider.dm
+++ b/code/modules/antagonists/spider/spider.dm
@@ -48,10 +48,14 @@
 	show_to_ghosts = TRUE
 	var/datum/team/spiders/spider_team
 
-// Team handling, for when we have a bunch of different spiders with different directives.
 /datum/antagonist/spider/create_team(datum/team/spiders/new_team)
 	if(!new_team)
-		spider_team = new()
+		for(var/datum/antagonist/spider/spooder in GLOB.antagonists) 
+			if(!spooder.owner || !spooder.spider_team)
+				continue
+			spider_team = spooder.spider_team //if we can find any existing team, use that one
+			return
+		spider_team = new //otherwise we make a new team
 	else
 		if(!istype(new_team))
 			CRASH("Wrong spider team type provided to create_team")

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -54,6 +54,7 @@
 		spider_antag.set_spider_team(spider_team)
 		if(fed)
 			spooder.fed += 3 // Give our spiders some friends to help them get started
+			spooder.lay_eggs.UpdateButtonIcon()
 			fed--
 		spawncount--
 		message_admins("[ADMIN_LOOKUPFLW(spooder)] has been made into a spider by an event.")

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -84,7 +84,11 @@
 /mob/living/simple_animal/hostile/poison/giant_spider/mind_initialize()
 	. = ..()
 	if(!mind.has_antag_datum(/datum/antagonist/spider))
-		mind.add_antag_datum(/datum/antagonist/spider)
+		var/datum/antagonist/spider/spooder = new
+		if(!spider_team)
+			spooder.create_team()
+			spider_team = spooder.spider_team
+		mind.add_antag_datum(spooder, spider_team)
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Destroy()
 	QDEL_NULL(lay_web)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -51,6 +51,7 @@
 	unique_name = 1
 	gold_core_spawnable = HOSTILE_SPAWN
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	sentience_type = SENTIENCE_OTHER // not eligible for sentience potions
 	var/busy = SPIDER_IDLE // What a spider's doing
 	var/datum/action/innate/spider/lay_web/lay_web // Web action
 	var/obj/effect/proc_holder/wrap/lesser/lesserwrap // Wrap action
@@ -101,21 +102,6 @@
 	if(spider_antag.spider_team.directive)
 		log_game("[key_name(src)] took control of [name] with the objective: '[spider_antag.spider_team.directive]'.")
 	return TRUE
-
-/mob/living/simple_animal/hostile/poison/giant_spider/sentience_act(mob/user)
-	. = ..()
-	var/datum/team/spiders/spiders
-	for(var/datum/team/spiders/team in GLOB.antagonist_teams)
-		if(team.master == user)
-			spiders = team
-			break
-	if(!spiders)
-		if(spider_team)
-			spiders = spider_team //Spider was AI controlled and then taken over by a ghost, so we apply the stored team datum
-		else
-			spiders = new(null, user)
-	var/datum/antagonist/spider/spider_antag = mind.has_antag_datum(/datum/antagonist/spider)
-	spider_antag.set_spider_team(spiders)
 
 // Allows spiders to take damage slowdown. 2 max, but they don't start moving slower until under 75% health
 /mob/living/simple_animal/hostile/poison/giant_spider/updatehealth()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -594,11 +594,6 @@ s
 	if(..())
 		if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/broodmother))
 			return FALSE
-		var/mob/living/simple_animal/hostile/poison/giant_spider/S = owner
-		var/datum/antagonist/spider/spider_antag = S.mind?.has_antag_datum(/datum/antagonist/spider)
-		if(spider_antag?.spider_team.directive)
-			to_chat(owner, "<span class='notice'>You already have a directive, you cannot change it!</span>")
-			return FALSE
 		return TRUE
 
 /datum/action/innate/spider/set_directive/Activate()
@@ -613,7 +608,6 @@ s
 	var/new_directive = stripped_input(S, "Enter the new directive", "Create directive")
 	if(new_directive)
 		spider_antag.spider_team.update_directives(new_directive)
-		message_admins("[ADMIN_LOOKUPFLW(owner)] set its directive to: '[new_directive]'.")
 		log_game("[key_name(owner)][spider_antag.spider_team.master ? " (master: [spider_antag.spider_team.master]" : ""] set its directive to: '[new_directive]'.")
 		S.lay_eggs.UpdateButtonIcon(TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Sentience potions no longer work on spiders.
* Broodmothers may set new directives again as the situation around them changes. All previous directives are available via the notes verb. 
* Spider directive now appears in large text upon spawn, since it's the most important piece of information for freshly spawned spiders to know. 
* The "lay eggs" ability is now appropriately lit up for event-spawned broodmothers. 
* Fixes spiders randomly losing their team, and ensures spiders are always on the same team.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* **Sentience** - Spiders are always antagonists upon receiving a mind, presenting a major conflict with sentience potions and their instructions to obey a master. Suffice to say they're too intelligent to be enslaved with a potion I suppose. 
* **Directives** - Frankly this ability just shouldn't exist if broodmothers aren't even going to be allowed to use it, and I'm not really sure why the ability was disabled without being removed. Only admin spawned broodmothers could set their own directives since all others were given their only and permanent directive automatically. Making the text especially large helps draw attention to updated directives for newly joining spiders. 
* **Egg laying** - Event spawned broodmothers are able to lay eggs immediately, and it's fairly important that they know this. Having the button show up in red is not only a bug, but a harmfully misleading one.
* **Teams** - Previous overhaul intended to force all spiders onto the same team, but I made an oversight in the code that causes spiders to occasionally lose their team upon spawn, and along with that they lose the helpful team HUD that lets them identify other sentient spiders apart from non-sentients. 



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/221396408-8b046ee3-88a6-4892-abc2-323c07057010.png)

![image](https://user-images.githubusercontent.com/9547572/221396412-fbaf3dc7-2662-49c6-a46d-1ec49f4524ff.png)

![image](https://user-images.githubusercontent.com/9547572/221396414-53ab9e80-78e2-449f-bc1b-a5702b79fbea.png)


Not really a good way to show this one, but all three of these spiders were spawned with null team values (what was causing the previous bug).
![image](https://user-images.githubusercontent.com/9547572/221396424-846b7a9a-698c-4b7e-9514-f486a8f1abb7.png)

</details>

## Changelog
:cl:
fix: Spiders are now correctly assigned to their team all of the time
fix: Fixes a bug with "lay eggs" not lighting up when it should for broodmothers
tweak: Broodmothers may now set new directives again, and a history of known directives are kept in each spiders "notes".
tweak: Spiders are are now invalid targets for sentience potions due to their innate intelligence
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
