### PR TITLE
Enabled CI to run on merge-group

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
+    branches:
+    - master
 
 jobs:
   run_linters:


### PR DESCRIPTION
This is required for the CI to run within the merge group