### PR TITLE
Space Dragon now costs more threat

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -499,7 +499,6 @@
 	cost = 11
 	minimum_players = 25
 	repeatable = TRUE
-	flags = HIGH_IMPACT_RULESET
 	var/list/spawn_locs = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/space_dragon/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -495,10 +495,11 @@
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
 	required_enemies = list(1,1,1,1,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 4
-	cost = 9
+	weight = 3
+	cost = 11
 	minimum_players = 25
 	repeatable = TRUE
+	flags = HIGH_IMPACT_RULESET
 	var/list/spawn_locs = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/space_dragon/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -495,7 +495,7 @@
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
 	required_enemies = list(1,1,1,1,0,0,0,0,0,0)
 	required_candidates = 1
-	weight = 3
+	weight = 4
 	cost = 11
 	minimum_players = 25
 	repeatable = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes the following changes to the Space Dragon dynamic ruleset:

 - **Cost**: 9 -> 11

## Why It's Good For The Game

Space Dragon is a murderbone antag which can very easily end the round and round-remove players en masse. It should have a threat cost that represents that.

So this makes it so space dragons require more threat (I chose 11: less than xenos, but more than swarmers).

## Testing Photographs and Procedure

N/A

## Changelog
:cl:
balance: Space Dragons now cost more threat in dynamic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
