### PR TITLE
Fix climbing over railings

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -72,7 +72,8 @@
 /obj/structure/proc/do_climb(atom/movable/A)
 	if(climbable)
 		set_density(FALSE)
-		. = step(A,get_dir(A,src.loc))
+		var/step_dir = (get_turf(A) == get_turf(src)) ? dir : get_dir(A, src.loc)
+		. = step(A, step_dir)
 		set_density(TRUE)
 
 /obj/structure/proc/climb_structure(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes climbing over railings on the edges of tiles.

## Why It's Good For The Game

Because climbing over edge railings should work.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/65794972/222138683-a786986e-bd5b-4dc7-800f-62981c2f2c49.mp4

</details>

## Changelog
:cl:
fix: Climbing over railings on the edge of tiles works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
