### PR TITLE
Fix Policies config - Polymorph and Cloning text

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -101,10 +101,6 @@
 #define STICKYBAN_DB_CACHE_TIME 10 SECONDS
 #define STICKYBAN_ROGUE_CHECK_TIME 5
 
-
-#define POLICY_POLYMORPH "polymorph" //Shown to victim of staff of change and related effects.
-#define POLICY_VERB_HEADER "policy_verb_header" //Shown on top of policy verb window
-
 // allowed ghost roles this round, starts as everything allowed
 GLOBAL_VAR_INIT(ghost_role_flags, (~0))
 

--- a/code/controllers/configuration/entries/policies.dm
+++ b/code/controllers/configuration/entries/policies.dm
@@ -1,2 +1,5 @@
 /datum/config_entry/string/policy_postclonetext
 	config_entry_value = "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>"
+
+/datum/config_entry/string/policy_polymorph
+	config_entry_value = "<span class='boldannounce'>Even if you take the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -287,12 +287,9 @@
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
 
-	var/poly_msg = CONFIG_GET(keyed_list/policy)["polymorph"]
+	var/poly_msg = CONFIG_GET(string/policy_polymorph)
 	if(poly_msg)
 		to_chat(new_mob, poly_msg)
-
-	if((istype(new_mob, /mob/living/silicon/robot/modules/syndicate) || istype(new_mob, /mob/living/carbon/alien/humanoid) || istype(new_mob, /mob/living/simple_animal/hostile)))
-		to_chat(new_mob, "<span class='userdanger'>Despite taking the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>")
 
 	M.transfer_observers_to(new_mob)
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -18,6 +18,8 @@ $include resources.txt
 $include interviews.txt
 # Performance stuff
 $include performance.txt
+# Server Policies/Rules
+$include policies.txt
 
 # You can use the @ character at the beginning of a config option to lock it from being edited in-game
 # Example usage:

--- a/config/policies.txt
+++ b/config/policies.txt
@@ -2,5 +2,5 @@
 # Each line is pure html that gets sent to the user under certain conditions
 
 # When a mob is polymorphed
-POLYMORPH <span class='danger'>Note that you are allowed to act as an antagonist while transformed into a hostile mob, unless you volunteered for or sought out transformation.</span>
-POSTCLONETEXT "<span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>"
+POLICY_POLYMORPH <span class='boldannounce'>Test config change 123</span>
+POLICY_POSTCLONETEXT <span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>

--- a/config/policies.txt
+++ b/config/policies.txt
@@ -2,5 +2,5 @@
 # Each line is pure html that gets sent to the user under certain conditions
 
 # When a mob is polymorphed
-POLICY_POLYMORPH <span class='boldannounce'>Test config change 123</span>
+POLICY_POLYMORPH <span class='boldannounce'>Even if you take the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>
 POLICY_POSTCLONETEXT <span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>


### PR DESCRIPTION
## About The Pull Request

#8333 config value does not actually work, this fixes it

Also fixes the incorrect polymorph text (which never was appearing in game anyway), and replaces #7422 with it.

Removes unused DEFINEs.

## Why It's Good For The Game

Fixes bugs, makes policy more clear.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

New message
![image](https://user-images.githubusercontent.com/10366817/222696465-b219c011-dad7-4814-9426-d8cb8e35059b.png)

Quotes were in config in this, since removed
![image](https://user-images.githubusercontent.com/10366817/222696416-d9f7be60-8235-4dbf-9996-5b69fd4777e8.png)

</details>

## Changelog
:cl:
config: Polymorph config now properly applies.
tweak: The antagonist transform message on polymorph/staff of change now always sends, regardless of what you changed into.
config: Post-Clone message config now properly applies.
/:cl: