### PR TITLE
Fixes the chaplains Nature Orb

### DIFF
--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -88,10 +88,10 @@
 
 /obj/structure/destructible/religion/nature_pylon/LateInitialize()
 	. = ..()
-	START_PROCESSING(SSfastprocess, src)
+	START_PROCESSING(SSobj, src)
 
 /obj/structure/destructible/religion/nature_pylon/Destroy()
-	STOP_PROCESSING(SSfastprocess, src)
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -71,7 +71,7 @@
 
 /obj/structure/destructible/religion/nature_pylon
 	name = "Orb of Nature"
-	desc = "A floating crystal that slowly heals all plantlife and holy creatures. It can be bolted in place."
+	desc = "A floating crystal that slowly heals all plantlife and holy creatures. It can be anchored with a null rod."
 	icon_state = "nature_orb"
 	anchored = FALSE
 	light_range = 5
@@ -91,8 +91,9 @@
 	START_PROCESSING(SSfastprocess, src)
 
 /obj/structure/destructible/religion/nature_pylon/Destroy()
-	return ..()
 	STOP_PROCESSING(SSfastprocess, src)
+	return ..()
+
 
 /obj/structure/destructible/religion/nature_pylon/process(delta_time)
 	if(last_heal <= world.time)
@@ -147,3 +148,17 @@
 				// Are we in space or something? No grass turfs or
 				// convertable turfs?
 				last_spread = world.time + spread_delay*2
+
+/obj/structure/destructible/religion/nature_pylon/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I, /obj/item/nullrod))
+		if(user.mind?.holy_role == NONE)
+			to_chat(user, "<span class='warning'>Only the faithful may control the disposition of [src]!</span>")
+			return
+		anchored = !anchored
+		user.visible_message("<span class ='notice'>[user] [anchored ? "" : "un"]anchors [src] [anchored ? "to" : "from"] the floor with [I].</span>", "<span class ='notice'>You [anchored ? "" : "un"]anchor [src] [anchored ? "to" : "from"] the floor with [I].</span>")
+		playsound(src.loc, 'sound/items/deconstruct.ogg', 50, 1)
+		user.do_attack_animation(src)
+		return
+	if(I.tool_behaviour == TOOL_WRENCH)
+		return
+	return ..()

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -88,9 +88,11 @@
 
 /obj/structure/destructible/religion/nature_pylon/LateInitialize()
 	. = ..()
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/structure/destructible/religion/nature_pylon/Destroy()
 	return ..()
+	STOP_PROCESSING(SSfastprocess, src)
 
 /obj/structure/destructible/religion/nature_pylon/process(delta_time)
 	if(last_heal <= world.time)


### PR DESCRIPTION
## About The Pull Request
At current, The Nature orb doesnt process at all, also it fails to anchor.
This PR fixes both issues by adding both Start and Stop processing, and adding an attackby null rod interaction to anchor and unanchor the orb.

## Why It's Good For The Game
Fixes good. I should have caught these issues before the original PR got merged.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



https://user-images.githubusercontent.com/17776299/222773004-2cfdd2c0-27d4-46bd-a288-11a91f175282.mp4



</details>

## Changelog
:cl:
fix: Nature orb now anchors with null rod
fix: Nature orb now actually works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
