### PR TITLE
Ports the storage squash animation from TG

### DIFF
--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -129,6 +129,7 @@
 	if(isitem(AM))
 		var/obj/item/I = AM
 		I.item_flags &= ~IN_STORAGE
+		animate_parent()
 		I.remove_outline()
 		if(ismob(parent.loc))
 			var/mob/M = parent.loc

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -879,5 +879,7 @@
 			user.balloon_alert(user, "[parent] now picks up single item")
 
 /datum/component/storage/proc/animate_parent()
+	if(!animated)
+		return
 	animate(parent, time = 1.5, loop = 0, transform = matrix().Scale(1.11, 0.85))
 	animate(time = 2, transform = null)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -881,5 +881,8 @@
 /datum/component/storage/proc/animate_parent()
 	if(!animated)
 		return
-	animate(parent, time = 1.5, loop = 0, transform = matrix().Scale(1.11, 0.85))
-	animate(time = 2, transform = null)
+	var/atom/parent_atom = parent
+	var/matrix/M = parent_atom.transform
+	var/matrix/old_M = parent_atom.transform
+	animate(parent, time = 1.5, loop = 0, transform = M.Scale(1.11, 0.85))
+	animate(time = 2, transform = old_M)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -49,6 +49,9 @@
 
 	var/datum/action/item_action/storage_gather_mode/modeswitch_action
 
+	/// whether or not we should have those cute little animations
+	var/animated = TRUE
+
 	//Screen variables: Do not mess with these vars unless you know what you're doing. They're not defines so storage that isn't in the same location can be supported in the future.
 	var/screen_max_columns = 7							//These two determine maximum screen sizes.
 	var/screen_max_rows = INFINITY
@@ -212,6 +215,7 @@
 		stoplag(1)
 	qdel(progress)
 	to_chat(pre_attack_mob, "<span class='notice'>You put everything you could [insert_preposition] [parent].</span>")
+	animate_parent()
 
 /datum/component/storage/proc/handle_mass_item_insertion(list/things, datum/component/storage/src_object, mob/user, datum/progressbar/progress)
 	var/atom/source_real_location = src_object.real_location()
@@ -379,6 +383,7 @@
 				return FALSE
 	if(M.active_storage)
 		M.active_storage.hide_from(M)
+	animate_parent()
 	orient2hud()
 	M.client.screen |= boxes
 	M.client.screen |= closer
@@ -404,6 +409,7 @@
 	M.client.screen -= boxes
 	M.client.screen -= closer
 	M.client.screen -= real_location.contents
+	animate_parent()
 	return TRUE
 
 /datum/component/storage/proc/close(mob/M)
@@ -675,6 +681,7 @@
 		return
 	if(rustle_sound)
 		playsound(parent, "rustle", 50, 1, -5)
+	animate_parent()
 	for(var/mob/viewing as() in viewers(user))
 		if(M == viewing)
 			to_chat(usr, "<span class='notice'>You put [I] [insert_preposition]to [parent].</span>")
@@ -870,3 +877,7 @@
 			user.balloon_alert(user, "[parent] now picks up all items")
 		if(COLLECT_ONE)
 			user.balloon_alert(user, "[parent] now picks up single item")
+
+/datum/component/storage/proc/animate_parent()
+	animate(parent, time = 1.5, loop = 0, transform = matrix().Scale(1.11, 0.85))
+	animate(time = 2, transform = null)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -180,6 +180,7 @@
 					continue
 	if(show_message)
 		playsound(user, "rustle", 50, TRUE)
+		STR.animate_parent()
 		if (box)
 			user.visible_message("<span class='notice'>[user] offloads the ores beneath [user.p_them()] into [box].</span>", \
 			"<span class='notice'>You offload the ores beneath you into your [box].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Very, very partially ports https://github.com/tgstation/tgstation/pull/67478
specifically the part that makes storage items to a bouncing animation when interacted with.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It looks nice
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/110184118/222834395-4cd5276a-6ec8-473e-a898-134a7a5b21e5.mp4

</details>

## Changelog
:cl:
add: Added a squash animations when interacting with storage items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
