### PR TITLE
Improves player security checks for Cyborg and Mechs

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -2,7 +2,12 @@
 
 //Values for antag preferences, event roles, etc. unified here
 
+//Hour requirements before players can choose to be specific jobs
 
+#define MINUTES_REQUIRED_BASIC 120 			//For jobs that are easy to grief with, but not necessarily hard for new players
+#define MINUTES_REQUIRED_INTERMEDIATE 600 	//For jobs that require a more detailed understanding of either the game in general, or a specific department.
+#define MINUTES_REQUIRED_ADVANCED 900 		//For jobs that aren't command, but hold a similar level of importance to either their department or the round as a whole.
+#define MINUTES_REQUIRED_COMMAND 1200 		//For command positions, to be weighed against the relevant department
 
 //These are synced with the Database, if you change the values of the defines
 //then you MUST update the database!

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -181,7 +181,7 @@
 	if(istype(W, /obj/item/mmi))
 		var/obj/item/mmi/M = W
 		var/mob/living/brain/BM = M.brainmob
-		if(is_banned_from(BM.ckey, JOB_NAME_CYBORG) || BM.client.get_exp_living(TRUE) <= 120)
+		if(is_banned_from(BM.ckey, JOB_NAME_CYBORG) || BM.client.get_exp_living(TRUE) <= MINUTES_REQUIRED_BASIC)
 			to_chat(user, "<span class='warning'>This [M.name] is not compatible, try a different one!</span>")
 			return
 		if(mmi_move_inside(W,user))

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -179,6 +179,11 @@
 /obj/mecha/attackby(obj/item/W as obj, mob/user as mob, params)
 
 	if(istype(W, /obj/item/mmi))
+		var/obj/item/mmi/M = W
+		var/mob/living/brain/BM = M.brainmob
+		if(is_banned_from(BM.ckey, JOB_NAME_CYBORG) || BM.client.get_exp_living(TRUE) <= 120)
+			to_chat(user, "<span class='warning'>This [M.name] is not compatible, try a different one!</span>")
+			return
 		if(mmi_move_inside(W,user))
 			to_chat(user, "[src]-[W] interface initialized successfully.")
 		else

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -263,7 +263,7 @@
 				to_chat(user, "<span class='warning'>The MMI indicates that the brain is damaged!</span>")
 				return
 
-			if(is_banned_from(BM.ckey, JOB_NAME_CYBORG) || BM.client.get_exp_living(TRUE) <= 120)
+			if(is_banned_from(BM.ckey, JOB_NAME_CYBORG) || BM.client.get_exp_living(TRUE) <= MINUTES_REQUIRED_BASIC)
 				to_chat(user, "<span class='warning'>This [M.name] is not compatible, try a different one!</span>")
 				return
 			

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -263,7 +263,11 @@
 				to_chat(user, "<span class='warning'>The MMI indicates that the brain is damaged!</span>")
 				return
 
-			if(is_banned_from(BM.ckey, JOB_NAME_CYBORG) || QDELETED(src) || QDELETED(BM) || QDELETED(user) || QDELETED(M) || !Adjacent(user))
+			if(is_banned_from(BM.ckey, JOB_NAME_CYBORG) || BM.client.get_exp_living(TRUE) <= 120)
+				to_chat(user, "<span class='warning'>This [M.name] is not compatible, try a different one!</span>")
+				return
+			
+			if(QDELETED(src) || QDELETED(BM) || QDELETED(user) || !Adjacent(user))
 				if(!QDELETED(M))
 					to_chat(user, "<span class='warning'>This [M.name] does not seem to fit!</span>")
 				return

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -10,7 +10,7 @@
 	supervisors = "your laws"
 	req_admin_notify = TRUE
 	minimal_player_age = 30
-	exp_requirements = 600
+	exp_requirements = MINUTES_REQUIRED_COMMAND
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SILICON
 	display_order = JOB_DISPLAY_ORDER_AI

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -7,7 +7,7 @@
 	total_positions = 3
 	spawn_positions = 2
 	selection_color = "#fff5cc"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/atmospheric_technician

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 1
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/brig_physician
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -10,7 +10,7 @@
 	selection_color = "#ccccff"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 1200
+	exp_requirements = MINUTES_REQUIRED_COMMAND
 	exp_type = EXP_TYPE_COMMAND
 	exp_type_department = EXP_TYPE_COMMAND
 

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -7,7 +7,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	selection_color = "#d4ebf2"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/chemist
 

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -11,7 +11,7 @@
 	selection_color = "#ffeeaa"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 1200
+	exp_requirements = MINUTES_REQUIRED_COMMAND
 	exp_type = EXP_TYPE_ENGINEERING
 	exp_type_department = EXP_TYPE_ENGINEERING
 

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -11,7 +11,7 @@
 	selection_color = "#c1e1ec"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 1200
+	exp_requirements = MINUTES_REQUIRED_COMMAND
 	exp_type = EXP_TYPE_MEDICAL
 	exp_type_department = EXP_TYPE_MEDICAL
 

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -9,7 +9,7 @@
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 	random_spawns_possible = FALSE
 

--- a/code/modules/jobs/job_types/deputy.dm
+++ b/code/modules/jobs/job_types/deputy.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 0
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 180
+	exp_requirements = MINUTES_REQUIRED_INTERMEDIATE
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/deputy

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -9,7 +9,7 @@
 	spawn_positions = 1
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 180
+	exp_requirements = MINUTES_REQUIRED_INTERMEDIATE
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -7,7 +7,7 @@
 	total_positions = 3
 	spawn_positions = 3
 	minimal_player_age = 3
-	exp_requirements = 900
+	exp_requirements = MINUTES_REQUIRED_INTERMEDIATE
 	exp_type = EXP_TYPE_CREW
 	selection_color = "#ffeeff"
 

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -7,7 +7,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	selection_color = "#d4ebf2"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/geneticist
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -11,7 +11,7 @@
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 600
+	exp_requirements = MINUTES_REQUIRED_INTERMEDIATE //They already need to qualify for a different head of staff before they start getting applicable experience
 	exp_type = EXP_TYPE_COMMAND
 	exp_type_department = EXP_TYPE_COMMAND
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -11,7 +11,7 @@
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 1200
+	exp_requirements = MINUTES_REQUIRED_COMMAND
 	exp_type = EXP_TYPE_SECURITY
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -7,7 +7,7 @@
 	total_positions = 5
 	spawn_positions = 3
 	selection_color = "#d4ebf2"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/medical_doctor
 

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -7,7 +7,7 @@
 	total_positions = 2
 	spawn_positions = 1
 	selection_color = "#d4ebf2"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/paramedic
 	access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_CLONING, ACCESS_MECH_MEDICAL, ACCESS_MINERAL_STOREROOM,

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -7,7 +7,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	selection_color = "#d7b088"
-	exp_requirements = 600
+	exp_requirements = MINUTES_REQUIRED_INTERMEDIATE
 	exp_type = EXP_TYPE_SUPPLY
 	exp_type_department = EXP_TYPE_SUPPLY
 

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -11,7 +11,7 @@
 	selection_color = "#ffddff"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 1200
+	exp_requirements = MINUTES_REQUIRED_COMMAND
 	exp_type = EXP_TYPE_SCIENCE
 	exp_type_department = EXP_TYPE_SCIENCE
 

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 2
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/roboticist

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -7,7 +7,7 @@
 	total_positions = 5
 	spawn_positions = 3
 	selection_color = "#ffeeff"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/scientist

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -9,7 +9,7 @@
 	spawn_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 840
+	exp_requirements = MINUTES_REQUIRED_ADVANCED
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/security_officer

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -7,7 +7,7 @@
 	total_positions = 5
 	spawn_positions = 5
 	selection_color = "#fff5cc"
-	exp_requirements = 120
+	exp_requirements = MINUTES_REQUIRED_BASIC
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/engineer

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -7,7 +7,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	selection_color = "#d4ebf2"
-	exp_requirements = 180
+	exp_requirements = MINUTES_REQUIRED_INTERMEDIATE
 	exp_type = EXP_TYPE_MEDICAL
 	exp_type_department = EXP_TYPE_MEDICAL
 	outfit = /datum/outfit/job/virologist

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -9,7 +9,7 @@
 	spawn_positions = 1
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 600
+	exp_requirements = MINUTES_REQUIRED_ADVANCED //Almost as important as Head of Security
 	exp_type = EXP_TYPE_SECURITY
 	exp_type_department = EXP_TYPE_SECURITY
 

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -91,7 +91,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(is_banned_from(user.ckey, ROLE_POSIBRAIN))
 		to_chat(user, "<span class='warning'>You are restricted from taking positronic brain spawns at this time.</span>")
 		return
-	if(user.client.get_exp_living(TRUE) <= 120)
+	if(user.client.get_exp_living(TRUE) <= MINUTES_REQUIRED_BASIC)
 		to_chat(user, "<span class='warning'>You aren't allowed to take positronic brain spawns yet.</span>")
 		return
 	if(is_occupied() || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -88,7 +88,10 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 /obj/item/mmi/posibrain/proc/activate(mob/user)
 	if(QDELETED(brainmob))
 		return
-	if(is_occupied() || is_banned_from(user.ckey, ROLE_POSIBRAIN) || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
+	if(user.client.get_exp_living(TRUE) <= 120 || is_banned_from(user.ckey, ROLE_POSIBRAIN))
+		to_chat(user, "<span class='warning'>You aren't allowed to take positronic brain spawns at this time.</span>")
+		return
+	if(is_occupied() || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
 		return
 	if(user.ckey in GLOB.posi_key_list)
 		to_chat(user, "<span class='warning'>Positronic brain spawns limited to 1 per round.</span>")

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -88,8 +88,11 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 /obj/item/mmi/posibrain/proc/activate(mob/user)
 	if(QDELETED(brainmob))
 		return
-	if(user.client.get_exp_living(TRUE) <= 120 || is_banned_from(user.ckey, ROLE_POSIBRAIN))
-		to_chat(user, "<span class='warning'>You aren't allowed to take positronic brain spawns at this time.</span>")
+	if(is_banned_from(user.ckey, ROLE_POSIBRAIN))
+		to_chat(user, "<span class='warning'>You are restricted from taking positronic brain spawns at this time.</span>")
+		return
+	if(user.client.get_exp_living(TRUE) <= 120)
+		to_chat(user, "<span class='warning'>You aren't allowed to take positronic brain spawns yet.</span>")
 		return
 	if(is_occupied() || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Adds a check for minimum hour requirements for both cyborg and mechs when adding an MMI or Posibrain (two hours living, the same amount set for cyborgs already)
* Adds a check for cyborg bans to mechs.
* Makes defines for use when checking how many hours are required for specific roles
  * As a result of this, some outlying values were tweaked to better fit a normal pattern


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Should help reduce griefing at least slightly. Have had a pretty serial run of cyborg griefer that has been bypassing the hours-played requirement by taking posibrains/mmi

Mechs are rarely utilized with posibrains/mmi, but also have a similar level of destructive capacity in the wrong, or very new player hands. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Trying to put MMI into each of these
![image](https://user-images.githubusercontent.com/9547572/222881061-e8d96962-526f-45fc-8f99-7d8af2122972.png)

Trying to take a posibrain as a ghost
![image](https://user-images.githubusercontent.com/9547572/222894860-ad4ac90c-de8d-41be-807b-79a54d8f81fc.png)


</details>

## Changelog
:cl:
add: Mechs now check for cyborg bans before allowing a player to control them
tweak: Players are now unable to circumvent playtime requirements for cyborgs
code: Set definitions for hours played requirements so that it is easier to tweak the values without causing discrepancies
tweak: Due to the implementation of consistent defines, some hours played requirements were tweaked for the sake of consistency. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
