### PR TITLE
Fix one mind vessels still having the pink glow and HUD after being deconverted

### DIFF
--- a/code/modules/antagonists/hivemind/spells/hivemind_dominance.dm
+++ b/code/modules/antagonists/hivemind/spells/hivemind_dominance.dm
@@ -27,6 +27,9 @@
 		addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, C, "<span class='boldwarning'>You try to remember who you are...</span>"), 90)
 		addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, C, "<span class='assimilator'>There is no you...</span>"), 110)
 		addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, C, "<span class='bigassimilator'>...there is only us.</span>"), 130)
+		var/datum/antagonist/hivevessel/woke_vessel = IS_WOKEVESSEL(C)
+		if (woke_vessel)
+			woke_vessel.glow = hive.glow
 		addtimer(CALLBACK(C, /atom/proc/add_overlay, hive.glow), 150)
 
 	for(var/datum/antagonist/hivemind/enemy in GLOB.hivehosts)

--- a/code/modules/antagonists/hivemind/spells/hivemind_thrall.dm
+++ b/code/modules/antagonists/hivemind/spells/hivemind_thrall.dm
@@ -72,4 +72,5 @@
 	flash_color(user, flash_color="#800080", flash_time=10)
 	to_chat(user,"<span class='assimilator'>This vessel is now an extension of our will.</span>")
 	if(hivehost.dominant)
+		V.glow = hivehost.glow
 		target.add_overlay(hivehost.glow)

--- a/code/modules/antagonists/hivemind/vessel.dm
+++ b/code/modules/antagonists/hivemind/vessel.dm
@@ -41,6 +41,7 @@
 	..()
 
 /datum/antagonist/hivevessel/on_removal()
+	remove_innate_effects()
 	owner.RemoveSpell(fist)
 	if(master)
 		to_chat(master.owner, "<span class='assimilator'>A figment of our consciousness snaps out, we have lost an awakened vessel!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hivemind vessels still glow and have the HUD after being deconverted. This fixes that.

## Why It's Good For The Game

Bugs bad. Plus this bug leads to IC confusion.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/65794972/222924708-0da4984d-9857-476d-aefc-33eb2819aa31.mp4

Note: video taken before I also fixed the HUD issue

</details>

## Changelog
:cl:
fix: One Mind vessels now stop glowing after being deconverted
fix: Hivemind vessels now lose the hivemind HUD after being deconverted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
