### PR TITLE
Fixed the security belt worn sprite

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -303,6 +303,7 @@
 	desc = "Can hold security gear like handcuffs and flashes."
 	icon_state = "securitybelt"
 	item_state = "security"//Could likely use a better one.
+	worn_icon_state = "security"
 	content_overlays = TRUE
 
 /obj/item/storage/belt/security/ComponentInitialize()


### PR DESCRIPTION
## About The Pull Request

Title

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/81387903/222963787-c2888c25-ac7f-4a79-b811-97a1e225f739.png)
![image](https://user-images.githubusercontent.com/81387903/222963797-d3ad7076-c8ea-4457-b538-bd597e550d58.png)
(After the fix)

## Changelog
:cl:
fix:fixed the security belt looking like a toolbelt on your character sprite when worn
/:cl: