### PR TITLE
Cayeene will no longer be attacked by carps

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -143,7 +143,7 @@
 	gender = FEMALE
 	speak_emote = list("squeaks")
 	gold_core_spawnable = NO_SPAWN
-	faction = list(ROLE_SYNDICATE)
+	faction = list("carp", ROLE_SYNDICATE)
 	AIStatus = AI_OFF
 	/// Keeping track of the nuke disk for the functionality of storing it.
 	var/obj/item/disk/nuclear/disky


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cayeene moves slower than carps, dies in 2 hits to them and is hostile to them making nuclear carp gameplay impossible when they spawn.

## Why It's Good For The Game

Cayeene will no longer get killed in 2 shots by carps in space.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/222982425-8a96e6db-82cb-4df8-b1e0-346400c73a1d.png)

## Changelog
:cl:
balance: Space carp will no longer attack cayeene
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
