### PR TITLE
Makes the "Operative" Exploration Assasination target spawn with a hardsuit rather than just a helmet.

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -59,7 +59,7 @@
 			created_human.flavor_text = "You are a Syndicate operative employed by Cybersun Industries, currently scavenging for valuable resources in the wrecks of Nanotrasen Derelicts. \
 			However, upon being dropped off for your shift, the shuttle that flew you onboard was shot down by Nanotrasen's forces. You know it's only a matter of time before they find you..."
 			created_human.equipOutfit(/datum/outfit/vip_target/vip_operative)
-			suit_type = /obj/item/clothing/head/helmet/space/hardsuit/cybersun //On par with the explorer suit, nothing too wacky.
+			suit_type = /obj/item/clothing/suit/space/hardsuit/cybersun //On par with the explorer suit, nothing too wacky.
 			mask_type = /obj/item/clothing/mask/gas/syndicate
 		if("funnyman")
 			created_human.flavor_text = "Slip, slip, slip! Your PDA's brought a lot of laughs to this crew, but now that they're - and it's - gone, the Head Of Security's threats are \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes https://github.com/BeeStation/BeeStation-Hornet/issues/8449
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People spawning with their proper gear good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

If I knew how to force a specific target to spawn I would, but
spawning an atom with that typepath spawns a working cybersun hardsuit
![image](https://user-images.githubusercontent.com/110184118/223102132-71f6fb00-4d0b-483d-9840-f2c23fe954f6.png)


</details>

## Changelog
:cl:
fix: fixed the Operative explo assasination target only spawning with a hardsuit helmet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
