### PR TITLE
ModPCs use the same TGUI window + ModPC fixes

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -56,3 +56,6 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 #define MS2DS(T) ((T) MILLISECONDS)
 
 #define DS2MS(T) ((T) * 100)
+
+/// Amount of years from the current year to offset in-universe
+#define YEAR_OFFSET 540

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -200,9 +200,9 @@
 	if (CONFIG_GET(flag/log_job_debug))
 		WRITE_LOG(GLOB.world_job_debug_log, "JOB: [text]")
 
-/proc/log_href_exploit(atom/user)
-	WRITE_LOG(GLOB.href_exploit_attempt_log, "HREF: [key_name(user)] has potentially attempted an href exploit.")
-	message_admins("[key_name_admin(user)] has potentially attempted an href exploit.")
+/proc/log_href_exploit(atom/user, data = "")
+	WRITE_LOG(GLOB.href_exploit_attempt_log, "HREF: [key_name(user)] has potentially attempted an href exploit.[data]")
+	message_admins("[key_name_admin(user)] has potentially attempted an href exploit.[data]")
 
 /* Log to both DD and the logfile. */
 /proc/log_world(text)

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -468,7 +468,7 @@
 				var/counter = 1
 				while(src.active2.fields[text("com_[]", counter)])
 					counter++
-				src.active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+				src.active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+YEAR_OFFSET, t1)
 
 			else if(href_list["del_c"])
 				if((istype(src.active2, /datum/data/record) && src.active2.fields[text("com_[]", href_list["del_c"])]))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -657,7 +657,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+YEAR_OFFSET, t1)
 
 			if("Delete Record (ALL)")
 				if(active1)

--- a/code/modules/NTNet/network.dm
+++ b/code/modules/NTNet/network.dm
@@ -316,12 +316,12 @@
 #endif
 
 // Checks whether NTNet operates. If parameter is passed checks whether specific function is enabled.
-/datum/ntnet/station_root/proc/check_function(specific_action = 0, zlevel)
+/datum/ntnet/station_root/proc/check_function(specific_action = 0, zlevel, ignore_relay = FALSE)
 	if(!SSnetworks.relays || !SSnetworks.relays.len) // No relays found. NTNet is down
 		return FALSE
 
 	// Check all relays. If we have at least one working relay, network is up.
-	if(!SSnetworks.check_relay_operation(zlevel))
+	if(!ignore_relay && !SSnetworks.check_relay_operation(zlevel))
 		return FALSE
 
 	if(setting_disabled)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -395,7 +395,7 @@
 				var/counter = 1
 				while(R.fields[text("com_[]", counter)])
 					counter++
-				R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+				R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+YEAR_OFFSET, t1)
 				to_chat(usr, "<span class='notice'>Successfully added comment.</span>")
 				return
 	..() //end of this massive fucking chain. TODO: make the hud chain not spooky.

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -298,14 +298,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		add_overlay(mutable_appearance(init_icon, "bsod"))
 		add_overlay(mutable_appearance(init_icon, "broken"))
 
-
-// On-click handling. Turns on the computer if it's off and opens the GUI.
-/obj/item/modular_computer/interact(mob/user)
-	if(enabled)
-		ui_interact(user)
-	else
-		turn_on(user)
-
 /obj/item/modular_computer/proc/turn_on(mob/user, open_ui = TRUE)
 	if(enabled)
 		if(open_ui)
@@ -503,7 +495,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 			program.alert_pending = FALSE
 			idle_threads.Remove(program)
 			update_icon()
-			updateUsrDialog()
 			return TRUE
 	else if(program in idle_threads)
 		return TRUE
@@ -522,7 +513,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	if(!in_background)
 		active_program = program
 		program.alert_pending = FALSE
-		updateUsrDialog()
+		ui_interact(user)
 	else
 		program.program_state = PROGRAM_STATE_BACKGROUND
 		idle_threads.Add(program)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -467,6 +467,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	data["PC_programheaders"] = program_headers
 
 	data["PC_stationtime"] = station_time_timestamp()
+	data["PC_stationdate"] = "[time2text(world.realtime, "DDD, Month DD")], [GLOB.year_integer+YEAR_OFFSET]"
 	data["PC_hasheader"] = 1
 	data["PC_showexitprogram"] = active_program ? 1 : 0 // Hides "Exit Program" button on mainscreen
 	return data

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -42,8 +42,10 @@
 	if(!ui)
 		if(active_program)
 			ui = new(user, src, active_program.tgui_id, active_program.filedesc)
+			ui.set_autoupdate(TRUE)
 		else
 			ui = new(user, src, "NtosMain")
+			ui.set_autoupdate(TRUE)
 		ui.open()
 		return
 

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -200,6 +200,12 @@
 	device_theme = THEME_SYNDICATE
 	theme_locked = TRUE
 
+/obj/item/modular_computer/tablet/pda/syndicate/Initialize(mapload)
+	. = ..()
+	var/obj/item/computer_hardware/network_card/network_card = all_components[MC_NET]
+	if(istype(network_card))
+		network_card.long_range = TRUE
+
 /obj/item/modular_computer/tablet/pda/chaplain
 	name = "chaplain PDA"
 	icon_state = "pda-chaplain"

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -204,7 +204,8 @@
 	. = ..()
 	var/obj/item/computer_hardware/network_card/network_card = all_components[MC_NET]
 	if(istype(network_card))
-		network_card.long_range = TRUE
+		forget_component(network_card)
+		install_component(new /obj/item/computer_hardware/network_card/advanced/norelay)
 
 /obj/item/modular_computer/tablet/pda/chaplain
 	name = "chaplain PDA"

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -14,6 +14,8 @@
 	has_light = TRUE //LED flashlight!
 	comp_light_luminosity = 2.3 //Same as the PDA
 	interaction_flags_atom = INTERACT_ATOM_ALLOW_USER_LOCATION
+	can_save_id = TRUE
+	saved_auto_imprint = TRUE
 
 	var/has_variants = TRUE
 	var/finish_color = null
@@ -60,6 +62,7 @@
 			qdel(stored_paper)
 		stored_paper = paper.copy(src)
 		to_chat(user, "<span class='notice'>Paper scanned. Saved to PDA's notekeeper.</span>")
+		ui_update()
 	return TRUE
 
 /obj/item/modular_computer/tablet/attackby(obj/item/attacking_item, mob/user)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -135,17 +135,6 @@
 	return FALSE
 
 /**
- * This attempts to retrieve header data for UIs.
- *
- * If implementing completely new device of different type than existing ones
- * always include the device here in this proc. This proc basically relays the request to whatever is running the program.
- **/
-/datum/computer_file/program/proc/get_header_data()
-	if(computer)
-		return computer.get_header_data()
-	return list()
-
-/**
  * Called on program startup.
  *
  * May be overridden to add extra logic. Remember to include ..() call. Return 1 on success, 0 on failure.
@@ -189,71 +178,6 @@
 	if(network_destination)
 		generate_network_log("Connection to [network_destination] closed.")
 	return 1
-
-/datum/computer_file/program/ui_assets(mob/user)
-	return list(
-		get_asset_datum(/datum/asset/simple/headers),
-	)
-
-/datum/computer_file/program/ui_state(mob/user)
-	return GLOB.default_state
-
-/datum/computer_file/program/ui_interact(mob/user, datum/tgui/ui)
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui && tgui_id)
-		ui = new(user, src, tgui_id, filedesc)
-		ui.set_autoupdate(TRUE)
-		if(ui.open())
-			ui.send_asset(get_asset_datum(/datum/asset/simple/headers))
-
-// CONVENTIONS, READ THIS WHEN CREATING NEW PROGRAM AND OVERRIDING THIS PROC:
-// Topic calls are automagically forwarded from NanoModule this program contains.
-// Calls beginning with "PRG_" are reserved for programs handling.
-// Calls beginning with "PC_" are reserved for computer handling (by whatever runs the program)
-// ALWAYS INCLUDE PARENT CALL ..() OR DIE IN FIRE.
-/datum/computer_file/program/ui_act(action,params,datum/tgui/ui)
-	if(..())
-		return TRUE
-	if(computer)
-		if(computer.device_theme == THEME_THINKTRONIC)
-			computer.send_select_sound()
-		switch(action)
-			if("PC_exit")
-				computer.kill_program()
-				ui.close()
-				return TRUE
-			if("PC_shutdown")
-				computer.shutdown_computer()
-				ui.close()
-				return TRUE
-			if("PC_minimize")
-				var/mob/user = usr
-				if(!computer.active_program || !computer.all_components[MC_CPU])
-					return
-
-				computer.idle_threads.Add(computer.active_program)
-				program_state = PROGRAM_STATE_BACKGROUND // Should close any existing UIs
-
-				computer.active_program = null
-				computer.update_icon()
-				ui.close()
-
-				if(user && istype(user))
-					computer.ui_interact(user) // Re-open the UI on this computer. It should show the main screen now.
-				return TRUE
-
-
-/datum/computer_file/program/ui_host()
-	if(computer)
-		if(computer.physical)
-			return computer.physical
-		return computer
-	return ..()
-
-/datum/computer_file/program/ui_status(mob/user)
-	if(program_state != PROGRAM_STATE_ACTIVE) // Our program was closed. Close the ui if it exists.
-		return UI_CLOSE
-	return ..()
 
 /// Return TRUE if nothing was processed. Return FALSE to prevent further actions running.
 /// Set use_attack = TRUE to receive proccalls from the parent computer.

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -90,7 +90,7 @@
 
 
 /datum/computer_file/program/aidiag/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/mob/living/silicon/ai/AI = get_ai()
 
 	var/obj/item/aicard/aicard = get_ai(2)

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -27,7 +27,7 @@
 	return 1
 
 /datum/computer_file/program/alarm_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["alarms"] = list()
 	for(var/class in GLOB.alarms)

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -126,7 +126,6 @@
 
 	if (hard_drive && hard_drive.traitor_data != null)
 		var/datum/antagonist/traitor/traitor_data = hard_drive.traitor_data
-		data += get_header_data()
 
 		if (traitor_data.contractor_hub.current_contract)
 			data["ongoing_contract"] = TRUE

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -73,7 +73,7 @@
 	if(!SSnetworks.station_network)
 		return
 
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["error"] = error
 	if(target && executed)

--- a/code/modules/modular_computers/file_system/programs/antagonist/emag.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/emag.dm
@@ -8,9 +8,6 @@
 	available_on_ntnet = FALSE
 	tgui_id = "NtosEmagConsole"
 
-/datum/computer_file/program/emag_console/ui_data(mob/user)
-	return get_header_data()
-
 /datum/computer_file/program/emag_console/ui_act(action,params,datum/tgui/ui)
 	if(!ui || ui.status != UI_INTERACTIVE)
 		return TRUE

--- a/code/modules/modular_computers/file_system/programs/antagonist/emag.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/emag.dm
@@ -11,9 +11,11 @@
 /datum/computer_file/program/emag_console/ui_act(action,params,datum/tgui/ui)
 	if(!ui || ui.status != UI_INTERACTIVE)
 		return TRUE
+	kill_program(forced = TRUE)
+	return TRUE
+
+/datum/computer_file/program/emag_console/kill_program(forced)
+	. = ..()
 	if(computer)
 		computer.device_theme = THEME_SYNDICATE
 		computer.allowed_themes = GLOB.ntos_device_themes_emagged
-	// bye bye UI
-	qdel(src)
-	return TRUE

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -72,7 +72,7 @@
 	return temp
 
 /datum/computer_file/program/revelation/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["armed"] = armed
 

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -81,7 +81,7 @@
 	)
 
 /datum/computer_file/program/arcade/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["Hitpoints"] = boss_hp
 	data["PlayerHitpoints"] = player_hp
 	data["PlayerMP"] = player_mp

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -18,9 +18,9 @@
 
 
 /datum/computer_file/program/atmosscan/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/list/airlist = list()
-	var/turf/T = get_turf(ui_host())
+	var/turf/T = get_turf(computer.ui_host())
 	var/obj/item/computer_hardware/sensorpackage/sensors = computer?.get_modular_computer_part(MC_SENSORS)
 	if(T && sensors?.check_functionality())
 		var/datum/gas_mixture/environment = T.return_air()

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -22,7 +22,7 @@
 
 
 /datum/computer_file/program/borg_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	// Syndicate version doesn't require an ID - so we use this proc instead of computer.GetID()
 	data["card"] = !!get_id_name()
@@ -61,13 +61,13 @@
 		if("messagebot")
 			var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 			if(!istype(R))
-				return
+				return TRUE
 			var/sender_name = get_id_name()
 			if(!sender_name)
 				// This can only happen if the action somehow gets called as UI blocks this action with no ID
 				computer.visible_message("<span class='notice'>Insert an ID to send messages.</span>")
 				playsound(usr, 'sound/machines/terminal_error.ogg', 15, TRUE)
-				return
+				return TRUE
 			if(R.stat == DEAD) //Dead borgs will listen to you no longer
 				to_chat(usr, "<span class='warn'>Error -- Could not open a connection to unit:[R]</span>")
 			var/message = stripped_input(usr, message = "Enter message to be sent to remote cyborg.", title = "Send Message")
@@ -85,6 +85,7 @@
 				SEND_SOUND(R.connected_ai, 'sound/machines/twobeep_high.ogg')
 			R.logevent("Message from [sender_name] -- \"[message]\"")
 			usr.log_talk(message, LOG_PDA, tag="Cyborg Monitor Program: ID name \"[sender_name]\" to [R]")
+			return TRUE
 
 ///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
 /datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)

--- a/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
@@ -31,7 +31,7 @@
 	return FALSE
 
 /datum/computer_file/program/borg_self_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(!iscyborg(user))
 		return data
 	var/mob/living/silicon/robot/borgo = tablet.borgo

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -48,8 +48,7 @@
 	return TRUE
 
 /datum/computer_file/program/budgetorders/ui_data(mob/user)
-	. = ..()
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["location"] = SSshuttle.supply.getStatusText()
 	var/datum/bank_account/buyer = SSeconomy.get_budget_account(ACCOUNT_CAR_ID)
 	var/obj/item/card/id/id_card = get_buyer_id(user)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -343,7 +343,7 @@
 	return data
 
 /datum/computer_file/program/card_mod/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["station_name"] = station_name()
 

--- a/code/modules/modular_computers/file_system/programs/cargobounty.dm
+++ b/code/modules/modular_computers/file_system/programs/cargobounty.dm
@@ -27,7 +27,7 @@
 	. = ..()
 
 /datum/computer_file/program/bounty/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)

--- a/code/modules/modular_computers/file_system/programs/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/configurator.dm
@@ -28,7 +28,7 @@
 	if(!computer)
 		return FALSE
 
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["disk_size"] = hard_drive.max_capacity
 	data["disk_used"] = hard_drive.used_capacity
 	data["power_usage"] = computer.last_power_usage

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -18,7 +18,7 @@
 	return data
 
 /datum/computer_file/program/crew_manifest/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -88,7 +88,7 @@
 			binary.alert_silenced = !binary.alert_silenced
 
 /datum/computer_file/program/filemanager/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/obj/item/computer_hardware/hard_drive/HDD = computer.all_components[MC_HDD]
 	var/obj/item/computer_hardware/hard_drive/portable/RHDD = computer.all_components[MC_SDD]

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -62,14 +62,14 @@
 	var/obj/item/card/id/user_id = card_slot?.stored_card
 
 	if(!user_id || !(ACCESS_CHANGE_IDS in user_id.access))
-		return
+		return TRUE
 
 	switch(action)
 		if("PRG_open_job")
 			var/edit_job_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(edit_job_target)
 			if(!j || !can_open_job(j))
-				return
+				return TRUE
 			if(opened_positions[edit_job_target] >= 0)
 				GLOB.time_last_changed_position = world.time / 10
 			j.total_positions++
@@ -80,7 +80,7 @@
 			var/edit_job_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(edit_job_target)
 			if(!j || !can_close_job(j))
-				return
+				return TRUE
 			//Allow instant closing without cooldown if a position has been opened before
 			if(opened_positions[edit_job_target] <= 0)
 				GLOB.time_last_changed_position = world.time / 10
@@ -92,9 +92,9 @@
 			var/priority_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(priority_target)
 			if(!j)
-				return
+				return TRUE
 			if(j.total_positions <= j.current_positions)
-				return
+				return TRUE
 			if(j in SSjob.prioritized_jobs)
 				SSjob.prioritized_jobs -= j
 			else
@@ -107,7 +107,7 @@
 
 
 /datum/computer_file/program/job_management/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/authed = FALSE
 	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]

--- a/code/modules/modular_computers/file_system/programs/log_viewer.dm
+++ b/code/modules/modular_computers/file_system/programs/log_viewer.dm
@@ -45,7 +45,7 @@
 			return TRUE
 
 /datum/computer_file/program/log_viewer/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(!istype(computer))
 		return data
 	var/list/datum/computer_file/data/log_file/data_files = list()

--- a/code/modules/modular_computers/file_system/programs/newscaster.dm
+++ b/code/modules/modular_computers/file_system/programs/newscaster.dm
@@ -21,7 +21,7 @@
 	return ..()
 
 /datum/computer_file/program/newscaster/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data += newscaster_ui.ui_data(user)
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -32,7 +32,7 @@
 
 
 /datum/computer_file/program/notepad/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/obj/item/modular_computer/tablet/tablet = computer
 	if(!istype(tablet))
 		return data

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -140,7 +140,7 @@
 	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
 	var/list/access = card_slot?.GetAccess()
 
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["downloading"] = !!downloaded_file
 	data["error"] = downloaderror || FALSE

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -148,7 +148,7 @@
 			if(!disk?.spam_delay)
 				if(!disk)
 					return
-				log_href_exploit(usr)
+				log_href_exploit(usr, " Attempted sending PDA message to all without a disk capable of doing so: [disk].")
 				return
 
 			var/list/targets = list()
@@ -213,7 +213,7 @@
 			return TRUE
 
 /datum/computer_file/program/messenger/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/obj/item/computer_hardware/hard_drive/role/disk = computer.all_components[MC_HDD_JOB]
 

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -52,7 +52,7 @@
 /datum/computer_file/program/ntnetmonitor/ui_data(mob/user)
 	if(!SSnetworks.station_network)
 		return
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["ntnetstatus"] = SSnetworks.station_network.check_function(zlevel=user.get_virtual_z_level())
 	data["ntnetrelays"] = SSnetworks.relays.len

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -218,8 +218,6 @@
 
 	var/list/data = list()
 
-	data = get_header_data()
-
 	var/list/all_channels = list()
 	for(var/C in SSnetworks.station_network.chat_channels)
 		var/datum/ntnet_conversation/conv = C

--- a/code/modules/modular_computers/file_system/programs/phys_scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/phys_scanner.dm
@@ -107,7 +107,7 @@
 
 
 /datum/computer_file/program/phys_scanner/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["set_mode"] = ReadCurrent()
 	data["last_record"] = last_record

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -80,7 +80,7 @@
 
 /datum/computer_file/program/power_monitor/ui_data()
 	var/datum/powernet/connected_powernet = get_powernet()
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["stored"] = record_size
 	data["interval"] = record_interval / 10
 	data["attached"] = connected_powernet ? TRUE : FALSE

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -49,7 +49,7 @@
 	)
 
 /datum/computer_file/program/radar/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	// PDAs should not have full radar capabilities
 	data["full_capability"] = !istype(computer, /obj/item/modular_computer/tablet/pda)
 	data["selected"] = selected

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -75,8 +75,10 @@
 	switch(action)
 		if("selecttarget")
 			selected = params["ref"]
+			return TRUE
 		if("scan")
 			scan()
+			return TRUE
 
 /**
   *Updates tracking information of the selected target.

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -81,7 +81,7 @@
 
 
 /datum/computer_file/program/records/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["records"] = GetRecordsReadable()
 	data["mode"] = mode
 	return data

--- a/code/modules/modular_computers/file_system/programs/remote_airlock.dm
+++ b/code/modules/modular_computers/file_system/programs/remote_airlock.dm
@@ -44,6 +44,9 @@
 			var/obj/item/computer_hardware/hard_drive/drive = computer.all_components[MC_HDD]
 			if(istype(drive) && length(drive.controllable_airlocks))
 				all_controllable += drive.controllable_airlocks
+			drive = computer.all_components[MC_HDD_JOB]
+			if(istype(drive) && length(drive.controllable_airlocks))
+				all_controllable += drive.controllable_airlocks
 			for(var/obj/machinery/door/poddoor/airlock in GLOB.airlocks)
 				if(airlock.id == params["id"])
 					if(!(airlock.id in all_controllable))

--- a/code/modules/modular_computers/file_system/programs/remote_airlock.dm
+++ b/code/modules/modular_computers/file_system/programs/remote_airlock.dm
@@ -11,7 +11,7 @@
 	unsendable = TRUE
 
 /datum/computer_file/program/remote_airlock/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/list/airlocks = list()
 	var/list/all_controllable = list()
 	var/obj/item/computer_hardware/hard_drive/drive = computer.all_components[MC_HDD]
@@ -40,8 +40,15 @@
 		if("airlock_control")
 			if(!params["id"])
 				return
+			var/list/all_controllable = list()
+			var/obj/item/computer_hardware/hard_drive/drive = computer.all_components[MC_HDD]
+			if(istype(drive) && length(drive.controllable_airlocks))
+				all_controllable += drive.controllable_airlocks
 			for(var/obj/machinery/door/poddoor/airlock in GLOB.airlocks)
 				if(airlock.id == params["id"])
+					if(!(airlock.id in all_controllable))
+						log_href_exploit(usr, " Attempted control of airlock: [params["id"]] which they do not have access to (access: [english_list(all_controllable)]).")
+						return TRUE
 					// Fail, but reload data
 					if(airlock.get_virtual_z_level() != computer.get_virtual_z_level())
 						return TRUE

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -18,8 +18,8 @@
 	var/list/current_access = list()
 
 /datum/computer_file/program/robocontrol/ui_data(mob/user)
-	var/list/data = get_header_data()
-	var/turf/current_turf = get_turf(ui_host())
+	var/list/data = list()
+	var/turf/current_turf = get_turf(computer.ui_host())
 	var/zlevel = current_turf.get_virtual_z_level()
 	var/list/botlist = list()
 	var/list/mulelist = list()
@@ -95,7 +95,7 @@
 				GLOB.data_core.manifest_modify(id_card.registered_name, id_card.assignment, id_card.hud_state)
 				card_slot.try_eject(current_user)
 			else
-				playsound(get_turf(ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
+				playsound(get_turf(computer.ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
 	if(!selected_bot)
 		return
 	var access_okay = TRUE

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -81,7 +81,7 @@
 		return ..()
 
 /datum/computer_file/program/secureye/ui_data()
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["network"] = network
 	data["activeCamera"] = null
 	if(active_camera)

--- a/code/modules/modular_computers/file_system/programs/signaller.dm
+++ b/code/modules/modular_computers/file_system/programs/signaller.dm
@@ -28,7 +28,7 @@
 	SSradio.remove_object(computer, signal_frequency)
 
 /datum/computer_file/program/signaller/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/obj/item/computer_hardware/radio_card/sensor = computer?.get_modular_computer_part(MC_SIGNALLER)
 	if(sensor?.check_functionality())
 		data["frequency"] = signal_frequency

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -50,7 +50,7 @@
 	for(var/supermatter in supermatters)
 		clear_supermatter(supermatter)
 	supermatters = list()
-	var/turf/T = get_turf(ui_host())
+	var/turf/T = get_turf(computer.ui_host())
 	if(!T)
 		return
 	for(var/obj/machinery/power/supermatter_crystal/S in GLOB.machines)
@@ -118,7 +118,7 @@
 		computer.alert_call(src, "Crystal delamination in progress!")
 
 /datum/computer_file/program/supermatter_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	if(istype(active))
 		var/turf/T = get_turf(active)

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -61,7 +61,7 @@
 			SendSignal("alert")
 
 /datum/computer_file/program/status/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["upper"] = upper_text
 	data["lower"] = lower_text

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -33,7 +33,7 @@
 
 // heavy data from this proc should be moved to static data when possible
 /datum/computer_file/program/science/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data += list(
 		"nodes" = list(),
 		"experiments" = list(),

--- a/code/modules/modular_computers/file_system/programs/wiki_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/wiki_uplink.dm
@@ -9,7 +9,7 @@
 	size = 2
 
 /datum/computer_file/program/databank_uplink/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 
 	data["src"] = wikiurl

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -107,6 +107,7 @@
 	current_identification = null
 	current_job = null
 	holder?.update_icon()
+	holder?.ui_update()
 	return TRUE
 
 /obj/item/computer_hardware/card_slot/attackby(obj/item/I, mob/living/user)

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -6,8 +6,11 @@
 	network_id = NETWORK_CARDS	// Network we are on
 	var/hardware_id = null	// Identification ID. Technically MAC address of this device. Can't be changed by user.
 	var/identification_string = "" 	// Identification string, technically nickname seen in the network. Can be set by user.
-	var/long_range = 0
-	var/ethernet = 0 // Hard-wired, therefore always on, ignores NTNet wireless checks.
+	/// If this works without being on the same zlevel, as long as there is a tcomms relay
+	var/long_range = FALSE
+	/// If this works without a tcomms relay on the zlevel (requires long_range)
+	var/ignore_relay = FALSE
+	var/ethernet = FALSE // Hard-wired, therefore always on, ignores NTNet wireless checks.
 	malfunction_probability = 1
 	device_type = MC_NET
 
@@ -43,7 +46,7 @@
 	if(ethernet) // Computer is connected via wired connection.
 		return 3
 
-	if(!SSnetworks.station_network || !SSnetworks.station_network.check_function(specific_action, get_virtual_z_level())) // NTNet is down and we are not connected via wired connection. No signal.
+	if(!SSnetworks.station_network || !SSnetworks.station_network.check_function(specific_action, get_virtual_z_level(), ignore_relay)) // NTNet is down and we are not connected via wired connection. No signal.
 		return 0
 
 	if(holder)
@@ -65,12 +68,17 @@
 /obj/item/computer_hardware/network_card/advanced
 	name = "advanced network card"
 	desc = "An advanced network card for usage with standard NTNet frequencies. Its transmitter is strong enough to connect even off-station."
-	long_range = 1
+	long_range = TRUE
 	power_usage = 100 // Better range but higher power usage.
 	icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/computer_hardware/network_card/advanced/norelay
+	name = "ultra-advanced network card"
+	desc = "An advanced network card for usage with standard NTNet frequencies. Its transmitter is strong enough to connect even off-station, even without a telecomms relay."
+	ignore_relay = TRUE
 
 /obj/item/computer_hardware/network_card/wired
 	name = "wired network card"

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -102,6 +102,15 @@
 			))
 	else
 		window.send_message("ping")
+	send_assets()
+	window.send_message("update", get_payload(
+		with_data = TRUE,
+		with_static_data = TRUE))
+	SStgui.on_open(src)
+
+	return TRUE
+
+/datum/tgui/proc/send_assets()
 	var/flush_queue = window.send_asset(get_asset_datum(
 		/datum/asset/simple/namespaced/fontawesome))
 	flush_queue |= window.send_asset(get_asset_datum(
@@ -110,12 +119,6 @@
 		flush_queue |= window.send_asset(asset)
 	if (flush_queue)
 		user.client.browse_queue_flush()
-	window.send_message("update", get_payload(
-		with_data = TRUE,
-		with_static_data = TRUE))
-	SStgui.on_open(src)
-
-	return TRUE
 
 /**
  * public

--- a/tgui/packages/tgui/layouts/NtosWindow.js
+++ b/tgui/packages/tgui/layouts/NtosWindow.js
@@ -26,6 +26,7 @@ export const NtosWindow = (props, context) => {
     PC_ntneticon,
     PC_apclinkicon,
     PC_stationtime,
+    PC_stationdate,
     PC_programheaders = [],
     PC_showexitprogram,
     PC_classic_color,
@@ -41,6 +42,15 @@ export const NtosWindow = (props, context) => {
         <div className="NtosWindow__header NtosHeader">
           <div className="NtosHeader__left">
             <Box inline bold mr={2}>
+              <Button
+                width="26px"
+                lineHeight="22px"
+                textAlign="left"
+                tooltip={PC_stationdate}
+                color="transparent"
+                icon="calendar"
+                tooltipPosition="bottom"
+              />
               {PC_stationtime}
             </Box>
             <Box inline italic mr={2} opacity={0.33}>


### PR DESCRIPTION
## About The Pull Request

Ports:
- https://github.com/tgstation/tgstation/pull/73635
- https://github.com/tgstation/tgstation/pull/72988
- https://github.com/tgstation/tgstation/pull/70754

Closes #8377

- https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-88347605
- https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-88347465

Also adds a ton of ui_updates and update returns for ui_act, since ModPCs autoupdated, they didn't really enforce this well. This PR accidentally turned it off, so I had to add a bunch to fix it. Eventually it was enough of a problem causer I just enabled autoupdate, since stuff like the radar app need it.

See CL for more

## Why It's Good For The Game

ModPCs can be VERY clunky to use since the window jumps around the screen. Now it stays in one window that resizes.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Got tired of rerecording, so here's a video. I fixed the stupid false href bug at the end of the video.

https://user-images.githubusercontent.com/10366817/223582656-81d903c9-1c60-4536-8c30-deb6a1503716.mp4

fixed

![image](https://user-images.githubusercontent.com/10366817/223583068-5a3a4048-1d02-42ea-8de4-227e6c95baa5.png)

</details>

## Changelog
:cl:
tweak: ModPCs/Tablets/PDAs will now use the same window for all apps, reducing the lag between switching apps and preventing the window from jumping around the screen.
add: Added the IC date to the NtOS header.
balance: Nukie PDAs can now connect to NTNet while off-station.
fix: You can no longer imprint IDs onto ModPCs that don't support it.
code: Converted the IC year offset to a define.
fix: Fixed a potential exploit where any airlock could be remotely controlled with the airlock control app.
admin: Added more detail to some href exploit logs.
tweak: Illiterate people can no longer use ModPCs.
/:cl:
