### PR TITLE
misc. say fixes (mostly custom say emote fixes)

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -331,6 +331,13 @@
 		text = copytext_char(text, 1, max_length)
 	return trim_left(trim_right(text))
 
+/// Returns a string with proper punctuation if there is none.
+/proc/punctuate(message)
+	var/end = copytext(message, length(message))
+	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
+		message += "."
+	return message
+	
 /// Returns a string with the first element of the string capitalized.
 /proc/capitalize(t)
 	. = t

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -49,8 +49,8 @@ GLOBAL_PROTECT(topic_servers)
 GLOBAL_LIST_EMPTY(tooltips)
 
 //Should be in the form of "tag to be replaced" = list("replacement for beginning", "replacement for end")
-GLOBAL_LIST_INIT(markup_tags, list("/"  = list("<i>", "</i>"),
+GLOBAL_LIST_INIT(markup_tags, list("_"  = list("<i>", "</i>"),
 								   "**" = list("<b>", "</b>")))
 //Should be in the form of "((\\W|^)@)(\[^@\]*)(@(\\W|$)), "g"", where @ is the appropriate tag from markup_tags
-GLOBAL_LIST_INIT(markup_regex, list("/"  = new /regex("((\\W|^)_)(\[^_\]*)(_(\\W|$))", "g"),
+GLOBAL_LIST_INIT(markup_regex, list("_"  = new /regex("((\\W|^)_)(\[^_\]*)(_(\\W|$))", "g"),
 									"**" = new /regex("((\\W|^)\\*\\*)(\[^\\*\\*\]*)(\\*\\*(\\W|$))", "g")))

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -7,9 +7,6 @@
 		to_chat(src, "<span class='warning'>That message contained a word prohibited in OOC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ooc_chat'>\"[message]\"</span></span>")
 		return
 
-	var/list/message_mods = list()
-	message = get_message_mods(message, message_mods)
-
 	if(check_emote(message, forced))
 		return
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -377,13 +377,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	return treat_message_min(message)
 
-/// Returns a string with proper punctuation if there is none.
-/proc/punctuate(message)
-	var/end = copytext(message, length(message))
-	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
-		message += "."
-	return message
-
 /mob/proc/treat_message_min(message)
 	message = punctuate(message)
 	message = capitalize(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -375,11 +375,15 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	return treat_message_min(message)
 
-/mob/proc/treat_message_min(message)
+/// Returns a string with proper punctuation if there is none.
+/proc/punctuate(message)
 	var/end = copytext(message, length(message))
 	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
 		message += "."
+	return message
 
+/mob/proc/treat_message_min(message)
+	message = punctuate(message)
 	message = capitalize(message)
 	return message
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -200,6 +200,11 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(radio_return & NOPASS)
 		return TRUE
 
+	//now that the radio message is sent, if the custom say message was just an emote we return
+	if (message_mods[MODE_CUSTOM_SAY_ERASE_INPUT] && message_mods[MODE_CUSTOM_SAY_EMOTE])
+		emote("me", 1, message_mods[MODE_CUSTOM_SAY_EMOTE], TRUE)
+		return
+
 	//No screams in space, unless you're next to someone.
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/environment = T.return_air()
@@ -293,10 +298,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 					show_overhead_message_to += M
 			AM.Hear(rendered, src, message_language, message, , spans, message_mods)
 	if(length(show_overhead_message_to))
-		if(message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
-			create_chat_message(src, message_language, show_overhead_message_to, message_mods[MODE_CUSTOM_SAY_EMOTE], spans)
-		else
-			create_chat_message(src, message_language, show_overhead_message_to, message, spans)
+		create_chat_message(src, message_language, show_overhead_message_to, message, spans)
 	if(length(show_overhead_message_to_eavesdrop))
 		create_chat_message(src, message_language, show_overhead_message_to_eavesdrop, eavesdropping, spans)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LIVING_SAY_SPECIAL, src, message)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -112,19 +112,16 @@
  * Example
  * * "mutters| hello" will be marked as a custom say emote of "mutters" and the message will be "hello"
  * * and it will appear as Joe Average mutters, "hello"
- * * "screams|" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams
+ * * "screams|" will be marked as a custom say emote of "screams" and it will appear as Joe Average screams.
  */
 /mob/proc/check_for_custom_say_emote(message, list/mods)
 	var/customsaypos = findtext(message, "|")
-	var/messagetextpos = 1
 	if(!customsaypos)
 		return message
-	if(findtext(message, " ", customsaypos + 1, customsaypos + 2))
-		messagetextpos = 2
 	if(is_banned_from(ckey, "Emote"))
-		return copytext(message, customsaypos + messagetextpos)
-	mods[MODE_CUSTOM_SAY_EMOTE] = lowertext(copytext_char(message, 1, customsaypos))
-	message = copytext(message, customsaypos + messagetextpos)
+		return copytext(message, customsaypos + 1)
+	mods[MODE_CUSTOM_SAY_EMOTE] = trim_right(lowertext(copytext_char(message, 1, customsaypos)))
+	message = trim_left(copytext(message, customsaypos + 1))
 	if(!message)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
 		mods[MODE_CUSTOM_SAY_EMOTE] = punctuate(mods[MODE_CUSTOM_SAY_EMOTE])

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -127,6 +127,7 @@
 	message = copytext(message, customsaypos + messagetextpos)
 	if(!message)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
+		mods[MODE_CUSTOM_SAY_EMOTE] = punctuate(mods[MODE_CUSTOM_SAY_EMOTE])
 		message = ""
 	return message
 


### PR DESCRIPTION
## About The Pull Request

- dead_say no longer checks message modifiers for no reason (you can now :trollface: at the beginning of messages)
- custom say emotes now actually make you emote instead of a weird say message
- custom say emotes now actually punctuate over the radio
- putting a space between the separator and the emote doesn't leave a gap anymore
- (moved the punctuation part of treat_message_min to it's own proc)

## Why It's Good For The Game

the custom say stuff is really weird and jank

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
-- Proper emoting and punctuation --

https://user-images.githubusercontent.com/39193182/223626072-1835f580-3021-43f2-abca-1709fc551eae.mp4

-- Trollface --

https://user-images.githubusercontent.com/39193182/223626247-43814f98-d059-4d7b-8410-630f6410b94d.mp4

</details>

## Changelog
:cl: tonty
fix: you can finally emote at the beginning of messages in dchat
fix: custom say emotes properly punctuate over the radio
fix: custom say emotes actually EMOTE NOW (can you believe it)
fix: you can have spaces around the custom say separator without it looking jank
code: text.dm has a punctuate proc now
/:cl: