### PR TITLE
Fix runtime with PDA admin message

### DIFF
--- a/code/modules/tgui/tgui_input_pda_message.dm
+++ b/code/modules/tgui/tgui_input_pda_message.dm
@@ -28,6 +28,7 @@
 		if(messenger.saved_identification == pda_input.name && messenger.saved_job == pda_input.job && (pda_input.send_all || messenger != pda_input.target))
 			ref = REF(messenger)
 			break
+	var/has_photo = !!pda_input.current_image
 	var/datum/signal/subspace/messaging/tablet_msg/signal = new(signal_source ? signal_source : server, list(
 		"name" = "[pda_input.name]",
 		"job" = "[pda_input.job]",
@@ -42,8 +43,9 @@
 	else
 		signal.send_to_receivers()
 	var/turf/source_turf = signal_source ? get_turf(signal_source) : null
-	usr.log_message("(PDA: [pda_input.name] | [usr.real_name]) sent \"[pda_input.text]\"[signal["photo"] ? " (Photo Attached)" : ""] to [signal.format_target()] via [signal_source ? "[signal_source] at [AREACOORD(source_turf)]" : "Admin UI"]", LOG_PDA)
-	message_admins("[key_name_admin(usr)][ADMIN_FLW(usr)] sent PDA message: \"[pda_input.text]\"[signal["photo"] ? " (Photo Attached)" : ""] to [signal.format_target()] via [signal_source ? "[signal_source] at [ADMIN_VERBOSEJMP(source_turf)]" : "Admin UI"]")
+	var/target_fmt = pda_input.send_all ? "Everyone" : signal.format_target()
+	usr.log_message("(PDA: [pda_input.name] | [usr.real_name]) sent \"[pda_input.text]\"[has_photo ? " (Photo Attached)" : ""] to [target_fmt] via [signal_source ? "[signal_source] at [AREACOORD(source_turf)]" : "Admin UI"]", LOG_PDA)
+	message_admins("[key_name_admin(usr)][ADMIN_FLW(usr)] sent PDA message: \"[pda_input.text]\"[has_photo ? " (Photo Attached)" : ""] to [target_fmt] via [signal_source ? "[signal_source] at [ADMIN_VERBOSEJMP(source_turf)]" : "Admin UI"]")
 	qdel(pda_input)
 
 /datum/tgui_input_pda_message


### PR DESCRIPTION
## About The Pull Request

A runtime was happening that prevented admin and message monitor console PDA messages from being logged

## Why It's Good For The Game

Having these be logged is a good idea

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/223925608-b4fd89c0-8f69-4e0a-a6ad-564f91d0bb78.png)
![image](https://user-images.githubusercontent.com/10366817/223925614-f4f5ab0e-9bd6-41da-985f-f56e2ab43ff5.png)
![image](https://user-images.githubusercontent.com/10366817/223925619-bce0fc89-102a-4cae-b087-e6efc43af544.png)

</details>

## Changelog
:cl:
fix: Fixed a runtime that caused message monitor PDA messages and admin PDA messages to not be logged.
/:cl: