### PR TITLE
Prevent mechs from bumping stuff onto other zlevels

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -622,6 +622,8 @@
 
 /obj/mecha/proc/mechstep(direction)
 	var/current_dir = dir
+	if(!isturf(get_step_multiz(src, direction))) // verify the turf we intend to step into is actually valid
+		direction = direction & ~(UP|DOWN)
 	var/result = step(src,direction)
 	if(strafe)
 		setDir(current_dir)
@@ -667,11 +669,11 @@
 		if(isobj(obstacle))
 			var/obj/O = obstacle
 			if(!O.anchored && O.move_resist <= move_force)
-				step(obstacle, dir)
+				step(obstacle, dir & ~(UP|DOWN))
 		else if(ismob(obstacle))
 			var/mob/M = obstacle
 			if(M.move_resist <= move_force)
-				step(obstacle, dir)
+				step(obstacle, dir & ~(UP|DOWN))
 
 
 


### PR DESCRIPTION
## About The Pull Request

Closes #8634

get_step does not respect z_up and z_down traits, meaning you can bump someone onto another z. Although, despite `step(mob, UP|SOUTH)` getting called on a mob via mech pushing, it didn't seem to be getting sent to lavaland.

I did manage to produce the bug by adding `movement_type |= PHASING` to the affected mob, allowing it to return true for CanPass checks. I assume this means that the original bug was on some type of turf that allowed them to enter it using `step()`, but I'm not sure under what conditions a normal player would be able to do so.

So, I'm fairly confident this fixes it.

## Why It's Good For The Game

Being teleported onto lavaland by a mech is cringe.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Previously mech would not go up stairs if player was in front of the exit turf. Now they are pushed away from the exit turf as expected. Going up and down stairs still works. Mechs can still zfall.

![image](https://user-images.githubusercontent.com/10366817/223998046-32c0e755-80b2-4724-b850-d2fbcd07528c.png)

</details>

## Changelog
:cl:
fix: Mechs can no longer push objects and mobs through stairs onto another z level.
fix: Mechs can now push people who are standing at the top of stairs out of the way.
/:cl: