### PR TITLE
Fix asay color sanitization not applying from the prefs menu

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1724,7 +1724,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("asaycolor")
 					var/new_asaycolor = input(user, "Choose your ASAY color:", "Game Preference",asaycolor) as color|null
 					if(new_asaycolor)
-						asaycolor = new_asaycolor
+						asaycolor = sanitize_ooccolor(new_asaycolor)
 
 				if("bag")
 					var/new_backbag = input(user, "Choose your character's style of bag:", "Character Preference")  as null|anything in GLOB.backbaglist


### PR DESCRIPTION
## About The Pull Request

When you set your asay color through other methods, it applies ooc color sanitization for sufficient contrast. The button in the prefs menu itself doesn't do this. This makes it consistent with other asay color setting via verb and from DB.

## Why It's Good For The Game

Fixes a bug.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Source: i tested it and it works (1 line change)

![image](https://user-images.githubusercontent.com/10366817/224008437-1ae15285-1540-48b2-b375-242410b24cf7.png)


</details>

## Changelog
:cl:
fix: Asay color is now properly sanitized from prefs menu.
/:cl: