### PR TITLE
Default to human for active character slot when there is no database

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -189,7 +189,7 @@
 
 /datum/config_entry/flag/show_game_type_odds	//if set this allows players to see the odds of each roundtype on the get revision screen
 
-/datum/config_entry/string/default_species
+/datum/config_entry/string/fallback_default_species
 	config_entry_value = SPECIES_HUMAN
 
 /datum/config_entry/keyed_list/roundstart_races	//races you can play as from the get go.

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -189,6 +189,9 @@
 
 /datum/config_entry/flag/show_game_type_odds	//if set this allows players to see the odds of each roundtype on the get revision screen
 
+/datum/config_entry/string/default_species
+	config_entry_value = SPECIES_HUMAN
+
 /datum/config_entry/keyed_list/roundstart_races	//races you can play as from the get go.
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_FLAG

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -115,9 +115,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//we couldn't load character data so just randomize the character appearance + name
 	active_character = character_saves[1]
-	var/default_species = CONFIG_GET(string/default_species)
-	if(!active_character.pref_species && default_species != "random")
-		var/datum/species/spath = GLOB.species_list[default_species || "human"]
+	var/fallback_default_species = CONFIG_GET(string/fallback_default_species)
+	if(!active_character.pref_species && fallback_default_species != "random")
+		var/datum/species/spath = GLOB.species_list[fallback_default_species || "human"]
 		active_character.pref_species = new spath
 	active_character.randomise()		//let's create a random character then - rather than a fat, bald and naked man.
 	active_character.real_name = active_character.pref_species.random_name(active_character.gender, TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -115,6 +115,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//we couldn't load character data so just randomize the character appearance + name
 	active_character = character_saves[1]
+	if(!active_character.pref_species)
+		var/datum/species/spath = GLOB.species_list[CONFIG_GET(string/default_species) || "human"]
+		active_character.pref_species = new spath
 	active_character.randomise()		//let's create a random character then - rather than a fat, bald and naked man.
 	active_character.real_name = active_character.pref_species.random_name(active_character.gender, TRUE)
 	if(!loaded_preferences_successfully)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -115,8 +115,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//we couldn't load character data so just randomize the character appearance + name
 	active_character = character_saves[1]
-	if(!active_character.pref_species)
-		var/datum/species/spath = GLOB.species_list[CONFIG_GET(string/default_species) || "human"]
+	var/default_species = CONFIG_GET(string/default_species)
+	if(!active_character.pref_species && default_species != "random")
+		var/datum/species/spath = GLOB.species_list[default_species || "human"]
 		active_character.pref_species = new spath
 	active_character.randomise()		//let's create a random character then - rather than a fat, bald and naked man.
 	active_character.real_name = active_character.pref_species.random_name(active_character.gender, TRUE)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -469,12 +469,12 @@ LAW_WEIGHT buildawall,0
 ## Attempting to upload laws past this point will fail unless the AI is reset
 SILICON_MAX_LAW_AMOUNT 12
 
-# Default Species
+# Fallback Default Species
 ##-------------------------------------------
 ## The default character slot species used as a fallback for when there is no database. You probably want this to be human.
-## Using "DEFAULT_SPECIES random" will just pick a random species
+## Using "FALLBACK_DEFAULT_SPECIES random" will just pick a random species
 
-DEFAULT_SPECIES human
+FALLBACK_DEFAULT_SPECIES human
 
 ## Roundstart Races
 ##-------------------------------------------------------------------------------------------

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -472,6 +472,7 @@ SILICON_MAX_LAW_AMOUNT 12
 # Default Species
 ##-------------------------------------------
 ## The default character slot species used as a fallback for when there is no database. You probably want this to be human.
+## Using "DEFAULT_SPECIES random" will just pick a random species
 
 DEFAULT_SPECIES human
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -469,6 +469,12 @@ LAW_WEIGHT buildawall,0
 ## Attempting to upload laws past this point will fail unless the AI is reset
 SILICON_MAX_LAW_AMOUNT 12
 
+# Default Species
+##-------------------------------------------
+## The default character slot species used as a fallback for when there is no database. You probably want this to be human.
+
+DEFAULT_SPECIES human
+
 ## Roundstart Races
 ##-------------------------------------------------------------------------------------------
 ## Uncommenting races will allow them to be choosen at roundstart while join_with_muntant_race is on. You'll need at least one.


### PR DESCRIPTION
## About The Pull Request

Closes #7863

Characters default to human when no database is attached.

## Why It's Good For The Game

Spawning as a plasmaman in debug is super annoying if you're the type to not bother setting up a database. This change only affects development.

## Testing Photographs and Procedure

Tested by starting the game 5 times without a database. Each time, the first character slot was human. The rest were random.

## Changelog
:cl:
add: Added fallback species config option, for use when there is no database attached.
/:cl: