### PR TITLE
Slightly rigs a specific d20

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -185,6 +185,8 @@
 /obj/item/dice/d20/fate/one_use/slightly_rigged/effect(mob/living/carbon/human/user, roll)
 	if(roll == 20)
 		roll = roll(19)
+		result = roll
+		update_icon()
 		var/turf/T = get_turf(src)
 		T.visible_message("<span class='boldwarning'>[src] falls to a [roll] as the magic flare causes it to tip over! What a scam!!</span>")
 	used = FALSE //we will at least give them a second roll though

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -180,7 +180,15 @@
 	reusable = FALSE
 
 /obj/item/dice/d20/fate/one_use/slightly_rigged
-	sides = 19 //no wizard, everything else is still fair game
+	sides = 20 //no wizard, everything else is still fair game
+
+/obj/item/dice/d20/fate/one_use/slightly_rigged/effect(mob/living/carbon/human/user, roll)
+	if(roll == 20)
+		roll = roll(19)
+		var/turf/T = get_turf(src)
+		T.visible_message("<span class='boldwarning'>[src] falls to a [roll] as the magic flare causes it to tip over! What a scam!!</span>")
+	used = FALSE //we will at least give them a second roll though
+	. = ..()
 
 /obj/item/dice/d20/fate/one_use/stealth
 	name = "d20"

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -179,6 +179,9 @@
 /obj/item/dice/d20/fate/one_use
 	reusable = FALSE
 
+/obj/item/dice/d20/fate/one_use/slightly_rigged
+	sides = 19 //no wizard, everything else is still fair game
+
 /obj/item/dice/d20/fate/one_use/stealth
 	name = "d20"
 	desc = "A die with twenty sides. The preferred die to throw at the GM."

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -189,6 +189,7 @@
 		update_icon()
 		var/turf/T = get_turf(src)
 		T.visible_message("<span class='boldwarning'>[src] falls to a [roll] as the magic flare causes it to tip over! What a scam!!</span>")
+		sleep(1 SECONDS)
 	used = FALSE //we will at least give them a second roll though
 	. = ..()
 

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -72,7 +72,7 @@
 		<span class='danger'>And see a bag full of dice. Confused, \
 		you take one... and the bag vanishes.</span>")
 	var/turf/T = get_turf(user)
-	var/obj/item/dice/d20/fate/one_use/critical_fail = new(T)
+	var/obj/item/dice/d20/fate/one_use/slightly_rigged/critical_fail = new(T)
 	user.put_in_hands(critical_fail)
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Adds a new subtype of the single-use die of fate which is not capable of rolling a 20 while it is still magical. Managing to hit a 20 causes the die to roll to a new side with the new side's effect, but also refreshes the magic to enable another roll.
* Replaces the reward for greed's ruin with this new die of fate, removing the final avenue of acquiring antag status through lavaland. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Over time most of the forms of willingly becoming an antagonist have been slowly removed from lavaland but one remained. One that at first was overlooked, and then just wasn't dealt with because it wasn't nearly as often abused as all those that fell before it. After all, it was only a 5% chance, and came with a 10% chance of instantly killing you and an 85% chance of something in between instead.

**And then someone realized you can recharge single-use dies of fate and that information propagated.** So yeah, this removes the final alluring possibility of giving yourself antag via lavaland because someone always has to ruin the fun by abusing the system. All of the other fun possibilities remain with the die, as well as the ability to recharge it. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/224019467-0eadb06d-4c64-4b0d-afa2-15b3f2331709.png)

https://user-images.githubusercontent.com/9547572/224019439-3a7608a5-b584-4353-962f-83e790f6c425.mp4


</details>

## Changelog
:cl:
tweak: The reward from greed's ruin can no longer grant players the ability to be wizards. All other rewards remain untouched.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
