### PR TITLE
Fixes fultons not working on necropolis chests

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -21,8 +21,6 @@
 /obj/structure/closet/crate/necropolis/proc/try_spawn_loot(datum/source, obj/item/item, mob/user, params)
 	SIGNAL_HANDLER
 
-	if(istype(item, /obj/item/extraction_pack)) //while we don't want people beating up the crates, we do still want fultons to work
-		INVOKE_ASYNC(item, /obj/item.proc/afterattack, src, user, TRUE) 
 	if(!istype(item, /obj/item/skeleton_key) || spawned_loot)
 		return FALSE
 	spawned_loot = TRUE
@@ -65,7 +63,6 @@
 	if(..())
 		var/necropolis_loot = pickweight(necropolis_goodies.Copy())
 		new necropolis_loot(src)
-	return TRUE
 
 /obj/structure/closet/crate/necropolis/can_open(mob/living/user, force = FALSE)
 	if(!spawned_loot)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -21,6 +21,8 @@
 /obj/structure/closet/crate/necropolis/proc/try_spawn_loot(datum/source, obj/item/item, mob/user, params)
 	SIGNAL_HANDLER
 
+	if(istype(item, /obj/item/extraction_pack)) //while we don't want people beating up the crates, we do still want fultons to work
+		INVOKE_ASYNC(item, /obj/item.proc/afterattack, src, user, TRUE) 
 	if(!istype(item, /obj/item/skeleton_key) || spawned_loot)
 		return FALSE
 	spawned_loot = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fultons now work on necropolis chests. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

* Bugfixes are good
* Fultons being used for the recovery of goods is kind of one of their intended uses. 
* Necropolis chests contain goods. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

![dreamseeker_3dPwR74dRX](https://user-images.githubusercontent.com/9547572/224028550-6291003b-15a5-4186-be16-a3f7d50f1ac7.gif)

## Changelog
:cl:
fix: fultons work on necropolis chests again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
