### PR TITLE
No longer runs the CI on every push to master.

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,10 +2,10 @@ name: Run tests
 
 on:
   workflow_dispatch:
-  push:
-    paths-ignore:
-      - "html/changelogs/**"
-      - "html/changelog.html"
+#  push:
+#    paths-ignore:
+#      - "html/changelogs/**"
+#      - "html/changelog.html"
   pull_request:
     branches:
       - master


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since we run checks within the merge queue before pushing to master, it doesn't really make sense to then run those exact same checks again post-merge.

Just commenting them out on the off chance a downstream wants to re-enable those checks or something.