### PR TITLE
Fix laser gatling gun

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -74,7 +74,7 @@
 	var/frequency_to_use = 0
 
 	if(shot.e_cost > 0)
-		shot_cost_percent = FLOOR(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100, 1)
+		shot_cost_percent = FLOOR(clamp(shot.e_cost / cell.maxcharge, 0.01, 1) * 100, 1)
 		max_shots = round(100/shot_cost_percent)
 		shots_left = round(batt_percent/shot_cost_percent)
 		frequency_to_use = sin((90/max_shots) * shots_left)

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -174,6 +174,7 @@
 
 /obj/item/gun/energy/minigun/proc/start_firing()
 	playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 40, 0, 0)
+	addtimer(CALLBACK(src, .proc/check_firing,), 2 SECONDS) //Check to ensure the gun actually started firing. Prevents players from priming the minigun
 	sleep(15) //Give some time for the spin-up to take place
 	firing = TRUE
 

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -14,23 +14,17 @@
 	var/obj/item/gun/energy/minigun/gun
 	var/armed = 0 //whether the gun is attached, 0 is attached, 1 is the gun is wielded.
 	var/overheat = 0
-	var/overheat_max = 40
-	var/heat_diffusion = 0.5
+	var/overheat_max = 80
 
 /obj/item/minigunpack/Initialize(mapload)
 	. = ..()
 	gun = new(src)
-	START_PROCESSING(SSobj, src)
 
 /obj/item/minigunpack/Destroy()
 	if(!QDELETED(gun))
 		qdel(gun)
 	gun = null
-	STOP_PROCESSING(SSobj, src)
 	return ..()
-
-/obj/item/minigunpack/process(delta_time)
-	overheat = max(0, overheat - heat_diffusion * delta_time)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/minigunpack/attack_hand(var/mob/living/carbon/user)
@@ -95,11 +89,6 @@
 	update_icon()
 	user.update_inv_back()
 
-/obj/item/minigunpack/on_emag(mob/user)
-	..()
-	to_chat(user, "<span class='warning'>You break the heat sensor.</span>")
-	overheat_max = 1000
-
 /obj/item/stock_parts/cell/minigun
 	name = "Minigun gun fusion core"
 	maxcharge = 500000
@@ -125,7 +114,9 @@
 	fire_sound = 'sound/weapons/laser.ogg'
 	item_flags = NEEDS_PERMIT | SLOWS_WHILE_IN_HAND
 	full_auto = TRUE
-	var/cooldown = 0
+	var/firing = FALSE
+	var/cooldown
+	var/last_fired
 	var/obj/item/minigunpack/ammo_pack
 
 /obj/item/gun/energy/minigun/Initialize(mapload)
@@ -153,23 +144,37 @@
 		qdel(src)
 
 /obj/item/gun/energy/minigun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	if(ammo_pack)
-		if(obj_flags & EMAGGED)
-			if(cooldown < world.time)
-				cooldown = world.time + 50
-				playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 50, 0, 0)
-				slowdown = 5
-				sleep(15)
-				if(ammo_pack.overheat < ammo_pack.overheat_max)
-					ammo_pack.overheat += burst_size
-					playsound(get_turf(src), 'sound/weapons/heavyminigunshoot.ogg', 60, 0, 0)
-					..()
-					playsound(get_turf(src), 'sound/weapons/heavyminigunstop.ogg', 50, 0, 0)
-					slowdown = initial(slowdown)
-				else
-					to_chat(user, "The gun's heat sensor locked the trigger to prevent lens damage.")
+	if(ammo_pack && cooldown < world.time)
+		if(firing)
+			if(ammo_pack.overheat < ammo_pack.overheat_max)
+				playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 40, 0, 0) //This just sounds much better to keep using than the actual firing sound. 
+				ammo_pack.overheat += 2
+				last_fired = world.time
+				addtimer(CALLBACK(src, .proc/check_firing,), 5) //Check to see if we have fired again yet and if not start the spin down.
+				..()
+			else
+				to_chat(user, "The gun's heat sensor locked the trigger to prevent lens damage.")
+				shoot_with_empty_chamber(user)
+				stop_firing()
 		else
-			..()
+			start_firing()
+	else
+		return //don't process firing the gun if it's on cooldown or doesn't have an ammo pack somehow. 
+
+/obj/item/gun/energy/minigun/proc/stop_firing()
+	playsound(get_turf(src), 'sound/weapons/heavyminigunstop.ogg', 50, 0, 0)
+	cooldown = world.time + max(ammo_pack.overheat, 2 SECONDS) //2 to 8 seconds depending on how hot it was
+	ammo_pack.overheat = 0
+	firing = FALSE
+
+/obj/item/gun/energy/minigun/proc/start_firing()
+	playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 40, 0, 0)
+	sleep(15) 
+	firing = TRUE
+
+/obj/item/gun/energy/minigun/proc/check_firing()
+	if(last_fired + 4 <= world.time)
+		stop_firing()
 
 /obj/item/gun/energy/minigun/afterattack(atom/target, mob/living/user, flag, params)
 	if(!ammo_pack || ammo_pack.loc != user)
@@ -179,13 +184,3 @@
 /obj/item/gun/energy/minigun/dropped(mob/living/user)
 	..()
 	ammo_pack.attach_gun(user)
-
-/obj/item/gun/energy/minigun/on_emag(mob/user)
-	..()
-	fire_sound = null
-	spread = 60
-	recoil = 1
-	burst_size = 120
-	fire_delay = 0.2
-	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 30, 0, 0)
-	to_chat(user, "<span class='colossus'>OVERDRIVE.</span>")

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -181,7 +181,7 @@
 
 /obj/item/gun/energy/minigun/proc/fire_effect(heating)
 	playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 40, 0, 0)
-	addtimer(CALLBACK(src, .proc/check_firing,), 5)
+	addtimer(CALLBACK(src, PROC_REF(check_firing),), 5)
 	if(heating)
 		current_heat += 2
 

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -115,7 +115,7 @@
 	var/cooldown
 	var/last_fired
 	var/spin = 0
-	var/heat = 0
+	var/current_heat = 0
 	var/overheat = 80 //8 second cooldown
 	var/obj/item/minigunpack/ammo_pack
 
@@ -146,7 +146,7 @@
 /obj/item/gun/energy/minigun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(ammo_pack)
 		if(cooldown < world.time)
-			if(heat >= overheat) //We've been firing too long, shut it down
+			if(current_heat >= overheat) //We've been firing too long, shut it down
 				to_chat(user, "<span class='warning'>[src]'s heat sensor locked the trigger to prevent lens damage.</span>")
 				shoot_with_empty_chamber(user)
 				stop_firing()
@@ -169,10 +169,10 @@
 		return //don't process firing the gun if it's on cooldown or doesn't have an ammo pack somehow. 
 
 /obj/item/gun/energy/minigun/proc/stop_firing()
-	if(heat) //Don't play the sound or apply cooldown unless it has actually fired at least once
+	if(current_heat) //Don't play the sound or apply cooldown unless it has actually fired at least once
 		playsound(get_turf(src), 'sound/weapons/heavyminigunstop.ogg', 50, 0, 0)
-		cooldown = world.time + max(heat, 2 SECONDS) //2 to 8 seconds depending on how hot it was. At least 1.5 seconds is required to prevent overlapping conflicts with spinups and spindowns.
-		heat = 0
+		cooldown = world.time + max(current_heat, 2 SECONDS) //2 to 8 seconds depending on how hot it was. At least 1.5 seconds is required to prevent overlapping conflicts with spinups and spindowns.
+		current_heat = 0
 	spin = 0
 
 /obj/item/gun/energy/minigun/proc/check_firing()
@@ -183,7 +183,7 @@
 	playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 40, 0, 0)
 	addtimer(CALLBACK(src, .proc/check_firing,), 5)
 	if(heating)
-		heat += 2
+		current_heat += 2
 
 /obj/item/gun/energy/minigun/afterattack(atom/target, mob/living/user, flag, params)
 	if(!ammo_pack || ammo_pack.loc != user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Fixes a divide by zero error causing the gatling laser to not play the "laser go pew" sound effect when lasers came out
* Completely overhauls almost all of the mechanics behind the gatling laser that I didn't even know were present (and broken) until looking into fixing the silent laser sounds
  * Gun now properly plays its sound for spinning up before firing, and delays the initial shots while it spins up
  * Gun continually plays firing sounds while it is being fired (although I elected not to use the given firing sounds for this, because the sound clip was too long and also mismatched the gun due to making ballistic gunfire sounds)
  * Gun now properly plays a spin down sound effect when it stops firing and goes on a literal cooldown period based on how hot it was. 
  * Overheat mechanics have been totally refactored from scratch
    * Every consecutive shot fired increases heat by 2
    * Gun overheats when it reaches 80, causing it to forcibly click off and spin down.
    * Gun goes on cooldown equal to its current heat in deciseconds, with a minimum cooldown time of 2 seconds and a maximum of 8 seconds due to the cap of 80 heat.
* Additionally removed the emag functionality on the gun for reasons outlined below. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Most of the time these changes are going to be completely and utterly irrelevant to the game. This is a weapon that only exists if an admin spawns it in, and there will almost never be a round that it's a good idea to spawn it in. *However, on those exceedingly rare rounds, this will now be a much more immersive and bad-ass weapon than it currently is*.

As for the emag functionality:
1) This gun is already excessively overpowered and doesn't need an emag effect to make it even moreso. It already borders on so powerful that admins will rarely see justifiable reason to introduce it to the round, I don't see a reason to keep a more powerful mode available as an option on the weapon.

2) The emag functionality was largely broken in the literal sense - it attempted to make the gun fire 5x faster, but the gun already fires as fast as the code allows it so this function was broken. It additionally makes the gun fire silently - not because of some bug but because it changes the sound to `null` for no conceivable reason. It increases bullet spread into a 60 degree cone which... without the increased fire rate is just very bad. And finally it removed the overheat mechanics 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Shown:
* Fire and stop early, with minimal cooldown
* Fire until forced overheat with maximum cooldown
* Spinning up without firing not triggering any cooldown (no spindown sound effect)

https://user-images.githubusercontent.com/9547572/224371124-469edc99-594b-43a4-9161-e5ee2c600a04.mp4

## Changelog
:cl:
fix: Fixed the laser gatling gun's sounds and intended functionality. It is still only available via admin spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
