### PR TITLE
Fix SecurEye and Bounty Viewer apps not working

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -59,6 +59,13 @@
 	if(old_open_ui != ui.interface)
 		update_static_data(user, ui) // forces a static UI update for the new UI
 		ui.send_assets() // sends any new asset datums from the new UI
+		if(active_program)
+			active_program.on_ui_create(user, ui)
+
+
+/obj/item/modular_computer/ui_close(mob/user, datum/tgui/tgui)
+	if(active_program)
+		active_program.on_ui_close(user, tgui)
 
 /obj/item/modular_computer/ui_assets(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -188,3 +188,11 @@
 /// Set use_attack_obj = TRUE to receive proccalls from the parent computer.
 /datum/computer_file/program/proc/attack_obj(obj/target, mob/living/user)
 	return TRUE
+
+/// Called when the datum/tgui is initialized by the computer
+/datum/computer_file/program/proc/on_ui_create(mob/user, datum/tgui/ui)
+	return
+
+/// Called when ui_close is called on the computer while this program is active. Any behavior in this should also be in kill_program.
+/datum/computer_file/program/proc/on_ui_close(mob/user, datum/tgui/tgui)
+	return

--- a/code/modules/modular_computers/file_system/programs/cargobounty.dm
+++ b/code/modules/modular_computers/file_system/programs/cargobounty.dm
@@ -11,23 +11,23 @@
 	tgui_id = "NtosBountyConsole"
 	program_icon = "tags"
 
-	///cooldown var for printing paper sheets.
-	var/printer_ready = 0
-	///The cargo account for grabbing the cargo account's credits.
+	/// Cooldown var for printing paper sheets.
+	COOLDOWN_DECLARE(printer_ready)
+	/// The cargo account for grabbing the cargo account's credits.
 	var/static/datum/bank_account/cargocash
 
 /datum/computer_file/program/bounty/proc/print_paper()
 	new /obj/item/paper/bounty_printout(get_turf(computer))
 
-/datum/computer_file/program/bounty/ui_interact(mob/user, datum/tgui/ui)
-	if(!GLOB.bounties_list.len)
-		setup_bounties()
-	printer_ready = world.time + PRINTER_TIMEOUT
-	cargocash = SSeconomy.get_budget_account(ACCOUNT_CAR_ID)
-	. = ..()
+/datum/computer_file/program/bounty/on_ui_create(mob/user, datum/tgui/ui)
+	COOLDOWN_START(src, printer_ready, PRINTER_TIMEOUT)
 
 /datum/computer_file/program/bounty/ui_data(mob/user)
 	var/list/data = list()
+
+	if(!GLOB.bounties_list.len)
+		setup_bounties()
+	cargocash = SSeconomy.get_budget_account(ACCOUNT_CAR_ID)
 
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)
@@ -48,7 +48,7 @@
 
 	data["has_printer"] = printer ? TRUE : FALSE
 
-	data["stored_cash"] = cargocash.account_balance
+	data["stored_cash"] = cargocash ? cargocash.account_balance : 0
 	data["bountydata"] = bountyinfo
 
 	return data
@@ -63,6 +63,9 @@
 				cashmoney.claim()
 			return TRUE
 		if("Print")
+			if(!COOLDOWN_FINISHED(src, printer_ready))
+				to_chat(usr, "<span class='warning'>The printer is not ready to print yet!</span>")
+				return
 			var/obj/item/computer_hardware/printer/printer
 			if(computer)
 				printer = computer.all_components[MC_PRINT]
@@ -72,4 +75,5 @@
 					to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
 					return
 				else
+					COOLDOWN_START(src, printer_ready, PRINTER_TIMEOUT)
 					computer.visible_message("<span class='notice'>\The [computer] prints out a paper.</span>")

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -92,11 +92,6 @@
 		usr << browse_rsc(img, deter_path) // funny random assignment for now, i'll make an actual key later
 		photo_path = deter_path
 
-/datum/computer_file/program/messenger/ui_state(mob/user)
-	if(istype(user, /mob/living/silicon))
-		return GLOB.reverse_contained_state
-	return GLOB.default_state
-
 /datum/computer_file/program/messenger/ui_assets(mob/user)
 	return list(
 		get_asset_datum(/datum/asset/spritesheet/chat),

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -60,25 +60,20 @@
 	QDEL_NULL(cam_background)
 	return ..()
 
-/datum/computer_file/program/secureye/ui_interact(mob/user, datum/tgui/ui)
-	// Update UI
-	ui = SStgui.try_update_ui(user, src, ui)
-
+/datum/computer_file/program/secureye/on_ui_create(mob/user, datum/tgui/ui)
 	// Update the camera, showing static if necessary and updating data if the location has moved.
 	update_active_camera_screen()
 
-	if(!ui)
-		var/user_ref = REF(user)
-		// Ghosts shouldn't count towards concurrent users, which produces
-		// an audible terminal_on click.
-		if(isliving(user))
-			concurrent_users += user_ref
-		// Register map objects
-		user.client.register_map_obj(cam_screen)
-		for(var/plane in cam_plane_masters)
-			user.client.register_map_obj(plane)
-		user.client.register_map_obj(cam_background)
-		return ..()
+	var/user_ref = REF(user)
+	// Ghosts shouldn't count towards concurrent users, which produces
+	// an audible terminal_on click.
+	if(isliving(user))
+		concurrent_users += user_ref
+	// Register map objects
+	user.client.register_map_obj(cam_screen)
+	for(var/plane in cam_plane_masters)
+		user.client.register_map_obj(plane)
+	user.client.register_map_obj(cam_background)
 
 /datum/computer_file/program/secureye/ui_data()
 	var/list/data = list()
@@ -124,8 +119,18 @@
 
 		return TRUE
 
-/datum/computer_file/program/secureye/ui_close(mob/user)
+/datum/computer_file/program/secureye/on_ui_close(mob/user, datum/tgui/tgui)
+	on_exit(user)
+
+/datum/computer_file/program/secureye/kill_program(forced)
 	. = ..()
+	on_exit()
+
+/datum/computer_file/program/secureye/proc/on_exit(mob/user)
+	if(!ismob(user))
+		user = usr
+	if(!ismob(user))
+		return
 	var/user_ref = REF(user)
 	var/is_living = isliving(user)
 	// Living creature or not, we remove you anyway.


### PR DESCRIPTION
## About The Pull Request

An oversight in #8639 caused SecurEye and Bounty Viewer to not work. This fixes them.

It also fixes a seemingly unimplemented cooldown on the Bounty Viewer printer, so now you cannot spam print.

Removed a useless ui_state in NTMessenger. AIs can still use the messenger.

## Why It's Good For The Game

Fixes a bug.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/224322765-b1bd8672-1376-471b-8942-d87dbf102beb.png)

</details>

## Changelog
:cl:
fix: NT Bounty Hunter and SecurEye apps work again
tweak: Added a cooldown to the bounty list printer in NT Bounty Hunter.
/:cl:
