### PR TITLE
Happy medium die-of-fate change

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -172,6 +172,10 @@
 	var/used = FALSE
 	var/roll_in_progress = FALSE
 
+/obj/item/dice/d20/fate/proc/crystalrefresh()
+	sides = 19
+	visible_message("<span class='danger'>The 20th face of the [src] falls off and crumbles to dust!</span>")
+
 /obj/item/dice/d20/fate/stealth
 	name = "d20"
 	desc = "A die with twenty sides. The preferred die to throw at the GM."

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -172,9 +172,10 @@
 	var/used = FALSE
 	var/roll_in_progress = FALSE
 
-/obj/item/dice/d20/fate/proc/crystalrefresh()
+/obj/item/dice/d20/fate/proc/crystalrefresh(sendmessage = FALSE)
 	sides = 19
-	visible_message("<span class='danger'>The 20th face of the [src] falls off and crumbles to dust!</span>")
+	if(sendmessage)
+		visible_message("<span class='danger'>The 20th face of the [src] falls off and crumbles to dust!</span>")
 
 /obj/item/dice/d20/fate/stealth
 	name = "d20"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -779,8 +779,12 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 		if(L.len)
 			var/obj/item/CHOSEN = pick(L)
 			if(istype(CHOSEN, /obj/item/dice/d20/fate))
-				var/obj/item/dice/d20/fate/newdie = new CHOSEN.type(T)
-				newdie.crystalrefresh() //Antag rollers begone
+				var/obj/item/dice/d20/fate/olddie = CHOSEN
+				var/obj/item/dice/d20/fate/newdie = new olddie.type(T)
+				if(olddie.sides == 19)
+					newdie.crystalrefresh(FALSE) //Antag rollers begone
+				else
+					newdie.crystalrefresh(TRUE)
 			else
 				new CHOSEN.type(T)
 			qdel(CHOSEN)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -778,7 +778,11 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 					L += W
 		if(L.len)
 			var/obj/item/CHOSEN = pick(L)
-			new CHOSEN.type(T)
+			if(istype(CHOSEN, /obj/item/dice/d20/fate))
+				var/obj/item/dice/d20/fate/newdie = new CHOSEN.type(T)
+				newdie.crystalrefresh() //Antag rollers begone
+			else
+				new CHOSEN.type(T)
 			qdel(CHOSEN)
 
 /obj/machinery/anomalous_crystal/possessor //Allows you to bodyjack small animals, then exit them at your leisure, but you can only do this once per activation. Because they blow up. Also, if the bodyjacked animal dies, SO DO YOU.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Attempts to reconcile #8654 and #8665 
Dice of Fate lose the 20th side when refreshed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops excessive antag rolling while still allowing a niche, rare interaction to be carried out in a fun and engaging manner.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![die o fate](https://user-images.githubusercontent.com/22421329/224437721-6a55b9b1-01a0-469d-a793-617cf7c7fbcd.png)
</details>

## Changelog
:cl:
balance: The Die of Fate loses its 20th face when being refreshed by an anomalous crystal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
