### PR TITLE
Morphs now husk victims on digestion instead of dusting

### DIFF
--- a/code/modules/antagonists/morph/morph_stomach.dm
+++ b/code/modules/antagonists/morph/morph_stomach.dm
@@ -115,6 +115,7 @@
 							I.pixel_y = rand(-10, 10)
 					morph.RemoveContents(L)
 					L.death(0)
+					L.apply_damage(50, BURN)
 					L.become_husk()
 					morph.adjustHealth(-(L.maxHealth / 2))
 					to_chat(morph, "<span class='danger'>You digest [L], restoring some health</span>")

--- a/code/modules/antagonists/morph/morph_stomach.dm
+++ b/code/modules/antagonists/morph/morph_stomach.dm
@@ -97,6 +97,9 @@
 		var/mob/living/L = target
 		switch(action)
 			if("digest")
+				if(HAS_TRAIT(L, TRAIT_HUSK))
+					to_chat(morph, "<span class='warning'>[L] has already been stripped of all nutritional value!</span>")
+					return FALSE
 				if(morph.throwatom == L)
 					morph.throwatom = null
 				to_chat(morph, "<span class='danger'>You begin digesting [L]</span>")
@@ -111,7 +114,8 @@
 							I.pixel_x = rand(-10, 10)
 							I.pixel_y = rand(-10, 10)
 					morph.RemoveContents(L)
-					L.dust()
+					L.death(0)
+					L.become_husk()
 					morph.adjustHealth(-(L.maxHealth / 2))
 					to_chat(morph, "<span class='danger'>You digest [L], restoring some health</span>")
 					playsound(morph, 'sound/effects/splat.ogg', 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, upon digestion, morphs would dust corpses and spit out their items. Now, morphs husk their victims and expel their corpse - stripping them of all nutritional value and leaving behind the waste, like changeling absorption. Morphs can't digest husks or simplemobs they've already digested as well, to prevent infinite healing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

An antag like the morph being able to delete a target forever with little effort (digesting after critting/downing the target) is odd. The corpse can still be held by the morph until the morph dies or spits it out, anyway.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/35978630/224594179-3ec02050-e8c1-4de4-88e5-dd48a0bbebf8.png)
_Message delivered upon attempting to digest a husked corpse_

</details>

## Changelog
:cl:
balance: Morphs now husk digested corpses instead of deleting them outright
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
