### PR TITLE
Allow blind people to use modular computers / PDAs again

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -16,7 +16,7 @@
 	)
 
 /obj/item/modular_computer/ui_interact(mob/user, datum/tgui/ui)
-	if(!enabled || !user.can_read(src) || !use_power())
+	if(!enabled || !user.is_literate() || !use_power())
 		if(ui)
 			ui.close()
 		return


### PR DESCRIPTION
## About The Pull Request

Allows blind people to use PDAs while not allowing illiterate people.

## Why It's Good For The Game

I made a mistake in #8639 that meant blind people could not use PDAs. This is just bleh, and makes the game suck more for blind characters. We can say NT improved screen reader tech or like brain links or something. Either way, from a gameplay perspective it's kind of good to be able to use modular PC UIs, since they can use literally every other UI. It was intended that only illiterate people could not use the UI (i.e. ashwalkers).

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/224607276-974b2aa6-ee18-4c38-9391-fadcddaa00c3.png)

</details>

## Changelog
:cl:
tweak: Blind people can now use ModPCs/PDAs again, this was caused by an oversight in not allowing illiterate people to use PDAs.
/:cl:
