### PR TITLE
Overlay subsystem fixes, adds overlay logging

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -117,6 +117,7 @@
 #include "code\__DEFINES\networks.dm"
 #include "code\__DEFINES\obj_flags.dm"
 #include "code\__DEFINES\orbit_defines.dm"
+#include "code\__DEFINES\overlays.dm"
 #include "code\__DEFINES\pai.dm"
 #include "code\__DEFINES\particles.dm"
 #include "code\__DEFINES\pinpointers.dm"

--- a/code/__DEFINES/overlays.dm
+++ b/code/__DEFINES/overlays.dm
@@ -1,0 +1,3 @@
+// A reasonable number of maximum overlays an object needs
+// If you think you need more, rethink it
+#define MAX_ATOM_OVERLAYS 100

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -38,23 +38,47 @@ SUBSYSTEM_DEF(overlays)
 		count = 0 //so if we runtime on the Cut, we don't try again.
 		queue.Cut(1,c+1)
 
-	for (var/thing in queue)
+	for (var/atom/atom_to_compile as anything in queue)
 		count++
-		if(thing)
-			STAT_START_STOPWATCH
-			var/atom/A = thing
-			COMPILE_OVERLAYS(A)
-			STAT_STOP_STOPWATCH
-			STAT_LOG_ENTRY(stats, A.type)
+		if(!atom_to_compile)
+			continue
+		STAT_START_STOPWATCH
+		COMPILE_OVERLAYS(atom_to_compile)
+		UNSETEMPTY(atom_to_compile.add_overlays)
+		UNSETEMPTY(atom_to_compile.remove_overlays)
+		STAT_STOP_STOPWATCH
+		STAT_LOG_ENTRY(stats, atom_to_compile.type)
+		if(length(atom_to_compile.overlays) >= MAX_ATOM_OVERLAYS)
+			//Break it real GOOD
+			var/text_lays = overlays2text(atom_to_compile.overlays)
+			stack_trace("Too many overlays on [atom_to_compile.type] - [length(atom_to_compile.overlays)], refusing to update and cutting.\
+				\n What follows is a printout of all existing overlays at the time of the overflow \n[text_lays]")
+			atom_to_compile.overlays.Cut()
+			//Let them know they fucked up
+			atom_to_compile.add_overlay(mutable_appearance('icons/testing/greyscale_error.dmi'))
+			continue
 		if(mc_check)
 			if(MC_TICK_CHECK)
 				break
 		else
 			CHECK_TICK
-
 	if (count)
 		queue.Cut(1,count+1)
 		count = 0
+
+/// Converts an overlay list into text for debug printing
+/// Of note: overlays aren't actually mutable appearances, they're just appearances
+/// Don't have access to that type tho, so this is the best you're gonna get
+/proc/overlays2text(list/overlays)
+	var/list/unique_overlays = list()
+	// As anything because we're basically doing type coerrsion, rather then actually filtering for mutable apperances
+	for(var/mutable_appearance/overlay as anything in overlays)
+		var/key = "[overlay.icon]-[overlay.icon_state]-[overlay.dir]"
+		unique_overlays[key] += 1
+	var/list/output_text = list()
+	for(var/key in unique_overlays)
+		output_text += "([key]) = [unique_overlays[key]]"
+	return output_text.Join("\n")
 
 /proc/iconstate2appearance(icon, iconstate)
 	var/static/image/stringbro = new()


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/50915
- https://github.com/tgstation/tgstation/pull/67497

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This will stop lag from adding an obscene amount of overlays, and should clean it up when it does occur.

It will also log such an event, so we know what's doing it

This is a atomization of #8372 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Cutting out the fat.

Knowing when something is breaking is good too

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/62388554/224784023-de5bcf6e-5498-46c8-b700-5ecb139e6e46.png)

</details>

## Changelog
:cl: RKz, optimumtact, LemonInTheDark
fix: overlay subsystem cleans itself up when over 100 overlays are applied to one thing
tweak: it logs it too
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
