### PR TITLE
Fixes gamebreaking oversight introduced in #8541

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1627,7 +1627,7 @@
 		//Regardless of power, whatever is burning will go up in a brilliant flash with at least a fizzle
 		playsound(T,'sound/magic/fireball.ogg', max(strength*20, 20), 1)
 		T.visible_message("<b><span class='userdanger'>[src] ignites in a brilliant flash!</span></b>") 
-		if(reagent_reaction)
+		if(reagent_reaction) // Don't qdel(src). It's a reaction inside of something (or someone) important.
 			return TRUE
 		else if(isturf(src))
 			var/turf/srcTurf = src

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1630,6 +1630,8 @@
 		if(isturf(src))
 			var/turf/srcTurf = src
 			srcTurf.ScrapeAway() //Can't just qdel turfs
+		else if(src.reagents)
+			return TRUE
 		else
 			qdel(src)
 		return TRUE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1602,7 +1602,7 @@
 * Intended for use only with plasma that is ignited outside of some form of containment
 * Contained plasma ignitions (such as power cells or light fixtures) should explode with proper force
 */
-/atom/proc/plasma_ignition(strength, mob/user)
+/atom/proc/plasma_ignition(strength, mob/user, reagent_reaction)
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/environment = T.return_air()
 	if(environment.get_moles(GAS_O2) >= PLASMA_MINIMUM_OXYGEN_NEEDED) //Flashpoint ignition can only occur with at least this much oxygen present
@@ -1627,11 +1627,11 @@
 		//Regardless of power, whatever is burning will go up in a brilliant flash with at least a fizzle
 		playsound(T,'sound/magic/fireball.ogg', max(strength*20, 20), 1)
 		T.visible_message("<b><span class='userdanger'>[src] ignites in a brilliant flash!</span></b>") 
-		if(isturf(src))
+		if(reagent_reaction)
+			return TRUE
+		else if(isturf(src))
 			var/turf/srcTurf = src
 			srcTurf.ScrapeAway() //Can't just qdel turfs
-		else if(src.reagents)
-			return TRUE
 		else
 			qdel(src)
 		return TRUE

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -94,7 +94,7 @@
 	required_temp = 320 //extremely volatile
 
 /datum/chemical_reaction/plasma/on_reaction(datum/reagents/holder, created_volume)
-	holder.my_atom.plasma_ignition(created_volume/30)
+	holder.my_atom.plasma_ignition(created_volume/30, reagent_reaction = TRUE)
 	holder.clear_reagents()
 
 /datum/chemical_reaction/blackpowder

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -91,7 +91,7 @@
 	name = "Plasma Flash"
 	id = /datum/reagent/toxin/plasma
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
-	required_temp = 301 //extremely volatile
+	required_temp = 320 //extremely volatile
 
 /datum/chemical_reaction/plasma/on_reaction(datum/reagents/holder, created_volume)
 	holder.my_atom.plasma_ignition(created_volume/30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Changes plasma ignition temperature to 320
Humans are hot enough to detonate plasma immediately upon injection, resulting in extraordinarily bad interactions

* Adds a check to plasma ignition proc to see if it is a reagent reaction
This proc was written with the intention of things made *out of* plasma igniting. It should not qdel things that are not literally *made of* plasma, it should only be the plasma burning up in a brilliant flash

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The above two issues combined to create a perfect storm - injecting players with ordinary plasma immediately qdels them. This is an absolutely gamebreaking bug. 

This additionally prevents machines such as chemmasters and sleepers from being hit with qdel during a plasma flash

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_L6FSFoDU1x](https://user-images.githubusercontent.com/9547572/224853185-62ce06bb-90fd-46ee-a17f-b90620d404f1.gif)

![dreamseeker_xmtVPkyMSi](https://user-images.githubusercontent.com/9547572/224853193-a3bc7851-66b8-4432-8427-e9d67fb96530.gif)


## Changelog
:cl:
fix: Plasma ignition no longer calls qdel on reagent reactions, and its reaction temperature was increased to account for normal human body temperatures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
