### PR TITLE
Staff of storms fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -194,7 +194,7 @@ Difficulty: Medium
 	var/datum/weather/A
 	for(var/V in SSweather.processing)
 		var/datum/weather/W = V
-		if((user_turf.z in W.impacted_z_levels) && W.area_type == user_area.type)
+		if((user_turf.z in W.impacted_z_levels))
 			A = W
 			break
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -177,7 +177,7 @@ Difficulty: Medium
 	hitsound = 'sound/weapons/sear.ogg'
 	var/storm_type = /datum/weather/ash_storm
 	var/storm_cooldown = 0
-	var/static/list/allowed_areas = list(/area/lavaland/surface/outdoors)
+	var/static/list/allowed_areas = list(/area/lavaland/surface/outdoors, /area/lavaland/surface/outdoors/explored)
 
 /obj/item/staff/storm/attack_self(mob/user)
 	if(storm_cooldown > world.time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #8539 by fixing the staff's inability to interact with active weather, and also enables the staff to work in the labor camp because this outdoor area was not previously included as part of the valid "outdoor" turfs list. 

* Adds the outdoor labor camp area to the staff's allowed areas list

* Removes a redundant check from staff of storms comparing the user's area to the weather's affected area - the staff already checks that it is in a valid area at an earlier point. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The staff is currently bugged in such a way that renders it borderline not only unusable, but borderline gamebreaking - using the staff during a storm immediately cancels the visual and audio effects of the storm without actually stopping the storm, easily resulting in players being tricked into thinking it's safe. What's worse is that shortly after this a secondary storm summons on top of the now invisible first storm resulting in double damage. 

This PR fixes that issue and makes the staff work as intended - if a storm is active it cancels the storm. If no storm is active it summons one. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Main lavaland area
![image](https://user-images.githubusercontent.com/9547572/224975125-daa65dcf-4085-4f4f-89b3-dededab64266.png)

Labor camp area.
![image](https://user-images.githubusercontent.com/9547572/224975070-723d6c04-e52d-42b9-8cb2-e84345be3132.png)


</details>

## Changelog
:cl:
fix: Staff of storms now works as intended again - using it during a storm will properly cancel that storm, and using it with clear skies will summon a storm. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
