### PR TITLE
Fixes floodlights

### DIFF
--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -51,6 +51,10 @@
 	var/setting = 1
 	light_power = 1.75
 
+/obj/machinery/power/floodlight/Initialize(mapload)
+	. = ..()
+	connect_to_network()
+	
 /obj/machinery/power/floodlight/process()
 	if(avail(active_power_usage))
 		add_load(active_power_usage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #8699

Floodlights now check for a powernet on `Initialize()`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Building a floodlight but not having it connect to power until you unwrench and rewrench it when that was already part of construction is dumb. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_l5YB0KVkMC](https://user-images.githubusercontent.com/9547572/224983349-6112408f-5aee-464e-ba73-6efa5c574c99.gif)

</details>

## Changelog
:cl:
fix: floodlights now check for power when built instead of only after being unwrenched and re-wrenched
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
