### PR TITLE
Fix soundtrack music stopping early

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -196,7 +196,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 
 	// Clear any existing soundtrack
 	if(is_global && !isnull(GLOB.current_soundtrack))
-		stop_soundtrack_music()
+		stop_soundtrack_music(stop_playing = TRUE)
 
 	if(!hearers)
 		hearers = GLOB.player_list
@@ -235,8 +235,10 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 /mob/proc/play_current_soundtrack(volume = 80)
 	return !isnull(GLOB.current_soundtrack) ? play_soundtrack_music(GLOB.current_soundtrack, list(src), is_global = FALSE) : null
 
-/proc/stop_soundtrack_music()
+/proc/stop_soundtrack_music(stop_playing = FALSE)
 	GLOB.current_soundtrack = null
+	if(!stop_playing)
+		return
 	for(var/mob/M as() in GLOB.player_list)
 		M?.stop_sound_channel(CHANNEL_SOUNDTRACK)
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -429,7 +429,7 @@
 	if(safety)
 		if(timing)
 			set_security_level(previous_level)
-			stop_soundtrack_music()
+			stop_soundtrack_music(stop_playing = TRUE)
 			for(var/obj/item/pinpointer/nuke/syndicate/S in GLOB.pinpointer_list)
 				S.switch_mode_to(initial(S.mode))
 				S.alert = FALSE
@@ -457,7 +457,7 @@
 	else
 		detonation_timer = null
 		set_security_level(previous_level)
-		stop_soundtrack_music()
+		stop_soundtrack_music(stop_playing = TRUE)
 
 		for(var/obj/item/pinpointer/nuke/syndicate/S in GLOB.pinpointer_list)
 			S.switch_mode_to(initial(S.mode))


### PR DESCRIPTION
## About The Pull Request

A bug in #8650 would cause all soundtracks to stop playing early on the client, since the client timer system is not very accurate, apparently.

This new system allows the sound to continue playing on the client, but will not re-trigger it if the pref is toggled.

## Why It's Good For The Game

Hearing the entire song is a good idea.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

It doesn't stop early

</details>

## Changelog
:cl:
fix: Fixed soundtrack music stopping early.
/:cl: