### PR TITLE
Fix cavity implants not being able to be cauterized with a searing tool

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -18,7 +18,7 @@
 	success_sound = 'sound/surgery/organ2.ogg'
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
-	if(istype(tool, /obj/item/cautery) || istype(tool, /obj/item/gun/energy/laser))
+	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser))
 		return FALSE
 	return !tool.is_hot()
 


### PR DESCRIPTION
## About The Pull Request

This fixes the cavity implant being hardcoded to only check for cauteries. It now checks tool behavior instead.

## Why It's Good For The Game

Because searing tools should work as fully functional cauteries

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/65794972/225986849-aaae8c98-25a8-491a-ac38-1cd325dbda10.mp4

</details>

## Changelog
:cl:
fix: Searing tools and such now properly work to cauterize a chest cavity implant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
