### PR TITLE
Ports vent directional control

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -383,7 +383,7 @@
 			if(usr.has_unlimited_silicon_privilege && !wires.is_cut(WIRE_IDSCAN))
 				locked = !locked
 				. = TRUE
-		if("power", "toggle_filter", "widenet", "scrubbing")
+		if("power", "toggle_filter", "widenet", "scrubbing", "direction")
 			send_signal(device_id, list("[action]" = params["val"]), usr)
 			. = TRUE
 		if("excheck")

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -156,7 +156,7 @@
 		"device" = "VP",
 		"timestamp" = world.time,
 		"power" = on,
-		"direction" = pump_direction ? "release" : "siphon",
+		"direction" = pump_direction,
 		"checks" = pressure_checks,
 		"internal" = internal_pressure_bound,
 		"external" = external_pressure_bound,

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -6,6 +6,7 @@ import { Box, Button, LabeledList, NumberInput, Section } from '../components';
 import { getGasLabel } from '../constants';
 import { Window } from '../layouts';
 import { InterfaceLockNoticeBox } from './common/InterfaceLockNoticeBox';
+import { Vent, Scrubber } from './common/AtmosControls';
 
 export const AirAlarm = (props, context) => {
   const { act, data } = useBackend(context);
@@ -204,108 +205,6 @@ const AirAlarmControlVents = (props, context) => {
   ));
 };
 
-const Vent = (props, context) => {
-  const { vent } = props;
-  const { act } = useBackend(context);
-  const {
-    id_tag,
-    long_name,
-    power,
-    checks,
-    excheck,
-    incheck,
-    direction,
-    external,
-    internal,
-    extdefault,
-    intdefault,
-  } = vent;
-  return (
-    <Section
-      level={2}
-      title={decodeHtmlEntities(long_name)}
-      buttons={(
-        <Button
-          icon={power ? 'power-off' : 'times'}
-          selected={power}
-          content={power ? 'On' : 'Off'}
-          onClick={() => act('power', {
-            id_tag,
-            val: Number(!power),
-          })} />
-      )}>
-      <LabeledList>
-        <LabeledList.Item label="Mode">
-          {direction === 'release' ? 'Pressurizing' : 'Releasing'}
-        </LabeledList.Item>
-        <LabeledList.Item label="Pressure Regulator">
-          <Button
-            icon="sign-in-alt"
-            content="Internal"
-            selected={incheck}
-            onClick={() => act('incheck', {
-              id_tag,
-              val: checks,
-            })} />
-          <Button
-            icon="sign-out-alt"
-            content="External"
-            selected={excheck}
-            onClick={() => act('excheck', {
-              id_tag,
-              val: checks,
-            })} />
-        </LabeledList.Item>
-        {!!incheck && (
-          <LabeledList.Item label="Internal Target">
-            <NumberInput
-              value={Math.round(internal)}
-              unit="kPa"
-              width="75px"
-              minValue={0}
-              step={10}
-              maxValue={5066}
-              onChange={(e, value) => act('set_internal_pressure', {
-                id_tag,
-                value,
-              })} />
-            <Button
-              icon="undo"
-              disabled={intdefault}
-              content="Reset"
-              onClick={() => act('reset_internal_pressure', {
-                id_tag,
-              })} />
-          </LabeledList.Item>
-        )}
-        {!!excheck && (
-          <LabeledList.Item label="External Target">
-            <NumberInput
-              value={Math.round(external)}
-              unit="kPa"
-              width="75px"
-              minValue={0}
-              step={10}
-              maxValue={5066}
-              onChange={(e, value) => act('set_external_pressure', {
-                id_tag,
-                value,
-              })} />
-            <Button
-              icon="undo"
-              disabled={extdefault}
-              content="Reset"
-              onClick={() => act('reset_external_pressure', {
-                id_tag,
-              })} />
-          </LabeledList.Item>
-        )}
-      </LabeledList>
-    </Section>
-  );
-};
-
-
 //  Scrubbers
 // --------------------------------------------------------
 
@@ -321,71 +220,6 @@ const AirAlarmControlScrubbers = (props, context) => {
       scrubber={scrubber} />
   ));
 };
-
-const Scrubber = (props, context) => {
-  const { scrubber } = props;
-  const { act } = useBackend(context);
-  const {
-    long_name,
-    power,
-    scrubbing,
-    id_tag,
-    widenet,
-    filter_types,
-  } = scrubber;
-  return (
-    <Section
-      level={2}
-      title={decodeHtmlEntities(long_name)}
-      buttons={(
-        <Button
-          icon={power ? 'power-off' : 'times'}
-          content={power ? 'On' : 'Off'}
-          selected={power}
-          onClick={() => act('power', {
-            id_tag,
-            val: Number(!power),
-          })} />
-      )}>
-      <LabeledList>
-        <LabeledList.Item label="Mode">
-          <Button
-            icon={scrubbing ? 'filter' : 'sign-in-alt'}
-            color={scrubbing || 'danger'}
-            content={scrubbing ? 'Scrubbing' : 'Siphoning'}
-            onClick={() => act('scrubbing', {
-              id_tag,
-              val: Number(!scrubbing),
-            })} />
-          <Button
-            icon={widenet ? 'expand' : 'compress'}
-            selected={widenet}
-            content={widenet ? 'Expanded range' : 'Normal range'}
-            onClick={() => act('widenet', {
-              id_tag,
-              val: Number(!widenet),
-            })} />
-        </LabeledList.Item>
-        <LabeledList.Item label="Filters">
-          {scrubbing
-            && filter_types.map(filter => (
-              <Button key={filter.gas_id}
-                icon={filter.enabled ? 'check-square-o' : 'square-o'}
-                content={getGasLabel(filter.gas_id, filter.gas_name)}
-                title={filter.gas_name}
-                selected={filter.enabled}
-                onClick={() => act('toggle_filter', {
-                  id_tag,
-                  val: filter.gas_id,
-                })} />
-            ))
-            || 'N/A'}
-        </LabeledList.Item>
-      </LabeledList>
-    </Section>
-  );
-};
-
 
 //  Modes
 // --------------------------------------------------------

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.js
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.js
@@ -1,0 +1,178 @@
+import { decodeHtmlEntities } from 'common/string';
+import { useBackend, useLocalState } from '../../backend';
+import { Box, Button, LabeledList, NumberInput, Section } from '../../components';
+import { getGasLabel } from '../../constants';
+
+
+export const Vent = (props, context) => {
+  const { vent } = props;
+  const { act } = useBackend(context);
+  const {
+    id_tag,
+    long_name,
+    power,
+    checks,
+    excheck,
+    incheck,
+    direction,
+    external,
+    internal,
+    extdefault,
+    intdefault,
+  } = vent;
+  return (
+    <Section
+      level={2}
+      title={decodeHtmlEntities(long_name)}
+      buttons={(
+        <Button
+          icon={power ? 'power-off' : 'times'}
+          selected={power}
+          content={power ? 'On' : 'Off'}
+          onClick={() => act('power', {
+            id_tag,
+            val: Number(!power),
+          })} />
+      )}>
+      <LabeledList>
+        <LabeledList.Item label="Mode">
+          <Button
+            icon="sign-in-alt"
+            content={direction ? 'Pressurizing' : 'Scrubbing'}
+            color={!direction && 'danger'}
+            onClick={() => act('direction', {
+              id_tag,
+              val: Number(!direction),
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Pressure Regulator">
+          <Button
+            icon="sign-in-alt"
+            content="Internal"
+            selected={incheck}
+            onClick={() => act('incheck', {
+              id_tag,
+              val: checks,
+            })} />
+          <Button
+            icon="sign-out-alt"
+            content="External"
+            selected={excheck}
+            onClick={() => act('excheck', {
+              id_tag,
+              val: checks,
+            })} />
+        </LabeledList.Item>
+        {!!incheck && (
+          <LabeledList.Item label="Internal Target">
+            <NumberInput
+              value={Math.round(internal)}
+              unit="kPa"
+              width="75px"
+              minValue={0}
+              step={10}
+              maxValue={5066}
+              onChange={(e, value) => act('set_internal_pressure', {
+                id_tag,
+                value,
+              })} />
+            <Button
+              icon="undo"
+              disabled={intdefault}
+              content="Reset"
+              onClick={() => act('reset_internal_pressure', {
+                id_tag,
+              })} />
+          </LabeledList.Item>
+        )}
+        {!!excheck && (
+          <LabeledList.Item label="External Target">
+            <NumberInput
+              value={Math.round(external)}
+              unit="kPa"
+              width="75px"
+              minValue={0}
+              step={10}
+              maxValue={5066}
+              onChange={(e, value) => act('set_external_pressure', {
+                id_tag,
+                value,
+              })} />
+            <Button
+              icon="undo"
+              disabled={extdefault}
+              content="Reset"
+              onClick={() => act('reset_external_pressure', {
+                id_tag,
+              })} />
+          </LabeledList.Item>
+        )}
+      </LabeledList>
+    </Section>
+  );
+};
+
+
+export const Scrubber = (props, context) => {
+  const { scrubber } = props;
+  const { act } = useBackend(context);
+  const {
+    long_name,
+    power,
+    scrubbing,
+    id_tag,
+    widenet,
+    filter_types,
+  } = scrubber;
+  return (
+    <Section
+      level={2}
+      title={decodeHtmlEntities(long_name)}
+      buttons={(
+        <Button
+          icon={power ? 'power-off' : 'times'}
+          content={power ? 'On' : 'Off'}
+          selected={power}
+          onClick={() => act('power', {
+            id_tag,
+            val: Number(!power),
+          })} />
+      )}>
+      <LabeledList>
+        <LabeledList.Item label="Mode">
+          <Button
+            icon={scrubbing ? 'filter' : 'sign-in-alt'}
+            color={scrubbing || 'danger'}
+            content={scrubbing ? 'Scrubbing' : 'Siphoning'}
+            onClick={() => act('scrubbing', {
+              id_tag,
+              val: Number(!scrubbing),
+            })} />
+          <Button
+            icon={widenet ? 'expand' : 'compress'}
+            selected={widenet}
+            content={widenet ? 'Expanded range' : 'Normal range'}
+            onClick={() => act('widenet', {
+              id_tag,
+              val: Number(!widenet),
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Filters">
+          {scrubbing
+            && filter_types.map(filter => (
+              <Button key={filter.gas_id}
+                icon={filter.enabled ? 'check-square-o' : 'square-o'}
+                content={getGasLabel(filter.gas_id, filter.gas_name)}
+                title={filter.gas_name}
+                selected={filter.enabled}
+                onClick={() => act('toggle_filter', {
+                  id_tag,
+                  val: filter.gas_id,
+                })} />
+            ))
+            || 'N/A'}
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
+  );
+};


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/51536


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds directional control to air vents. That being either Pressurize, or Siphon.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, these exist in the game locked away as gas tank-exclusives, and I would like more things to be able to built from scratch rather than be constrained to just mapping tools. (I am in the middle of refactoring control consoles on another branch to pursue this)

This UI change to vents should also provide an interesting alternative for atmosians to the Scrubber, as they have to give up the scrubber's ability to discern a single gas, in exchange for the being able to set activity according to air pressure. There are statistical differences between vents and scrubbers, so one will have to choose wisely.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![exists](https://user-images.githubusercontent.com/62388554/226066339-88ac94ae-d9e1-4531-8b20-0eb6232928cc.PNG)
heres how they currently appear


![scrubbers](https://user-images.githubusercontent.com/62388554/226066331-f7680028-3ae1-418b-9861-403362f9c100.PNG)
here is a the UI change.

</details>

## Changelog
:cl: RKz, WarlockD
add: added directional function to vents in the Air Alarm control. Choose to Pressurize or Siphon gas!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
