### PR TITLE
Adds new naming system for air alarms, fixes duplicate names

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -41,6 +41,10 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
+
+GLOBAL_LIST_EMPTY(air_scrub_names)			// Name list of all air scrubbers
+GLOBAL_LIST_EMPTY(air_vent_names)			// Name list of all air vents
+
 GLOBAL_LIST_INIT(alarms, list(
 	"Fire" = list(),
 	"Atmosphere" = list(),

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -668,6 +668,28 @@ Class Procs:
 /obj/machinery/rust_heretic_act()
 	take_damage(500, BRUTE, "melee", 1)
 
+/**
+ * Generate a name devices
+ *
+ * Creates a randomly generated tag or name for devices5
+ * The length of the generated name can be set by passing in an int
+ * args:
+ * * len (int)(Optional) Default=5 The length of the name
+ * Returns (string) The generated name
+ */
+/obj/machinery/proc/assign_random_name(len=5)
+	var/list/new_name = list()
+	// machine id's should be fun random chars hinting at a larger world
+	for(var/i = 1 to len)
+		switch(rand(1,3))
+			if(1)
+				new_name += ascii2text(rand(65, 90)) // A - Z
+			if(2)
+				new_name += ascii2text(rand(97,122)) // a - z
+			if(3)
+				new_name += ascii2text(rand(48, 57)) // 0 - 9
+	return new_name.Join()
+
 /obj/machinery/vv_edit_var(vname, vval)
 	if(vname == "occupant")
 		set_occupant(vval)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -186,8 +186,6 @@
 
 //all air alarms in area are connected via magic
 /area
-	var/list/air_vent_names = list()
-	var/list/air_scrub_names = list()
 	var/list/air_vent_info = list()
 	var/list/air_scrub_info = list()
 
@@ -297,8 +295,8 @@
 
 	if(!locked || user.has_unlimited_silicon_privilege)
 		data["vents"] = list()
-		for(var/id_tag in A.air_vent_names)
-			var/long_name = A.air_vent_names[id_tag]
+		for(var/id_tag in A.air_vent_info)
+			var/long_name = GLOB.air_vent_names[id_tag]
 			var/list/info = A.air_vent_info[id_tag]
 			if(!info || info["frequency"] != frequency || info["has_aac"])
 				continue
@@ -316,8 +314,8 @@
 					"intdefault"= (info["internal"] == 0)
 				))
 		data["scrubbers"] = list()
-		for(var/id_tag in A.air_scrub_names)
-			var/long_name = A.air_scrub_names[id_tag]
+		for(var/id_tag in A.air_scrub_info)
+			var/long_name = GLOB.air_scrub_names[id_tag]
 			var/list/info = A.air_scrub_info[id_tag]
 			if(!info || info["frequency"] != frequency)
 				continue
@@ -507,14 +505,14 @@
 	var/area/A = get_area(src)
 	switch(mode)
 		if(AALARM_MODE_SCRUBBING)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"set_filters" = list(GAS_CO2, GAS_BZ),
 					"scrubbing" = 1,
 					"widenet" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
@@ -539,7 +537,7 @@
 					"scrubbing" = 1,
 					"widenet" = 1
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
@@ -552,7 +550,7 @@
 					"widenet" = 0,
 					"scrubbing" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
@@ -566,7 +564,7 @@
 					"scrubbing" = 1,
 					"widenet" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
@@ -580,7 +578,7 @@
 					"widenet" = 1,
 					"scrubbing" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
@@ -591,7 +589,7 @@
 					"widenet" = 0,
 					"scrubbing" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
@@ -601,7 +599,7 @@
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
@@ -610,7 +608,7 @@
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
-			for(var/device_id in A.air_vent_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 2,

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -519,7 +519,7 @@
 					"set_external_pressure" = ONE_ATMOSPHERE
 				), signal_source)
 		if(AALARM_MODE_CONTAMINATED)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"set_filters" = list(
@@ -544,7 +544,7 @@
 					"set_external_pressure" = ONE_ATMOSPHERE
 				), signal_source)
 		if(AALARM_MODE_VENTING)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"widenet" = 0,
@@ -557,7 +557,7 @@
 					"set_external_pressure" = ONE_ATMOSPHERE*2
 				), signal_source)
 		if(AALARM_MODE_REFILL)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"set_filters" = list(GAS_CO2, GAS_BZ),
@@ -572,7 +572,7 @@
 				), signal_source)
 		if(AALARM_MODE_PANIC,
 			AALARM_MODE_REPLACEMENT)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"widenet" = 1,
@@ -583,7 +583,7 @@
 					"power" = 0
 				), signal_source)
 		if(AALARM_MODE_SIPHON)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
 					"widenet" = 0,
@@ -595,7 +595,7 @@
 				), signal_source)
 
 		if(AALARM_MODE_OFF)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)
@@ -604,7 +604,7 @@
 					"power" = 0
 				), signal_source)
 		if(AALARM_MODE_FLOOD)
-			for(var/device_id in A.air_scrub_names)
+			for(var/device_id in A.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 0
 				), signal_source)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -166,8 +166,9 @@
 
 	var/area/vent_area = get_area(src)
 	if(!GLOB.air_vent_names[id_tag])
-		// If we do not have a name, assign one
-		name = "[assign_random_name()] [vent_area.name] Vent Pump" // matching case
+		// If we do not have a name, assign one.
+		// Produces names like "Port Quarter Solar vent pump hZ2l6".
+		name = "\proper [vent_area.name] vent pump [assign_random_name()]"
 		GLOB.air_vent_names[id_tag] = name
 
 	vent_area.air_vent_info[id_tag] = signal.data

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -166,10 +166,11 @@
 
 	var/area/vent_area = get_area(src)
 	if(!GLOB.air_vent_names[id_tag])
+		// If we do not have a name, assign one
 		name = "[assign_random_name()] [vent_area.name] Vent Pump" // matching case
 		GLOB.air_vent_names[id_tag] = name
 
-	A.air_vent_info[id_tag] = signal.data
+	vent_area.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -44,10 +44,10 @@
 	. = ..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/Destroy()
-	var/area/A = get_area(src)
-	if (A)
-		A.air_vent_names -= id_tag
-		A.air_vent_info -= id_tag
+	var/area/vent_area = get_area(src)
+	if(vent_area)
+		vent_area.air_vent_info -= id_tag
+		GLOB.air_vent_names -= id_tag
 	if(aac)
 		aac.vents -= src
 
@@ -164,10 +164,11 @@
 		"has_aac" = aac != null
 	))
 
-	var/area/A = get_area(src)
-	if(!A.air_vent_names[id_tag])
-		name = "\improper [A.name] vent pump #[A.air_vent_names.len + 1]"
-		A.air_vent_names[id_tag] = name
+	var/area/vent_area = get_area(src)
+	if(!GLOB.air_vent_names[id_tag])
+		name = "[assign_random_name()] [vent_area.name] Vent Pump" // matching case
+		GLOB.air_vent_names[id_tag] = name
+
 	A.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -115,11 +115,11 @@
 	var/area/scrub_area = get_area(src)
 	if(!GLOB.air_scrub_names[id_tag])
 		// If we do not have a name, assign one
-		name = "[assign_random_name()] [scrub_area.name] Air Scrubber" // matching case
+		name = "\proper [scrub_area.name] air scrubber [assign_random_name()]"
 		GLOB.air_scrub_names[id_tag] = name
 
 	scrub_area.air_scrub_info[id_tag] = signal.data
-	
+
 	radio_connection.post_signal(src, signal, radio_filter_out)
 
 	return TRUE

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -37,10 +37,10 @@
 	. = ..()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/Destroy()
-	var/area/A = get_area(src)
-	if (A)
-		A.air_scrub_names -= id_tag
-		A.air_scrub_info -= id_tag
+	var/area/scrub_area = get_area(src)
+	if(scrub_area)
+		scrub_area.air_scrub_info -= id_tag
+		GLOB.air_scrub_names -= id_tag
 
 	SSradio.remove_object(src,frequency)
 	radio_connection = null
@@ -112,12 +112,14 @@
 		"sigtype" = "status"
 	))
 
-	var/area/A = get_area(src)
-	if(!A.air_scrub_names[id_tag])
-		name = "\improper [A.name] air scrubber #[A.air_scrub_names.len + 1]"
-		A.air_scrub_names[id_tag] = name
+	var/area/scrub_area = get_area(src)
+	if(!GLOB.air_scrub_names[id_tag])
+		// If we do not have a name, assign one
+		name = "[assign_random_name()] [scrub_area.name] Air Scrubber" // matching case
+		GLOB.air_scrub_names[id_tag] = name
 
-	A.air_scrub_info[id_tag] = signal.data
+	scrub_area.air_scrub_info[id_tag] = signal.data
+	
 	radio_connection.post_signal(src, signal, radio_filter_out)
 
 	return TRUE


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/52398
- https://github.com/tgstation/tgstation/pull/53230

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR introduces a new naming system for Air Vents/Scrubbers. This should fix events where they are ordered oddly in the air alarm, and should make distinguishing between them much simpler.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should make air vents/scrubbers a lot more distinguishable, and prevent duplicate naming.

This is particularly helpful for atmosians, or new players still learning the system.

It will especially work well when adding new devices to the air alarm, which has a chance of duplicating the entry ( i.e. Atmospherics Air Pump #2) in the current system.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![airscrubber](https://user-images.githubusercontent.com/62388554/226072883-3f418dbd-a390-46cd-bd5d-31e303f79d54.png)

![ventpump](https://user-images.githubusercontent.com/62388554/226072888-35641fa3-6a02-4f04-8d4d-9864aab9edd1.png)




</details>

## Changelog
:cl: RKz, SpaceManiac, Nightred
tweak: new unique naming system for air vents/scrubbers. Should prevent duplicate entries and decrease confusion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
