### PR TITLE
Malf AI can no longer occur on lowpop

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -187,6 +187,10 @@
 	integer = FALSE
 	min_val = 0
 
+/datum/config_entry/number/malf_ai_minimum_pop	// minimum population for malf AI to occur.
+	config_entry_value = 30
+	min_val = 0
+
 /datum/config_entry/flag/show_game_type_odds	//if set this allows players to see the odds of each roundtype on the get revision screen
 
 /datum/config_entry/string/fallback_default_species

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -248,7 +248,7 @@
 	exclusive_roles = list(JOB_NAME_AI)
 	required_enemies = list(3,3,2,2,2,1,1,1,1,0)
 	required_candidates = 1
-	minimum_players = 30
+	minimum_players = 0 // Handled by /datum/dynamic_ruleset/proc/acceptable override
 	weight = 2
 	cost = 13
 	required_type = /mob/living/silicon/ai
@@ -256,6 +256,11 @@
 	flags = HIGH_IMPACT_RULESET
 	var/ion_announce = 33
 	var/removeDontImproveChance = 10
+
+/datum/dynamic_ruleset/midround/malf/acceptable(population = 0, threat_level = 0)
+	. = ..()
+	if(population < CONFIG_GET(number/malf_ai_minimum_pop))
+		return FALSE
 
 /datum/dynamic_ruleset/midround/malf/trim_candidates()
 	..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -248,7 +248,7 @@
 	exclusive_roles = list(JOB_NAME_AI)
 	required_enemies = list(3,3,2,2,2,1,1,1,1,0)
 	required_candidates = 1
-	minimum_players = 25
+	minimum_players = 30
 	weight = 2
 	cost = 13
 	required_type = /mob/living/silicon/ai

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -22,7 +22,7 @@
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute(population)
 	. = ..()
-	if (population < 30)
+	if (population < CONFIG_GET(number/malf_ai_minimum_pop))
 		restricted_roles |= JOB_NAME_AI
 	var/num_traitors = get_antag_cap(population) * (scaled_times + 1)
 	for (var/i = 1 to num_traitors)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -22,6 +22,8 @@
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute(population)
 	. = ..()
+	if (population < 30)
+		restricted_roles |= JOB_NAME_AI
 	var/num_traitors = get_antag_cap(population) * (scaled_times + 1)
 	for (var/i = 1 to num_traitors)
 		if(candidates.len <= 0)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -44,6 +44,9 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(num_players() < 30)
+		restricted_jobs += JOB_NAME_AI
+
 	var/num_traitors = 1
 
 	var/tsc = CONFIG_GET(number/traitor_scaling_coeff)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -44,7 +44,7 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
-	if(num_players() < 30)
+	if(num_players() < CONFIG_GET(number/malf_ai_minimum_pop))
 		restricted_jobs += JOB_NAME_AI
 
 	var/num_traitors = 1

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -2,8 +2,13 @@
 	name = "Ion Storm"
 	typepath = /datum/round_event/ion_storm
 	weight = 15
-	min_players = 2
+	min_players = 0 // Handled by canSpawnEvent override
 	can_malf_fake_alert = TRUE
+
+/datum/round_event_control/ion_storm/canSpawnEvent(players_amt, gamemode)
+	. = ..()
+	if(players_amt < CONFIG_GET(number/malf_ai_minimum_pop))
+		return FALSE
 
 /datum/round_event/ion_storm
 	var/replaceLawsetChance = 25 //chance the AI's lawset is completely replaced with something else per config weights

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -2,13 +2,8 @@
 	name = "Ion Storm"
 	typepath = /datum/round_event/ion_storm
 	weight = 15
-	min_players = 0 // Handled by canSpawnEvent override
+	min_players = 2
 	can_malf_fake_alert = TRUE
-
-/datum/round_event_control/ion_storm/canSpawnEvent(players_amt, gamemode)
-	. = ..()
-	if(players_amt < CONFIG_GET(number/malf_ai_minimum_pop))
-		return FALSE
 
 /datum/round_event/ion_storm
 	var/replaceLawsetChance = 25 //chance the AI's lawset is completely replaced with something else per config weights

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -268,6 +268,10 @@ PROTECT_HEADS_FROM_ANTAGONIST
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS
 
+## The minimum amount of players for an malfunctioning AI to be rolled by a gamemode,
+## or for an ion storm to occur.
+MALF_AI_MINIMUM_POP 30
+
 ## Incursion Rules
 ## The more incursion-traitors spawn, the most pop is required to spawn the next
 ## Values of 6 and 2 will be 6 for 1 then (6) + (6 + 2) for 2

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -268,8 +268,7 @@ PROTECT_HEADS_FROM_ANTAGONIST
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS
 
-## The minimum amount of players for an malfunctioning AI to be rolled by a gamemode,
-## or for an ion storm to occur.
+## The minimum amount of players for malfunctioning AI to be occur.
 MALF_AI_MINIMUM_POP 30
 
 ## Incursion Rules


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This prevents malf AI - both roundstart and midround - from ever occuring at below 30 pop.

## Why It's Good For The Game

Lowpop malf AI is absolutely cancerous, and is most likely to lead to nobody besides the AI having any fun.

## Testing Photographs and Procedure

N/A

## Changelog
:cl:
tweak: Malf AI no longer occurs on lowpop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
