### PR TITLE
Fixes titlescreen bugs

### DIFF
--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -42,8 +42,9 @@ SUBSYSTEM_DEF(title)
 		var/new_player_x = splash_turf.x + FLOOR(width / 2, 1)
 		var/new_player_y = splash_turf.y + FLOOR(height / 2, 1)
 		newplayer_start_loc = locate(new_player_x, new_player_y, splash_turf.z)
-		for(var/atom/movable/new_player_start in GLOB.newplayer_start)
-			new_player_start.forceMove(newplayer_start_loc)
+		// Reset the newplayer start loc
+		GLOB.newplayer_start.Cut()
+		GLOB.newplayer_start += newplayer_start_loc
 
 		//Update fast joiners
 		for (var/mob/dead/new_player/fast_joiner in GLOB.new_player_list)
@@ -51,6 +52,10 @@ SUBSYSTEM_DEF(title)
 				fast_joiner.client?.change_view(getScreenSize(fast_joiner))
 			else
 				fast_joiner.client?.view_size.resetToDefault(getScreenSize(fast_joiner))
+			// Execute this immediately, change_view runs through SStimer which doesn't execute until after
+			// initialisation
+			if (fast_joiner.client?.prefs.toggles2 & PREFTOGGLE_2_AUTO_FIT_VIEWPORT)
+				fast_joiner.client?.fit_viewport()
 			fast_joiner.forceMove(newplayer_start_loc)
 
 	if(splash_turf)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -312,9 +312,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 
 /obj/effect/landmark/start/new_player/Initialize(mapload)
 	..()
-	GLOB.newplayer_start += loc
 	if (SStitle.newplayer_start_loc)
 		forceMove(SStitle.newplayer_start_loc)
+	GLOB.newplayer_start += loc
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/landmark/latejoin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes 2 bugs with the new title screens:
- Clients will now have the view resize immediately upon title screens loading in (change_size uses a 1 second timer which requires subsystem initialisation to be completed first).
- The global spawnpoint will be properly moved (Its a list of turfs, not a list of movable atoms).

## Why It's Good For The Game

This will fix the 2 bugs that we currently have with our title screens.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/226107777-58f67be0-8c7b-4983-8ae3-cd00d8bbdda5.png)

## Changelog
:cl:
fix: Fixes late joining clients having their lobby screen appearing off the side of the screen.
fix: Fixes early joining clients having to wait until subsystem initialisation until their views are correctly resized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
