### PR TITLE
Tweaks sleeper - accepts chem bag

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -18,19 +18,22 @@
 	var/min_health = -25
 	var/list/available_chems
 	var/controls_inside = FALSE
+	/// the maximum amount of chem containers the sleeper can hold. Value can be changed by parts tier and RefreshParts()
 	var/max_vials = 6
+	/// the list of vials that are in the sleeper. Do not define anything here.
 	var/list/inserted_vials = list()
+	/// the list of roundstart vials - especially predefined chem bags. (Warning: be careful of heritance when you make subtypes)
 	var/list/roundstart_vials = list(
-		/obj/item/reagent_containers/chem_bag/morphine
+		/obj/item/reagent_containers/chem_bag/oxy_mix
 	)
+	/// the list of roundstart chems. It will be automatically filled into a chem bag. (Warning: be careful of heritance when you make subtypes)
 	var/list/roundstart_chems = list(
-		/datum/reagent/medicine/epinephrine,
-		/datum/reagent/medicine/perfluorodecalin,
-		/datum/reagent/medicine/bicaridine,
-		/datum/reagent/medicine/kelotane,
-		/datum/reagent/medicine/antitoxin
+		/datum/reagent/medicine/epinephrine = 80,
+		/datum/reagent/medicine/morphine = 80,
+		/datum/reagent/medicine/bicaridine = 80,
+		/datum/reagent/medicine/kelotane = 80,
+		/datum/reagent/medicine/antitoxin = 80
 	)
-	var/roundstart_chem_default_size = 80
 	/// If true doesn't consume chems
 	var/synthesizing = FALSE
 	var/scrambled_chems = FALSE //Are chem buttons scrambled? used as a warning
@@ -48,20 +51,25 @@
 	var/created_vials = 0
 	if (mapload)
 		// create pre-defined vials first and insert it into sleeper
-		for (var/each in roundstart_vials)
+		for (var/each_vial in roundstart_vials)
 			if(created_vials >= max_vials)
 				stack_trace("Sleeper attempts to create roundstart chems more than [max_vials]")
 				break
-			inserted_vials += new each
+			if(!ispath(each_vial, /obj/item/reagent_containers))
+				stack_trace("Sleeper attempts to create weird item inside of it: [each_vial]")
+				continue
+			inserted_vials += new each_vial
 			created_vials++
 		// and then chemical bag with a single chem will go into sleeper
-		for (var/datum/reagent/default_chem as() in roundstart_chems)
+		for (var/each_chem in roundstart_chems)
 			if(created_vials >= max_vials)
 				stack_trace("Sleeper attempts to create roundstart chems more than [max_vials]")
 				break
+			if(!ispath(each_chem, /datum/reagent))
+				stack_trace("Sleeper attempts to create not-chemical inside of it: [each_chem]")
+				continue
 			var/obj/item/reagent_containers/chem_bag/beaker = new(null)
-			beaker.reagents.add_reagent(default_chem, roundstart_chem_default_size) // 80u for default chems
-			beaker.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, beaker.volume - beaker.reagents.total_volume) // the rest will be saline glucose
+			beaker.reagents.add_reagent(each_chem, roundstart_chems[each_chem])
 			var/datum/reagent/main_reagent = beaker.reagents.reagent_list[1]
 			beaker.name = "[main_reagent.name] [beaker.name]"
 			beaker.label_name = main_reagent.name
@@ -341,14 +349,13 @@
 	controls_inside = TRUE
 	roundstart_vials = list()
 	roundstart_chems = list(
-		/datum/reagent/medicine/syndicate_nanites,
-		/datum/reagent/medicine/oculine,
-		/datum/reagent/medicine/inacusiate,
-		/datum/reagent/medicine/mutadone,
-		/datum/reagent/medicine/mannitol,
-		/datum/reagent/medicine/omnizine
+		/datum/reagent/medicine/syndicate_nanites = 100,
+		/datum/reagent/medicine/omnizine = 100,
+		/datum/reagent/medicine/oculine = 100,
+		/datum/reagent/medicine/inacusiate = 100,
+		/datum/reagent/medicine/mannitol = 100,
+		/datum/reagent/medicine/mutadone = 100,
 	)
-	roundstart_chem_default_size = 100 // syndi nanites are strong chem, so should be limited.
 	efficiency = 2.5
 
 /obj/machinery/sleeper/syndie/fullupgrade
@@ -361,14 +368,13 @@
 	enter_message = "<span class='bold inathneq_small'>You hear the gentle hum and click of machinery, and are lulled into a sense of peace.</span>"
 	roundstart_vials = list()
 	roundstart_chems = list(
-		/datum/reagent/medicine/epinephrine,
-		/datum/reagent/medicine/salbutamol,
-		/datum/reagent/medicine/bicaridine,
-		/datum/reagent/medicine/kelotane,
-		/datum/reagent/medicine/oculine,
-		/datum/reagent/medicine/inacusiate,
-		/datum/reagent/medicine/mannitol)
-	roundstart_chem_default_size = 200
+		/datum/reagent/medicine/epinephrine = 200,
+		/datum/reagent/medicine/bicaridine = 200,
+		/datum/reagent/medicine/kelotane = 200,
+		/datum/reagent/medicine/salbutamol = 200,
+		/datum/reagent/medicine/oculine = 100,
+		/datum/reagent/medicine/inacusiate = 100,
+		/datum/reagent/medicine/mannitol = 100)
 	synthesizing = TRUE
 
 /obj/machinery/sleeper/old

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -62,6 +62,7 @@
 			beaker.reagents.add_reagent(default_chem, roundstart_chem_default_size) // 80u for default chems
 			beaker.reagents.add_reagent(/datum/reagent/medicine/salglu_solution, beaker.volume - beaker.reagents.total_volume) // the rest will be saline glucose
 			var/datum/reagent/main_reagent = beaker.reagents.reagent_list[1]
+			beaker.name = "[main_reagent.name] [beaker.name]"
 			beaker.label_name = main_reagent.name
 			inserted_vials += beaker
 			created_vials++

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -21,11 +21,10 @@
 	var/max_vials = 6
 	var/list/inserted_vials = list()
 	var/list/roundstart_vials = list(
-		// example: /obj/item/reagent_containers/chem_bag/epinephrine
+		/obj/item/reagent_containers/chem_bag/morphine
 	)
 	var/list/roundstart_chems = list(
 		/datum/reagent/medicine/epinephrine,
-		/datum/reagent/medicine/morphine,
 		/datum/reagent/medicine/perfluorodecalin,
 		/datum/reagent/medicine/bicaridine,
 		/datum/reagent/medicine/kelotane,
@@ -43,6 +42,8 @@
 	. = ..()
 	occupant_typecache = GLOB.typecache_living
 	update_icon()
+	RefreshParts()
+
 	//Create roundstart chems
 	var/created_vials = 0
 	if (mapload)
@@ -340,7 +341,12 @@
 	controls_inside = TRUE
 	roundstart_vials = list()
 	roundstart_chems = list(
-		/datum/reagent/medicine/syndicate_nanites, /datum/reagent/medicine/oculine, /datum/reagent/medicine/inacusiate, /datum/reagent/medicine/mutadone, /datum/reagent/medicine/mannitol, /datum/reagent/medicine/omnizine
+		/datum/reagent/medicine/syndicate_nanites,
+		/datum/reagent/medicine/oculine,
+		/datum/reagent/medicine/inacusiate,
+		/datum/reagent/medicine/mutadone,
+		/datum/reagent/medicine/mannitol,
+		/datum/reagent/medicine/omnizine
 	)
 	roundstart_chem_default_size = 100 // syndi nanites are strong chem, so should be limited.
 	efficiency = 2.5
@@ -354,7 +360,14 @@
 	icon_state = "sleeper_clockwork"
 	enter_message = "<span class='bold inathneq_small'>You hear the gentle hum and click of machinery, and are lulled into a sense of peace.</span>"
 	roundstart_vials = list()
-	roundstart_chems = list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/salbutamol, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/oculine, /datum/reagent/medicine/inacusiate, /datum/reagent/medicine/mannitol)
+	roundstart_chems = list(
+		/datum/reagent/medicine/epinephrine,
+		/datum/reagent/medicine/salbutamol,
+		/datum/reagent/medicine/bicaridine,
+		/datum/reagent/medicine/kelotane,
+		/datum/reagent/medicine/oculine,
+		/datum/reagent/medicine/inacusiate,
+		/datum/reagent/medicine/mannitol)
 	roundstart_chem_default_size = 200
 	synthesizing = TRUE
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -21,7 +21,7 @@
 	var/max_vials = 6
 	var/list/inserted_vials = list()
 	var/list/roundstart_vials = list(
-		/obj/item/reagent_containers/chem_bag/epinephrine
+		// example: /obj/item/reagent_containers/chem_bag/epinephrine
 	)
 	var/list/roundstart_chems = list(
 		/datum/reagent/medicine/epinephrine,

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -176,6 +176,7 @@
 /obj/machinery/sleeper/survival_pod
 	icon = 'icons/obj/lavaland/survival_pod.dmi'
 	icon_state = "sleeper"
+	roundstart_vials = list()
 
 /obj/machinery/sleeper/survival_pod/update_icon()
 	if(state_open)

--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -25,5 +25,5 @@
 
 /obj/item/reagent_containers/chem_bag/epinephrine
 	name = "epinephrine chemical bag"
-	label_name = "epinephrine"
+	label_name = "bag of epinephrine"
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 200)

--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -23,7 +23,7 @@
 		else
 			. += "<span class='notice'>It seems [round(reagents.total_volume/volume*100)]% filled.</span>"
 
-/obj/item/reagent_containers/chem_bag/epinephrine
-	name = "epinephrine chemical bag"
-	label_name = "bag of epinephrine"
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 200)
+/obj/item/reagent_containers/chem_bag/morphine
+	name = "morphine chemical bag"
+	label_name = "morphine"
+	list_reagents = list(/datum/reagent/medicine/morphine = 120)

--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -23,7 +23,14 @@
 		else
 			. += "<span class='notice'>It seems [round(reagents.total_volume/volume*100)]% filled.</span>"
 
-/obj/item/reagent_containers/chem_bag/morphine
-	name = "morphine chemical bag"
-	label_name = "morphine"
-	list_reagents = list(/datum/reagent/medicine/morphine = 120)
+// this is specifically made as an example for a sleeper feature that uses a chem bag at roundstart.
+/obj/item/reagent_containers/chem_bag/oxy_mix
+	name = "Quadra-oxymix Medicines Bag"
+	desc = "a small note on it says: Perfluorodecalin 70u, Dexalin 10u, Dexalin Plus 10u, Salbutamol 10u."
+	label_name = "Quadra-oxymix Medicines"
+	list_reagents = list(
+		/datum/reagent/medicine/perfluorodecalin = 70,
+		/datum/reagent/medicine/dexalin = 10,
+		/datum/reagent/medicine/dexalinp = 10,
+		/datum/reagent/medicine/salbutamol = 10
+		) // you are welcome to change the chem contents here

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -10,6 +10,7 @@ export const Sleeper = (props, context) => {
     open,
     occupant = {},
     occupied,
+    chems = {},
   } = data;
 
   const damageTypes = [
@@ -108,7 +109,7 @@ export const Sleeper = (props, context) => {
               onClick={() => act('door')} />
           )}>
           <Table>
-            {data.chems.map(chem => (
+            {chems.map(chem => (
               <Table.Row
                 key={chem.id} >
                 <Table.Cell>

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -12,19 +12,6 @@ export const Sleeper = (props, context) => {
     occupied,
   } = data;
 
-  const preSortChems = data.chems || [];
-  const chems = preSortChems.sort((a, b) => {
-    const descA = a.name.toLowerCase();
-    const descB = b.name.toLowerCase();
-    if (descA < descB) {
-      return -1;
-    }
-    if (descA > descB) {
-      return 1;
-    }
-    return 0;
-  });
-
   const damageTypes = [
     {
       label: 'Brute',
@@ -121,7 +108,7 @@ export const Sleeper = (props, context) => {
               onClick={() => act('door')} />
           )}>
           <Table>
-            {chems.map(chem => (
+            {data.chems.map(chem => (
               <Table.Row
                 key={chem.id} >
                 <Table.Cell>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks sleeper
* Accepts chemical bag
* Minor code improvement

also, I put a chem bag to roundstart vial so that you can easily recognise how to use it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
these were supposed to go with the sleeper PR. there aren't much balance aspect here.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/226136724-7f0ed767-505d-4087-a555-db7df526d3b3.png)

pre-defined chem bag at first
roundstart chems after it. anti-toxin is ignored since it reached max vial size (6)
also, sorting order is now inserted chem's order, not alphabetical order


![image](https://user-images.githubusercontent.com/87972842/226136846-e5111b3e-aaf3-4b0a-b247-75dc4d1a6a82.png)

chem bag details (the later one has name. it's fixed)


![image](https://user-images.githubusercontent.com/87972842/226136890-8bdcc208-3288-4a64-9f27-59f779497cca.png)

when re-inserted those above.



![image](https://user-images.githubusercontent.com/87972842/226405810-89de0f69-586e-48c6-b479-9637f8a63cc5.png)

sample chem bag

</details>

## Changelog
:cl:
code: touched sleeper code slightly better
tweak: sleeper accepts chemical bag
tweak: sleeper now roundstarts with chem bag(max 200u) instead of 30u bottle. chem units are different per chem and per sleeper type.
add: Quadra-oxymix medicine bag as a code example of the sleeper feature. It holds 70u perfluo, and each 10u of dexalin, dex plus, salbutamol, in total 100u. It's in roundstart sleepers.
tweak: sleeper vials are now sorted by inserted order, not alphabetical order
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
