### PR TITLE
Add PTech vendor to Kilo

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6861,7 +6861,7 @@
 	icon_state = "1-8"
 	},
 /mob/living/simple_animal/chicken/turkey{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=0,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A veteran of Nanotrasen's Animal Experimentation Program that attempted to replicate the organic space suit that some hostile entities are known to have exhibited, Tom now serves Nanotrasen as the mascot of the Exploration Crew.";
 	health = 200;
 	maxHealth = 200;
@@ -10835,6 +10835,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "asq" = (
@@ -12448,13 +12451,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "auY" = (
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
-	name = "command camera"
-	},
+/obj/machinery/vending/job_disk,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "auZ" = (
@@ -13033,6 +13030,10 @@
 /obj/machinery/pdapainter,
 /obj/structure/sign/poster/official/ian{
 	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Head of Personnel's Office";
+	name = "command camera"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -30721,7 +30722,7 @@
 "aXN" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -92374,7 +92375,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/beer{
 	desc = "A station exclusive. Consumption may result in seizures, blindness, drunkenness, or even death.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko=30);
 	name = "Kilo-Kocktail";
 	pixel_x = 5;
 	pixel_y = 5


### PR DESCRIPTION
## About The Pull Request

Adds a PTech vendor to the KiloStation HoP office. There is no other ptech on the map.

## Why It's Good For The Game

The PTech vendor is important for changing job disks on PDA reassignments.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/226195646-8a83383f-9e82-4c06-8983-5b9702ec7afd.png)

</details>

## Changelog
:cl:
add: KiloStation: Added a PTech vendor to the HoP office.
/:cl: