### PR TITLE
Quirks are now handled by the mind (and other quirk code changes)

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -36,7 +36,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		quirks[initial(T.name)] = T
 		quirk_points[initial(T.name)] = initial(T.value)
 
-/datum/controller/subsystem/processing/quirks/proc/AssignQuirks(mob/living/user, client/cli, spawn_effects)
+/datum/controller/subsystem/processing/quirks/proc/AssignQuirks(datum/mind/user, client/cli, spawn_effects)
 	var/bad_quirk_checker = 0
 	var/list/bad_quirks = list()
 	for(var/V in cli.prefs.active_character.all_quirks)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -447,7 +447,7 @@ SUBSYSTEM_DEF(ticker)
 			if(player.mind.assigned_role != player.mind.special_role)
 				SSjob.EquipRank(N, player.mind.assigned_role, FALSE)
 			if(CONFIG_GET(flag/roundstart_traits) && ishuman(N.new_character))
-				SSquirks.AssignQuirks(N.new_character, N.client, TRUE)
+				SSquirks.AssignQuirks(player.mind, N.client, TRUE)
 		CHECK_TICK
 	if(length(spare_id_candidates))			//No captain, time to choose acting captain
 		if(!enforce_coc)

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -4,120 +4,135 @@
 	var/name = "Test Quirk"
 	var/desc = "This is a test quirk."
 	var/value = 0
-	var/human_only = TRUE
+	var/mob/living/restricted_type = /mob/living/carbon/human //specifies which mob subtype can use this trait
 	var/gain_text
 	var/lose_text
-	var/medical_record_text //This text will appear on medical records for the trait. Not yet implemented
+	var/medical_record_text //This text will appear on medical records for the quirk. Not yet implemented
 	var/mood_quirk = FALSE //if true, this quirk affects mood and is unavailable if moodlets are disabled
-	var/mob_trait //if applicable, apply and remove this mob trait
+	var/mob_trait //if applicable, apply and remove this mob quirk
 	var/process = FALSE // Does this quirk use on_process()?
+	var/datum/mind/quirk_holder // The mind that contains this quirk
 	var/mob/living/quirk_target // The mob that will be affected by this quirk
 
-/datum/quirk/New(mob/living/quirk_mob, spawn_effects)
+/datum/quirk/New(datum/mind/quirk_mind, mob/living/quirk_mob, spawn_effects)
 	..()
-	if(!quirk_mob || (human_only && !ishuman(quirk_mob)) || quirk_mob.has_quirk(type))
+	if(!quirk_mind)
 		qdel(src)
 		return
+	if(!quirk_mob || quirk_mob.has_quirk(type))
+		qdel(src)
+		return
+	quirk_holder = quirk_mind
 	quirk_target = quirk_mob
 	SSquirks.quirk_objects += src
 	to_chat(quirk_target, gain_text)
-	quirk_target.roundstart_quirks += src
-	if(mob_trait)
-		ADD_TRAIT(quirk_target, mob_trait, ROUNDSTART_TRAIT)
+	quirk_holder.quirks += src
 	if(process)
 		START_PROCESSING(SSquirks, src)
-	RegisterSignal(quirk_target, COMSIG_PARENT_QDELETING, PROC_REF(handle_parent_del))
+	RegisterSignal(quirk_holder, COMSIG_PARENT_QDELETING, PROC_REF(handle_holder_del))
+	RegisterSignal(quirk_target, COMSIG_PARENT_QDELETING, PROC_REF(handle_mob_del))
+	if(!istype(quirk_target, restricted_type)) //we still want the quirk saved to the mind
+		return
+
+	if(mob_trait)
+		ADD_TRAIT(quirk_target, mob_trait, ROUNDSTART_TRAIT)
 	add()
 	if(spawn_effects)
 		on_spawn()
-		addtimer(CALLBACK(src, PROC_REF(post_add)), 30)
+		addtimer(CALLBACK(src, PROC_REF(post_spawn)), 30)
 
 /datum/quirk/Destroy()
 	if(process)
 		STOP_PROCESSING(SSquirks, src)
-	if(quirk_target)
+	if(quirk_holder)
 		remove()
-		UnregisterSignal(quirk_target, COMSIG_PARENT_QDELETING)
+		UnregisterSignal(quirk_holder, COMSIG_PARENT_QDELETING)
 		if(!QDELETED(quirk_target))
+			UnregisterSignal(quirk_target, COMSIG_PARENT_QDELETING)
 			to_chat(quirk_target, lose_text)
-		quirk_target.roundstart_quirks -= src
+		quirk_holder.quirks -= src
 		if(mob_trait)
 			REMOVE_TRAIT(quirk_target, mob_trait, ROUNDSTART_TRAIT)
+		quirk_holder = null
 		quirk_target = null
 	SSquirks.quirk_objects -= src
 	return ..()
 
+/* Don't use this, use the mind's transfer_to proc instead */
 /datum/quirk/proc/transfer_mob(mob/living/to_mob)
-	quirk_target.roundstart_quirks -= src
 	UnregisterSignal(quirk_target, COMSIG_PARENT_QDELETING)
-	to_mob.roundstart_quirks += src
-	if(mob_trait)
-		REMOVE_TRAIT(quirk_target, mob_trait, ROUNDSTART_TRAIT)
-		ADD_TRAIT(to_mob, mob_trait, ROUNDSTART_TRAIT)
+	if(istype(quirk_target, restricted_type))
+		if(mob_trait)
+			REMOVE_TRAIT(quirk_target, mob_trait, ROUNDSTART_TRAIT)
+		remove()
 	quirk_target = to_mob
+	if(process)
+		START_PROCESSING(SSquirks, src)
+	RegisterSignal(quirk_target, COMSIG_PARENT_QDELETING, PROC_REF(handle_mob_del))
+	if(istype(quirk_target, restricted_type))
+		if(mob_trait)
+			ADD_TRAIT(to_mob, mob_trait, ROUNDSTART_TRAIT)
+		add()
 	on_transfer()
-	RegisterSignal(quirk_target, COMSIG_PARENT_QDELETING, PROC_REF(handle_parent_del))
 
+// laid out in chronological order
 /datum/quirk/proc/add() //special "on add" effects
 /datum/quirk/proc/on_spawn() //these should only trigger when the character is being created for the first time, i.e. roundstart/latejoin
-/datum/quirk/proc/remove() //special "on remove" effects
+/datum/quirk/proc/post_spawn() //for text, disclaimers etc. given after you spawn in with the quirk
 /datum/quirk/proc/on_process() //process() has some special checks, so this is the actual process
-/datum/quirk/proc/post_add() //for text, disclaimers etc. given after you spawn in with the trait
-/datum/quirk/proc/on_transfer() //code called when the trait is transferred to a new mob
+/datum/quirk/proc/on_transfer() //code called right before the quirk is transferred to a new mob
+/datum/quirk/proc/remove() //special "on remove" effects
 
-/datum/quirk/proc/clone_data() //return additional data that should be remembered by cloning
-/datum/quirk/proc/on_clone(data) //create the quirk from clone data
-
-/datum/quirk/proc/handle_parent_del()
+/datum/quirk/proc/handle_holder_del()
 	SIGNAL_HANDLER
 	qdel(src)
+
+/datum/quirk/proc/handle_mob_del()
+	SIGNAL_HANDLER
+	UnregisterSignal(quirk_target, COMSIG_PARENT_QDELETING)
+	STOP_PROCESSING(SSquirks, src)
+	quirk_target = null
 
 /datum/quirk/process(delta_time)
 	if(quirk_target.stat == DEAD)
 		return
+	if(!istype(quirk_target, restricted_type))
+		return
 	on_process(delta_time)
 
-/mob/living/proc/get_trait_string(medical) //helper string. gets a string of all the traits the mob has
+/datum/mind/proc/get_quirk_string(medical) //helper string. gets a string of all the quirks the mind has
 	var/list/dat = list()
 	if(!medical)
-		for(var/datum/quirk/T as() in roundstart_quirks)
+		for(var/datum/quirk/T in quirks)
 			dat += T.name
 		if(!length(dat))
 			return "None"
 		return dat.Join(", ")
 	else
-		for(var/datum/quirk/T as() in roundstart_quirks)
+		for(var/datum/quirk/T in quirks)
 			dat += T.medical_record_text
 		if(!length(dat))
 			return "None"
 		return dat.Join("<br>")
 
-/mob/living/proc/cleanse_trait_datums() //removes all trait datums
-	for(var/datum/quirk/T as() in roundstart_quirks)
-		qdel(T)
-
-/mob/living/proc/transfer_trait_datums(mob/living/to_mob)
-	for(var/datum/quirk/T as() in roundstart_quirks)
-		T.transfer_mob(to_mob)
-
 /*
 
-Commented version of Nearsighted to help you add your own traits
+Commented version of Nearsighted to help you add your own quirks
 Use this as a guideline
 
 /datum/quirk/nearsighted
 	name = "Nearsighted"
-	///The trait's name
+	///The quirk's name
 
 	desc = "You are nearsighted without prescription glasses, but spawn with a pair."
-	///Short description, shows next to name in the trait panel
+	///Short description, shows next to name in the quirk panel
 
 	value = -1
-	///If this is above 0, it's a positive trait; if it's not, it's a negative one; if it's 0, it's a neutral
+	///If this is above 0, it's a positive quirk; if it's not, it's a negative one; if it's 0, it's a neutral
 
 	mob_trait = TRAIT_NEARSIGHT
 	///This define is in __DEFINES/traits.dm and is the actual "trait" that the game tracks
-	///You'll need to use "HAS_TRAIT_FROM(src, X, sources)" checks around the code to check this; for instance, the Ageusia trait is checked in taste code
+	///You'll need to use "HAS_TRAIT_FROM(src, X, sources)" checks around the code to check this; for instance, the Ageusia quirk is checked in taste code
 	///If you need help finding where to put it, the declaration finder on GitHub is the best way to locate it
 
 	gain_text = "<span class='danger'>Things far away from you start looking blurry.</span>"

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -10,11 +10,11 @@
 	process = TRUE
 
 /datum/quirk/badback/on_process()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(H.back && istype(H.back, /obj/item/storage/backpack))
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "back_pain", /datum/mood_event/back_pain)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "back_pain", /datum/mood_event/back_pain)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "back_pain")
+		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "back_pain")
 
 /datum/quirk/blooddeficiency
 	name = "Blood Deficiency"
@@ -26,7 +26,7 @@
 	process = TRUE
 
 /datum/quirk/blooddeficiency/on_process(delta_time)
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
 	else if(H.blood_volume > (BLOOD_VOLUME_SAFE - 25)) // just barely survivable without treatment
@@ -41,10 +41,10 @@
 	medical_record_text = "Subject has permanent blindness."
 
 /datum/quirk/blindness/add()
-	quirk_holder.become_blind(ROUNDSTART_TRAIT)
+	quirk_target.become_blind(ROUNDSTART_TRAIT)
 
 /datum/quirk/blindness/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/clothing/glasses/blindfold/white/B = new(get_turf(H))
 	if(!H.equip_to_slot_if_possible(B, ITEM_SLOT_EYES, bypass_equip_delay_self = TRUE)) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes
 		H.put_in_hands(B)
@@ -63,22 +63,22 @@
 	var/notified = FALSE
 
 /datum/quirk/brainproblems/on_process(delta_time)
-	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol))
+	if(!quirk_target.reagents.has_reagent(/datum/reagent/medicine/mannitol))
 		if(prob(80))
-			quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
-	var/obj/item/organ/brain/B = quirk_holder.getorgan(/obj/item/organ/brain)
+			quirk_target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
+	var/obj/item/organ/brain/B = quirk_target.getorgan(/obj/item/organ/brain)
 	if(B)
 		if(B.damage>BRAIN_DAMAGE_MILD-1 && !notified)
-			to_chat(quirk_holder, "<span class='danger'>You sense your brain is getting beyond your control...</span>")
+			to_chat(quirk_target, "<span class='danger'>You sense your brain is getting beyond your control...</span>")
 			notified = TRUE
 		if(B.damage<1 && notified)
-			to_chat(quirk_holder, "<span class='notice'>You feel your brain is quite well.</span>")
+			to_chat(quirk_target, "<span class='notice'>You feel your brain is quite well.</span>")
 			notified = FALSE
 
 
 
 /datum/quirk/brainproblems/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/storage/pill_bottle/mannitol/braintumor/P = new(get_turf(H))
 
 	var/list/slots = list(
@@ -90,9 +90,9 @@
 
 /datum/quirk/brainproblems/post_add()
 	if(where)
-		to_chat(quirk_holder, "<span class='boldnotice'>There is a bottle of mannitol [where]. You're going to need it.</span>")
+		to_chat(quirk_target, "<span class='boldnotice'>There is a bottle of mannitol [where]. You're going to need it.</span>")
 	else
-		to_chat(quirk_holder, "<span class='boldnotice'>You dropped your bottle of mannitol on the floor. Better pick it up, you are going to need it.</span>")
+		to_chat(quirk_target, "<span class='boldnotice'>You dropped your bottle of mannitol on the floor. Better pick it up, you are going to need it.</span>")
 
 /datum/quirk/deafness
 	name = "Deaf"
@@ -116,7 +116,7 @@
 
 /datum/quirk/depression/on_process(delta_time)
 	if(DT_PROB(0.05, delta_time))
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "depression", /datum/mood_event/depression)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "depression", /datum/mood_event/depression)
 
 /datum/quirk/family_heirloom
 	name = "Family Heirloom"
@@ -128,13 +128,13 @@
 	var/where
 
 /datum/quirk/family_heirloom/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/heirloom_type
 
 	if(is_species(H, /datum/species/moth) && prob(50))
 		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
 	else
-		switch(quirk_holder.mind.assigned_role)
+		switch(quirk_target.mind.assigned_role)
 			//Service jobs
 			if(JOB_NAME_CLOWN)
 				heirloom_type = /obj/item/bikehorn/golden
@@ -213,7 +213,7 @@
 		/obj/item/toy/cards/deck,
 		/obj/item/lighter,
 		/obj/item/dice/d20)
-	heirloom = new heirloom_type(get_turf(quirk_holder))
+	heirloom = new heirloom_type(get_turf(quirk_target))
 	var/list/slots = list(
 		"in your left pocket" = ITEM_SLOT_LPOCKET,
 		"in your right pocket" = ITEM_SLOT_RPOCKET,
@@ -223,26 +223,26 @@
 
 /datum/quirk/family_heirloom/post_add()
 	if(where == "in your backpack")
-		var/mob/living/carbon/human/H = quirk_holder
+		var/mob/living/carbon/human/H = quirk_target
 		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
 
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
+	to_chat(quirk_target, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
 
-	var/list/names = splittext(quirk_holder.real_name, " ")
+	var/list/names = splittext(quirk_target.real_name, " ")
 	var/family_name = names[names.len]
 
-	heirloom.AddComponent(/datum/component/heirloom, quirk_holder.mind, family_name)
+	heirloom.AddComponent(/datum/component/heirloom, quirk_target.mind, family_name)
 	if(istype(heirloom, /obj/item/reagent_containers/glass/chem_heirloom)) //Edge case for chem_heirloom. Solution to component not being present on init.
 		var/obj/item/reagent_containers/glass/chem_heirloom/H = heirloom
 		H.update_name()
 
 /datum/quirk/family_heirloom/on_process()
-	if(heirloom in quirk_holder.GetAllContents())
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)
+	if(heirloom in quirk_target.GetAllContents())
+		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom")
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom_missing", /datum/mood_event/family_heirloom_missing)
+		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom")
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "family_heirloom_missing", /datum/mood_event/family_heirloom_missing)
 
 /datum/quirk/family_heirloom/clone_data()
 	return heirloom
@@ -268,13 +268,13 @@
 	medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
 
 /datum/quirk/foreigner/add()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(ishuman(H) && H.job != JOB_NAME_CURATOR)
 		H.add_blocked_language(/datum/language/common)
 		H.grant_language(/datum/language/uncommon)
 
 /datum/quirk/foreigner/remove()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(ishuman(H) && H.job != JOB_NAME_CURATOR)
 		H.remove_blocked_language(/datum/language/common)
 		H.remove_language(/datum/language/uncommon)
@@ -296,12 +296,12 @@
 	lose_text = "<span class='notice'>You don't seem to make a big deal out of everything anymore.</span>"
 
 /datum/quirk/hypersensitive/add()
-	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
 	if(mood)
 		mood.mood_modifier += 0.5
 
 /datum/quirk/hypersensitive/remove()
-	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
 	if(mood)
 		mood.mood_modifier -= 0.5
 
@@ -322,10 +322,10 @@
 	medical_record_text = "Patient requires prescription glasses in order to counteract nearsightedness."
 
 /datum/quirk/nearsighted/add()
-	quirk_holder.become_nearsighted(ROUNDSTART_TRAIT)
+	quirk_target.become_nearsighted(ROUNDSTART_TRAIT)
 
 /datum/quirk/nearsighted/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/clothing/glasses/regular/glasses = new(get_turf(H))
 	H.put_in_hands(glasses)
 	H.equip_to_slot(glasses, ITEM_SLOT_EYES)
@@ -338,17 +338,17 @@
 	process = TRUE
 
 /datum/quirk/nyctophobia/on_process()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(H.dna.species.id in list("shadow", "nightmare"))
 		return //we're tied with the dark, so we don't get scared of it; don't cleanse outright to avoid cheese
-	var/turf/T = get_turf(quirk_holder)
+	var/turf/T = get_turf(quirk_target)
 	if(T.get_lumcount() <= 0.2)
-		if(quirk_holder.m_intent == MOVE_INTENT_RUN)
-			to_chat(quirk_holder, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
-			quirk_holder.toggle_move_intent()
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "nyctophobia", /datum/mood_event/nyctophobia)
+		if(quirk_target.m_intent == MOVE_INTENT_RUN)
+			to_chat(quirk_target, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
+			quirk_target.toggle_move_intent()
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "nyctophobia", /datum/mood_event/nyctophobia)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
+		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
 
 /datum/quirk/nonviolent
 	name = "Pacifist"
@@ -370,28 +370,28 @@
 
 /datum/quirk/paraplegic/add()
 	var/datum/brain_trauma/severe/paralysis/paraplegic/T = new()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/paraplegic/on_spawn()
-	if(quirk_holder.buckled) // Handle late joins being buckled to arrival shuttle chairs.
-		quirk_holder.buckled.unbuckle_mob(quirk_holder)
+	if(quirk_target.buckled) // Handle late joins being buckled to arrival shuttle chairs.
+		quirk_target.buckled.unbuckle_mob(quirk_target)
 
-	var/turf/T = get_turf(quirk_holder)
+	var/turf/T = get_turf(quirk_target)
 	var/obj/structure/chair/spawn_chair = locate() in T
 
 	var/obj/vehicle/ridden/wheelchair/wheels = new(T)
 	if(spawn_chair) // Makes spawning on the arrivals shuttle more consistent looking
 		wheels.setDir(spawn_chair.dir)
 
-	wheels.buckle_mob(quirk_holder)
+	wheels.buckle_mob(quirk_target)
 
 	// During the spawning process, they may have dropped what they were holding, due to the paralysis
 	// So put the things back in their hands.
 
 	for(var/obj/item/I in T)
-		if(I.fingerprintslast == quirk_holder.ckey)
-			quirk_holder.put_in_hands(I)
+		if(I.fingerprintslast == quirk_target.ckey)
+			quirk_target.put_in_hands(I)
 
 /datum/quirk/poor_aim
 	name = "Poor Aim"
@@ -415,28 +415,28 @@
 
 /datum/quirk/prosthetic_limb/on_spawn()
 	var/limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/bodypart/old_part = H.get_bodypart(limb_slot)
 	var/obj/item/bodypart/prosthetic
 	switch(limb_slot)
 		if(BODY_ZONE_L_ARM)
-			prosthetic = new/obj/item/bodypart/l_arm/robot/surplus(quirk_holder)
+			prosthetic = new/obj/item/bodypart/l_arm/robot/surplus(quirk_target)
 			slot_string = "left arm"
 		if(BODY_ZONE_R_ARM)
-			prosthetic = new/obj/item/bodypart/r_arm/robot/surplus(quirk_holder)
+			prosthetic = new/obj/item/bodypart/r_arm/robot/surplus(quirk_target)
 			slot_string = "right arm"
 		if(BODY_ZONE_L_LEG)
-			prosthetic = new/obj/item/bodypart/l_leg/robot/surplus(quirk_holder)
+			prosthetic = new/obj/item/bodypart/l_leg/robot/surplus(quirk_target)
 			slot_string = "left leg"
 		if(BODY_ZONE_R_LEG)
-			prosthetic = new/obj/item/bodypart/r_leg/robot/surplus(quirk_holder)
+			prosthetic = new/obj/item/bodypart/r_leg/robot/surplus(quirk_target)
 			slot_string = "right leg"
 	prosthetic.replace_limb(H)
 	qdel(old_part)
 	H.regenerate_icons()
 
 /datum/quirk/prosthetic_limb/post_add()
-	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] has been replaced with a surplus prosthetic. It is fragile and will easily come apart under duress. Additionally, \
+	to_chat(quirk_target, "<span class='boldannounce'>Your [slot_string] has been replaced with a surplus prosthetic. It is fragile and will easily come apart under duress. Additionally, \
 	you need to use a welding tool and cables to repair it, instead of bruise packs and ointment.</span>")
 
 /datum/quirk/pushover
@@ -459,19 +459,19 @@
 	process = TRUE
 
 /datum/quirk/insanity/on_process(delta_time)
-	if(quirk_holder.reagents.has_reagent(/datum/reagent/toxin/mindbreaker, needs_metabolizing = TRUE))
-		quirk_holder.hallucination = 0
+	if(quirk_target.reagents.has_reagent(/datum/reagent/toxin/mindbreaker, needs_metabolizing = TRUE))
+		quirk_target.hallucination = 0
 		return
 	if(DT_PROB(2, delta_time)) //we'll all be mad soon enough
 		madness()
 
 /datum/quirk/insanity/proc/madness()
-	quirk_holder.hallucination += rand(10, 25)
+	quirk_target.hallucination += rand(10, 25)
 
 /datum/quirk/insanity/post_add() //I don't /think/ we'll need this but for newbies who think "roleplay as insane" = "license to kill" it's probably a good thing to have
-	if(!quirk_holder.mind || quirk_holder.mind.special_role)
+	if(!quirk_target.mind || quirk_target.mind.special_role)
 		return
-	to_chat(quirk_holder, "<span class='big bold info'>Please note that your dissociation syndrome does NOT give you the right to attack people or otherwise cause any interference to \
+	to_chat(quirk_target, "<span class='big bold info'>Please note that your dissociation syndrome does NOT give you the right to attack people or otherwise cause any interference to \
 	the round. You are not an antagonist, and the rules will treat you the same as other crewmembers.</span>")
 
 /datum/quirk/social_anxiety
@@ -486,21 +486,21 @@
 
 /datum/quirk/social_anxiety/on_process(delta_time)
 	var/nearby_people = 0
-	for(var/mob/living/carbon/human/stranger in oview(3, quirk_holder))
+	for(var/mob/living/carbon/human/stranger in oview(3, quirk_target))
 		if(stranger.client)
 			nearby_people++
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(DT_PROB(2 + nearby_people, delta_time))
 		H.stuttering = max(3, H.stuttering)
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety", /datum/mood_event/anxiety)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "anxiety", /datum/mood_event/anxiety)
 	else if(DT_PROB(min(3, nearby_people), delta_time) && !H.silent)
 		to_chat(H, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
 		H.silent = max(10, H.silent)
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety_mute", /datum/mood_event/anxiety_mute)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "anxiety_mute", /datum/mood_event/anxiety_mute)
 	else if(DT_PROB(0.5, delta_time) && dumb_thing)
 		to_chat(H, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
 		dumb_thing = FALSE //only once per life
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety_dumb", /datum/mood_event/anxiety_dumb)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "anxiety_dumb", /datum/mood_event/anxiety_dumb)
 		if(prob(1))
 			new/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato(get_turf(H)) //now that's what I call spaghetti code
 
@@ -524,12 +524,12 @@
 	var/next_process = 0 //! ticker for processing
 
 /datum/quirk/junkie/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if (!reagent_type)
 		reagent_type = pick(drug_list)
 	reagent_instance = new reagent_type()
 	H.reagents.addiction_list.Add(reagent_instance)
-	var/current_turf = get_turf(quirk_holder)
+	var/current_turf = get_turf(quirk_target)
 	if (!drug_container_type)
 		drug_container_type = /obj/item/storage/pill_bottle
 	var/obj/item/drug_instance = new drug_container_type(current_turf)
@@ -555,14 +555,14 @@
 
 /datum/quirk/junkie/post_add()
 	if(where_drug == "in your backpack" || where_accessory == "in your backpack")
-		var/mob/living/carbon/human/H = quirk_holder
+		var/mob/living/carbon/human/H = quirk_target
 		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
 
 /datum/quirk/junkie/proc/announce_drugs()
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a [initial(drug_container_type.name)] of [initial(reagent_type.name)] [where_drug]. Better hope you don't run out...</span>")
+	to_chat(quirk_target, "<span class='boldnotice'>There is a [initial(drug_container_type.name)] of [initial(reagent_type.name)] [where_drug]. Better hope you don't run out...</span>")
 
 /datum/quirk/junkie/on_process()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(world.time > next_process)
 		next_process = world.time + process_interval
 		if(!H.reagents.addiction_list.Find(reagent_instance))
@@ -571,7 +571,7 @@
 			else
 				reagent_instance.addiction_stage = 0
 			H.reagents.addiction_list += reagent_instance
-			to_chat(quirk_holder, "<span class='danger'>You thought you kicked it, but you suddenly feel like you need [reagent_instance.name] again...</span>")
+			to_chat(quirk_target, "<span class='danger'>You thought you kicked it, but you suddenly feel like you need [reagent_instance.name] again...</span>")
 
 /datum/quirk/junkie/smoker
 	name = "Smoker"
@@ -594,19 +594,19 @@
 	. = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a [initial(drug_container_type.name)] [where_drug], and a lighter [where_accessory]. Make sure you get your favorite brand when you run out.</span>")
+	to_chat(quirk_target, "<span class='boldnotice'>There is a [initial(drug_container_type.name)] [where_drug], and a lighter [where_accessory]. Make sure you get your favorite brand when you run out.</span>")
 
 
 /datum/quirk/junkie/smoker/on_process()
 	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/I = H.get_item_by_slot(ITEM_SLOT_MASK)
 	if (istype(I, /obj/item/clothing/mask/cigarette))
 		var/obj/item/storage/fancy/cigarettes/C = drug_container_type
 		if(istype(I, initial(C.spawn_type)))
-			SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "wrong_cigs")
+			SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "wrong_cigs")
 			return
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
 
 /datum/quirk/alcoholic
 	name = "Alcoholic"
@@ -632,16 +632,16 @@
 	drink_instance = pick(drink_types)
 	drink_instance = new drink_instance()
 	var/list/slots = list("in your backpack" = ITEM_SLOT_BACKPACK)
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	where_drink = H.equip_in_one_of_slots(drink_instance, slots, FALSE) || "at your feet"
 
 /datum/quirk/alcoholic/post_add()
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a small bottle of [drink_instance] [where_drink]. You only have a single bottle, might have to find some more...</span>")
+	to_chat(quirk_target, "<span class='boldnotice'>There is a small bottle of [drink_instance] [where_drink]. You only have a single bottle, might have to find some more...</span>")
 
 /datum/quirk/alcoholic/on_process()
 	if(tick_number >= 6) // how many ticks should pass between a check
 		tick_number = 0
-		var/mob/living/carbon/human/H = quirk_holder
+		var/mob/living/carbon/human/H = quirk_target
 		if(H.drunkenness > 0) // If they're not drunk, need goes up. else they're satisfied
 			need = -15
 		else
@@ -687,9 +687,9 @@
 
 /datum/quirk/phobia/add()
 	var/datum/brain_trauma/mild/phobia/T = new()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
 
 /datum/quirk/phobia/remove()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	H.cure_trauma_type(/datum/brain_trauma/mild/phobia, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/code/datums/traits/neutral_quirk.dm
+++ b/code/datums/traits/neutral_quirk.dm
@@ -18,13 +18,13 @@
 	lose_text = "<span class='notice'>You feel like eating meat isn't that bad.</span>"
 
 /datum/quirk/vegetarian/add()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	T?.liked_food &= ~MEAT
 	T?.disliked_food |= MEAT
 
 /datum/quirk/vegetarian/remove()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	if(H)
 		if(initial(T.liked_food) & MEAT)
@@ -40,12 +40,12 @@
 	lose_text = "<span class='notice'>Your feelings towards pineapples seem to return to a lukewarm state.</span>"
 
 /datum/quirk/pineapple_liker/add()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	T?.liked_food |= PINEAPPLE
 
 /datum/quirk/pineapple_liker/remove()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	T?.liked_food &= ~PINEAPPLE
 
@@ -57,12 +57,12 @@
 	lose_text = "<span class='notice'>Your feelings towards pineapples seem to return to a lukewarm state.</span>"
 
 /datum/quirk/pineapple_hater/add()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	T?.disliked_food |= PINEAPPLE
 
 /datum/quirk/pineapple_hater/remove()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	T?.disliked_food &= ~PINEAPPLE
 
@@ -74,14 +74,14 @@
 	lose_text = "<span class='notice'>You feel like eating normal food again.</span>"
 
 /datum/quirk/deviant_tastes/add()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	var/liked = T?.liked_food
 	T?.liked_food = T?.disliked_food
 	T?.disliked_food = liked
 
 /datum/quirk/deviant_tastes/remove()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	T?.liked_food = initial(T?.liked_food)
 	T?.disliked_food = initial(T?.disliked_food)
@@ -93,15 +93,15 @@
 	medical_record_text = "Patient is afflicted with almost complete color blindness."
 
 /datum/quirk/monochromatic/add()
-	quirk_holder.add_client_colour(/datum/client_colour/monochrome)
+	quirk_target.add_client_colour(/datum/client_colour/monochrome)
 
 /datum/quirk/monochromatic/post_add()
-	if(quirk_holder.mind.assigned_role == JOB_NAME_DETECTIVE)
-		to_chat(quirk_holder, "<span class='boldannounce'>Mmm. Nothing's ever clear on this station. It's all shades of gray.</span>")
-		quirk_holder.playsound_local(quirk_holder, 'sound/ambience/ambidet1.ogg', 50, FALSE)
+	if(quirk_target.mind.assigned_role == JOB_NAME_DETECTIVE)
+		to_chat(quirk_target, "<span class='boldannounce'>Mmm. Nothing's ever clear on this station. It's all shades of gray.</span>")
+		quirk_target.playsound_local(quirk_target, 'sound/ambience/ambidet1.ogg', 50, FALSE)
 
 /datum/quirk/monochromatic/remove()
-	quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
+	quirk_target.remove_client_colour(/datum/client_colour/monochrome)
 
 /datum/quirk/mute
 	name = "Mute"

--- a/code/datums/traits/neutral_quirk.dm
+++ b/code/datums/traits/neutral_quirk.dm
@@ -95,8 +95,8 @@
 /datum/quirk/monochromatic/add()
 	quirk_target.add_client_colour(/datum/client_colour/monochrome)
 
-/datum/quirk/monochromatic/post_add()
-	if(quirk_target.mind.assigned_role == JOB_NAME_DETECTIVE)
+/datum/quirk/monochromatic/post_spawn()
+	if(quirk_holder.assigned_role == JOB_NAME_DETECTIVE)
 		to_chat(quirk_target, "<span class='boldannounce'>Mmm. Nothing's ever clear on this station. It's all shades of gray.</span>")
 		quirk_target.playsound_local(quirk_target, 'sound/ambience/ambidet1.ogg', 50, FALSE)
 

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -16,12 +16,12 @@
 	mood_quirk = TRUE
 
 /datum/quirk/apathetic/add()
-	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
 	if(mood)
 		mood.mood_modifier -= 0.2
 
 /datum/quirk/apathetic/remove()
-	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
 	if(mood)
 		mood.mood_modifier += 0.2
 
@@ -69,7 +69,7 @@
 
 /datum/quirk/jolly/on_process(delta_time)
 	if(DT_PROB(0.05, delta_time))
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "jolly", /datum/mood_event/jolly)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "jolly", /datum/mood_event/jolly)
 
 /datum/quirk/light_step
 	name = "Light Step"
@@ -88,7 +88,7 @@
 	lose_text = "<span class='danger'>You forget how musical instruments work.</span>"
 
 /datum/quirk/musician/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/choice_beacon/music/B = new(get_turf(H))
 	var/list/slots = list (
 		"backpack" = ITEM_SLOT_BACKPACK,
@@ -113,7 +113,7 @@
 	lose_text = "<span class='danger'>You have forgotten how to understand a language.</span>"
 
 /datum/quirk/multilingual/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	if(H.job == JOB_NAME_CURATOR)
 		return
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
@@ -136,7 +136,7 @@
 	lose_text = "<span class='danger'>Everything seems a little darker.</span>"
 
 /datum/quirk/night_vision/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/organ/eyes/eyes = H.getorgan(/obj/item/organ/eyes)
 	if(!eyes || eyes.lighting_alpha)
 		return
@@ -151,7 +151,7 @@
 	lose_text = "<span class='danger'>You forget how photo cameras work.</span>"
 
 /datum/quirk/photographer/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/camera/spooky/camera = new(get_turf(H))
 	var/list/camera_slots = list (
 		"neck" = ITEM_SLOT_NECK,
@@ -185,20 +185,20 @@
 	process = TRUE
 
 /datum/quirk/spiritual/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	H.equip_to_slot_or_del(new /obj/item/storage/fancy/candle_box(H), ITEM_SLOT_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/matches(H), ITEM_SLOT_BACKPACK)
 
 /datum/quirk/spiritual/on_process()
 	var/comforted = FALSE
-	for(var/mob/living/carbon/human/H in oview(5, quirk_holder))
+	for(var/mob/living/carbon/human/H in oview(5, quirk_target))
 		if(H.mind?.holy_role && H.stat == CONSCIOUS)
 			comforted = TRUE
 			break
 	if(comforted)
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "religious_comfort", /datum/mood_event/religiously_comforted)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "religious_comfort", /datum/mood_event/religiously_comforted)
 	else
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "religious_comfort")
+		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "religious_comfort")
 
 /datum/quirk/tagger
 	name = "Tagger"
@@ -209,7 +209,7 @@
 	lose_text = "<span class='danger'>You forget how to tag walls properly.</span>"
 
 /datum/quirk/tagger/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/toy/crayon/spraycan/spraycan = new(get_turf(H))
 	H.put_in_hands(spraycan)
 	H.equip_to_slot(spraycan, ITEM_SLOT_BACKPACK)
@@ -234,7 +234,7 @@
 	process = TRUE
 
 /datum/quirk/neet/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_target
 	var/datum/bank_account/D = H.get_bank_account()
 	if(!D) //if their current mob doesn't have a bank account, likely due to them being a special role (ie nuke op)
 		return

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -114,29 +114,30 @@
 	var/datum/language/known_language
 
 /datum/quirk/multilingual/proc/set_up_language()
-	var/mob/living/carbon/human/H = quirk_target
+	var/datum/language_holder/LH = quirk_holder.get_language_holder()
 	if(quirk_holder.assigned_role == JOB_NAME_CURATOR)
 		return
-	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+	var/obj/item/organ/tongue/T = quirk_target.getorganslot(ORGAN_SLOT_TONGUE)
 	var/list/languages_possible = T.languages_possible
 	languages_possible = languages_possible - typecacheof(/datum/language/codespeak) - typecacheof(/datum/language/narsie) - typecacheof(/datum/language/ratvar)
-	languages_possible = languages_possible - H.language_holder.understood_languages
-	languages_possible = languages_possible - H.language_holder.spoken_languages
-	languages_possible = languages_possible - H.language_holder.blocked_languages
+	languages_possible = languages_possible - LH.understood_languages
+	languages_possible = languages_possible - LH.spoken_languages
+	languages_possible = languages_possible - LH.blocked_languages
 	if(length(languages_possible))
 		known_language = pick(languages_possible)
-		quirk_target.grant_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
 //Credit To Yowii/Yoworii/Yorii for a much more streamlined method of language library building
 
 /datum/quirk/multilingual/add()
-	if(known_language)
-		quirk_target.grant_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
-	else
+	if(!known_language)
 		set_up_language()
+	var/datum/language_holder/LH = quirk_holder.get_language_holder()
+	LH.grant_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
 
 /datum/quirk/multilingual/remove()
-	if(known_language)
-		quirk_target.remove_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
+	if(!known_language)
+		return
+	var/datum/language_holder/LH = quirk_holder.get_language_holder()
+	LH.remove_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
 
 /datum/quirk/night_vision
 	name = "Night Vision"

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -111,10 +111,11 @@
 	mob_trait = TRAIT_MULTILINGUAL
 	gain_text = "<span class='notice'>You have learned to understand an additional language.</span>"
 	lose_text = "<span class='danger'>You have forgotten how to understand a language.</span>"
+	var/datum/language/known_language
 
-/datum/quirk/multilingual/on_spawn()
+/datum/quirk/multilingual/proc/set_up_language()
 	var/mob/living/carbon/human/H = quirk_target
-	if(H.job == JOB_NAME_CURATOR)
+	if(quirk_holder.assigned_role == JOB_NAME_CURATOR)
 		return
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	var/list/languages_possible = T.languages_possible
@@ -123,9 +124,19 @@
 	languages_possible = languages_possible - H.language_holder.spoken_languages
 	languages_possible = languages_possible - H.language_holder.blocked_languages
 	if(length(languages_possible))
-		var/datum/language/random_language = pick(languages_possible)
-		H.grant_language(random_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
+		known_language = pick(languages_possible)
+		quirk_target.grant_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
 //Credit To Yowii/Yoworii/Yorii for a much more streamlined method of language library building
+
+/datum/quirk/multilingual/add()
+	if(known_language)
+		quirk_target.grant_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
+	else
+		set_up_language()
+
+/datum/quirk/multilingual/remove()
+	if(known_language)
+		quirk_target.remove_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
 
 /datum/quirk/night_vision
 	name = "Night Vision"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -280,10 +280,6 @@
 		H.faction |= factions
 		remove_hivemember(H)
 
-		for(var/V in quirks)
-			var/datum/quirk/Q = new V(H)
-			Q.on_clone(quirks[V])
-
 		for(var/t in traumas)
 			var/datum/brain_trauma/BT = t
 			var/datum/brain_trauma/cloned_trauma = BT.on_clone()

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -68,7 +68,7 @@
 				. = pod
 
 /proc/grow_clone_from_record(obj/machinery/clonepod/pod, datum/data/record/R, experimental)
-	return pod.growclone(R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mindref"], R.fields["last_death"], R.fields["mrace"], R.fields["features"], R.fields["factions"], R.fields["quirks"], R.fields["bank_account"], R.fields["traumas"], R.fields["body_only"], experimental)
+	return pod.growclone(R.fields["name"], R.fields["UI"], R.fields["SE"], R.fields["mindref"], R.fields["last_death"], R.fields["mrace"], R.fields["features"], R.fields["factions"], R.fields["bank_account"], R.fields["traumas"], R.fields["body_only"], experimental)
 
 /obj/machinery/computer/cloning/process()
 	if(!(scanner && LAZYLEN(pods) && autoprocess))
@@ -286,7 +286,7 @@
 			temp = "Warning: Cloning cycle already in progress."
 			playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		else
-			switch(pod.growclone(C.fields["name"], C.fields["UI"], C.fields["SE"], C.fields["mindref"], C.fields["last_death"], C.fields["mrace"], C.fields["features"], C.fields["factions"], C.fields["quirks"], C.fields["bank_account"], C.fields["traumas"], C.fields["body_only"], experimental))
+			switch(pod.growclone(C.fields["name"], C.fields["UI"], C.fields["SE"], C.fields["mindref"], C.fields["last_death"], C.fields["mrace"], C.fields["features"], C.fields["factions"], C.fields["bank_account"], C.fields["traumas"], C.fields["body_only"], experimental))
 				if(CLONING_SUCCESS)
 					temp = "Notice: [C.fields["name"]] => Cloning cycle in progress..."
 					playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
@@ -607,17 +607,7 @@
 	R.fields["blood_type"] = dna.blood_type
 	R.fields["features"] = dna.features
 	R.fields["factions"] = mob_occupant.faction
-	R.fields["quirks"] = list()
 	R.fields["traumas"] = list()
-	if(!body_only || experimental) //Body only will not copy quirks.
-		for(var/V in mob_occupant.roundstart_quirks)
-			var/datum/quirk/T = V
-			R.fields["quirks"][T.type] = T.clone_data()
-			/*
-			Quirks 'should be' personal features from a brain, not a body. but quirks actually come from a body.
-			This will not transfer your quirks if your brain is transfered to the body_only cloned body, because someone's brain in your clone is not a musician/smoker/brain-tumored or something else.
-			This is likely a bug from the structure of quirks. We need to fix the quirk code.
-			*/
 
 	if(isbrain(mob_occupant)) //We'll detect the brain first because trauma is from the brain, not from the body.
 		R.fields["traumas"] = B.get_traumas()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -186,8 +186,8 @@ GENE SCANNER
 				trauma_desc += B.scan_desc
 				trauma_text += trauma_desc
 			message += "\t<span class='alert'>Cerebral traumas detected: subject appears to be suffering from [english_list(trauma_text)].</span>"
-		if(C.roundstart_quirks.len)
-			message += "\t<span class='info'>Subject has the following physiological traits: [C.get_trait_string()].</span>"
+		if(length(C.last_mind?.quirks))
+			message += "\t<span class='info'>Subject has the following physiological traits: [C.last_mind.get_quirk_string()].</span>"
 	if(advanced)
 		message += "\t<span class='info'>Brain Activity Level: [(200 - M.getOrganLoss(ORGAN_SLOT_BRAIN))/2]%.</span>"
 

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -55,11 +55,7 @@
 	kill.set_target(obsessionmind)
 	var/datum/quirk/family_heirloom/family_heirloom
 
-	for(var/datum/quirk/quirky in obsessionmind.current.roundstart_quirks)
-		if(istype(quirky, /datum/quirk/family_heirloom))
-			family_heirloom = quirky
-			break
-	if(family_heirloom)//oh, they have an heirloom? Well you know we have to steal that.
+	if(obsessionmind.has_quirk(family_heirloom))//oh, they have an heirloom? Well you know we have to steal that.
 		objectives_left += "heirloom"
 
 	if(obsessionmind.assigned_role && obsessionmind.assigned_role != JOB_NAME_CAPTAIN)

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -25,7 +25,7 @@
 	var/mob/living/M = mob_override || owner.current
 	update_synd_icons_added(M)
 	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, NUKEOP_TRAIT)
-	M.remove_all_quirks()
+	owner.remove_all_quirks()
 
 /datum/antagonist/nukeop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	if(allow_rename)
 		rename_wizard()
-	owner.current.remove_all_quirks()
+	owner.remove_all_quirks()
 
 /datum/antagonist/wizard/proc/register()
 	SSticker.mode.wizards |= owner

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -43,7 +43,6 @@
 				blood_type = B.data["blood_type"]
 				features = B.data["features"]
 				factions = B.data["factions"]
-				quirks = B.data["quirks"]
 				sampleDNA = B.data["blood_DNA"]
 				contains_sample = TRUE
 				visible_message("<span class='notice'>The [src] is injected with a fresh blood sample.</span>")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -365,7 +365,7 @@
 						SSticker.mode.make_special_antag_chance(humanc)
 
 	if(humanc && CONFIG_GET(flag/roundstart_traits))
-		SSquirks.AssignQuirks(humanc, humanc.client, TRUE)
+		SSquirks.AssignQuirks(character.mind, humanc.client, TRUE)
 
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -195,10 +195,6 @@
 		blood_data["real_name"] = real_name
 		blood_data["features"] = dna.features
 		blood_data["factions"] = faction
-		blood_data["quirks"] = list()
-		for(var/V in roundstart_quirks)
-			var/datum/quirk/T = V
-			blood_data["quirks"] += T.type
 		return blood_data
 
 //get the id of the substance this mob use as blood.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -331,7 +331,7 @@
 	if (!isnull(trait_exam))
 		. += trait_exam
 
-	var/traitstring = get_trait_string()
+	var/traitstring = mind?.get_quirk_string()
 
 	var/perpname = get_face_name(get_id_name(""))
 	if(perpname && (HAS_TRAIT(user, TRAIT_SECURITY_HUD) || HAS_TRAIT(user, TRAIT_MEDICAL_HUD)))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -780,6 +780,8 @@
 	if(href_list[VV_HK_MOD_QUIRKS])
 		if(!check_rights(R_SPAWN))
 			return
+		if(!mind)
+			return
 
 		var/list/options = list("Clear"="Clear")
 		for(var/x in subtypesof(/datum/quirk))
@@ -790,14 +792,14 @@
 		var/result = input(usr, "Choose quirk to add/remove","Quirk Mod") as null|anything in options
 		if(result)
 			if(result == "Clear")
-				for(var/datum/quirk/q in roundstart_quirks)
-					remove_quirk(q.type)
+				for(var/datum/quirk/q in mind.quirks)
+					mind.remove_quirk(q.type)
 			else
 				var/T = options[result]
 				if(has_quirk(T))
-					remove_quirk(T)
+					mind.remove_quirk(T)
 				else
-					add_quirk(T,TRUE)
+					mind.add_quirk(T,TRUE)
 	if(href_list[VV_HK_MAKE_MONKEY])
 		if(!check_rights(R_SPAWN))
 			return

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -830,8 +830,8 @@
 			damaged_message += D
 		to_chat(src, "<span class='info'>Your [damaged_message] [damaged_plural ? "are" : "is"] hurt.</span>")
 
-	if(roundstart_quirks.len)
-		to_chat(src, "<span class='notice'>You have these quirks: [get_trait_string()].</span>")
+	if(length(mind.quirks))
+		to_chat(src, "<span class='notice'>You have these quirks: [mind.get_quirk_string()].</span>")
 
 /mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
 	if(damage_type != BRUTE && damage_type != BURN)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -261,7 +261,6 @@
 	var/datum/species/jelly/slime/spare_datum = spare.dna.species
 	spare_datum.bodies = origin_datum.bodies
 
-	H.transfer_trait_datums(spare)
 	H.mind.transfer_to(spare)
 	spare.visible_message("<span class='warning'>[H] distorts as a new body \
 		\"steps out\" of [H.p_them()].</span>",
@@ -406,7 +405,6 @@
 			"<span class='notice'>You stop moving this body...</span>")
 	else
 		to_chat(M.current, "<span class='notice'>You abandon this body...</span>")
-	M.current.transfer_trait_datums(dupe)
 	M.transfer_to(dupe)
 	dupe.visible_message("<span class='notice'>[dupe] blinks and looks \
 		around.</span>",

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -42,8 +42,6 @@
 	var/incorporeal_move = FALSE //FALSE is off, INCORPOREAL_MOVE_BASIC is normal, INCORPOREAL_MOVE_SHADOW is for ninjas
 								 //and INCORPOREAL_MOVE_JAUNT is blocked by holy water/salt
 
-	var/list/roundstart_quirks = list()
-
 	var/list/surgeries = list()	//a list of surgery datums. generally empty, they're added when the player wants them.
 
 	var/now_pushing = null //used by living/Bump() and living/PushAM() to prevent potential infinite loop.

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -386,33 +386,11 @@
 /mob/living/proc/SetStasis(apply, updating = TRUE)
 	. = apply ? apply_status_effect(STATUS_EFFECT_STASIS, null, updating) : remove_status_effect(STATUS_EFFECT_STASIS)
 
-/////////////////////////////////// DISABILITIES ////////////////////////////////////
-/mob/living/proc/add_quirk(quirktype, spawn_effects) //separate proc due to the way these ones are handled
-	if(HAS_TRAIT(src, quirktype))
-		return
-	var/datum/quirk/T = quirktype
-	var/qname = initial(T.name)
-	if(!SSquirks || !SSquirks.quirks[qname])
-		return
-	new quirktype (src, spawn_effects)
-	return TRUE
-
-/mob/living/proc/remove_quirk(quirktype)
-	for(var/datum/quirk/Q in roundstart_quirks)
-		if(Q.type == quirktype)
-			qdel(Q)
-			return TRUE
-	return FALSE
-
-/mob/living/proc/remove_all_quirks()
-	for(var/datum/quirk/Q in roundstart_quirks)
-		qdel(Q)
+/////////////////////////////////// QUIRKS ///////////////////////////////////
+/* These are here to make checking quirks more straightforward, actual functionality is in mind.dm */
 
 /mob/living/proc/has_quirk(quirktype)
-	for(var/datum/quirk/Q in roundstart_quirks)
-		if(Q.type == quirktype)
-			return TRUE
-	return FALSE
+	return src.mind?.has_quirk(quirktype)
 
 /////////////////////////////////// TRAIT PROCS ////////////////////////////////////
 


### PR DESCRIPTION
## About The Pull Request

* (!!) Quirks are now assigned and handled inside the mind
* (!!) When the mind transfers, quirks will "transfer" with it (they simply retarget to the new mob)
* Closes #6456
* Cloning/Blood data no longer get quirks
* Health analyzers use last_mind when checking quirks

Misc. quirk code changes:
* (!!) all previous instances of quirk_holder has been renamed to quirk_target (rip diffs)
* (!) human_only is replaced with a more specific restricted_mobtype variable for more flexibility (i.e it could affect you as any living mob or only as a human), however the functionality of quirks were not changed in this PR
* (!) added a restricted_species proc to specify what species this would affect on humans, with a boolean for whitelist/blacklist functionality
* (!) the phobia type has been turned into a functionally identical "trauma" type and paraplegic is now a subtype of it (no this won't break prefs)
* 2 procs were removed as they were unused/identical to another proc elsewhere
* other things that I'm probably forgetting

## Why It's Good For The Game

Quirks are meant to be personal characteristics, but they currently are handled in the mob's body, which causes anybody who's transferred/removed from that body to gain/lose those quirks. This leads to strange situations such as completely and permanently losing interest in your heirloom when you are monkeyized, and being put inside the body of a mute making you unable to speak, even if you yourself aren't mute.

Moving them to the mind makes them stay attached to their respective character, and also makes transferring quirks easier.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

demonstrates that quirks are preserved across mind transfers, previously this would have removed all of your quirks

https://user-images.githubusercontent.com/39193182/226461461-f1659560-0e29-4455-8bea-f282c81e1795.mp4

</details>

## Changelog
:cl: tonty
tweak: Quirks are no longer bound to the body, instead being assigned to the character itself
fix: Having your character transferred (ex: cloning, monkeyize) should no longer remove your quirks
/:cl: