### PR TITLE
Fix voice of god muting people for absurd amounts of time

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -2,6 +2,7 @@
 #define COOLDOWN_DAMAGE 1 MINUTES
 #define COOLDOWN_MEME 30 SECONDS
 #define COOLDOWN_NONE 10 SECONDS
+#define VOICE_OF_GOD_MAX_SILENCE_TIME 1 MINUTES
 
 /obj/item/organ/vocal_cords //organs that are activated through speech with the :x/MODE_KEY_VOCALCORDS channel
 	name = "vocal cords"
@@ -285,9 +286,9 @@
 	//SILENCE
 	else if((findtext(message, silence_words)))
 		cooldown = COOLDOWN_STUN
-		var/max_silent_time = 1 MINUTES
 		for(var/mob/living/carbon/C in listeners)
-			C.silent = min(C.silent + (10 SECONDS * power_multiplier), max_silent_time)
+			if(C.silent < VOICE_OF_GOD_MAX_SILENCE_TIME)
+				C.silent = min(C.silent + (10 SECONDS * power_multiplier), VOICE_OF_GOD_MAX_SILENCE_TIME)
 
 	//HALLUCINATE
 	else if((findtext(message, hallucinate_words)))
@@ -574,7 +575,7 @@
 
 	return cooldown
 
-
+#undef VOICE_OF_GOD_MAX_SILENCE_TIME
 #undef COOLDOWN_STUN
 #undef COOLDOWN_DAMAGE
 #undef COOLDOWN_MEME

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -285,8 +285,9 @@
 	//SILENCE
 	else if((findtext(message, silence_words)))
 		cooldown = COOLDOWN_STUN
+		var/max_silent_time = 1 MINUTES
 		for(var/mob/living/carbon/C in listeners)
-			C.silent += (10 SECONDS * power_multiplier)
+			C.silent = min(C.silent + (10 SECONDS * power_multiplier), max_silent_time)
 
 	//HALLUCINATE
 	else if((findtext(message, hallucinate_words)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This caps the silent time that can be set by VoG at 1 minute, mainly so people with Godwoken Syndrome don't semi-permanently take away people's voices.

## Why It's Good For The Game

Because being perma-muted because someone has godwoken isn't very fun.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Voice of God can no longer mute-lock people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
