### PR TITLE
Smelter/furnace QOL update

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -109,6 +109,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/mineral/processing_unit_console{
+	pixel_x = 30
+	},
 /turf/open/floor/noslip/standard,
 /area/mine/laborcamp)
 "aT" = (
@@ -867,10 +870,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/mine/production)
-"gh" = (
-/obj/machinery/mineral/processing_unit_console,
-/turf/closed/wall,
-/area/mine/laborcamp)
 "gl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/item/kirbyplants/random,
@@ -31906,7 +31905,7 @@ np
 DF
 aw
 rw
-gh
+rw
 rw
 wB
 rw

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1262,6 +1262,7 @@
 /obj/item/circuitboard/machine/processing_unit_console
 	name = "furnace console (Machine Board)"
 	build_path = /obj/machinery/mineral/processing_unit_console
+	req_components = list()
 
 
 //Misc

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1251,6 +1251,18 @@
 		/obj/item/stack/sheet/glass = 2,
 		/obj/item/stack/cable_coil = 5)
 
+/obj/item/circuitboard/machine/processing_unit
+	name = "furnace (Machine Board)"
+	build_path = /obj/machinery/mineral/processing_unit
+	req_components = list(
+		/obj/item/stock_parts/micro_laser = 1,
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/assembly/igniter = 1)
+
+/obj/item/circuitboard/machine/processing_unit_console
+	name = "furnace console (Machine Board)"
+	build_path = /obj/machinery/mineral/processing_unit_console
+
 
 //Misc
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -158,7 +158,7 @@
 			machine.smelt_amount_limit = CLAMP(text2num(params["amount"]), 1, 100)
 
 /obj/machinery/mineral/processing_unit_console/Destroy()
-	machine = null
+	machine.console = null
 	return ..()
 
 /obj/machinery/mineral/processing_unit_console/attackby(obj/item/W, mob/user, params)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -55,6 +55,7 @@
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "console"
 	density = TRUE
+	circuit = /obj/item/circuitboard/machine/processing_unit_console
 	var/obj/machinery/mineral/processing_unit/machine = null
 	var/machinedir = EAST
 	var/link_id = null
@@ -67,8 +68,6 @@
 		machine = locate(/obj/machinery/mineral/processing_unit, get_step(src, machinedir))
 		if (machine)
 			machine.CONSOLE = src
-		else
-			return INITIALIZE_HINT_QDEL
 
 // Only called if mappers set ID
 /obj/machinery/mineral/processing_unit_console/LateInitialize()
@@ -80,7 +79,7 @@
 
 /obj/machinery/mineral/processing_unit_console/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui)
+	if(machine && !ui)
 		ui = new(user, src, "Smelter")
 		ui.open()
 		ui.set_autoupdate(TRUE) // Material amounts
@@ -127,8 +126,43 @@
 			machine.selected_material = null
 			machine.selected_alloy = params["id"]
 
+		if("toggle_auto_shutdown")
+			machine.toggle_auto_shutdown()
+
+		if("set_smelt_amount")
+			machine.smelt_amount_limit = CLAMP(text2num(params["amount"]), 1, 100)
+
 /obj/machinery/mineral/processing_unit_console/Destroy()
 	machine = null
+	return ..()
+
+/obj/machinery/mineral/processing_unit_console/attackby(obj/item/W, mob/user, params)
+	if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
+		return
+
+	if(default_unfasten_wrench(user, W))
+		return
+
+	if(default_deconstruction_crowbar(W))
+		return
+
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(!multitool_check_buffer(user, W))
+			return
+		var/obj/item/multitool/P = W
+
+		if(istype(P.buffer, /obj/machinery/mineral/processing_unit))
+			if(get_area(P.buffer) != get_area(src))
+				to_chat(user, "<font color = #666633>-% Cannot link machines across power zones. %-</font color>")
+				return
+			to_chat(user, "<font color = #666633>-% Successfully linked [P.buffer] with [src] %-</font color>")
+			machine = P.buffer
+			machine.CONSOLE = src
+		else
+			P.buffer = src
+			to_chat(user, "<font color = #666633>-% Successfully stored [REF(P.buffer)] [P.buffer.name] in buffer %-</font color>")
+		return
+
 	return ..()
 
 
@@ -141,7 +175,8 @@
 	icon_state = "furnace"
 	density = TRUE
 	needs_item_input = TRUE
-	var/obj/machinery/mineral/CONSOLE = null
+	circuit = /obj/item/circuitboard/machine/processing_unit
+	var/obj/machinery/mineral/processing_unit_console/CONSOLE = null
 	var/on = FALSE
 	var/datum/material/selected_material = null
 	var/selected_alloy = null
@@ -149,6 +184,11 @@
 	var/link_id = null
 	var/stored_points = 0
 	var/allow_point_redemption = FALSE
+	var/smelt_amount_limit = 50
+	var/amount_already_smelted = 0
+	var/auto_shutdown = FALSE
+	var/smelt_amount = 5
+	var/point_upgrade = 1
 
 /obj/machinery/mineral/processing_unit/laborcamp
 	allow_point_redemption = FALSE
@@ -161,8 +201,49 @@
 	selected_material = getmaterialref(/datum/material/iron)
 
 /obj/machinery/mineral/processing_unit/Destroy()
+	if(CONSOLE)
+		SStgui.close_uis(CONSOLE)
 	CONSOLE = null
 	QDEL_NULL(stored_research)
+	return ..()
+
+/obj/machinery/mineral/processing_unit/RefreshParts()
+	var/point_upgrade_temp = 0
+	var/smelt_amount_temp = 1
+	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
+		smelt_amount_temp += 1 + (1 * B.rating)
+	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
+		point_upgrade_temp += 0.65 + (0.35 * L.rating)
+	point_upgrade = point_upgrade_temp
+	smelt_amount = round(smelt_amount_temp, 1)
+
+/obj/machinery/mineral/processing_unit/attackby(obj/item/W, mob/user, params)
+	if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
+		return
+
+	if(default_unfasten_wrench(user, W))
+		return
+
+	if(default_deconstruction_crowbar(W))
+		return
+
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(!multitool_check_buffer(user, W))
+			return
+		var/obj/item/multitool/P = W
+
+		if(istype(P.buffer, /obj/machinery/mineral/processing_unit_console))
+			if(get_area(P.buffer) != get_area(src))
+				to_chat(user, "<font color = #666633>-% Cannot link machines across power zones. %-</font color>")
+				return
+			to_chat(user, "<font color = #666633>-% Successfully linked [P.buffer] with [src] %-</font color>")
+			CONSOLE = P.buffer
+			CONSOLE.machine = src
+		else
+			P.buffer = src
+			to_chat(user, "<font color = #666633>-% Successfully stored [REF(P.buffer)] [P.buffer.name] in buffer %-</font color>")
+		return
+
 	return ..()
 
 /obj/machinery/mineral/processing_unit/proc/process_ore(obj/item/stack/ore/O)
@@ -174,7 +255,7 @@
 		unload_mineral(O)
 	else
 		if(allow_point_redemption)
-			stored_points += O.points * O.amount
+			points += O.points * O.amount * point_upgrade
 		materials.insert_item(O)
 		qdel(O)
 
@@ -201,6 +282,9 @@
 		var/datum/design/D = SSresearch.techweb_design_by_id(v)
 		data["alloys"] += list(list("name" = D.name, "id" = D.id, "smelting" = (selected_alloy == D.id), "amount" = can_smelt(D)))
 
+	data["auto_shutdown"] = auto_shutdown
+	data["smelt_amount_limit"] = smelt_amount_limit
+
 	return data
 
 /obj/machinery/mineral/processing_unit/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
@@ -214,6 +298,10 @@
 	if(on)
 		begin_processing()
 
+/obj/machinery/mineral/processing_unit/proc/toggle_auto_shutdown()
+	auto_shutdown = !auto_shutdown
+	amount_already_smelted = 0
+
 /obj/machinery/mineral/processing_unit/process(delta_time)
 	if(on)
 		if(selected_material)
@@ -224,18 +312,23 @@
 
 	else
 		end_processing()
+		amount_already_smelted = 0
 
 /obj/machinery/mineral/processing_unit/proc/smelt_ore(delta_time = 2)
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	var/datum/material/mat = selected_material
+	var/desired_amount_sheets = auto_shutdown ? min(smelt_amount * delta_time, smelt_amount_limit - amount_already_smelted) : smelt_amount * delta_time
 	if(mat)
-		var/sheets_to_remove = (materials.materials[mat] >= (MINERAL_MATERIAL_AMOUNT * SMELT_AMOUNT * delta_time) ) ? SMELT_AMOUNT * delta_time : round(materials.materials[mat] /  MINERAL_MATERIAL_AMOUNT)
+		var/sheets_to_remove = (materials.materials[mat] >= (MINERAL_MATERIAL_AMOUNT * desired_amount_sheets) ) ? desired_amount_sheets : round(materials.materials[mat] /  MINERAL_MATERIAL_AMOUNT)
 		if(!sheets_to_remove)
 			on = FALSE
 		else
 			var/out = get_step(src, output_dir)
-			materials.retrieve_sheets(sheets_to_remove, mat, out)
-
+			var/retrieved = materials.retrieve_sheets(sheets_to_remove, mat, out)
+			if(auto_shutdown)
+				amount_already_smelted += retrieved
+				if(amount_already_smelted >= smelt_amount_limit)
+					on = FALSE
 
 /obj/machinery/mineral/processing_unit/proc/smelt_alloy(delta_time = 2)
 	var/datum/design/alloy = stored_research.isDesignResearchedID(selected_alloy) //check if it's a valid design
@@ -245,7 +338,7 @@
 
 	var/amount = can_smelt(alloy, delta_time)
 
-	if(!amount)
+	if(!amount || (auto_shutdown && (amount_already_smelted >= smelt_amount_limit)))
 		on = FALSE
 		return
 
@@ -253,12 +346,13 @@
 	materials.use_materials(alloy.materials, amount)
 
 	generate_mineral(alloy.build_path)
+	amount_already_smelted += amount
 
 /obj/machinery/mineral/processing_unit/proc/can_smelt(datum/design/D, delta_time = 2)
 	if(D.make_reagents.len)
 		return FALSE
 
-	var/build_amount = SMELT_AMOUNT * delta_time
+	var/build_amount = auto_shutdown ? min(smelt_amount * delta_time, smelt_amount_limit - amount_already_smelted) : smelt_amount * delta_time
 
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -67,7 +67,7 @@
 	else
 		machine = locate(/obj/machinery/mineral/processing_unit, get_step(src, machinedir))
 		if (machine)
-			machine.CONSOLE = src
+			machine.console = src
 	if(!mapload)
 		handle_pixel_offset()
 
@@ -76,8 +76,12 @@
 	for(var/obj/machinery/mineral/processing_unit/PU in GLOB.machines)
 		if(PU.link_id == link_id)
 			machine = PU
-			machine.CONSOLE = src
+			machine.console = src
 			return
+
+/obj/machinery/mineral/processing_unit_console/Destroy()
+	machine.console = null
+	return ..()
 
 /obj/machinery/mineral/processing_unit_console/AltClick()
 	if(anchored)
@@ -178,7 +182,7 @@
 				return
 			to_chat(user, "<font color = #666633>-% Successfully linked [P.buffer] with [src] %-</font color>")
 			machine = P.buffer
-			machine.CONSOLE = src
+			machine.console = src
 		else
 			P.buffer = src
 			to_chat(user, "<font color = #666633>-% Successfully stored [REF(P.buffer)] [P.buffer.name] in buffer %-</font color>")
@@ -197,7 +201,7 @@
 	density = TRUE
 	needs_item_input = TRUE
 	circuit = /obj/item/circuitboard/machine/processing_unit
-	var/obj/machinery/mineral/processing_unit_console/CONSOLE = null
+	var/obj/machinery/mineral/processing_unit_console/console = null
 	var/on = FALSE
 	var/datum/material/selected_material = null
 	var/selected_alloy = null
@@ -222,9 +226,9 @@
 	selected_material = getmaterialref(/datum/material/iron)
 
 /obj/machinery/mineral/processing_unit/Destroy()
-	if(CONSOLE)
-		SStgui.close_uis(CONSOLE)
-	CONSOLE = null
+	if(console)
+		SStgui.close_uis(console)
+	console = null
 	QDEL_NULL(stored_research)
 	return ..()
 
@@ -269,8 +273,8 @@
 				to_chat(user, "<font color = #666633>-% Cannot link machines across power zones. %-</font color>")
 				return
 			to_chat(user, "<font color = #666633>-% Successfully linked [P.buffer] with [src] %-</font color>")
-			CONSOLE = P.buffer
-			CONSOLE.machine = src
+			console = P.buffer
+			console.machine = src
 		else
 			P.buffer = src
 			to_chat(user, "<font color = #666633>-% Successfully stored [REF(P.buffer)] [P.buffer.name] in buffer %-</font color>")

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -31,6 +31,7 @@
 
 	/// Only used for storing pending research for examine()
 	var/list/pending_research = list()
+	var/base_storage = 75000 // NSV13 - moved base storage multiplier into a variable
 
 /obj/machinery/rnd/production/Initialize(mapload)
 	. = ..()
@@ -281,7 +282,7 @@
 	if(materials)
 		var/total_storage = 0
 		for(var/obj/item/stock_parts/matter_bin/M in component_parts)
-			total_storage += M.rating * 75000
+			total_storage += M.rating * base_storage //NSV13 - moved base multiplier into a variable
 		materials.set_local_size(total_storage)
 	var/total_rating = 1.2
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -31,7 +31,7 @@
 
 	/// Only used for storing pending research for examine()
 	var/list/pending_research = list()
-	var/base_storage = 75000 // NSV13 - moved base storage multiplier into a variable
+	var/base_storage = 75000
 
 /obj/machinery/rnd/production/Initialize(mapload)
 	. = ..()
@@ -282,7 +282,7 @@
 	if(materials)
 		var/total_storage = 0
 		for(var/obj/item/stock_parts/matter_bin/M in component_parts)
-			total_storage += M.rating * base_storage //NSV13 - moved base multiplier into a variable
+			total_storage += M.rating * base_storage
 		materials.set_local_size(total_storage)
 	var/total_rating = 1.2
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -771,7 +771,7 @@
 	display_name = "Mining Technology"
 	description = "Better than Efficiency V."
 	prereq_ids = list("engineering")
-	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "hypermod", "ore_redemption", "mining_equipment_vendor", "exploration_equipment_vendor", "cargoexpress")
+	design_ids = list("drill", "superresonator", "triggermod", "damagemod", "cooldownmod", "rangemod", "hypermod", "ore_redemption", "mining_equipment_vendor", "exploration_equipment_vendor", "cargoexpress", "furnace", "furnace_console")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/tgui/packages/tgui/interfaces/Smelter.js
+++ b/tgui/packages/tgui/interfaces/Smelter.js
@@ -1,7 +1,8 @@
 import { toTitleCase } from 'common/string';
 import { useBackend } from '../backend';
-import { Box, Button, Section, Table } from '../components';
+import { Box, Button, NumberInput, Section, Table } from '../components';
 import { Window } from '../layouts';
+import { round, scale } from 'common/math';
 
 export const Smelter = (props, context) => {
   const { act, data } = useBackend(context);
@@ -11,6 +12,8 @@ export const Smelter = (props, context) => {
     stored_points,
     materials,
     alloys,
+    auto_shutdown,
+    smelt_amount_limit,
   } = data;
   return (
     <Window
@@ -21,12 +24,39 @@ export const Smelter = (props, context) => {
           <Table.Row>
             <Table.Cell>
               <Box inline color="label" mr={1}>
+                Auto-off:
+              </Box>
+              <Button
+                icon={auto_shutdown ? 'power-off' : 'times'}
+                content={auto_shutdown ? 'On' : 'Off'}
+                onClick={() => act('toggle_auto_shutdown')} />
+            </Table.Cell>
+            <Table.Cell>
+              <Box inline color="label" mr={1}>
                 Machine Status:
               </Box>
               <Button
                 icon={on ? 'power-off' : 'times'}
                 content={on ? 'On' : 'Off'}
                 onClick={() => act('Toggle_on')} />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Box inline color="label" mr={1}>
+                Stop after:
+              </Box>
+              <NumberInput
+                value={smelt_amount_limit}
+                unit="sheets"
+                width="55px"
+                minValue={1}
+                maxValue={100}
+                step={10}
+                stepPixelSize={1}
+                onChange={(e, value) => act('set_smelt_amount', {
+                  amount: value,
+                })} />
             </Table.Cell>
             {!!allowredeem && (
               <Table.Cell collapsing textAlign="right">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This allows people to construct, deconstruct, rotate, and upgrade furnaces and their consoles. It also adds an auto-shutdown feature which will smelt only a fixed amount of ore of the selected type instead of all available ore of that type.
In order to handle rotation and wall placement, the console is now pixel-shifted onto walls instead of placed on top of them, which is the map change.
Also replaces a magic number in default 'lathe capacity calculations with a variable.

Port of non-downstream-specific parts of https://github.com/BeeStation/NSV13/pull/2347

## Why It's Good For The Game
Makes alternate mining equipment more fully-featured and allows replacement of equipment if destroyed.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/17987483/226800811-0f991d2e-623c-4ed0-b3f4-69b56bbc18f2.mp4

</details>

## Changelog
:cl:
add: Furnace and console can now be constructed rotated
add: Furnace can be set to smelt a certain number of sheets instead of all possible sheets
tweak: Furnace can be upgraded for faster processing (and more points if smelter points are enabled)
code: Added support for production machines having base capacities other than 75 sheets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
