### PR TITLE
Storage animation tweaks

### DIFF
--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -134,7 +134,7 @@
 		if(ismob(parent.loc))
 			var/mob/M = parent.loc
 			I.dropped(M, TRUE)
-		if(!(I.item_flags & NO_PIXEL_RANDOM_DROP) && !(I.item_flags & WAS_THROWN))
+		if(!(I.item_flags & (NO_PIXEL_RANDOM_DROP | WAS_THROWN)))
 			I.pixel_x = rand(-6, 6)
 			I.pixel_y = rand(-6, 6)
 	if(new_location)

--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -134,6 +134,9 @@
 		if(ismob(parent.loc))
 			var/mob/M = parent.loc
 			I.dropped(M, TRUE)
+		if(!(I.item_flags & NO_PIXEL_RANDOM_DROP) && !(I.item_flags & WAS_THROWN))
+			I.pixel_x = rand(-6, 6)
+			I.pixel_y = rand(-6, 6)
 	if(new_location)
 		//Reset the items values
 		_removal_reset(AM)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -383,7 +383,8 @@
 				return FALSE
 	if(M.active_storage)
 		M.active_storage.hide_from(M)
-	animate_parent()
+	if(!istype(M, /mob/dead/observer))
+		animate_parent()
 	orient2hud()
 	M.client.screen |= boxes
 	M.client.screen |= closer
@@ -409,7 +410,8 @@
 	M.client.screen -= boxes
 	M.client.screen -= closer
 	M.client.screen -= real_location.contents
-	animate_parent()
+	if(!istype(M, /mob/dead/observer))
+		animate_parent()
 	return TRUE
 
 /datum/component/storage/proc/close(mob/M)
@@ -681,7 +683,8 @@
 		return
 	if(rustle_sound)
 		playsound(parent, "rustle", 50, 1, -5)
-	animate_parent()
+	if(!istype(user, /mob/dead/observer))
+		animate_parent()
 	for(var/mob/viewing as() in viewers(user))
 		if(M == viewing)
 			to_chat(usr, "<span class='notice'>You put [I] [insert_preposition]to [parent].</span>")

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -324,6 +324,7 @@
 	max_items = 1
 	max_w_class = WEIGHT_CLASS_NORMAL
 	insert_while_closed = FALSE // We don't want clicking plants with items to insert it, you have to alt click then click the slots
+	animated = FALSE
 
 /obj/item/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prevents the 'squash' storage animation from happening if the one opening/closing the storage item is a ghost.
Prevents the 'squash' animation from playing when inserting/removing items from potted plants.
Also makes items that get mass dumped out of storage get pixelshifted.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less spooky activity
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/110184118/226827095-0b387209-ecab-46d5-8990-262fad2d7341.mp4

https://user-images.githubusercontent.com/110184118/226903464-54458603-08f9-4ce0-9b80-527bccb66ded.mp4

</details>

## Changelog
:cl:
add: Added pixelshifting to items that get mass dumped out of a storage item
tweak: ghosts no longer cause the 'squash' storage animation when opening or closing storage items
tweak: plant pots no longer 'squash' when you put items inside of them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
