### PR TITLE
Removes another mentor keywords_lookup moment (leaking admin href token)

### DIFF
--- a/code/modules/admin/verbs/mentorhelp.dm
+++ b/code/modules/admin/verbs/mentorhelp.dm
@@ -154,7 +154,7 @@ GLOBAL_DATUM_INIT(mhelp_tickets, /datum/help_tickets/mentor, new)
 	var/ref_src = "[REF(src)]"
 
 	//Message to be sent to all admins
-	var/admin_msg = "<span class='mentornotice'><span class='mentorhelp'>Mentor Ticket [TicketHref("#[id]", ref_src)]</span>: [LinkedReplyName(ref_src)] [ClosureLinks(ref_src)]: <span class='linkify'>[keywords_lookup(msg)]</span></span>"
+	var/admin_msg = "<span class='mentornotice'><span class='mentorhelp'>Mentor Ticket [TicketHref("#[id]", ref_src)]</span>: [LinkedReplyName(ref_src)] [ClosureLinks(ref_src)]: <span class='linkify'>[msg]</span></span>"
 
 	if(add_to_ticket)
 		AddInteraction("red", msg, initiator_key_name, claimee_key_name, "You", "Mentor")


### PR DESCRIPTION
## About The Pull Request

I probably introduced this one, my bad. This appears to be the last of it though.

## Why It's Good For The Game

Leaking the admin href token is cringe

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

No longer present

![image](https://user-images.githubusercontent.com/10366817/227771798-8331a412-ea0a-4c04-9405-101040417e3e.png)


</details>

## Changelog
:cl:
fix: Removed keywords lookup from mentor ticket notifications.
/:cl: