### PR TITLE
Mute/blindness/stutter/drunk/etc now respects delta time

### DIFF
--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -29,10 +29,10 @@
 		else
 			emp_damage = max(emp_damage-1, 0)
 
-/mob/living/brain/handle_status_effects()
+/mob/living/brain/handle_status_effects(delta_time)
 	return
 
-/mob/living/brain/handle_traits()
+/mob/living/brain/handle_traits(delta_time)
 	return
 
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -53,11 +53,11 @@
 		breath.set_volume(BREATH_VOLUME)
 	check_breath(breath)
 
-/mob/living/carbon/alien/handle_status_effects()
+/mob/living/carbon/alien/handle_status_effects(delta_time)
 	..()
 	//natural reduction of movement delay due to stun.
 	if(move_delay_add > 0)
-		move_delay_add = max(0, move_delay_add - rand(1, 2))
+		move_delay_add = max(0, move_delay_add - (rand(1, 2) * delta_time))
 
 /mob/living/carbon/alien/handle_fire()//Aliens on fire code
 	. = ..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -62,7 +62,7 @@
 	return pressure
 
 
-/mob/living/carbon/human/handle_traits()
+/mob/living/carbon/human/handle_traits(delta_time)
 	if (getOrganLoss(ORGAN_SLOT_BRAIN) >= 60)
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "brain_damage", /datum/mood_event/brain_damage)
 	else
@@ -70,14 +70,14 @@
 
 	if(eye_blind)			//blindness, heals slowly over time
 		if(HAS_TRAIT_FROM(src, TRAIT_BLIND, EYES_COVERED)) //covering your eyes heals blurry eyes faster
-			adjust_blindness(-3)
+			adjust_blindness(-3 * delta_time)
 		else
-			adjust_blindness(-1)
+			adjust_blindness(-delta_time)
 		//If you have blindness from a trait, heal blurryness too, otherwise return and ignore that.
 		if(!(HAS_TRAIT(src, TRAIT_BLIND)))
 			return
 	if(eye_blurry)			//blurry eyes heal slowly
-		adjust_blurriness(-1)
+		adjust_blurriness(-delta_time)
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
 	if(!dna || !dna.species.handle_mutations_and_radiation(src))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -394,10 +394,11 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 												"What if we use a language that was written on a napkin and created over 1 weekend for all of our servers?"))
 
 //this updates all special effects: stun, sleeping, knockdown, druggy, stuttering, etc..
-/mob/living/carbon/handle_status_effects()
+/mob/living/carbon/handle_status_effects(delta_time)
 	..()
 
 	var/restingpwr = 1 + 4 * resting
+	var/adjusted_restingpwr = restingpwr * delta_time
 
 	//Dizziness
 	if(dizziness)
@@ -431,60 +432,60 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 						C.pixel_x -= pixel_x_diff
 						C.pixel_y -= pixel_y_diff
 			src = oldsrc
-		dizziness = max(dizziness - restingpwr, 0)
+		dizziness = max(dizziness - adjusted_restingpwr, 0)
 
 	if(drowsyness)
-		drowsyness = max(drowsyness - restingpwr, 0)
+		drowsyness = max(drowsyness - adjusted_restingpwr, 0)
 		blur_eyes(2)
-		if(prob(5))
+		if(DT_PROB(5, delta_time))
 			AdjustSleeping(20)
 			Unconscious(100)
 
 	//Jitteriness
 	if(jitteriness)
 		do_jitter_animation(jitteriness)
-		jitteriness = max(jitteriness - restingpwr, 0)
+		jitteriness = max(jitteriness - adjusted_restingpwr, 0)
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "jittery", /datum/mood_event/jittery)
 	else
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "jittery")
 
 	if(stuttering)
-		stuttering = max(stuttering-1, 0)
+		stuttering = max(stuttering - delta_time, 0)
 
 	if(slurring)
-		slurring = max(slurring-1,0)
+		slurring = max(slurring - delta_time,0)
 
 	if(cultslurring)
-		cultslurring = max(cultslurring-1, 0)
+		cultslurring = max(cultslurring - delta_time, 0)
 
 	if(clockslurring)
-		clockslurring = max(clockslurring-1, 0)
+		clockslurring = max(clockslurring - delta_time, 0)
 
 	if(silent)
-		silent = max(silent-1, 0)
+		silent = max(silent - delta_time, 0)
 
 	if(druggy)
-		adjust_drugginess(-1)
+		adjust_drugginess(-delta_time)
 
 	if(hallucination)
 		handle_hallucinations()
 
 	if(drunkenness)
-		drunkenness = max(drunkenness - (drunkenness * 0.04) - 0.01, 0)
+		drunkenness = max(drunkenness - ((drunkenness * 0.04) * delta_time) - 0.01, 0)
 		if(drunkenness >= 6)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "drunk", /datum/mood_event/drunk)
-			if(prob(25))
-				slurring += 2
-			jitteriness = max(jitteriness - 3, 0)
+			if(DT_PROB(25, delta_time))
+				slurring += 2 * delta_time
+			jitteriness = max(jitteriness - (3 * delta_time), 0)
 			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING))
-				adjustBruteLoss(-0.12, FALSE)
-				adjustFireLoss(-0.06, FALSE)
+				adjustBruteLoss(-0.12 * delta_time, FALSE)
+				adjustFireLoss(-0.06 * delta_time, FALSE)
 		else
 			SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "drunk")
 			sound_environment_override = SOUND_ENVIRONMENT_NONE
 
 		if(drunkenness >= 11 && slurring < 5)
-			slurring += 1.2
+			slurring += 1.2 * delta_time
 
 		if(mind && (mind.assigned_role == JOB_NAME_SCIENTIST || mind.assigned_role == JOB_NAME_RESEARCHDIRECTOR))
 			if(SSresearch.science_tech)
@@ -495,47 +496,47 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 						ballmer_percent = 1
 					else
 						ballmer_percent = (-abs(drunkenness - 13.35) / 0.9) + 1
-					if(prob(5))
+					if(DT_PROB(5, delta_time))
 						say(pick(GLOB.ballmer_good_msg), forced = "ballmer")
 					SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = BALLMER_POINTS * ballmer_percent))
 				if(drunkenness > 26) // by this point you're into windows ME territory
-					if(prob(5))
+					if(DT_PROB(5, delta_time))
 						SSresearch.science_tech.remove_point_list(list(TECHWEB_POINT_TYPE_GENERIC = BALLMER_POINTS))
 						say(pick(GLOB.ballmer_windows_me_msg), forced = "ballmer")
 
 		if(drunkenness >= 41)
-			if(prob(25))
-				confused += 2
+			if(DT_PROB(25, delta_time))
+				confused += 2 * delta_time
 			Dizzy(10)
 			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING)) // effects stack with lower tiers
-				adjustBruteLoss(-0.3, FALSE)
-				adjustFireLoss(-0.15, FALSE)
+				adjustBruteLoss(-0.3 * delta_time, FALSE)
+				adjustFireLoss(-0.15 * delta_time, FALSE)
 
 		if(drunkenness >= 51)
-			if(prob(3))
-				confused += 15
+			if(DT_PROB(3, delta_time))
+				confused += 15 * delta_time
 				vomit() // vomiting clears toxloss, consider this a blessing
 			Dizzy(25)
 
 		if(drunkenness >= 61)
-			if(prob(50))
-				blur_eyes(5)
+			if(DT_PROB(50, delta_time))
+				blur_eyes(5 * delta_time)
 			if(HAS_TRAIT(src, TRAIT_DRUNK_HEALING))
-				adjustBruteLoss(-0.4, FALSE)
-				adjustFireLoss(-0.2, FALSE)
+				adjustBruteLoss(-0.4 * delta_time, FALSE)
+				adjustFireLoss(-0.2 * delta_time, FALSE)
 
 		if(drunkenness >= 71)
-			blur_eyes(5)
+			blur_eyes(5 * delta_time)
 
 		if(drunkenness >= 81)
-			adjustToxLoss(1)
-			if(prob(5) && !stat)
+			adjustToxLoss(delta_time)
+			if(DT_PROB(5, delta_time) && !stat)
 				to_chat(src, "<span class='warning'>Maybe you should lie down for a bit.</span>")
 
 		if(drunkenness >= 91)
-			adjustToxLoss(1)
-			adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.4)
-			if(prob(20) && !stat)
+			adjustToxLoss(delta_time)
+			adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.4 * delta_time)
+			if(DT_PROB(20, delta_time) && !stat)
 				if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && is_station_level(z)) //QoL mainly
 					to_chat(src, "<span class='warning'>You're so tired, but you can't miss that shuttle.</span>")
 				else
@@ -543,7 +544,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					Sleeping(900)
 
 		if(drunkenness >= 101)
-			adjustToxLoss(2) //Let's be honest you shouldn't be alive by now
+			adjustToxLoss(2 * delta_time) //Let's be honest you shouldn't be alive by now
 
 //used in human and monkey handle_environment()
 /mob/living/carbon/proc/natural_bodytemperature_stabilization()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -1,8 +1,8 @@
-/mob/living/proc/Life(seconds, times_fired)
+/mob/living/proc/Life(delta_time, times_fired)
 	set waitfor = FALSE
 	set invisibility = 0
 
-	SEND_SIGNAL(src, COMSIG_LIVING_LIFE, seconds, times_fired)
+	SEND_SIGNAL(src, COMSIG_LIVING_LIFE, delta_time, times_fired)
 
 	if((movement_type & FLYING) && !(movement_type & FLOATING))	//TODO: Better floating
 		float(on = TRUE)
@@ -46,8 +46,8 @@
 			handle_high_gravity(gravity)
 
 		if(stat != DEAD)
-			handle_traits() // eye, ear, brain damages
-			handle_status_effects() //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc
+			handle_traits(delta_time) // eye, ear, brain damages
+			handle_status_effects(delta_time) //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc
 
 	handle_fire()
 
@@ -91,24 +91,24 @@
 	location.hotspot_expose(700, 50, 1)
 
 //this updates all special effects: knockdown, druggy, stuttering, etc..
-/mob/living/proc/handle_status_effects()
+/mob/living/proc/handle_status_effects(delta_time)
 	if(confused)
-		confused = max(0, confused - 1)
+		confused = max(0, confused - (1 * delta_time))
 
-/mob/living/proc/handle_traits()
+/mob/living/proc/handle_traits(delta_time)
 	//Eyes
 	if(eye_blind)			//blindness, heals slowly over time
 		if(!stat && !(HAS_TRAIT(src, TRAIT_BLIND)))
-			eye_blind = max(eye_blind-1,0)
+			eye_blind = max(eye_blind - delta_time, 0)
 			if(client && !eye_blind)
 				clear_alert("blind")
 				clear_fullscreen("blind")
 			//Prevents healing blurryness while blind from normal means
 			return
 		else
-			eye_blind = max(eye_blind-1,1)
+			eye_blind = max(eye_blind - delta_time, 1)
 	if(eye_blurry)			//blurry eyes heal slowly
-		eye_blurry = max(eye_blurry-1, 0)
+		eye_blurry = max(eye_blurry - delta_time, 0)
 		if(client)
 			update_eye_blur()
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -3,7 +3,7 @@
 #define POWER_RESTORATION_SEARCH_APC 2
 #define POWER_RESTORATION_APC_FOUND 3
 
-/mob/living/silicon/ai/Life()
+/mob/living/silicon/ai/Life(delta_time)
 	if (stat == DEAD)
 		return
 	else //I'm not removing that shitton of tabs, unneeded as they are. -- Urist
@@ -11,7 +11,7 @@
 
 		update_gravity(has_gravity())
 
-		handle_status_effects()
+		handle_status_effects(delta_time)
 
 		if(malfhack && malfhack.aidisabled)
 			deltimer(malfhacking)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -161,7 +161,7 @@
 	med_hud_set_status()
 
 
-/mob/living/simple_animal/handle_status_effects()
+/mob/living/simple_animal/handle_status_effects(delta_time)
 	..()
 	if(stuttering)
 		stuttering = 0

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -133,14 +133,14 @@
 	temp_change = (temperature - current)
 	return temp_change
 
-/mob/living/simple_animal/slime/handle_status_effects()
+/mob/living/simple_animal/slime/handle_status_effects(delta_time)
 	..()
-	if(prob(30) && !stat)
+	if(DT_PROB(30, delta_time) && !stat)
 		var/heal = 1
 		if(transformeffects & SLIME_EFFECT_PURPLE)
 			heal += 0.5
 		adjustBruteLoss(-heal)
-	if((transformeffects & SLIME_EFFECT_RAINBOW) && prob(5))
+	if((transformeffects & SLIME_EFFECT_RAINBOW) && DT_PROB(5, delta_time))
 		random_colour()
 
 /mob/living/simple_animal/slime/proc/handle_feeding()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I am trying to hunt down why godwoken mutes people for absurdly long times, and my next candidate is: lag causing the mute timer not to tick down properly.

So I made the mute timer (and everything near it) respect `delta_time`, which should mean `silent = 15` goes away in 15 seconds, regardless of lag.

**EDIT**: turns out the cause was me being an idiot with my fix and probably not this, but eh, this'll still help with laggy situations anyways.

## Why It's Good For The Game

Reduces the effects of lag.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-03-26-1679885161-dreamseeker](https://user-images.githubusercontent.com/65794972/227828810-33ab3293-3ce6-4606-baba-db4dc093520a.png)


</details>

## Changelog
:cl:
fix: Status effects like mute, blindness, stutter, or drunkenness should be less affected by lag now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
