### PR TITLE
The surgical serverlink brain implant can now download surgeries from held disks

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -182,7 +182,7 @@
 			var/obj/item/disk/tech_disk/tech_disk = held_item
 			for(var/D in tech_disk.stored_research.researched_designs)
 				var/datum/design/surgery/surgery_design = SSresearch.techweb_design_by_id(D)
-				if(!istype(design))
+				if(!istype(surgery_design))
 					continue
 				if(!(surgery_design.surgery in old_advanced_surgeries))
 					surgeries_to_add |= surgery_design.surgery

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -160,12 +160,45 @@
 	number_of_surgeries = 0
 
 /obj/item/organ/cyberimp/brain/linkedsurgery/proc/update_surgery()
+	var/list/old_advanced_surgeries = advanced_surgeries.Copy()
 	advanced_surgeries.Cut()
 	for(var/i in linked_techweb.researched_designs)
 		var/datum/design/surgery/D = SSresearch.techweb_design_by_id(i)
 		if(!istype(D))
 			continue
 		advanced_surgeries += D.surgery
+	for(var/held_item in owner.held_items)
+		if(!held_item)
+			continue
+		var/list/surgeries_to_add = list()
+		var/new_surgeries = 0
+		if(istype(held_item, /obj/item/disk/surgery))
+			var/obj/item/disk/surgery/surgery_disk = held_item
+			for(var/surgery in surgery_disk.surgeries)
+				if(!(surgery in old_advanced_surgeries))
+					surgeries_to_add |= surgery
+					new_surgeries++
+		else if(istype(held_item, /obj/item/disk/tech_disk))
+			var/obj/item/disk/tech_disk/tech_disk = held_item
+			for(var/D in tech_disk.stored_research.researched_designs)
+				var/datum/design/surgery/surgery_design = SSresearch.techweb_design_by_id(D)
+				if(!istype(design))
+					continue
+				if(!(surgery_design.surgery in old_advanced_surgeries))
+					surgeries_to_add |= surgery_design.surgery
+					new_surgeries++
+		else
+			continue
+		var/hand_name = owner.get_held_index_name(owner.get_held_index_of_item(held_item))
+		if(!new_surgeries)
+			to_chat(owner, "<span class='notice'>No new surgical programs detected on \the [held_item] in your [hand_name].</span>")
+			continue
+		to_chat(owner, "<span class='notice'><b>[new_surgeries]</b> new surgical program\s detected on \the [held_item] in your [hand_name]! Please hold still while the surgical program is being downloaded...</span>")
+		if(!do_after(owner, 5 SECONDS, held_item))
+			to_chat(owner, "<span class='warning'>Surgical program transfer interrupted!</span>")
+			return
+		to_chat(owner, "<span class='notice'><b>[new_surgeries]</b> new surgical program\s were transferred from \the [held_item] in your [hand_name] to \the [src]!</span>")
+		advanced_surgeries |= surgeries_to_add
 
 /obj/item/organ/cyberimp/brain/linkedsurgery/proc/check_surgery_update()
 	if(number_of_surgeries<length(advanced_surgeries))

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -175,7 +175,7 @@
 		if(istype(held_item, /obj/item/disk/surgery))
 			var/obj/item/disk/surgery/surgery_disk = held_item
 			for(var/surgery in surgery_disk.surgeries)
-				if(!(surgery in old_advanced_surgeries))
+				if(!(surgery in old_advanced_surgeries) && !(surgery in advanced_surgeries))
 					surgeries_to_add |= surgery
 					new_surgeries++
 		else if(istype(held_item, /obj/item/disk/tech_disk))
@@ -184,7 +184,7 @@
 				var/datum/design/surgery/surgery_design = SSresearch.techweb_design_by_id(D)
 				if(!istype(surgery_design))
 					continue
-				if(!(surgery_design.surgery in old_advanced_surgeries))
+				if(!(surgery_design.surgery in old_advanced_surgeries) && !(surgery_design.surgery in advanced_surgeries))
 					surgeries_to_add |= surgery_design.surgery
 					new_surgeries++
 		else

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -187,6 +187,10 @@
 				if(!(surgery_design.surgery in old_advanced_surgeries) && !(surgery_design.surgery in advanced_surgeries))
 					surgeries_to_add |= surgery_design.surgery
 					new_surgeries++
+		else if(istype(held_item, /obj/item/disk/nuclear))
+			// funny joke message
+			to_chat(owner, "<span class='warning'>Do you <i>want</i> to explode? You can't get surgery data from \the [held_item]!</span>")
+			continue
 		else
 			continue
 		var/hand_name = owner.get_held_index_name(owner.get_held_index_of_item(held_item))


### PR DESCRIPTION
## About The Pull Request

This makes it so the surgical serverlink brain implant will, if you're holding a tech disk or surgery disk in hand, also try to download surgery programs from the disks in your hands.

## Why It's Good For The Game

This implant seems to be _super rare_ to obtain, it should be a bit more useful. Also this is just a cool nice-to-have.

Also would be useful for testing surgery stuff, as you could just spawn in the implant and a debug surgery disk, no having to faff about with the R&D console, operating computers, and operating tables.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-03-27-1679961386-dreamseeker](https://user-images.githubusercontent.com/65794972/228093073-09a71fac-8cbc-461f-a2bd-56e6951dc180.png)
![23-03-27-1679961525-dreamseeker](https://user-images.githubusercontent.com/65794972/228093075-c4f3264d-e5a5-484d-afb2-59aaebcacf2f.png)

</details>

## Changelog
:cl:
add: Surgical serverlink brain implant can now download surgical programs from tech and surgery disks being held in your hand!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
