### PR TITLE
Fix stationloving objects (nuke disk) teleporting from allowed shuttles

### DIFF
--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -7,7 +7,7 @@
 /datum/component/stationloving/Initialize(inform_admins = FALSE, allow_death = FALSE)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, list(COMSIG_MOVABLE_Z_CHANGED), PROC_REF(check_in_bounds))
+	RegisterSignal(parent, list(COMSIG_MOVABLE_Z_CHANGED), PROC_REF(z_check))
 	RegisterSignal(parent, list(COMSIG_MOVABLE_SECLUDED_LOCATION), PROC_REF(relocate))
 	RegisterSignal(parent, list(COMSIG_PARENT_PREQDELETED), PROC_REF(check_deletion))
 	RegisterSignal(parent, list(COMSIG_ITEM_IMBUE_SOUL), PROC_REF(check_soul_imbue))
@@ -40,9 +40,11 @@
 	// move the disc, so ghosts remain orbiting it even if it's "destroyed"
 	return targetturf
 
-/datum/component/stationloving/proc/check_in_bounds(is_retrying = FALSE)
+/datum/component/stationloving/proc/z_check(datum/source, old_z, new_z)
 	SIGNAL_HANDLER
+	check_in_bounds()
 
+/datum/component/stationloving/proc/check_in_bounds(is_retrying = FALSE)
 	if(in_bounds(is_retrying))
 		return
 	else

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -81,6 +81,9 @@
 		// Whenever shuttles move, everything seems to be on a hyperspace tile temporarily,
 		// so we need this to stop it from teleporting off of allowed shuttles.
 		if (istype(T, /turf/open/space/transit))
+			// We still might be on a disallowed shuttle,
+			// so we need to check again in a second to make sure.
+			addtimer(CALLBACK(src, PROC_REF(check_in_bounds)), 1 SECONDS)
 			return TRUE
 
 	return FALSE

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -78,6 +78,10 @@
 	if(is_reserved_level(T.z))
 		if (is_type_in_typecache(A, allowed_shuttles))
 			return TRUE
+		// Whenever shuttles move, everything seems to be on a hyperspace tile temporarily,
+		// so we need this to stop it from teleporting off of allowed shuttles.
+		if (istype(T, /turf/open/space/transit))
+			return TRUE
 
 	return FALSE
 

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -40,10 +40,10 @@
 	// move the disc, so ghosts remain orbiting it even if it's "destroyed"
 	return targetturf
 
-/datum/component/stationloving/proc/check_in_bounds()
+/datum/component/stationloving/proc/check_in_bounds(is_retrying = FALSE)
 	SIGNAL_HANDLER
 
-	if(in_bounds())
+	if(in_bounds(is_retrying))
 		return
 	else
 		var/turf/currentturf = get_turf(src)
@@ -62,7 +62,7 @@
 
 	return COMPONENT_BLOCK_MARK_RETRIEVAL
 
-/datum/component/stationloving/proc/in_bounds()
+/datum/component/stationloving/proc/in_bounds(is_retrying = FALSE)
 	var/static/list/allowed_shuttles = typecacheof(list(/area/shuttle/syndicate, /area/shuttle/escape, /area/shuttle/pod_1, /area/shuttle/pod_2, /area/shuttle/pod_3, /area/shuttle/pod_4))
 	var/static/list/disallowed_centcom_areas = typecacheof(list(/area/abductor_ship, /area/awaymission/errorroom))
 	var/turf/T = get_turf(parent)
@@ -80,10 +80,10 @@
 			return TRUE
 		// Whenever shuttles move, everything seems to be on a hyperspace tile temporarily,
 		// so we need this to stop it from teleporting off of allowed shuttles.
-		if (istype(T, /turf/open/space/transit))
+		if (!is_retrying && istype(T, /turf/open/space/transit))
 			// We still might be on a disallowed shuttle,
 			// so we need to check again in a second to make sure.
-			addtimer(CALLBACK(src, PROC_REF(check_in_bounds)), 1 SECONDS)
+			addtimer(CALLBACK(src, PROC_REF(check_in_bounds), TRUE), 1 SECONDS)
 			return TRUE
 
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

This fixes stationloving objects (like the nuke disk) from teleporting back to the station because they were on a hyperspace tile for a brief moment before the rest of the shuttle is initialized in the reserved z-level.

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/8770  
Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/8787

## Why It's Good For The Game

So "steal nuke disk" objectives and the captain's crew objective work, and so the nukies can take the nuke back to their base.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/65794972/228374023-b9027a84-9df2-4f73-a61a-e349b5a6baff.mp4

</details>

## Changelog
:cl:
fix: Stationloving objects, such as the nuclear authentication disk, can now be properly taken onto allowed shuttles (emergency shuttle, nukie shuttle).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
