### PR TITLE
[s] Disable byond debug links

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -33,11 +33,19 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		- Are the processes being called by Topic() particularly laggy?
 		- If so, is there any protection against somebody spam-clicking a link?
 	If you have any  questions about this stuff feel free to ask. ~Carn
+
+	the undocumented 4th argument is for ?[0x\ref] style topic links. hsrc is set to the reference and anything after the ] gets put into hsrc_command
 	*/
 
-/client/Topic(href, href_list, hsrc)
+/client/Topic(href, href_list, hsrc, hsrc_command)
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
+
+#ifndef TESTING
+	//disable the integrated byond vv in the client side debugging tools since it doesn't respect vv read protections
+	if (lowertext(hsrc_command) == "_debug")
+		return
+#endif
 
 	// asset_cache
 	var/asset_cache_job


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/74373

This disables a byond debugging functionality which allows for anyone with access to the debugging tools to access any values stored in variables inside objects.

## Why It's Good For The Game

This is a pretty bad information leaking exploit.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/228932919-be7f4f3c-0e6f-40a9-873f-e097ae6e1d76.png)
Performing the exploit results in the return being triggered and no result being returned to the user.
The user can still access the status debugger command to debug currently running procs.

## Changelog
:cl:
fix: Fixes an exploit with the byond debugger leaking information.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
