### PR TITLE
You can now manually link stasis beds to operating computers

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -51,12 +51,12 @@
 /obj/machinery/computer/operating/proc/find_table()
 	for(var/direction in GLOB.alldirs)
 		table = locate(/obj/structure/table/optable) in get_step(src, direction)
-		if(table)
+		if(table && !table.computer)
 			table.computer = src
 			break
 		else
 			sbed = locate(/obj/machinery/stasis) in get_step(src, direction)
-			if(sbed)
+			if(sbed && !sbed.op_computer)
 				sbed.op_computer = src
 				break
 
@@ -151,8 +151,6 @@
 			))
 	return data
 
-
-
 /obj/machinery/computer/operating/ui_act(action, params)
 	if(..())
 		return
@@ -161,6 +159,24 @@
 			sync_surgeries()
 			. = TRUE
 	. = TRUE
+
+/obj/machinery/computer/operating/multitool_act(mob/living/user, obj/item/I)
+	var/obj/item/multitool/multitool = I
+	if(!I || !istype(I))
+		return ..()
+	. = TOOL_ACT_TOOLTYPE_SUCCESS
+	if(QDELETED(multitool.buffer))
+		to_chat(user, "<span class='warning'>\The [multitool]'s buffer is empty.</span>")
+		return
+	if(!istype(multitool.buffer, /obj/machinery/stasis))
+		to_chat(user, "<span class='warning'>You cannot link \the [multitool.buffer] to \the [src].</span>")
+		return
+	var/obj/machinery/stasis/new_stasis_bed = multitool.buffer
+	if(sbed)
+		sbed.op_computer = null
+	new_stasis_bed.op_computer = src
+	sbed = new_stasis_bed
+	to_chat(user, "<span class='notice'>You link \the [src] with \the [new_stasis_bed] to its [dir2text(get_dir(src, new_stasis_bed))].</span>")
 
 #undef MENU_OPERATION
 #undef MENU_SURGERIES

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -172,6 +172,7 @@
 		to_chat(user, "<span class='warning'>You cannot link \the [multitool.buffer] to \the [src].</span>")
 		return
 	var/obj/machinery/stasis/new_stasis_bed = multitool.buffer
+	balloon_alert(user, "linked to \the [new_stasis_bed]")
 	if(sbed)
 		sbed.op_computer = null
 	new_stasis_bed.op_computer = src

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -172,6 +172,9 @@
 		to_chat(user, "<span class='warning'>You cannot link \the [multitool.buffer] to \the [src].</span>")
 		return
 	var/obj/machinery/stasis/new_stasis_bed = multitool.buffer
+	if(get_dist(src, new_stasis_bed) > 3)
+		to_chat(user, "<span class='warning'>\The [src] is too far away from \the [new_stasis_bed] to link!</span>")
+		return
 	balloon_alert(user, "linked to \the [new_stasis_bed]")
 	if(sbed)
 		sbed.op_computer = null

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -22,14 +22,15 @@
 /obj/machinery/stasis/Initialize(mapload)
 	. = ..()
 	for(var/direction in GLOB.alldirs)
-		op_computer = locate(/obj/machinery/computer/operating) in get_step(src, direction)
-		if(op_computer)
+		var/obj/machinery/computer/operating/op_computer = locate(/obj/machinery/computer/operating) in get_step(src, direction)
+		if(op_computer && !op_computer.sbed)
 			op_computer.sbed = src
+			src.op_computer = op_computer
 			break
 
 /obj/machinery/stasis/Destroy()
 	. = ..()
-	if(op_computer && op_computer.sbed == src)
+	if(op_computer?.sbed == src)
 		op_computer.sbed = null
 
 /obj/machinery/stasis/examine(mob/user)
@@ -146,6 +147,17 @@
 
 /obj/machinery/stasis/crowbar_act(mob/living/user, obj/item/I)
 	return default_deconstruction_crowbar(I)
+
+/obj/machinery/stasis/multitool_act(mob/living/user, obj/item/I)
+	var/obj/item/multitool/multitool = I
+	if(!I || !istype(I))
+		return ..()
+	. = TOOL_ACT_TOOLTYPE_SUCCESS
+	if(!panel_open)
+		to_chat(user, "<span class='warning'>\The [src]'s panel must be open in order to add it to \the [multitool]'s buffer.</span>")
+		return
+	multitool.buffer = src
+	to_chat(user, "<span class='notice'>You store the linking data of \the [src] in \the [multitool]'s buffer. Use it on an operating computer to complete linking.</span>")
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -158,6 +158,7 @@
 		return
 	multitool.buffer = src
 	to_chat(user, "<span class='notice'>You store the linking data of \the [src] in \the [multitool]'s buffer. Use it on an operating computer to complete linking.</span>")
+	balloon_alert(user, "saved in buffer")
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This allows you to directly link a stasis bed to an operating computer using a multitool, no more reconstructing stasis beds to try to get it to link to the right computer.

Also, surgery tables and stasis beds will now only try to link to unused operating computers, rather than cannibalizing an operating computer already linked to something.

## Why It's Good For The Game

Because getting the right stasis bed to link with the right operating computer, when building them near each other, can be frustrating.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-03-31-1680281036-dreamseeker](https://user-images.githubusercontent.com/65794972/229180700-f32be503-8ae9-4caa-a7e1-462210d5df9c.png)

note: hitting it with the multitool should be fixed now

</details>

## Changelog
:cl:
add: You can now link stasis beds to operating computers with a multitool!
tweak: Surgery tables and stasis beds will now only try to link to unused operating computers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
