### PR TITLE
[April Fools] Makes Ian green

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -375,6 +375,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	var/memory_saved = FALSE
 	var/saved_head //path
 	worn_slot_flags = ITEM_SLOT_HEAD
+	color = "green"
 
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/Initialize(mapload)


### PR DESCRIPTION
This is it.
This is what we have been waiting for.
A collaberative effort between all the greatest minds of SS13.
Green Ian.

## Testing Evidence

![image](https://user-images.githubusercontent.com/26465327/229298496-ee3c5d1a-b6cc-4b13-9177-675375a17ab7.png)


## Changelog
:cl:
fix: Ian is now green.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
