### PR TITLE
Lavaland Ghost Spawners are More Heavily Weighted

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -4,7 +4,7 @@
 	prefix = "_maps/RandomRuins/LavaRuins/"
 
 /datum/map_template/ruin/lavaland/biodome
-	cost = 5
+	cost = 15
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/biodome/beach
@@ -74,7 +74,7 @@
 	name = "Animal Hospital"
 	id = "animal-hospital"
 	description = "An ancient animal hospital, its true purpose long forgotten. The doctors awaken with a singular purpose: heal the dying, sick, and injured habitants of the wasteland around them."
-	cost = 5
+	cost = 15
 	suffix = "lavaland_surface_animal_hospital.dmm"
 	allow_duplicates = FALSE
 
@@ -198,7 +198,7 @@
 	description = "A place of shelter for a lone hermit, scraping by to live another day."
 	suffix = "lavaland_surface_hermit.dmm"
 	allow_duplicates = FALSE
-	cost = 10
+	cost = 15
 
 /datum/map_template/ruin/lavaland/swarmer_boss
 	name = "Crashed Shuttle"
@@ -222,7 +222,7 @@
 	description = "Mystery to be solved."
 	suffix = "lavaland_surface_puzzle.dmm"
 	cost = 5
-  
+
 /datum/map_template/ruin/lavaland/elite_tumor
 	name = "Pulsating Tumor"
 	id = "tumor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Round after round, the only ghost spawners that are available on Lavaland are the Beach Bums, Lavaland Veternarians and Hermit roles. These roles are very rarely selected by ghosts and are more heavily RP focused. With small mining teams, there is not a lot of people down on Lavaland to interact with, so these roles are very limited.

I have simply increased the cost of the Hermit, Biodome and Vet spawns to 15, above the weight of Lifebringers, but below Ashwalkers and Free Golems. This should at least decrease the rate of spawn, allowing for ghost roles which can actually enhance Lavaland or act as better areas to mess around in without impacting the station. This weight still allows them to spawn at a decent rate.

I selected a weight which I think would be an okay compromise, but I could see adjusting it more.

## Why It's Good For The Game

These three ghost spawners are rarely used, and do not have much potential due to their limited gear and reason to stick to Lavaland (plus fairly unclear rules in the Wiki).  Golems, Ashwalkers, Syndicate base, and Lifebringers infrequently spawn due to their cost, and these are the roles which are the most replayable and useful if you want to mess around with other things without impacting the round.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

It builds... not sure what other testing you would like to see on a 3 character change.

## Changelog
:cl:
balance: CC has dispatched "Recruitment Patrols" to Lavaland to recruit more Beach Bums, Vets and Hermits. There should be fewer of them near where you are mining.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
