### PR TITLE
Deconstructing blast doors now gives 15 plasteel

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -62,7 +62,7 @@
 			to_chat(user, "<span class='notice'>You start tearing apart the [src].</span>")
 			playsound(src.loc, 'sound/items/welder.ogg', 50, 1)
 			if(do_after(user, 15 SECONDS, target = src))
-				new /obj/item/stack/sheet/plasteel(loc, 5)
+				new /obj/item/stack/sheet/plasteel(loc, 15)
 				qdel(src)
 
 /obj/machinery/door/poddoor/examine(mob/user)


### PR DESCRIPTION

## About The Pull Request

Fixes: https://github.com/BeeStation/BeeStation-Hornet/issues/8798

(based 1 line fix??)

## Testing Photographs and Procedure

Deconstructed a blast door on a private server, everything works as intended

![dreamseeker_KV55tfvQH2](https://user-images.githubusercontent.com/81387903/229470884-e9ccf78c-52fc-49df-b1f3-8ffbace7aa15.png)

![dreamseeker_Vv6BFkyrcq](https://user-images.githubusercontent.com/81387903/229470770-fba54658-c7b7-4268-8173-50b00ded87c3.png)

## Changelog
:cl:
fix: Blast doors now give as much plasteel as they take to construct
/:cl: