### PR TITLE
Fixes looping sounds

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -1,5 +1,5 @@
 /*
-	output_atoms	(list of atoms)			The destination(s) for the sounds
+	parent	(atom)							The sound source
 
 	mid_sounds		(list or soundfile)		Since this can be either a list or a single soundfile you can have random sounds. May contain further lists but must contain a soundfile at the end.
 	mid_length		(num)					The length to wait between playing mid_sounds
@@ -25,6 +25,7 @@
 	var/volume = 100
 	var/max_loops
 	var/direct
+	var/vary
 	var/extra_range
 
 	var/timerid
@@ -83,7 +84,7 @@
 		S.volume = volume
 		SEND_SOUND(parent, S)
 	else
-		playsound(parent, S, volume, extra_range)
+		playsound(parent, S, volume, vary, extra_range)
 
 /datum/looping_sound/proc/get_sound(starttime, _mid_sounds)
 	. = _mid_sounds || mid_sounds


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a 6 year old bug in _looping_sound.dm
`extra_range` was set as the 4th argument, which is the input for `vary`. 

Strangely, this should have been fixed in #7584 as this issue appears to have been fixed years prior on TG.

## Changelog
:cl:
fix: fixes an old bug with looping sounds.
/:cl:
