### PR TITLE
Converts the old send2chat messages to datums

### DIFF
--- a/code/__HELPERS/chat.dm
+++ b/code/__HELPERS/chat.dm
@@ -11,7 +11,7 @@ For example if you have the following channels in tgs4 set up
 - Channel 4, No Tag
 - Channel 5, Tag: butts
 and you make the call:
-send2chat("I sniff butts", CONFIG_GET(string/where_to_send_sniff_butts))
+send2chat(new /datum/tgs_message_content("I sniff butts"), CONFIG_GET(string/where_to_send_sniff_butts))
 and the config option is set like:
 WHERE_TO_SEND_SNIFF_BUTTS asdf
 It will be sent to channels 1 and 2
@@ -24,11 +24,11 @@ In TGS3 it will always be sent to all connected designated game chats.
 /**
  * Sends a message to TGS chat channels.
  *
- * message - The message to send.
+ * message - The [/datum/tgs_message_content] to send.
  * channel_tag - Required. If "", the message with be sent to all connected (Game-type for TGS3) channels. Otherwise, it will be sent to TGS4 channels with that tag (Delimited by ','s).
  * admin_only - Determines if this communication can only be sent to admin only channels.
  */
-/proc/send2chat(message, channel_tag, admin_only = FALSE)
+/proc/send2chat(datum/tgs_message_content/message, channel_tag, admin_only = FALSE)
 	if(channel_tag == null || !world.TgsAvailable())
 		return
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -157,7 +157,7 @@ SUBSYSTEM_DEF(ticker)
 			for(var/client/C in GLOB.clients)
 				window_flash(C, ignorepref = TRUE) //let them know lobby has opened up.
 			to_chat(world, "<span class='boldnotice'>Welcome to [station_name()]!</span>")
-			send2chat("New round starting on [SSmapping.config.map_name]!", CONFIG_GET(string/chat_announce_new_game))
+			send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.config.map_name]!"), CONFIG_GET(string/chat_announce_new_game))
 			current_state = GAME_STATE_PREGAME
 			//Everyone who wants to be an observer is now spawned
 			create_observers()

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -15,7 +15,7 @@
 	var/list/allmins = adm["total"]
 	var/status = "Admins: [allmins.len] (Active: [english_list(adm["present"])] AFK: [english_list(adm["afk"])] Stealth: [english_list(adm["stealth"])] Skipped: [english_list(adm["noflags"])]). "
 	status += "Players: [GLOB.clients.len] (Active: [get_active_player_count(0,1,0)]). Mode: [SSticker.mode ? SSticker.mode.name : "Not started"]."
-	return status
+	return new /datum/tgs_message_content(status)
 
 /datum/tgs_chat_command/irccheck
 	name = "check"
@@ -28,7 +28,7 @@
 		return
 	last_irc_check = rtod
 	var/server = CONFIG_GET(string/server)
-	return "[GLOB.round_id ? "Round #[GLOB.round_id]: " : ""][GLOB.clients.len] players on [SSmapping.config.map_name], Mode: [GLOB.master_mode]; Round [SSticker.HasRoundStarted() ? (SSticker.IsRoundInProgress() ? "Active" : "Finishing") : "Starting"] -- [server ? server : "[world.internet_address]:[world.port]"]"
+	return new /datum/tgs_message_content("[GLOB.round_id ? "Round #[GLOB.round_id]: " : ""][GLOB.clients.len] players on [SSmapping.config.map_name], Mode: [GLOB.master_mode]; Round [SSticker.HasRoundStarted() ? (SSticker.IsRoundInProgress() ? "Active" : "Finishing") : "Starting"] -- [server ? server : "[world.internet_address]:[world.port]"]")
 
 /** -- Not for use within BeeStation
 /datum/tgs_chat_command/ahelp
@@ -62,10 +62,10 @@
 /datum/tgs_chat_command/namecheck/Run(datum/tgs_chat_user/sender, params)
 	params = trim(params)
 	if(!params)
-		return "Insufficient parameters"
+		return new /datum/tgs_message_content("Insufficient parameters")
 	log_admin("Chat Name Check: [sender.friendly_name] on [params]")
 	message_admins("Name checking [params] from [sender.friendly_name]")
-	return keywords_lookup(params, 1)
+	return new /datum/tgs_message_content(keywords_lookup(params, 1))
 
 /datum/tgs_chat_command/adminwho
 	name = "adminwho"
@@ -73,7 +73,7 @@
 	admin_only = TRUE
 
 /datum/tgs_chat_command/adminwho/Run(datum/tgs_chat_user/sender, params)
-	return tgsadminwho()
+	return new /datum/tgs_message_content(tgsadminwho())
 
 GLOBAL_LIST(round_end_notifiees)
 
@@ -84,10 +84,10 @@ GLOBAL_LIST(round_end_notifiees)
 
 /datum/tgs_chat_command/notify/Run(datum/tgs_chat_user/sender, params)
 	if(!SSticker.IsRoundInProgress() && SSticker.HasRoundStarted())
-		return "[sender.mention], the round has already ended!"
+		return new /datum/tgs_message_content("[sender.mention], the round has already ended!")
 	LAZYINITLIST(GLOB.round_end_notifiees)
 	GLOB.round_end_notifiees[sender.mention] = TRUE
-	return "I will notify [sender.mention] when the round ends."
+	return new /datum/tgs_message_content("I will notify [sender.mention] when the round ends.")
 
 /** -- Not for use within BeeStation
 /datum/tgs_chat_command/sdql


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Addresses the warnings added in https://github.com/BeeStation/BeeStation-Hornet/pull/8818

## Why It's Good For The Game

Better compliance with TGS's dmapi.

## Testing Photographs and Procedure
Will need to check TGS logs to confirm that it's all working.

## Changelog
:cl:
code: Converts send2chat messages into tgs_message_content datums
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
