### PR TITLE
Replace GlowStation Secure Elevator with an actual elevator

### DIFF
--- a/_maps/map_files/GlowStation/GlowStation.dmm
+++ b/_maps/map_files/GlowStation/GlowStation.dmm
@@ -853,12 +853,11 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "aiJ" = (
-/obj/structure/railing/corner,
 /obj/machinery/camera{
-	c_tag = "Floor 2 Command staircase";
-	name = "hallway camera"
+	c_tag = "Secure Elevator"
 	},
-/turf/open/floor/plasteel/elevatorshaft,
+/obj/structure/elevator_segment/secure,
+/turf/open/floor/noslip/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "aiK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2522,10 +2521,21 @@
 /area/chapel/main/monastery)
 "aCp" = (
 /obj/machinery/atmospherics/pipe/multiz/layer2,
-/obj/effect/turf_decal/delivery/white,
 /obj/machinery/camera{
 	c_tag = "Floor 5 AI Sat hallway - Central";
 	name = "hallway camera"
+	},
+/obj/machinery/elevator_interface/secure{
+	preset_z = 1;
+	pixel_y = 24
+	},
+/obj/machinery/elevator_indicator/secure{
+	pixel_y = 24;
+	preset_z = 1;
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/upper/secondary/command)
@@ -9293,6 +9303,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "bWX" = (
@@ -15098,7 +15112,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
 "dpM" = (
-/turf/open/floor/plasteel/elevatorshaft,
+/obj/machinery/door/airlock/public/glass{
+	req_access_txt = "16"
+	},
+/obj/structure/elevator_segment/secure,
+/turf/open/floor/noslip/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "dpU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17058,6 +17076,15 @@
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/atmospherics/pipe/multiz/layer2,
+/obj/machinery/elevator_indicator/secure{
+	pixel_y = 24;
+	preset_z = 1;
+	pixel_x = 10
+	},
+/obj/machinery/elevator_interface/secure{
+	preset_z = 1;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/upper/secondary/command)
 "dKn" = (
@@ -18437,12 +18464,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/iceland_surface,
 /area/chapel/main/monastery)
-"dYB" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "dYC" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8
@@ -19934,13 +19955,6 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"eql" = (
-/obj/structure/stairs,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "eqn" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -26412,20 +26426,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
-"fHA" = (
-/obj/structure/railing{
-	layer = 3
-	},
-/obj/machinery/camera{
-	c_tag = "Floor 1 Command staircase";
-	name = "hallway camera"
-	},
-/obj/effect/turf_decal/numbers/two_nine{
-	dir = 4
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "fHC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark{
@@ -28919,12 +28919,6 @@
 "ghB" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
-"ghG" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/ai_monitored/turret_protected/ai_upload_foyer)
 "ghH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -29680,6 +29674,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"gqQ" = (
+/obj/machinery/elevator_indicator/secure{
+	pixel_x = -24
+	},
+/obj/structure/elevator_segment/secure,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/noslip/dark,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "gqR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -32179,7 +32183,9 @@
 /area/tcommsat/relay)
 "gRD" = (
 /obj/machinery/atmospherics/pipe/multiz/layer4,
-/obj/effect/turf_decal/delivery/red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/hallway/upper/secondary/command)
 "gRG" = (
@@ -34110,12 +34116,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/crew_quarters/heads/hop)
-"hkL" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/hallway/upper/secondary/command)
 "hkO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -36224,14 +36224,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"hGG" = (
-/obj/machinery/camera{
-	c_tag = "Floor 5 Command staircase";
-	name = "hallway camera"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/openspace,
-/area/hallway/upper/secondary/command)
 "hGH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36696,11 +36688,6 @@
 	},
 /turf/open/openspace/cold,
 /area/iceland/shaded)
-"hKP" = (
-/obj/effect/turf_decal/numbers/two_nine,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "hKU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -39030,12 +39017,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"ijG" = (
-/obj/structure/railing{
-	layer = 3
-	},
-/turf/open/openspace,
-/area/hallway/upper/secondary/command)
 "ijK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -48339,13 +48320,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/upper/primary/central)
-"kgs" = (
-/obj/machinery/camera{
-	c_tag = "Floor 4 Command staircase";
-	name = "hallway camera"
-	},
-/turf/open/openspace,
-/area/hallway/upper/secondary/command)
 "kgC" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/wood/normal{
@@ -50008,6 +49982,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
+"kyY" = (
+/obj/structure/elevator_segment/secure,
+/turf/open/floor/noslip/dark,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "kza" = (
 /obj/machinery/door/airlock/research{
 	name = "Shuttle dock";
@@ -50661,6 +50639,13 @@
 	},
 /turf/open/openspace/cold,
 /area/iceland)
+"kHy" = (
+/obj/effect/turf_decal/caution/stand_clear/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/upper/secondary/command)
 "kHC" = (
 /obj/structure/window/plasma/reinforced,
 /turf/open/floor/plating/asteroid/basalt/iceland_surface,
@@ -52801,6 +52786,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
+"ldD" = (
+/obj/structure/sign/warning{
+	name = "\improper WARNING: ELEVATOR SHAFT"
+	},
+/turf/closed/wall/r_wall,
+/area/hallway/upper/secondary/command)
 "ldL" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -54462,6 +54453,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/upper/secondary/command)
 "luE" = (
@@ -55340,6 +55332,12 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/plasteel/white,
 /area/hallway/upper/primary/port)
+"lFX" = (
+/obj/structure/sign/warning{
+	name = "\improper WARNING: ELEVATOR SHAFT"
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "lFY" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -60643,12 +60641,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"mJC" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/ai_monitored/turret_protected/ai_upload_foyer)
 "mJD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -72127,15 +72119,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"per" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "pet" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/five,
@@ -77775,19 +77758,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"qoe" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "qog" = (
 /obj/item/stack/medical/gauze,
 /obj/item/stack/medical/ointment,
@@ -79782,10 +79752,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/library)
-"qIj" = (
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "qIm" = (
 /obj/structure/table/wood,
 /obj/structure/disposalpipe/segment,
@@ -80218,6 +80184,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -82980,10 +82950,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rro" = (
-/obj/structure/railing{
-	layer = 3
+/obj/structure/elevator_segment/secure,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/elevatorshaft,
+/turf/open/floor/noslip/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "rrv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -84402,13 +84373,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/carpet/royalblack,
 /area/library)
-"rJS" = (
-/obj/structure/railing/corner{
-	dir = 4;
-	pixel_y = -23
-	},
-/turf/open/openspace,
-/area/hallway/upper/secondary/command)
 "rJY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -84673,13 +84637,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rOj" = (
-/obj/effect/turf_decal/numbers{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/ai_monitored/turret_protected/ai_upload_foyer)
 "rOq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -86872,6 +86829,10 @@
 "siC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -90778,6 +90739,18 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/elevator_interface/secure{
+	preset_z = 1;
+	pixel_y = 24
+	},
+/obj/machinery/elevator_indicator/secure{
+	pixel_y = 24;
+	preset_z = 1;
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -94825,10 +94798,6 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"tNi" = (
-/obj/structure/railing,
-/turf/open/openspace,
-/area/hallway/upper/secondary/command)
 "tNm" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
@@ -102948,17 +102917,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
 /area/crew_quarters/locker)
-"vvZ" = (
-/obj/machinery/camera{
-	c_tag = "Floor 3 Command staircase";
-	name = "hallway camera"
-	},
-/obj/effect/turf_decal/numbers/two_nine{
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "vwb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/command/glass{
@@ -108473,13 +108431,6 @@
 /obj/structure/ladder,
 /turf/open/floor/plasteel/dark/snowdin,
 /area/iceland)
-"wFz" = (
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/numbers/two_nine{
-	dir = 8
-	},
-/turf/open/floor/plasteel/elevatorshaft,
-/area/hallway/upper/secondary/command)
 "wFD" = (
 /obj/structure/railing{
 	dir = 8
@@ -110256,6 +110207,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -114421,6 +114375,13 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/plasteel/white,
 /area/hallway/upper/primary/aft)
+"yat" = (
+/obj/machinery/elevator_interface/secure{
+	pixel_x = -24
+	},
+/obj/structure/elevator_segment/secure,
+/turf/open/floor/noslip/dark,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "yaw" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -148066,10 +148027,10 @@ obX
 jvh
 uDz
 qSj
-qfB
-dpM
-dpM
-dpM
+lFX
+gqQ
+yat
+kyY
 dpM
 bWW
 gnM
@@ -148325,9 +148286,9 @@ tii
 rZn
 qfB
 aiJ
-mJC
-mJC
-rOj
+kyY
+kyY
+dpM
 qMj
 kQj
 bCG
@@ -148580,10 +148541,10 @@ sKv
 jvh
 gxG
 lRV
-qfB
+lFX
 rro
-ghG
-ghG
+kyY
+kyY
 dpM
 siC
 gak
@@ -213350,7 +213311,7 @@ lgz
 lgz
 lgz
 lgz
-lgz
+ldD
 hOC
 nCW
 eTW
@@ -213603,10 +213564,10 @@ eTW
 eTW
 gVf
 lgz
-rdV
-eql
-eql
-rdV
+qkU
+qkU
+qkU
+qkU
 xto
 dHb
 iXM
@@ -213860,10 +213821,10 @@ eTW
 eTW
 gVf
 lgz
-vvZ
-rdV
-rdV
-rdV
+qkU
+qkU
+qkU
+qkU
 mWb
 luD
 iXM
@@ -214117,11 +214078,11 @@ eTW
 eTW
 gVf
 lgz
-rdV
-hkL
-hkL
-rdV
-goN
+qkU
+qkU
+qkU
+qkU
+lgz
 dKj
 iXM
 eTW
@@ -214378,7 +214339,7 @@ lgz
 lgz
 lgz
 lgz
-lgz
+goN
 iXM
 iXM
 eTW
@@ -279141,8 +279102,8 @@ ohO
 lgz
 qkU
 qkU
-rJS
-rdV
+qkU
+qkU
 lgz
 vKF
 vHs
@@ -279396,10 +279357,10 @@ eTW
 eTW
 vzA
 lgz
-kgs
 qkU
-tNi
-hKP
+qkU
+qkU
+qkU
 lgz
 vHs
 vHs
@@ -279654,9 +279615,9 @@ yjJ
 ohO
 lgz
 qkU
-per
-qoe
-rdV
+qkU
+qkU
+qkU
 lgz
 qat
 vHs
@@ -344675,9 +344636,9 @@ eTW
 mkL
 ohO
 lgz
-qIj
-eql
-eql
+qkU
+qkU
+qkU
 qkU
 lgz
 qoN
@@ -344932,7 +344893,7 @@ eTW
 eTW
 qJI
 lgz
-fHA
+qkU
 qkU
 qkU
 qkU
@@ -345189,7 +345150,7 @@ eTW
 xgu
 ohO
 lgz
-dYB
+qkU
 qkU
 qkU
 qkU
@@ -410214,7 +410175,7 @@ lgz
 qkU
 qkU
 qkU
-rdV
+qkU
 xto
 gRD
 dzv
@@ -410468,12 +410429,12 @@ ntU
 hNE
 ots
 lgz
-hGG
 qkU
-ijG
-wFz
+qkU
+qkU
+qkU
 aWI
-tBx
+kHy
 qAX
 dvj
 dvj
@@ -410727,8 +410688,8 @@ ahW
 lgz
 qkU
 qkU
-ijG
-rdV
+qkU
+qkU
 lgz
 aCp
 uHr
@@ -410986,7 +410947,7 @@ lgz
 lgz
 lgz
 lgz
-lgz
+ldD
 tBx
 dQO
 tBx

--- a/code/modules/elevator/elevator_indicator.dm
+++ b/code/modules/elevator/elevator_indicator.dm
@@ -18,6 +18,10 @@
 /obj/machinery/elevator_indicator/primary
 	id = "primary"
 
+// Glowstation
+/obj/machinery/elevator_indicator/secure
+	id = "secure"
+
 /obj/machinery/elevator_indicator/Initialize(mapload)
 	. = ..()
 	update_display(force = TRUE)

--- a/code/modules/elevator/elevator_interface.dm
+++ b/code/modules/elevator/elevator_interface.dm
@@ -23,6 +23,11 @@
 	id = "primary"
 	available_levels = list(1, 2, 3)
 
+// Glowstation
+/obj/machinery/elevator_interface/secure
+	id = "secure"
+	available_levels = list(1, 2, 5)
+
 /obj/machinery/elevator_interface/Initialize(mapload)
 	. = ..()
 	if(standing)
@@ -37,10 +42,10 @@
 /obj/machinery/elevator_interface/proc/select_level(level)
 	if(!powered() || SSelevator_controller.elevator_group_timers[id])
 		if(powered())
-			say("Unable to call elevator...")
+			say("Elevator is currently moving, please wait.")
 		return
 	var/destination = preset_z ? get_virtual_z_level() : level + z_offset
-	if(!(destination in available_levels))
+	if(!((destination - 1) in available_levels)) // available_levels is shifted by 1, since centcom is z1
 		return
 	destination -= preset_z ? 0 : z_offset
 	if(!destination || (destination == get_virtual_z_level() && !preset_z))

--- a/code/modules/elevator/elevator_interface.dm
+++ b/code/modules/elevator/elevator_interface.dm
@@ -27,6 +27,7 @@
 /obj/machinery/elevator_interface/secure
 	id = "secure"
 	available_levels = list(1, 2, 5)
+	calltime = 3.5 SECONDS // this is a long elevator, please don't take 5 years
 
 /obj/machinery/elevator_interface/Initialize(mapload)
 	. = ..()
@@ -37,22 +38,22 @@
 /obj/machinery/elevator_interface/attack_hand(mob/living/user)
 	. = ..()
 	if(preset_z)
-		select_level()
+		select_level(get_virtual_z_level() + z_offset)
 
-/obj/machinery/elevator_interface/proc/select_level(level)
+/obj/machinery/elevator_interface/proc/select_level(display_level)
 	if(!powered() || SSelevator_controller.elevator_group_timers[id])
 		if(powered())
 			say("Elevator is currently moving, please wait.")
 		return
-	var/destination = preset_z ? get_virtual_z_level() : level + z_offset
-	if(!((destination - 1) in available_levels)) // available_levels is shifted by 1, since centcom is z1
+	var/real_destination = display_level - z_offset
+	var/display_destination = display_level
+	if(!(display_destination in available_levels))
 		return
-	destination -= preset_z ? 0 : z_offset
-	if(!destination || (destination == get_virtual_z_level() && !preset_z))
+	if(!real_destination || (real_destination == get_virtual_z_level() && !preset_z))
 		return
 	if(preset_z)
 		say("Calling elevator...")
-	if(!SSelevator_controller.move_elevator(id, destination, calltime * abs(get_virtual_z_level() - destination), obj_flags & EMAGGED))
+	if(!SSelevator_controller.move_elevator(id, real_destination, calltime * abs(get_virtual_z_level() - real_destination), obj_flags & EMAGGED))
 		say("Elevator obstructed...")
 
 /obj/machinery/elevator_interface/on_emag(mob/user)

--- a/code/modules/elevator/elevator_interface.dm
+++ b/code/modules/elevator/elevator_interface.dm
@@ -83,5 +83,5 @@
 		return
 	var/num = text2num(action)
 	if(isnum(num))
-		select_level(num-z_offset)
+		select_level(num)
 	return TRUE

--- a/code/modules/elevator/elevator_segment.dm
+++ b/code/modules/elevator/elevator_segment.dm
@@ -16,6 +16,11 @@
 	id = "primary"
 	base_turf = /turf/open/floor/plasteel/elevatorshaft
 
+// Glowstation
+/obj/structure/elevator_segment/secure
+	id = "secure"
+	base_turf = /turf/open/floor/plasteel/elevatorshaft
+
 /obj/structure/elevator_segment/Initialize(mapload)
 	music_files = list('sound/effects/turbolift/elevatormusic.ogg' = 45, 'sound/effects/turbolift/elevator_loop.ogg' = 25)
 	move_blacklist = typecacheof(list(/atom/movable/lighting_object, /obj/structure/cable, /obj/structure/disposalpipe, /obj/machinery/atmospherics/pipe))


### PR DESCRIPTION
## About The Pull Request

We've got elevators in the code, now let's make it a real one!

Also fixes a bug where available floors would not properly respect the z_offset on preset_z mode.

## Why It's Good For The Game

Elevators are cool, plus it gives these an actual use.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/230551477-355543b4-1a52-4ecb-b0c1-bdeaace7e9b7.png)

![image](https://user-images.githubusercontent.com/10366817/230551486-73ebf75e-9a8e-49f4-998a-fa8ebee97442.png)

</details>

## Changelog
:cl:
add: GlowStation: Replaced the secure elevator staircase with an actual elevator.
fix: Elevator call buttons now work on the top floor.
tweak: Improved elevator call button feedback if the elevator is currently moving.
/:cl:
