### PR TITLE
Fix bug with surgeries imported via disk into the serverlink implant

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -151,22 +151,18 @@
 	actions_types = list(/datum/action/item_action/update_linkedsurgery)
 	var/list/advanced_surgeries = list()
 	var/static/datum/techweb/linked_techweb
-	var/number_of_surgeries
 
 /obj/item/organ/cyberimp/brain/linkedsurgery/Initialize()
 	. = ..()
 	if(isnull(linked_techweb))
 		linked_techweb = SSresearch.science_tech
-	number_of_surgeries = 0
 
 /obj/item/organ/cyberimp/brain/linkedsurgery/proc/update_surgery()
-	var/list/old_advanced_surgeries = advanced_surgeries.Copy()
-	advanced_surgeries.Cut()
 	for(var/i in linked_techweb.researched_designs)
 		var/datum/design/surgery/D = SSresearch.techweb_design_by_id(i)
 		if(!istype(D))
 			continue
-		advanced_surgeries += D.surgery
+		advanced_surgeries |= D.surgery
 	for(var/held_item in owner.held_items)
 		if(!held_item)
 			continue
@@ -175,8 +171,8 @@
 		if(istype(held_item, /obj/item/disk/surgery))
 			var/obj/item/disk/surgery/surgery_disk = held_item
 			for(var/surgery in surgery_disk.surgeries)
-				if(!(surgery in old_advanced_surgeries) && !(surgery in advanced_surgeries))
-					surgeries_to_add |= surgery
+				if(!(surgery in advanced_surgeries))
+					surgeries_to_add += surgery
 					new_surgeries++
 		else if(istype(held_item, /obj/item/disk/tech_disk))
 			var/obj/item/disk/tech_disk/tech_disk = held_item
@@ -184,8 +180,8 @@
 				var/datum/design/surgery/surgery_design = SSresearch.techweb_design_by_id(D)
 				if(!istype(surgery_design))
 					continue
-				if(!(surgery_design.surgery in old_advanced_surgeries) && !(surgery_design.surgery in advanced_surgeries))
-					surgeries_to_add |= surgery_design.surgery
+				if(!(surgery_design.surgery in advanced_surgeries))
+					surgeries_to_add += surgery_design.surgery
 					new_surgeries++
 		else if(istype(held_item, /obj/item/disk/nuclear))
 			// funny joke message
@@ -204,21 +200,18 @@
 		to_chat(owner, "<span class='notice'><b>[new_surgeries]</b> new surgical program\s were transferred from \the [held_item] in your [hand_name] to \the [src]!</span>")
 		advanced_surgeries |= surgeries_to_add
 
-/obj/item/organ/cyberimp/brain/linkedsurgery/proc/check_surgery_update()
-	if(number_of_surgeries<length(advanced_surgeries))
-		to_chat(usr, "<span class='notice'>Surgical Implant updated.</span>")
-		number_of_surgeries = length(advanced_surgeries)
-	else
-		to_chat(usr, "<span class='notice'>None of new surgical programs detected.</span>")
-
 /datum/action/item_action/update_linkedsurgery
 	name = "Update Surgical Implant"
 
 /datum/action/item_action/update_linkedsurgery/Trigger()
 	if(istype(target, /obj/item/organ/cyberimp/brain/linkedsurgery))
 		var/obj/item/organ/cyberimp/brain/linkedsurgery/I = target
+		var/old_surgeries_amount = length(I.advanced_surgeries)
 		I.update_surgery()
-		I.check_surgery_update()
+		if(length(I.advanced_surgeries) > old_surgeries_amount)
+			to_chat(usr, "<span class='notice'>Surgical Implant updated.</span>")
+		else
+			to_chat(usr, "<span class='notice'>None of new surgical programs detected.</span>")
 	return ..()
 
 //[[[[MOUTH]]]]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i made a logic whoopsie, it'd accidentally delete disk implants if you re-updated it.

## Why It's Good For The Game

bugs bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-04-09-1681040994-dreamseeker](https://user-images.githubusercontent.com/65794972/230770891-7a04d19f-d2da-408d-9acb-fb8014f08579.png)

</details>

## Changelog
:cl:
fix: re-updating serverlink implants no longer wipes all disk surgeries off them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
