### PR TITLE
Lavaland Spawners will now spawn more Ashwalkers, Golems, and Syndicate Bases

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -4,7 +4,7 @@
 	prefix = "_maps/RandomRuins/LavaRuins/"
 
 /datum/map_template/ruin/lavaland/biodome
-	cost = 5
+	cost = 10
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/biodome/beach
@@ -50,7 +50,7 @@
 	description = "A race of unbreathing lizards live here, that run faster than a human can, worship a broken dead city, and are capable of reproducing by something involving tentacles? \
 	Probably best to stay clear."
 	suffix = "lavaland_surface_ash_walker1.dmm"
-	cost = 20
+	cost = 10
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/syndicate_base
@@ -58,7 +58,7 @@
 	id = "lava-base"
 	description = "A secret base researching illegal bioweapons, it is closely guarded by an elite team of syndicate agents."
 	suffix = "lavaland_surface_syndicate_base1.dmm"
-	cost = 20
+	cost = 10
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/free_golem
@@ -66,7 +66,7 @@
 	id = "golem-ship"
 	description = "Lumbering humanoids, made out of precious metals, move inside this ship. They frequently leave to mine more minerals, which they somehow turn into more of them. \
 	Seem very intent on research and individual liberty, and also geology based naming?"
-	cost = 20
+	cost = 10
 	suffix = "lavaland_surface_golem_ship.dmm"
 	allow_duplicates = FALSE
 
@@ -74,7 +74,7 @@
 	name = "Animal Hospital"
 	id = "animal-hospital"
 	description = "An ancient animal hospital, its true purpose long forgotten. The doctors awaken with a singular purpose: heal the dying, sick, and injured habitants of the wasteland around them."
-	cost = 5
+	cost = 10
 	suffix = "lavaland_surface_animal_hospital.dmm"
 	allow_duplicates = FALSE
 
@@ -222,7 +222,7 @@
 	description = "Mystery to be solved."
 	suffix = "lavaland_surface_puzzle.dmm"
 	cost = 5
-  
+
 /datum/map_template/ruin/lavaland/elite_tumor
 	name = "Pulsating Tumor"
 	id = "tumor"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -4,7 +4,7 @@
 	prefix = "_maps/RandomRuins/LavaRuins/"
 
 /datum/map_template/ruin/lavaland/biodome
-	cost = 10
+	cost = 5
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/biodome/beach
@@ -41,7 +41,7 @@
 	description = "The creators of these vaults were a highly advanced and benevolent race, and launched many into the stars, hoping to aid fledgling civilizations. \
 	However, all the inhabitants seem to do is grow drugs and guns."
 	suffix = "lavaland_surface_seed_vault.dmm"
-	cost = 10
+	cost = 5
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/ash_walker
@@ -50,7 +50,7 @@
 	description = "A race of unbreathing lizards live here, that run faster than a human can, worship a broken dead city, and are capable of reproducing by something involving tentacles? \
 	Probably best to stay clear."
 	suffix = "lavaland_surface_ash_walker1.dmm"
-	cost = 10
+	cost = 5
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/syndicate_base
@@ -58,7 +58,7 @@
 	id = "lava-base"
 	description = "A secret base researching illegal bioweapons, it is closely guarded by an elite team of syndicate agents."
 	suffix = "lavaland_surface_syndicate_base1.dmm"
-	cost = 10
+	cost = 5
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/free_golem
@@ -66,7 +66,7 @@
 	id = "golem-ship"
 	description = "Lumbering humanoids, made out of precious metals, move inside this ship. They frequently leave to mine more minerals, which they somehow turn into more of them. \
 	Seem very intent on research and individual liberty, and also geology based naming?"
-	cost = 10
+	cost = 5
 	suffix = "lavaland_surface_golem_ship.dmm"
 	allow_duplicates = FALSE
 
@@ -74,7 +74,7 @@
 	name = "Animal Hospital"
 	id = "animal-hospital"
 	description = "An ancient animal hospital, its true purpose long forgotten. The doctors awaken with a singular purpose: heal the dying, sick, and injured habitants of the wasteland around them."
-	cost = 10
+	cost = 5
 	suffix = "lavaland_surface_animal_hospital.dmm"
 	allow_duplicates = FALSE
 
@@ -198,7 +198,7 @@
 	description = "A place of shelter for a lone hermit, scraping by to live another day."
 	suffix = "lavaland_surface_hermit.dmm"
 	allow_duplicates = FALSE
-	cost = 10
+	cost = 5
 
 /datum/map_template/ruin/lavaland/swarmer_boss
 	name = "Crashed Shuttle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Round after round, the only ghost spawners that are available on Lavaland are the Beach Bums, Lavaland Veterinarians and Hermit roles. These roles are very rarely selected by ghosts and are more heavily RP focused. With small mining teams, there is not a lot of people down on Lavaland to interact with, so these roles are very limited.

I decreased the weight of the major spawners instead of increasing the weight of the low impact spawns, as recommended by Bacon.

## Why It's Good For The Game

Beach bums, lavaland vets, and lavaland hermit ghost spawners are rarely used, and do not have much potential due to their limited gear and reason to stick to Lavaland (plus fairly unclear rules in the Wiki). Golems, Ashwalkers, Syndicate base, and Lifebringers infrequently spawn due to their cost, and these are the roles which are the most replayable and useful if you want to mess around with other things without impacting the round.

## Testing Photographs and Procedure

It builds... not sure what other testing you would like to see on a 5 line change.

## Changelog
:cl:
balance: Lavaland will now be more dangerous: Some ghost spawns will be more readily available.
/:cl: