### PR TITLE
Camera recognises ghost orbiting + [Port] Camera gets sprite transformation

### DIFF
--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -3,6 +3,42 @@
 #define LUMA_G 0.715
 #define LUMA_B 0.072
 
+/// Datum which stores information about a matrix decomposed with decompose().
+/datum/decompose_matrix
+	///?
+	var/scale_x = 1
+	///?
+	var/scale_y = 1
+	///?
+	var/rotation = 0
+	///?
+	var/shift_x = 0
+	///?
+	var/shift_y = 0
+
+/// Decomposes a matrix into scale, shift and rotation.
+///
+/// If other operations were applied on the matrix, such as shearing, the result
+/// will not be precise.
+///
+/// Negative scales are now supported. =)
+/matrix/proc/decompose()
+	var/datum/decompose_matrix/decompose_matrix = new
+	. = decompose_matrix
+	var/flip_sign = (a*e - b*d < 0)? -1 : 1 // Det < 0 => only 1 axis is flipped - start doing some sign flipping
+	// If both axis are flipped, nothing bad happens and Det >= 0, it just treats it like a 180° rotation
+	// If only 1 axis is flipped, we need to flip one direction - in this case X, so we flip a, b and the x scaling
+	decompose_matrix.scale_x = sqrt(a * a + d * d) * flip_sign
+	decompose_matrix.scale_y = sqrt(b * b + e * e)
+	decompose_matrix.shift_x = c
+	decompose_matrix.shift_y = f
+	if(!decompose_matrix.scale_x || !decompose_matrix.scale_y)
+		return
+	// If only translated, scaled and rotated, a/xs == e/ys and -d/xs == b/xy
+	var/cossine = (a/decompose_matrix.scale_x + e/decompose_matrix.scale_y) / 2
+	var/sine = (b/decompose_matrix.scale_y - d/decompose_matrix.scale_x) / 2 * flip_sign
+	decompose_matrix.rotation = arctan(cossine, sine) * flip_sign
+
 /matrix/proc/TurnTo(old_angle, new_angle)
 	. = new_angle - old_angle
 	Turn(.) //BYOND handles cases such as -270, 360, 540 etc. DOES NOT HANDLE 180 TURNS WELL, THEY TWEEN AND LOOK LIKE SHIT
@@ -60,29 +96,13 @@
 	. += f
 	. += 1
 
-//The X pixel offset of this matrix
+///The X pixel offset of this matrix
 /matrix/proc/get_x_shift()
 	. = c
 
-//The Y pixel offset of this matrix
+///The Y pixel offset of this matrix
 /matrix/proc/get_y_shift()
 	. = f
-
-/matrix/proc/get_x_skew()
-	. = b
-
-/matrix/proc/get_y_skew()
-	. = d
-
-//Skews a matrix in a particular direction
-//Missing arguments are treated as no skew in that direction
-
-//As Rotation is defined as a scale+skew, these procs will break any existing rotation
-//Unless the result is multiplied against the current matrix
-/matrix/proc/set_skew(x = 0, y = 0)
-	b = x
-	d = y
-
 
 //-----------------//
 // COLOUR MATRICES //

--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -104,6 +104,21 @@
 /matrix/proc/get_y_shift()
 	. = f
 
+/matrix/proc/get_x_skew()
+	. = b
+
+/matrix/proc/get_y_skew()
+	. = d
+
+//Skews a matrix in a particular direction
+//Missing arguments are treated as no skew in that direction
+
+//As Rotation is defined as a scale+skew, these procs will break any existing rotation
+//Unless the result is multiplied against the current matrix
+/matrix/proc/set_skew(x = 0, y = 0)
+	b = x
+	d = y
+
 //-----------------//
 // COLOUR MATRICES //
 //-----------------//

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -93,8 +93,6 @@
 	var/list/part_overlays
 	var/panel_attachment = "right"
 	var/note_attachment = "left"
-	/// this is only to know it's opened or closed to get sprite image. opening(closing) status only counts to just open(closed)
-	var/last_used_state = "closed"
 
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
@@ -552,13 +550,6 @@
 		if(AIRLOCK_DENY, AIRLOCK_OPENING, AIRLOCK_CLOSING, AIRLOCK_EMAG)
 			icon_state = "nonexistenticonstate" //MADNESS
 	set_airlock_overlays(state)
-
-	// used for get_overlays_for_photo()
-	switch(state)
-		if(AIRLOCK_OPEN, AIRLOCK_OPENING)
-			last_used_state = "open"
-		if(AIRLOCK_CLOSED, AIRLOCK_CLOSING, AIRLOCK_DENY)
-			last_used_state = "closed"
 
 /obj/machinery/door/airlock/proc/set_side_overlays(obj/effect/overlay/airlock_part/base, show_lights = FALSE)
 	var/side = base.side_id

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -560,36 +560,6 @@
 		if(AIRLOCK_CLOSED, AIRLOCK_CLOSING, AIRLOCK_DENY)
 			last_used_state = "closed"
 
-/// returns the current shape of an airlock to render these in a photo
-/obj/machinery/door/airlock/proc/get_overlays_for_photo()
-	var/list/displaying_overlay = list()
-	displaying_overlay += get_airlock_overlay("[last_used_state]", icon)
-	if(last_used_state == "closed")
-		if(airlock_material)
-			displaying_overlay += get_airlock_overlay("[airlock_material]_[last_used_state]", overlays_file)
-		else
-			displaying_overlay += get_airlock_overlay("fill_[last_used_state]", icon)
-
-		if(lights && hasPower())
-			if(locked)
-				displaying_overlay += get_airlock_overlay("lights_bolts", overlays_file)
-			else if(emergency)
-				displaying_overlay += get_airlock_overlay("lights_emergency", overlays_file)
-
-		if(welded)
-			displaying_overlay += get_airlock_overlay("welded", overlays_file)
-
-		if(note)
-			displaying_overlay += get_airlock_overlay(note_type(), note_overlay_file)
-
-	if(panel_open)
-		if(security_level)
-			displaying_overlay += get_airlock_overlay("panel_[last_used_state]_protected", overlays_file)
-		else
-			displaying_overlay += get_airlock_overlay("panel_[last_used_state]", overlays_file)
-
-	return displaying_overlay
-
 /obj/machinery/door/airlock/proc/set_side_overlays(obj/effect/overlay/airlock_part/base, show_lights = FALSE)
 	var/side = base.side_id
 	base.icon = icon

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -560,6 +560,7 @@
 		if(AIRLOCK_CLOSED, AIRLOCK_CLOSING, AIRLOCK_DENY)
 			last_used_state = "closed"
 
+/// returns the current shape of an airlock to render these in a photo
 /obj/machinery/door/airlock/proc/get_overlays_for_photo()
 	var/list/displaying_overlay = list()
 	displaying_overlay += get_airlock_overlay("[last_used_state]", icon)

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -179,9 +179,9 @@
 	var/list/dead_spotted = list()
 	var/ai_user = isAI(user)
 	var/list/seen
-	var/list/viewlist = (user && user.client)? getviewsize(user.client.view) : getviewsize(world.view)
+	var/list/viewlist = user?.client ? getviewsize(user.client.view) : getviewsize(world.view)
 	var/viewr = max(viewlist[1], viewlist[2]) + max(size_x, size_y)
-	var/viewc = user.client? user.client.eye : target
+	var/viewc = user?.client ? user.client.eye : target
 	seen = get_hear(viewr, get_turf(viewc))
 	var/list/turfs = list()
 	var/list/mobs = list()

--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -15,31 +15,6 @@
 			is_orbiting = AM.orbiting ? TRUE : FALSE
 	. = ..()
 
-// airlocks don't have actual overlays. make fake overlays temporary
-// tried to get vis_content in airlock, but it doesn't capture things properly
-/image/photo/airlock/New(location, obj/machinery/door/airlock/airlock)
-	. = ..()
-	add_overlay(get_airlock_overlay("[airlock.last_used_state]", icon))
-	if(airlock.last_used_state == "closed")
-		var/panel_base = airlock.airlock_material ? airlock.airlock_material : "fill"
-		add_overlay(get_airlock_overlay("[panel_base]_[airlock.last_used_state]", airlock.overlays_file))
-
-		if(airlock.lights && airlock.hasPower())
-			if(airlock.locked)
-				add_overlay(get_airlock_overlay("lights_bolts", airlock.overlays_file))
-			else if(airlock.emergency)
-				add_overlay(get_airlock_overlay("lights_emergency", airlock.overlays_file))
-
-		if(airlock.welded)
-			add_overlay(get_airlock_overlay("welded", airlock.overlays_file))
-
-		if(airlock.note)
-			add_overlay(get_airlock_overlay(airlock.note_type(), airlock.note_overlay_file))
-
-	if(airlock.panel_open)
-		var/protected = airlock.security_level ? "_protected" : ""
-		add_overlay(get_airlock_overlay("panel_[airlock.last_used_state][protected]", airlock.overlays_file))
-
 /obj/item/camera/proc/camera_get_icon(list/turfs, turf/center, psize_x = 96, psize_y = 96, datum/turf_reservation/clone_area, size_x, size_y, total_x, total_y)
 	var/list/images = list()
 	var/skip_normal = FALSE
@@ -61,10 +36,7 @@
 			for(var/i in T.contents)
 				var/atom/A = i
 				if(!A.invisibility || (see_ghosts && can_camera_see_atom(A)))
-					if(istype(A, /obj/machinery/door/airlock))
-						images += new /image/photo/airlock(newT, A)
-					else
-						images += new /image/photo(newT, A)
+					images += new /image/photo(newT, A)
 		skip_normal = TRUE
 		wipe_images = TRUE
 		center = locate(cloned_center_x, cloned_center_y, clone_area.bottom_left_coords[3])
@@ -147,10 +119,7 @@
 			playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, 1, -3)
 
 	if(wipe_images)
-		for(var/image/I in images)
-			I.cut_overlays()
-			qdel(I)
-			images.Cut()
+		QDEL_LIST(images)
 	sorted.Cut()
 
 	return res

--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -16,35 +16,29 @@
 	. = ..()
 
 // airlocks don't have actual overlays. make fake overlays temporary
+// tried to get vis_content in airlock, but it doesn't capture things properly
 /image/photo/airlock/New(location, obj/machinery/door/airlock/airlock)
 	. = ..()
-	var/list/displaying_overlay = list()
-	displaying_overlay += get_airlock_overlay("[airlock.last_used_state]", icon)
+	add_overlay(get_airlock_overlay("[airlock.last_used_state]", icon))
 	if(airlock.last_used_state == "closed")
-		if(airlock.airlock_material)
-			displaying_overlay += get_airlock_overlay("[airlock.airlock_material]_[airlock.last_used_state]", airlock.overlays_file)
-		else
-			displaying_overlay += get_airlock_overlay("fill_[airlock.last_used_state]", icon)
+		var/panel_base = airlock.airlock_material ? airlock.airlock_material : "fill"
+		add_overlay(get_airlock_overlay("[panel_base]_[airlock.last_used_state]", airlock.overlays_file))
 
 		if(airlock.lights && airlock.hasPower())
 			if(airlock.locked)
-				displaying_overlay += get_airlock_overlay("lights_bolts", airlock.overlays_file)
+				add_overlay(get_airlock_overlay("lights_bolts", airlock.overlays_file))
 			else if(airlock.emergency)
-				displaying_overlay += get_airlock_overlay("lights_emergency", airlock.overlays_file)
+				add_overlay(get_airlock_overlay("lights_emergency", airlock.overlays_file))
 
 		if(airlock.welded)
-			displaying_overlay += get_airlock_overlay("welded", airlock.overlays_file)
+			add_overlay(get_airlock_overlay("welded", airlock.overlays_file))
 
 		if(airlock.note)
-			displaying_overlay += get_airlock_overlay(airlock.note_type(), airlock.note_overlay_file)
+			add_overlay(get_airlock_overlay(airlock.note_type(), airlock.note_overlay_file))
 
 	if(airlock.panel_open)
-		if(airlock.security_level)
-			displaying_overlay += get_airlock_overlay("panel_[airlock.last_used_state]_protected", airlock.overlays_file)
-		else
-			displaying_overlay += get_airlock_overlay("panel_[airlock.last_used_state]", airlock.overlays_file)
-
-	add_overlay(displaying_overlay)
+		var/protected = airlock.security_level ? "_protected" : ""
+		add_overlay(get_airlock_overlay("panel_[airlock.last_used_state][protected]", airlock.overlays_file))
 
 /obj/item/camera/proc/camera_get_icon(list/turfs, turf/center, psize_x = 96, psize_y = 96, datum/turf_reservation/clone_area, size_x, size_y, total_x, total_y)
 	var/list/images = list()
@@ -153,7 +147,10 @@
 			playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, 1, -3)
 
 	if(wipe_images)
-		QDEL_LIST(images)
+		for(var/image/I in images)
+			I.cut_overlays()
+			qdel(I)
+			images.Cut()
 	sorted.Cut()
 
 	return res

--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -121,30 +121,10 @@
 					else // there's no way to get real orbit animation. faking orbit animation here.
 						var/ghost_rotated = rand(0, 360)
 						img.Turn(-ghost_rotated)
-						switch(ghost_rotated)
-							if(0 to 90)
-								ghost_rotated = round(ghost_rotated/3)
-								xo += (30-ghost_rotated)
-								yo += ghost_rotated
-
-							if(90 to 180)
-								ghost_rotated -= 90
-								ghost_rotated = round(ghost_rotated/3)
-								xo -= ghost_rotated
-								yo += (30-ghost_rotated)
-
-							if(180 to 270)
-								ghost_rotated -= 180
-								ghost_rotated = round(ghost_rotated/3)
-								xo -= (30-ghost_rotated)
-								yo -= ghost_rotated
-
-							if(270 to 360)
-								ghost_rotated -= 270
-								ghost_rotated = round(ghost_rotated/3)
-								xo += ghost_rotated
-								yo -= (30-ghost_rotated)
-						// I don't know math... it's closer enough to a circle
+						xo += round(cos(ghost_rotated)*25) // 25 pixels away from the centre
+						yo += round(sin(ghost_rotated)*25)
+						// put ghost images randomly scattered on a line of a circle
+						// credit to Aramix for the circle math
 
 				res.Blend(img, blendMode2iconMode(clone.blend_mode), xo, yo)
 			CHECK_TICK

--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -1,6 +1,7 @@
 /image/photo
 	var/_step_x = 0
 	var/_step_y = 0
+	var/is_orbiting = FALSE
 
 /image/photo/New(location, atom/A)			//Intentionally not Initialize(), to make sure the clone assumes the intended appearance in time for the camera getFlatIcon.
 	if(istype(A))
@@ -11,7 +12,13 @@
 			var/atom/movable/AM = A
 			_step_x = AM.step_x
 			_step_y = AM.step_y
+			is_orbiting = AM.orbiting ? TRUE : FALSE
 	. = ..()
+
+// airlocks don't have actual overlays. make fake overlays temporary
+/image/photo/airlock/New(location, obj/machinery/door/airlock/airlock)
+	. = ..()
+	add_overlay(airlock.get_overlays_for_photo())
 
 /obj/item/camera/proc/camera_get_icon(list/turfs, turf/center, psize_x = 96, psize_y = 96, datum/turf_reservation/clone_area, size_x, size_y, total_x, total_y)
 	var/list/images = list()
@@ -34,7 +41,10 @@
 			for(var/i in T.contents)
 				var/atom/A = i
 				if(!A.invisibility || (see_ghosts && can_camera_see_atom(A)))
-					images += new /image/photo(newT, A)
+					if(istype(A, /obj/machinery/door/airlock))
+						images += new /image/photo/airlock(newT, A)
+					else
+						images += new /image/photo(newT, A)
 		skip_normal = TRUE
 		wipe_images = TRUE
 		center = locate(cloned_center_x, cloned_center_y, clone_area.bottom_left_coords[3])
@@ -59,7 +69,7 @@
 		var/image/c = images[i]
 		for(j = sorted.len, j > 0, --j)
 			var/image/c2 = sorted[j]
-			if(c2.layer <= c.layer)
+			if((c2.plane <= c.plane) && ((c2.layer <= c.layer)))
 				break
 		sorted.Insert(j+1, c)
 		CHECK_TICK
@@ -68,14 +78,76 @@
 	var/ycomp = FLOOR(psize_y / 2, 1) - 15
 
 
-	for(var/Adummy in sorted)
-		var/image/photo/A = Adummy
-		var/xo = (A.x - center.x) * world.icon_size + A.pixel_x + xcomp + A._step_x
-		var/yo = (A.y - center.y) * world.icon_size + A.pixel_y + ycomp + A._step_y
-		var/icon/img = getFlatIcon(A)
-		if(img)
-			res.Blend(img, blendMode2iconMode(A.blend_mode), xo, yo)
-		CHECK_TICK
+	if(!skip_normal) //these are not clones
+		for(var/Adummy in sorted)
+			var/image/photo/A = Adummy
+			var/xo = (A.x - center.x) * world.icon_size + A.pixel_x + xcomp + A._step_x
+			var/yo = (A.y - center.y) * world.icon_size + A.pixel_y + ycomp + A._step_y
+			var/icon/img = getFlatIcon(A)
+			if(img)
+				res.Blend(img, blendMode2iconMode(A.blend_mode), xo, yo)
+			CHECK_TICK
+
+	else
+		for(var/Adummy in sorted) //these are clones
+			var/image/photo/clone = Adummy
+			// Center of the image in X
+			var/xo = (clone.x - center.x) * world.icon_size + clone.pixel_x + xcomp + clone._step_x
+			// Center of the image in Y
+			var/yo = (clone.y - center.y) * world.icon_size + clone.pixel_y + ycomp + clone._step_y
+			var/icon/img = getFlatIcon(clone, no_anim = TRUE)
+			if(img)
+				if(clone.transform) // getFlatIcon doesn't give a snot about transforms.
+					var/datum/decompose_matrix/decompose = clone.transform.decompose()
+					// Scale in X, Y
+					if(decompose.scale_x != 1 || decompose.scale_y != 1)
+						var/base_w = img.Width()
+						var/base_h = img.Height()
+						// scale_x can be negative
+						img.Scale(base_w * abs(decompose.scale_x), base_h * decompose.scale_y)
+						if(decompose.scale_x < 0)
+							img.Flip(EAST)
+						xo -= base_w * (decompose.scale_x - SIGN(decompose.scale_x)) / 2 * SIGN(decompose.scale_x)
+						yo -= base_h * (decompose.scale_y - 1) / 2
+
+					if(!clone.is_orbiting)
+						// Rotation
+						if(decompose.rotation != 0)
+							img.Turn(decompose.rotation)
+						// Shift
+						xo += decompose.shift_x
+						yo += decompose.shift_y
+
+					else // there's no way to get real orbit animation. faking orbit animation here.
+						var/ghost_rotated = rand(0, 360)
+						img.Turn(-ghost_rotated)
+						switch(ghost_rotated)
+							if(0 to 90)
+								ghost_rotated = round(ghost_rotated/3)
+								xo += (30-ghost_rotated)
+								yo += ghost_rotated
+
+							if(90 to 180)
+								ghost_rotated -= 90
+								ghost_rotated = round(ghost_rotated/3)
+								xo -= ghost_rotated
+								yo += (30-ghost_rotated)
+
+							if(180 to 270)
+								ghost_rotated -= 180
+								ghost_rotated = round(ghost_rotated/3)
+								xo -= (30-ghost_rotated)
+								yo -= ghost_rotated
+
+							if(270 to 360)
+								ghost_rotated -= 270
+								ghost_rotated = round(ghost_rotated/3)
+								xo += ghost_rotated
+								yo -= (30-ghost_rotated)
+						// I don't know math... it's closer enough to a circle
+
+				res.Blend(img, blendMode2iconMode(clone.blend_mode), xo, yo)
+			CHECK_TICK
 
 	if(!silent)
 		if(istype(custom_sound))				//This is where the camera actually finishes its exposure.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Ports [#53976](https://github.com/tgstation/tgstation/pull/53976)
If a mob sprite is different (like it's big or small, or rotated, whatever) it will properly capture its state. especially when you're in rest...
* ~Airlock is now captured in photo. It was because our airlock is different for overlay process.~ rejected
* Photo will take ghosts orbiting shape. Actually, it's not capturing orbiting. It's just faking ghosts orbiting by relocating & rotating ghosts

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bad looking photo bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/231443291-67da5a6f-ee86-4343-a359-306b348d6cba.png)

~airlocks~ removed




left: ingame // right: photo
------------

![image](https://user-images.githubusercontent.com/87972842/231443391-3a7dd792-f9cc-4749-9909-95c67d35e2d0.png)

![image](https://user-images.githubusercontent.com/87972842/231443416-9b366d89-e8ad-49ec-98fd-a621ef5869a4.png)

![image](https://user-images.githubusercontent.com/87972842/231443433-2271fb6f-a5e4-423f-9a2c-fe70a4c708ae.png)



</details>

## Changelog
:cl: EvilDragonfiend, Aramix, nicbn(TG)
fix: ported a camera code - Camera will capture your current shape correctly - especially when you're big or resting. (credit to nicbn in TG)
fix: ghosts in a photo will be looked like they're orbiting. (credit to Aramix in bee discord)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
