### PR TITLE
Fix shuttle buying + night lighting

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -164,8 +164,8 @@
 	else
 		log_world("map_link missing from json!")
 
-	allow_custom_shuttles = !isnull(json["allow_custom_shuttles"]) && json["allow_custom_shuttles"] != FALSE
-	allow_night_lighting = !isnull(json["allow_night_lighting"]) && json["allow_night_lighting"] != FALSE
+	allow_custom_shuttles = json["allow_custom_shuttles"] != FALSE
+	allow_night_lighting = json["allow_night_lighting"] != FALSE
 	planetary_station = !isnull(json["planetary_station"]) && json["planetary_station"] != FALSE
 	planet_name = json["planet_name"]
 	planet_mass = text2num(json["planet_mass"]) || planet_mass


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This sets the map config values for night lighting and custom shuttles back to "true if not specifically set to false", like they were intended to be originally.

They were broken in https://github.com/BeeStation/BeeStation-Hornet/pull/8178

## Why It's Good For The Game

As far as I know, shuttle buying and night lighting weren't _intended_ to be broken, so this fixes them.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/65794972/231729772-a5865988-015e-40f6-b85a-3ec7944c14b1.png)

</details>

## Changelog
:cl:
fix: Shuttle buying and night lighting should work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
