### PR TITLE
Fixes plumbing pipes

### DIFF
--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -27,6 +27,7 @@
 	anchored = bolt
 	create_reagents(buffer, reagent_flags)
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, PROC_REF(can_be_rotated)))
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/proc/can_be_rotated(mob/user, rotation_type)
 	if(anchored)
@@ -73,6 +74,7 @@
 /obj/machinery/plumbing/input/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_supply, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 ///We can fill beakers in here and everything. we dont inheret from input because it has nothing that we need
 /obj/machinery/plumbing/output
@@ -86,6 +88,7 @@
 /obj/machinery/plumbing/output/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_demand, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/tank
 	name = "chemical tank"
@@ -98,3 +101,4 @@
 /obj/machinery/plumbing/tank/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/tank, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init

--- a/code/modules/plumbing/plumbers/acclimator.dm
+++ b/code/modules/plumbing/plumbers/acclimator.dm
@@ -32,6 +32,7 @@
 /obj/machinery/plumbing/acclimator/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/acclimator, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/acclimator/process(delta_time)
 	if(machine_stat & NOPOWER || !enabled || !reagents.total_volume || reagents.chem_temp == target_temperature)
@@ -64,6 +65,7 @@
 			icon_state += "_cold"
 		if(HEATING)
 			icon_state += "_hot"
+	..()
 
 
 /obj/machinery/plumbing/acclimator/ui_state(mob/user)

--- a/code/modules/plumbing/plumbers/bottle_dispenser.dm
+++ b/code/modules/plumbing/plumbers/bottle_dispenser.dm
@@ -21,6 +21,7 @@
 /obj/machinery/plumbing/bottle_dispenser/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_demand, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/bottle_dispenser/process()
 	if(machine_stat & NOPOWER)

--- a/code/modules/plumbing/plumbers/destroyer.dm
+++ b/code/modules/plumbing/plumbers/destroyer.dm
@@ -9,6 +9,7 @@
 /obj/machinery/plumbing/disposer/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_demand, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/disposer/process(delta_time)
 	if(machine_stat & NOPOWER)

--- a/code/modules/plumbing/plumbers/filter.dm
+++ b/code/modules/plumbing/plumbers/filter.dm
@@ -19,6 +19,7 @@
 /obj/machinery/plumbing/filter/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/filter, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 
 /obj/machinery/plumbing/filter/ui_state(mob/user)

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -17,6 +17,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/grinder_chemical/setDir(newdir)
 	. = ..()

--- a/code/modules/plumbing/plumbers/patch_dispenser.dm
+++ b/code/modules/plumbing/plumbers/patch_dispenser.dm
@@ -23,6 +23,7 @@
 /obj/machinery/plumbing/patch_dispenser/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_demand, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/patch_dispenser/process()
 	if(machine_stat & NOPOWER)

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -40,6 +40,7 @@
 			style_list["id"] = each_pill_shape
 			style_list["pill_icon_name"] = each_pill_shape
 			pill_styles += list(style_list)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/pill_press/process()
 	if(machine_stat & NOPOWER)

--- a/code/modules/plumbing/plumbers/pumps.dm
+++ b/code/modules/plumbing/plumbers/pumps.dm
@@ -24,6 +24,7 @@
 	. = ..()
 	create_reagents(volume)
 	AddComponent(/datum/component/plumbing/simple_supply, TRUE)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/power/liquid_pump/attackby(obj/item/W, mob/user, params)
 	if(!powered)

--- a/code/modules/plumbing/plumbers/reaction_chamber.dm
+++ b/code/modules/plumbing/plumbers/reaction_chamber.dm
@@ -18,6 +18,7 @@
 /obj/machinery/plumbing/reaction_chamber/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/reaction_chamber, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/reaction_chamber/on_reagent_change()
 	if(reagents.total_volume == 0 && emptying) //we were emptying, but now we aren't

--- a/code/modules/plumbing/plumbers/splitters.dm
+++ b/code/modules/plumbing/plumbers/splitters.dm
@@ -21,6 +21,7 @@
 /obj/machinery/plumbing/splitter/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/splitter, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 
 /obj/machinery/plumbing/splitter/ui_state(mob/user)

--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -59,6 +59,7 @@
 /obj/machinery/plumbing/synthesizer/Initialize(mapload, bolt)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_supply, bolt)
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/plumbing/synthesizer/process(delta_time)
 	if(machine_stat & NOPOWER || !reagent_id || !amount)
@@ -153,3 +154,4 @@
 		r_overlay.color = "#FFFFFF"
 
 	overlays += r_overlay
+	..()

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -38,6 +38,7 @@
 		reagents.maximum_volume += REAGENTS_BASE_VOLUME * B.rating
 
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, PROC_REF(can_be_rotated)))
+	update_appearance() //so the input/output pipes will overlay properly during init
 
 /obj/machinery/smoke_machine/proc/can_be_rotated(mob/user,rotation_type)
 	return !anchored


### PR DESCRIPTION
## About The Pull Request
Closes #8766

* Plumbing machines now correctly display their pipes on initialization
* Fixes Synthesizers and Acclimators having no pipes at all, even after updates as well. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Plumbing machines are extraordinarily difficult to utilize when one can't see the pipes, particularly since they don't have directional sprites outside of the pipes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://user-images.githubusercontent.com/9547572/231915028-cfbc970c-884e-45e6-859c-24b855d9ac44.png)

![image](https://user-images.githubusercontent.com/9547572/231915041-25af90ec-8129-46ab-877d-2631b7998794.png)

![image](https://user-images.githubusercontent.com/9547572/231915047-02dd0842-4c18-4f0b-87f9-8e1373b078a9.png)

## Changelog
:cl:
fix: Plumbing pipes now display properly on all plumbing machines. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
