### PR TITLE
You can now build frames on indestructible floors

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -35,6 +35,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define isfloorturf(A) (istype(A, /turf/open/floor))
 
+#define isanyfloor(A) (isfloorturf(A) || isindestructiblefloor(A))
+
 #define isclosedturf(A) (istype(A, /turf/closed))
 
 #define isindestructiblewall(A) (istype(A, /turf/closed/indestructible))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -288,7 +288,7 @@
 		to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
 		return FALSE
 	if(R.on_floor)
-		if(!isfloorturf(T))
+		if(!isanyfloor(T))
 			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
 			return FALSE
 		for(var/obj/AM in T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This allows you to build machine/computer frames on indestructible floors, such as the floor in the pocket dimension accessed via warping rainbow extracts.

## Why It's Good For The Game

Mainly so you can build cool stuff in the xenobio pocket dimension.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-04-14-1681489555-dreamseeker](https://user-images.githubusercontent.com/65794972/232101908-0fc0d041-7699-4c1d-b7f5-061f6c45f65d.png)
![23-04-14-1681489551-dreamseeker](https://user-images.githubusercontent.com/65794972/232101917-6ab97e84-a5af-4ee0-a57d-a89a7b3f05a5.png)


</details>

## Changelog
:cl:
tweak: You can now properly build frames on indestructible flooring, such at that in the warping rainbow extract's pocket dimension.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
