### PR TITLE
Stamina damage is now logged

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1443,6 +1443,10 @@
 
 	var/mob/living/living_target = target
 	var/hp = istype(living_target) ? " (NEWHP: [living_target.health]) " : ""
+	var/stam = ""
+	if(iscarbon(living_target))
+		var/mob/living/carbon/C = living_target
+		stam = "(STAM: [C.getStaminaLoss()]) "
 
 	var/sobject = ""
 	if(object)
@@ -1451,7 +1455,7 @@
 	if(addition)
 		saddition = " [addition]"
 
-	var/postfix = "[sobject][saddition][hp]"
+	var/postfix = "[sobject][saddition][hp][stam]"
 
 	var/message = "has [what_done] [starget][postfix]"
 	user.log_message(message, LOG_ATTACK, color="red")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1443,7 +1443,7 @@
 
 	var/mob/living/living_target = target
 	var/hp = istype(living_target) ? " (NEWHP: [living_target.health]) " : ""
-	var/stam = ""
+	var/stam
 	if(iscarbon(living_target))
 		var/mob/living/carbon/C = living_target
 		stam = "(STAM: [C.getStaminaLoss()]) "


### PR DESCRIPTION
## About The Pull Request

* Adds logging for stamina damage

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to see current stamina damage and by extension whether or not someone is in stamcrit have the potential to be helpful to admins during investigations. 

This was loosely requested by @CydiaLamiales (mentioned in passing that it would be nice to have)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://user-images.githubusercontent.com/9547572/232262347-e61c2cb2-5f6a-454e-9d8a-b0aa44392c94.png)

```
[2023-04-16 02:08:42.272] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 94.8) (STAM: 7.4)  (Arrival Shuttle (22, 62, 2))
[2023-04-16 02:08:43.037] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 87.8) (STAM: 17.9)  (Arrival Shuttle (22, 62, 2))
[2023-04-16 02:08:45.987] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 80.8) (STAM: 19.9)  (Arrival Shuttle (22, 62, 2))
[2023-04-16 02:08:46.837] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 73.8) (STAM: 30.4)  (Arrival Shuttle (23, 62, 2))
[2023-04-16 02:08:47.812] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 68.5) (STAM: 37.8)  (Arrival Shuttle (23, 62, 2))
[2023-04-16 02:08:48.736] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 61.5) (STAM: 48.3)  (Arrival Shuttle (23, 62, 2))
[2023-04-16 02:08:49.711] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 54.5) (STAM: 58.8)  (Arrival Shuttle (22, 63, 2))
[2023-04-16 02:08:50.587] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 47.5) (STAM: 69.3)  (Arrival Shuttle (22, 64, 2))
[2023-04-16 02:08:51.462] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 40.5) (STAM: 79.8)  (Arrival Shuttle Hallway (22, 66, 2))
[2023-04-16 02:08:52.490] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 33.5) (STAM: 90.3)  (Arrival Shuttle Hallway (25, 66, 2))
[2023-04-16 02:08:53.439] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 28.3) (STAM: 97.7)  (Arrival Shuttle Hallway (28, 66, 2))
[2023-04-16 02:08:54.316] ATTACK: RukoFamicom/(Trenton Dennis) has punched RukoFamicom/(Trenton Dennis) (NEWHP: 21.3) (STAM: 108.2)  (Arrival Shuttle Hallway (30, 66, 2))
```

## Changelog
:cl:
admin: The recipient of an attack now has their current stamina damage logged alongside their current HP within attack logs. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
