### PR TITLE
Brand Intelligence event is no more miserable (mimic venders), makes mimic code a little better

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -626,7 +626,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		var/turf/T = get_turf(M)
 		message_admins("[ADMIN_LOOKUPFLW(owner)] overrided (animated) [M.name] at [ADMIN_VERBOSEJMP(T)].")
 		log_game("[key_name(owner)] overrided (animated) [M.name] at [AREACOORD(T)].")
-		new/mob/living/simple_animal/hostile/mimic/copy/machine(get_turf(M), M, owner, 1)
+		new/mob/living/simple_animal/hostile/mimic/copy/machine(get_turf(M), M, owner)
 
 /obj/effect/proc_holder/ranged_ai/override_machine
 	active = FALSE

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -58,15 +58,31 @@
 		return
 	vendingMachines = remove_nulls_from_list(vendingMachines)
 	if(!vendingMachines.len)	//if every machine is infected
+		infectedMachines.Add(originMachine)
 		for(var/obj/machinery/vending/upriser in infectedMachines)
-			if(prob(70) && !QDELETED(upriser))
-				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
-				M.faction = list("profit")
-				M.speak = rampant_speeches.Copy()
-				M.speak_chance = 7
-			else
-				explosion(upriser.loc, -1, 1, 2, 4, 0)
-				qdel(upriser)
+			if(QDELETED(upriser))
+				continue
+			var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null) // it will delete upriser on creation and override any machine checks
+			M.faction = list("profit")
+			M.speak = rampant_speeches.Copy()
+			M.speak_chance = 7
+
+			switch(rand(1, 100)) // for 30% chance, they're stronger
+				if(1 to 70) // these are usually weak
+					var/adjusted_health = max(M.health-20, 20) // don't make it negative-health
+					M.health = adjusted_health
+					M.maxHealth = adjusted_health
+				if(71 to 80) // has more health
+					var/bonus_health = 15+rand(1, 7)*5
+					M.health += bonus_health
+					M.maxHealth += bonus_health
+					M.desc += " By the way, this seems to be robust..."
+				if(81 to 90) // does stronger damage
+					M.melee_damage += 2+rand(1, 6) // 3~8
+					M.desc += " By the way, this seems to be hurting..."
+				if(91 to 100) // moves faster
+					M.move_to_delay /= 2 // just half
+					M.desc += " By the way, this is obviously faster."
 
 		kill()
 		return

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -79,7 +79,7 @@
 					M.desc += " This one seems extra robust..."
 				if(81 to 90) // does stronger damage
 					M.melee_damage += 2+rand(1, 6) // 3~8
-					M.desc += " By the way, this seems to be hurting..."
+					M.desc += " This one seems extra painful..."
 				if(91 to 100) // moves faster
 					M.move_to_delay /= 2 // just half
 					M.desc += " This one seems more agile..."

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -76,7 +76,7 @@
 					var/bonus_health = 15+rand(1, 7)*5
 					M.health += bonus_health
 					M.maxHealth += bonus_health
-					M.desc += " By the way, this seems to be robust..."
+					M.desc += " This one seems extra robust..."
 				if(81 to 90) // does stronger damage
 					M.melee_damage += 2+rand(1, 6) // 3~8
 					M.desc += " By the way, this seems to be hurting..."

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -82,7 +82,7 @@
 					M.desc += " By the way, this seems to be hurting..."
 				if(91 to 100) // moves faster
 					M.move_to_delay /= 2 // just half
-					M.desc += " By the way, this is obviously faster."
+					M.desc += " This one seems more agile..."
 
 		kill()
 		return

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -122,10 +122,10 @@
 /mob/living/simple_animal/hostile/mimic/copy/pop_out_stuff()
 	..()
 	// death of this mob means the destruction of the original stuff of the copied mob.
-	// but the destruction of an item is cringe.
-	if(istype(original_of_this, /obj/machine/vending))
+	if(istype(original_of_this, /obj/machinery/vending))
 		original_of_this.take_damage(original_of_this.obj_integrity, BRUTE, 0, FALSE)
 		// currently do this to vending machines only.
+		// because the destruction of stuff (especially items) is annoying.
 
 GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/cable, /obj/structure/window, /obj/structure/grille))
 

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -112,8 +112,8 @@
 /mob/living/simple_animal/hostile/mimic/copy/pop_out_stuff()
 	..()
 	// death of this mob means the destruction of the original stuff of the copied mob.
-	// but the destruction of an item is cringe. only does this to machines. so, if(!istype(each_atom, /obj/item))
-	if(isobj(original_of_this) && !istype(original_of_this, /obj/item)) // don't use CheckObject() here
+	// but the destruction of an item is cringe. only does this to machines. so, check `!isitem()`
+	if(isobj(original_of_this) && !isitem(original_of_this)) // don't use CheckObject() here
 		original_of_this.take_damage(original_of_this.obj_integrity, sound_effect=FALSE)
 
 GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/cable, /obj/structure/window))
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 		if(destroy_original)
 			qdel(O)
 		else
-			O.forceMove(src) // the original item will be hidden inside of this mob
+			O.forceMove(src) // the original object will be hidden inside of this mob
 			original_of_this = O
 		return TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -122,11 +122,12 @@
 /mob/living/simple_animal/hostile/mimic/copy/pop_out_stuff()
 	..()
 	// death of this mob means the destruction of the original stuff of the copied mob.
-	// but the destruction of an item is cringe. only does this to machines. so, check `!isitem()`
-	if(isobj(original_of_this) && !isitem(original_of_this)) // don't use CheckObject() here
+	// but the destruction of an item is cringe.
+	if(itype(original_of_this, /obj/machine/vending))
 		original_of_this.take_damage(original_of_this.obj_integrity, BRUTE, 0, FALSE)
+		// currently do this to vending machines only.
 
-GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/cable, /obj/structure/window))
+GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/cable, /obj/structure/window, /obj/structure/grille))
 
 /mob/living/simple_animal/hostile/mimic/copy
 	health = 100
@@ -144,7 +145,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 	if (no_googlies)
 		overlay_googly_eyes = FALSE
 	if(!CopyObject(original, creator, destroy_original))
-		stack_trace("something's wrong to create a mimic. It failed to copy something.")
+		stack_trace("something's wrong to create a mimic. It failed to mimic something - [original].")
 
 /mob/living/simple_animal/hostile/mimic/copy/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -62,7 +62,7 @@
 
 /mob/living/simple_animal/hostile/mimic/Destroy()
 	var/turf_to_spawn = get_turf(src)
-	// spawns a crate or an obj to spawn. Don't specify `spawaning_obj_type` to copy stuff
+	// spawns a crate/a closet/a locker, whatever
 	if(spawaning_obj_type && ispath(spawaning_obj_type, /obj/structure/closet))
 		var/obj/structure/closet/crate = new spawaning_obj_type(turf_to_spawn)
 		crate.opened = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -123,7 +123,7 @@
 	..()
 	// death of this mob means the destruction of the original stuff of the copied mob.
 	// but the destruction of an item is cringe.
-	if(itype(original_of_this, /obj/machine/vending))
+	if(istype(original_of_this, /obj/machine/vending))
 		original_of_this.take_damage(original_of_this.obj_integrity, BRUTE, 0, FALSE)
 		// currently do this to vending machines only.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Brand Intelligence event is no more miserable (mimic venders)
this means animating venders will return stuff
also makes mimic mob code better
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's super annoying event
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/232287154-264dfa3c-e8b6-48a5-b20e-ebf5701a4988.png)

dead mimics


![image](https://user-images.githubusercontent.com/87972842/232294335-1e491c6e-3a36-4652-9e85-fae907d2d916.png)


</details>

## Changelog
:cl:
code: made mimic code less bad
tweak: mimic mobs (especially, animating venders) will become back to how it was. For Brand Intelligence event, dead mimics will become a destroyed vending machine
tweak: Brand Intelligence targeted vendors no longer explode when the event happens. These will become a stronger version instead. (i.e. more HP, more damage, etc) Otherwise, vending machine mobs have slightly less HP.
tweak: mimic crate will eat items on where it is spawned - including important items like a nuke disk. Still, nuke disk is trackable, and dead mimic will let things out. (Admins can use this to contain stuff into a mimic crate by spawning that mob - but items should be placed on it.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
