### PR TITLE
MultiZ Tracking Beacon HUD

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -202,7 +202,7 @@
 	active = TRUE
 	begin_processing()
 	//Global teamfinder signal trackable on the synd frequency.
-	AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#ff2b2b", TRUE, TRUE)
+	AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#ff2b2b", TRUE, TRUE, "#c32bff")
 	countdown.start()
 	next_beep = world.time + 10
 	detonation_timer = world.time + (timer_set * 10)

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -89,7 +89,7 @@
 	trigger_event = new
 	AddSpell(trigger_event)
 	//Wooooo, you are a ghost
-	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE)
+	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE, "#490066")
 	internal_radio = new(src)
 	cog_change()
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -674,7 +674,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	AddComponent(/datum/component/stationloving, !fake)
 	if(!fake)
 		//Global teamfinder signal trackable on the synd frequency.
-		AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#ebeca1", TRUE, TRUE)
+		AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#ebeca1", TRUE, TRUE, "#818157")
 
 /obj/item/disk/nuclear/process()
 	++process_tick

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -78,7 +78,7 @@
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/blight(null))
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction(null))
 	random_revenant_name()
-	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE)
+	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE, "#490066")
 
 /mob/living/simple_animal/revenant/Destroy()
 	. = ..()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -327,7 +327,7 @@
 /obj/item/clothing/glasses/welding/ghostbuster/ComponentInitialize()
 	. = ..()
 	//Have the HUD enabled by default, since the glasses start in the down position.
-	var/datum/component/team_monitor/ghost_vision = AddComponent(/datum/component/team_monitor, "ghost", 1)
+	var/datum/component/team_monitor/worn/ghost_vision = AddComponent(/datum/component/team_monitor/worn, "ghost", 1)
 	ghost_vision.toggle_hud(TRUE, null)
 
 /obj/item/clothing/glasses/welding/ghostbuster/weldingvisortoggle()
@@ -347,7 +347,7 @@
 			C = null
 	//Toggle the hud of the component
 	//Pass in the wearer, or null if they are not wearing the goggles
-	var/datum/component/team_monitor/ghost_vision = GetComponent(/datum/component/team_monitor)
+	var/datum/component/team_monitor/worn/ghost_vision = GetComponent(/datum/component/team_monitor/worn)
 	ghost_vision.toggle_hud(!ghost_vision.hud_visible, C)
 	//Update the hud colour
 	if(ghost_vision.hud_visible)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -352,11 +352,11 @@
 		linkedsuit = loc
 		//NOTE FOR COPY AND PASTING: BEACON MUST BE MADE FIRST
 		//Add the monitor (Default to null - No tracking)
-		var/datum/component/tracking_beacon/component_beacon = linkedsuit.AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#8f4a4b")
+		var/datum/component/tracking_beacon/component_beacon = linkedsuit.AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#8f4a4b", FALSE, FALSE, "#573d3d")
 		//Add the monitor (Default to null - No tracking)
-		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor, "synd", null, component_beacon)
+		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor/worn, "synd", null, component_beacon)
 	else
-		AddComponent(/datum/component/team_monitor, "synd", null)
+		AddComponent(/datum/component/team_monitor/worn, "synd", null)
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/ui_action_click(mob/user, datum/action)
 	switch(action.type)
@@ -366,7 +366,7 @@
 			toggle_hud(user)
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/proc/toggle_hud(mob/user)
-	var/datum/component/team_monitor/monitor = GetComponent(/datum/component/team_monitor)
+	var/datum/component/team_monitor/worn/monitor = GetComponent(/datum/component/team_monitor/worn)
 	if(!monitor)
 		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
 		return
@@ -965,11 +965,11 @@
 		var/obj/linkedsuit = loc
 		//NOTE FOR COPY AND PASTING: BEACON MUST BE MADE FIRST
 		//Add the monitor (Default to null - No tracking)
-		var/datum/component/tracking_beacon/component_beacon = linkedsuit.AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#8f4a4b")
+		var/datum/component/tracking_beacon/component_beacon = linkedsuit.AddComponent(/datum/component/tracking_beacon, "synd", null, null, TRUE, "#8f4a4b", FALSE, FALSE, "#573d3d")
 		//Add the monitor (Default to null - No tracking)
-		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor, "synd", null, component_beacon)
+		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor/worn, "synd", null, component_beacon)
 	else
-		AddComponent(/datum/component/team_monitor, "synd", null)
+		AddComponent(/datum/component/team_monitor/worn, "synd", null)
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi/ui_action_click(mob/user, datum/action)
 	switch(action.type)
@@ -979,7 +979,7 @@
 			toggle_hud(user)
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi/proc/toggle_hud(mob/user)
-	var/datum/component/team_monitor/monitor = GetComponent(/datum/component/team_monitor)
+	var/datum/component/team_monitor/worn/monitor = GetComponent(/datum/component/team_monitor/worn)
 	if(!monitor)
 		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
 		return

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -176,6 +176,7 @@ Contains:
 		/datum/action/item_action/toggle_beacon_hud
 	)
 	var/beacon_colour = "#4b48ec"
+	var/beacon_zdiff_colour = "#0b0a47"
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/Initialize(mapload)
 	. = ..()
@@ -185,11 +186,11 @@ Contains:
 		var/obj/linkedsuit = loc
 		//NOTE FOR COPY AND PASTING: BEACON MUST BE MADE FIRST
 		//Add the monitor (Default to null - No tracking)
-		var/datum/component/tracking_beacon/component_beacon = linkedsuit.AddComponent(/datum/component/tracking_beacon, "cent", null, null, TRUE, beacon_colour)
+		var/datum/component/tracking_beacon/component_beacon = linkedsuit.AddComponent(/datum/component/tracking_beacon, "cent", null, null, TRUE, beacon_colour, FALSE, FALSE, beacon_zdiff_colour)
 		//Add the monitor (Default to null - No tracking)
-		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor, "cent", null, component_beacon)
+		component_beacon.attached_monitor = AddComponent(/datum/component/team_monitor/worn, "cent", null, component_beacon)
 	else
-		AddComponent(/datum/component/team_monitor, "cent", null)
+		AddComponent(/datum/component/team_monitor/worn, "cent", null)
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/ui_action_click(mob/user, datum/action)
 	switch(action.type)
@@ -199,7 +200,7 @@ Contains:
 			toggle_hud(user)
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/proc/toggle_hud(mob/user)
-	var/datum/component/team_monitor/monitor = GetComponent(/datum/component/team_monitor)
+	var/datum/component/team_monitor/worn/monitor = GetComponent(/datum/component/team_monitor/worn)
 	if(!monitor)
 		to_chat(user, "<span class='notice'>The suit is not fitted with a tracking beacon.</span>")
 		return
@@ -262,6 +263,7 @@ Contains:
 	icon_state = "hardsuit0-ert_security"
 	item_state = "hardsuit0-ert_security"
 	beacon_colour = "#ec4848"
+	beacon_zdiff_colour = "#ca7878"
 
 /obj/item/clothing/suit/space/hardsuit/ert/sec
 	name = "emergency response team security hardsuit"
@@ -278,6 +280,7 @@ Contains:
 	icon_state = "hardsuit0-ert_engineer"
 	item_state = "hardsuit0-ert_engineer"
 	beacon_colour = "#ecaa48"
+	beacon_zdiff_colour = "#daa960"
 
 /obj/item/clothing/suit/space/hardsuit/ert/engi
 	name = "emergency response team engineering hardsuit"
@@ -294,6 +297,7 @@ Contains:
 	icon_state = "hardsuit0-ert_medical"
 	item_state = "hardsuit0-ert_medical"
 	beacon_colour = "#88ecec"
+	beacon_zdiff_colour = "#4f8888"
 
 /obj/item/clothing/suit/space/hardsuit/ert/med
 	name = "emergency response team medical hardsuit"
@@ -310,6 +314,7 @@ Contains:
 	icon_state = "hardsuit0-ert_janitor"
 	item_state = "hardsuit0-ert_janitor"
 	beacon_colour = "#be43ce"
+	beacon_zdiff_colour = "#895d8f"
 
 /obj/item/clothing/suit/space/hardsuit/ert/jani
 	name = "emergency response team janitorial hardsuit"
@@ -413,6 +418,7 @@ Contains:
 	actions_types = list()
 	resistance_flags = FIRE_PROOF
 	beacon_colour = "#9ddb56"
+	beacon_zdiff_colour = "#6a9e2f"
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal
 	name = "paranormal response team hardsuit"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -152,7 +152,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	show_data_huds()
 	data_huds_on = 1
 
-	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE)
+	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE, "#490066")
 
 /mob/dead/observer/get_photo_description(obj/item/camera/camera)
 	return "You can also see a g-g-g-g-ghooooost!"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/ghost.dm
@@ -50,7 +50,7 @@
 				name = "ghost of [pick(GLOB.first_names_male)] [pick(GLOB.last_names)]"
 			if(1)
 				name = "ghost of [pick(GLOB.first_names_female)] [pick(GLOB.last_names)]"
-	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE)
+	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE, "#490066")
 
 /mob/living/simple_animal/hostile/retaliate/ghost/Destroy()
 	. = ..()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1508,7 +1508,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/suits/hardsuit/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
 	var/obj/item/clothing/suit/space/hardsuit/suit = ..()
 	var/datum/component/tracking_beacon/beacon = suit.GetComponent(/datum/component/tracking_beacon)
-	var/datum/component/team_monitor/hud = suit.helmet.GetComponent(/datum/component/team_monitor)
+	var/datum/component/team_monitor/worn/hud = suit.helmet.GetComponent(/datum/component/team_monitor/worn)
 
 	var/datum/antagonist/nukeop/nukie = is_nuclear_operative(user)
 	if(nukie?.nuke_team?.team_frequency)


### PR DESCRIPTION
## About The Pull Request

Tracking beacons will now support tracking within the same multiz group, as long as each z level is the same orbital map object, the arrow will flash between the zdiff color and the regular color if you are on a different z level. Beacons will not work between orbital map objects.

Also splits out logic relating to items onto a /worn beacon subtype, so beacons can be imbued into things.

Atomization of changes from #8452

## Why It's Good For The Game

Increases multiz support and makes tracking beacons work on multiz stations.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/232585210-d9530da2-9135-4c1d-9cc1-88c116e0995c.png)

Changing zgroup, you can't see the beacon anymore

![image](https://user-images.githubusercontent.com/10366817/232585369-d0a77d6a-f441-4691-b817-611971d6e8dd.png)

Non-worn beacons test with frostwing, works well.

</details>

## Changelog
:cl:
add: Tracking beacon HUDs will now flash color when you are on a different z level within the same orbital object (e.g. a multiz station on different floors).
code: Added support for non-worn tracking beacons.
/:cl: