### PR TITLE
Minor sleeper tweaks

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -110,12 +110,18 @@
 		if (length(inserted_vials) >= max_vials)
 			to_chat(user, "<span class='warning'>[src] cannot hold any more!</span>")
 			return
+		user.visible_message("<span class='notice'>[user] inserts \the [I] into \the [src]</span>", "<span class='notice'>You insert \the [I] into \the [src]</span>")
 		user.temporarilyRemoveItemFromInventory(I)
 		I.forceMove(null)
 		inserted_vials += I
 		ui_update()
 		return
 	. = ..()
+
+/obj/machinery/sleeper/on_deconstruction()
+	for(var/atom/movable/A as anything in inserted_vials)
+		A.forceMove(drop_location())
+	return ..()
 
 /obj/machinery/sleeper/container_resist(mob/living/user)
 	visible_message("<span class='notice'>[occupant] emerges from [src]!</span>",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a message for adding items into the sleeper, makes the sleeper drop its medicine holders when deconstructed.
* Closes https://github.com/BeeStation/BeeStation-Hornet/issues/8889
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things being visible good, medicine not being deleted also good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/110184118/232608681-9afe3e99-dd9d-4ea8-904e-840dadf10939.png)

Being deconstructed
![image](https://user-images.githubusercontent.com/110184118/232610601-de925bfa-7819-4c33-b011-c323e753b92f.png)

![image](https://user-images.githubusercontent.com/110184118/232610628-0aff5e66-25d2-481c-be48-c1f230fbefd5.png)

</details>

## Changelog
:cl:
add: Added a text for inserting an item into the sleeper
tweak: made the sleeper drop its contents upon being deconstructed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
