### PR TITLE
Brainwashing refactor + potential exploit fix

### DIFF
--- a/code/game/machinery/race_converter.dm
+++ b/code/game/machinery/race_converter.dm
@@ -99,7 +99,7 @@
 		if(brainwash)
 			to_chat(C, "<span class='userdanger'>A new compulsion fills your mind... you feel forced to obey it!</span>")
 			var/objective = "Convert as many people as possible into a [initial(desired_race.name)]. Racewar!"
-			brainwash(C, objective)
+			brainwash(C, objective, "species converter")
 			log_game("[key_name(C)] has been brainwashed with the objective '[objective]' via the species converter.")
 
 	iterations++

--- a/code/game/objects/items/implants/implant_mindshield.dm
+++ b/code/game/objects/items/implants/implant_mindshield.dm
@@ -24,7 +24,7 @@
 			return TRUE
 
 		if(target.mind.has_antag_datum(/datum/antagonist/brainwashed))
-			target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+			unbrainwash(target)
 
 		if(target.mind.has_antag_datum(/datum/antagonist/rev/head) || target.mind.unconvertable)
 			if(!silent)

--- a/code/game/objects/items/implants/implantchair.dm
+++ b/code/game/objects/items/implants/implantchair.dm
@@ -198,7 +198,7 @@
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 75)
 			H.emote("scream")
 			return TRUE
-	brainwash(C, objective)
+	brainwash(C, objective, "neural imprinter")
 	message_admins("[ADMIN_LOOKUPFLW(user)] brainwashed [key_name_admin(C)] with objective '[objective]'.")
 	log_game("[key_name(user)] brainwashed [key_name(C)] with objective '[objective]'.")
 	return TRUE

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -63,7 +63,7 @@
 			victim.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 		QDEL_LIST(removed_objectives)
 	else
-		log_admin("[key_name(victim)] had all of their brainwashing objective[length(brainwash.objectives) > 1 ? "s" : ""] removed: [english_list(brainwash.objectives)].")
+		log_admin("[key_name(victim)] had all of their brainwashing objectives removed: [english_list(brainwash.objectives)].")
 		QDEL_LIST(brainwash.objectives)
 		victim.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -1,30 +1,71 @@
-/proc/brainwash(mob/living/L, directives)
-	if(!L.mind)
+/// Brainwash a mob, adding objectives to an existing brainwash if it already exists.
+/proc/brainwash(mob/living/victim, list/directives, source)
+	. = list()
+	if(!victim.mind)
 		return
 	if(!islist(directives))
 		directives = list(directives)
-	var/datum/mind/M = L.mind
-	var/datum/antagonist/brainwashed/B = M.has_antag_datum(/datum/antagonist/brainwashed)
-	if(B)
-		for(var/O in directives)
-			var/datum/objective/brainwashing/objective = new(O)
-			B.objectives += objective
-			log_objective(M, objective.explanation_text)
-		B.greet()
+	var/datum/mind/victim_mind = victim.mind
+	var/datum/antagonist/brainwashed/brainwash = victim_mind.has_antag_datum(/datum/antagonist/brainwashed)
+	if(brainwash)
+		for(var/directive in directives)
+			var/datum/objective/brainwashing/objective = new(directive)
+			if(source)
+				objective.source = source
+			brainwash.objectives += objective
+			. += WEAKREF(objective)
+			log_objective(victim_mind, objective.explanation_text)
+		brainwash.greet()
 	else
-		B = new()
-		for(var/O in directives)
-			var/datum/objective/brainwashing/objective = new(O)
-			B.objectives += objective
-			log_objective(M, objective.explanation_text)
-		M.add_antag_datum(B)
+		brainwash = new()
+		for(var/directive in directives)
+			var/datum/objective/brainwashing/objective = new(directive)
+			if(source)
+				objective.source = source
+			brainwash.objectives += objective
+			. += WEAKREF(objective)
+			log_objective(victim_mind, objective.explanation_text)
+		victim_mind.add_antag_datum(brainwash)
 
-	var/begin_message = "<span class='deadsay'><b>[L]</b> has been brainwashed with the following objectives: "
+	var/source_message = source ? " by [source]" : ""
+	var/begin_message = "<span class='deadsay'><b>[victim]</b> has been brainwashed with the following objective[length(directives) > 1 ? "s" : ""][source_message]: "
 	var/obj_message = english_list(directives)
 	var/end_message = "</b>.</span>"
 	var/rendered = begin_message + obj_message + end_message
-	deadchat_broadcast(rendered, follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_REGULAR)
-	L.log_message(rendered, LOG_ATTACK, color="#960000")
+	deadchat_broadcast(rendered, follow_target = victim, turf_target = get_turf(victim), message_type=DEADCHAT_REGULAR)
+	victim.log_message(rendered, LOG_ATTACK, color="#960000")
+
+/// Removes objectives from someone's brainwash.
+/proc/unbrainwash(mob/living/victim, list/directives)
+	var/datum/antagonist/brainwashed/brainwash = victim?.mind?.has_antag_datum(/datum/antagonist/brainwashed)
+	if(!brainwash)
+		return FALSE
+	if(directives)
+		if(!isnull(directives) && !islist(directives))
+			directives = list(directives)
+		var/list/removed_objectives = list()
+		for(var/D in directives)
+			var/datum/objective/directive
+			if(istype(D, /datum/weakref))
+				var/datum/weakref/directive_weakref = D
+				directive = directive_weakref.resolve()
+			else if(istype(D, /datum/objective))
+				directive = D
+			if(!directive || !istype(directive))
+				continue
+			brainwash.objectives -= directive
+			removed_objectives += directive
+		log_admin("[key_name(victim)] had the following brainwashing objective[length(removed_objectives) > 1 ? "s" : ""] removed: [english_list(removed_objectives)].")
+		if(LAZYLEN(brainwash.objectives))
+			to_chat(victim, "<big><span class='warning'><b>[length(removed_objectives) > 1 ? "Some" : "One"] of your Directives fade away! You only have to obey the remaining Directives now.</b></span></big>")
+			victim.mind.announce_objectives()
+		else
+			victim.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+		QDEL_LIST(removed_objectives)
+	else
+		log_admin("[key_name(victim)] had all of their brainwashing objective[length(brainwash.objectives) > 1 ? "s" : ""] removed: [english_list(brainwash.objectives)].")
+		QDEL_LIST(brainwash.objectives)
+		victim.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 
 /datum/antagonist/brainwashed
 	name = "Brainwashed Victim"
@@ -98,10 +139,11 @@
 		to_chat(admin, "Mob doesn't exist anymore")
 		return
 
-	brainwash(C, objectives)
+	brainwash(C, objectives, "adminbus")
 	var/obj_list = english_list(objectives)
 	message_admins("[key_name_admin(admin)] has brainwashed [key_name_admin(C)] with the following objectives: [obj_list].")
 	log_admin("[key_name(admin)] has brainwashed [key_name(C)] with the following objectives: [obj_list].")
 
 /datum/objective/brainwashing
 	completed = TRUE
+	var/source

--- a/code/modules/antagonists/hivemind/vessel.dm
+++ b/code/modules/antagonists/hivemind/vessel.dm
@@ -21,19 +21,19 @@
 	if(!HAS_TRAIT(user, TRAIT_MINDSHIELD))
 		to_chat(user, "<span class='assimilator'>Foreign energies force themselves upon your thoughts!</span>")
 		flash_color(user, flash_color="#800080", flash_time=10)
-		brainwash(user, directive)
+		var/objective = brainwash(user, directive, "hivemind compel")
 		to_chat(user, "<span class='assimilator'>A figment of your subconscious stays firm, you would be incapable of killing yourself if ordered!</span>")
 		user.overlay_fullscreen("hive_mc", /atom/movable/screen/fullscreen/hive_mc)
-		addtimer(CALLBACK(user, PROC_REF(hive_weak_clear), user.mind), 1800, TIMER_STOPPABLE)
+		addtimer(CALLBACK(user, PROC_REF(hive_weak_clear), objective), 1800, TIMER_STOPPABLE)
 
-/mob/living/proc/hive_weak_clear()
-	if(!mind)
+/mob/living/proc/hive_weak_clear(objective)
+	if(!mind || !objective)
 		return
 	var/mob/living/user = mind.current
 	to_chat(user, "<span class='assimilator'>Our subconscious fights back the invasive forces, our will is once again our own!</span>")
 	flash_color(user, flash_color="#800080", flash_time=10)
 	user.clear_fullscreen("hive_mc")
-	mind.remove_antag_datum(/datum/antagonist/brainwashed)
+	unbrainwash(user, objective)
 
 /datum/antagonist/hivevessel/on_gain()
 	owner.special_role = special_role

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -177,13 +177,12 @@
 	if(!comm_message)
 		var/datum/nanite_extra_setting/ES = extra_settings[NES_DIRECTIVE]
 		sent_directive = ES.get_value()
-	brainwash(host_mob, sent_directive)
+	var/directive = brainwash(host_mob, sent_directive, nanites.cloud_id ? "nanites in cloud [nanites.cloud_id]" : "nanites")
 	log_game("A mind control nanite program brainwashed [key_name(host_mob)] with the objective '[sent_directive]'.")
-	addtimer(CALLBACK(src, PROC_REF(end_brainwashing)), 600)
+	addtimer(CALLBACK(src, PROC_REF(end_brainwashing), directive), 600)
 
-/datum/nanite_program/comm/mind_control/proc/end_brainwashing()
-	if(host_mob.mind && host_mob.mind.has_antag_datum(/datum/antagonist/brainwashed))
-		host_mob.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+/datum/nanite_program/comm/mind_control/proc/end_brainwashing(directive)
+	unbrainwash(host_mob, directive)
 	log_game("[key_name(host_mob)] is no longer brainwashed by nanites.")
 
 /datum/nanite_program/comm/mind_control/disable_passive_effect()

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -53,7 +53,7 @@
 		"[user] successfully fixes [target]'s brain!",
 		"[user] completes the surgery on [target]'s brain.")
 	to_chat(target, "<span class='userdanger'>A new compulsion fills your mind... you feel forced to obey it!</span>")
-	brainwash(target, objective)
+	brainwash(target, objective, "brainwashing surgery from [user.mind ? user.mind.name : user.real_name]")
 	message_admins("[ADMIN_LOOKUPFLW(user)] surgically brainwashed [ADMIN_LOOKUPFLW(target)] with the objective '[objective]'.")
 	log_game("[key_name(user)] surgically brainwashed [key_name(target)] with the objective '[objective]'.")
 	return TRUE

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -46,7 +46,7 @@
 			"[user] completes the surgery on [target]'s brain.")
 	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
-		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+		unbrainwash(target)
 	switch(rand(0,3))//Now let's see what hopefully-not-important part of the brain we cut off
 		if(1)
 			target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)

--- a/code/modules/surgery/brain_recalibration.dm
+++ b/code/modules/surgery/brain_recalibration.dm
@@ -37,7 +37,7 @@
 		"[user] successfully fixes [target]'s brain!",
 		"[user] completes the surgery on [target]'s brain.")
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
-		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+		unbrainwash(target)
 	target.setOrganLoss(ORGAN_SLOT_BRAIN, target.getOrganLoss(ORGAN_SLOT_BRAIN) - 60)	//we set damage in this case in order to clear the "failing" flag
 	target.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
 	if(target.getOrganLoss(ORGAN_SLOT_BRAIN))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This slightly refactors brainwashing, accomplishing several things:
 - It's possible for the code to track and remove only a single brainwashing objective now, rather than just trashing the whole antag datum.
   - This means the potential exploit of using mind control nanites to instantly clear someone's brainwash from another source is fixed.
 - The 'source' of brainwashing objectives is tracked. Right now this is only used for telling deadchat/logs where a brainwash came from, but this could be used for more in the future.

## Why It's Good For The Game

Fixing potential exploits good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-04-17-1681770861-dreamseeker](https://user-images.githubusercontent.com/65794972/232625327-075894ec-0d91-42b5-9276-ad1c3566725e.png)
![23-04-17-1681771116-dreamseeker](https://user-images.githubusercontent.com/65794972/232625420-a999887b-2852-43c0-9663-b1d9a2a2a0b4.png)

</details>

## Changelog
:cl:
refactor: Slightly refactored brainwashing.
fix: You can no longer use mind control nanites to clear a brainwash from another source.
add: Deadchat is now shown the source of an objective when someone is brainwashed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
