### PR TITLE
Telekinesis fixes

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -27,11 +27,6 @@
 		return ..()
 	attack_tk_grab(user)
 
-/obj/item/attack_tk(mob/user)
-	if(user.stat)
-		return
-	attack_tk_grab(user)
-
 /obj/proc/attack_tk_grab(mob/user)
 	var/obj/item/tk_grab/O = new(src)
 	O.tk_user = user

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -637,7 +637,7 @@
 	cut_overlay(MA)
 
 /mob/living/carbon/human/can_interact_with(atom/A, treat_mob_as_adjacent)
-	return ..() || (dna.check_mutation(TK) && tkMaxRangeCheck(src, M))
+	return ..() || (dna.check_mutation(TK) && tkMaxRangeCheck(src, A))
 
 /mob/living/carbon/human/canUseTopic(atom/movable/M, be_close=FALSE, no_dexterity=FALSE, no_tk=FALSE)
 	if(!(mobility_flags & MOBILITY_UI))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -636,6 +636,9 @@
 	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, "#000000")
 	cut_overlay(MA)
 
+/mob/living/carbon/human/can_interact_with(atom/A, treat_mob_as_adjacent)
+	return ..() || (dna.check_mutation(TK) && tkMaxRangeCheck(src, M))
+
 /mob/living/carbon/human/canUseTopic(atom/movable/M, be_close=FALSE, no_dexterity=FALSE, no_tk=FALSE)
 	if(!(mobility_flags & MOBILITY_UI))
 		to_chat(src, "<span class='warning'>You can't do that right now!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -938,7 +938,7 @@
 		return TRUE
 	if(treat_mob_as_adjacent && src == A.loc)
 		return TRUE
-	return Adjacent(A)
+	return Adjacent(A) || canUseTopic(A)
 
 ///Can the mob use Topic to interact with machines
 /mob/proc/canUseTopic(atom/movable/M, be_close=FALSE, no_dexterity=FALSE, no_tk=FALSE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -938,7 +938,7 @@
 		return TRUE
 	if(treat_mob_as_adjacent && src == A.loc)
 		return TRUE
-	return Adjacent(A) || canUseTopic(A)
+	return Adjacent(A)
 
 ///Can the mob use Topic to interact with machines
 /mob/proc/canUseTopic(atom/movable/M, be_close=FALSE, no_dexterity=FALSE, no_tk=FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes up some code, allowing for telekinesis to be used with more things, including anchored item objects (such as intercoms)

I have no idea why there was an /obj/item/attack_tk override that was the exact same minus the `if(anchored) return ..()` - what's the point of that? So I removed that override entirely.

In addition, I made it so `can_interact_with` will also check for TK if the adjacency check fails.

## Why It's Good For The Game

i want to turn on intercoms with TK. this probably allows some other neat thing to be used with TK, too.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-04-18-1681819399-dreamseeker](https://user-images.githubusercontent.com/65794972/232771883-1b3bee23-b63c-4789-9a93-a1340d2365aa.png)

</details>

## Changelog
:cl:
tweak: Telekinesis can now be properly used with more objects, including anchored item-objects like intercoms!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
