### PR TITLE
Fixes the Reagents in Rice

### DIFF
--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -59,7 +59,7 @@
 	plantname = "Rice Stalks"
 	product = /obj/item/reagent_containers/food/snacks/grown/rice
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/silicon = 0.1)
+	reagents_add = list(/datum/reagent/consumable/rice = 0.1)
 	growthstages = 3
 
 /obj/item/reagent_containers/food/snacks/grown/rice


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Fixes #8623
Changes the reagents in rice from silicon to rice.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think this is a bug, so bug bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Assam Tomb Rho 4_21_2023 3_47_35 PM](https://user-images.githubusercontent.com/87689371/233722611-82571845-7486-4308-b3ec-f6034843e41c.png)

</details>

## Changelog
:cl:
fix: Rice will now contain rice instead of silicon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
