### PR TITLE
Minor Proximity monitor fixes

### DIFF
--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -307,15 +307,17 @@ SUBSYSTEM_DEF(zclear)
 	var/max = world.maxx-TRANSITIONEDGE
 	var/min = 1+TRANSITIONEDGE
 
-	var/list/possible_transtitons = list()
+	var/list/possible_transitions = list()
 	for(var/datum/space_level/D as() in SSmapping.z_list)
 		if (D.linkage == CROSSLINKED)
-			possible_transtitons += D.z_value
+			possible_transitions += D.z_value
 
-	if(!length(possible_transtitons))
-		possible_transtitons = list(SSmapping.empty_space)
+	if(!length(possible_transitions))
+		possible_transitions = list(SSmapping.empty_space)
+		if(!length(possible_transitions)) //Just throw them back on station, if not just runtime.
+			possible_transitions = SSmapping.levels_by_trait(ZTRAIT_STATION)
 
-	var/_z = pick(possible_transtitons)
+	var/_z = pick(possible_transitions)
 
 	//now select coordinates for a border turf
 	var/_x = rand(min,max)

--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -314,8 +314,6 @@ SUBSYSTEM_DEF(zclear)
 
 	if(!length(possible_transitions))
 		possible_transitions = list(SSmapping.empty_space)
-		if(!length(possible_transitions)) //Just throw them back on station, if not just runtime.
-			possible_transitions = SSmapping.levels_by_trait(ZTRAIT_STATION)
 
 	var/_z = pick(possible_transitions)
 

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -11,7 +11,7 @@
 		for (var/obj/machinery/camera/M in src)
 			if(M.isMotion())
 				motioncameras.Add(M)
-				M.area_motion = src
+				M.set_area_motion(src)
 
 //Only need to use one camera
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -87,12 +87,19 @@
 	if (isturf(loc))
 		myarea = get_area(src)
 		LAZYADD(myarea.cameras, src)
-	proximity_monitor = new(src, 1)
 
 	if(mapload && is_station_level(z) && prob(3) && !start_active)
 		toggle_cam()
 	else //this is handled by toggle_camera, so no need to update it twice.
 		update_icon()
+
+/obj/machinery/proc/create_prox_monitor()
+	if(!proximity_monitor)
+		proximity_monitor = new(src, 1)
+
+/obj/machinery/camera/proc/set_area_motion(area/A)
+	area_motion = A
+	create_prox_monitor()
 
 /obj/machinery/camera/Destroy()
 	if(can_use())

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -133,8 +133,11 @@
 	if(!assembly.proxy_module)
 		assembly.proxy_module = new(assembly)
 	upgrades |= CAMERA_UPGRADE_MOTION
+	create_prox_monitor()
 
 /obj/machinery/camera/proc/removeMotion()
 	if(name == "motion-sensitive security camera")
 		name = "security camera"
 	upgrades &= ~CAMERA_UPGRADE_MOTION
+	if(!area_motion)
+		QDEL_NULL(proximity_monitor)

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -146,12 +146,12 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
                                 to_chat(M, "<span class='warning'>As the sphere breaks apart, you're suddenly ejected into the depths of space!")
                         var/max = world.maxx-TRANSITIONEDGE
                         var/min = 1+TRANSITIONEDGE
-                        var/list/possible_transtitons = list()
+                        var/list/possible_transitions = list()
                         for(var/AZ in SSmapping.z_list)
                             var/datum/space_level/D = AZ
                             if (D.linkage == CROSSLINKED)
-                                possible_transtitons += D.z_value
-                        var/_z = pick(possible_transtitons)
+                                possible_transitions += D.z_value
+                        var/_z = pick(possible_transitions)
                         var/_x = rand(min,max)
                         var/_y = rand(min,max)
                         var/turf/T = locate(_x, _y, _z)
@@ -164,12 +164,12 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
             for(var/atom/movable/A in atomList)
                 var/max = world.maxx-TRANSITIONEDGE
                 var/min = 1+TRANSITIONEDGE
-                var/list/possible_transtitons = list()
+                var/list/possible_transitions = list()
                 for(var/AZ in SSmapping.z_list)
                     var/datum/space_level/D = AZ
                     if (D.linkage == CROSSLINKED)
-                        possible_transtitons += D.z_value
-                var/_z = pick(possible_transtitons)
+                        possible_transitions += D.z_value
+                var/_z = pick(possible_transitions)
                 var/_x = rand(min,max)
                 var/_y = rand(min,max)
                 var/turf/T = locate(_x, _y, _z)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -147,6 +147,8 @@ All ShuttleMove procs go here
 		update_light()
 	if(rotation)
 		shuttleRotate(rotation)
+	if(proximity_monitor)
+		proximity_monitor.HandleMove()
 
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Ports:
- https://github.com/tgstation/tgstation/pull/51544

## About The Pull Request
1. Cameras dont utilize proximity monitor code 24/7, but only when they actually have the upgrade
2. Proximity monitors are less buggy on shuttles
3. fixes the spelling of some stupid transition code

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. performance
2. wow this feature actually works now
3. trans-tit-on

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![proxo](https://user-images.githubusercontent.com/62388554/233805810-c1e8230e-e89d-44b7-97b0-81b277b5b138.JPG)

![proxo2](https://user-images.githubusercontent.com/62388554/233805812-806d3f78-107f-4e2c-bee4-1efa9ffaa197.JPG)

They work as expected.

</details>

## Changelog
:cl: Rkz, AnturK
fix: cameras dont use proximity monitoring 24/7, only when they actually have the upgrade (no functionality change ingame, it just means unecessary processing)
fix: proximity monitors actually are usable on shuttles now, woaw
spellcheck: removes the tits from "possible_transtitons". Spelled correctly as "possible_transitions"

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
