### PR TITLE
Adds "assassinate once" objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -291,6 +291,25 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	if(target && !target.current)
 		explanation_text = "Assassinate [target.name], who was obliterated"
 
+/datum/objective/assassinate/once
+	name = "assasinate once"
+	var/start_time = 0
+
+/datum/objective/assassinate/once/find_target(list/dupe_search_range, list/blacklist)
+	. = ..()
+	if(.)
+		start_time = world.time
+
+/datum/objective/assassinate/once/update_explanation_text()
+	..()
+	if(target?.current)
+		explanation_text = "Assassinate [target.name], the [!target_role_type ? target.assigned_role : target.special_role], at least once, regardless of subsequent revival."
+	else
+		explanation_text = "Free Objective"
+
+/datum/objective/assassinate/once/check_completion()
+	return ..() || (target && target.last_death >= start_time)
+
 /datum/objective/mutiny
 	name = "mutiny"
 	var/target_role_type=FALSE

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -172,7 +172,7 @@
 		else if(prob(30))
 			add_objective(new/datum/objective/maroon, TRUE)
 		else
-			add_objective(prob(60) ? new /datum/objective/assassinate : new /datum/objective/assassinate/once, TRUE)
+			add_objective(prob(60) ? new /datum/objective/assassinate/once : new /datum/objective/assassinate, TRUE)
 	else
 		add_objective(new/datum/objective/steal, TRUE)
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -172,7 +172,7 @@
 		else if(prob(30))
 			add_objective(new/datum/objective/maroon, TRUE)
 		else
-			add_objective(new/datum/objective/assassinate, TRUE)
+			add_objective(prob(60) ? new /datum/objective/assassinate : new /datum/objective/assassinate/once, TRUE)
 	else
 		add_objective(new/datum/objective/steal, TRUE)
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -122,7 +122,7 @@
 				objectives += S
 				log_objective(owner, S.explanation_text)
 			else
-				var/datum/objective/assassinate/A = new()
+				var/datum/objective/assassinate/A = prob(60) ? new /datum/objective/assassinate/once : new /datum/objective/assassinate
 				A.owner = owner
 				var/list/owners = A.get_owners()
 				A.find_target(owners,protection)

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -171,7 +171,7 @@
 				add_objective(new/datum/objective/destroy, TRUE)
 			else if(prob(32))						//~26%
 				//Kill head
-				var/datum/objective/assassinate/killchosen = new
+				var/datum/objective/assassinate/killchosen = prob(40) ? new /datum/objective/assassinate/once : new /datum/objective/assassinate
 				var/list/current_heads = SSjob.get_all_heads()
 				if(!current_heads.len)
 					generate_traitor_kill_objective(restricted_jobs)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -161,7 +161,11 @@
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
 		else
-			var/datum/objective/assassinate/kill_objective = new
+			var/datum/objective/assassinate/kill_objective
+			if(prob(60))
+				kill_objective = new /datum/objective/assassinate/once
+			else
+				kill_objective = new /datum/objective/assassinate
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			add_objective(kill_objective)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -161,11 +161,7 @@
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
 		else
-			var/datum/objective/assassinate/kill_objective
-			if(prob(60))
-				kill_objective = new /datum/objective/assassinate/once
-			else
-				kill_objective = new /datum/objective/assassinate
+			var/datum/objective/assassinate/kill_objective = prob(60) ? new /datum/objective/assassinate/once : new /datum/objective/assassinate
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			add_objective(kill_objective)

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -65,7 +65,7 @@
 		return
 	switch(rand(1,100))
 		if(1 to 30)
-			var/datum/objective/assassinate/kill_objective = new
+			var/datum/objective/assassinate/kill_objective = prob(60) ? new /datum/objective/assassinate/once : new /datum/objective/assassinate
 			kill_objective.owner = owner
 			kill_objective.find_target()
 			objectives += kill_objective


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds an "assassinate once" objective - which is just an assassinate objective, but it also passes if the target's `last_death` is later than when you got the objective.

## Why It's Good For The Game

Discourages round removal.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-04-23-1682274989-dreamseeker](https://user-images.githubusercontent.com/65794972/233858639-cbe47e38-9ede-47f8-9b4a-227191853b58.png)

</details>

## Changelog
:cl:
add: Added an "assassinate once" objective, where you only have to ensure that you kill your target at least once, even if they're revived afterwards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
