### PR TITLE
Multi-Z Battle Royale support

### DIFF
--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -307,18 +307,18 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	to_chat(world, "<span class='boldannounce'>Battle Royale: Starting game.</span>")
 	titanfall()
 	death_wall = list()
-	var/z_level = SSmapping.station_start
-	var/turf/center = SSmapping.get_station_center()
-	var/list/edge_turfs = list()
-	edge_turfs += block(locate(12, 12, z_level), locate(244, 12, z_level))			//BOTTOM
-	edge_turfs += block(locate(12, 244, z_level), locate(244, 244, z_level))		//TOP
-	edge_turfs |= block(locate(12, 12, z_level), locate(12, 244, z_level))			//LEFT
-	edge_turfs |= block(locate(244, 12, z_level), locate(244, 244, z_level)) 	//RIGHT
-	for(var/turf/T in edge_turfs)
-		var/obj/effect/death_wall/DW = new(T)
-		DW.set_center(center)
-		death_wall += DW
-		CHECK_TICK
+	for(var/z_level in SSmapping.levels_by_trait(ZTRAIT_STATION))
+		var/turf/center = SSmapping.get_station_center(level = z_level)
+		var/list/edge_turfs = list()
+		edge_turfs += block(locate(12, 12, z_level), locate(244, 12, z_level))		//BOTTOM
+		edge_turfs += block(locate(12, 244, z_level), locate(244, 244, z_level))	//TOP
+		edge_turfs |= block(locate(12, 12, z_level), locate(12, 244, z_level))		//LEFT
+		edge_turfs |= block(locate(244, 12, z_level), locate(244, 244, z_level))	//RIGHT
+		for(var/turf/T in edge_turfs)
+			var/obj/effect/death_wall/DW = new(T)
+			DW.set_center(center)
+			death_wall += DW
+			CHECK_TICK
 	START_PROCESSING(SSprocessing, src)
 
 /datum/battle_royale_controller/proc/titanfall()

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -68,6 +68,5 @@
 	return locate(T.x, T.y, T.z + offset)
 
 // Prefer not to use this one too often
-/datum/controller/subsystem/mapping/proc/get_station_center()
-	var/station_z = levels_by_trait(ZTRAIT_STATION)[1]
-	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), station_z)
+/datum/controller/subsystem/mapping/proc/get_station_center(level = levels_by_trait(ZTRAIT_STATION)[1])
+	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), level)


### PR DESCRIPTION
## About The Pull Request

Ports:
- https://github.com/Rukofamicom/Royale-Station-13/pull/76

Fixes the wall not showing on anything except z1. Some work could probably be put in the cordon off certain z-levels with some type of warning timer, but for now the wall will just be the same between all zs, making being a z level below totally plausible yet annoying.

Also fixes walls not being properly "abstract" and doing zfalls and stuff

## Why It's Good For The Game

Better multiz support.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/234546505-ef4f2bb5-8d77-46a3-a7d3-c3196eb1b9ec.png)

![image](https://user-images.githubusercontent.com/10366817/234550412-3a101f23-a9a5-4f04-a004-a226cf33a929.png)

</details>

## Changelog
:cl:
fix: Battle royale walls will now show properly on multiz stations.
fix: BR walls can no longer be pulled by singularities or zfall.
/:cl:
