### PR TITLE
Fixes mindless human self-examine runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -830,7 +830,7 @@
 			damaged_message += D
 		to_chat(src, "<span class='info'>Your [damaged_message] [damaged_plural ? "are" : "is"] hurt.</span>")
 
-	if(length(mind.quirks))
+	if(length(mind?.quirks))
 		to_chat(src, "<span class='notice'>You have these quirks: [mind.get_quirk_string()].</span>")
 
 /mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)


### PR DESCRIPTION
## About The Pull Request
Fixes runtime caused by mindless humans checking themselves for injuries because I forgot a single question mark

Closes #8914 
## Why It's Good For The Game
Working code is good

## Testing Photographs and Procedures
<details>
<summary>Screenshots</summary>

Example of what happens with current code (bad)
![B8C318B8-BBF0-4C2C-A171-3FE2EE6D1A26](https://user-images.githubusercontent.com/39193182/234892033-9e8a2c18-0ae6-4709-b963-c06a8b3937ba.jpeg)

Example of what happens with new code (good)
![28F3B7CC-FC0D-418A-ADF7-16C7F896174C](https://user-images.githubusercontent.com/39193182/234893539-aab90dd1-50b5-471f-976a-7e56b15f93db.jpeg)

</details>

## Changelog
:cl: tonty
fix: mindless humans are less likely to upset coders
/:cl:
