### PR TITLE
Orbit panel now tracks antag team correctly + Minor tweak

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -150,6 +150,10 @@ GLOBAL_LIST(admin_antag_list)
 /datum/antagonist/proc/farewell()
 	return
 
+/// gets antag name for orbit category. Reasoning is described in each subtype
+/datum/antagonist/proc/get_antag_name()
+	return name
+
 /datum/antagonist/proc/give_antag_moodies()
 	if(!antag_moodlet)
 		return

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -60,3 +60,9 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"
+
+/datum/team/proc/get_team_name()
+	if(name == "team")
+		stack_trace("[type] has no team name")
+		return "Unnamed team"
+	return name

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -61,6 +61,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"
 
+/// gets team name for orbit category. Reasoning is described in each subtype
 /datum/team/proc/get_team_name()
 	if(name == "team")
 		stack_trace("[type] has no team name")

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -244,7 +244,7 @@
 		H.update_body()
 
 /datum/team/cult
-	name = "Cult"
+	name = "Bloodcult"
 
 	var/blood_target
 	var/image/blood_target_image

--- a/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
@@ -8,6 +8,7 @@
 	var/antag_hud_type = ANTAG_HUD_HERETIC
 	var/antag_hud_name = "heretic_beast"
 	var/datum/antagonist/heretic/master
+	show_to_ghosts = TRUE
 
 /datum/antagonist/heretic_monster/admin_add(datum/mind/new_owner,mob/admin)
 	new_owner.add_antag_datum(src)
@@ -25,6 +26,11 @@
 		to_chat(owner, "<span class='boldannounce'>Your no longer bound to your master, [master.owner.current.real_name]</span>")
 		master = null
 	return ..()
+
+/datum/antagonist/heretic_monster/get_antag_name() // good to recognise who's responsible with these monsters
+	if(!master)
+		return "Unchained Eldritch Horror"
+	return "Eldritch Horrors of [master.owner.name]"
 
 /datum/antagonist/heretic_monster/proc/set_owner(datum/antagonist/_master)
 	master = _master

--- a/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
@@ -30,7 +30,7 @@
 /datum/antagonist/heretic_monster/get_antag_name() // good to recognise who's responsible with these monsters
 	if(!master)
 		return "Unchained Eldritch Horror"
-	return "Eldritch Horrors of [master.owner.name]"
+	return "Eldritch Horror of [master.owner.name]"
 
 /datum/antagonist/heretic_monster/proc/set_owner(datum/antagonist/_master)
 	master = _master

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -42,6 +42,7 @@
 				fugitive_team = H.fugitive_team
 				return
 		fugitive_team = new /datum/team/fugitive
+		fugitive_team.backstory = backstory
 		fugitive_team.forge_team_objectives()
 		return
 	if(!istype(new_team))
@@ -67,6 +68,10 @@
 /datum/team/fugitive
 	name = "Fugitives"
 	member_name = "fugitive"
+	var/datum/fugitive_type/backstory
+
+/datum/team/fugitive_hunters/get_team_name() // simple to know fugitive story
+	return "Fugitive: [backstory.name]"
 
 /datum/team/fugitive/roundend_report() //shows the number of fugitives, but not if they won in case there is no security
 	var/list/fugitives = list()

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -71,8 +71,7 @@
 	var/datum/fugitive_type/backstory
 
 /datum/team/fugitive/get_team_name() // simple to know fugitive story
-	var/s = length(members) "s" : ""
-	return "Fugitive[s]: [backstory.name]"
+	return backstory.multiple_name
 
 /datum/team/fugitive/roundend_report() //shows the number of fugitives, but not if they won in case there is no security
 	var/list/fugitives = list()

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -70,8 +70,9 @@
 	member_name = "fugitive"
 	var/datum/fugitive_type/backstory
 
-/datum/team/fugitive_hunters/get_team_name() // simple to know fugitive story
-	return "Fugitive: [backstory.name]"
+/datum/team/fugitive/get_team_name() // simple to know fugitive story
+	var/s = length(members) "s" : ""
+	return "Fugitive[s]: [backstory.name]"
 
 /datum/team/fugitive/roundend_report() //shows the number of fugitives, but not if they won in case there is no security
 	var/list/fugitives = list()

--- a/code/modules/antagonists/fugitive/fugitive_types.dm
+++ b/code/modules/antagonists/fugitive/fugitive_types.dm
@@ -8,6 +8,8 @@ GLOBAL_LIST_INIT(fugitive_types, list(
 /datum/fugitive_type
 	/// The name of the group
 	var/name
+	/// The plural form of the group/team
+	var/multiple_name
 	/// The message sent when they are created
 	var/greet_message
 	/// The outfit given, or a list of outfits that will be enumerated for each spawn
@@ -21,12 +23,14 @@ GLOBAL_LIST_INIT(fugitive_types, list(
 
 /datum/fugitive_type/prisoner
 	name = "Prisoner"
+	multiple_name = "Nanotrasen Superjail Escapists"
 	greet_message = "<span class='bold'>I can't believe we managed to break out of a Nanotrasen superjail! Sadly though, our work is not done. The emergency teleport at the station logs everyone who uses it, and where they went.</span>\n\
 		<span class='bold'>It won't be long until CentCom tracks where we've gone off to. I need to work with my fellow escapees to prepare for the troops Nanotrasen is sending, I'm not going back.</span>"
 	outfit = /datum/outfit/prisoner
 
 /datum/fugitive_type/cult
 	name = "Cultist of Yalp Elor"
+	multiple_name = "Faithfuls of Yalp Elor"
 	greet_message = "<span class='bold'>Blessed be our journey so far, but I fear the worst has come to our doorstep, and only those with the strongest faith for Yalp Elor will survive.</span>\n\
 		<span class='bold'>Our religion has been repeatedly culled by Nanotrasen because it is categorized as an \"Enemy of the Corporation\", whatever that means.</span>\n\
 		<span class='bold'>Now there are only a few of us left, and Nanotrasen is coming. When will our god show itself to save us from this hellish station?!</span>"
@@ -34,6 +38,7 @@ GLOBAL_LIST_INIT(fugitive_types, list(
 
 /datum/fugitive_type/waldo
 	name = "Waldo"
+	multiple_name = "Your best friend, Waldo" // not plural but he's the only one in the team - used in orbit panel
 	greet_message = "<span class='big bold'>Hi, Friends!</span>\n\
 		<span class='bold'>My name is Waldo. I'm just setting off on a galaxywide hike. You can come too. All you have to do is find me.</span>\n\
 		<span class='bold'>By the way, I'm not traveling on my own. wherever I go, there are lots of other characters for you to spot. First find the people trying to capture me! They're somewhere around the station!</span>"
@@ -42,6 +47,7 @@ GLOBAL_LIST_INIT(fugitive_types, list(
 
 /datum/fugitive_type/synth
 	name = "Synthetic"
+	multiple_name = "Synthetic defectors"
 	greet_message = "<span class='bold'>ALERT: Wide-range teleport has scrambled primary systems.</span>\n\
 		<span class='bold'>Initiating diagnostics...</span>\n\
 		<span class='bold'>ERROR ER0RR $R0RRO$!R41.%%!! loaded.</span>\n\

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -73,8 +73,7 @@
 	var/datum/fugitive_type/hunter/backstory
 
 /datum/team/fugitive_hunters/get_team_name() // simple to know fugitive hunter's story
-	var/s = length(members) "s" : ""
-	return "Fugitive Hunter[s]: [backstory.multiple_name]"
+	return backstory.multiple_name
 
 /datum/team/fugitive_hunters/proc/forge_team_objectives()
 	for(var/datum/antagonist/fugitive/A in GLOB.antagonists)

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -73,7 +73,8 @@
 	var/datum/fugitive_type/hunter/backstory
 
 /datum/team/fugitive_hunters/get_team_name() // simple to know fugitive hunter's story
-	return "Fugitive Hunters: [backstory.multiple_name]"
+	var/s = length(members) "s" : ""
+	return "Fugitive Hunter[s]: [backstory.multiple_name]"
 
 /datum/team/fugitive_hunters/proc/forge_team_objectives()
 	for(var/datum/antagonist/fugitive/A in GLOB.antagonists)

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -72,6 +72,9 @@
 	member_name = "hunter"
 	var/datum/fugitive_type/hunter/backstory
 
+/datum/team/fugitive_hunters/get_team_name() // simple to know fugitive hunter's story
+	return "Fugitive Hunters: [backstory.multiple_name]"
+
 /datum/team/fugitive_hunters/proc/forge_team_objectives()
 	for(var/datum/antagonist/fugitive/A in GLOB.antagonists)
 		if(!A.owner)

--- a/code/modules/antagonists/fugitive/hunter_types.dm
+++ b/code/modules/antagonists/fugitive/hunter_types.dm
@@ -8,8 +8,6 @@ GLOBAL_LIST_INIT(hunter_types, list(
 	max_amount = 4
 	/// The ship this type uses
 	var/ship_type
-	/// The plural form of the group
-	var/multiple_name
 
 /datum/fugitive_type/hunter/space_police
 	name = "Space Police"

--- a/code/modules/antagonists/guardian/guardian.dm
+++ b/code/modules/antagonists/guardian/guardian.dm
@@ -26,3 +26,6 @@
 /datum/antagonist/guardian/antag_panel_data()
 	var/mob/living/simple_animal/hostile/guardian/G = owner.current
 	return "<B>Summoner: [G.summoner.name]/([ckey(G.summoner.key)])</B>"
+
+/datum/antagonist/guardian/get_antag_name() // good to recognise whose holoparasite is
+	return "Guardian of [summoner.name]"

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -74,7 +74,7 @@
 	return ..()
 
 /datum/team/pirate
-	name = "Pirate crew"
+	name = "Space Pirates"
 
 /datum/team/pirate/proc/forge_objectives()
 	var/datum/objective/loot/getbooty = new()

--- a/code/modules/antagonists/slaughter/slaughter_antag.dm
+++ b/code/modules/antagonists/slaughter/slaughter_antag.dm
@@ -15,6 +15,9 @@
 	. = ..()
 	owner.announce_objectives()
 
+/datum/antagonist/slaughter/get_antag_name() // makes laughter demon in the same category with slaughter demon in orbit panel
+	return "Slaughter demon"
+
 /datum/antagonist/slaughter/proc/forge_objectives()
 	if(summoner)
 		var/datum/objective/assassinate/new_objective = new /datum/objective/assassinate

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -721,7 +721,7 @@
 		Ctrl-Clicking on a mob will attempt to remove it from the area and place it in a safe environment for storage.")
 
 /datum/team/swarmer
-	name = "The Swarm"
+	name = "Swarmers"
 	var/total_resources_eaten = 0
 
 /datum/antagonist/swarmer/get_team()

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -12,6 +12,7 @@
 
 /// Team for storing both the contractor and their support unit - only really for the HUD and admin logging.
 /datum/team/contractor_team
+	name = "Contractors"
 	show_roundend_report = FALSE
 
 /datum/antagonist/traitor/contractor_support/forge_traitor_objectives()

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -26,6 +26,9 @@
 		rename_wizard()
 	owner.remove_all_quirks()
 
+/datum/antagonist/wizard/get_antag_name() // wizards are not in the same team
+	return "Space Wizard [owner.name]"
+
 /datum/antagonist/wizard/proc/register()
 	SSticker.mode.wizards |= owner
 
@@ -47,8 +50,9 @@
 	var/datum/antagonist/wizard/master_wizard
 
 /datum/antagonist/wizard/proc/create_wiz_team()
+	var/static/count = 0
 	wiz_team = new(owner)
-	wiz_team.name = "[owner.current.real_name] team"
+	wiz_team.name = "Wizard team No.[++count]" // it will be only displayed to admins
 	wiz_team.master_wizard = src
 	update_wiz_icons_added(owner.current)
 
@@ -59,6 +63,13 @@
 		SSjob.SendToLateJoin(owner.current)
 		to_chat(owner, "HOT INSERTION, GO GO GO")
 	owner.current.forceMove(pick(GLOB.wizardstart))
+
+/datum/team/wizard/get_team_name() // team name is based on the master wizard's current form
+	var/mind_name = master_wizard.owner.name
+	var/mob_name = master_wizard.owner?.current.real_name
+	if(mind_name == mob_name)
+		return "Spece Wizard [mind_name]"
+	return "Space Wizard [mind_name] in [mob_name]" // tells which one is the real master
 
 /datum/antagonist/wizard/proc/create_objectives()
 	if(!give_objectives)

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -1,5 +1,5 @@
 /datum/team/xeno
-	name = "Aliens"
+	name = "Xenomorphs"
 
 //Simply lists them.
 /datum/team/xeno/roundend_report()

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -75,7 +75,11 @@
 					var/datum/antagonist/A = _A
 					if (A.show_to_ghosts)
 						was_antagonist = TRUE
-						serialized["antag"] = A.name
+						var/datum/team/antag_team = A.get_team()
+						if(antag_team)
+							serialized["antag"] = antag_team.get_team_name()
+						else
+							serialized["antag"] = A.name
 						antagonists += list(serialized)
 						break
 

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -79,7 +79,7 @@
 						if(antag_team)
 							serialized["antag"] = antag_team.get_team_name()
 						else
-							serialized["antag"] = A.name
+							serialized["antag"] = A.get_antag_name()
 						antagonists += list(serialized)
 						break
 

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -66,7 +66,8 @@ const OrbitedButton = (props, context) => {
       })}>
       {job && (
         <Box inline
-          ml={1}
+          ml={0.1}
+          mr={0.6}
           style={{ "transform": "translateY(2.5px)" }}
           className={`job-icon16x16 job-icon-${job}`} />
       )}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Orbit panel now tracks antag team correctly
Abductors/ERTs will not be in separated category

* changes some code to display antag category pretty
* eldritch horrors are now displayed in orbit antag panel (they're obvious already)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixing old shit + improve orbit panel

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/235031362-79b91441-3484-48e9-917c-c9ebddd9c4f1.png)

</details>

## Changelog
:cl:
add: Orbit panel tracks antag team rather than individual antag name (i.e. ERTs, Abductors)
fix: job icon in orbit panel no longer looks horrible
tweak: some antagonists/teams will display some different name in orbit panel
tweak: eldritch horrors are now tracked in antag category in orbit panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
