### PR TITLE
Errors will print to the chat while the debugger is enabled.

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -133,7 +133,7 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 #endif
 
 	if (Debugger?.enabled)
-		to_chat(world, "<span class='alertwarning'>[main_line]</span>")
+		to_chat(world, "<span class='alertwarning'>[main_line]</span>", MESSAGE_TYPE_DEBUG)
 
 
 	// This writes the regular format (unwrapping newlines and inserting timestamps as needed).

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -132,6 +132,9 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		GLOB.current_test.Fail("[main_line]\n[desclines.Join("\n")]")
 #endif
 
+	if (Debugger?.enabled)
+		to_chat(world, "<span class='alertwarning'>[main_line]</span>")
+
 
 	// This writes the regular format (unwrapping newlines and inserting timestamps as needed).
 	log_runtime("runtime error: [E.name]\n[E.desc]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If the debugger is attached, then errors will be printed to the console.
This will have no effect on the server.

## Why It's Good For The Game

While testing, people should really know when runtime errors occur and shouldn't rely on checking runtimes to see when there is an error. This makes debugging significantly easier since you can instantly tell if you have mistaken the behaviour of something or used it wrong.
This should prevent easy runtimes from being added to the game as they are more likely to be spotted during testing.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/235108702-b658fa6c-05f0-49bf-be5a-a08b8636b69b.png)


## Changelog
:cl:
code: Runtimes will now print to the chat while debugging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
