### PR TITLE
Adds an extra sanity check to tongueless speech

### DIFF
--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -1,6 +1,10 @@
 /mob/living/carbon/proc/handle_tongueless_speech(mob/living/carbon/speaker, list/speech_args)
 	SIGNAL_HANDLER
 
+	var/obj/item/organ/tongue/tongue = speaker.getorganslot(ORGAN_SLOT_TONGUE)
+	if(tongue && !CHECK_BITFIELD(tongue.organ_flags, ORGAN_FAILING))
+		speaker.UnregisterSignal(speaker, COMSIG_MOB_SAY)
+		return
 	var/message = speech_args[SPEECH_MESSAGE]
 	var/static/regex/tongueless_lower = new("\[gdntke]+", "g")
 	var/static/regex/tongueless_upper = new("\[GDNTKE]+", "g")
@@ -11,7 +15,7 @@
 
 /mob/living/carbon/can_speak_vocal(message)
 	if(silent)
-		return 0
+		return FALSE
 	return ..()
 
 /mob/living/carbon/could_speak_language(datum/language/dt)
@@ -19,5 +23,5 @@
 	if(T)
 		. = T.could_speak_language(dt)
 	else
-		. = initial(dt.flags) & TONGUELESS_SPEECH
+		. = CHECK_BITFIELD(initial(dt.flags), TONGUELESS_SPEECH)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds an extra sanity check to tongueless speech - if someone has the `handle_tongueless_speech` signal handler, while having a working tongue in them, `handle_tongueless_speech` will remove itself from their signal handlers.

## Why It's Good For The Game

Fixes having to take biometallic replication victims tongues out and put them back in.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Added an extra sanity check to tongueless speech. This should fix the speech issue with biometallic replication.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
