### PR TITLE
Cleans up silicon deletion, adds stack_trace for erroneous lawset reset/removal

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -20,6 +20,16 @@
 	var/list/valentine_laws = list()
 	var/id = DEFAULT_AI_LAWID
 
+/datum/ai_laws/Destroy(force = FALSE, ...)
+	if(!QDELETED(owner)) //Stopgap to help with laws randomly being lost. This stack_trace will hopefully help find the real issues.
+		if(force) //Unless we're forced...
+			stack_trace("AI law datum for [owner] has been forcefully destroyed incorrectly; the owner variable should be cleared first!")
+			return ..()
+		stack_trace("AI law datum for [owner] has ignored Destroy() call; the owner variable must be cleared first!")
+		return QDEL_HINT_LETMELIVE
+	owner = null
+	return ..()
+
 /datum/ai_laws/proc/lawid_to_type(lawid)
 	var/all_ai_laws = subtypesof(/datum/ai_laws)
 	for(var/al in all_ai_laws)

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -23,19 +23,16 @@
 		circuit = null
 		if((state != GLASS_CORE) && (state != AI_READY_CORE))
 			state = EMPTY_CORE
-			update_icon()
+			update_appearance()
 	if(A == brain)
 		brain = null
-	. = ..()
+	return ..()
 
 
-/obj/structure/AIcore/Destroy()
-	if(circuit)
-		qdel(circuit)
-		circuit = null
-	if(brain)
-		qdel(brain)
-		brain = null
+/obj/structure/ai_core/Destroy()
+	QDEL_NULL(circuit)
+	QDEL_NULL(brain)
+	QDEL_NULL(laws)
 	return ..()
 
 /obj/structure/AIcore/latejoin_inactive

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -29,7 +29,7 @@
 	return ..()
 
 
-/obj/structure/ai_core/Destroy()
+/obj/structure/AIcore/Destroy()
 	QDEL_NULL(circuit)
 	QDEL_NULL(brain)
 	QDEL_NULL(laws)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -14,7 +14,7 @@
 	var/force_replace_ai_name = FALSE
 	var/overrides_aicore_laws = FALSE // Whether the laws on the MMI, if any, override possible pre-existing laws loaded on the AI core.
 
-/obj/item/mmi/Initialize()
+/obj/item/mmi/Initialize(mapload)
 	. = ..()
 	radio = new(src) //Spawns a radio inside the MMI.
 	radio.broadcasting = FALSE //researching radio mmis turned the robofabs into radios because this didnt start as 0.
@@ -45,12 +45,6 @@
 		add_overlay("mmi_alive")
 	else
 		add_overlay("mmi_dead")
-
-/obj/item/mmi/Initialize(mapload)
-	. = ..()
-	radio = new(src) //Spawns a radio inside the MMI.
-	radio.broadcasting = FALSE //researching radio mmis turned the robofabs into radios because this didnt start as 0.
-	laws.set_laws_config()
 
 /obj/item/mmi/attackby(obj/item/O, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -14,6 +14,23 @@
 	var/force_replace_ai_name = FALSE
 	var/overrides_aicore_laws = FALSE // Whether the laws on the MMI, if any, override possible pre-existing laws loaded on the AI core.
 
+/obj/item/mmi/Initialize()
+	. = ..()
+	radio = new(src) //Spawns a radio inside the MMI.
+	radio.broadcasting = FALSE //researching radio mmis turned the robofabs into radios because this didnt start as 0.
+	laws.set_laws_config()
+
+/obj/item/mmi/Destroy()
+	if(iscyborg(loc))
+		var/mob/living/silicon/robot/borg = loc
+		borg.mmi = null
+	mecha = null
+	QDEL_NULL(brainmob)
+	QDEL_NULL(brain)
+	QDEL_NULL(radio)
+	QDEL_NULL(laws)
+	return ..()
+
 /obj/item/mmi/update_icon()
 	if(!brain)
 		icon_state = "mmi_off"
@@ -175,23 +192,6 @@
 			if(3)
 				brainmob.emp_damage = min(brainmob.emp_damage + rand(0,10), 30)
 		brainmob.emote("alarm")
-
-/obj/item/mmi/Destroy()
-	if(iscyborg(loc))
-		var/mob/living/silicon/robot/borg = loc
-		borg.mmi = null
-	if(brainmob)
-		qdel(brainmob)
-		brainmob = null
-	if(brain)
-		qdel(brain)
-		brain = null
-	if(mecha)
-		mecha = null
-	if(radio)
-		qdel(radio)
-		radio = null
-	return ..()
 
 /obj/item/mmi/deconstruct(disassembled = TRUE)
 	if(brain)

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -37,7 +37,7 @@
 
 /mob/living/silicon/robot/proc/lawsync()
 	laws_sanity_check()
-	var/datum/ai_laws/master = connected_ai ? connected_ai.laws : null
+	var/datum/ai_laws/master = connected_ai?.laws
 	var/temp
 	if (master)
 		laws.devillaws.len = master.devillaws.len

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -71,6 +71,7 @@
 	QDEL_NULL(radio)
 	QDEL_NULL(aicamera)
 	QDEL_NULL(builtInCamera)
+	laws?.owner = null //Laws will refuse to die otherwise.
 	QDEL_NULL(laws)
 	QDEL_NULL(modularInterface)
 	QDEL_NULL(internal_id_card)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -67,6 +67,16 @@
 	create_access_card(default_access_list)
 	default_access_list = null
 
+/mob/living/silicon/Destroy()
+	QDEL_NULL(radio)
+	QDEL_NULL(aicamera)
+	QDEL_NULL(builtInCamera)
+	QDEL_NULL(laws)
+	QDEL_NULL(modularInterface)
+	QDEL_NULL(internal_id_card)
+	GLOB.silicon_mobs -= src
+	return ..()
+
 /mob/living/silicon/proc/create_access_card(list/access_list)
 	if(!internal_id_card)
 		internal_id_card = new()
@@ -102,15 +112,6 @@
 
 /mob/living/silicon/med_hud_set_status()
 	return //we use a different hud
-
-/mob/living/silicon/Destroy()
-	radio = null
-	aicamera = null
-	modularInterface = null
-	QDEL_NULL(builtInCamera)
-	QDEL_NULL(internal_id_card)
-	GLOB.silicon_mobs -= src
-	return ..()
 
 /mob/living/silicon/contents_explosion(severity, target)
 	return


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/53680
- https://github.com/tgstation/tgstation/pull/59409

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cleans up cyborg and AI /destroy, because they werent QDELing all of the variables they should be. Converts a bunch of `var = null` to the proper `QDEL_NULL(var)`s

TG had a check to look for erroneous AI law datum deletions/resets on `/datum/ai_laws/Destroy`, which seemed useful if we do actually have that problem, so I brought that over too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
law datums were not being QDEL'd

law datums could get QDEL'd for the wrong reason without a way to know when or why

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Roundstart AI

![roundstart](https://user-images.githubusercontent.com/62388554/235334464-e3ac4f07-4661-46b3-b6fc-17bc7b01a04d.JPG)

Deletion without issue or runtime

![killedered](https://user-images.githubusercontent.com/62388554/235334470-b0ca87f7-1ff3-47c3-95a6-a0a086067a73.JPG)



</details>

## Changelog
:cl: RKz, TiviPlus, xzaber
fix: silicons will actually QDEL their law datum when they get destroyed
admin: if an AI's law datum gets deleted for spaghetti reasons, a stack_trace will be sent letting you be able to determine when, (and probably) how it occurred
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
