### PR TITLE
Fixes spider venom / nanite interactions

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -477,7 +477,7 @@
 		for(var/datum/component/nanites/N in L.datum_components)
 			for(var/X in N.programs)
 				var/datum/nanite_program/NP = X
-				NP.software_error(5) //all programs are overwritten with /glitch which does no harm, but gradually drains nanites. 
+				NP.software_error(1) //all programs are destroyed, nullifying all nanites
 
 /datum/reagent/toxin/spidervenom/on_mob_life(mob/living/carbon/M)
 	if(M.getStaminaLoss() <= 70)				//Will never stamcrit


### PR DESCRIPTION
## About The Pull Request

Changes the nanites software error from type 5 to type 1. 
Instead of forcing all programs to glitch, it will now delete all programs instead. 

## Why It's Good For The Game

This fixes a critical oversight in #8789
I was mistaken and in fact not all nanite programs become `/datum/nanite_program/glitch` when subjected to corruption, it's just the default and by far most common option. 

Spider venom is incredibly lethal to people who have specific nanite programs in their system currently and this is not intended behavior. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
As outlined in #8789: 

![image](https://user-images.githubusercontent.com/9547572/235352365-073a3c07-3d20-4658-ae69-2e0eaa595a4b.png)

I am still unable to actually test this specific facet of the code.
</details>

## Changelog
:cl:
fix: Fixed an unintended interaction between spider venom and nanites. Spider venom will still render nanites inert, but they will no longer be drained automatically after this. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
