### PR TITLE
Adds more logging to blood and cult logs

### DIFF
--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -354,6 +354,8 @@
 	if(!check_if_in_ritual_site(cultist, cult_team))
 		return FALSE
 	priority_announce("Figments from an eldritch god are being summoned by [cultist.real_name] into [get_area(cultist)] from an unknown dimension. Disrupt the ritual at all costs!","Central Command Higher Dimensional Affairs", ANNOUNCER_SPANOMALIES)
+	log_game("[key_name(cultist)] has begun inscribing the Narsie summon rune at [AREACOORD(cultist)]")
+
 	for(var/shielded_turf in spiral_range_turfs(1, cultist, 1))
 		LAZYADD(shields, new /obj/structure/emergency_shield/sanguine(shielded_turf))
 

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -300,6 +300,7 @@
 		"<span class='warning'>[cultist] [cultist.blood_volume ? "cuts open [cultist.p_their()] arm and begins writing in [cultist.p_their()] own blood":"begins sketching out a strange design"]!</span>",
 		"<span class='cult'>You [cultist.blood_volume ? "slice open your arm and ":""]begin drawing a sigil of the Geometer.</span>"
 		)
+	log_game("[key_name(cultist)] has begun inscribing the Narsie summon rune at [AREACOORD(cultist)]")
 
 	if(cultist.blood_volume)
 		cultist.apply_damage(initial(rune_to_scribe.scribe_damage), BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)) // *cuts arm* *bone explodes* ever have one of those days?
@@ -320,6 +321,7 @@
 		"<span class='warning'>[cultist] creates a strange circle[cultist.blood_volume ? " in [cultist.p_their()] own blood":""].</span>",
 		"<span class='cult'>You finish drawing the arcane markings of the Geometer.</span>"
 		)
+	log_game("[key_name(cultist)] has finished inscribing the Narsie summon rune at [AREACOORD(cultist)]")
 
 	cleanup_shields()
 	var/obj/effect/rune/made_rune = new rune_to_scribe(our_turf, chosen_keyword)
@@ -354,7 +356,6 @@
 	if(!check_if_in_ritual_site(cultist, cult_team))
 		return FALSE
 	priority_announce("Figments from an eldritch god are being summoned by [cultist.real_name] into [get_area(cultist)] from an unknown dimension. Disrupt the ritual at all costs!","Central Command Higher Dimensional Affairs", ANNOUNCER_SPANOMALIES)
-	log_game("[key_name(cultist)] has begun inscribing the Narsie summon rune at [AREACOORD(cultist)]")
 
 	for(var/shielded_turf in spiral_range_turfs(1, cultist, 1))
 		LAZYADD(shields, new /obj/structure/emergency_shield/sanguine(shielded_turf))

--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -262,6 +262,7 @@ GLOBAL_VAR(clockcult_eminence)
 			to_chat(O, "[FOLLOW_LINK(O, sender)] [hierophant_message]")
 		else
 			to_chat(O, hierophant_message)
+	sender.log_talk(msg, LOG_SAY, tag="clock cult")
 
 /proc/send_hierophant_message_to(datum/mind/mind, hierophant_message)
 	var/mob/M = mind.current

--- a/code/modules/antagonists/clock_cult/clockwork_massive.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_massive.dm
@@ -137,6 +137,7 @@ GLOBAL_LIST_INIT(clockwork_portals, list())
 	,"Central Command Higher Dimensional Affairs", 'sound/magic/clockwork/ark_activation.ogg')
 	sound_to_playing_players(volume = 10, channel = CHANNEL_JUSTICAR_ARK, S = sound('sound/effects/clockcult_gateway_charging.ogg', TRUE))
 	GLOB.ratvar_arrival_tick = world.time + 6000 + grace_time
+	log_game("The clock cult has begun opening the Ark of the Clockwork Justiciar.")
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/mass_recall(add_overlay = FALSE)
 	var/list/spawns = GLOB.servant_spawns.Copy()
@@ -164,6 +165,7 @@ GLOBAL_LIST_INIT(clockwork_portals, list())
 	for(var/i in 1 to 100)
 		var/turf/T = get_random_station_turf()
 		GLOB.clockwork_portals += new /obj/effect/portal/wormhole/clockcult(T, null, 0, null, FALSE)
+	log_game("The opening of the Ark of the Clockwork Justiciar has caused portals to open around the station.")
 	addtimer(CALLBACK(src, PROC_REF(begin_activation)), 2400)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/begin_activation()

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -274,6 +274,7 @@
 			if(B.current)
 				SEND_SOUND(B.current, 'sound/hallucinations/i_see_you2.ogg')
 				to_chat(B.current, "<span class='cultlarge'>The veil weakens as your cult grows, your eyes begin to glow...")
+				log_game("The blood cult was given red eyes at cult population of [cultplayers].")
 				addtimer(CALLBACK(src, PROC_REF(rise), B.current), 200)
 		cult_risen = TRUE
 
@@ -282,6 +283,7 @@
 			if(B.current)
 				SEND_SOUND(B.current, 'sound/hallucinations/im_here1.ogg')
 				to_chat(B.current, "<span class='cultlarge'>Your cult is ascendent and the red harvest approaches - you cannot hide your true nature for much longer!!")
+				log_game("The blood cult was given halos at cult population of [cultplayers].")
 				addtimer(CALLBACK(src, PROC_REF(ascend), B.current), 200)
 		cult_ascendent = TRUE
 

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -52,7 +52,7 @@
 			var/link = FOLLOW_LINK(M, user)
 			to_chat(M, "[link] [my_message]")
 
-	user.log_talk(message, LOG_SAY, tag="cult")
+	user.log_talk(message, LOG_SAY, tag="blood cult")
 
 /datum/action/innate/cult/comm/spirit
 	name = "Spiritual Communion"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes clock cult speech logged, also adds "blood cult" text to blood cult speech logs.
Adds logging for beginning and finishing to inscribe the Narsie summon rune, as well as beginning to open the clock cult Ark as well as portals appearing.
Adds logging for blood cult getting red eyes and halos.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Proper logged speech is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/110184118/235376428-9048fbea-57e8-4533-9294-be62f817a75a.png)

![image](https://user-images.githubusercontent.com/110184118/235376435-d85c9454-85c8-4e1c-ab83-ea0c173b0772.png)


</details>

## Changelog
:cl:
admin: Added logging to clock cult speech
admin: Changed "cult" to "blood cult" in blood cult speech logs
admin: Added logging for blood cult getting red eyes and halos
admin: Added logging for beginning and finishing to inscribe the Narsie summon rune
admin: Added logging for activating the Ark of the Ark of the Clockwork Justiciar and portals appearing after.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
