### PR TITLE
Lobotomies can now cure abductees!

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -193,6 +193,11 @@
 		"Something isn't right with your brain, you feel like there is something you have to do no matter what...\n\
 		[LAZYLEN(objectives)?"<B>Objective</B>: [first_objective.explanation_text]": "Nevermind..."]")
 
+/datum/antagonist/abductee/farewell()
+	owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like a massive burden was just lifted from [owner.current.p_them()]!</span>", ignored_mobs = owner.current)
+	to_chat(owner, "<big><span class='boldnotice'>Sanity floods back into you, as you begin to forget what you were even so worried about anyways...</span></big>")
+	owner.announce_objectives()
+
 /datum/antagonist/abductee/proc/give_objective()
 	var/mob/living/carbon/human/H = owner.current
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -45,8 +45,15 @@
 			"[user] successfully lobotomizes [target]!",
 			"[user] completes the surgery on [target]'s brain.")
 	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
-	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
-		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+	if(target.mind)
+		var/datum/mind/mind = target.mind
+		if(mind.has_antag_datum(/datum/antagonist/brainwashed))
+			mind.remove_antag_datum(/datum/antagonist/brainwashed)
+		if(mind.has_antag_datum(/datum/antagonist/abductee))
+			if(istype(target.getorganslot(ORGAN_SLOT_HEART), /obj/item/organ/heart/gland))
+				to_chat(target, "<span class='userdanger'>You feel a brief moment of calm lucidity, before your chest begins to feel warm and your sanity painfully slips away once more...</span>")
+			else
+				mind.remove_antag_datum(/datum/antagonist/abductee)
 	switch(rand(0,3))//Now let's see what hopefully-not-important part of the brain we cut off
 		if(1)
 			target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This allows the abductee objectives to be "cured", if the abductor gland is removed and then the victim is lobotomized.

This is of course, not a full cure - the victim will still be fundamentally _broken_, but in a different way - they might just be permanently afraid of felinids now, instead of constantly screaming about how it's the end of times or whatever.

## Why It's Good For The Game

There's no current way in the code (outside of admin intervention, obviously) to get rid of someone's abductee objective. Some abductee objectives can make people massively disruptive, and it's better to be able to _somewhat_ fix that than to feel forced to throw them in brig for the rest of the round or something.

Plus, being able to make someone forget some horrible obsession they had by lopping off some part of their brain does kinda make sense.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Abductees can be "cured" from their insanity by removing their abductor gland then lobotomizing them... Of course, lobotomies come at a cost, so they will never be truly back to normal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
