### PR TITLE
Fix for perma locked suit storage.

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -4,6 +4,7 @@
 	desc = "An industrial unit made to hold and decontaminate irradiated equipment. It comes with a built-in UV cauterization mechanism. A small warning label advises that organic matter should not be placed into the unit."
 	icon = 'icons/obj/machines/suit_storage.dmi'
 	icon_state = "close"
+	obj_flags = CAN_BE_HIT | USES_TGUI
 	use_power = ACTIVE_POWER_USE
 	active_power_usage = 60
 	power_channel = AREA_USAGE_EQUIP
@@ -153,7 +154,6 @@
 
 /obj/machinery/suit_storage_unit/Initialize(mapload)
 	. = ..()
-	obj_flags |= USES_TGUI
 	wires = new /datum/wires/suit_storage_unit(src)
 	if(suit_type)
 		suit = new suit_type(src)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -379,6 +379,7 @@
 			return
 		user.visible_message("<span class='warning'>[user] successfully broke out of [src]!</span>", \
 			"<span class='notice'>You successfully break out of [src]!</span>")
+		locked = FALSE
 		open_machine()
 		dump_contents()
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -385,6 +385,7 @@
 
 	add_fingerprint(user)
 
+
 /obj/machinery/suit_storage_unit/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_CROWBAR && user.a_intent == INTENT_HARM && !panel_open && machine_stat & NOPOWER)
 		if(locked)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -384,19 +384,6 @@
 		dump_contents()
 
 	add_fingerprint(user)
-	if(locked)
-		visible_message("<span class='notice'>You see [user] kicking against the doors of [src]!</span>", \
-			"<span class='notice'>You start kicking against the doors...</span>")
-		addtimer(CALLBACK(src, PROC_REF(resist_open), user), 300)
-	else
-		open_machine()
-		dump_contents()
-
-/obj/machinery/suit_storage_unit/proc/resist_open(mob/user)
-	if(!state_open && occupant && (user in src) && user.stat == 0) // Check they're still here.
-		visible_message("<span class='notice'>You see [user] burst out of [src]!</span>", \
-			"<span class='notice'>You escape the cramped confines of [src]!</span>")
-		open_machine()
 
 /obj/machinery/suit_storage_unit/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_CROWBAR && user.a_intent == INTENT_HARM && !panel_open && machine_stat & NOPOWER)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -153,6 +153,7 @@
 
 /obj/machinery/suit_storage_unit/Initialize(mapload)
 	. = ..()
+	obj_flags |= USES_TGUI
 	wires = new /datum/wires/suit_storage_unit(src)
 	if(suit_type)
 		suit = new suit_type(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes issue https://github.com/BeeStation/BeeStation-Hornet/issues/8858, and a runtime error due to a missing object flag

## Why It's Good For The Game

Fixes a thing. We all like fixes around here, right?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Found that the state of the unit would enter a simultaneous existence of locked and open, which was not accounted for in the TGUI menu. To resolve this, the unit's lock state is now properly reset to false when successfully breaking out.

![image](https://user-images.githubusercontent.com/22382345/235570259-07ee6208-e8e2-4bd0-8472-e34aa720c296.png)

Also while testing I found a runtime error anytime a mob exited the unit, due to the machine not including USES_TGUI in it's flags. Added the flag and it no longer errors.

![image](https://user-images.githubusercontent.com/22382345/235570685-8c787821-3bd3-4849-b8ae-537576651b90.png)

And while looking at the code, I noticed that it tried doing the same thing twice; so I gutted that.

![image](https://user-images.githubusercontent.com/22382345/235574082-8ce8b3d4-ed7d-493e-a904-a7fd39cdb258.png)

</details>

## Changelog
:cl:
fix: Suit Storage no longer becomes anonamously locked open when breaking out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
