### PR TITLE
Fixes gain and lose notice of the Linguist trait

### DIFF
--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -101,8 +101,8 @@
 	desc = "Although you don't know every language, your intense interest in languages allows you to recognise the features of most languages."
 	value = 1
 	mob_trait = TRAIT_LINGUIST
-	gain_text = "span class='notice'>You can recognise the linguistic features of every language.</span>"
-	lose_text = "span class='danger'>You can no longer recognise linguistic features for each language.</span>"
+	gain_text = "<span class='notice'>You can recognise the linguistic features of every language.</span>"
+	lose_text = "<span class='danger'>You can no longer recognise linguistic features for each language.</span>"
 
 /datum/quirk/multilingual
 	name = "Multilingual"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added a missing '<' character into the linguist trait's gain and lost texts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix good, typo bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

before:
![nk3JFoo](https://user-images.githubusercontent.com/48320612/235647599-84af3578-6eb9-4a5a-92c9-358c46b8c09e.png)


after:
![Screenshot 2023-05-02 124022](https://user-images.githubusercontent.com/48320612/235647480-60ccca15-638a-4c9d-9034-366a8e27639c.png)

</details>

## Changelog
:cl:
spellcheck: fixed a typo in the linguist trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
