### PR TITLE
Soft removes bluespace body bag

### DIFF
--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -16,12 +16,6 @@
 	reward = 10000
 	wanted_types = list(/obj/item/reagent_containers/syringe/bluespace)
 
-/datum/bounty/item/science/bluespace_body_bag
-	name = "Bluespace Body Bag"
-	description = "Nanotrasen would make good use of high-capacity body bags. If you have any, please ship them."
-	reward = 10000
-	wanted_types = list(/obj/item/bodybag/bluespace)
-
 /datum/bounty/item/science/nightvision_goggles
 	name = "Night Vision Goggles"
 	description = "An electrical storm has busted all the lights at CentCom. While management is waiting for replacements, perhaps some night vision goggles can be shipped?"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -102,16 +102,6 @@
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/bluespacebodybag
-	name = "Bluespace Body Bag"
-	desc = "A bluespace body bag, powered by experimental bluespace technology. It can hold loads of bodies and the largest of creatures."
-	id = "bluespacebodybag"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 3000, /datum/material/plasma = 2000, /datum/material/diamond = 500, /datum/material/bluespace = 500)
-	build_path = /obj/item/bodybag/bluespace
-	category = list("Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
-
 /datum/design/plasmarefiller
 	name = "Plasma-Man Jumpsuit Refill"
 	desc = "A refill pack for the auto-extinguisher on Plasma-man suits."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -285,7 +285,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "bluespacebodybag", "phasic_scanning", "roastingstick", "ore_silo", "antivirus3")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "roastingstick", "ore_silo", "antivirus3")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

* Removes Bluespace bodybag from Applied Bluespace tech node
* Removes the crafting recipe for bluespace body bags
* Removes the bluespace body bag from bounties

* Does not remove the bluespace body bag that spawns in Hilbert's Hotel
* Does not completely remove them from the code, so that admins may still spawn them at their discretion

#### I have opened a companion PR (#8981) which replaces much of the utility lost by adding a bluespace storage capsule. The storage capsule can very notably not hold bulky objects, players or most mobs, but will help bridge the gap between normal storage limitations and bags of holding. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bluespace body bags are a portable way to nearly guarantee the permanent removal of victims from rounds while leaving no evidence and taking almost no effort or opportunity cost to utilize. You don't even have to kill or even crit the victim because they will conveniently suffocate inside of the bag if you can just manage to incapacitate or trick them well enough to shove them inside and fold it shut!

This doesn't even touch on the sheer capacity for carrying oversized things that aren't bodies, because an unfolded/open bag has the same contents capacity as a locker.

### "Why removal instead of just fixing those issues though?"

Because when we have fixed the all of the issues that the bluespace body bag presents, we are left with an ordinary body bag which already exists within the game. There is no redeeming quality about the bag that is worth salvaging, and they aren't really utilized outside of ensuring that a body is completely unrecoverable for the most part. 

Making a body completely unrecoverable should require at least as much time, cleanup or other opportunity cost as it does through other existing methods, because it isn't something that should generally be done. Greentext is not the point, and it shouldn't be quick and easy to ensure there's no chance of being caught.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/235711422-82913e55-a886-4d05-9515-c78ae3c4dfcd.png)

</details>

## Changelog
:cl:
del: Bluespace bodybags can no longer be researched or created at lathes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
