### PR TITLE
Fixes Immobilize() for simplemobs and silicons

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -97,7 +97,7 @@
 		cut_overlay(fire_overlay)
 
 /mob/living/silicon/robot/update_mobility()
-	if(stat || buckled || lockcharge)
+	if(stat || buckled || lockcharge || incapacitated(check_immobilized = TRUE))
 		mobility_flags &= ~MOBILITY_MOVE
 	else
 		mobility_flags = MOBILITY_FLAGS_DEFAULT

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -459,10 +459,10 @@
 		..()
 
 /mob/living/simple_animal/update_mobility(value_otherwise = TRUE)
-	if(IsUnconscious() || IsParalyzed() || IsStun() || IsKnockdown() || IsParalyzed() || stat || resting)
+	if(IsUnconscious() || IsParalyzed() || IsStun() || IsKnockdown() || stat || resting)
 		drop_all_held_items()
 		mobility_flags = NONE
-	else if(buckled)
+	else if(buckled || IsImmobilized())
 		mobility_flags = MOBILITY_FLAGS_INTERACTION
 	else
 		if(value_otherwise)


### PR DESCRIPTION
## About The Pull Request

* Closes #8974 
* Fixes the fact silicons and simplemobs completely ignore the status effect that Immobilize() applies
* Cleans up a redundant `IsParalyzed()` check for simplemobs

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a bug, it was never particularly relevant before I changed how spiderwebs worked but now that they rely on Immobilize to impede movement, it's pretty important that Immobilize actually works when applied. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![dreamseeker_bYpb3XxAWu](https://user-images.githubusercontent.com/9547572/235776267-a2c7036f-afba-49b1-990f-5ec97b799a2f.gif)

(Drones are simplemobs, not silicons)
![dreamseeker_ASpXFmubS1](https://user-images.githubusercontent.com/9547572/235776273-2d036eb5-e10a-4930-8536-90016363c6c0.gif)


## Changelog
:cl:
fix: Immobilize() procs now work on silicons and simplemobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
