### PR TITLE
Fix feeding organs to people after inserting them

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -124,6 +124,12 @@
 
 // Put any "can we eat this" checks for edible organs here
 /obj/item/organ/proc/pre_eat(eater, feeder)
+	if(iscarbon(eater))
+		var/mob/living/carbon/target = eater
+		for(var/S in target.surgeries)
+			var/datum/surgery/surgery = S
+			if(surgery.location == zone)
+				return FALSE
 	return TRUE
 
 /obj/item/organ/proc/pre_compost(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes feeding organs to someone during organ manipulation

## Why It's Good For The Game

this is a bug

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-05-05-1683339707-dreamseeker](https://user-images.githubusercontent.com/65794972/236593647-5f41e791-ee59-4aeb-8f65-451c7227cd17.png)


</details>

## Changelog
:cl:
fix: Inserting a new organ into someone will no longer feed it to them too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
