### PR TITLE
Slime crossbreeds and slime colors can now be scanned for discovery points

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -107,10 +107,13 @@
 	if(!loc)
 		stack_trace("Simple animal being instantiated in nullspace")
 	update_simplemob_varspeed()
+
+/mob/living/simple_animal/ComponentInitialize()
+	. = ..()
 	if(dextrous)
 		AddComponent(/datum/component/personal_crafting)
 	if(discovery_points)
-		AddComponent(/datum/component/discoverable, discovery_points)
+		AddComponent(/datum/component/discoverable, discovery_points, get_discover_id = CALLBACK(src, PROC_REF(get_discovery_id)))
 
 /mob/living/simple_animal/Destroy()
 	GLOB.simple_animals[AIStatus] -= src
@@ -609,6 +612,9 @@
 			AIStatus = togglestatus
 		else
 			stack_trace("Something attempted to set simple animals AI to an invalid state: [togglestatus]")
+
+/mob/living/simple_animal/proc/get_discovery_id()
+	return type
 
 /mob/living/simple_animal/proc/consider_wakeup()
 	if (pulledby || shouldwakeup)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -531,6 +531,9 @@
 		blocked += 50
 	. = ..(damage, damagetype, def_zone, blocked, forced)
 
+/mob/living/simple_animal/slime/get_discovery_id()
+	return "[colour] slime"
+
 /mob/living/simple_animal/slime/give_mind(mob/user)
 	. = ..()
 	if (.)

--- a/code/modules/research/xenobiology/crossbreeding/__corecross.dm
+++ b/code/modules/research/xenobiology/crossbreeding/__corecross.dm
@@ -96,6 +96,7 @@ To add a crossbreed:
 	. = ..()
 	if(discovery_points)
 		AddComponent(/datum/component/discoverable, discovery_points)
+
 /obj/item/slimecrossbeaker //To be used as a result for extract reactions that make chemicals.
 	name = "result extract"
 	desc = "You shouldn't see this."

--- a/code/modules/research/xenobiology/crossbreeding/__corecross.dm
+++ b/code/modules/research/xenobiology/crossbreeding/__corecross.dm
@@ -38,6 +38,7 @@ To add a crossbreed:
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 6
+	var/discovery_points = 750
 
 /obj/item/slimecross/examine(mob/user)
     . = ..()
@@ -91,6 +92,10 @@ To add a crossbreed:
 			itemcolor = "#008B8B"
 	add_atom_colour(itemcolor, FIXED_COLOUR_PRIORITY)
 
+/obj/item/slimecross/ComponentInitialize()
+	. = ..()
+	if(discovery_points)
+		AddComponent(/datum/component/discoverable, discovery_points)
 /obj/item/slimecrossbeaker //To be used as a result for extract reactions that make chemicals.
 	name = "result extract"
 	desc = "You shouldn't see this."


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This allows each slime color to be scanned for discovery points, rather than just one slime counting for all of them.

This also adds discovery points (750, to be exact) to slime crossbreeds.

## Why It's Good For The Game

It allows xenobio to be more useful to the rest of science, taking a more active role in point generation, which is especially helpful when miners can't/aren't scanning fauna and no scientist knows toxins.

Having points associated with crossbreeds also encourages xenobiologists to make and potentially try out crossbreeds they wouldn't make normally.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-05-08-1683549297-dreamseeker](https://user-images.githubusercontent.com/65794972/236825721-677ad819-9d4a-4f97-a6bf-20f663c0ccfd.png)
![23-05-08-1683549316-dreamseeker](https://user-images.githubusercontent.com/65794972/236825724-f6a17d79-de52-4327-b92c-8e805d929fb7.png)

</details>

## Changelog
:cl:
add: Slime crossbreeds can be scanned for 750 discovery points each.
tweak: Each color slime can be discovery scanned, rather than just scanning a slime once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
