### PR TITLE
Fixes a runtime with Plasmaman job outfits

### DIFF
--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -20,8 +20,12 @@
 	rpg_title = "Peasant"
 	allow_bureaucratic_error = FALSE
 	outfit = /datum/outfit/job/gimmick
+	species_outfits = list(
+		SPECIES_PLASMAMAN = /datum/outfit/plasmaman
+	)
 /datum/outfit/job/gimmick
 	can_be_admin_equipped = FALSE // we want just the parent outfit to be unequippable since this leads to problems
+
 /datum/job/gimmick/barber
 	title = JOB_NAME_BARBER
 	flag = BARBER
@@ -40,9 +44,6 @@
 	payment_per_department = list(ACCOUNT_SRV_ID = PAYCHECK_ASSISTANT)
 
 	rpg_title = "Scissorhands"
-	species_outfits = list(
-		SPECIES_PLASMAMAN = /datum/outfit/plasmaman
-	)
 /datum/outfit/job/gimmick/barber
 	name = JOB_NAME_BARBER
 	jobtype = /datum/job/gimmick/barber
@@ -54,6 +55,7 @@
 	l_hand = /obj/item/storage/wallet
 	l_pocket = /obj/item/razor/straightrazor
 	can_be_admin_equipped = TRUE
+
 /datum/job/gimmick/stage_magician
 	title = JOB_NAME_STAGEMAGICIAN
 	flag = MAGICIAN
@@ -89,6 +91,7 @@
 	l_hand = /obj/item/cane
 	backpack_contents = list(/obj/item/choice_beacon/magic=1)
 	can_be_admin_equipped = TRUE
+
 /datum/job/gimmick/psychiatrist
 	title = JOB_NAME_PSYCHIATRIST
 	flag = PSYCHIATRIST
@@ -108,11 +111,6 @@
 	mind_traits = list(TRAIT_MADNESS_IMMUNE, TRAIT_MEDICAL_METABOLISM)
 
 	rpg_title = "Enchanter"
-
-
-	species_outfits = list(
-		SPECIES_PLASMAMAN = /datum/outfit/plasmaman
-	)
 /datum/outfit/job/gimmick/psychiatrist //psychiatrist doesnt get much shit, but he has more access and a cushier paycheck
 	name = JOB_NAME_PSYCHIATRIST
 	jobtype = /datum/job/gimmick/psychiatrist
@@ -123,6 +121,7 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	backpack_contents = list(/obj/item/choice_beacon/pet/ems=1)
 	can_be_admin_equipped = TRUE
+
 /datum/job/gimmick/vip
 	title = JOB_NAME_VIP
 	flag = CELEBRITY

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -72,6 +72,7 @@
 	var/path = J.species_outfits?[SPECIES_PLASMAMAN]
 	if (!path) //Somehow we were given a job without a plasmaman suit, use the default one so we don't go in naked!
 		path = /datum/outfit/plasmaman
+		stack_trace("Job [J] lacks a species_outfits entry for plasmamen!")
 	var/datum/outfit/plasmaman/O = new path
 	var/datum/character_save/CS = preference_source.prefs.active_character
 	if(CS.helmet_style != HELMET_DEFAULT)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -69,7 +69,9 @@
 
 	if(!preference_source)
 		return
-	var/path = J.species_outfits[SPECIES_PLASMAMAN]
+	var/path = J.species_outfits?[SPECIES_PLASMAMAN]
+	if (!path) //Somehow we were given a job without a plasmaman suit, use the default one so we don't go in naked!
+		path = /datum/outfit/plasmaman
 	var/datum/outfit/plasmaman/O = new path
 	var/datum/character_save/CS = preference_source.prefs.active_character
 	if(CS.helmet_style != HELMET_DEFAULT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Edit on May 12th 2023: Revised the contents of the PR to be more clear and concise.

This is a fix for #9000 
The underlying issue was exposed by the chance of rolling the job type `/datum/job/gimmick`, which serves as an indirect preference selector for jobs like `/datum/job/gimmick/vip`.

The variable that caused the runtime error was the list `species_outfits` initially declared as null in `/datum/job`, leaving the possibility for it to be null at any point. So as the PR title says, I added a check to make sure that `species_outfits` is not empty, and if it is empty we then resort to a default value instead of the list. (The default is `/datum/outfit/plasmaman`)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Another day, another fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Since it would take a *lot* of reloading of the game to get the exact situation that caused this, and I don't feel like depending on RNJesus right now, here's proof that I know it at least compiles on my machine:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/e8e1aea0-3763-44eb-9b3f-24f1ce65a47a)

And I did load into the game just fine as a plasmaman, so nothing broken at runtime either.
</details>

## Changelog
:cl:
fix: Fixed a runtime involving Plasmamen outfits given by jobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
