### PR TITLE
Fixes nukie team unnanmed

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -212,7 +212,7 @@
 
 /datum/team/nuclear/proc/rename_team(new_name)
 	syndicate_name = new_name
-	name = "[syndicate_name] Team"
+	name = "Family [syndicate_name]"
 	for(var/I in members)
 		var/datum/mind/synd_mind = I
 		var/mob/living/carbon/human/H = synd_mind.current
@@ -252,6 +252,7 @@
 		else
 			stack_trace("Station self-destruct not found during lone op team creation.")
 			nuke_team.memorized_code = null
+		nuke_team.name = "Lone Operative - [nuke_team.syndicate_name]"
 
 /datum/antagonist/nukeop/reinforcement
 	send_to_spawnpoint = FALSE
@@ -268,6 +269,7 @@
 /datum/team/nuclear/New()
 	..()
 	syndicate_name = syndicate_name()
+	name = "Family [syndicate_name]"
 	team_frequency = get_free_team_frequency("synd")
 
 /datum/team/nuclear/proc/update_objectives()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes nukie team unnated
follow-up fix of:
* #8942
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
nuke team displays `'unnamed team'`
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/2168561c-f027-46ab-a89d-48b6665b8337)


</details>

## Changelog
:cl:
fix: nukie team will properly display the team name in the orbit panel (including lone operative)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
