### PR TITLE
Telecrystal lottery by stabilized metal slime extract

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -519,7 +519,7 @@
 	colour = "metal"
 	var/cooldown = 30
 	var/max_cooldown = 30
-	var/lottery_attempt = 4 // lottery materials will consume this by 1, and remove the slime once it ran out
+	var/lottery_attempt = 7 // lottery materials will consume this by 1, and remove the slime once it ran out
 	var/static/list/lottery_materials = list(
 		/obj/item/stack/sheet/telecrystal = 42 // 42% chance. weird chance that is good enough to bait people into certainly losing lottery.
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stabilized metal slime extract will duplicate TC with a special chance instead of duplicating 100% chance
The extract has 7 attempts for the lottery, and your TC crystal will be increased or decreased by 1 with 42% chance


* closes #8995

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make something exploitable into a feature instead of letting it be still exploitable

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/ec302339-9b99-47c5-9357-4d603493772d)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/0f024ac0-abd4-4a3c-b7db-842e12470607)

Y Starting point: 20 (because 20 TC)
X label literally means attempts

42% chance is fairly awful to abuse this
each line means a user, and It's 10,000 users

I know the graph is a bit weird to read, but I am not sure which is the best to draw lol

</details>

## Changelog
:cl:
add: stabilized metal slime extract no longer duplicates TCs for free. Now it has 7 charges to 'attempt' duplicating TCs with 42% chance. If you fail, you lose one instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
