### PR TITLE
Improves chameleon card behaviour that can be affected by EMP or changeable by outfit selection when it's inside of a PDA

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -206,11 +206,11 @@
 			H?.sec_hud_set_ID()
 
 /datum/action/item_action/chameleon/change/proc/update_look(mob/user, obj/item/picked_item, emp=FALSE)
+	message_admins("EMP on - item: [target] / user: [user]")
 	if(isliving(user))
 		var/mob/living/C = user
 		if(C.stat != CONSCIOUS)
 			return
-
 		update_item(picked_item, emp)
 		if(ispath(picked_item, /obj/item/card/id))
 			var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -103,8 +103,13 @@
 	var/datum/outfit/O = new outfit_type()
 	var/list/outfit_types = O.get_chameleon_disguise_info()
 
-	for(var/V in user.chameleon_item_actions)
-		var/datum/action/item_action/chameleon/change/A = V
+	var/obj/item/card/id/syndicate/chamel_card // this is awful but this hardcoding is better than adding `obj/proc/get_chameleon_variable()` for every chalemon item
+	for(var/datum/action/item_action/chameleon/change/A in user.chameleon_item_actions)
+		if(istype(A.target, /obj/item/modular_computer))
+			var/obj/item/modular_computer/comp = A.target
+			if(istype(comp.GetID(), /obj/item/card/id/syndicate))
+				chamel_card = comp.GetID()
+
 		var/done = FALSE
 		for(var/T in outfit_types)
 			for(var/name in A.chameleon_list)
@@ -115,6 +120,20 @@
 					break
 			if(done)
 				break
+
+	if(chamel_card) // changes chameleon card inside of PDA
+		var/datum/action/item_action/chameleon/change/A = chamel_card.chameleon_action
+		var/done = FALSE
+		for(var/T in outfit_types)
+			for(var/name in A.chameleon_list)
+				if(A.chameleon_list[name] == T)
+					A.update_look(user, T)
+					outfit_types -= T
+					done = TRUE
+					break
+			if(done)
+				break
+
 	//hardsuit helmets/suit hoods
 	if(O.toggle_helmet && (ispath(O.suit, /obj/item/clothing/suit/space/hardsuit) || ispath(O.suit, /obj/item/clothing/suit/hooded)) && ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -201,31 +220,19 @@
 
 	else
 		update_item(picked_item, emp=TRUE)
-		if(ispath(picked_item, /obj/item/card/id))
-			var/mob/living/carbon/human/H = user
-			H?.sec_hud_set_ID()
 
 /datum/action/item_action/chameleon/change/proc/update_look(mob/user, obj/item/picked_item, emp=FALSE)
-	message_admins("EMP on - item: [target] / user: [user]")
 	if(isliving(user))
 		var/mob/living/C = user
 		if(C.stat != CONSCIOUS)
 			return
-		update_item(picked_item, emp)
-		if(ispath(picked_item, /obj/item/card/id))
-			var/mob/living/carbon/human/H = user
-			H?.sec_hud_set_ID()
-		if(istype(target, /obj/item/modular_computer/tablet/pda))
-			var/mob/living/carbon/human/H = user
-			H?.sec_hud_set_ID()
-			var/obj/item/modular_computer/tablet/pda/PDA = target
-			PDA.update_id_display()
+		update_item(picked_item, emp=emp, item_holder=user)
 
 		var/obj/item/thing = target
 		thing.update_slot_icon()
 	UpdateButtonIcon()
 
-/datum/action/item_action/chameleon/change/proc/update_item(obj/item/picked_item, emp=FALSE)
+/datum/action/item_action/chameleon/change/proc/update_item(obj/item/picked_item, emp=FALSE, mob/item_holder=null)
 	var/keepname = FALSE
 	if(isitem(target))
 		var/obj/item/clothing/I = target
@@ -265,12 +272,50 @@
 							ID.update_label()
 			else
 				keepname = TRUE
-				ID.assignment = initial(ID_from.assignment) ? initial(ID_from.assignment) : "Unknown"
+				ID.assignment = initial(ID_from.assignment) || "Unknown"
 				ID.update_label()
+
+			// we're going to find a PDA that this ID card is inserted into, then force-update PDA
+			var/atom/current_holder = target.loc
+			if(istype(current_holder, /obj/item/computer_hardware/card_slot))
+				current_holder = current_holder.loc
+				if(istype(current_holder, /obj/item/modular_computer))
+					var/obj/item/modular_computer/comp = current_holder
+					if(comp)
+						comp.saved_identification = ID.registered_name
+						comp.saved_job = ID.assignment
+						comp.update_id_display()
+
+			update_mob_hud(item_holder)
+		if(istype(target, /obj/item/modular_computer))
+			var/obj/item/modular_computer/comp = target
+			var/obj/item/card/id/id = comp.GetID()
+			if(id)
+				comp.saved_identification = id.registered_name
+				comp.saved_job = id.assignment
+				comp.update_id_display()
+			keepname = TRUE // do not change PDA name unnecesarily
+			update_mob_hud(item_holder)
 	if(!keepname)
 		target.name = initial(picked_item.name)
 	target.desc = initial(picked_item.desc)
 	target.icon_state = initial(picked_item.icon_state)
+
+/datum/action/item_action/chameleon/change/proc/update_mob_hud(atom/card_holder)
+	// we're going to find a human, and store human ref to 'card_holder' by checking loc multiple time.
+	if(!ishuman(card_holder))
+		if(!card_holder)
+			card_holder = target.loc
+		if(istype(card_holder, /obj/item/storage/wallet))
+			card_holder = card_holder.loc // this should be human
+		if(istype(card_holder, /obj/item/computer_hardware/card_slot))
+			card_holder = card_holder.loc
+			if(istype(card_holder, /obj/item/modular_computer/tablet))
+				card_holder = card_holder.loc // tihs should be human
+	if(!ishuman(card_holder))
+		return
+	var/mob/living/carbon/human/card_holding_human = card_holder
+	card_holding_human.sec_hud_set_ID()
 
 /datum/action/item_action/chameleon/change/Trigger()
 	if(!IsAvailable())

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -50,6 +50,14 @@
 		icon_state_unpowered = "tablet-[finish_color]"
 		icon_state_powered = "tablet-[finish_color]"
 
+/obj/item/modular_computer/tablet/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	var/obj/item/card/id/inserted_id = GetID() // chain EMP to cards
+	if(inserted_id)
+		inserted_id.emp_act(severity)
+
 /obj/item/modular_computer/tablet/proc/try_scan_paper(obj/target, mob/user)
 	if(!istype(target, /obj/item/paper))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Improves chameleon card behaviour that can be affected by EMP or changeable by outfit selection when it's inside of a PDA

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes it more usable, and fixes a found bug that card in PDA isn't affected by emp
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/928fb756-786f-4885-91e9-4ef86b709780)

EMPing on a PDA while it has chameleon card works
Broken chameleon card in a PDA works
Selecting an outfit affects to a card in a PDA too

</details>

## Changelog
:cl:
tweak: Chameleon card in PDA works more smoothly. Chameleon Outfit selection will change the chameleon card inside of PDA as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
