### PR TITLE
Prevents stabilized metal crossbreeds from being able to replicate TC

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -527,7 +527,7 @@
 		cooldown = max_cooldown
 		var/list/sheets = list()
 		for(var/obj/item/stack/sheet/S in owner.GetAllContents())
-			if(S.amount < S.max_amount)
+			if(S.amount < S.max_amount && S.type != /obj/item/stack/sheet/telecrystal)
 				sheets += S
 
 		if(sheets.len > 0)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -527,7 +527,7 @@
 		cooldown = max_cooldown
 		var/list/sheets = list()
 		for(var/obj/item/stack/sheet/S in owner.GetAllContents())
-			if(S.amount < S.max_amount && S.type != /obj/item/stack/sheet/telecrystal)
+			if(S.amount < S.max_amount && !istype(S, /obj/item/stack/sheet/telecrystal))
 				sheets += S
 
 		if(sheets.len > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Alternative PR of #9010 
* Fixes #8995 

Prevents the stabilized metal crossbreed in xenobiology from replicating Telecrystals.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Telecrystals shouldn't be producable in round, definitely not in potentially infinite amounts.

I don't believe that leaving this in game in any capacity as proposed in #9010 is a good idea.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

A sheet of metal, glass, and reinforced glass were placed within the same bag. I then waited a few minutes.
No telecrystals were created. Other materials were created as expected.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/45af8547-b2b6-4f51-abcd-a492b17f5f83)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/8706e229-8030-4182-831e-1a519e88c896)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/fae1ea1e-334e-4a9c-a201-0937419c52fa)


</details>

## Changelog
:cl:
fix: Fixes Stabilized Metal crossbreeds from being able to replicate telecrystals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
