### PR TITLE
Flandstation fix batch (FlandStation Sp5.6)

### DIFF
--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -23957,6 +23957,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"gkw" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gkE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -149307,8 +149312,8 @@ wXD
 nnx
 csJ
 csJ
-cZO
-cZO
+gkw
+gkw
 nnx
 nnx
 nnx
@@ -149565,7 +149570,7 @@ nnx
 csJ
 nnx
 nnx
-cZO
+gkw
 nnx
 nnx
 nnx
@@ -150079,7 +150084,7 @@ nnx
 csJ
 nnx
 nnx
-cZO
+gkw
 nnx
 nnx
 nnx
@@ -150335,8 +150340,8 @@ wXD
 nnx
 csJ
 csJ
-cZO
-cZO
+gkw
+gkw
 nnx
 nnx
 nnx

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -3293,8 +3293,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = -28
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/medical/surgery)
@@ -5239,6 +5239,9 @@
 /area/science/shuttle)
 "bkP" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -6872,6 +6875,13 @@
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/grid/steel,
 /area/medical/virology)
+"bIV" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bJk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -10745,6 +10755,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/medical/apothecary)
 "cQD" = (
@@ -11317,10 +11330,11 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/medical/virology)
 "cWM" = (
-/obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engine_room)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/maintenance/port/fore)
 "cXc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
@@ -18219,6 +18233,9 @@
 "eOj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/modular_fabricator/exosuit_fab,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/science/robotics/lab)
 "eOs" = (
@@ -20083,18 +20100,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "fnP" = (
-/obj/effect/turf_decal/guideline/guideline_in/bar{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/guideline/guideline_mid/darkblue{
-	dir = 8
-	},
-/obj/effect/turf_decal/guideline/guideline_out/blue{
-	dir = 8
+/obj/effect/turf_decal/siding/white{
+	dir = 4
 	},
 /obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+	dir = 8;
+	pixel_x = 22
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -21495,6 +21509,9 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "fEp" = (
@@ -21510,7 +21527,7 @@
 "fEu" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/medical/glass{
+/obj/machinery/door/airlock/medical{
 	name = "Surgery";
 	req_access_txt = "45"
 	},
@@ -22928,10 +22945,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/department/engine)
 "fXt" = (
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -28821,12 +28834,11 @@
 /turf/open/floor/plasteel/checker,
 /area/quartermaster/storage)
 "hBC" = (
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hBE" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -41650,8 +41662,8 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "kWV" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/engine/engine_room)
 "kWW" = (
@@ -44032,12 +44044,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "lxN" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 22
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
@@ -47393,6 +47404,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 24;
 	pixel_y = 24
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -54157,6 +54171,9 @@
 /obj/item/tank/internals/emergency_oxygen{
 	pixel_x = 6
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "oeU" = (
@@ -55129,6 +55146,9 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/item/toy/plush/moth/ragged,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engine_room)
 "osl" = (
@@ -72104,6 +72124,9 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/science/research)
 "sCD" = (
@@ -72962,6 +72985,10 @@
 /obj/structure/chair/fancy/sofa/old/right{
 	color = "#742925";
 	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 22
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
@@ -75247,6 +75274,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grid/steel,
 /area/science/robotics/lab)
 "trL" = (
@@ -82783,12 +82813,12 @@
 "vhn" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /obj/machinery/newscaster{
 	pixel_y = -28
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
@@ -85250,6 +85280,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark/side,
 /area/engine/atmos)
 "vIh" = (
@@ -86185,6 +86216,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
@@ -90389,6 +90424,9 @@
 /area/science/lobby)
 "wQP" = (
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lobby)
 "wQQ" = (
@@ -91188,7 +91226,8 @@
 /area/security/prison)
 "wYf" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
 /area/engine/engine_room)
 "wYg" = (
 /obj/machinery/door/firedoor,
@@ -92689,6 +92728,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -94102,9 +94144,6 @@
 /obj/item/gps,
 /obj/item/clothing/glasses/science,
 /obj/item/assembly/flash/handheld/weak,
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
 /obj/item/assembly/signaler,
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -113599,7 +113638,7 @@ eoO
 hxK
 pyE
 leT
-dWC
+hBC
 eFZ
 cXA
 fam
@@ -116414,7 +116453,7 @@ kHH
 aeN
 eFZ
 aBt
-jOT
+cWM
 leT
 yjW
 yjW
@@ -116423,7 +116462,7 @@ yjW
 yjW
 yjW
 vNZ
-ddP
+bIV
 yfU
 cIP
 oOp
@@ -120854,7 +120893,7 @@ dnT
 hUV
 ewN
 lsk
-fnP
+jjS
 jjS
 jjS
 jjS
@@ -121368,7 +121407,7 @@ xMW
 ejA
 rZX
 cbk
-xWO
+fnP
 xWO
 xWO
 xWO
@@ -125253,7 +125292,7 @@ xYg
 xZW
 lCT
 vGD
-hBC
+xxw
 nNh
 rHr
 myk
@@ -149145,7 +149184,7 @@ mdb
 vNM
 scz
 ose
-cWM
+wYf
 dOV
 bGF
 rTd

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -582,7 +582,7 @@
 /area/solar/port/fore)
 "aia" = (
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
@@ -6421,7 +6421,7 @@
 /area/science/lab)
 "bBu" = (
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
@@ -7368,7 +7368,7 @@
 /area/drydock)
 "bQy" = (
 /obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-right-fland";
 	pixel_y = 32
 	},
@@ -10421,14 +10421,14 @@
 	name = "Miscellaneous medical Supplies";
 	req_access_txt = "5"
 	},
-/obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
-	icon_state = "map-right-fland";
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	icon_state = "map-right-fland";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
@@ -24005,7 +24005,7 @@
 /area/maintenance/aft)
 "glq" = (
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
@@ -25463,7 +25463,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "gEs" = (
@@ -30045,7 +30044,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "hRK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -30351,7 +30350,7 @@
 /obj/effect/turf_decal/guideline/guideline_out/yellow,
 /obj/effect/turf_decal/guideline/guideline_in/blue,
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
@@ -30613,7 +30612,7 @@
 /area/maintenance/port/aft)
 "hZG" = (
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
@@ -35211,7 +35210,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/wt550,
+/obj/item/gun/ballistic/automatic/wt550/rubber_loaded,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "jka" = (
@@ -36915,13 +36914,13 @@
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/port)
 "jKy" = (
-/obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
-	icon_state = "map-right-fland";
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	icon_state = "map-right-fland";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -37952,7 +37951,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
@@ -42963,7 +42962,7 @@
 /area/hallway/secondary/service)
 "llb" = (
 /obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-right-fland";
 	pixel_y = 32
 	},
@@ -43327,6 +43326,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
+"lpl" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lpr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48825,6 +48834,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/medical/exam_room)
+"mMf" = (
+/obj/structure/sign/map/right{
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	icon_state = "map-right-fland";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "mMk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -48939,12 +48956,12 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
 "mNx" = (
@@ -52418,7 +52435,7 @@
 "nGk" = (
 /obj/effect/turf_decal/guideline/guideline_in/red,
 /obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-right-fland";
 	pixel_y = 32
 	},
@@ -57927,7 +57944,7 @@
 "phi" = (
 /obj/effect/turf_decal/guideline/guideline_in/red,
 /obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-left-fland";
 	pixel_y = 32
 	},
@@ -62733,6 +62750,7 @@
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Center"
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qpE" = (
@@ -63187,7 +63205,7 @@
 /area/tcommsat/server)
 "que" = (
 /obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-right-fland";
 	pixel_y = 32
 	},
@@ -70314,15 +70332,15 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "sfg" = (
-/obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
-	icon_state = "map-right-fland";
-	pixel_y = 32
-	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Starboard";
 	dir = 6;
 	name = "hallway camera"
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	icon_state = "map-right-fland";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -71221,7 +71239,7 @@
 /obj/effect/turf_decal/guideline/guideline_out/yellow,
 /obj/effect/turf_decal/guideline/guideline_in/blue,
 /obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-right-fland";
 	pixel_y = 32
 	},
@@ -74739,7 +74757,7 @@
 	dir = 1
 	},
 /obj/structure/sign/map/right{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
 	icon_state = "map-right-fland";
 	pixel_y = 32
 	},
@@ -84978,6 +84996,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/sign/map/left{
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	icon_state = "map-left-fland";
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "vDh" = (
@@ -86840,13 +86863,13 @@
 	},
 /area/medical/surgery)
 "vYE" = (
-/obj/structure/sign/map/left{
-	desc = "A framed detailed picture of the station. there's even the permanent prison wing in the bottom left!";
-	icon_state = "map-left-fland";
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/map/left{
+	desc = "A framed outdated, yet detailed picture of the station. there's even the permanent prison wing in the bottom left!";
+	icon_state = "map-left-fland";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -128618,7 +128641,7 @@ kHi
 jjl
 sUb
 wVj
-sUb
+lpl
 siM
 sCK
 tCp
@@ -130714,7 +130737,7 @@ rio
 veC
 isS
 isS
-xUL
+mMf
 qbd
 gtO
 yfq

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -3414,7 +3414,7 @@
 /area/gateway)
 "aPp" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/department/engine)
 "aPA" = (
 /obj/structure/cable{
@@ -4327,6 +4327,9 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/light/small,
+/obj/structure/sign/warning/fire{
+	pixel_y = -32
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aXT" = (
@@ -11548,7 +11551,7 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "das" = (
 /obj/effect/turf_decal/siding/wood{
@@ -29262,10 +29265,10 @@
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hIb" = (
@@ -33489,6 +33492,18 @@
 	dir = 9
 	},
 /obj/structure/lattice/catwalk/over,
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_x = 34;
+	pixel_y = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "iKl" = (
@@ -42209,18 +42224,6 @@
 "lcI" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = 24;
-	pixel_y = 8
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = 24;
-	pixel_y = -8
-	},
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 34;
-	pixel_y = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
@@ -59359,6 +59362,9 @@
 /obj/structure/lattice/catwalk/over,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 10
+	},
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
@@ -80027,7 +80033,7 @@
 /area/chapel/office)
 "uyt" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "uyu" = (
 /obj/effect/landmark/event_spawn,
@@ -84030,7 +84036,8 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/depleteduranium,
+/turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "vty" = (
 /obj/effect/landmark/start/geneticist,
@@ -91188,9 +91195,6 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/science/lab)
-"wXJ" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "wXP" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
@@ -91811,10 +91815,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"xdz" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "xdD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -147162,7 +147162,6 @@ hgB
 yaw
 wRN
 xtQ
-wXJ
 rTo
 rTo
 rTo
@@ -147170,7 +147169,8 @@ rTo
 rTo
 rTo
 rTo
-wXJ
+rTo
+rTo
 xWY
 xWY
 xWY
@@ -147419,7 +147419,7 @@ lXU
 yaw
 qPG
 yaw
-wXJ
+rTo
 eeo
 bVm
 pIq
@@ -147933,7 +147933,7 @@ wnB
 pLM
 jZL
 wLN
-wXJ
+rTo
 tby
 tQQ
 uam
@@ -147941,7 +147941,7 @@ pip
 uam
 aqG
 bPL
-wXJ
+rTo
 vXB
 jVC
 vXB
@@ -148179,18 +148179,18 @@ bNY
 rHd
 xCJ
 vBw
-vpD
-rXm
+hKD
+hgB
 rTd
 rTd
 rTd
 rTd
 rTd
-rXm
-rXm
-rXm
+hgB
+hgB
+hgB
 ble
-wXJ
+rTo
 wSL
 tQQ
 xyv
@@ -148198,7 +148198,7 @@ frM
 gLO
 aqG
 bsm
-wXJ
+rTo
 air
 ylJ
 qri
@@ -148447,7 +148447,7 @@ gNU
 cfM
 hgB
 ufE
-wXJ
+rTo
 toW
 eek
 mrz
@@ -148455,7 +148455,7 @@ wkL
 udf
 hiT
 rqz
-wXJ
+rTo
 iQD
 jtj
 eZm
@@ -148693,7 +148693,7 @@ jXl
 wWM
 nLC
 jLt
-rXm
+hgB
 vLM
 vPv
 nLx
@@ -148704,7 +148704,7 @@ nLx
 lGr
 hgB
 rSR
-wXJ
+rTo
 wUB
 nih
 ahp
@@ -148712,7 +148712,7 @@ qxK
 kCA
 gsd
 ymc
-wXJ
+rTo
 vXB
 nwT
 vXB
@@ -148961,7 +148961,7 @@ pLj
 eXB
 hgB
 itO
-wXJ
+rTo
 gzZ
 pAX
 sgY
@@ -148969,7 +148969,7 @@ apI
 lcI
 iKk
 hoD
-wXJ
+rTo
 mmz
 vjf
 vjf
@@ -149218,15 +149218,15 @@ lGr
 eXB
 vjf
 reh
-wXJ
+rTo
 vOV
-xdz
+rTo
 dap
 lZI
 vtx
-xdz
+rTo
 voV
-wXJ
+rTo
 fDn
 abN
 abN
@@ -149477,11 +149477,11 @@ abN
 vfL
 upj
 jSq
-wXJ
+rTo
 apJ
 duk
 aXP
-wXJ
+rTo
 pdG
 vjf
 hzW
@@ -149734,11 +149734,11 @@ wHW
 abN
 abN
 sXg
-wXJ
+rTo
 vtx
 wVv
 vtx
-wXJ
+rTo
 trG
 nnx
 abN
@@ -149995,7 +149995,7 @@ qNr
 vvA
 vby
 kaB
-wXJ
+rTo
 trG
 nnx
 nnx
@@ -150248,11 +150248,11 @@ csJ
 csJ
 wYL
 vLM
-wXJ
-wXJ
+rTo
+rTo
 hIV
-wXJ
-wXJ
+rTo
+rTo
 trG
 nnx
 nnx
@@ -150506,9 +150506,9 @@ nnx
 nnx
 vLM
 vLM
-wXJ
+rTo
 azz
-wXJ
+rTo
 vLM
 trG
 nnx
@@ -150763,9 +150763,9 @@ xJu
 xJu
 csJ
 wbm
-wXJ
+rTo
 tVl
-wXJ
+rTo
 vLM
 hHX
 csJ

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -428,6 +428,9 @@
 	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "agn" = (
@@ -17846,18 +17849,18 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary/commissary1)
 "eKf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/effect/turf_decal/trimline/purple/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/science/research)
 "eKp" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -23389,10 +23392,6 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/side,
 /area/quartermaster/sorting)
@@ -24669,10 +24668,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -30641,10 +30636,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/customs)
 "hZN" = (
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -32031,6 +32022,9 @@
 /area/asteroid/nearstation/bomb_site)
 "irF" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "irW" = (
@@ -38438,6 +38432,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/sorting)
 "kcJ" = (
@@ -39818,6 +39816,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "kyo" = (
@@ -40424,10 +40426,6 @@
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -42872,6 +42870,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lkb" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/science/research)
 "lkd" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -49337,6 +49348,9 @@
 /area/medical/break_room)
 "mSH" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "mTi" = (
@@ -50228,10 +50242,6 @@
 "nep" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -55411,6 +55421,9 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel,
 /area/science/breakroom)
 "ovY" = (
@@ -55525,7 +55538,6 @@
 	},
 /mob/living/simple_animal/parrot/Poly,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "oxU" = (
@@ -61206,10 +61218,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
@@ -62176,6 +62184,9 @@
 	dir = 4
 	},
 /obj/item/toy/plush/moth/moonfly,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/storage/tech)
 "qiI" = (
@@ -65861,6 +65872,10 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 24
+	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "rde" = (
@@ -68503,12 +68518,14 @@
 /area/maintenance/solars/port)
 "rIA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/keycard_auth{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/keycard_auth{
+	pixel_x = 26;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -88258,10 +88275,6 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -90925,10 +90938,6 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = 24
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "wVh" = (
@@ -91829,6 +91838,10 @@
 /obj/structure/disposalpipe/junction/flip,
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /obj/effect/turf_decal/siding/purple,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lobby)
 "xdK" = (
@@ -132256,7 +132269,7 @@ wEL
 hRU
 gAu
 hRU
-ifo
+eKf
 ifo
 eCG
 vLF
@@ -135338,7 +135351,7 @@ uwQ
 dhQ
 oDd
 pAj
-pAj
+lkb
 sQL
 pAj
 yeR
@@ -139648,7 +139661,7 @@ qFd
 flF
 fAw
 geb
-eKf
+aFA
 lCN
 qSu
 rPR
@@ -143028,8 +143041,8 @@ fOM
 yif
 dRb
 skT
-qos
 aRe
+qos
 qos
 nZM
 qos

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -26054,10 +26054,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/science/mixing)
 "gNb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Maintenance";
-	req_one_access_txt = "10;24"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -26067,6 +26063,10 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Distribution Loop";
+	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/atmos)
@@ -38012,11 +38012,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Generator Access";
-	req_one_access_txt = "24;10"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Turbine Maintenance";
+	req_one_access_txt = "10;24"
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/maintenance/disposal/incinerator)
 "jYk" = (
@@ -72291,7 +72291,7 @@
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine";
-	req_one_access_txt = "10;24"
+	req_one_access_txt = s
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)
@@ -76684,7 +76684,7 @@
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
 	name = "Supermatter Chamber";
-	req_access_txt = "10"
+	req_one_access_txt = "10;24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -91523,16 +91523,16 @@
 /turf/open/floor/plasteel/sepia,
 /area/engine/break_room)
 "wZZ" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
+	},
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -6875,13 +6875,6 @@
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/open/floor/plasteel/grid/steel,
 /area/medical/virology)
-"bIV" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "bJk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -11330,11 +11323,10 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/medical/virology)
 "cWM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating/rust,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "cXc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
@@ -16273,6 +16265,7 @@
 /obj/structure/chair/fancy/bench/pew/left{
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "ere" = (
@@ -20100,18 +20093,12 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "fnP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/siding/white{
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fnR" = (
 /obj/item/kirbyplants/random,
 /obj/item/toy/plush/moth/redish,
@@ -28834,11 +28821,15 @@
 /turf/open/floor/plasteel/checker,
 /area/quartermaster/storage)
 "hBC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/structure/chair/fancy/bench/pew/right{
+	dir = 1
+	},
 /obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "hBE" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -51319,6 +51310,19 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
+"nsU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "nsW" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/trinary/filter/critical{
@@ -86175,6 +86179,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
+"vRj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vRu" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Carbon Dioxide Cell";
@@ -91225,10 +91235,14 @@
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
 "wYf" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/engine/engine_room)
+/obj/effect/turf_decal/pool{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/noslip,
+/area/crew_quarters/fitness/recreation)
 "wYg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -94808,6 +94822,12 @@
 	},
 /turf/closed/wall,
 /area/janitor)
+"xFL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/maintenance/port/fore)
 "xFN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -113638,7 +113658,7 @@ eoO
 hxK
 pyE
 leT
-hBC
+vRj
 eFZ
 cXA
 fam
@@ -116453,7 +116473,7 @@ kHH
 aeN
 eFZ
 aBt
-cWM
+xFL
 leT
 yjW
 yjW
@@ -116462,7 +116482,7 @@ yjW
 yjW
 yjW
 vNZ
-bIV
+fnP
 yfU
 cIP
 oOp
@@ -119809,7 +119829,7 @@ frp
 pdV
 szu
 rza
-szu
+hBC
 eAy
 hqg
 sXL
@@ -121407,7 +121427,7 @@ xMW
 ejA
 rZX
 cbk
-fnP
+nsU
 xWO
 xWO
 xWO
@@ -141701,7 +141721,7 @@ vtk
 dNa
 qPc
 wId
-wYc
+wYf
 lky
 xII
 xUm
@@ -148927,7 +148947,7 @@ kWV
 vNA
 nkF
 vQp
-wYf
+cWM
 qvc
 bGF
 rTd
@@ -149184,7 +149204,7 @@ mdb
 vNM
 scz
 ose
-wYf
+cWM
 dOV
 bGF
 rTd

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -7248,6 +7248,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bOU" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/grid/steel,
+/area/science/research)
 "bOW" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/pump{
@@ -17850,14 +17863,14 @@
 /area/vacant_room/commissary/commissary1)
 "eKf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
-	pixel_x = -24
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/science/research)
@@ -19928,6 +19941,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 24
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
@@ -42870,19 +42887,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lkb" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/grid/steel,
-/area/science/research)
 "lkd" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -132269,7 +132273,7 @@ wEL
 hRU
 gAu
 hRU
-eKf
+bOU
 ifo
 eCG
 vLF
@@ -135351,7 +135355,7 @@ uwQ
 dhQ
 oDd
 pAj
-lkb
+eKf
 sQL
 pAj
 yeR

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -72291,7 +72291,7 @@
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine";
-	req_one_access_txt = s
+	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engine_room)


### PR DESCRIPTION
## About The Pull Request

This PR fixes some oversights i've done over to 5.5, also updated the turbine to be en par with the other stations, nothing unusual here.

## Why It's Good For The Game

Fixed stuff around, usual Fixes good here.

## Testing Photographs and Procedure

![immagine](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/0bbcea05-e1d4-482c-bc05-95016537b04f)


</details>

## Changelog
:cl:
tweak: [Flandstation] Adapted the turbine to be standardized with all the other stations
tweak: [Flandstation] Switched the WT550 in the armory to be loaded with rubber ammos
fix: [Flandstation] Removed some floating elements, added some lights and, also tweaked an area i forgot in Sp5.5
fix: [Flandstation] fixed the broken air alarm for toxins
/:cl:
