### PR TITLE
Makes UI code use Ease-out transitions

### DIFF
--- a/tgui/packages/tgui-panel/styles/components/Chat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Chat.scss
@@ -27,7 +27,7 @@ $color-bg-section: base.$color-bg-section !default;
   vertical-align: middle;
   background-color: crimson;
   border-radius: 10px;
-  transition: font-size 200ms;
+  transition: font-size 200ms ease-out;
 
   &:before {
     content: 'x';

--- a/tgui/packages/tgui/styles/components/Dropdown.scss
+++ b/tgui/packages/tgui/styles/components/Dropdown.scss
@@ -58,7 +58,7 @@
   font-family: Verdana, sans-serif;
   font-size: base.em(12px);
   line-height: base.em(17px);
-  transition: background-color 100ms;
+  transition: background-color 100ms ease-out;
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.2);

--- a/tgui/packages/tgui/styles/components/Knob.scss
+++ b/tgui/packages/tgui/styles/components/Knob.scss
@@ -117,7 +117,7 @@ $pi: 3.1416;
   stroke-width: 8;
   stroke-linecap: round;
   stroke-dasharray: 100 * $pi;
-  transition: stroke 50ms;
+  transition: stroke 50ms ease-out;
 }
 
 @each $color-name, $color-value in $fg-map {

--- a/tgui/packages/tgui/styles/components/ProgressBar.scss
+++ b/tgui/packages/tgui/styles/components/ProgressBar.scss
@@ -19,7 +19,7 @@ $bg-map: colors.$bg-map !default;
   padding: 0 0.5em;
   border-radius: $border-radius;
   background-color: $background-color;
-  transition: border-color 500ms;
+  transition: border-color 900ms ease-out;
 }
 
 .ProgressBar__fill {
@@ -30,7 +30,7 @@ $bg-map: colors.$bg-map !default;
 }
 
 .ProgressBar__fill--animated {
-  transition: background-color 500ms, width 500ms;
+  transition: background-color 900ms ease-out, width 900ms ease-out;
 }
 
 .ProgressBar__content {

--- a/tgui/packages/tgui/styles/interfaces/AlertModal.scss
+++ b/tgui/packages/tgui/styles/interfaces/AlertModal.scss
@@ -22,7 +22,7 @@
 
 .AlertModal__LoaderProgress {
   position: absolute;
-  transition: background-color 500ms, width 500ms;
+  transition: background-color 500ms ease-out, width 500ms ease-out;
   background-color: colors.bg(colors.$primary);
   height: 100%;
 }

--- a/tgui/packages/tgui/styles/interfaces/ListInput.scss
+++ b/tgui/packages/tgui/styles/interfaces/ListInput.scss
@@ -23,7 +23,7 @@
 
  .ListInput__LoaderProgress {
    position: absolute;
-   transition: background-color 500ms, width 500ms;
+   transition: background-color 500ms ease-out, width 500ms ease-out;
    background-color: colors.bg(colors.$primary);
    height: 100%;
  }

--- a/tgui/packages/tgui/styles/layouts/TitleBar.scss
+++ b/tgui/packages/tgui/styles/layouts/TitleBar.scss
@@ -27,7 +27,7 @@ $shadow-height: 2px !default;
 .TitleBar__clickable {
   color: color.change($text-color, $alpha: 0.5);
   background-color: $background-color;
-  transition: color 250ms, background-color 250ms;
+  transition: color 250ms ease-out, background-color 250ms ease-out;
 
   &:hover {
     color: rgba(255, 255, 255, 1);


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/56762

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds ease out to most uses of transition. UI widgets will look a lot smoother.

before
![107281141-32ac9b00-6a51-11eb-8d8a-5161606bb98a](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/4b597ffd-7e96-4064-a2f1-8c38ea1890b5)


after
![107281131-2fb1aa80-6a51-11eb-85af-d589375cf3aa](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/ab27b773-9f3b-473d-9aac-2c1489d92a73)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Progress bars will now look like actual progress bars and not a fucking screensaver moving from photo to photo.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://discordapp.com/channels/427337870844362753/586312879200927767/1107247497711194160

</details>

## Changelog
:cl: RKz, Thalpy
add: Add ease out transitions on TGUI elements. Progress bars will now smoothly update.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
