### PR TITLE
Nerfs bunnysuit speedup

### DIFF
--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -90,7 +90,6 @@
 	icon_state = "bunnyhead"
 	item_state = "bunnyhead"
 	desc = "Considerably more cute than 'Frank'."
-	slowdown = -1
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/suit/bunnysuit
@@ -98,7 +97,7 @@
 	desc = "Hop Hop Hop!"
 	icon_state = "bunnysuit"
 	item_state = "bunnysuit"
-	slowdown = -1
+	slowdown = -0.2
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The bunnysuit can be obtained by farming rabbit and provides a huge 2x speed boost to anyone wearing it. This nerfs the speedup from -1 to -0.2. Also removes the speedup from the head to prevent stacking.

## Why It's Good For The Game

The bunnysuit allows you to move around at insane speeds that are way too high.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/cf5262ff-36e5-496e-bd8c-8cca0d72a8bc

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/ca5498e6-7355-4c9c-9818-25322ed697c3

## Changelog
:cl:
balance: Nerfs bunnysuit slowdown from -1 to -0.2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
