### PR TITLE
[PR RECOUP] Ecto Sniffer yells over Science Comms now 

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -13,10 +13,19 @@
 	var/sensor_enabled = TRUE
 	///List of ckeys containing players who have recently activated the device, players on this list are prohibited from activating the device until their residue decays.
 	var/list/ectoplasmic_residues = list()
+	///Internal radio
+	var/obj/item/radio/radio
+	///Cooldown for repathing, prevents spam
+	COOLDOWN_DECLARE(radio_cooldown)
 
 /obj/machinery/ecto_sniffer/Initialize()
 	. = ..()
 	wires = new/datum/wires/ecto_sniffer(src)
+	radio = new(src)
+	radio.keyslot = new /obj/item/encryptionkey/headset_sci
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.recalculateChannels()
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)
 	if(!on || !sensor_enabled || !is_operational)
@@ -29,12 +38,19 @@
 	if(is_banned_from(user.ckey, ROLE_POSIBRAIN))
 		to_chat(user, "<span class='warning'>Central Command outlawed your soul from interacting with the living...</span>")
 		return
+
 	activate(user)
 
 /obj/machinery/ecto_sniffer/proc/activate(mob/activator)
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
-	visible_message("<span class='notice'>[src] beeps, detecting ectoplasm! There may be additional positronic brain matrixes available!</span>")
+
+	if(COOLDOWN_FINISHED(src, radio_cooldown))
+		COOLDOWN_START(src, radio_cooldown, 3 MINUTES)
+		radio.talk_into(src, "Ectoplasm has been detected! There may be additional positronic brain matrices available!", RADIO_CHANNEL_SCIENCE)
+	else
+		visible_message("<span class='notice'>[src] has detected ectoplasm! There may be additional positronic brain matrices available!</span>")
+
 	use_power(10)
 	if(activator?.ckey)
 		ectoplasmic_residues[activator.ckey] = TRUE
@@ -72,6 +88,7 @@
 
 /obj/machinery/ecto_sniffer/Destroy()
 	QDEL_NULL(wires)
+	QDEL_NULL(radio)
 	ectoplasmic_residues = null
 	. = ..()
 

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -15,7 +15,7 @@
 	var/list/ectoplasmic_residues = list()
 	///Internal radio
 	var/obj/item/radio/radio
-	///Cooldown for repathing, prevents spam
+	///Cooldown for radio, prevents spam
 	COOLDOWN_DECLARE(radio_cooldown)
 
 /obj/machinery/ecto_sniffer/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Originally created at https://github.com/BeeStation/BeeStation-Hornet/pull/8229

> Changes the Ecto Sniffer to now send a message to Science Comms rather than just locally to whoever is in the room, if anyone is even in there. It's much more delayed than beforehand, now taking 60 seconds rather than 30, and can still be disabled by just anyone clicking on the thing if ghosts decide to abuse it.

Modifications include the addition of the 3 minute global-cooldown to prevent radio spam, but we still keep the 30 second one for local visible_message.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

> Allows for ghosts to more noticeably beg for posi brains. When there isn't anyone in robotics, or if the Roboticist is new and doesn't notice/understand what the weird beeping messaging machine means, it can take quite a long while for a single posibrain to be printed, if ever. If the message is blared over Science Comms now, it'll make it easier for others to take notice and hopefully either print one themselves or inform the Roboticist what it means and all that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

The cooldown in question:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/346b480d-4176-4ec6-8365-7196e00ccc65)


</details>

## Changelog
:cl: WhereAmO, recouped by mystery3525
tweak: Ecto Sniffer now sends a message over Science Comms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
