### PR TITLE
All species can now wag their tails if they get one.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -100,7 +100,7 @@
 			var/obj/item/organ/tail/tail = H.getorganslot(ORGAN_SLOT_TAIL)
 			if(tail)
 				tail.set_wagging(H, TRUE)
-				addtimer(CALLBACK(H.dna.species, TYPE_PROC_REF(/obj/item/organ/tail, set_wagging), H, FALSE), 3 SECONDS)
+				addtimer(CALLBACK(tail, TYPE_PROC_REF(/obj/item/organ/tail, set_wagging), H, FALSE), 3 SECONDS)
 			description =  "<span class='nicegreen'>They want to play on the table!</span>\n"
 			mood_change = 2
 

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -96,9 +96,11 @@
 	var/mob/living/T = L.parent
 	if(ishuman(T))
 		var/mob/living/carbon/human/H = T
-		if(iscatperson(H))
-			H.dna.species.start_wagging_tail(H)
-			addtimer(CALLBACK(H.dna.species, TYPE_PROC_REF(/datum/species, stop_wagging_tail), H), 30)
+		if(iscatperson(H) || (istype(H.getorganslot(ORGAN_SLOT_EARS), /obj/item/organ/ears/cat) && istype(H.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail/cat)))
+			var/obj/item/organ/tail/tail = H.getorganslot(ORGAN_SLOT_TAIL)
+			if(tail)
+				tail.set_wagging(H, TRUE)
+				addtimer(CALLBACK(H.dna.species, TYPE_PROC_REF(/obj/item/organ/tail, set_wagging), H, FALSE), 3 SECONDS)
 			description =  "<span class='nicegreen'>They want to play on the table!</span>\n"
 			mood_change = 2
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -133,25 +133,22 @@
 	if(!.)
 		return
 	var/mob/living/carbon/human/H = user
-	if(!istype(H) || !H.dna || !H.dna.species || !H.dna.species.can_wag_tail(H))
+	var/obj/item/organ/tail/tail = H?.getorganslot(ORGAN_SLOT_TAIL)
+	if(!tail)
 		return
-	if(!H.dna.species.is_wagging_tail())
-		H.dna.species.start_wagging_tail(H)
-	else
-		H.dna.species.stop_wagging_tail(H)
+	tail.toggle_wag(H)
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check = TRUE , intentional)
 	if(!..())
 		return FALSE
 	var/mob/living/carbon/human/H = user
-	return H.dna?.species?.can_wag_tail(user)
+	return istype(H?.getorganslot(ORGAN_SLOT_TAIL), /obj/item/organ/tail)
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()
 	var/mob/living/carbon/human/H = user
-	if(!H.dna || !H.dna.species)
-		return
-	if(H.dna.species.is_wagging_tail())
+	var/obj/item/organ/tail/tail = H.getorganslot(ORGAN_SLOT_TAIL)
+	if(tail?.is_wagging(H))
 		. = null
 
 /datum/emote/living/carbon/human/wing

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2066,15 +2066,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 //Tail Wagging//
 ////////////////
 
-/datum/species/proc/can_wag_tail(mob/living/carbon/human/H)
-	return FALSE
-
-/datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)
-	return FALSE
-
-/datum/species/proc/start_wagging_tail(mob/living/carbon/human/H)
-
 /datum/species/proc/stop_wagging_tail(mob/living/carbon/human/H)
+	var/obj/item/organ/tail/tail = H?.getorganslot(ORGAN_SLOT_TAIL)
+	tail?.set_wagging(H, FALSE)
 
 ///////////////
 //FLIGHT SHIT//

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -30,24 +30,6 @@
 		stop_wagging_tail(H)
 	. = ..()
 
-/datum/species/human/felinid/can_wag_tail(mob/living/carbon/human/H)
-	return ("tail_human" in mutant_bodyparts) || ("waggingtail_human" in mutant_bodyparts)
-
-/datum/species/human/felinid/is_wagging_tail(mob/living/carbon/human/H)
-	return ("waggingtail_human" in mutant_bodyparts)
-
-/datum/species/human/felinid/start_wagging_tail(mob/living/carbon/human/H)
-	if("tail_human" in mutant_bodyparts)
-		mutant_bodyparts -= "tail_human"
-		mutant_bodyparts |= "waggingtail_human"
-	H.update_body()
-
-/datum/species/human/felinid/stop_wagging_tail(mob/living/carbon/human/H)
-	if("waggingtail_human" in mutant_bodyparts)
-		mutant_bodyparts -= "waggingtail_human"
-		mutant_bodyparts |= "tail_human"
-	H.update_body()
-
 /datum/species/human/felinid/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -52,28 +52,6 @@
 		stop_wagging_tail(H)
 	. = ..()
 
-/datum/species/lizard/can_wag_tail(mob/living/carbon/human/H)
-	return ("tail_lizard" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)
-
-/datum/species/lizard/is_wagging_tail(mob/living/carbon/human/H)
-	return ("waggingtail_lizard" in mutant_bodyparts)
-
-/datum/species/lizard/start_wagging_tail(mob/living/carbon/human/H)
-	if("tail_lizard" in mutant_bodyparts)
-		mutant_bodyparts -= "tail_lizard"
-		mutant_bodyparts -= "spines"
-		mutant_bodyparts |= "waggingtail_lizard"
-		mutant_bodyparts |= "waggingspines"
-	H.update_body()
-
-/datum/species/lizard/stop_wagging_tail(mob/living/carbon/human/H)
-	if("waggingtail_lizard" in mutant_bodyparts)
-		mutant_bodyparts -= "waggingtail_lizard"
-		mutant_bodyparts -= "waggingspines"
-		mutant_bodyparts |= "tail_lizard"
-		mutant_bodyparts |= "spines"
-	H.update_body()
-
 /datum/species/lizard/get_scream_sound(mob/living/carbon/user)
 	return pick('sound/voice/lizard/lizard_scream_1.ogg', 'sound/voice/lizard/lizard_scream_2.ogg', 'sound/voice/lizard/lizard_scream_3.ogg', 'sound/voice/lizard/lizard_scream_4.ogg')
 

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -8,10 +8,14 @@
 	slot = ORGAN_SLOT_TAIL
 	var/tail_type = "None"
 
-/obj/item/organ/tail/Remove(mob/living/carbon/human/H,  special = 0)
-	..()
-	if(H?.dna?.species)
-		H.dna.species.stop_wagging_tail(H)
+/obj/item/organ/tail/proc/is_wagging(mob/living/carbon/human/H)
+	return FALSE
+
+/obj/item/organ/tail/proc/set_wagging(mob/living/carbon/human/H, wagging = FALSE)
+	return FALSE
+
+/obj/item/organ/tail/proc/toggle_wag(mob/living/carbon/human/H)
+	return set_wagging(H, !is_wagging(H))
 
 /obj/item/organ/tail/cat
 	name = "cat tail"
@@ -33,6 +37,25 @@
 		H.dna.species.mutant_bodyparts -= "tail_human"
 		color = H.hair_color
 		H.update_body()
+
+/obj/item/organ/tail/cat/is_wagging(mob/living/carbon/human/H)
+	if(!H?.dna?.species)
+		return FALSE
+	return ("waggingtail_human" in H.dna.species.mutant_bodyparts)
+
+/obj/item/organ/tail/cat/set_wagging(mob/living/carbon/human/H, wagging = FALSE)
+	. = FALSE
+	if(!H?.dna?.species)
+		return FALSE
+	var/datum/species/species = H.dna.species
+	if(wagging)
+		species.mutant_bodyparts -= "tail_human"
+		species.mutant_bodyparts |= "waggingtail_human"
+		. = TRUE
+	else
+		species.mutant_bodyparts -= "waggingtail_human"
+		species.mutant_bodyparts |= "tail_human"
+	H.update_body()
 
 /obj/item/organ/tail/lizard
 	name = "lizard tail"
@@ -63,3 +86,22 @@
 		tail_type = H.dna.features["tail_lizard"]
 		spines = H.dna.features["spines"]
 		H.update_body()
+
+/obj/item/organ/tail/lizard/is_wagging(mob/living/carbon/human/H)
+	if(!H?.dna?.species)
+		return FALSE
+	return ("waggingtail_lizard" in H.dna.species.mutant_bodyparts)
+
+/obj/item/organ/tail/lizard/set_wagging(mob/living/carbon/human/H, wagging = FALSE)
+	. = FALSE
+	if(!H?.dna?.species)
+		return
+	var/datum/species/species = H.dna.species
+	if(wagging)
+		species.mutant_bodyparts -= list("tail_lizard", "spines")
+		species.mutant_bodyparts |= list("waggingtail_lizard", "waggingspines")
+		. = TRUE
+	else
+		species.mutant_bodyparts -= list("waggingtail_lizard", "waggingspines")
+		species.mutant_bodyparts |= list("tail_lizard", "spines")
+	H.update_body()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This refactors tail wagging, so it's based on the tail organ rather than specific species. Mostly.

The result is that now _all_ species can *wag, if they have a tail.

## Why It's Good For The Game

What good is a tail if you can't wag it?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-05-16-1684211128-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/67a35362-e0ea-4cfa-a1ad-62c3dc08354e)


</details>

## Changelog
:cl:
refactor: Refactored tail wagging code a bit.
tweak: All species can now *wag their tail if they have one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
