### PR TITLE
Potential fix for singularity eating itself

### DIFF
--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -225,6 +225,8 @@
 				break
 			// eat the stuff if we're going to move into it so it doesn't mess up our movement
 			for(var/atom/thing_on_turf in current_turf.contents)
+				if(thing_on_turf == parent)
+					continue
 				consume(src, thing_on_turf)
 			consume(src, current_turf)
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -228,8 +228,7 @@
 
 /obj/anomaly/singularity/proc/consume(atom/thing)
 	if(thing == src)
-		stack_trace("consume() called on self by singularity [src]")
-		return
+		CRASH("consume() called on self by singularity [src]")
 	var/gain = thing.singularity_act(current_size, src)
 	energy += gain
 	if(istype(thing, /obj/machinery/power/supermatter_crystal) && !consumed_supermatter)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -227,6 +227,9 @@
 	return 1
 
 /obj/anomaly/singularity/proc/consume(atom/thing)
+	if(thing == src)
+		stack_trace("consume() called on self by singularity [src]")
+		return
 	var/gain = thing.singularity_act(current_size, src)
 	energy += gain
 	if(istype(thing, /obj/machinery/power/supermatter_crystal) && !consumed_supermatter)
@@ -368,6 +371,7 @@
 	var/dist = max((current_size - 2),1)
 	explosion(src.loc,(dist),(dist*2),(dist*4))
 	qdel(src)
+	log_game("Singularity [src] consumed by another singularity at [AREACOORD(src)]")
 	return(gain)
 
 /obj/anomaly/singularity/deadchat_controlled


### PR DESCRIPTION
## About The Pull Request

The singulo ate itself last round. I think this is how? Also adds some logging and sanity checks.

## Why It's Good For The Game

Fixes a bug.

## Testing Photographs and Procedure

The cause of this is really hard to identify, it has to move onto a turf it's queued to eat. Not sure how to test this.

## Changelog
:cl:
fix: Potentially fix singularities eating themselves.
/:cl:
