### PR TITLE
Fixes a possible case that a silicon can't state laws permanently

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -297,8 +297,9 @@
 					number++
 					sleep(10)
 
-	S.client.silicon_spam_grace_done(total_laws_count)
 	currently_stating_laws = FALSE
+	if(S.client)
+		S.client.silicon_spam_grace_done(total_laws_count)
 
 /mob/living/silicon/proc/checklaws() //Gives you a link-driven interface for deciding what laws the statelaws() proc will share with the crew. --NeoFite
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -232,7 +232,7 @@
 
 	//"radiomod" is inserted before a hardcoded message to change if and how it is handled by an internal radio.
 	say("[radiomod] Current Active Laws:")
-	S.client.silicon_spam_grace()
+	S.client?.silicon_spam_grace()
 	//laws_sanity_check()
 	//laws.show_laws(world)
 	var/number = 1
@@ -242,7 +242,7 @@
 		for(var/index = 1, index <= laws.devillaws.len, index++)
 			if (force || devillawcheck[index] == "Yes")
 				say("[radiomod] 666. [laws.devillaws[index]]")
-				S.client.silicon_spam_grace()
+				S.client?.silicon_spam_grace()
 				total_laws_count++
 				sleep(10)
 
@@ -250,7 +250,7 @@
 	if (laws.zeroth)
 		if (force || lawcheck[1] == "Yes")
 			say("[radiomod] 0. [laws.zeroth]")
-			S.client.silicon_spam_grace()
+			S.client?.silicon_spam_grace()
 			total_laws_count++
 			sleep(10)
 
@@ -260,7 +260,7 @@
 		if (length(law) > 0)
 			if (force || hackedcheck[index] == "Yes")
 				say("[radiomod] [num]. [law]")
-				S.client.silicon_spam_grace()
+				S.client?.silicon_spam_grace()
 				total_laws_count++
 				sleep(10)
 
@@ -270,7 +270,7 @@
 		if (length(law) > 0)
 			if (force || ioncheck[index] == "Yes")
 				say("[radiomod] [num]. [law]")
-				S.client.silicon_spam_grace()
+				S.client?.silicon_spam_grace()
 				total_laws_count++
 				sleep(10)
 
@@ -280,7 +280,7 @@
 		if (length(law) > 0)
 			if (force || lawcheck[index+1] == "Yes")
 				say("[radiomod] [number]. [law]")
-				S.client.silicon_spam_grace()
+				S.client?.silicon_spam_grace()
 				total_laws_count++
 				number++
 				sleep(10)
@@ -292,14 +292,13 @@
 			if(lawcheck.len >= number+1)
 				if (force || lawcheck[number+1] == "Yes")
 					say("[radiomod] [number]. [law]")
-					S.client.silicon_spam_grace()
+					S.client?.silicon_spam_grace()
 					total_laws_count++
 					number++
 					sleep(10)
 
+	S.client?.silicon_spam_grace_done(total_laws_count)
 	currently_stating_laws = FALSE
-	if(S.client)
-		S.client.silicon_spam_grace_done(total_laws_count)
 
 /mob/living/silicon/proc/checklaws() //Gives you a link-driven interface for deciding what laws the statelaws() proc will share with the crew. --NeoFite
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a possible case that a silicon can't state laws permanently
the lines using client seem to cause runtime when you're disconnected while stating laws, making them client-less.
and runtime makes the code can't reach to `currently_stating_laws = FALSE` making the silicons permanently stucked in the state of stating laws.
I made the logic slightly changed.

Also, this issue seems to be related.

* fixes #8114
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

I didn't test in the local, but the change of the logic is simple and obvious enough.

## Changelog
:cl:
fix: Fixed a case that a silicon can't state laws permanently
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
