### PR TITLE
Cleanup Fax Manager

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -20,7 +20,6 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/stop_sounds,
 	/client/proc/mark_datum_mapview,
 	/client/proc/requests,
-	/client/proc/fax_manager
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
@@ -82,6 +81,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/battle_royale,
 	/client/proc/delete_book,
 	/client/proc/cmd_admin_send_pda_msg,
+	/client/proc/fax_manager,
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1916,6 +1916,10 @@
 			GLOB.fugitive_backstory_selection = list(choice)
 			message_admins("[key_name_admin(usr)] selected backstory: [choice]")
 			log_admin("[key_name(usr)] selected backstory: [choice]")
+	else if(href_list["open_fax_manager"])
+		if(!check_rights(R_ADMIN))
+			return
+		usr.client.fax_manager()
 
 /datum/admins/proc/HandleCMode()
 	if(!check_rights(R_ADMIN))

--- a/code/modules/admin/verbs/fax_manager.dm
+++ b/code/modules/admin/verbs/fax_manager.dm
@@ -1,7 +1,7 @@
 /client/proc/fax_manager()
 	set name = "Fax Manager"
 	set desc = "Open the manager panel to view all requests during the round in progress."
-	set category = "Adminbus"
+	set category = "Admin"
 	if(!check_rights(R_ADMIN))
 		return
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Fax Manager")

--- a/code/modules/admin/verbs/fax_manager.dm
+++ b/code/modules/admin/verbs/fax_manager.dm
@@ -1,6 +1,8 @@
 /client/proc/fax_manager()
 	set name = "Fax Manager"
 	set desc = "Open the manager panel to view all requests during the round in progress."
-	set category = "Admin"
+	set category = "Adminbus"
+	if(!check_rights(R_ADMIN))
+		return
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Fax Manager")
 	GLOB.fax_manager.ui_interact(usr)

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -171,7 +171,7 @@
 // Switches access to the "legal" administrator's fax list. Access to the "illegal" is switched by hacking.
 /obj/machinery/fax/proc/access_additional_faxes_toggle()
 	access_additional_faxes = !access_additional_faxes
-	say("The channel of communication with CentCom is [access_additional_faxes ? "open" : "close"].")
+	say("The channel of communication with CentCom is now: [access_additional_faxes ? "open" : "closed"].")
 
 /**
  * Attempts to clean out a jammed machine using a passed item.
@@ -356,6 +356,7 @@
 /obj/machinery/fax/proc/send_to_additional_faxes(obj/item/loaded, mob/sender, receiver_name, receiver_color)
 	GLOB.fax_manager.receive_request(sender, src, receiver_name, loaded, receiver_color)
 	playback_sending(loaded, receiver_name)
+	log_fax(loaded, "ADDITIONAL", receiver_name)
 	return TRUE
 
 /**

--- a/code/modules/paperwork/fax_manager.dm
+++ b/code/modules/paperwork/fax_manager.dm
@@ -130,7 +130,9 @@ GLOBAL_DATUM_INIT(fax_manager, /datum/fax_manager, new)
 	request["paper"] = message
 	requests += list(request)
 	var/msg = "<span class='adminnotice'><b><font color=[receiver_color]>\"[sanitize(receiver_fax_name)]\" fax</font> received a message from \"[sanitize(sender_fax.fax_name)]\" fax SENT BY [ADMIN_FULLMONTY(sender)] (<a href='?_src_=holder;[HrefToken(TRUE)];open_fax_manager=1'>Open Fax Manager</a>)</b></span>"
-	to_chat(GLOB.admins, msg)
+	for(var/client/C in GLOB.admins)
+		if(C.prefs.chat_toggles & CHAT_PRAYER)
+			to_chat(C, msg)
 	for(var/client/admin in GLOB.admins)
 		if((admin.prefs.chat_toggles & CHAT_PRAYER) && (admin.prefs.toggles & PREFTOGGLE_SOUND_PRAYERS))
 			SEND_SOUND(admin, sound('sound/items/poster_being_created.ogg'))

--- a/code/modules/paperwork/fax_manager.dm
+++ b/code/modules/paperwork/fax_manager.dm
@@ -129,7 +129,7 @@ GLOBAL_DATUM_INIT(fax_manager, /datum/fax_manager, new)
 	message.copy_properties(paper)
 	request["paper"] = message
 	requests += list(request)
-	var/msg = "<span class='adminnotice'><b><font color=[receiver_color]>\"[sanitize(receiver_fax_name)]\" fax</font> received a message from \"[sanitize(sender_fax.fax_name)]\" fax SENT BY [ADMIN_FULLMONTY(sender)] <a href='?_src_=holder;[HrefToken(TRUE)];open_fax_manager=1'>(Open Fax Manager)</a></b></span>"
+	var/msg = "<span class='adminnotice'><b><font color=[receiver_color]>\"[sanitize(receiver_fax_name)]\" fax</font> received a message from \"[sanitize(sender_fax.fax_name)]\" fax SENT BY [ADMIN_FULLMONTY(sender)] (<a href='?_src_=holder;[HrefToken(TRUE)];open_fax_manager=1'>Open Fax Manager</a>)</b></span>"
 	to_chat(GLOB.admins, msg)
 	for(var/client/admin in GLOB.admins)
 		if((admin.prefs.chat_toggles & CHAT_PRAYER) && (admin.prefs.toggles & PREFTOGGLE_SOUND_PRAYERS))

--- a/code/modules/paperwork/fax_manager.dm
+++ b/code/modules/paperwork/fax_manager.dm
@@ -129,7 +129,7 @@ GLOBAL_DATUM_INIT(fax_manager, /datum/fax_manager, new)
 	message.copy_properties(paper)
 	request["paper"] = message
 	requests += list(request)
-	var/msg = "<span class='adminnotice'><b><font color=[receiver_color]>[sanitize(receiver_fax_name)] fax</font> received a message from [sanitize(sender_fax.fax_name)][ADMIN_FLW(sender)][ADMIN_JMP(sender_fax)]/[ADMIN_FULLMONTY(sender)]</b></span>"
+	var/msg = "<span class='adminnotice'><b><font color=[receiver_color]>\"[sanitize(receiver_fax_name)]\" fax</font> received a message from \"[sanitize(sender_fax.fax_name)]\" fax SENT BY [ADMIN_FULLMONTY(sender)] <a href='?_src_=holder;[HrefToken(TRUE)];open_fax_manager=1'>(Open Fax Manager)</a></b></span>"
 	to_chat(GLOB.admins, msg)
 	for(var/client/admin in GLOB.admins)
 		if((admin.prefs.chat_toggles & CHAT_PRAYER) && (admin.prefs.toggles & PREFTOGGLE_SOUND_PRAYERS))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -468,6 +468,8 @@
 
 /obj/item/paper/ui_data(mob/user)
 	var/list/data = list()
+	if(!isliving(user))
+		return data
 
 	var/obj/item/holding = user.get_active_held_item()
 	// Use a clipboard's pen, if applicable
@@ -476,7 +478,8 @@
 		if(clipboard.pen)
 			holding = clipboard.pen
 
-	data["held_item_details"] = holding?.get_writing_implement_details()
+	if(istype(holding))
+		data["held_item_details"] = holding.get_writing_implement_details()
 
 	// If the paper is on an unwritable noticeboard, clear the held item details so it's read-only.
 	if(istype(loc, /obj/structure/noticeboard))

--- a/tgui/packages/tgui/components/Modal.js
+++ b/tgui/packages/tgui/components/Modal.js
@@ -12,6 +12,7 @@ export const Modal = props => {
   const {
     className,
     children,
+    fitted,
     ...rest
   } = props;
   return (
@@ -19,6 +20,7 @@ export const Modal = props => {
       <div
         className={classes([
           'Modal',
+          fitted && 'Modal--fitted',
           className,
           computeBoxClassName(rest),
         ])}

--- a/tgui/packages/tgui/interfaces/FaxManager.tsx
+++ b/tgui/packages/tgui/interfaces/FaxManager.tsx
@@ -1,6 +1,16 @@
 import { sortBy } from '../../common/collections';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, LabeledList, Flex, Dropdown, Section, Modal, TextArea, Input } from '../components';
+import {
+  Box,
+  Button,
+  LabeledList,
+  Flex,
+  Dropdown,
+  Section,
+  Modal,
+  TextArea,
+  Input,
+} from '../components';
 import { Window } from '../layouts';
 
 type FaxManagerData = {
@@ -34,9 +44,7 @@ export const FaxManager = (props, context) => {
   const { act } = useBackend(context);
   const { data } = useBackend<FaxManagerData>(context);
   const faxes = data.faxes
-    ? sortBy((sortFax: FaxInfo) => sortFax.fax_name)(
-      data.faxes
-    )
+    ? sortBy((sortFax: FaxInfo) => sortFax.fax_name)(data.faxes)
     : [];
 
   const [messagingAssociates, setMessagingAssociates] = useLocalState(
@@ -85,8 +93,7 @@ export const FaxManager = (props, context) => {
         </Section>
         <Section title="Messages">
           <Flex direction="column">
-            {!!data.requests
-            && data.requests.map((request: RequestsList) => (
+            {!!data.requests && data.requests.map((request: RequestsList) => (
               <Flex.Item key={request.id_message}>
                 <RequestControl
                   id_message={request.id_message}
@@ -102,6 +109,7 @@ export const FaxManager = (props, context) => {
                 />
               </Flex.Item>
             ))}
+            {!data.requests && 'No faxes have been sent.'}
           </Flex>
         </Section>
       </Window.Content>
@@ -155,103 +163,106 @@ const FaxMessageModal = (props, context) => {
   additional_faxes.push('Custom Name');
 
   return (
-    <Modal>
-      <Flex direction="column">
-        <Flex.Item fontSize="16px" maxWidth="90vw" mb={1}>
-          Send a message to {props.selectedFaxName}/{props.selectedFaxId}:
-        </Flex.Item>
-        <Flex.Item maxWidth="100%">
-          <LabeledList.Item label="Selecting the sender: ">
-            <Dropdown
-              options={additional_faxes}
-              selected={additional_faxes[0]}
-              onSelected={(value) => setSelectedSenderName(value)}
-            />
-          </LabeledList.Item>
-        </Flex.Item>
-        {selectedSenderName === 'Custom Name' && (
+    <Modal fitted>
+      <Section title={`Send a message to ${props.selectedFaxName}/${props.selectedFaxId}`} fill>
+        <Flex direction="column">
           <Flex.Item maxWidth="100%">
-            <LabeledList.Item label="Custom name for the sender: ">
-              <Input onInput={(_, value) => setCustomSenderName(value)} />
+            <LabeledList.Item label="Sender Name">
+              <Dropdown
+                width="200px"
+                options={additional_faxes}
+                selected={additional_faxes[0]}
+                onSelected={(value) => setSelectedSenderName(value)}
+              />
             </LabeledList.Item>
           </Flex.Item>
-        )}
-        <Flex.Item mr={2} mb={1}>
-          <TextArea
-            fluid
-            height="20vh"
-            width="80vw"
-            backgroundColor="black"
-            textColor="white"
-            onInput={(_, value) => {
-              setMessageInput(value.substring(0, 5000));
-            }}
-            value={messageInput}
-          />
-        </Flex.Item>
-        <Flex.Item>
-          <Button
-            icon={props.icon}
-            content="Send"
-            color="good"
-            tooltipPosition="right"
-            disabled={
-              !messageInput || messageInput.length === 0
-                ? true
-                : selectedSenderName === 'Custom Name'
-                  ? !сustomSenderName || сustomSenderName.length === 0
-                    ? true
+          {selectedSenderName === 'Custom Name' && (
+            <Flex.Item maxWidth="100%">
+              <LabeledList.Item label="Custom name for the sender">
+                <Input onInput={(_, value) => setCustomSenderName(value)} />
+              </LabeledList.Item>
+            </Flex.Item>
+          )}
+          <Flex.Item mr={2} mb={1} mt={1}>
+            <TextArea
+              fluid
+              height="20vh"
+              width="80vw"
+              backgroundColor="black"
+              textColor="white"
+              onInput={(_, value) => {
+                setMessageInput(value.substring(0, 5000));
+              }}
+              value={messageInput}
+            />
+          </Flex.Item>
+          <Flex.Item>
+            <Button
+              icon={props.icon}
+              content="Send Fax To"
+              color="good"
+              tooltipPosition="right"
+              disabled={
+                !messageInput || messageInput.length === 0
+                  ? true
+                  : selectedSenderName === 'Custom Name'
+                    ? !сustomSenderName || сustomSenderName.length === 0
+                      ? true
+                      : false
                     : false
-                  : false
-            }
-            onClick={() => {
-              if (messageInput && messageInput.length !== 0) {
-                if (selectedSenderName !== 'Custom Name' && selectedSenderName.length !== 0) {
-                  props.onSubmit(
-                    props.selectedFaxId,
-                    selectedSenderName,
-                    messageInput
-                  );
-                } else if (сustomSenderName && сustomSenderName.length !== 0) {
-                  props.onSubmit(
-                    props.selectedFaxId,
-                    сustomSenderName,
-                    messageInput
-                  );
-                  setCustomSenderName('');
-                  setSelectedSenderName(additional_faxes[0]);
-                  setMessageInput('');
-                } else if (selectedSenderName.length === 0) {
-                  props.onSubmit(
-                    props.selectedFaxId,
-                    additional_faxes[0],
-                    messageInput
-                  );
+              }
+              onClick={() => {
+                if (messageInput && messageInput.length !== 0) {
+                  if (
+                    selectedSenderName !== 'Custom Name' && selectedSenderName.length !== 0
+                  ) {
+                    props.onSubmit(
+                      props.selectedFaxId,
+                      selectedSenderName,
+                      messageInput
+                    );
+                  } else if (сustomSenderName && сustomSenderName.length !== 0) {
+                    props.onSubmit(
+                      props.selectedFaxId,
+                      сustomSenderName,
+                      messageInput
+                    );
+                    setCustomSenderName('');
+                    setSelectedSenderName(additional_faxes[0]);
+                    setMessageInput('');
+                  } else if (selectedSenderName.length === 0) {
+                    props.onSubmit(
+                      props.selectedFaxId,
+                      additional_faxes[0],
+                      messageInput
+                    );
+                  }
                 }
-              } }}
-          />
-          <Button
-            icon="times"
-            content="Cancel"
-            color="bad"
-            onClick={() => {
-              props.onBack();
-              setSelectedSenderName(additional_faxes[0]);
-              setMessageInput('');
-            }}
-          />
-          <Button
-            icon="times"
-            content="Follow Fax"
-            onClick={() => {
-              props.onFollow(props.selectedFaxId);
-            }}
-          />
-        </Flex.Item>
-        {!!props.notice && (
-          <Flex.Item maxWidth="90vw">{props.notice}</Flex.Item>
-        )}
-      </Flex>
+              }}
+            />
+            <Button
+              icon="times"
+              content="Cancel"
+              color="bad"
+              onClick={() => {
+                props.onBack();
+                setSelectedSenderName(additional_faxes[0]);
+                setMessageInput('');
+              }}
+            />
+            <Button
+              icon="times"
+              content="Follow Fax"
+              onClick={() => {
+                props.onFollow(props.selectedFaxId);
+              }}
+            />
+          </Flex.Item>
+          {!!props.notice && (
+            <Flex.Item maxWidth="90vw">{props.notice}</Flex.Item>
+          )}
+        </Flex>
+      </Section>
     </Modal>
   );
 };
@@ -264,8 +275,7 @@ const RequestControl = (props, context) => {
       buttons={
         <>
           <Button
-            onClick={() =>
-              act('read_message', { id_message: props.id_message })}
+            onClick={() => act('read_message', { id_message: props.id_message })}
             color="good">
             Read
           </Button>

--- a/tgui/packages/tgui/styles/components/Modal.scss
+++ b/tgui/packages/tgui/styles/components/Modal.scss
@@ -12,3 +12,8 @@ $background-color: base.$color-bg !default;
   max-width: calc(100% - 1rem);
   padding: 1rem;
 }
+
+.Modal--fitted {
+  max-width: 100%;
+  padding: 0;
+}


### PR DESCRIPTION
## About The Pull Request

- Improves general UI
- Adds paper logging to centcom faxes
- Improves grammar
- Fixes a runtime from viewing papers as a ghost
- Fixes admin usability by cleaning up href links on fax messages and adding "Open Fax Manager"

## Why It's Good For The Game

More usable and understandable fax system, runtime fixes.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/f284de71-90db-40c7-9909-834df1031bd0)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/f78775ac-c3ac-4e5f-a58d-1415a4cda7d1)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/3cab69d8-cb27-4f47-bdf7-79d0d57363a6)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/25e9a673-b8ca-42a3-9fd4-e20d0a75ee8b)

</details>

## Changelog
:cl:
admin: Fax Manager now requires R_ADMIN to use.
admin: CentCom faxes are now logged.
admin: CentCom faxes now respect the PRAYER chat toggle.
tweak: CentCom faxes have cleaner hrefs and a button to Open Fax Manager.
fix: Fixed a runtime caused by having a paper open as an observer.
tweak: Cleaned up fax manager UI.
/:cl:
