### PR TITLE
You need 90 seconds before ghostize yourself

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -77,6 +77,9 @@
 	/// your bank account id in your mind
 	var/account_id
 
+	/// Do not let people ghostize/succumb because their health is -1%
+	COOLDOWN_DECLARE(force_ghost_timer)
+
 /datum/mind/New(var/key)
 	src.key = key
 	soulOwner = src

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -309,17 +309,31 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(stat == DEAD)
 		ghostize(1)
 	else
-		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+		var/response
+		if(!COOLDOWN_FINISHED(mind, force_ghost_timer))
+			response = alert(src, "Your ghotize timer isn't over yet. You need to wait [round(COOLDOWN_TIMELEFT(mind, force_ghost_timer)/10)] seconds more for safe ghostize.","Are you sure you want to ghost?","Ghost","Stay in body")
+			if(response != "Ghost")
+				return
+			response = alert(src, "Last check. [round(COOLDOWN_TIMELEFT(mind, force_ghost_timer)/10)] seconds left for safe ghotize. Are you sure to Ghost?","Are you really sure","Ghost","Stay in body")
+		else
+			response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")
-			return	//didn't want to ghost after-all
-		ghostize(FALSE,SENTIENCE_RETAIN)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+			return
+		ghostize(FALSE,SENTIENCE_RETAIN) //0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 
 /mob/camera/verb/ghost()
 	set category = "OOC"
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+	var/response
+	if(!COOLDOWN_FINISHED(mind, force_ghost_timer))
+		response = alert(src, "Your ghotize timer isn't over yet. You need to wait [round(COOLDOWN_TIMELEFT(mind, force_ghost_timer)/10)] seconds more for safe ghostize.","Are you sure you want to ghost?","Ghost","Stay in body")
+		if(response != "Ghost")
+			return
+		response = alert(src, "Last check. [round(COOLDOWN_TIMELEFT(mind, force_ghost_timer)/10)] seconds left for safe ghotize. Are you sure to Ghost?","Are you really sure","Ghost","Stay in body")
+	else
+		response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 	if(response != "Ghost")
 		return
 	ghostize(FALSE,SENTIENCE_RETAIN)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -408,6 +408,9 @@
 
 /mob/living/verb/succumb(whispered as null)
 	set hidden = TRUE
+	if(!COOLDOWN_FINISHED(mind, force_ghost_timer))
+		to_chat(src, "<span class='notice'>You need to wait [round(COOLDOWN_TIMELEFT(mind, force_ghost_timer)/10, 0.1)] seconds to ghostize yourself!</span>")
+		return
 	if (InCritical())
 		log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] while in [InFullCritical() ? "hard":"soft"] critical with [round(health, 0.1)] points of health!", LOG_ATTACK)
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -408,7 +408,7 @@
 
 /mob/living/verb/succumb(whispered as null)
 	set hidden = TRUE
-	if(!COOLDOWN_FINISHED(mind, force_ghost_timer))
+	if(!COOLDOWN_FINISHED(mind, force_ghost_timer) && !mind.has_antag_datum(/datum/antagonist))
 		to_chat(src, "<span class='notice'>You need to wait [round(COOLDOWN_TIMELEFT(mind, force_ghost_timer)/10, 0.1)] seconds to ghostize yourself!</span>")
 		return
 	if (InCritical())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1231,8 +1231,6 @@
 /mob/proc/hears_radio()
 	return TRUE
 
-#define GHOSTIZE_TIMER 3 MINUTES
-
 /mob/proc/set_stat(new_stat)
 	if(new_stat == stat)
 		return
@@ -1246,10 +1244,8 @@
 				COOLDOWN_RESET(mind, force_ghost_timer)
 			if(SOFT_CRIT, UNCONSCIOUS)
 				if(COOLDOWN_FINISHED(mind, force_ghost_timer + 6 MINUTES))
-					COOLDOWN_START(mind, force_ghost_timer, GHOSTIZE_TIMER)
+					COOLDOWN_START(mind, force_ghost_timer, 90 SECONDS)
 				// 6 minutes are necessary because the cooldown will start again even if they're eligible to ghostize when they become unconscious from soft-crit.
-
-#undef GHOSTIZE_TIMER
 
 /mob/proc/set_active_storage(new_active_storage)
 	if(active_storage)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1231,12 +1231,25 @@
 /mob/proc/hears_radio()
 	return TRUE
 
+#define GHOSTIZE_TIMER 3 MINUTES
+
 /mob/proc/set_stat(new_stat)
 	if(new_stat == stat)
 		return
 	SEND_SIGNAL(src, COMSIG_MOB_STATCHANGE, new_stat)
 	. = stat
 	stat = new_stat
+
+	if(mind)
+		switch(new_stat) // sets a timer when this person can ghotize with no penalty
+			if(CONSCIOUS, DEAD)
+				COOLDOWN_RESET(mind, force_ghost_timer)
+			if(SOFT_CRIT, UNCONSCIOUS)
+				if(COOLDOWN_FINISHED(mind, force_ghost_timer + 6 MINUTES))
+					COOLDOWN_START(mind, force_ghost_timer, GHOSTIZE_TIMER)
+				// 6 minutes are necessary because the cooldown will start again even if they're eligible to ghostize when they become unconscious from soft-crit.
+
+#undef GHOSTIZE_TIMER
 
 /mob/proc/set_active_storage(new_active_storage)
 	if(active_storage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You need 90 seconds before ghostize yourself
Once you become `soft-crit`/`unconscious`, a timer preventing force-ghost starts.
After 90 seconds passed, you are allowed to ghost yourself with no penalty.

(Check conversations for the suggested change)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Attacked by someone then go ghost instantly after you become crit.
Ghostize yourself when xeno disables you but before they hug you.

Quite metagaming, isn't it?

At least you're allowed to do that if you have antag datum.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/97ca3fa9-10dc-404f-8c3b-e268e14bab42)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d811d396-e676-4b42-be3c-f5c757cbc887)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/b4eed1a5-17bf-4df9-b858-5b5a526dcc6e)

</details>

## Changelog
:cl:
add: ghost(=succumb) verb needs 90 seconds timer once you fall into soft-crit or unconscious. If you dare it, it would work the normal ghost verb, and it's round-removal of yourself. Antagonists will ignore this timer, so they can use this to frame someone when they fall into crit.
code: changed some ghost & succumb verb logic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
