### PR TITLE
Interrupting a martial arts granter last second no longer breaks it

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -59,7 +59,7 @@
 			return
 	if(do_after(user,50, user))
 		on_reading_finished(user)
-		reading = FALSE
+	reading = FALSE
 	return TRUE
 
 ///ACTION BUTTONS///


### PR DESCRIPTION
## About The Pull Request

Reading is set to true but never restored if you cancel the last do_after

## Why It's Good For The Game

Fixes a bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

The code explains itself, now the var is always set to false even if it fails.

</details>

## Changelog
:cl:
fix: Martial arts granting books (karate scroll, CQC manual, etc) no longer break permanently if you interrupt it last second.
/:cl: