### PR TITLE
food reagent transfer runtime hotfix

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -290,17 +290,25 @@ All foods are distributed among various categories. Use common sense.
 	add_overlay(filling)
 
 // initialize_cooked_food() is called when microwaving the food
-/obj/item/reagent_containers/food/snacks/proc/initialize_cooked_food(obj/item/reagent_containers/food/snacks/S, cooking_efficiency = 1)
-	S.create_reagents(S.volume)
-	if(reagents)
-		reagents.trans_to(S, reagents.total_volume)
-	if(S.bonus_reagents && S.bonus_reagents.len)
-		for(var/r_id in S.bonus_reagents)
-			var/amount = S.bonus_reagents[r_id] * cooking_efficiency
-			if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
-				S.reagents.add_reagent(r_id, amount, tastes)
-			else
-				S.reagents.add_reagent(r_id, amount)
+/obj/item/reagent_containers/food/snacks/proc/initialize_cooked_food(obj/item/S, cooking_efficiency = 1)
+	if(istype(S, /obj/item/reagent_containers/food/snacks))
+		var/obj/item/reagent_containers/food/snacks/snackyfood = S
+		snackyfood.create_reagents(snackyfood.volume)
+		if(reagents)
+			reagents.trans_to(snackyfood, reagents.total_volume)
+		if(snackyfood.bonus_reagents && snackyfood.bonus_reagents.len)
+			for(var/r_id in snackyfood.bonus_reagents)
+				var/amount = snackyfood.bonus_reagents[r_id] * cooking_efficiency
+				if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
+					snackyfood.reagents.add_reagent(r_id, amount, tastes)
+				else
+					snackyfood.reagents.add_reagent(r_id, amount)
+		return
+	if(istype(S, /obj/item/food))
+		var/obj/item/food/non_snackyfood = S
+		non_snackyfood.create_reagents(non_snackyfood.max_volume)
+		if(reagents)
+			reagents.trans_to(non_snackyfood, reagents.total_volume)
 
 /obj/item/reagent_containers/food/snacks/microwave_act(obj/machinery/microwave/M)
 	var/turf/T = get_turf(src)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -296,7 +296,7 @@ All foods are distributed among various categories. Use common sense.
 		snackyfood.create_reagents(snackyfood.volume)
 		if(reagents)
 			reagents.trans_to(snackyfood, reagents.total_volume)
-		if(snackyfood.bonus_reagents && snackyfood.bonus_reagents.len)
+		if(length(snackyfood.bonus_reagents))
 			for(var/r_id in snackyfood.bonus_reagents)
 				var/amount = snackyfood.bonus_reagents[r_id] * cooking_efficiency
 				if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Ports:
- https://github.com/tgstation/tgstation/pull/53693

## About The Pull Request
I forgot to grab this pr in Newfood Part 1. It'll be irrelevant by newfood part 3, but this will stop the runtime that occurs when food is microwaved.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no more runtime

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![noruntime](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/94b3d7a9-28c2-4e49-a28e-672306a69e4f)

![noruntime21](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/17d8e842-6de2-41c1-881c-6b8010b34dd8)


</details>

## Changelog
:cl: RKz, Timberpoes
fix: reagent food runtime when microwaving
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
