### PR TITLE
Cigarette lighting QoL

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -147,7 +147,7 @@
 	. = ..()
 	. += "<span class='notice'>Alt-click to extract contents.</span>"
 	var/obj/item/lighter/L = locate(/obj/item/lighter) in contents
-	if(L && contents.len > 0)
+	if(L)
 		. += "<span class='notice'>There seems to be a lighter inside. Ctrl-click to pull it out.</span>"
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/living/carbon/user)
@@ -166,13 +166,13 @@
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	var/obj/item/I = locate(/obj/item/lighter) in contents
-	if(I && contents.len > 0)
+	if(I)
 		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_TAKE, I, user)
 		user.put_in_hands(I)
 		contents -= I
 		to_chat(user, "<span class='notice'>You take \a [I] out of the pack.</span>")
 	else
-		to_chat(user, "<span class='notice'>There is no lighter in the pack.</span>")
+		to_chat(user, "<span class='warning'>There is no lighter in the pack.</span>")
 
 /obj/item/storage/fancy/cigarettes/update_icon()
 	if(fancy_open || !contents.len)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -146,6 +146,9 @@
 /obj/item/storage/fancy/cigarettes/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Alt-click to extract contents.</span>"
+	var/obj/item/lighter/L = locate(/obj/item/lighter) in contents
+	if(L && contents.len > 0)
+		. += "<span class='notice'>There seems to be a lighter inside. Ctrl-click to pull it out.</span>"
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/living/carbon/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
@@ -158,6 +161,18 @@
 		to_chat(user, "<span class='notice'>You take \a [I] out of the pack.</span>")
 	else
 		to_chat(user, "<span class='notice'>There is nothing left in the pack.</span>")
+
+/obj/item/storage/fancy/cigarettes/CtrlClick(mob/living/carbon/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+		return
+	var/obj/item/I = locate(/obj/item/lighter) in contents
+	if(I && contents.len > 0)
+		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_TAKE, I, user)
+		user.put_in_hands(I)
+		contents -= I
+		to_chat(user, "<span class='notice'>You take \a [I] out of the pack.</span>")
+	else
+		to_chat(user, "<span class='notice'>There is no lighter in the pack.</span>")
 
 /obj/item/storage/fancy/cigarettes/update_icon()
 	if(fancy_open || !contents.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the ability to pull out a lighter from a cig pack on Ctrl+Click.

## Why It's Good For The Game

QoL. Makes smokers actually smoke and get more cigs, as simply lighting a cigarette is no longer a chore.

## Testing Photographs and Procedure

<details>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/34888552/0ef9eba8-a177-4c03-a6db-f1ffffb1ac9d)


</details>

## Changelog
:cl:
add: You can now pull out a lighter from a cigarette pack by using Ctrl+Click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. --