### PR TITLE
Fixes lattices not connecting to open turfs

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -16,6 +16,8 @@
 	heat_capacity = 10000
 	intact = 1
 	tiled_dirt = TRUE
+	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
+	canSmoothWith = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
 
 	var/icon_plating = "plating"
 	var/broken = 0


### PR DESCRIPTION
## About The Pull Request

This PR finally address the issue of lattices acting odd compared to what they used to be, since they where unable to smooth with open turfs.

## Why It's Good For The Game

No more silly catwalks floating and not connecting with platings.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Old behavoir

![immagine](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/9997f882-7058-4919-b7ad-8b4432f3a018)

New behavoir

![immagine](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/f7b7c5e9-3b8f-41d5-9a83-f006263cb94c)

</details>

## Changelog
:cl:
fix: finally addressed the floating lattices not connecting to open turfs
/:cl:
