### PR TITLE
Readd tooltips to the R&D console

### DIFF
--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -155,6 +155,7 @@
 		var/size = spritesheet.icon_size_id(design.id)
 		design_cache[compressed_id] = list(
 			design.name,
+			design.desc,
 			"[size == size32x32 ? "" : "[size] "][design.id]"
 		)
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -337,6 +337,7 @@ Nothing else in the console has ID requirements.
 		var/size = spritesheet.icon_size_id(design.id)
 		design_cache[compressed_id] = list(
 			design.name,
+			design.desc,
 			"[size == size32x32 ? "" : "[size] "][design.id]"
 		)
 

--- a/tgui/packages/tgui/interfaces/Techweb.js
+++ b/tgui/packages/tgui/interfaces/Techweb.js
@@ -714,7 +714,7 @@ const TechNodeDetail = (props, context) => {
 const DesignTooltip = (props, _context) => {
   const { design } = props;
   return (
-    <Flex direction="column" className={"Techweb__DesignTooltip"}>
+    <Flex direction="column">
       <Flex.Item>
         <b>{design.name}</b>
       </Flex.Item>

--- a/tgui/packages/tgui/interfaces/Techweb.js
+++ b/tgui/packages/tgui/interfaces/Techweb.js
@@ -30,9 +30,10 @@ const selectRemappedStaticData = data => {
   // Do the same as the above for the design cache
   const design_cache = {};
   for (let id of Object.keys(data.static_data.design_cache)) {
-    const [name, classes] = data.static_data.design_cache[id];
+    const [name, desc, classes] = data.static_data.design_cache[id];
     design_cache[remapId(id)] = {
       name: name,
+      desc: desc,
       class: classes.startsWith("design") ? classes : `design32x32 ${classes}`,
     };
   }
@@ -710,6 +711,22 @@ const TechNodeDetail = (props, context) => {
   );
 };
 
+const DesignTooltip = (props, _context) => {
+  const { design } = props;
+  return (
+    <Flex direction="column" className={"Techweb__DesignTooltip"}>
+      <Flex.Item>
+        <b>{design.name}</b>
+      </Flex.Item>
+      {design.desc !== "Desc" && (
+        <Flex.Item>
+          <i>{design.desc}</i>
+        </Flex.Item>
+      )}
+    </Flex>
+  );
+};
+
 const TechNode = (props, context) => {
   const { act, data } = useRemappedBackend(context);
   const {
@@ -821,16 +838,11 @@ const TechNode = (props, context) => {
       {!!compact && (
         <Box className="Techweb__NodeUnlockedDesigns" mt={1}>
           {design_ids.map((k, i) => (
-            <Box
+            <Button
               key={id}
               className={`${design_cache[k].class} Techweb__DesignIcon`}
-              // Tooltips are disabled due to performance issues
-              // The interace stutters every time it updates
-              // Those can be uncommented and the Box can be swapped for a
-              //  Button when the issues are resolved. Make sure to test
-              //  that they don't lag and *actually work*.
-              // tooltip={design_cache[k].name}
-              // tooltipPosition={i % 15 < 7 ? "right" : "left"}
+              tooltip={(<DesignTooltip design={design_cache[k]} />)}
+              tooltipPosition={i % 15 < 7 ? "right" : "left"}
             />
           ))}
         </Box>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This re-adds tooltips to the R&D console, showing the user the name+description of a design when hovering over it.

They were apparently removed due to lag _several years ago,_ but presumably from tgui improvements, I did not experience any GUI lag when testing this locally.

## Why It's Good For The Game

So you can see what you're actually researching.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-05-22-1684776037](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/dca3d409-06ea-45c1-94d2-94af690a9f7a)
![23-05-22-1684776086](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/d1617266-50ed-42c8-9817-2e29bcf6eeb0)


</details>

## Changelog
:cl:
add: Re-added tooltips to the R&D console, so you can now actually see what you're researching!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
