### PR TITLE
Fixes orbit panel shows a mob twice

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -17,6 +17,7 @@
 	rotate_on_lying = 0
 	bodyparts = list(/obj/item/bodypart/chest/larva, /obj/item/bodypart/head/larva)
 	flavor_text = FLAVOR_TEXT_EVIL
+	playable = TRUE
 
 
 //This is fine right now, if we're adding organ specific damage this needs to be updated

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -17,7 +17,6 @@
 	rotate_on_lying = 0
 	bodyparts = list(/obj/item/bodypart/chest/larva, /obj/item/bodypart/head/larva)
 	flavor_text = FLAVOR_TEXT_EVIL
-	playable = TRUE
 
 
 //This is fine right now, if we're adding organ specific damage this needs to be updated

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -19,7 +19,7 @@
 	GLOB.mob_living_list += src
 	initialize_footstep()
 	if (playable)
-		set_playable()	//announce to ghosts
+		delayed_set_playable()	//announce to ghosts
 
 /mob/living/proc/initialize_footstep()
 	AddComponent(/datum/component/footstep)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -19,7 +19,9 @@
 	GLOB.mob_living_list += src
 	initialize_footstep()
 	if (playable)
-		delayed_set_playable()	//announce to ghosts
+		addtimer(CALLBACK(src, PROC_REF(set_playable)), 2 SECONDS) //announce playable mobs to ghosts
+		// this should be delayed because some 'playable=TRUE' mobs are not actually playable because mob key is automatically given
+		// it prevents 'GLOB.poi_list' being glitched. without this, it will show xeno(or some mobs) twice in orbit panel.
 
 /mob/living/proc/initialize_footstep()
 	AddComponent(/datum/component/footstep)

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -46,12 +46,7 @@
 // this exists because some 'playable=TRUE' mobs are not actually playable because mob key is automatically given
 // it prevents 'GLOB.poi_list' being glitched. without this, it will show xeno(or some mobs) twice in orbit panel.
 /mob/living/proc/delayed_set_playable(called_again=FALSE)
-	set waitfor = 0 // I didn't want to use 'addtimer(CALLBACK(), 2 SECONDS)' so I tried this instead
-	if(called_again)
-		sleep(20)
-		set_playable()
-		return
-	delayed_set_playable(TRUE) // need to call this again because Init() proc is waiting for this
+	addtimer(CALLBACK(src, PROC_REF(set_playable)), 2 SECONDS)
 
 /mob/living/proc/set_playable()
 	playable = TRUE

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -43,11 +43,6 @@
 		to_chat(src, "<span class='notice'>[get_spawner_flavour_text()]</span>")
 	return TRUE
 
-// this exists because some 'playable=TRUE' mobs are not actually playable because mob key is automatically given
-// it prevents 'GLOB.poi_list' being glitched. without this, it will show xeno(or some mobs) twice in orbit panel.
-/mob/living/proc/delayed_set_playable(called_again=FALSE)
-	addtimer(CALLBACK(src, PROC_REF(set_playable)), 2 SECONDS)
-
 /mob/living/proc/set_playable()
 	playable = TRUE
 	if (!key)	//check if there is nobody already inhibiting this mob

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -43,6 +43,16 @@
 		to_chat(src, "<span class='notice'>[get_spawner_flavour_text()]</span>")
 	return TRUE
 
+// this exists because some 'playable=TRUE' mobs are not actually playable because mob key is automatically given
+// it prevents 'GLOB.poi_list' being glitched. without this, it will show xeno(or some mobs) twice in orbit panel.
+/mob/living/proc/delayed_set_playable(called_again=FALSE)
+	set waitfor = 0 // I didn't want to use 'addtimer(CALLBACK(), 2 SECONDS)' so I tried this instead
+	if(called_again)
+		sleep(20)
+		set_playable()
+		return
+	delayed_set_playable(TRUE) // need to call this again because Init() proc is waiting for this
+
 /mob/living/proc/set_playable()
 	playable = TRUE
 	if (!key)	//check if there is nobody already inhibiting this mob
@@ -50,6 +60,9 @@
 		LAZYADD(GLOB.mob_spawners["[name]"], src)
 		GLOB.poi_list |= src
 		SSmobs.update_spawners()
+	else // it's spawned but someone occupied already
+		notify_ghosts("[name] has appeared!", source=src, action=NOTIFY_ORBIT, header="Something's Interesting!")
+
 
 /mob/living/get_spawner_desc()
 	return "Become [name]."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes orbit panel shows a mob twice

This is because a mob is added to `mob_list` and `poi_list` at the same time when its `var/playable` is set to TRUE in a mob type (i.e. xeno)
a mob that's added to `poi_list` will not be removed because a mob key is automatically given by code but it's not occupied by players. when it's occupied by player action, a playable mob is removed from `poi_list`, but xenos are spawned then force-occupied.
I added a new proc `delayed_set_playable()` which will be used in mob init().

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/7a2e901c-7495-42a6-b73e-177737f2de98)

</details>

## Changelog
:cl:
fix: Fixed orbit panel shows a mob twice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
