### PR TITLE
Corgstation Security Rework

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -624,6 +624,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "afO" = (
@@ -1519,24 +1522,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aqr" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqt" = (
@@ -4377,16 +4367,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aZQ" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "aZS" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4
@@ -7753,6 +7733,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"cii" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "cir" = (
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
@@ -7793,6 +7780,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -11533,6 +11523,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dBI" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dBL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11626,6 +11623,12 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/security/warden)
+"dDz" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "dDH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -12882,6 +12885,16 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"dYX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "dYZ" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/structure/disposalpipe/segment{
@@ -19597,6 +19610,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"gnJ" = (
+/obj/structure/sign/directions/security{
+	dir = 1
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_y = -8
+	},
+/turf/closed/wall,
+/area/hallway/primary/starboard)
 "gnK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -22430,13 +22456,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"hiL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "hiP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/coffee,
@@ -25852,6 +25871,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ioJ" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ioQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -26202,6 +26232,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"ito" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "itu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29141,14 +29178,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
-"jvy" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jvD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -32942,6 +32971,27 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"kLh" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kLm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34933,6 +34983,13 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"luf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "luj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -37860,6 +37917,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
+	},
+/obj/item/radio/intercom{
+	pixel_x = 29
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -42275,8 +42335,14 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "nIH" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/fore)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nIO" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -45531,13 +45597,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"oIV" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "oIZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -48787,6 +48846,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"pRv" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking{
+	pixel_y = -32
+	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("aisat")
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pRx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49358,17 +49436,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"qbQ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qcd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53076,16 +53143,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"rkV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "rlh" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -53379,6 +53436,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -54371,6 +54431,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"rFP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "rFR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/siding/wood,
@@ -55319,16 +55389,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"rVY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "rWe" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/hydroponics/constructable,
@@ -58410,15 +58470,24 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "sVT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/starboard)
 "sVU" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -58798,6 +58867,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tdr" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tdR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59912,6 +59996,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"tAQ" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tBb" = (
 /obj/structure/marker_beacon,
 /turf/open/floor/plating/airless,
@@ -62296,13 +62395,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"unM" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uof" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -63454,6 +63546,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uGU" = (
@@ -64195,12 +64290,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uSb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "uSz" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -66326,6 +66415,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"vAU" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vBf" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -68597,6 +68699,16 @@
 "woR" = (
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
+"wpa" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "wpg" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -72851,6 +72963,16 @@
 	},
 /turf/open/floor/wood,
 /area/security/warden)
+"xNp" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xNy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -73425,6 +73547,9 @@
 "xVp" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -102889,7 +103014,7 @@ hZO
 bOW
 qqf
 vBK
-uSb
+dDz
 vKb
 iCv
 eey
@@ -103660,7 +103785,7 @@ qvj
 kMZ
 cah
 nAV
-uSb
+dDz
 bpq
 anz
 qQo
@@ -103917,7 +104042,7 @@ teE
 mbl
 cah
 fYh
-uSb
+dDz
 bpq
 anz
 opS
@@ -104666,7 +104791,7 @@ jHI
 dQx
 fAL
 lpb
-rVY
+dYX
 cft
 mif
 eAm
@@ -110055,13 +110180,13 @@ mJo
 vRi
 wGS
 npu
-duF
+hmy
 hmy
 mSH
 hmy
 hmy
 hmy
-nIH
+kVl
 fNE
 kVl
 qcP
@@ -110312,13 +110437,13 @@ mJo
 cUd
 uln
 aIt
-duF
+hmy
 vXs
 eOJ
 gbY
 ngU
 pPJ
-nIH
+kVl
 gOQ
 buQ
 xyB
@@ -110575,7 +110700,7 @@ osh
 odA
 ltb
 eiJ
-nIH
+kVl
 rTt
 rTt
 nEu
@@ -110832,7 +110957,7 @@ dde
 bFR
 gfy
 fwt
-nIH
+kVl
 jrs
 qhk
 bBw
@@ -111089,7 +111214,7 @@ duF
 duF
 duF
 duF
-nIH
+kVl
 qcP
 kVl
 kVl
@@ -111348,9 +111473,9 @@ sRa
 xyq
 xVp
 qac
-qac
+nIH
 vjo
-qac
+vAU
 qac
 qac
 jzx
@@ -112118,12 +112243,12 @@ hmy
 hmy
 duF
 tdf
-dkg
+tdr
 gnj
 gnj
 iaU
 gnj
-gnj
+gnJ
 gnj
 iaU
 gnj
@@ -112375,7 +112500,7 @@ uWc
 sRa
 xyq
 tdf
-dkg
+tAQ
 gnj
 aMT
 aMT
@@ -113403,7 +113528,7 @@ uWc
 sRa
 xyq
 tdf
-dkg
+pRv
 gnj
 aMT
 aMT
@@ -113413,7 +113538,7 @@ cxY
 aMT
 aMT
 gnj
-sNC
+sVT
 tSC
 esi
 iDL
@@ -113882,7 +114007,7 @@ duF
 qIa
 vVU
 nTY
-oIV
+cii
 hmy
 dpB
 amM
@@ -114161,7 +114286,7 @@ sXL
 wtJ
 bQp
 hwc
-sVT
+xNp
 fRR
 lRh
 aer
@@ -114396,9 +114521,9 @@ nwA
 bRD
 mHW
 pek
-jvy
+aqr
 hmy
-rkV
+rFP
 sgY
 lJV
 hmy
@@ -114436,9 +114561,9 @@ qPa
 qBd
 wKH
 vov
-qbQ
-sVw
 afM
+sVw
+ioJ
 cdX
 fkM
 sqh
@@ -114687,8 +114812,8 @@ aIt
 aIt
 eZE
 avM
-aZQ
-unM
+wpa
+ito
 xzF
 gHq
 kgL
@@ -114951,7 +115076,7 @@ jWm
 vLi
 aCN
 kQI
-ieI
+dBI
 ieI
 gPc
 kEB
@@ -115936,7 +116061,7 @@ feb
 hfz
 duF
 rDK
-aqr
+kLh
 hmy
 xtv
 oQB
@@ -117478,8 +117603,8 @@ naL
 naL
 duF
 duF
-hiL
-hiL
+luf
+luf
 duF
 iRh
 tbi

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -1519,9 +1519,23 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aqr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -3788,16 +3802,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"aSY" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "aTc" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -4373,6 +4377,16 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aZQ" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aZS" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4
@@ -12082,7 +12096,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "dLB" = (
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/biogenerator,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "dLC" = (
@@ -13839,13 +13853,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "epK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/chili,
+/turf/open/floor/grass,
+/area/hallway/primary/fore)
 "epT" = (
 /obj/machinery/light{
 	dir = 1
@@ -21122,12 +21133,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gMF" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/apple,
+/turf/open/floor/grass,
+/area/hallway/primary/fore)
 "gMV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -22421,6 +22430,13 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"hiL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "hiP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/coffee,
@@ -28281,26 +28297,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jcG" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/hydroponics/soil,
+/obj/item/seeds/banana,
+/turf/open/floor/grass,
+/area/hallway/primary/fore)
 "jcX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -29141,6 +29141,14 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
+"jvy" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jvD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -43564,6 +43572,7 @@
 /area/medical/medbay/central)
 "obn" = (
 /obj/machinery/hydroponics/soil,
+/obj/item/seeds/cocoapod,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "obB" = (
@@ -44342,16 +44351,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"opD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "opS" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/drone,
@@ -44367,16 +44366,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"oqd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "oqj" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner{
@@ -45542,6 +45531,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oIV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oIZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -49362,6 +49358,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"qbQ" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qcd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53069,6 +53076,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"rkV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "rlh" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -55302,6 +55319,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"rVY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "rWe" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/hydroponics/constructable,
@@ -58383,11 +58410,15 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "sVT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sVU" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -58484,17 +58515,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sYb" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "sYe" = (
 /obj/machinery/light{
 	dir = 4
@@ -62276,6 +62296,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"unM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uof" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -64168,6 +64195,12 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"uSb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "uSz" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -64914,13 +64947,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"vgk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "vgx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70707,16 +70733,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"xcp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xdj" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -98961,9 +98977,9 @@ aMT
 aMT
 jxO
 jxO
-obn
+jcG
 wLX
-obn
+gMF
 orw
 cWH
 mvn
@@ -101017,7 +101033,7 @@ aMT
 aMT
 jxO
 jxO
-obn
+epK
 dLB
 obn
 udH
@@ -102873,7 +102889,7 @@ hZO
 bOW
 qqf
 vBK
-sVT
+uSb
 vKb
 iCv
 eey
@@ -103644,7 +103660,7 @@ qvj
 kMZ
 cah
 nAV
-sVT
+uSb
 bpq
 anz
 qQo
@@ -103901,7 +103917,7 @@ teE
 mbl
 cah
 fYh
-sVT
+uSb
 bpq
 anz
 opS
@@ -104650,7 +104666,7 @@ jHI
 dQx
 fAL
 lpb
-oqd
+rVY
 cft
 mif
 eAm
@@ -113866,7 +113882,7 @@ duF
 qIa
 vVU
 nTY
-aqr
+oIV
 hmy
 dpB
 amM
@@ -114145,7 +114161,7 @@ sXL
 wtJ
 bQp
 hwc
-xcp
+sVT
 fRR
 lRh
 aer
@@ -114380,9 +114396,9 @@ nwA
 bRD
 mHW
 pek
-epK
+jvy
 hmy
-opD
+rkV
 sgY
 lJV
 hmy
@@ -114420,7 +114436,7 @@ qPa
 qBd
 wKH
 vov
-sYb
+qbQ
 sVw
 afM
 cdX
@@ -114671,8 +114687,8 @@ aIt
 aIt
 eZE
 avM
-aSY
-gMF
+aZQ
+unM
 xzF
 gHq
 kgL
@@ -115920,7 +115936,7 @@ feb
 hfz
 duF
 rDK
-jcG
+aqr
 hmy
 xtv
 oQB
@@ -117462,8 +117478,8 @@ naL
 naL
 duF
 duF
-vgk
-vgk
+hiL
+hiL
 duF
 iRh
 tbi

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -38,21 +38,6 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
-"aae" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
-	health = 45;
-	icon_state = "secbot1";
-	idcheck = 1;
-	name = "Sergeant-at-Armsky";
-	weaponscheck = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "aaf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -347,6 +332,21 @@
 	},
 /turf/closed/wall,
 /area/engine/engineering)
+"abK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "abL" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -518,6 +518,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"aer" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aew" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4;
@@ -613,6 +620,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"afM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "afO" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -656,6 +671,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"agj" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "agr" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -754,18 +776,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"ahc" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ahe" = (
 /obj/machinery/computer/warrant,
 /obj/structure/sign/departments/minsky/security/security{
@@ -804,6 +814,18 @@
 "ahG" = (
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"ahP" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ahW" = (
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/light{
@@ -1108,6 +1130,27 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"alg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "alH" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner{
@@ -1161,13 +1204,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"amh" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "amk" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/airalarm/engine{
@@ -1219,6 +1255,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"amM" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "amW" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
@@ -1365,16 +1419,6 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
-"apj" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "apk" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -1432,18 +1476,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"apD" = (
+"apR" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "apW" = (
 /obj/structure/chair{
 	dir = 1
@@ -1465,6 +1509,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"aqk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "aql" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -1598,6 +1647,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"asx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Long-Term Cell 1";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "asD" = (
 /obj/machinery/atmospherics/components/binary/volume_pump/on{
 	dir = 1;
@@ -1614,6 +1678,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"asP" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "atb" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
@@ -1694,6 +1762,22 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"auc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "auo" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -1713,15 +1797,6 @@
 /obj/machinery/light,
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"auC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "auG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1786,6 +1861,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"avq" = (
+/obj/machinery/flasher{
+	id = "PCell 2";
+	pixel_x = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Cell 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "avt" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -1799,6 +1889,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"avM" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "avP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1845,6 +1947,20 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"awr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aws" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -1866,14 +1982,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"awt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "awJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -1964,25 +2072,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"ayr" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 3
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ayt" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -2001,6 +2090,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"ayB" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ayG" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -2084,6 +2183,18 @@
 "azB" = (
 /turf/closed/wall/r_wall,
 /area/security/nuke_storage)
+"azE" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "azN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2517,18 +2628,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"aEC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aEQ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Shuttle Lab";
@@ -3072,6 +3171,14 @@
 "aLq" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_room)
+"aLs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aLw" = (
 /obj/machinery/atmospherics/components/binary/volume_pump,
 /turf/open/floor/plasteel/dark,
@@ -3282,6 +3389,17 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"aOy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aOz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -3613,6 +3731,17 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"aRU" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -3704,6 +3833,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"aTs" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aTA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -3883,6 +4019,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"aVK" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "aVS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -4229,6 +4374,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"aZV" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aZX" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -4343,22 +4498,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"bdm" = (
-/obj/structure/closet/crate/secure/gear,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/head/beret/ccguardnavy,
-/obj/item/clothing/head/beret/ccguardnavy,
-/obj/item/clothing/head/beret/ccguardnavy,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "bdw" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -4376,17 +4515,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"bdC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bdG" = (
 /obj/structure/bed/dogbed,
 /obj/item/toy/cattoy,
@@ -4452,19 +4580,6 @@
 "bfm" = (
 /turf/closed/wall,
 /area/medical/morgue)
-"bfE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bfH" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -4675,6 +4790,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"biG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "biK" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -4773,16 +4895,6 @@
 	dir = 5
 	},
 /area/chapel/main/monastery)
-"bjV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bkv" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -4918,22 +5030,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"bmU" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig Medical";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bnc" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -5054,6 +5150,24 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/brig)
+"bpM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "armour_exterior";
+	name = "Armoury Access";
+	pixel_x = 29;
+	pixel_y = 28;
+	req_access_txt = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/warden)
 "bpU" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 10
@@ -5199,6 +5313,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
+"btl" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "btt" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
@@ -5210,25 +5333,6 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
-"bul" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/carpet/red,
-/area/security/detectives_office)
-"buo" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "buq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5326,19 +5430,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port)
-"bvr" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "bvt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -5444,12 +5535,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"bwG" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bwW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/button/door{
@@ -5591,17 +5676,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"bzN" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bzS" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -5609,6 +5683,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"bAf" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bAn" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -5636,6 +5722,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"bAH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bAY" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -5646,21 +5741,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"bBh" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bBo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5826,6 +5906,14 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"bEl" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "bEw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6155,6 +6243,23 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"bJe" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bJB" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -6359,6 +6464,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"bMA" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "bMC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -6599,15 +6713,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"bPW" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bQa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6617,6 +6722,18 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"bQp" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bQr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6688,6 +6805,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"bRD" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bRV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -6815,6 +6941,17 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"bTI" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bTK" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -6834,19 +6971,6 @@
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"bTR" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bTU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output,
 /turf/open/floor/engine/o2,
@@ -6876,21 +7000,6 @@
 /obj/item/wirecutters,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"bUY" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bUZ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -7006,6 +7115,16 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/command)
+"bXi" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bXn" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -7249,6 +7368,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"cbV" = (
+/obj/machinery/door/airlock/security{
+	name = "Interogation Holding";
+	req_one_access_txt = "4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cca" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -7397,6 +7529,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/medical/morgue)
+"cee" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ceh" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -7443,23 +7587,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
-"cfK" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cfL" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable/yellow{
@@ -7629,26 +7756,23 @@
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"ciM" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ciW" = (
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"cju" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "cjv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -7678,15 +7802,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"ckw" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "cky" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -7786,6 +7901,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"cmq" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt2";
+	name = "Cell 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cmv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7996,24 +8124,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"cqr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cqs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8024,15 +8134,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cqD" = (
-/obj/structure/sign/poster/random{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "cqV" = (
 /obj/structure/transit_tube/diagonal/crossing,
 /obj/structure/lattice,
@@ -8232,22 +8333,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"cvC" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "cvP" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/fore)
@@ -8353,6 +8438,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"cxw" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "cxO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -8411,6 +8506,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"cyJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cyL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -8663,21 +8770,14 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"cCI" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+"cCE" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "cCU" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -8712,6 +8812,21 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"cDu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "cDz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -8805,6 +8920,25 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"cGP" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"cGY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cHg" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -8888,37 +9022,32 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/medical/morgue)
-"cIn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cIu" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"cIz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "cIE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
-"cJf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Armoury Access Hallway";
-	req_access_txt = "3";
-	security_level = 6
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "cJj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9213,6 +9342,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"cOL" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "cOM" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/structure/reagent_dispensers/peppertank{
@@ -9264,6 +9408,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"cPx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cPS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9319,22 +9473,22 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"cQS" = (
-/turf/open/floor/carpet/royalblue,
-/area/crew_quarters/theatre)
-"cQT" = (
+"cQz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
+"cQS" = (
+/turf/open/floor/carpet/royalblue,
+/area/crew_quarters/theatre)
 "cRh" = (
 /obj/machinery/airalarm/server{
 	pixel_y = 24
@@ -9418,6 +9572,30 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"cTx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Briefing Room";
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "cTD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -9510,18 +9688,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"cUA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "cUF" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -9667,18 +9833,6 @@
 "cWM" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
-"cWO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cWW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9884,15 +10038,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"dcj" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "dcn" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -9991,23 +10136,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"ddE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	req_one_access_txt = "66;3";
-	security_level = 6
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "ddN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10027,12 +10155,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"deq" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "deF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -10100,18 +10222,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"dfy" = (
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dfA" = (
 /obj/machinery/light{
 	dir = 8
@@ -10163,22 +10273,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"dgh" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "armour_exterior";
-	name = "Armoury Access";
-	pixel_x = 29;
-	pixel_y = 28;
-	req_access_txt = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/wood,
-/area/security/warden)
 "dgp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10559,19 +10653,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"dka" = (
-/obj/effect/landmark/start/detective,
-/obj/structure/chair/fancy/comfy{
+"dkg" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -10621,15 +10714,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"dlj" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "dlk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10794,17 +10878,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dox" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "doz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -10818,6 +10891,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"doW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "doY" = (
 /obj/machinery/door/window/southleft{
 	name = "Cloning Shower"
@@ -10828,6 +10916,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/techmaint,
 /area/medical/genetics/cloning)
+"dpq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/warden)
 "dpt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10857,6 +10951,15 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"dpB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dpG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -10963,6 +11066,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"drv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "drK" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -11221,22 +11339,6 @@
 /obj/machinery/computer/atmos_control/tank/air_tank,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"dxe" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "dxf" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -11255,19 +11357,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"dxw" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/wood,
-/area/security/warden)
 "dxz" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -11362,21 +11451,6 @@
 "dzt" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"dzB" = (
-/obj/machinery/flasher{
-	id = "PCell 1";
-	pixel_x = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Cell 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "dzP" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -11422,19 +11496,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"dAw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/spawner/room/fivexfour,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "dAF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11567,13 +11628,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"dEv" = (
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dEw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -11637,16 +11691,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"dEQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dFg" = (
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
@@ -11753,6 +11797,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"dGK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dGP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -11996,15 +12058,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"dLh" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "dLv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -12021,12 +12074,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"dLA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "dLB" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -12156,6 +12203,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"dME" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dMF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -12257,6 +12320,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"dPA" = (
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dPZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -12493,6 +12565,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
+"dSP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dTm" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -12599,16 +12678,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"dVq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dVx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -13051,6 +13120,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"ecG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "armorydoors";
+	name = "Blast Doors"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	req_one_access_txt = "66;3";
+	security_level = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ecP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -13199,19 +13290,6 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"eeC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eeE" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/window/eastleft{
@@ -13355,11 +13433,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"ehI" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ehT" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -13506,18 +13579,6 @@
 	dir = 5
 	},
 /area/science/breakroom)
-"ekn" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ekC" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -13580,19 +13641,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"eml" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "emu" = (
 /obj/structure/table/reinforced,
 /obj/item/soap/nanotrasen,
@@ -13710,6 +13758,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
+"eoH" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "eoV" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -13866,19 +13935,27 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"ers" = (
-/obj/machinery/door/airlock/security{
-	name = "Interogation Holding";
-	req_one_access_txt = "4"
+"ert" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "ery" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13979,22 +14056,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"euH" = (
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_one_access_txt = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/detectives_office)
 "euO" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8
@@ -14238,6 +14299,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"exr" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "exs" = (
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel,
@@ -14353,30 +14424,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"ezg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall14";
-	location = "hall13"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"ezz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "ezJ" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/plasteel,
@@ -14503,15 +14550,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"eBL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/departments/minsky/security/security{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "eBM" = (
 /obj/structure/barricade/wooden,
 /obj/effect/turf_decal/tile/green{
@@ -14705,11 +14743,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"eEZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eFK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -14894,19 +14927,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"eJJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eJK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14955,20 +14975,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"eKV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eLd" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/turf_decal/siding/wood{
@@ -15095,6 +15101,16 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"eNJ" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "eNN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -15274,6 +15290,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"eQn" = (
+/obj/effect/landmark/start/head_of_security,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "eQs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -15337,10 +15364,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"eRv" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "eRF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -15361,6 +15384,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"eRP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eSM" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -15392,6 +15432,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"eSY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "eTb" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
@@ -15756,21 +15807,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"fbk" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "fbo" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -15954,6 +15990,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library)
+"fdS" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fdU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -15976,6 +16020,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
+"feb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "feh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -16141,6 +16191,15 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"fhx" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "fhO" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -16257,16 +16316,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
-"fjL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fjM" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -16340,13 +16389,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"fkO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fkQ" = (
 /obj/machinery/power/smes/engineering{
 	charge = 2e+006
@@ -16495,6 +16537,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"fnn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/warden)
 "fnu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -17171,6 +17228,12 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fzT" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "fzY" = (
 /obj/machinery/firealarm{
 	pixel_y = -24
@@ -17396,17 +17459,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"fDi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "fDo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17531,6 +17583,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
+"fGw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "fGL" = (
 /obj/machinery/light{
 	dir = 1
@@ -17658,18 +17715,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"fIg" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fIm" = (
 /obj/machinery/door/airlock/medical{
 	id_tag = "QuarantineB";
@@ -17693,6 +17738,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"fIO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/warden)
 "fJc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -17701,15 +17752,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
-"fJe" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "fJw" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -17964,15 +18006,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"fNu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "fNy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18118,6 +18151,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"fPo" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fPs" = (
 /obj/machinery/libraryscanner,
 /turf/open/floor/carpet/green,
@@ -18260,6 +18306,15 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fRR" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fRY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/red{
@@ -18394,16 +18449,16 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/library)
-"fVD" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+"fVF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fVN" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -18739,6 +18794,25 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gbb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2;1;4;34;3"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gbd" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 2";
@@ -18924,6 +18998,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ger" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "geF" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -19104,15 +19191,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"giG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "giS" = (
 /turf/open/floor/plasteel/white,
 /area/quartermaster/storage)
+"giV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gje" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/delivery,
@@ -19231,6 +19324,17 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"gkl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall10";
+	location = "hall9"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "gks" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -19352,6 +19456,23 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"gmw" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gmD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -19398,6 +19519,21 @@
 "gnj" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
+"gnm" = (
+/obj/machinery/flasher{
+	id = "PCell 1";
+	pixel_x = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Cell 2";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gnD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19444,6 +19580,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"gnK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gnQ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -19473,6 +19620,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"goH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "goI" = (
 /turf/closed/wall,
 /area/science/lab)
@@ -19601,6 +19754,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
+"gpX" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gpY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19665,6 +19831,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"gse" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gsq" = (
 /obj/machinery/door/airlock/external{
 	name = "Shuttle Construction Yard";
@@ -19760,21 +19941,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"gtR" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"gtV" = (
-/turf/open/floor/wood,
-/area/security/warden)
 "gtW" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -20004,15 +20170,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"gyw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gyB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20056,6 +20213,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gyS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	req_one_access_txt = "66;3";
+	security_level = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "gyV" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/sign/warning/vacuum/external{
@@ -20102,23 +20278,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"gzH" = (
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -4
-	},
-/obj/machinery/button/door{
-	id = "detective_shutters";
-	name = "detective's office shutters control";
-	pixel_x = -26;
-	pixel_y = 6;
-	req_access_txt = "4"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "gzO" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/delivery,
@@ -20233,6 +20392,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"gBj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gBm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -20349,19 +20518,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"gDy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gDH" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
@@ -20400,39 +20556,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/relay)
-"gEc" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Medical";
-	req_access_txt = "34"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"gEd" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gEl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -20442,12 +20565,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"gEu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "gEw" = (
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
@@ -20604,6 +20721,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"gGD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gHf" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20802,6 +20931,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"gKs" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gKA" = (
 /obj/structure/table/wood,
 /obj/item/computer_hardware/hard_drive/role/lawyer,
@@ -20981,19 +21122,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
-"gMM" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt2";
-	name = "Cell 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "gMV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -21064,6 +21192,34 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"gNs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"gNx" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gNF" = (
 /obj/machinery/light_switch{
 	pixel_x = -25;
@@ -21276,6 +21432,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"gQz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/warden)
 "gQA" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -21363,16 +21529,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"gSb" = (
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gSk" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -21404,12 +21560,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"gTl" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "gTH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -21744,6 +21894,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gZC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gZU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monestary Access"
@@ -21763,16 +21931,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"gZX" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "hal" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21940,24 +22098,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"hcJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Education Center";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/security/execution/education)
 "hdd" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -22277,22 +22417,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"hiD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Secure Brig";
-	req_one_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "hiP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/coffee,
@@ -22653,19 +22777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"how" = (
-/obj/structure/chair/stool/bar,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hox" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -23043,6 +23154,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"hwc" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hwe" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -23194,6 +23317,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"hzj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hzu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -23543,11 +23682,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"hFx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "hFA" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery,
@@ -23919,27 +24053,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"hLP" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "hLT" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"hLY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "hMB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -23971,17 +24090,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"hMM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall9";
-	location = "hall8"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hMT" = (
 /obj/structure/table/wood,
 /obj/structure/desk_bell{
@@ -24073,6 +24181,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"hOs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hOZ" = (
 /obj/effect/spawner/room/threexthree,
 /turf/open/floor/plating,
@@ -24164,12 +24287,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"hQz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/security/warden)
 "hQN" = (
 /obj/machinery/light{
 	dir = 1
@@ -24393,6 +24510,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"hTL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hUp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24445,6 +24571,24 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/janitor)
+"hUY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hVd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24508,6 +24652,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hVO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hWl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -24547,6 +24701,16 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"hXi" = (
+/obj/item/radio/intercom{
+	pixel_y = 22
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hXj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window,
@@ -24755,19 +24919,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"hZN" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "hZO" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -24882,16 +25033,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"icl" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ict" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -25093,6 +25234,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"ifE" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ifF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
@@ -25132,6 +25285,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"igr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "igE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -25173,21 +25334,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"ihm" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "iht" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
@@ -25205,6 +25351,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
+"ihB" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ihC" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -25257,6 +25414,28 @@
 "ihY" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
+"iiC" = (
+/obj/machinery/computer/security/hos{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "iiH" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -25331,20 +25510,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"ijA" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Head of Security";
-	req_access_txt = "58"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hos)
 "ijB" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -25382,6 +25547,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iko" = (
+/obj/machinery/holopad{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ikv" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 8
@@ -25509,6 +25686,20 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"imP" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/wood,
+/area/security/warden)
 "imR" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
@@ -25517,6 +25708,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics)
+"imU" = (
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "inp" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -25612,6 +25816,19 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"ioC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ioQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -25768,13 +25985,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ipZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "iqa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -25891,18 +26101,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"irD" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "irJ" = (
 /obj/structure/chair/fancy/sofa/old{
 	dir = 8
@@ -25959,15 +26157,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"isF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "isL" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable/yellow{
@@ -26009,13 +26198,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"itA" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "itT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26271,28 +26453,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"izG" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "izP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -26345,6 +26505,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"iAs" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "secmain";
+	name = "Blast Doors"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iAu" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
@@ -26456,6 +26639,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iBW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iCu" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/light{
@@ -26575,6 +26765,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"iEe" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iEf" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating,
@@ -26597,6 +26796,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"iEI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iEL" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
@@ -26725,6 +26937,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"iGq" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iGD" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -26969,6 +27191,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"iKK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iKT" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/plasteel/dark,
@@ -27039,18 +27269,6 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"iNK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "iNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -27273,24 +27491,6 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
-"iRC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_one_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "iRG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -27405,26 +27605,6 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
-"iSC" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "iSD" = (
 /obj/structure/transit_tube/curved/flipped,
 /obj/effect/spawner/structure/window/reinforced,
@@ -27642,6 +27822,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"iWZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iXf" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/charcoal{
@@ -27865,16 +28060,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jaf" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/chef_recipes,
-/obj/item/kitchen/rollingpin,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "jal" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28093,6 +28278,16 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
+"jcX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "jdc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -28103,6 +28298,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"jdx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jdB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28188,6 +28391,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"jfG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jfJ" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -28423,23 +28632,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/medical/medbay/lobby)
-"jkd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/button/door{
-	id = "armorydoors";
-	name = "Armory Blast Doors";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "jkl" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -28555,16 +28747,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"jnq" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jnD" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -28655,27 +28837,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"jph" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_one_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jpk" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
@@ -29104,11 +29265,6 @@
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"jxw" = (
-/obj/structure/window/reinforced/spawner,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "jxO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29231,13 +29387,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"jAg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jAj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -29259,6 +29408,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"jAF" = (
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "jAH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -29268,16 +29439,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"jAL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jAO" = (
 /obj/machinery/light{
 	dir = 1
@@ -29398,15 +29559,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"jDl" = (
-/obj/machinery/holopad{
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jDv" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/displaycase,
@@ -29476,12 +29628,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jEy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jEF" = (
 /obj/machinery/light{
 	dir = 1
@@ -29756,26 +29902,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"jIN" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jIR" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
@@ -29806,6 +29932,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"jJt" = (
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "jJw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -30073,6 +30205,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jPx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jPQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -30099,6 +30238,19 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"jQn" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jQz" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -30397,18 +30549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"jVB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "jVV" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -30423,6 +30563,27 @@
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jWb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_one_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jWk" = (
 /turf/closed/wall,
 /area/bridge)
@@ -30573,17 +30734,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"jYd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jYg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -30783,25 +30933,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/surgery)
-"kcc" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"kci" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kco" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -30813,6 +30944,14 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
+"kcq" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "kcx" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -30851,12 +30990,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"kde" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "kdj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
@@ -31057,6 +31190,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen/coldroom)
+"khy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "khz" = (
 /obj/machinery/vending/job_disk{
 	req_access_txt = "57"
@@ -31288,6 +31436,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"klu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "klB" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutters2";
@@ -31609,17 +31768,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"kpN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kpP" = (
 /obj/item/radio/intercom{
 	pixel_x = 29;
@@ -31686,6 +31834,21 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"krx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Head of Security";
+	req_access_txt = "58"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hos)
 "krC" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -32262,14 +32425,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kAj" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
+"kAh" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "kAm" = (
 /obj/structure/table,
@@ -32374,13 +32539,6 @@
 /obj/structure/marker_beacon,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"kCD" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kCE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -32393,15 +32551,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"kDc" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kDe" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -32420,13 +32569,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kDl" = (
-/obj/machinery/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/security/warden)
 "kDz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -32546,12 +32688,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"kFG" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kFS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -32569,6 +32705,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"kGe" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kGm" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -32580,6 +32723,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kGy" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "kGD" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
@@ -32615,6 +32774,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/relay)
+"kIp" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kIy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -32692,16 +32861,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"kJU" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kKf" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -32864,11 +33023,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"kMT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kMU" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 1
@@ -32961,6 +33115,22 @@
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"kPw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/spawner/room/fivexfour,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kPy" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plasteel,
@@ -33141,21 +33311,21 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"kTC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "kTL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"kTR" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "kTX" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -33607,20 +33777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"lbH" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lbJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -33892,6 +34048,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"lfw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lfO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -34004,6 +34170,35 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
+"lhK" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"lhV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lib" = (
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
@@ -34053,6 +34248,27 @@
 "liF" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"liL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"ljk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ljs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -34069,22 +34285,6 @@
 "lju" = (
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"ljz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ljB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34122,6 +34322,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"lkF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lkI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34187,6 +34396,18 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"lly" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "llQ" = (
 /obj/structure/sign/painting/library{
 	pixel_x = 32
@@ -34324,6 +34545,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"loj" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "loo" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -34987,6 +35216,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"lyu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lyy" = (
 /obj/machinery/light{
 	dir = 8
@@ -35209,18 +35444,6 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"lBZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lCz" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -35306,6 +35529,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"lDc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lDv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -35369,6 +35605,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"lEH" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lEI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -35430,6 +35676,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"lFC" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lFF" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 8
@@ -35724,6 +35980,22 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"lKU" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lLa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -35846,6 +36118,16 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"lNg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lNs" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 1
@@ -36119,6 +36401,22 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"lRh" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2;1;4;34;3"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lRk" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/pump,
@@ -36179,15 +36477,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"lSx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "lSB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36248,22 +36537,19 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"lTo" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lTv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lTA" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lTO" = (
 /obj/effect/landmark/observer_start,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -36450,6 +36736,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"lWK" = (
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_one_access_txt = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/detectives_office)
 "lWS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -36859,26 +37164,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mdT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "armorydoors";
-	name = "Blast Doors"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	req_one_access_txt = "66;3";
-	security_level = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "mea" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -36909,6 +37194,19 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
+"meF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "meI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36972,14 +37270,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"mfA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mfD" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom{
@@ -37138,6 +37428,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"mix" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/chef_recipes,
+/obj/item/kitchen/rollingpin,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "miG" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -37314,27 +37614,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"mkC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Briefing Room";
-	req_one_access_txt = "1;4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "mkF" = (
 /turf/closed/wall,
 /area/chapel/main/monastery)
@@ -37543,6 +37822,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"mnX" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "moe" = (
 /obj/machinery/light{
 	dir = 1
@@ -38089,6 +38375,18 @@
 "mvn" = (
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
+"mvo" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mvC" = (
 /obj/structure/chair/fancy/sofa/old/left{
 	dir = 4
@@ -38156,6 +38454,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mwH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall9";
+	location = "hall8"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mwP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -38270,27 +38580,9 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port)
-"mxI" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "mxX" = (
 /turf/closed/wall,
 /area/science/xenobiology)
-"mya" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/warden)
 "myf" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -38478,6 +38770,16 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"mCj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "mCm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -38513,6 +38815,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"mCt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "mCz" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -38547,6 +38861,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"mCS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mCV" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -38705,6 +39031,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"mFk" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "mFq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -38714,6 +39050,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"mFz" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mFB" = (
 /obj/structure/sign/directions/medical{
 	pixel_y = -8
@@ -38827,6 +39181,22 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"mHW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mIy" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/straight_jacket,
@@ -39087,6 +39457,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"mME" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "mMI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -39494,11 +39873,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"mTx" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "mTz" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
@@ -39513,6 +39887,17 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mUi" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mUl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -39524,16 +39909,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"mUs" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "mUv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -39957,14 +40332,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"ncw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ncB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
@@ -40158,6 +40525,16 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
+"nfW" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nfX" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light{
@@ -40202,13 +40579,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"ngl" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ngq" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -40302,6 +40672,16 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"nhv" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nia" = (
 /obj/machinery/door/airlock/command{
 	name = "E.V.A. Secure Storage";
@@ -40545,16 +40925,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"noa" = (
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "nof" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -40843,21 +41213,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"nsv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "nsw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white,
@@ -41082,6 +41437,18 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"nwA" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Long-Term Cell 2";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nwE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41541,6 +41908,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"nDx" = (
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nDJ" = (
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -41554,6 +41937,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"nDR" = (
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nEf" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -41580,6 +41975,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/hallway/primary/fore)
+"nEI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "nEX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/matches{
@@ -41641,6 +42048,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nFL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "nFQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -42100,6 +42521,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
+"nMo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "nMw" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -42295,6 +42725,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"nOx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nOz" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -42310,18 +42757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"nOC" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "nOF" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner{
@@ -42628,6 +43063,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"nTY" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "nTZ" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -42715,6 +43160,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"nVZ" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "nWe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -42842,6 +43303,24 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"nXO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Education Center";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "nXW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -42859,17 +43338,6 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"nYf" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nYi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -42939,21 +43407,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"nZV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "oab" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -43035,15 +43488,6 @@
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/janitor)
-"oaF" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "oaL" = (
 /turf/closed/wall,
 /area/medical/medbay/aft)
@@ -43119,6 +43563,28 @@
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"obI" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Evidence";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "obO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -43197,16 +43663,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ocV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "odl" = (
 /obj/machinery/requests_console{
 	department = "Arrivals Dock";
@@ -43308,6 +43764,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"oeX" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ofc" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -43466,6 +43937,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"oiK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "oiM" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -43496,16 +43981,6 @@
 "ojH" = (
 /turf/closed/wall,
 /area/engine/engine_room)
-"ojK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ojP" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -43796,18 +44271,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"opd" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "opq" = (
 /turf/closed/wall,
 /area/science/breakroom)
@@ -43938,15 +44401,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
-"orJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "orN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43997,21 +44451,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"osU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "osX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44158,16 +44597,6 @@
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ovS" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ovW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -44184,16 +44613,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"owH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "owJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -44489,16 +44908,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"oAF" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "oAH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -44567,16 +44976,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"oBD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "oBJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -44684,21 +45083,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"oDx" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Long-Term Cell 1";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "oDB" = (
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -44889,6 +45273,21 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/surgery)
+"oFX" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/evidence,
+/obj/item/melee/classic_baton/police,
+/obj/item/reagent_containers/food/drinks/flask/det,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/security/detectives_office)
 "oGf" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -45071,16 +45470,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"oIS" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "oIU" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -45256,21 +45645,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
-"oNe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "oNk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -45331,11 +45705,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"oNY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "oOl" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
@@ -45560,6 +45929,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"oSI" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oSJ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -45892,14 +46276,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"oYY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall10";
-	location = "hall9"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "oZk" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/disposalpipe/segment,
@@ -46118,6 +46494,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
+"pdW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"pek" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pep" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
@@ -46159,15 +46558,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"pfd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "pfu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46236,6 +46626,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"pgs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pgG" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -46512,19 +46913,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"pkS" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "plC" = (
 /obj/structure/chair/fancy/sofa/old/right{
 	dir = 8
@@ -46579,13 +46967,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"pmg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "pmj" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -46602,6 +46983,16 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"pmy" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pmz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46658,6 +47049,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pnY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/warden)
 "poB" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
@@ -46740,23 +47140,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
-"pqj" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/starboard)
 "pql" = (
 /obj/machinery/computer/slot_machine,
 /obj/structure/sign/poster/random{
@@ -46789,24 +47172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"pqN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Secure Brig";
-	req_one_access_txt = "2;1;4;34;3"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pqO" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /obj/structure/cable/yellow{
@@ -46872,6 +47237,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"psC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "psS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -46910,20 +47295,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"pte" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ptf" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 1
@@ -47421,6 +47792,16 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"pBy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pCa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -47583,6 +47964,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"pEp" = (
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "pEC" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -47738,21 +48129,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"pGx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Secure Brig";
-	req_one_access_txt = "2;1;4;34;3"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pGV" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -47786,21 +48162,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"pHK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pHL" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -47895,12 +48256,6 @@
 	dir = 4
 	},
 /area/science/research)
-"pIW" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/warden)
 "pIZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48113,23 +48468,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"pMr" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"pMz" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "pMX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 1
@@ -48231,6 +48569,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"pOv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pOx" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable/white{
@@ -48239,21 +48584,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"pOK" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "pOL" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -48322,6 +48652,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pPs" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall14";
+	location = "hall13"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pPJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
@@ -48905,17 +49245,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"qad" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "qay" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -48951,24 +49280,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/engine/engine_room)
-"qba" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "qbO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48994,6 +49305,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"qcd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qce" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -49037,21 +49369,6 @@
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
-"qcO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "qcP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -49143,6 +49460,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"qdU" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qeh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49158,6 +49488,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"qew" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qeA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49258,13 +49600,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qhg" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qhk" = (
 /obj/structure/chair/fancy/comfy{
 	dir = 8
@@ -49966,18 +50301,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"qsV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/security/detectives_office)
 "qsX" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -50176,13 +50499,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
-"qve" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "qvj" = (
 /obj/effect/landmark/start/research_director,
 /obj/structure/cable/yellow{
@@ -50247,6 +50563,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"qvU" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "qwa" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -50400,6 +50729,18 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/bridge)
+"qzi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qzS" = (
 /obj/machinery/food_cart,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -50464,6 +50805,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qBd" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qBi" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 8
@@ -50666,12 +51016,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"qDk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qDx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50681,6 +51025,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"qDG" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	sortType = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qDH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -50721,28 +51077,6 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"qDX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"qEd" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qEg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50855,6 +51189,25 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/bridge)
+"qGg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qGi" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
@@ -50910,6 +51263,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
+"qGZ" = (
+/obj/structure/chair,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qHm" = (
 /obj/machinery/light{
 	dir = 1
@@ -50984,6 +51350,17 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qIa" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qIg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -51342,16 +51719,18 @@
 "qOk" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"qOm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "qOq" = (
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"qOr" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qOx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -51406,6 +51785,19 @@
 /obj/structure/displaycase/captain,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
+"qPa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qPh" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable/yellow{
@@ -51505,6 +51897,23 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"qRc" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qRp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -51542,6 +51951,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"qSc" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qSi" = (
 /obj/structure/chair,
 /obj/machinery/camera/autoname,
@@ -51557,6 +51984,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"qSm" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig Medical";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qSI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -51729,6 +52172,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"qWW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qWX" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
@@ -52094,19 +52546,6 @@
 "rdA" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
-"rdK" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rdL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -52157,6 +52596,21 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/blue,
+/area/security/brig)
+"reB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "reL" = (
 /obj/structure/window/reinforced/spawner{
@@ -52262,17 +52716,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"rgb" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "rgc" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -52362,6 +52805,21 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"rhk" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Armoury Access Hallway";
+	req_access_txt = "3";
+	security_level = 6
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "rhG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 1
@@ -52551,13 +53009,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"rkX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rlh" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -52572,12 +53023,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"rlr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rlw" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/seclite,
@@ -52592,6 +53037,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"rlH" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "rlK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52862,17 +53315,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"rpl" = (
-/obj/effect/landmark/start/head_of_security,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "rpq" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -52967,19 +53409,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rqt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rqF" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -53252,6 +53681,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rwi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "rwF" = (
 /obj/item/soap,
 /turf/open/floor/plasteel/white,
@@ -53292,12 +53739,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"rwP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rwV" = (
 /obj/machinery/door/window{
 	name = "Pet cage";
@@ -53551,16 +53992,22 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"rBK" = (
+"rBr" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rCa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -53671,6 +54118,13 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"rDK" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "rDO" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -53711,6 +54165,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rEx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rEC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -53960,16 +54431,6 @@
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
-"rHH" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rHV" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -54283,6 +54744,17 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"rNb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "rNy" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/sparker/toxmix{
@@ -54347,17 +54819,6 @@
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"rPn" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3";
-	security_level = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "rPs" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/rack,
@@ -54455,25 +54916,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"rQl" = (
-/obj/machinery/computer/security/hos{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "rQp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -54687,6 +55129,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"rTQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rTW" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname,
@@ -55416,13 +55871,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"sfS" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
 "sgi" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -55468,6 +55916,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sgY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "shl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -55488,18 +55949,6 @@
 "shJ" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
-"shK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "shL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -55555,24 +56004,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
-"sir" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "siV" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -56006,6 +56437,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"spy" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "spz" = (
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -56027,16 +56473,22 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"spJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "sqh" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sqm" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sqo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -56049,6 +56501,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"sqp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sqK" = (
 /obj/machinery/xenoartifact_inbox,
 /obj/effect/turf_decal/delivery,
@@ -56103,6 +56569,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ssd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ssf" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -56165,16 +56644,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"ssD" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt1";
-	name = "Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ssI" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -56188,12 +56657,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ssT" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "ssV" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	filter_type = "n2"
@@ -56308,13 +56771,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"suN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "suQ" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
@@ -56446,6 +56902,17 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/tools)
+"sxi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "sxK" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56522,15 +56989,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"syF" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "syX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -56569,6 +57027,14 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
+"szz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "szC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -56751,21 +57217,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sCf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "sCm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56837,29 +57288,12 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
-"sEP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "sEV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"sFh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "sFB" = (
 /obj/structure/chair/fancy/bench/pew/left{
 	dir = 8
@@ -56899,6 +57333,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
+"sGi" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3";
+	security_level = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/warden)
 "sGn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56945,6 +57391,27 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating/asteroid/airless,
 /area/maintenance/starboard/secondary)
+"sHa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "sHo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -57000,13 +57467,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"sHZ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "sIf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -57264,14 +57724,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"sLV" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sLX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -57405,6 +57857,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"sOd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sOg" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -57522,6 +57984,17 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/carpet/blue,
+/area/security/brig)
+"sRc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sRn" = (
 /obj/structure/cable/yellow{
@@ -57676,6 +58149,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"sTH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "sTN" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
@@ -57806,6 +58289,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sVw" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sVB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -57926,6 +58417,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"sXL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sYe" = (
 /obj/machinery/light{
 	dir = 4
@@ -58104,6 +58604,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"taZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/warden)
 "tbi" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -58203,13 +58709,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"tdr" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tdR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -58302,19 +58801,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"tfB" = (
-/obj/structure/chair,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tfH" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -58584,15 +59070,6 @@
 /obj/item/clothing/neck/petcollar,
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
-"tlU" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tlY" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -58884,6 +59361,15 @@
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"trH" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "trJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -58896,17 +59382,6 @@
 "trM" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"tsl" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tss" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
@@ -58941,13 +59416,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
-"tsE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "tsG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/disposalpipe/segment{
@@ -59136,6 +59604,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"twi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "twH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -59633,6 +60119,27 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/relay)
+"tEO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_one_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tET" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -59939,21 +60446,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"tLh" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tLk" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"tLn" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "tLo" = (
 /obj/structure/cable/yellow{
@@ -60060,16 +60563,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"tNe" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tNf" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing{
@@ -60301,21 +60794,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
-"tQv" = (
-/obj/machinery/flasher{
-	id = "PCell 2";
-	pixel_x = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Cell 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "tQE" = (
 /obj/machinery/rnd/production/protolathe/department/service,
 /turf/open/floor/plasteel,
@@ -60339,20 +60817,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
-"tRg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tRq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall22";
@@ -60500,11 +60964,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"tUt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tUv" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/item/pipe_dispenser,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"tUw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tUy" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -60789,6 +61274,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"tZW" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "tZZ" = (
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
@@ -60940,6 +61435,26 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
+"ubP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ucj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uco" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -61220,6 +61735,13 @@
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ugk" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ugr" = (
 /obj/machinery/power/generator,
 /obj/structure/cable{
@@ -61286,6 +61808,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"uhN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/button/door{
+	id = "armorydoors";
+	name = "Armory Blast Doors";
+	pixel_x = 26;
+	pixel_y = -26;
+	req_access_txt = "3"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "uhX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -61447,14 +61988,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"ukc" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ukj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -61546,6 +62079,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ulx" = (
+/obj/effect/landmark/start/detective,
+/obj/structure/chair/fancy/comfy{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "ulG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -61704,6 +62253,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"uos" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "uou" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/telecomms/broadcaster/preset_right,
@@ -61815,12 +62379,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"uqu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uqv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61946,6 +62504,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"usI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "usR" = (
 /obj/structure/closet{
 	name = "Evidence Closet 3"
@@ -61988,32 +62559,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
-"utE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"uui" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "uuu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62049,6 +62594,14 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"uuM" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uuV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -62235,18 +62788,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"uxY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Long-Term Cell 2";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "uxZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -62486,6 +63027,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uDe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "uDq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62527,6 +63083,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"uDA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uDM" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/delivery,
@@ -62583,18 +63154,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/noslip/white,
 /area/medical/medbay/central)
-"uEv" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "uEx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -62624,27 +63183,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"uEE" = (
+"uEI" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/area/security/brig)
 "uEX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62780,15 +63336,19 @@
 "uGg" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
-"uGK" = (
+"uGq" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uGL" = (
@@ -62849,12 +63409,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uHq" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uHw" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4;
@@ -62997,6 +63551,21 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
+"uJC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uJD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63195,6 +63764,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"uLX" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt1";
+	name = "Cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "uMk" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -63246,11 +63825,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"uMN" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uMT" = (
 /obj/structure/table,
 /obj/item/phone{
@@ -63423,18 +63997,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"uPQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uPX" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/stripes/line{
@@ -63447,15 +64009,6 @@
 	dir = 9
 	},
 /area/medical/surgery)
-"uQv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "uQB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -63687,16 +64240,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"uUY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uVh" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -63846,6 +64389,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"uXW" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uXX" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Escape Pod Alpha"
@@ -63856,17 +64419,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"uYf" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "uYo" = (
 /obj/effect/landmark/start/captain,
 /obj/structure/cable/yellow{
@@ -63993,19 +64545,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_room)
-"vby" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "vbD" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -64085,14 +64624,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"vcI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "vcO" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
@@ -64234,6 +64765,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"veH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "veI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64243,12 +64788,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"veJ" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "veT" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
@@ -64259,16 +64798,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"veY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vfo" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/plasteel,
@@ -64324,6 +64853,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"vgx" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vgF" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -64331,24 +64870,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"vgI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vgK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64508,13 +65029,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"vjJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vjN" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
@@ -64527,6 +65041,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"vkw" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "vky" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -64546,6 +65075,12 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"vkD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vkH" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -64614,6 +65149,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"vmq" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "vmr" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/yellow{
@@ -64631,14 +65177,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"vmI" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vmQ" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -64726,6 +65264,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"vov" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "voK" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable/white,
@@ -64916,13 +65465,17 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
-"vrj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"vrl" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "vrp" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -64968,18 +65521,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"vrV" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/evidence,
-/obj/item/melee/classic_baton/police,
-/obj/item/reagent_containers/food/drinks/flask/det,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/red,
-/area/security/detectives_office)
 "vsg" = (
 /obj/machinery/light{
 	dir = 4
@@ -65081,14 +65622,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"vuh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "vum" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65161,13 +65694,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"vvb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vve" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65215,6 +65741,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vvq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "vvv" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -65347,20 +65879,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"vxq" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "vxy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -65448,6 +65966,18 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vyg" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vys" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/bottle/chloralhydrate,
@@ -65462,13 +65992,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"vyt" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vyv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -65492,6 +66015,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"vyx" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vyB" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -65695,22 +66224,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"vAI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "vAQ" = (
 /obj/machinery/gateway/centerstation,
 /obj/effect/turf_decal/stripes/line,
@@ -65728,9 +66241,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
-"vBE" = (
-/turf/open/floor/plasteel,
-/area/security/warden)
 "vBI" = (
 /obj/structure/kitchenspike,
 /obj/item/radio/intercom{
@@ -65870,11 +66380,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"vDL" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vDQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -65926,16 +66431,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"vEG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vEJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -66023,24 +66518,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"vGx" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vGB" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -66264,22 +66741,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"vJc" = (
-/obj/machinery/computer/card/minor/hos{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "vJi" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -66488,6 +66949,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"vMR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vMV" = (
 /obj/structure/chair/fancy/comfy,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
@@ -66963,6 +67439,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"vVU" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vVW" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -67164,6 +67653,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"way" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/security/detectives_office)
 "waJ" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -67183,6 +67687,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"waX" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wbc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
@@ -67254,21 +67773,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"wci" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wcn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -67515,6 +68019,18 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"wha" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "whe" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/yellow{
@@ -67576,15 +68092,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"wiw" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "wiA" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -67876,17 +68383,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wnr" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "wnN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -68179,16 +68675,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wsv" = (
-/obj/machinery/camera/autoname,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wsI" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -68232,6 +68718,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"wtJ" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wul" = (
 /obj/effect/spawner/structure/window/depleteduranium,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -68275,16 +68767,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
-"wuV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wuY" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -68338,30 +68820,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"wvQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"wvW" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wwk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -68389,17 +68847,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"wwA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wwI" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -68657,28 +69104,6 @@
 /obj/item/stack/rods,
 /turf/open/space/basic,
 /area/space/nearstation)
-"wBL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "wBU" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -68738,20 +69163,29 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"wCB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"wCK" = (
+/obj/machinery/firealarm{
+	pixel_y = -24
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"wDb" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Secure Brig";
-	req_one_access_txt = "2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -68784,6 +69218,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wDC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wDG" = (
 /turf/closed/wall,
 /area/maintenance/department/science/central)
@@ -68794,6 +69243,31 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"wDV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wEp" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -69021,6 +69495,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"wIK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "wIU" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -69139,6 +69624,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"wKH" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "wKJ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/dark,
@@ -69209,17 +69704,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"wLE" = (
-/obj/machinery/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wLT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -69372,6 +69856,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"wOk" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wOD" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -69479,6 +69974,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"wPY" = (
+/obj/machinery/computer/card/minor/hos{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wQe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -69506,18 +70018,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"wQU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "wRj" = (
 /obj/structure/chair{
 	dir = 4
@@ -69558,6 +70058,22 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"wSa" = (
+/obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/warden)
 "wSk" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -69675,6 +70191,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
+"wUu" = (
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wUD" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -70049,17 +70588,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xaC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "xaO" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/scientist,
@@ -70103,6 +70631,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"xcm" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xdj" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -70354,13 +70892,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"xhZ" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xim" = (
 /obj/effect/landmark/carpspawn,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -70540,6 +71071,15 @@
 	},
 /turf/open/floor/noslip/standard,
 /area/hallway/secondary/service)
+"xlq" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "xlu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -71011,6 +71551,12 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"xtv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xtL" = (
 /obj/structure/railing{
 	dir = 8
@@ -71091,6 +71637,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"xvj" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xvl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -71137,6 +71693,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"xwm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xwv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -71278,15 +71849,6 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"xyG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xyJ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -71297,6 +71859,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"xyZ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Medical";
+	req_access_txt = "34"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xza" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -71322,6 +71903,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science/central)
+"xzh" = (
+/obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xzr" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -71348,6 +71943,26 @@
 	},
 /turf/open/floor/dock/drydock,
 /area/science/shuttle)
+"xzC" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "xzF" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -71364,18 +71979,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xzR" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "xzZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -71506,28 +72109,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/relay)
-"xBP" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "secmain";
-	name = "Blast Doors"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xBS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -71673,14 +72254,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
-"xDM" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xDZ" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -71691,6 +72264,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"xEa" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "xEc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
@@ -72165,6 +72748,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
+"xNm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/warden)
 "xNy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -72390,19 +72982,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xQa" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xQv" = (
 /obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -72482,15 +73061,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"xRF" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "xRL" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -72626,6 +73196,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xTy" = (
+/obj/machinery/light_switch{
+	pixel_x = -25;
+	pixel_y = -4
+	},
+/obj/machinery/button/door{
+	id = "detective_shutters";
+	name = "detective's office shutters control";
+	pixel_x = -26;
+	pixel_y = 6;
+	req_access_txt = "4"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "xTN" = (
 /obj/structure/chair/fancy/comfy{
 	dir = 8
@@ -72678,6 +73266,21 @@
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"xUh" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/security/detectives_office)
 "xUk" = (
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
@@ -72701,18 +73304,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"xUq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xUK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -72827,12 +73418,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"xWi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "xXa" = (
 /turf/closed/wall,
 /area/library)
@@ -72968,6 +73553,38 @@
 "yak" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/central)
+"yam" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"ybj" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ybt" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/suit_storage_unit/open,
@@ -73387,11 +74004,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"yjs" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3";
+	security_level = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/warden)
 "yjv" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"yjG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "yjH" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/stripes/line{
@@ -73496,14 +74137,6 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"yma" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3";
-	security_level = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/warden)
 "ymf" = (
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science/central)
@@ -110623,8 +111256,8 @@ xUk
 mJo
 seE
 plZ
-utE
-auC
+rTQ
+ahP
 oHE
 dHi
 xFa
@@ -110642,7 +111275,7 @@ qac
 jzx
 ike
 lpT
-sfj
+bAH
 gNl
 jmv
 qOx
@@ -110865,7 +111498,7 @@ anT
 anT
 oXI
 dMz
-suN
+sTH
 qwN
 qwN
 nNW
@@ -110881,7 +111514,7 @@ tTo
 tTo
 tTo
 lbs
-cIn
+wDb
 qyk
 iqD
 rez
@@ -110890,16 +111523,16 @@ fSU
 iYG
 xyq
 tdf
-oYY
-pMz
-kgL
-kgL
-kgL
-kgL
-jzx
-vjJ
-hMM
-cpp
+gkl
+szz
+rlH
+fzT
+fzT
+fzT
+xvj
+jdx
+mwH
+biG
 tgT
 cpp
 cpp
@@ -111122,7 +111755,7 @@ aMT
 aMT
 oXI
 xhX
-ipZ
+lfw
 uTe
 toH
 vZO
@@ -111138,7 +111771,7 @@ nBt
 mrc
 tTo
 gXo
-vvb
+hVO
 kVp
 dHi
 mEg
@@ -111147,9 +111780,9 @@ wqt
 kNB
 xyq
 tdf
-eRv
-ieI
-ieI
+aZV
+ugk
+mnX
 ieI
 hzZ
 ieI
@@ -111379,14 +112012,14 @@ nXe
 tQH
 oXI
 htD
-aae
-veJ
-buo
-jkd
-mdT
-sir
-ddE
-jVB
+sHa
+kcq
+btl
+uhN
+ecG
+psC
+gyS
+cIz
 lGd
 lQx
 vdg
@@ -111395,7 +112028,7 @@ dvq
 iSx
 fAg
 tch
-rwP
+lkF
 qZp
 hmy
 hmy
@@ -111404,7 +112037,7 @@ hmy
 hmy
 duF
 tdf
-uHq
+dkg
 gnj
 gnj
 iaU
@@ -111624,35 +112257,35 @@ ujv
 tBd
 skM
 fNy
-bjV
-syF
+pBy
+qOr
 eyU
 hmy
 ksE
-fVD
-gzH
-amh
+qvU
+xTy
+xEa
 nXe
 aMT
 oXI
 hwK
-ipZ
+lNg
 uTe
 ent
 jbs
 oXI
 hIC
 oXI
-mxI
+dGK
 ecE
 tNg
 dHN
-vBE
-sfS
+taZ
+eNJ
 qsm
 dDl
 tch
-rwP
+lkF
 oHE
 dHi
 xFa
@@ -111661,7 +112294,7 @@ uWc
 sRa
 xyq
 tdf
-uHq
+dkg
 gnj
 aMT
 aMT
@@ -111881,35 +112514,35 @@ nrw
 mhz
 pCL
 tPB
-gtR
-xhZ
+gGD
+aTs
 byP
 hmy
 rAb
-dka
-dcj
+ulx
+kTR
 nsY
 nXe
 anT
 oXI
 dus
-lSx
+lly
 eFY
 ucx
 dMe
 oXI
 aOu
 oXI
-dLh
+drv
 jAj
 lpe
 mqN
-mya
-mya
+pnY
+xNm
 qYB
 tTo
 jDz
-wLE
+xzh
 qyk
 gbd
 rez
@@ -111918,7 +112551,7 @@ fSU
 iYG
 xyq
 tdf
-uHq
+dkg
 iaU
 aMT
 aMT
@@ -112137,14 +112770,14 @@ uKT
 uKT
 uKT
 duF
-ehI
-xUq
-jDl
+fdS
+cQz
+iko
 mNF
 hmy
 vNG
-vrV
-apj
+oFX
+jcX
 mMs
 nXe
 aMT
@@ -112157,16 +112790,16 @@ oXI
 oXI
 anT
 oXI
-wiw
+cOL
 nUQ
 lpe
 hPv
-gtV
-gtV
+fIO
+dpq
 rPL
 dDl
 tch
-rwP
+lkF
 deS
 dHi
 iUQ
@@ -112174,8 +112807,8 @@ vqG
 wqt
 kNB
 xyq
-tdf
-uHq
+agj
+xcm
 iaU
 aMT
 aMT
@@ -112383,25 +113016,25 @@ anT
 vyE
 kvB
 uNK
-wvW
+cyJ
 oHv
 oHv
-dlj
+fhx
 oHv
 uKT
 pRp
-tQv
-cqD
+avq
+dPA
 jQz
 duF
 mGW
-bzN
-kDc
+eSY
+ifE
 ikY
 hmy
 fZM
-bul
-nsv
+xUh
+khy
 lPI
 nXe
 aMT
@@ -112414,16 +113047,16 @@ oXI
 aMT
 aMT
 oXI
-bdm
-ssT
-cJf
-dgh
-hQz
-kDl
-dxw
-rPn
-opd
-uPQ
+jAF
+bEl
+rhk
+bpM
+gQz
+wSa
+imP
+sGi
+nfW
+spy
 sBB
 hmy
 hmy
@@ -112432,7 +113065,7 @@ hmy
 hmy
 duF
 pmF
-uHq
+dkg
 iaU
 aMT
 aMT
@@ -112640,24 +113273,24 @@ anT
 vyE
 rHY
 lxK
-how
-jaf
-oAF
-cCI
-uYf
-gMM
-vuh
-ovS
-oBD
-vuh
-oDx
-bdC
-shK
-hLP
+jQn
+mix
+tZW
+uos
+sxi
+cmq
+iKK
+cPx
+sOd
+iKK
+asx
+ihB
+liL
+pmy
 oHg
 hmy
 eqX
-qsV
+way
 phE
 tuH
 nXe
@@ -112676,11 +113309,11 @@ ubm
 lpe
 mXD
 kDz
-pIW
+fnn
 swK
 tTo
 fLj
-gyw
+azE
 oHE
 dHi
 xFa
@@ -112689,7 +113322,7 @@ uWc
 sRa
 xyq
 tdf
-uHq
+dkg
 gnj
 aMT
 aMT
@@ -112900,7 +113533,7 @@ lxK
 oEY
 gpE
 oaA
-uEv
+ybj
 bPO
 uKT
 mJk
@@ -112909,12 +113542,12 @@ xqJ
 bNP
 duF
 wFK
-jph
-iRC
+jWb
+tEO
 hmy
 hmy
 hmy
-euH
+lWK
 hmy
 hmy
 duF
@@ -112933,11 +113566,11 @@ wiI
 lpe
 gBw
 lpe
-yma
+yjs
 lpe
 tTo
 vcF
-cIn
+wDb
 qyk
 fZw
 rez
@@ -112946,7 +113579,7 @@ fSU
 iYG
 xyq
 tdf
-uHq
+dkg
 gnj
 gnj
 fjt
@@ -113157,7 +113790,7 @@ ehT
 xsV
 bFY
 aXL
-uEv
+ybj
 tWA
 uKT
 uKT
@@ -113165,13 +113798,13 @@ uKT
 uKT
 uKT
 duF
-xDM
-qDX
-ngl
+qIa
+vVU
+nTY
 mug
 duF
-uQv
-wci
+dpB
+amM
 bKF
 hmy
 usR
@@ -113179,22 +113812,22 @@ niF
 clb
 tMp
 hmy
-bUY
-rqt
-pMr
-xQa
-tRg
-ljz
-ekn
-fjL
-eKV
-ekn
-pMr
-kpN
-pMr
-pqN
-eeC
-wvQ
+qSc
+awr
+cGP
+pdW
+uJC
+nOx
+ucj
+wOk
+waX
+ucj
+cGP
+auc
+cGP
+gbb
+sqp
+wDC
 tJh
 dHi
 mVf
@@ -113203,8 +113836,8 @@ wqt
 kNB
 xyq
 tdf
-dLA
-bwG
+cee
+cju
 gnj
 frx
 sib
@@ -113414,45 +114047,45 @@ sjC
 qIY
 tGP
 jif
-irD
+wha
 otJ
 uKT
 pRp
-dzB
-cqD
+gnm
+dPA
 jQz
 duF
-lJV
-tNe
-mUs
+rDK
+fPo
+cxw
 aqr
 hmy
-wsv
-aEC
+lEH
+oSI
 xtd
 hmy
 frC
-iNK
-eJJ
+giV
+ssd
 axR
 hmy
-oIS
-tdr
-eEZ
-kJU
-uUY
-mfA
-nYf
-mfA
-eEZ
-lTA
-dox
-eEZ
-vmI
-pGx
-qDk
-fIg
-hZN
+meF
+iGq
+wtJ
+gnK
+vrl
+sXL
+nDR
+sXL
+wtJ
+bQp
+hwc
+wtJ
+fRR
+lRh
+aer
+gse
+nDx
 hmy
 hmy
 hmy
@@ -113460,8 +114093,8 @@ hmy
 duF
 jwG
 tdf
-uMN
-uHq
+fGw
+lFC
 gnj
 gks
 gnj
@@ -113668,38 +114301,38 @@ anT
 vyE
 kad
 xxK
-ahc
-kci
-ocV
-orJ
-sLV
-ssD
-oNY
-pmg
-tsE
-oNY
-uxY
-deq
-bTR
-fNu
+tUt
+pOv
+fVF
+tUw
+uuM
+uLX
+aqk
+iBW
+jPx
+aqk
+nwA
+bRD
+mHW
+pek
 fRY
 hmy
-xyG
-jAL
+nMo
+sgY
 lJV
 hmy
 xAZ
-oNe
-cqr
+xwm
+gNs
 jTf
 hmy
-cfK
-gEd
+uXW
+qRc
 cSo
 cSo
 cSo
 wqm
-mkC
+cTx
 mqH
 cSo
 cSo
@@ -113708,23 +114341,23 @@ duF
 duF
 duF
 fJO
-qEd
-uqu
-rkX
-rgb
-tlU
-eBL
-xBP
-kTC
+iWZ
+qWW
+cGY
+bAf
+kIp
+gBj
+iAs
+vyg
 wod
 gDT
-vrj
-sHZ
-qac
-xRF
-qac
-qac
-qac
+qPa
+qBd
+wKH
+vov
+afM
+sVw
+afM
 cdX
 fkM
 sqh
@@ -113925,10 +114558,10 @@ anT
 vyE
 dZW
 lxK
-giG
+vkD
 lxK
 pCu
-rlr
+lyu
 drK
 uKT
 cFU
@@ -113936,27 +114569,27 @@ tNa
 xqJ
 bNP
 duF
+rDK
+rwi
+hmy
+hmy
+hmy
+nMo
+mCS
 lJV
-fbk
 hmy
 hmy
 hmy
-xyG
-bPW
-lJV
+obI
 hmy
 hmy
-hmy
-izG
-hmy
-hmy
-bBh
-kCD
+hUY
+gNx
 cSo
 cOM
 vxE
 qAF
-vby
+lKU
 fCx
 mth
 jhz
@@ -113965,14 +114598,14 @@ erD
 ivK
 hmy
 hmy
-bmU
+qSm
 bpE
 hmy
 hmy
 aIt
 aIt
 eZE
-isF
+avM
 hzZ
 ieI
 xzF
@@ -113980,12 +114613,12 @@ gHq
 kgL
 kgL
 kgL
-kgL
+dSP
 kgL
 hbK
 tQc
 pIh
-ezg
+pPs
 hJO
 wSu
 okw
@@ -114193,28 +114826,28 @@ uKT
 uKT
 uKT
 duF
-dEv
-pHK
-hiD
-wwA
-sFh
-wuV
-ncw
-hFx
-dfy
-nOC
-tsl
-ihm
-kFG
-vyt
-cQT
-awt
+hXi
+mFz
+eRP
+gKs
+hTL
+sRc
+qDG
+jfG
+imU
+gpX
+mvo
+hzj
+kGe
+tLh
+rBr
+mUi
 cSo
 rTW
 vxE
-cvC
-ezz
-osU
+kGy
+rEx
+cDu
 xts
 uRG
 oRA
@@ -114222,14 +114855,14 @@ ivK
 ivK
 hmy
 dtI
-noa
+pEp
 oKx
 kWM
 hmy
 hmy
 hmy
 hmy
-pqj
+xzC
 gnj
 rxo
 gnj
@@ -114450,27 +115083,27 @@ mPj
 bpZ
 mQd
 duF
-qve
-vGx
-wCB
-qOm
-vEG
-bfE
-eml
-jYd
-jAg
-jnq
-vEG
-veY
-jAg
-ukc
-kcc
-spJ
+yjG
+alg
+gZC
+aLs
+klu
+nFL
+veH
+lhV
+igr
+pgs
+klu
+aOy
+igr
+iEe
+ioC
+nhv
 cSo
 ngN
 vxE
 tXe
-bvr
+nVZ
 nto
 bQr
 dDa
@@ -114479,14 +115112,14 @@ ivK
 ivK
 hmy
 gjU
-xzR
+apR
 qOG
 bvE
 hmy
 ivK
 ivK
 ivK
-dAw
+kPw
 vnF
 fnz
 vnF
@@ -114703,16 +115336,16 @@ nhn
 naL
 oEb
 cWG
-gEu
+vvq
 gHo
 vCs
 duF
-kMT
-pkS
+cCE
+dME
 hmy
 hmy
 hmy
-ers
+cbV
 hmy
 hmy
 hmy
@@ -114722,12 +115355,12 @@ hmy
 pxi
 hmy
 rGg
-gSb
+wCK
 cSo
 xlT
 uKd
 tXe
-vxq
+bJe
 nto
 nJT
 kdY
@@ -114736,14 +115369,14 @@ jdN
 ivK
 hmy
 bpE
-gEc
+xyZ
 bpE
 hmy
 hmy
 ivK
 ivK
 ivK
-apD
+uDe
 vnF
 tre
 ciw
@@ -114960,17 +115593,17 @@ mGe
 vpH
 pjQ
 nYi
-pfd
-rBK
-fDi
-hcJ
-sEP
-lbH
+mME
+mCj
+wIK
+nXO
+nEI
+gmw
 hmy
-tfB
-rdK
-sCf
-gDy
+qGZ
+iEI
+uDA
+sqm
 hmy
 ieK
 cKb
@@ -114979,12 +115612,12 @@ bsc
 mSg
 hmy
 vCO
-dEQ
+lDc
 etB
 wcn
 wxW
 tXe
-bvr
+nVZ
 nto
 khK
 wcn
@@ -114993,14 +115626,14 @@ cwf
 ivK
 hmy
 uga
-oaF
+aVK
 kEU
 clW
 hmy
 ivK
-cUA
-hLY
-wQU
+vMR
+ljk
+doW
 vnF
 vrh
 ldw
@@ -115218,16 +115851,16 @@ naL
 hBg
 naL
 msu
-kde
+feb
 hfz
 duF
-lJV
-fbk
+rDK
+rwi
 hmy
-jEy
+xtv
 oQB
 xXK
-fkO
+ubP
 pxi
 tLk
 uMT
@@ -115235,13 +115868,13 @@ ssj
 jjv
 phc
 hmy
-dVq
-icl
+exr
+usI
 aUS
 whr
 nms
 msz
-wBL
+wDV
 lwX
 lLK
 whr
@@ -115250,12 +115883,12 @@ nst
 trr
 hmy
 sVv
-kAj
-ckw
+bMA
+xlq
 wNR
 hmy
 ivK
-apD
+uDe
 ivK
 ivK
 vnF
@@ -115475,11 +116108,11 @@ iiH
 eNA
 mqu
 sVq
-xWi
+goH
 cWx
 duF
-gTl
-qcO
+trH
+uEI
 hmy
 hSn
 nTD
@@ -115493,12 +116126,12 @@ lOG
 oBY
 hmy
 vcZ
-vDL
+loj
 cSo
-mTx
-jxw
-vJc
-rQl
+vyx
+jJt
+wPY
+iiC
 wTM
 lJU
 qEw
@@ -115512,7 +116145,7 @@ wKc
 cBK
 hmy
 ivK
-apD
+uDe
 ivK
 ivK
 vnF
@@ -115735,8 +116368,8 @@ rrp
 wFk
 fex
 duF
-vgI
-jIN
+qcd
+wUu
 hmy
 hmy
 iRh
@@ -115754,9 +116387,9 @@ duF
 cSo
 pSQ
 bQL
-xaC
-rpl
-gZX
+bTI
+eQn
+bXi
 bQL
 pSQ
 fOv
@@ -115769,7 +116402,7 @@ hmy
 hmy
 hmy
 jdN
-vAI
+qGg
 jdN
 jdN
 vnF
@@ -115992,16 +116625,16 @@ mwP
 oJx
 cWx
 duF
-qhg
-lBZ
-tLn
+vgx
+reB
+qew
 cpB
 ohA
 rnf
-qba
-owH
-fJe
-uui
+ert
+vmq
+mFk
+lhK
 iRh
 aMT
 jdN
@@ -116020,14 +116653,14 @@ fOv
 vre
 lcF
 lJA
-eLr
-eLr
-eLr
-ciM
-eLr
-ayr
-dxe
-eLr
+nst
+nst
+nst
+oiK
+nst
+oeX
+twi
+ayB
 eLr
 iCO
 cVj
@@ -116249,15 +116882,15 @@ naL
 vys
 nYj
 duF
-ojK
-itA
-pte
-uGK
-ijA
-wnr
-vcI
-qad
-uEE
+ger
+kAh
+uGq
+qzi
+krx
+mCt
+aRU
+rNb
+eoH
 ihC
 iRh
 aMT
@@ -116282,9 +116915,9 @@ mbE
 mbE
 mbE
 tMF
-nZV
-ivK
-erD
+abK
+asP
+lTo
 rwJ
 aWM
 iqt
@@ -116506,15 +117139,15 @@ naL
 wur
 uau
 duF
-rHH
-cWO
+qdU
+hOs
 qzU
 nRs
 iRh
 wvD
 eEV
 hig
-iSC
+yam
 hpD
 iRh
 aMT
@@ -116771,7 +117404,7 @@ iRh
 tbi
 kVs
 pgn
-pOK
+vkw
 vxp
 sUf
 anT

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -1519,13 +1519,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aqr" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqt" = (
@@ -3791,6 +3788,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"aSY" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aTc" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -5803,14 +5810,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"bCb" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bCh" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/stripes/line,
@@ -7030,12 +7029,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
-"bVy" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "bVz" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat AI Access";
@@ -13846,9 +13839,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "epK" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/hallway/primary/fore)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "epT" = (
 /obj/machinery/light{
 	dir = 1
@@ -20412,16 +20409,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"gBl" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gBm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -21135,12 +21122,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gMF" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "gMV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -28294,9 +28281,23 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jcG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -35879,27 +35880,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"lJo" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lJq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -43583,15 +43563,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "obn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/hallway/primary/fore)
 "obB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44368,6 +44342,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"opD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "opS" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/drone,
@@ -44383,6 +44367,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"oqd" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "oqj" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner{
@@ -50871,13 +50865,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qBc" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qBd" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -52953,16 +52940,6 @@
 	dir = 6
 	},
 /area/chapel/main/monastery)
-"riw" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "riE" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -58406,8 +58383,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "sVT" = (
-/turf/open/space/basic,
-/area/engine/atmospherics_engine)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "sVU" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -58504,6 +58484,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sYb" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sYe" = (
 /obj/machinery/light{
 	dir = 4
@@ -64923,6 +64914,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"vgk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "vgx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70709,6 +70707,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xcp" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xdj" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -73548,17 +73556,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"xYn" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "xYC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -98964,9 +98961,9 @@ aMT
 aMT
 jxO
 jxO
-epK
+obn
 wLX
-epK
+obn
 orw
 cWH
 mvn
@@ -99447,7 +99444,7 @@ aMT
 aMT
 aMT
 aMT
-sVT
+aMT
 aMT
 aMT
 aMT
@@ -101020,9 +101017,9 @@ aMT
 aMT
 jxO
 jxO
-epK
+obn
 dLB
-epK
+obn
 udH
 kVl
 qno
@@ -102876,7 +102873,7 @@ hZO
 bOW
 qqf
 vBK
-bVy
+sVT
 vKb
 iCv
 eey
@@ -103647,7 +103644,7 @@ qvj
 kMZ
 cah
 nAV
-bVy
+sVT
 bpq
 anz
 qQo
@@ -103904,7 +103901,7 @@ teE
 mbl
 cah
 fYh
-bVy
+sVT
 bpq
 anz
 opS
@@ -104653,7 +104650,7 @@ jHI
 dQx
 fAL
 lpb
-obn
+oqd
 cft
 mif
 eAm
@@ -113869,7 +113866,7 @@ duF
 qIa
 vVU
 nTY
-jcG
+aqr
 hmy
 dpB
 amM
@@ -114148,7 +114145,7 @@ sXL
 wtJ
 bQp
 hwc
-gBl
+xcp
 fRR
 lRh
 aer
@@ -114383,9 +114380,9 @@ nwA
 bRD
 mHW
 pek
-bCb
+epK
 hmy
-aqr
+opD
 sgY
 lJV
 hmy
@@ -114423,7 +114420,7 @@ qPa
 qBd
 wKH
 vov
-xYn
+sYb
 sVw
 afM
 cdX
@@ -114674,8 +114671,8 @@ aIt
 aIt
 eZE
 avM
-riw
-qBc
+aSY
+gMF
 xzF
 gHq
 kgL
@@ -115923,7 +115920,7 @@ feb
 hfz
 duF
 rDK
-lJo
+jcG
 hmy
 xtv
 oQB
@@ -117465,8 +117462,8 @@ naL
 naL
 duF
 duF
-gMF
-gMF
+vgk
+vgk
 duF
 iRh
 tbi

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -614,6 +614,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"afs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "afz" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -1522,13 +1529,12 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aqr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aqt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7733,13 +7739,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"cii" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "cir" = (
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
@@ -8484,7 +8483,7 @@
 	id = "laborcamp_home";
 	name = "laborcamp shuttle dock";
 	roundstart_template = /datum/map_template/shuttle/labour/corg;
-	width = 7
+	width = 8
 	},
 /turf/open/space/basic,
 /area/space)
@@ -10147,6 +10146,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"ddy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ddN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11517,19 +11526,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
-"dBG" = (
-/obj/machinery/light/small/broken{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"dBI" = (
+"dBg" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dBG" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dBL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11623,12 +11632,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/security/warden)
-"dDz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "dDH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -11948,6 +11951,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"dIt" = (
+/obj/structure/sign/directions/security{
+	dir = 1
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_y = -8
+	},
+/turf/closed/wall,
+/area/hallway/primary/starboard)
 "dIv" = (
 /turf/closed/wall,
 /area/quartermaster/office)
@@ -12885,16 +12901,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
-"dYX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "dYZ" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/structure/disposalpipe/segment{
@@ -15642,6 +15648,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"eXN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "eYb" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/poppy/lily,
@@ -19610,19 +19622,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"gnJ" = (
-/obj/structure/sign/directions/security{
-	dir = 1
-	},
-/obj/structure/sign/directions/evac{
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/command{
-	dir = 1;
-	pixel_y = -8
-	},
-/turf/closed/wall,
-/area/hallway/primary/starboard)
 "gnK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -21793,6 +21792,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gXh" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "gXl" = (
 /obj/machinery/light_switch{
 	pixel_x = -25
@@ -25871,17 +25881,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ioJ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ioQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -26232,13 +26231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
-"ito" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "itu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27126,6 +27118,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"iIj" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "iIv" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -28912,6 +28919,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jqm" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jqo" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -32971,27 +32988,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"kLh" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kLm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34983,13 +34979,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"luf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "luj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -40330,6 +40319,21 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"naC" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "naE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -42336,10 +42340,20 @@
 /area/bridge)
 "nIH" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking{
+	pixel_y = -32
+	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("aisat")
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -44236,6 +44250,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"omq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "oms" = (
 /obj/machinery/light_switch{
 	pixel_x = -25;
@@ -45899,6 +45932,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"oPD" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "oPJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white,
@@ -47740,6 +47783,16 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
+"pzk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "pzl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -48846,25 +48899,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"pRv" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/sign/warning/docking{
-	pixel_y = -32
-	},
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("aisat")
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "pRx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54431,16 +54465,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"rFP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "rFR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/siding/wood,
@@ -58470,24 +58494,26 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "sVT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "sVU" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -58867,21 +58893,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"tdr" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tdR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -58999,6 +59010,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
+"tgc" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tgs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59996,21 +60020,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"tAQ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/sign/warning/docking{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tBb" = (
 /obj/structure/marker_beacon,
 /turf/open/floor/plating/airless,
@@ -66415,19 +66424,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"vAU" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "vBf" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -68699,16 +68695,6 @@
 "woR" = (
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
-"wpa" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "wpg" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -71057,6 +71043,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xhe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xhq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72913,6 +72907,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"xLU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xMf" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -72963,16 +72964,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/warden)
-"xNp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xNy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -74196,6 +74187,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"yix" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "yiZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -103014,7 +103014,7 @@ hZO
 bOW
 qqf
 vBK
-dDz
+eXN
 vKb
 iCv
 eey
@@ -103785,7 +103785,7 @@ qvj
 kMZ
 cah
 nAV
-dDz
+eXN
 bpq
 anz
 qQo
@@ -104042,7 +104042,7 @@ teE
 mbl
 cah
 fYh
-dDz
+eXN
 bpq
 anz
 opS
@@ -104791,7 +104791,7 @@ jHI
 dQx
 fAL
 lpb
-dYX
+pzk
 cft
 mif
 eAm
@@ -105587,7 +105587,7 @@ lxe
 eJK
 eJK
 uMr
-lxe
+eJK
 nYH
 hzU
 fKx
@@ -111473,9 +111473,9 @@ sRa
 xyq
 xVp
 qac
-nIH
+yix
 vjo
-vAU
+tgc
 qac
 qac
 jzx
@@ -112243,12 +112243,12 @@ hmy
 hmy
 duF
 tdf
-tdr
+naC
 gnj
 gnj
 iaU
 gnj
-gnJ
+dIt
 gnj
 iaU
 gnj
@@ -112500,7 +112500,7 @@ uWc
 sRa
 xyq
 tdf
-tAQ
+iIj
 gnj
 aMT
 aMT
@@ -113528,7 +113528,7 @@ uWc
 sRa
 xyq
 tdf
-pRv
+nIH
 gnj
 aMT
 aMT
@@ -113538,7 +113538,7 @@ cxY
 aMT
 aMT
 gnj
-sVT
+omq
 tSC
 esi
 iDL
@@ -114007,7 +114007,7 @@ duF
 qIa
 vVU
 nTY
-cii
+xLU
 hmy
 dpB
 amM
@@ -114286,7 +114286,7 @@ sXL
 wtJ
 bQp
 hwc
-xNp
+jqm
 fRR
 lRh
 aer
@@ -114521,9 +114521,9 @@ nwA
 bRD
 mHW
 pek
-aqr
+xhe
 hmy
-rFP
+ddy
 sgY
 lJV
 hmy
@@ -114563,7 +114563,7 @@ wKH
 vov
 afM
 sVw
-ioJ
+gXh
 cdX
 fkM
 sqh
@@ -114812,8 +114812,8 @@ aIt
 aIt
 eZE
 avM
-wpa
-ito
+oPD
+aqr
 xzF
 gHq
 kgL
@@ -115076,7 +115076,7 @@ jWm
 vLi
 aCN
 kQI
-dBI
+dBg
 ieI
 gPc
 kEB
@@ -116061,7 +116061,7 @@ feb
 hfz
 duF
 rDK
-kLh
+sVT
 hmy
 xtv
 oQB
@@ -117603,8 +117603,8 @@ naL
 naL
 duF
 duF
-luf
-luf
+afs
+afs
 duF
 iRh
 tbi

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -556,6 +556,15 @@
 /obj/effect/spawner/lootdrop/job_scale/medical/medkits,
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"aeB" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "aeC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1037,6 +1046,19 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"ajN" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ajO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -1471,6 +1493,16 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"aqr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aqt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -1496,6 +1528,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"aqN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "aqT" = (
 /obj/structure/chair{
 	dir = 4
@@ -2268,6 +2309,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"aBY" = (
+/obj/item/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aCa" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 4
@@ -2339,6 +2394,16 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"aCN" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aCQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -4190,6 +4255,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/science/test_area)
+"aXL" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "aXM" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -4450,6 +4526,22 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
+"bdm" = (
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "bdw" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -4502,6 +4594,15 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
+"beH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "beW" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -4830,6 +4931,21 @@
 	},
 /turf/open/floor/wood,
 /area/bridge)
+"bjv" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bjA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -4891,6 +5007,16 @@
 	dir = 5
 	},
 /area/chapel/main/monastery)
+"bkv" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "bkH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
@@ -5146,6 +5272,13 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/maintenance/port)
+"bpZ" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "bql" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -5250,6 +5383,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bsc" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Interrogation room";
+	dir = 4;
+	network = list("interrogation")
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bse" = (
 /obj/structure/chair/fancy/sofa/old/left,
 /obj/effect/landmark/start/assistant,
@@ -5323,6 +5468,13 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
+"buo" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "buq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5614,6 +5766,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"byP" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "byS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -5770,6 +5936,18 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"bBE" = (
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/job_scale/medical/medkits,
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "bBL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -5965,6 +6143,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"bFY" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/fork,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "bGh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -6637,6 +6824,21 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"bPO" = (
+/obj/structure/table/reinforced,
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
+/obj/machinery/light_switch{
+	pixel_x = 1;
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "bPU" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
@@ -6668,6 +6870,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"bQr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bQz" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
@@ -6681,6 +6890,22 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bQG" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Head of Security";
+	req_access_txt = "58"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hos)
+"bQL" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bQO" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/tile/yellow{
@@ -7125,6 +7350,21 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/central)
+"bZF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bZH" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes,
@@ -7388,6 +7628,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"cdX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ceb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7739,6 +7992,19 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"clb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "clk" = (
 /obj/machinery/light_switch{
 	pixel_x = -25;
@@ -7995,6 +8261,13 @@
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"cpB" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cpR" = (
 /obj/structure/curtain{
 	layer = 4.5
@@ -8022,6 +8295,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cra" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cri" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -8176,6 +8456,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"ctM" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cue" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
@@ -8303,6 +8587,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cwI" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "cwS" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -8553,6 +8843,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"cBy" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/wheat,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cBC" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -8643,6 +8942,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cCv" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cCA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -8946,6 +9257,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"cKb" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "cKt" = (
 /obj/structure/sink{
 	dir = 8;
@@ -9024,6 +9353,17 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"cLi" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -14;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "cLm" = (
 /obj/structure/table/reinforced,
 /obj/item/coin/arcade_token,
@@ -9203,6 +9543,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"cOM" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "cOV" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -9630,6 +9978,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
+"cWx" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "cWA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -9655,6 +10009,18 @@
 "cWM" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
+"cWO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cWW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9885,6 +10251,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dcg" = (
+/obj/machinery/computer/security/hos{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "dcn" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -10960,6 +11339,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"drK" = (
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dsb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -11186,6 +11572,18 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/secondary)
+"dwD" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/dark/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dwN" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -11363,6 +11761,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"dzf" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"dzs" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "dzt" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
@@ -11527,6 +11950,16 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"dDa" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Brig Control Desk";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "dDe" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
@@ -11605,6 +12038,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dEE" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dEK" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/computer/security/telescreen{
@@ -12040,6 +12483,15 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dLh" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dLv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -12835,6 +13287,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dZm" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Shower";
+	dir = 9;
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "dZs" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
@@ -12868,6 +13334,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"dZW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eag" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -12960,6 +13438,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"eaE" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "eaG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13055,6 +13539,17 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"ecE" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ecP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -13404,6 +13899,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"ehI" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"ehT" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ehX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13749,6 +14254,13 @@
 /obj/machinery/advanced_airlock_controller/directional/east,
 /turf/open/floor/plating,
 /area/medical/virology)
+"ent" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/job_scale/armoury/laser_gun,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "enz" = (
 /obj/machinery/door/airlock/external{
 	name = "Transport Airlock"
@@ -13916,6 +14428,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
+"eqJ" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "eqV" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -14210,6 +14732,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"ewT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ewZ" = (
 /obj/machinery/requests_console{
 	department = "Botany";
@@ -14375,10 +14906,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"eyC" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/qm{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "eyN" = (
 /obj/machinery/telecomms/server/presets/science,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"eyU" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ezg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14665,6 +15220,20 @@
 /obj/effect/turf_decal/siding/wood/end,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"eDI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
+/obj/structure/desk_bell{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "eDP" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -14961,6 +15530,16 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eKw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eKL" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/yellow{
@@ -15266,6 +15845,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ePW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "eQl" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
@@ -15554,6 +16142,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"eVO" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "eVW" = (
 /obj/machinery/door/airlock{
 	name = "Bar Bedroom";
@@ -15984,6 +16582,13 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fdr" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fdx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/delivery,
@@ -16067,6 +16672,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
+"fex" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "feP" = (
 /obj/machinery/computer/security/wooden_tv{
 	pixel_x = 1;
@@ -16622,6 +17234,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"fnz" = (
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/supply)
 "fod" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -17473,6 +18095,15 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics)
+"fCx" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "fCz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -17554,6 +18185,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"fFa" = (
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fFq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17743,6 +18379,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"fHW" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fId" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -17802,6 +18445,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"fJe" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "fJw" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -18095,6 +18747,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"fNy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fNA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18422,6 +19083,13 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fRY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fSz" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -18611,6 +19279,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"fWT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "fXv" = (
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
@@ -18950,6 +19630,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"gbT" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gbY" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air Inlet Pump";
@@ -19548,6 +20233,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"gmN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "gmQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -19717,6 +20413,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"gpE" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/cards/deck,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "gpF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -20003,6 +20707,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"guv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "guH" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -20137,6 +20857,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gxo" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gxs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20383,6 +21113,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"gAx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "gAI" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -20580,6 +21319,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"gDT" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall12";
+	location = "hall10"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "gEb" = (
 /obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -21024,6 +21771,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"gKY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "gLf" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Thermoelectric Generator";
@@ -21584,6 +22339,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"gTB" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"gTG" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gTH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -21705,6 +22479,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gVK" = (
+/obj/item/beacon,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "gVV" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/structure/table/wood,
@@ -21801,6 +22585,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"gXr" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "gXA" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -22177,6 +22968,15 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/theatre)
+"hek" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "heC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -22187,6 +22987,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"heM" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "heQ" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -22276,6 +23085,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"hfz" = (
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "hgm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -22348,6 +23166,14 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
+"hhi" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "hhn" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/turf_decal/tile/red{
@@ -22401,6 +23227,17 @@
 	},
 /turf/open/floor/noslip/dark,
 /area/engine/engineering)
+"hig" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/baton/loaded,
+/obj/item/restraints/handcuffs,
+/obj/item/storage/secure/briefcase,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "hiu" = (
 /obj/structure/chair{
 	dir = 8
@@ -22539,6 +23376,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"hkQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hlf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -22831,6 +23678,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"hpD" = (
+/obj/machinery/light,
+/obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "hpQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -23039,6 +23895,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"htG" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/medical/medbay/lobby)
 "htN" = (
 /obj/machinery/modular_fabricator/exosuit_fab,
 /obj/effect/turf_decal/bot,
@@ -23250,6 +24117,15 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/science/shuttle)
+"hxx" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "hxC" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -23433,6 +24309,12 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
+"hAA" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hAD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23458,6 +24340,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"hBg" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Kill Chamber";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "hBh" = (
 /obj/machinery/light{
 	dir = 4
@@ -24095,6 +24989,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hMB" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/structure/weightmachine/weightlifter,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hMH" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -24420,6 +25328,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"hSn" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hSo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -24933,6 +25850,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"hZN" = (
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hZO" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -25238,6 +26168,19 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ieK" = (
+/obj/structure/chair,
+/obj/item/radio/intercom{
+	frequency = 1423;
+	name = "Interrogation Intercom";
+	pixel_x = -28
+	},
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ifc" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
@@ -25369,6 +26312,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
+"ihC" = (
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/mob/living/simple_animal/hostile/carp/cayenne{
+	desc = "A failed experiment of Nanotrasen to create weaponised carp technology. This less than intimidating carp now serves as an authority figure's pet.";
+	health = 200;
+	icon_dead = "magicarp_dead";
+	icon_gib = "magicarp_gib";
+	icon_living = "magicarp";
+	icon_state = "magicarp";
+	maxHealth = 200;
+	name = "Lia"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "ihJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -25437,6 +26401,17 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ijc" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/kitchen/knife/combat/bone,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ijf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25527,6 +26502,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
+"ikY" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iln" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -25695,6 +26678,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"ior" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iot" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26139,6 +27131,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"iuB" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iuM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -26522,6 +27518,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
+"iBM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iBO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26887,6 +27892,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"iHZ" = (
+/obj/effect/landmark/start/head_of_security,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "iIe" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -27456,6 +28466,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"iSq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "iSx" = (
 /obj/machinery/button/door{
 	id = "secmain";
@@ -27521,6 +28546,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iUa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iUk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
 	dir = 4
@@ -27822,6 +28858,14 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
+"iZu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "iZH" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -28301,6 +29345,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"jhz" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "jhD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -28324,6 +29373,15 @@
 	},
 /turf/open/floor/plating,
 /area/medical/medbay/aft)
+"jif" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/seeds/tea,
+/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jin" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -28395,6 +29453,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"jjv" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/item/taperecorder,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jjx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28583,6 +29650,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"jnq" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jnD" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -29122,6 +30199,11 @@
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"jxw" = (
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "jxO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29223,6 +30305,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/central)
+"jzX" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jzY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29254,6 +30343,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"jAj" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "jAp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29347,6 +30444,12 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"jBR" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jBS" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
@@ -29422,6 +30525,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"jDl" = (
+/obj/machinery/holopad{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jDv" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/displaycase,
@@ -29516,6 +30628,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"jEM" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jEZ" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -29666,6 +30786,19 @@
 "jGG" = (
 /turf/closed/wall,
 /area/science/robotics)
+"jGM" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jGQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -30103,6 +31236,21 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"jOI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jOL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -30526,6 +31674,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"jVB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "jVV" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -30715,6 +31875,17 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"jYd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jYg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -30758,6 +31929,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jZh" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jZm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -30852,6 +32032,24 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"kad" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kan" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/tile/red,
@@ -30919,6 +32117,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/surgery)
+"kcc" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kco" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -30990,6 +32200,18 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"kdY" = (
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	pixel_y = -32
+	},
+/obj/machinery/vending/security,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "keg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31205,6 +32427,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
+"khK" = (
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "kih" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Panel Airlock";
@@ -31825,6 +33055,11 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"ksr" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ksC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
@@ -31906,6 +33141,15 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"ktU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kub" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32058,6 +33302,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"kvB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kvG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -32303,6 +33559,19 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kyF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kyP" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -32439,6 +33708,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kCn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kCx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -32668,6 +33948,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kEU" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "kEY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -33165,6 +34449,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"kOD" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Distro to Waste"
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kOS" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -33641,6 +34940,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kXF" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "kXP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -34459,6 +35776,17 @@
 	},
 /turf/open/floor/carpet/green,
 /area/library)
+"llX" = (
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "llY" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/dress/skirt/blue,
@@ -34932,6 +36260,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lub" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "luc" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -35123,6 +36464,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lwX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lxe" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -35215,6 +36572,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
+"lxP" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lya" = (
 /obj/machinery/light,
 /obj/machinery/firealarm/directional/west,
@@ -35536,6 +36901,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
+"lCD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "lCJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -35606,6 +36986,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"lDV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Cargo Window";
+	pixel_y = 1;
+	req_access_txt = "31"
+	},
+/obj/structure/desk_bell{
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "lEl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -35693,6 +37089,18 @@
 "lGb" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"lGd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lGe" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -35857,6 +37265,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"lHW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lIe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35971,6 +37388,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"lJU" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lJV" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
@@ -36085,6 +37509,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"lLK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lLS" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -36108,6 +37545,19 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"lMm" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lMt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -36237,6 +37687,25 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"lOG" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1423;
+	listening = 0;
+	name = "Interrogation Intercom";
+	pixel_x = 29
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -36538,6 +38007,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"lTk" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lTv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -37468,6 +38942,13 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/engine/cult,
 /area/library)
+"mhz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mif" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
@@ -37631,6 +39112,15 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"mjN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mjV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38224,12 +39714,56 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"mso" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"msu" = (
+/obj/machinery/button/ignition{
+	pixel_x = 4;
+	pixel_y = 27
+	},
+/obj/machinery/button/door{
+	desc = "Welcome to your new life, employee.";
+	id = "deathdoor";
+	name = "Transfer Switch";
+	pixel_x = -6;
+	pixel_y = 27
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "msv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"msz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/table,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "msC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -38255,6 +39789,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"msO" = (
+/obj/structure/table/glass,
+/obj/machinery/door/window/eastleft{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/effect/spawner/lootdrop/job_scale/medical/medkits,
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "msT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable/yellow{
@@ -38320,6 +39865,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"mth" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -25
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "mtj" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -38524,6 +40080,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mwP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/item/wrench,
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "mwV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -38604,6 +40173,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mxB" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "mxF" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -38619,6 +40194,18 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port)
+"mxI" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "mxX" = (
 /turf/closed/wall,
 /area/science/xenobiology)
@@ -38786,6 +40373,13 @@
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"mBT" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mBU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -39094,6 +40688,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mGe" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28;
+	prison_radio = 1
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "mGf" = (
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
@@ -39125,6 +40733,24 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"mGW" = (
+/obj/machinery/button/door{
+	id = "permacell2";
+	name = "Cell 1 Lockdown";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "PCell 2";
+	pixel_x = 6;
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mHb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 1
@@ -39138,6 +40764,16 @@
 "mHr" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
+"mHw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mHK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -39167,6 +40803,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/secondary)
+"mIH" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	sortType = 15
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "mIU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -39289,6 +40944,18 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"mLp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mLt" = (
 /obj/structure/table/reinforced,
 /obj/item/nanite_remote,
@@ -39325,6 +40992,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"mLX" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mLY" = (
 /turf/closed/wall,
 /area/science/research)
@@ -39481,6 +41160,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"mNF" = (
+/obj/structure/table/reinforced,
+/obj/item/pickaxe/mini,
+/obj/item/pickaxe/mini,
+/obj/item/storage/bag/ore,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mNH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall6";
@@ -39579,6 +41267,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"mPj" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "mPm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -39605,6 +41303,18 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/carpet/green,
 /area/library)
+"mQd" = (
+/obj/machinery/requests_console{
+	pixel_x = -32
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/balaclava,
+/obj/item/reagent_containers/syringe,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "mQi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -39684,6 +41394,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"mSg" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"mSq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "mSH" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -39768,6 +41495,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"mTx" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "mTz" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
@@ -40084,6 +41816,18 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"mZo" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "mZD" = (
 /obj/machinery/rnd/server,
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -40138,6 +41882,21 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"naw" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "naE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -40528,6 +42287,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"ngN" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ngU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -40562,6 +42329,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nhn" = (
+/obj/machinery/camera{
+	c_tag = "Prison Toilet";
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "nho" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -40639,6 +42416,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"niF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "njl" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/structure/cable{
@@ -40779,6 +42568,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nms" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "nne" = (
 /obj/machinery/door/airlock/external{
 	name = "Exploration Shuttle Bay"
@@ -41064,6 +42864,21 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
+"nrr" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
+"nrw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "nrH" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Break Room";
@@ -41179,6 +42994,15 @@
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"nto" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ntF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41402,6 +43226,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
+"nyc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "nym" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41711,6 +43544,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"nBt" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "nBB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -41865,6 +43710,23 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"nFr" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "nFy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42006,6 +43868,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"nIe" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nIl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -42134,6 +44009,14 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"nJT" = (
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "nJZ" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -42713,6 +44596,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"nRs" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nRF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -42838,6 +44726,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"nTD" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nTO" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/red{
@@ -42896,6 +44794,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nUQ" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "nUY" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -43095,6 +45002,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"nYj" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "nYw" = (
 /obj/machinery/conveyor{
 	id = "recycling"
@@ -43214,6 +45131,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"oaA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "oaB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43706,6 +45632,16 @@
 "ojH" = (
 /turf/closed/wall,
 /area/engine/engine_room)
+"ojK" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ojP" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -43891,6 +45827,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"onh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "onl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -44004,6 +45948,18 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"opd" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oph" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -44282,6 +46238,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"otJ" = (
+/obj/structure/table/reinforced,
+/obj/item/coin/antagtoken,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "otM" = (
 /obj/effect/spawner/room/threexfive,
 /turf/open/floor/plating,
@@ -44390,6 +46355,28 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"owj" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
+"owH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "owJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -44822,6 +46809,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oBY" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oCo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -44955,6 +46946,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"oEb" = (
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oEe" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L3"
@@ -45015,6 +47018,16 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"oEY" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oFb" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -45107,11 +47120,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"oGs" = (
+/obj/structure/table,
+/obj/item/storage/lockbox/loyalty,
+/obj/item/radio,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "oGx" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
+"oGH" = (
+/obj/structure/closet/secure_closet/injection,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oGN" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -45150,6 +47183,18 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"oHg" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"oHv" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "oHE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -45616,6 +47661,19 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"oQu" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oQx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -46043,6 +48101,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"oYY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall10";
+	location = "hall9"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "oZk" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/disposalpipe/segment,
@@ -46136,6 +48202,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"pbI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "pbP" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/telecomms/server,
@@ -46345,6 +48421,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/storage)
+"pgn" = (
+/obj/machinery/computer/card/minor/hos{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "pgq" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -46366,6 +48450,13 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"phc" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "phh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -46583,6 +48674,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"pjQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "pjT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -46689,6 +48792,22 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"pmz" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pmF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pmQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/vending/engivend,
@@ -46741,6 +48860,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"poV" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ppd" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -47282,6 +49411,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"pxv" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/chef_recipes,
+/obj/item/kitchen/rollingpin,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "pxI" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "dorm1"
@@ -47388,6 +49526,16 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
+"pzl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "pzm" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -47794,6 +49942,18 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pFC" = (
+/obj/structure/table/glass,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/effect/spawner/lootdrop/job_scale/medical/medkits,
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "pFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -48154,6 +50314,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"pLn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pLz" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -48597,6 +50766,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"pSQ" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "pTe" = (
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
@@ -49109,6 +51285,24 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"qba" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "qbO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50328,6 +52522,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
+"qve" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qvj" = (
 /obj/effect/landmark/start/research_director,
 /obj/structure/cable/yellow{
@@ -50571,6 +52772,13 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"qzU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qAf" = (
 /obj/structure/rack{
 	pixel_y = -3
@@ -50610,6 +52818,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qAF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "qAG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -50775,6 +52993,27 @@
 /obj/machinery/suit_storage_unit/exploration,
 /turf/open/floor/plasteel/white,
 /area/quartermaster/exploration_prep)
+"qCz" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "HOS's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_x = 32
+	},
+/obj/structure/bed/pod,
+/obj/item/bedsheet/hos,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/item/storage/secure/safe/HoS{
+	pixel_x = 37;
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "qCK" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -50899,6 +53138,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"qEw" = (
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "qEz" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51104,6 +53350,10 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qId" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qIg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -51142,6 +53392,15 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"qIY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qIZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -51460,6 +53719,13 @@
 "qOk" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
+"qOm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qOq" = (
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -51470,6 +53736,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qOG" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "qOJ" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -51938,6 +54211,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qYc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qYd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/disposal/bin,
@@ -52231,6 +54514,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"rcQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "rcV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
@@ -52712,6 +55005,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"rkf" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Medical";
+	req_access_txt = "34"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "rki" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52790,6 +55099,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rlw" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/restraints/legcuffs/bola/energy,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/storage/box/prisoner,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "rlK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52888,6 +55211,28 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
+"rnf" = (
+/obj/structure/closet/secure_closet/hos,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch.";
+	id = "hosoffice";
+	name = "Head of Security's Office Shutters";
+	pixel_x = -26
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "rnn" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -52936,6 +55281,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"rnG" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rnW" = (
 /mob/living/simple_animal/pet/dog/pug,
 /turf/open/floor/engine,
@@ -52946,6 +55301,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"roq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "rou" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -53180,6 +55544,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
+"rrp" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "rrx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -53851,6 +56224,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"rEi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rEt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -54120,6 +56502,16 @@
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
+"rHH" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rHV" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -54137,6 +56529,20 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"rHY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/weightmachine/stacklifter,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rIv" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
@@ -54616,6 +57022,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"rPZ" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/hand_labeler,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "rQb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54633,6 +57052,14 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"rQp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "rQz" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -54852,6 +57279,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"rTW" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rTY" = (
 /obj/structure/sink{
 	dir = 4;
@@ -55011,6 +57445,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"rWp" = (
+/obj/item/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rXb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55095,6 +57540,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rXS" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "rYf" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -55269,6 +57724,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
+"saL" = (
+/obj/machinery/door/airlock{
+	name = "Toilet Unit"
+	},
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "saT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55594,6 +58056,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
+"sfS" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/warden)
 "sgi" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -55656,6 +58125,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"shz" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "shJ" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
@@ -55674,6 +58155,18 @@
 /obj/structure/transit_tube/diagonal/crossing/topleft,
 /turf/open/space/basic,
 /area/space)
+"sib" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sig" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -55684,6 +58177,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"sio" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/radio,
+/obj/item/radio/intercom{
+	pixel_x = -29;
+	pixel_y = -29
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/supply)
 "sir" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55745,6 +58256,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"sjC" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sjD" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -56401,6 +58918,25 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"suq" = (
+/obj/machinery/vending/hydroseeds,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sut" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -56614,6 +59150,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"syx" = (
+/obj/machinery/photocopier,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "syA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -56633,6 +59178,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_prep)
+"syZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "sze" = (
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -57891,6 +60448,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/research)
+"sVq" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "sVv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/crate/freezer/blood,
@@ -58078,6 +60641,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"sZe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "sZh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -58209,6 +60781,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"tbe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"tbi" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "tbj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/firealarm{
@@ -58313,6 +60904,12 @@
 "tdY" = (
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
+"ted" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "teD" = (
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
@@ -58388,6 +60985,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"tfC" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "tfH" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -58415,6 +61019,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
+"tfY" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "tgs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -58456,6 +61066,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"tgT" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall15";
+	location = "hall14"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tgX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -58557,6 +61178,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"tiy" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tiJ" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -58802,6 +61429,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"toH" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/job_scale/armoury/disabler,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "toN" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -58918,6 +61552,16 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tre" = (
+/obj/machinery/requests_console{
+	pixel_y = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/supply)
 "trf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -59214,6 +61858,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"txw" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "txB" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/firealarm{
@@ -59406,6 +62059,15 @@
 /obj/structure/marker_beacon,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"tBd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tBk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -59513,6 +62175,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tCO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tCR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59755,6 +62427,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tFU" = (
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "tFX" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
@@ -59784,6 +62460,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"tGP" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/seeds/sugarcane,
+/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tHs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59936,6 +62618,21 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tKc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "tKh" = (
 /obj/item/bedsheet/mime,
 /obj/structure/bed,
@@ -60178,6 +62875,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"tNU" = (
+/obj/machinery/computer/security/hos{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -5;
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "tNW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -60245,6 +62954,18 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/relay)
+"tPa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tPm" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -60252,6 +62973,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tPz" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"tPB" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tPO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -60289,6 +63029,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tQi" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light_switch{
+	pixel_x = 1;
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "tQE" = (
 /obj/machinery/rnd/production/protolathe/department/service,
 /turf/open/floor/plasteel,
@@ -60593,6 +63345,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"tWA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera{
+	c_tag = "Prison Main South";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "tWI" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -60625,6 +63392,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"tXe" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "tXf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
@@ -60816,6 +63595,13 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"uau" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "uax" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -60941,6 +63727,15 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
+/area/security/brig)
+"uci" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uco" = (
 /obj/effect/turf_decal/stripes/line,
@@ -61174,6 +63969,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ufp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ufq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61263,6 +64068,13 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
+"uhp" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uhq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -61376,6 +64188,15 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"ujv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ujE" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/roboticist,
@@ -61686,6 +64507,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"uof" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/command)
 "uoj" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname,
@@ -61773,6 +64608,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uoZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "upa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -61971,6 +64815,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"usn" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "usA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -62035,6 +64889,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"uui" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "uuu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62445,6 +65313,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"uBk" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "uBo" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -62802,6 +65679,18 @@
 "uGg" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
+"uGk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uGL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -63067,6 +65956,12 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"uKd" = (
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uKr" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -63269,6 +66164,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"uMT" = (
+/obj/structure/table,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "uMY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -63534,6 +66440,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"uRG" = (
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uRO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -63584,6 +66502,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"uTe" = (
+/obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "uTg" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/plasteel/freezer,
@@ -63799,6 +66723,20 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/security/brig)
+"uWd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uWk" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -63928,6 +66866,12 @@
 	dir = 5
 	},
 /area/science/breakroom)
+"uYI" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uYN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64271,6 +67215,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"veJ" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "veT" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
@@ -64281,6 +67231,16 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"veY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vfo" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/plasteel,
@@ -64508,6 +67468,15 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
+"vjo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vjC" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -64950,6 +67919,21 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
+"vrh" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/supply)
 "vrj" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -65038,6 +68022,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"vsJ" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vta" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -65380,6 +68370,19 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"vxp" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "vxy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -65411,6 +68414,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
+"vxE" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vxL" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
@@ -65461,6 +68470,20 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vys" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bottle/chloralhydrate,
+/obj/item/reagent_containers/glass/bottle/chloralhydrate,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 8;
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "vyv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -65799,6 +68822,15 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"vCs" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "vCt" = (
 /obj/machinery/door/airlock/external{
 	name = "Transport Airlock"
@@ -65835,6 +68867,21 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"vCO" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vDg" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -65854,6 +68901,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"vDL" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vDQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -66247,6 +69299,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"vJc" = (
+/obj/machinery/computer/card/minor/hos{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vJi" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -66413,6 +69481,24 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"vLZ" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/supply)
 "vMc" = (
 /obj/machinery/disposal/bin{
 	pixel_y = 3
@@ -66931,6 +70017,16 @@
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
+"vVK" = (
+/obj/structure/chair,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vVR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
@@ -67267,6 +70363,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"wcn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wct" = (
 /obj/machinery/vending/custom{
 	pixel_x = -3
@@ -67491,6 +70595,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"wgN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wgR" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
@@ -67519,6 +70633,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"whr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "whv" = (
 /obj/structure/rack{
 	pixel_x = -2
@@ -67546,6 +70670,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"wiw" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "wiA" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -67587,6 +70720,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"wiU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wiV" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/shorts/green,
@@ -67617,6 +70759,18 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"wjd" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "wjs" = (
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
@@ -68232,6 +71386,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"wur" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "wuI" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
@@ -68312,6 +71473,16 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
+"wvD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/hos,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "wvU" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/eastleft{
@@ -68451,6 +71622,14 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/customs)
+"wxW" = (
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wxY" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -68603,6 +71782,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"wAz" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wAU" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -68676,6 +71867,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"wCi" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Escape Pod Alpha"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wCt" = (
 /obj/structure/rack,
 /obj/item/clothing/neck/petcollar,
@@ -69097,6 +72295,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"wKl" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wKq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69141,6 +72346,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/lobby)
+"wKJ" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "wKN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -69593,6 +72802,13 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"wSa" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wSe" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -69706,6 +72922,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"wTM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/storage/secure/briefcase,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wUp" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/cable/yellow{
@@ -70634,6 +73863,14 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
+"xlT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "xmg" = (
 /obj/structure/table,
 /obj/item/shuttle_creator{
@@ -70650,6 +73887,13 @@
 	},
 /turf/open/floor/dock/drydock,
 /area/science/shuttle)
+"xmi" = (
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xmq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -71046,6 +74290,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"xsV" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xsZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -71079,6 +74331,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"xtd" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xte" = (
 /obj/machinery/light{
 	dir = 8
@@ -71096,6 +74353,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"xts" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "xtL" = (
 /obj/structure/railing{
 	dir = 8
@@ -71734,6 +75002,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"xDj" = (
+/obj/machinery/camera{
+	c_tag = "Prison Main North";
+	network = list("ss13","prison")
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xDD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -72878,6 +76160,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"xUU" = (
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/job_scale/medical/first_aid_kit,
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/medical/storage)
 "xUX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -73037,6 +76331,29 @@
 "xXK" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
+"xXN" = (
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"xXS" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xXY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -73417,6 +76734,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"yft" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/item/seeds/tea,
+/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "yfw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -94594,7 +97921,7 @@ umK
 vrb
 lmd
 kOj
-meS
+dwD
 aGC
 aNF
 kNC
@@ -95875,7 +99202,7 @@ aPf
 aPf
 aPf
 aPf
-keH
+ajN
 pnS
 rmN
 aaz
@@ -96132,7 +99459,7 @@ aMT
 sLb
 fcp
 csS
-lxt
+xXS
 dbq
 xrc
 mJL
@@ -96389,7 +99716,7 @@ oCW
 mBU
 fdV
 ofE
-qXq
+bZF
 xMW
 mdS
 aoM
@@ -96650,8 +99977,8 @@ aJZ
 kqo
 gdK
 bqm
-rhg
-eRe
+tPz
+mSq
 qjA
 qjA
 qjA
@@ -97932,9 +101259,9 @@ oCW
 nya
 wZA
 uwE
-mqD
-kJK
-pNb
+uWd
+kOD
+rEi
 hsK
 aPf
 aMT
@@ -98714,9 +102041,9 @@ anT
 anT
 jxO
 jXv
-ljg
-uXT
-sEE
+ktU
+fWT
+beH
 iNB
 cWH
 mlh
@@ -98971,9 +102298,9 @@ bxE
 bxE
 hmn
 gif
-xJW
+wgN
 bvI
-jNl
+hkQ
 tTV
 cWH
 cWH
@@ -99228,10 +102555,10 @@ anT
 anT
 jxO
 nXF
-wSB
+gAx
 vhl
-wlV
-kHo
+tKc
+kCn
 kWf
 iUr
 lOh
@@ -99240,7 +102567,7 @@ xAd
 xte
 csY
 csY
-xdc
+iUa
 dGP
 csY
 nNC
@@ -99485,7 +102812,7 @@ aMT
 aMT
 jxO
 hSz
-vho
+gVK
 aoU
 xRh
 iUE
@@ -99742,10 +103069,10 @@ anT
 anT
 jxO
 jXv
-wSB
+gAx
 kRQ
-eaX
-gWG
+gmN
+onh
 hmL
 wWA
 jvD
@@ -99999,9 +103326,9 @@ nFF
 nFF
 lIe
 lPF
-jCz
+pbI
 xvl
-lYG
+kyF
 jtc
 kVl
 inJ
@@ -100256,9 +103583,9 @@ anT
 anT
 jxO
 nXF
-kuk
-hlu
-sJH
+nyc
+mso
+rcQ
 mqL
 kVl
 bDH
@@ -106688,16 +110015,16 @@ aRL
 atA
 mvU
 yjK
-crW
+iSq
 iJP
-rlR
+uof
 xOZ
 xBw
 jNI
 cFt
 iCu
 mBV
-qBa
+mIH
 dbu
 bLQ
 xiP
@@ -107203,15 +110530,15 @@ atA
 yki
 pfN
 bIG
-oqF
+lCD
 tSv
 pzb
 tuK
-xCW
+naw
 oGx
 oYC
 oGx
-hai
+kXF
 dYV
 mwV
 hVG
@@ -108291,7 +111618,7 @@ lpj
 qYI
 boA
 iAr
-doA
+eDI
 sDS
 umy
 boA
@@ -109509,7 +112836,7 @@ aMT
 iZV
 dkK
 imy
-lHw
+mZo
 lXw
 sGH
 uYo
@@ -109765,8 +113092,8 @@ gds
 atz
 raq
 cdb
-tva
-brE
+wKJ
+eVO
 lXw
 oSb
 mPm
@@ -110829,15 +114156,15 @@ xyq
 xVp
 qac
 qac
-qXX
+vjo
 qac
 qac
 qac
 jzx
 ike
 lpT
-maH
-cXx
+sfj
+gNl
 jmv
 qOx
 lld
@@ -111084,7 +114411,7 @@ fSU
 iYG
 xyq
 tdf
-vuY
+oYY
 kgL
 kgL
 kgL
@@ -111094,7 +114421,7 @@ jzx
 vjJ
 hMM
 cpp
-mKU
+tgT
 cpp
 cpp
 iof
@@ -111300,12 +114627,12 @@ bhs
 anM
 duF
 duF
-dbJ
+wCi
 duF
 duF
-pOI
-aKK
-wlR
+lMm
+rlw
+fHW
 xQE
 hmy
 anT
@@ -111317,8 +114644,8 @@ aMT
 oXI
 xhX
 ipZ
-fNn
-lIw
+uTe
+toH
 vZO
 oXI
 crF
@@ -111328,7 +114655,7 @@ lbl
 lpe
 izC
 ghw
-umx
+nBt
 mrc
 tTo
 gXo
@@ -111345,13 +114672,13 @@ eRv
 ieI
 ieI
 ieI
-mmg
+hzZ
 ieI
 jzx
 mEx
 rpc
 uVk
-uJI
+tCO
 sWM
 mpX
 nIm
@@ -111557,12 +114884,12 @@ vvX
 efG
 mnB
 mug
-fKn
-riA
+vsJ
+jzX
 duF
-flw
+heM
 aIt
-qLx
+cwI
 vgb
 hmy
 sef
@@ -111574,14 +114901,14 @@ tQH
 oXI
 htD
 aae
-lXS
-fdx
+veJ
+buo
 jkd
 mdT
 sir
 ddE
-vNt
-mVY
+jVB
+lGd
 lQx
 vdg
 nyJ
@@ -111814,13 +115141,13 @@ gNo
 lBE
 esZ
 fie
-tQG
-lro
+ujv
+tBd
 skM
-lOC
-eiF
-fKn
-muO
+fNy
+uBk
+vsJ
+eyU
 hmy
 ksE
 fVD
@@ -111831,18 +115158,18 @@ aMT
 oXI
 hwK
 ipZ
-fNn
-gIX
+uTe
+ent
 jbs
 oXI
 hIC
 oXI
-wYo
-hEt
+mxI
+ecE
 tNg
 dHN
 vBE
-cGF
+sfS
 qsm
 dDl
 tch
@@ -112063,7 +115390,7 @@ anT
 uKT
 uKT
 pXe
-gis
+pmz
 pXe
 uKT
 uKT
@@ -112071,13 +115398,13 @@ uKT
 uKT
 duF
 buF
-dvx
-idg
+nrw
+mhz
 pCL
-wmg
-dJW
-aFJ
-oeX
+tPB
+uci
+bKF
+byP
 hmy
 rAb
 dka
@@ -112094,8 +115421,8 @@ dMe
 oXI
 aOu
 oXI
-eit
-eWy
+dLh
+jAj
 lpe
 mqN
 mya
@@ -112318,23 +115645,23 @@ aMT
 qBt
 aMT
 uKT
-nnB
-veG
-rXL
-xAk
-ois
-xLs
-guo
+lub
+uYI
+ewT
+iZu
+cLi
+ijc
+rQp
 uKT
 uKT
 uKT
 uKT
 uKT
 duF
-dKp
-bhN
-pim
-nan
+ehI
+uoZ
+jDl
+mNF
 hmy
 vNG
 vrV
@@ -112351,8 +115678,8 @@ oXI
 oXI
 anT
 oXI
-acn
-hsg
+wiw
+nUQ
 lpe
 hPv
 gtV
@@ -112575,23 +115902,23 @@ anT
 qBt
 anT
 vyE
-oVN
+kvB
 uNK
-jRv
-bsi
-bsi
-bsi
-bsi
+mjN
+oHv
+oHv
+oHv
+oHv
 uKT
 pRp
 sZt
 iuV
 jQz
 duF
-aGO
-jAh
-lCJ
-vAm
+mGW
+wSa
+eaE
+ikY
 hmy
 fZM
 ckG
@@ -112608,7 +115935,7 @@ oXI
 aMT
 aMT
 oXI
-elB
+bdm
 ssT
 cJf
 dgh
@@ -112616,7 +115943,7 @@ hQz
 kDl
 dxw
 rPn
-nyy
+opd
 uPQ
 sBB
 hmy
@@ -112625,7 +115952,7 @@ hmy
 hmy
 hmy
 duF
-hHM
+pmF
 uHq
 iaU
 aMT
@@ -112832,23 +116159,23 @@ aMT
 qBt
 anT
 vyE
-lUR
+rHY
 lxK
-cjA
-mTp
-ggy
-pOG
-pOG
+oEY
+pxv
+aeB
+ePW
+ePW
 bjN
 kDU
 kDU
 kDU
 kDU
 ylA
-jHm
-okc
-hdO
-tRy
+wiU
+qYc
+jBR
+oHg
 hmy
 eqX
 ckG
@@ -113089,13 +116416,13 @@ aMT
 qBt
 aMT
 uKT
-bxD
+hMB
 lxK
-cjA
-vJp
-nzL
-bsi
-pqg
+oEY
+gpE
+oaA
+oHv
+bPO
 uKT
 mJk
 tNa
@@ -113154,7 +116481,7 @@ laR
 rzc
 kxN
 iDL
-wKA
+htG
 hFG
 tCk
 ccc
@@ -113346,13 +116673,13 @@ anT
 qBt
 aHG
 uKT
-bgw
-ljA
-jHc
-jpR
-eJi
-bsi
-grc
+xDj
+ehT
+xsV
+bFY
+aXL
+oHv
+tWA
 uKT
 uKT
 uKT
@@ -113369,23 +116696,23 @@ tUH
 bKF
 hmy
 usR
-wAW
-icI
+niF
+clb
 tMp
 hmy
-wwu
-fsF
-pvo
+gTG
+tPa
+jxp
 kNI
-uRO
-sFf
+mHw
+jOI
 jxp
 vps
-mEM
-pvo
-pvo
-vbr
-pvo
+jGM
+jxp
+jxp
+eKw
+jxp
 oHT
 eeC
 qSB
@@ -113401,10 +116728,10 @@ dLA
 bwG
 gnj
 frx
-tZD
+sib
 gnj
 frx
-tZD
+sib
 gnj
 pTz
 nUE
@@ -113603,13 +116930,13 @@ aMT
 qBt
 aMT
 uKT
-hxd
-vne
-eSG
-lTR
-kEP
-vne
-wXU
+suq
+sjC
+qIY
+tGP
+jif
+sjC
+otJ
 uKT
 pRp
 pJm
@@ -113617,36 +116944,36 @@ iuV
 jQz
 duF
 lJV
-wEy
-lTY
-oph
+wSa
+bKF
+aqr
 hmy
-pAz
+wKl
 iYj
-eez
+xtd
 hmy
 frC
-kVK
-rOC
+pLn
+usn
 axR
 hmy
-kyC
+cra
 vcZ
 vcZ
 pCL
-pYy
-uce
-gci
-uce
+fdr
+qhg
+fFa
+qhg
 vcZ
-poQ
-uPF
+mBT
+rnG
 vcZ
-pYy
+fdr
 wSe
 qVf
 rwP
-pwA
+hZN
 hmy
 hmy
 hmy
@@ -113860,13 +117187,13 @@ aMT
 qBt
 anT
 vyE
-xXy
+kad
 xxK
 qUF
 xxK
 xAP
 lxK
-fwf
+hAA
 djF
 vjU
 vjU
@@ -113876,15 +117203,15 @@ xLu
 lJV
 tUH
 qwL
-lNv
+fRY
 hmy
 qwL
 exi
 lJV
 hmy
 xAZ
-nMg
-cri
+uGk
+mLp
 jTf
 hmy
 jGQ
@@ -113911,7 +117238,7 @@ eBL
 xBP
 kTC
 wod
-exZ
+gDT
 vrj
 sHZ
 qac
@@ -113919,7 +117246,7 @@ xRF
 qac
 qac
 qac
-jZD
+cdX
 fkM
 sqh
 tSC
@@ -114117,13 +117444,13 @@ anT
 qBt
 anT
 vyE
-uXP
+dZW
 lxK
 lxK
 lxK
 pCu
 lxK
-kDs
+drK
 uKT
 cFU
 tNa
@@ -114144,16 +117471,16 @@ hmy
 aIf
 hmy
 hmy
-fMJ
-dXV
+shz
+qId
 cSo
-wam
-lLS
-dFt
-wHp
-jVs
-uTp
-uKa
+cOM
+vxE
+qAF
+gTB
+fCx
+mth
+jhz
 oRA
 erD
 ivK
@@ -114374,13 +117701,13 @@ aMT
 qBt
 aMT
 uKT
-ejS
-qAq
-eIj
-cmh
-iMC
-eIj
-rFO
+oQu
+lTk
+ctM
+cBy
+yft
+ctM
+gbT
 uKT
 uKT
 uKT
@@ -114390,33 +117717,33 @@ duF
 dEv
 tUH
 ldQ
-pNM
+iBM
 qwL
 qwL
 iYj
 aIt
-nIJ
-ibI
-wMC
-qXL
+xXN
+dzf
+ior
+tUH
 bKF
 wYR
 bHm
 vcZ
 cSo
-oze
-lLS
-fgB
-uDR
-eeZ
-gyo
-jno
+rTW
+vxE
+bjv
+ufp
+syZ
+xts
+uRG
 oRA
 ivK
 ivK
 hmy
 dtI
-fZQ
+tFU
 oKx
 kWM
 hmy
@@ -114429,7 +117756,7 @@ rxo
 gnj
 jWm
 vLi
-aKy
+aCN
 kQI
 ieI
 ieI
@@ -114636,45 +117963,45 @@ uKT
 fti
 uKT
 uKT
-bJm
+saL
 uKT
 uKT
-uoA
-rhZ
-gRi
-jAA
+oGH
+mPj
+bpZ
+mQd
 duF
-vID
-kPl
+qve
+wAz
 wCB
-xoV
+qOm
 vEG
 jAg
-mUB
-aCH
+dEE
+jYd
 jAg
-fIr
-osL
-rBh
+jnq
+vEG
+veY
 jAg
 ukc
-tDh
+kcc
 vcZ
 cSo
-gqz
-lLS
-hYR
-cWA
-asI
-beW
-cbC
+ngN
+vxE
+tXe
+uhp
+nto
+bQr
+dDa
 scG
 ivK
 ivK
 hmy
 gjU
-kne
-jDD
+tfY
+qOG
 bvE
 hmy
 ivK
@@ -114682,7 +118009,7 @@ ivK
 ivK
 dAw
 vnF
-hER
+fnz
 vnF
 ePs
 dIv
@@ -114711,8 +118038,8 @@ ndt
 quz
 cap
 eJz
-cNR
-lrH
+xUU
+msO
 qrT
 ndt
 kDi
@@ -114889,20 +118216,20 @@ qBt
 anT
 anT
 uKT
-roW
-wxA
-jfU
+txw
+mxB
+hxx
 uKT
-uaZ
+nhn
 naL
-lHh
+oEb
 cWG
 gHo
 gHo
-eRO
+vCs
 duF
 lJV
-qXL
+tUH
 hmy
 hmy
 hmy
@@ -114916,21 +118243,21 @@ hmy
 pxi
 hmy
 rGg
-txB
+xmi
 cSo
-kFE
-gSy
-hYR
-suf
-asI
-kBt
-vKL
+xlT
+uKd
+tXe
+hhi
+nto
+nJT
+kdY
 fOv
 jdN
 ivK
 hmy
 bpE
-brR
+rkf
 bpE
 hmy
 hmy
@@ -114939,9 +118266,9 @@ ivK
 ivK
 apD
 vnF
-hXA
+tre
 ciw
-wtS
+sio
 qGQ
 uLr
 vWw
@@ -115146,49 +118473,49 @@ qBt
 qBt
 qBt
 uKT
-roW
+txw
 rwF
-jfU
+hxx
 uKT
-dFy
+mGe
 vpH
-xEI
+pjQ
 nYi
 nYi
 nYi
-uWk
+aqN
 dCU
-vIl
-eQV
+jAg
+mLX
 hmy
-qTW
-mqm
-jLV
-rOj
+vVK
+cCv
+tbe
+gxo
 hmy
-pUM
-tku
+ieK
+cKb
 ssj
-kOy
-hVU
+bsc
+mSg
 hmy
-kNF
+vCO
 jKY
 etB
-uqZ
-bgb
-hYR
-cWA
-asI
-uBo
-uqZ
+wcn
+wxW
+tXe
+uhp
+nto
+khK
+wcn
 fOv
 cwf
 ivK
 hmy
 uga
-kDo
-pEy
+nrr
+kEU
 clW
 hmy
 ivK
@@ -115196,7 +118523,7 @@ cUA
 hLY
 wQU
 vnF
-eYn
+vrh
 ldw
 hRG
 ftE
@@ -115204,7 +118531,7 @@ xjP
 bfS
 yfw
 nzW
-oyb
+lDV
 lEI
 rMh
 gRG
@@ -115403,17 +118730,17 @@ aMT
 aMT
 qBt
 uKT
-fQS
-dxu
-jfU
+dZm
+rXS
+hxx
 naL
 naL
 naL
-dmz
+hBg
 naL
-lkB
+msu
 gHo
-oCV
+hfz
 duF
 lJV
 tUH
@@ -115424,28 +118751,28 @@ xXK
 bWt
 pxi
 tLk
-tne
+uMT
 ssj
-oAF
-xYK
+jjv
+phc
 hmy
-lYU
+jZh
 jKY
 aUS
-lrA
-nTO
-rgB
-tOG
-rJI
-aBp
-ajD
+whr
+nms
+msz
+guv
+lwX
+lLK
+whr
 oUZ
 nst
 trr
 hmy
 sVv
-kne
-qdv
+tfY
+ted
 wNR
 hmy
 ivK
@@ -115453,7 +118780,7 @@ apD
 ivK
 ivK
 vnF
-fQk
+vLZ
 onl
 qEH
 ftE
@@ -115668,34 +118995,34 @@ pCd
 iiH
 eNA
 mqu
-wxY
+sVq
 gHo
-xdF
+cWx
 duF
 gTl
 qug
 hmy
-ydt
-ngF
-lHJ
-kDf
+hSn
+nTD
+ksr
+nIe
 hmy
-cim
-hjj
+iuB
+llX
 ssj
-vlk
-uSA
+lOG
+oBY
 hmy
 vcZ
-aSM
+vDL
 cSo
-wnA
-vEm
-aDh
-jPv
-xYi
-unc
-jYt
+mTx
+jxw
+vJc
+dcg
+wTM
+lJU
+qEw
 fOv
 ivK
 cfP
@@ -115739,8 +119066,8 @@ ndt
 uqG
 yhw
 abS
-aeA
-wvU
+bBE
+pFC
 aIr
 ndt
 qTk
@@ -115925,9 +119252,9 @@ kYc
 roQ
 vcQ
 bkH
-csa
+rrp
 wFk
-xqF
+fex
 duF
 vgI
 cgU
@@ -115946,13 +119273,13 @@ duF
 nxz
 duF
 cSo
-mZR
-crC
-aDJ
-fRC
-fjd
-crC
-mZR
+pSQ
+bQL
+poV
+iHZ
+tfC
+bQL
+pSQ
 fOv
 jdN
 cfP
@@ -116182,20 +119509,20 @@ bUs
 gHo
 biN
 mqu
-rSn
+mwP
 oJx
-vCi
+cWx
 duF
 qhg
 jin
-lxx
-gOl
+tiy
+cpB
 ohA
-jWw
-xGM
-vWy
-wGk
-lJh
+rnf
+qba
+owH
+fJe
+uui
 iRh
 aMT
 jdN
@@ -116203,13 +119530,13 @@ ivK
 ivK
 nkH
 cSo
-oAG
-gBr
-edV
-uyN
-ejo
-pHz
-kLJ
+gXr
+lxP
+aBY
+pzl
+rWp
+oGs
+eqJ
 fOv
 vre
 lcF
@@ -116440,19 +119767,19 @@ nVo
 nVo
 naL
 naL
-rWf
-lzn
+vys
+nYj
 duF
-qaA
-mkB
-jTl
-hQu
-mqa
-cSy
+ojK
+qId
+jEM
+lHW
+bQG
+hek
 kVs
-rUL
-ore
-htP
+sZe
+dzs
+ihC
 iRh
 aMT
 ivy
@@ -116697,19 +120024,19 @@ anT
 aMT
 aMT
 naL
-qkE
-hBq
+wur
+uau
 duF
-nhc
-tTD
-kDG
-iPj
+rHH
+cWO
+qzU
+nRs
 iRh
-xPR
+wvD
 eEV
-wvq
-mnY
-wPi
+hig
+nFr
+hpD
 iRh
 aMT
 jdN
@@ -116727,7 +120054,7 @@ aMT
 jdN
 eTq
 mbE
-llM
+eyC
 tXj
 pFY
 wUp
@@ -116962,11 +120289,11 @@ duF
 duF
 duF
 iRh
-fIJ
+tbi
 kVs
-nih
-qwH
-fjk
+pgn
+owj
+vxp
 sUf
 anT
 jdN
@@ -116984,7 +120311,7 @@ jdN
 jdN
 cfP
 mbE
-cCR
+syx
 dvZ
 wwY
 xsa
@@ -117219,11 +120546,11 @@ aMT
 aMT
 aMT
 iRh
-xoW
-geg
-bPX
-xHC
-vuu
+qCz
+gKY
+bkv
+wjd
+tNU
 iRh
 aMT
 jdN
@@ -117241,7 +120568,7 @@ nst
 jYG
 oUo
 mbE
-pya
+tQi
 etf
 lmg
 jGh
@@ -117498,7 +120825,7 @@ jdN
 aWM
 ofc
 mbE
-eAu
+rPZ
 vjf
 cSi
 xjB
@@ -118010,9 +121337,9 @@ oal
 cBi
 cBi
 wmD
-sKs
-uWu
-sux
+ozg
+fJL
+roq
 pno
 nSp
 pno

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -1519,11 +1519,15 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aqr" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aqt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2978,13 +2982,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aJn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "aJt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -5806,6 +5803,14 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"bCb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bCh" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/stripes/line,
@@ -7025,6 +7030,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
+"bVy" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "bVz" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat AI Access";
@@ -11509,13 +11520,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
-"dAW" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dBG" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -12085,11 +12089,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "dLB" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "dLC" = (
@@ -13846,11 +13846,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "epK" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "epT" = (
@@ -14685,6 +14681,9 @@
 	},
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -20413,6 +20412,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"gBl" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gBm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -21126,13 +21135,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gMF" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/security/brig)
 "gMV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -27767,16 +27775,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"iVI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "iVW" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
@@ -28296,13 +28294,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jcG" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jcX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -35882,6 +35879,27 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"lJo" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lJq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -43209,16 +43227,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"nWd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "nWe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -43575,13 +43583,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "obn" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel,
+/area/science/research)
 "obB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48333,17 +48343,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"pJe" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "pJf" = (
 /mob/living/simple_animal/pet/hamster/vector,
 /obj/structure/bed/dogbed/vector,
@@ -50872,6 +50871,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qBc" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qBd" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -52947,6 +52953,16 @@
 	dir = 6
 	},
 /area/chapel/main/monastery)
+"riw" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "riE" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -57337,12 +57353,16 @@
 /turf/open/floor/wood,
 /area/library)
 "sDS" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/biogenerator,
+/obj/machinery/door/window/eastleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
@@ -60297,13 +60317,6 @@
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"tHe" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tHs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60574,16 +60587,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
-"tMg" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tMm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 10
@@ -60888,16 +60891,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
-"tRd" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tRq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall22";
@@ -69797,14 +69790,10 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "wLX" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "wMg" = (
@@ -71186,27 +71175,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"xmd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xmg" = (
 /obj/structure/table,
 /obj/item/shuttle_creator{
@@ -73580,6 +73548,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"xYn" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xYC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -74159,14 +74138,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"yks" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ykK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -98993,9 +98964,9 @@ aMT
 aMT
 jxO
 jxO
-jcG
+epK
 wLX
-gMF
+epK
 orw
 cWH
 mvn
@@ -101051,7 +101022,7 @@ jxO
 jxO
 epK
 dLB
-obn
+epK
 udH
 kVl
 qno
@@ -102905,7 +102876,7 @@ hZO
 bOW
 qqf
 vBK
-aqr
+bVy
 vKb
 iCv
 eey
@@ -103676,7 +103647,7 @@ qvj
 kMZ
 cah
 nAV
-aqr
+bVy
 bpq
 anz
 qQo
@@ -103933,7 +103904,7 @@ teE
 mbl
 cah
 fYh
-aqr
+bVy
 bpq
 anz
 opS
@@ -104682,7 +104653,7 @@ jHI
 dQx
 fAL
 lpb
-nWd
+obn
 cft
 mif
 eAm
@@ -113898,7 +113869,7 @@ duF
 qIa
 vVU
 nTY
-dAW
+jcG
 hmy
 dpB
 amM
@@ -114177,7 +114148,7 @@ sXL
 wtJ
 bQp
 hwc
-tRd
+gBl
 fRR
 lRh
 aer
@@ -114412,9 +114383,9 @@ nwA
 bRD
 mHW
 pek
-yks
+bCb
 hmy
-iVI
+aqr
 sgY
 lJV
 hmy
@@ -114452,7 +114423,7 @@ qPa
 qBd
 wKH
 vov
-pJe
+xYn
 sVw
 afM
 cdX
@@ -114703,8 +114674,8 @@ aIt
 aIt
 eZE
 avM
-tMg
-tHe
+riw
+qBc
 xzF
 gHq
 kgL
@@ -115952,7 +115923,7 @@ feb
 hfz
 duF
 rDK
-xmd
+lJo
 hmy
 xtv
 oQB
@@ -117494,8 +117465,8 @@ naL
 naL
 duF
 duF
-aJn
-aJn
+gMF
+gMF
 duF
 iRh
 tbi

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -376,9 +376,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "ack" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -586,6 +584,16 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"aeH" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aeN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -957,9 +965,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aiU" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -1523,14 +1529,14 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aqr" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 1
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqt" = (
 /obj/structure/cable/yellow{
@@ -1776,6 +1782,9 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "auo" = (
@@ -1898,6 +1907,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -3084,9 +3096,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aKJ" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -4099,9 +4109,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aWy" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -4240,6 +4248,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"aXX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aYd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
@@ -6323,6 +6339,7 @@
 /area/medical/cryo)
 "bKF" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bKR" = (
@@ -7578,6 +7595,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "cfA" = (
@@ -8470,7 +8490,7 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "laborcamp shuttle dock";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/corg;
 	width = 7
 	},
 /turf/open/space/basic,
@@ -8874,9 +8894,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
 "cFH" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -12616,9 +12634,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dUs" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -13209,9 +13225,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "edw" = (
@@ -14323,6 +14337,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "exL" = (
@@ -14990,9 +15007,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "eLy" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -15525,6 +15540,27 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"eVn" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "eVI" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/button/door{
@@ -16778,6 +16814,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "frA" = (
@@ -20143,6 +20182,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "gxR" = (
@@ -20253,9 +20295,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "gyZ" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
@@ -21958,9 +21998,7 @@
 /area/hallway/primary/fore)
 "haX" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -22666,9 +22704,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_vest,
 /obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_helmet,
 /turf/open/floor/plasteel,
@@ -24185,14 +24221,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -25165,6 +25201,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
@@ -25375,7 +25415,8 @@
 	icon_living = "magicarp";
 	icon_state = "magicarp";
 	maxHealth = 200;
-	name = "Lia"
+	name = "Lia";
+	base_icon_state = "magicarp"
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -26450,6 +26491,9 @@
 	department = "Warden's Office";
 	departmentType = 5;
 	pixel_y = 32
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -28319,6 +28363,13 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"jdU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "jeb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -28584,11 +28635,11 @@
 /area/quartermaster/miningdock)
 "jjv" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/item/taperecorder,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jjx" = (
@@ -31391,6 +31442,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"kky" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "kkP" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -31779,9 +31836,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kpR" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -31888,6 +31943,7 @@
 "ksr" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/item/taperecorder,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ksC" = (
@@ -32326,6 +32382,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kya" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kyg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33143,6 +33206,8 @@
 "kQI" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kRc" = (
@@ -33349,6 +33414,9 @@
 /area/security/checkpoint/customs)
 "kUD" = (
 /obj/effect/landmark/start/scientist,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kUJ" = (
@@ -34364,6 +34432,9 @@
 "lla" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "lld" = (
@@ -35021,9 +35092,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lwg" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -35089,6 +35158,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "lxe" = (
@@ -35438,9 +35508,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -35606,7 +35674,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "lEH" = (
-/obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -37854,9 +37921,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "moh" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -38435,6 +38500,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "mwm" = (
@@ -38667,6 +38736,16 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"mAC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "mAJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -39383,6 +39462,9 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "mLY" = (
@@ -44008,6 +44090,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"okq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "okw" = (
 /obj/structure/table/glass,
 /obj/structure/sign/poster/random{
@@ -46883,9 +46975,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "pke" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -47471,6 +47561,9 @@
 "pwq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "pwv" = (
@@ -47574,6 +47667,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "pyv" = (
@@ -48126,6 +48222,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -48760,6 +48859,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -50751,6 +50853,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qAf" = (
@@ -51258,6 +51363,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"qGG" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qGQ" = (
 /obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced,
@@ -53763,9 +53875,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rxk" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -55103,9 +55213,7 @@
 /turf/open/floor/carpet/cyan,
 /area/crew_quarters/heads/cmo)
 "rTo" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -55457,9 +55565,7 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "rZa" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -55744,9 +55850,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -56487,6 +56591,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sqo" = (
@@ -56873,9 +56978,7 @@
 	pixel_x = -2;
 	pixel_y = -3
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -58738,9 +58841,7 @@
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "teE" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -59399,9 +59500,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "tsz" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
@@ -61776,9 +61875,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uhc" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -62423,7 +62520,7 @@
 	moveable = 1
 	},
 /obj/machinery/mass_driver{
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70);
+	armor = list("melee"=10,"bullet"=10,"laser"=10,"energy"=0,"bomb"=0,"bio"=0,"rad"=0,"fire"=100,"acid"=70);
 	critical_machine = 1;
 	dir = 8;
 	id = "smeject";
@@ -64693,9 +64790,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vdU" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -64860,6 +64955,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -67022,6 +67120,10 @@
 /obj/item/poster/random_official,
 /obj/item/poster/random_official,
 /obj/item/poster/random_official,
+/obj/machinery/light_switch{
+	pixel_y = 28;
+	pixel_x = 1
+	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "vNJ" = (
@@ -67346,9 +67448,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "vTj" = (
@@ -70192,9 +70292,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
 "wUu" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -71968,6 +72065,8 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xzO" = (
@@ -73197,17 +73296,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xTy" = (
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -4
-	},
-/obj/machinery/button/door{
-	id = "detective_shutters";
-	name = "detective's office shutters control";
-	pixel_x = -26;
-	pixel_y = 6;
-	req_access_txt = "4"
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -73846,9 +73934,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/item/seeds/tea,
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
@@ -102808,7 +102894,7 @@ hZO
 bOW
 qqf
 vBK
-lIO
+kky
 vKb
 iCv
 eey
@@ -103579,7 +103665,7 @@ qvj
 kMZ
 cah
 nAV
-lIO
+kky
 bpq
 anz
 qQo
@@ -103836,7 +103922,7 @@ teE
 mbl
 cah
 fYh
-lIO
+kky
 bpq
 anz
 opS
@@ -104585,7 +104671,7 @@ jHI
 dQx
 fAL
 lpb
-lpb
+mAC
 cft
 mif
 eAm
@@ -113801,8 +113887,8 @@ duF
 qIa
 vVU
 nTY
-mug
-duF
+kya
+hmy
 dpB
 amM
 bKF
@@ -114058,8 +114144,8 @@ duF
 rDK
 fPo
 cxw
-aqr
-hmy
+fRY
+bpE
 lEH
 oSI
 xtd
@@ -114080,7 +114166,7 @@ sXL
 wtJ
 bQp
 hwc
-wtJ
+aqr
 fRR
 lRh
 aer
@@ -114315,9 +114401,9 @@ nwA
 bRD
 mHW
 pek
-fRY
+aXX
 hmy
-nMo
+okq
 sgY
 lJV
 hmy
@@ -114606,8 +114692,8 @@ aIt
 aIt
 eZE
 avM
-hzZ
-ieI
+aeH
+qGG
 xzF
 gHq
 kgL
@@ -115855,7 +115941,7 @@ feb
 hfz
 duF
 rDK
-rwi
+eVn
 hmy
 xtv
 oQB
@@ -117397,8 +117483,8 @@ naL
 naL
 duF
 duF
-duF
-duF
+jdU
+jdU
 duF
 iRh
 tbi

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -376,7 +376,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "ack" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -394,15 +396,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"acn" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "acp" = (
 /obj/structure/rack,
 /obj/item/pet_carrier,
@@ -544,27 +537,6 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aeA" = (
-/obj/structure/table/glass,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
-/obj/effect/spawner/lootdrop/job_scale/medical/medkits,
-/turf/open/floor/plasteel,
-/area/medical/storage)
-"aeB" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aeC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -782,6 +754,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"ahc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ahe" = (
 /obj/machinery/computer/warrant,
 /obj/structure/sign/departments/minsky/security/security{
@@ -951,7 +935,9 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aiU" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -1016,22 +1002,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"ajD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "ajI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1395,6 +1365,16 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
+"apj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "apk" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -1528,15 +1508,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"aqN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "aqT" = (
 /obj/structure/chair{
 	dir = 4
@@ -1639,19 +1610,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"asI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "asK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
@@ -1908,6 +1866,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"awt" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "awJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -2250,25 +2216,6 @@
 /obj/structure/transit_tube/curved/flipped,
 /turf/open/space/basic,
 /area/space)
-"aBp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "aBq" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -2348,12 +2295,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engine_room)
-"aCw" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aCz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -2367,17 +2308,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"aCH" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aCI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -2428,37 +2358,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aDh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/computer/card/minor/hos{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "aDm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2527,28 +2426,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"aDJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "aDM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2640,6 +2517,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"aEC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aEQ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Shuttle Lab";
@@ -2715,13 +2604,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"aFJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aFX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2801,27 +2683,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"aGO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "permacell2";
-	name = "Cell 1 Lockdown";
-	pixel_x = -4;
-	pixel_y = 25;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/flasher{
-	id = "PCell 2";
-	pixel_x = 6;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aGU" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -2933,22 +2794,6 @@
 "aHZ" = (
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"aIf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aIi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3139,40 +2984,15 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aKy" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "aKJ" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"aKK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/item/restraints/legcuffs/bola/energy,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/storage/box/prisoner,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aKL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3842,11 +3662,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"aSM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aTc" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -4139,7 +3954,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aWy" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -4559,6 +4376,17 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"bdC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bdG" = (
 /obj/structure/bed/dogbed,
 /obj/item/toy/cattoy,
@@ -4603,16 +4431,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"beW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "bfc" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4634,6 +4452,19 @@
 "bfm" = (
 /turf/closed/wall,
 /area/medical/morgue)
+"bfE" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bfH" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -4672,17 +4503,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bgb" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "bgd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4717,24 +4537,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"bgw" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Main North";
-	network = list("ss13","prison")
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bgy" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666"
@@ -4826,16 +4628,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"bhN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bia" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4931,21 +4723,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge)
-"bjv" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "bjA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -4970,17 +4747,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"bjN" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt2";
-	name = "Cell 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "bjS" = (
 /obj/item/bedsheet/clown,
 /obj/structure/bed,
@@ -5007,6 +4773,16 @@
 	dir = 5
 	},
 /area/chapel/main/monastery)
+"bjV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bkv" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -5142,6 +4918,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"bmU" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig Medical";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bnc" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -5327,22 +5119,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"brE" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "brJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/lattice/catwalk,
@@ -5354,31 +5130,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"brR" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Medical";
-	req_access_txt = "34"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "brS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -5412,15 +5163,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bsi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "bsr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -5468,6 +5210,18 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
+"bul" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/carpet/red,
+/area/security/detectives_office)
 "buo" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/delivery,
@@ -5572,6 +5326,19 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port)
+"bvr" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bvt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -5698,29 +5465,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"bxD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/structure/weightmachine/weightlifter,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bxE" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5847,6 +5591,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"bzN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bzS" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -5891,6 +5646,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bBh" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bBo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6385,22 +6155,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"bJm" = (
-/obj/machinery/door/airlock{
-	name = "Toilet Unit"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "bJB" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -6845,22 +6599,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"bPX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"bPW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
+/area/security/brig)
 "bQa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -6890,18 +6637,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bQG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Head of Security";
-	req_access_txt = "58"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hos)
 "bQL" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
@@ -7099,6 +6834,19 @@
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"bTR" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bTU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output,
 /turf/open/floor/engine/o2,
@@ -7128,6 +6876,21 @@
 /obj/item/wirecutters,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"bUY" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bUZ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -7167,10 +6930,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"bWt" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bWu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Library Maintenance";
@@ -7464,19 +7223,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"cbC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Brig Control Desk";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "cbG" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -7697,6 +7443,23 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
+"cfK" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cfL" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable/yellow{
@@ -7776,20 +7539,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"cgU" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cgZ" = (
 /obj/item/radio/intercom{
 	pixel_x = 29;
@@ -7854,13 +7603,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"cim" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "cir" = (
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
@@ -7922,17 +7664,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"cjA" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cjE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -7947,17 +7678,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"ckw" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "cky" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"ckG" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/red,
-/area/security/detectives_office)
 "ckO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -8038,24 +7772,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"cmh" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/wheat,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cmm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -8280,6 +7996,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cqr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cqs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8290,38 +8024,20 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"cqD" = (
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cqV" = (
 /obj/structure/transit_tube/diagonal/crossing,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cra" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"cri" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"crC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "crF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -8347,33 +8063,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"crW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
-"csa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "csd" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -8543,6 +8232,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"cvC" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "cvP" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/fore)
@@ -8942,18 +8647,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"cCv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cCA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -8970,27 +8663,21 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"cCR" = (
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+"cCI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/qm)
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "cCU" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -9072,7 +8759,9 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
 "cFH" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -9116,13 +8805,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"cGF" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
 "cHg" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -9487,18 +9169,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"cNR" = (
-/obj/structure/table/glass,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
-/obj/effect/spawner/lootdrop/job_scale/medical/first_aid_kit,
-/turf/open/floor/plasteel,
-/area/medical/storage)
 "cNX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -9652,6 +9322,19 @@
 "cQS" = (
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/theatre)
+"cQT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cRh" = (
 /obj/machinery/airalarm/server{
 	pixel_y = 24
@@ -9719,18 +9402,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"cSy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "cSO" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -9984,19 +9655,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"cWA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "cWG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -10061,15 +9719,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"cXx" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cXE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10235,35 +9884,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"dbJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+"dcj" = (
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/airlock/external/glass{
-	name = "Escape Pod Alpha"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"dcg" = (
-/obj/machinery/computer/security/hos{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "dcn" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -10374,8 +10003,8 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Armory";
-	security_level = 6;
-	req_one_access_txt = "66;3"
+	req_one_access_txt = "66;3";
+	security_level = 6
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
@@ -10398,6 +10027,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"deq" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "deF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -10465,6 +10100,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"dfy" = (
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dfA" = (
 /obj/machinery/light{
 	dir = 8
@@ -10912,14 +10559,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"djF" = (
-/obj/machinery/door/airlock/public/glass{
-	id_tag = "permabolt1";
-	name = "Cell 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "dka" = (
 /obj/effect/landmark/start/detective,
 /obj/structure/chair/fancy/comfy{
@@ -10982,6 +10621,15 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"dlj" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "dlk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11036,27 +10684,6 @@
 "dmv" = (
 /turf/open/floor/circuit,
 /area/hallway/secondary/entry)
-"dmz" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Kill Chamber";
-	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "dmC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -11167,6 +10794,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dox" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "doz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11180,20 +10818,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"doA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	name = "Hydroponics Desk";
-	req_access_txt = "35"
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/structure/desk_bell{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "doY" = (
 /obj/machinery/door/window/southleft{
 	name = "Cloning Shower"
@@ -11500,19 +11124,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"dvx" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dvy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -11644,19 +11255,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"dxu" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "dxw" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable/yellow{
@@ -11761,34 +11359,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
-"dzf" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"dzs" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "dzt" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"dzB" = (
+/obj/machinery/flasher{
+	id = "PCell 1";
+	pixel_x = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Cell 2";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dzP" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -11919,22 +11507,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"dCU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Education Center";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/execution/education)
 "dCW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -12038,16 +11610,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dEE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dEK" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/computer/security/telescreen{
@@ -12075,6 +11637,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"dEQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dFg" = (
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
@@ -12114,22 +11686,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"dFt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "dFu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -12144,23 +11700,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dFy" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28;
-	prison_radio = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "dFA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -12402,18 +11941,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"dJW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dKn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -12424,20 +11951,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"dKp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dKv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -13024,7 +12537,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dUs" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -13084,6 +12599,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"dVq" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dVx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -13221,13 +12746,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"dXV" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dYA" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -13438,12 +12956,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"eaE" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "eaG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13486,17 +12998,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"eaX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "eaY" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/machinery/camera/autoname{
@@ -13617,7 +13118,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "edw" = (
@@ -13658,32 +13161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/secondary)
-"edV" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "eeb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -13722,11 +13199,6 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"eez" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "eeC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13791,22 +13263,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"eeZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "efi" = (
 /obj/effect/spawner/room/tenxfive,
 /turf/open/floor/plating,
@@ -13941,28 +13397,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"eit" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"eiF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "eiJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
@@ -13994,27 +13428,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"ejo" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/kirbyplants/random,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "ejp" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/flasher{
@@ -14043,23 +13456,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/fore)
-"ejS" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ejT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -14110,6 +13506,18 @@
 	dir = 5
 	},
 /area/science/breakroom)
+"ekn" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ekC" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -14124,22 +13532,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"elB" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/closet/crate/secure/gear,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/head/beret/ccguardnavy,
-/obj/item/clothing/head/beret/ccguardnavy,
-/obj/item/clothing/head/beret/ccguardnavy,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "elS" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -14188,6 +13580,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"eml" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "emu" = (
 /obj/structure/table/reinforced,
 /obj/item/soap/nanotrasen,
@@ -14461,6 +13866,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
+"ers" = (
+/obj/machinery/door/airlock/security{
+	name = "Interogation Holding";
+	req_one_access_txt = "4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ery" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14561,6 +13979,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"euH" = (
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_one_access_txt = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/detectives_office)
 "euO" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8
@@ -14792,13 +14226,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"exi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "exk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -14871,14 +14298,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"exZ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall12";
-	location = "hall10"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "eya" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -14944,6 +14363,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ezz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ezJ" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/plasteel,
@@ -14996,32 +14429,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
-"eAu" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/qm)
 "eAx" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
@@ -15298,6 +14705,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"eEZ" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eFK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -15412,13 +14824,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"eIj" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eIv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15469,20 +14874,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eJi" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/reagent_containers/food/drinks/britcup,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "eJz" = (
 /obj/effect/landmark/start/paramedic,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -15503,6 +14894,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"eJJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eJK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15530,16 +14934,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"eKw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "eKL" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/yellow{
@@ -15561,6 +14955,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"eKV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eLd" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/turf_decal/siding/wood{
@@ -15576,7 +14984,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "eLy" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -15845,15 +15255,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ePW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "eQl" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
@@ -15936,29 +15337,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"eQV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"eRe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "eRv" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
@@ -15983,28 +15361,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"eRO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"eSG" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eSM" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -16179,14 +15535,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
-"eWy" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "eWN" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
@@ -16232,21 +15580,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"eYn" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/checkpoint/supply)
 "eYB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -16423,6 +15756,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"fbk" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fbo" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -16582,29 +15930,6 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"fdr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"fdx" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "fdD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16807,25 +16132,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"fgB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "fgF" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -16888,23 +16194,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/library)
-"fjd" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "fje" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -16927,20 +16216,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"fjk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "fjt" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -16982,6 +16257,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
+"fjL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fjM" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -17055,6 +16340,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"fkO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fkQ" = (
 /obj/machinery/power/smes/engineering{
 	charge = 2e+006
@@ -17130,18 +16422,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"flw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "flN" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -17497,18 +16777,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"fsF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fsT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17664,13 +16932,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
-"fwf" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fwt" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 1
@@ -18135,6 +17396,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"fDi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "fDo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18185,11 +17457,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"fFa" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fFq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18391,6 +17658,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"fIg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fIm" = (
 /obj/machinery/door/airlock/medical{
 	id_tag = "QuarantineB";
@@ -18402,16 +17681,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"fIr" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "fIx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18424,19 +17693,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
-"fIJ" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "fJc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -18510,18 +17766,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"fKn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "fKv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18662,18 +17906,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"fMJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fMM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -18732,21 +17964,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"fNn" = (
-/obj/vehicle/ridden/secway,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red,
+"fNu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "fNy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18962,24 +18188,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
-"fQk" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/checkpoint/supply)
 "fQp" = (
 /obj/structure/closet/secure_closet/medical2{
 	req_access = list(29)
@@ -19001,23 +18209,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port)
-"fQS" = (
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Shower";
-	dir = 9;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "fRb" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
@@ -19049,20 +18240,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"fRC" = (
-/obj/effect/landmark/start/head_of_security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "fRG" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -19501,19 +18678,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
-"fZQ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "fZW" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -19646,11 +18810,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"gci" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gcn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -19752,17 +18911,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"geg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "geh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -19888,18 +19036,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"ggy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ggN" = (
 /obj/machinery/conveyor{
 	id = "QMLoad"
@@ -19953,22 +19089,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"gis" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "giA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -19984,6 +19104,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"giG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "giS" = (
 /turf/open/floor/plasteel/white,
 /area/quartermaster/storage)
@@ -20497,17 +19623,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
-"gqz" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "gqE" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/brig)
@@ -20527,24 +19642,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"grc" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Main South";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "grd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/components/binary/valve/digital/layer4{
@@ -20663,6 +19760,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"gtR" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "gtV" = (
 /turf/open/floor/wood,
 /area/security/warden)
@@ -20696,33 +19805,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"guo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"guv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "guH" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
@@ -20857,16 +19939,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gxo" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gxs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20919,20 +19991,6 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
-"gyo" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "gyr" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -21019,7 +20077,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "gyZ" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
@@ -21184,17 +20244,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"gBr" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/recharger{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "gBw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -21300,6 +20349,19 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"gDy" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gDH" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
@@ -21338,6 +20400,39 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/relay)
+"gEc" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Medical";
+	req_access_txt = "34"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"gEd" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gEl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -21347,6 +20442,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"gEu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "gEw" = (
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
@@ -21647,22 +20748,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"gIX" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/laser_gun,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "gIZ" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/drone,
@@ -21896,6 +20981,19 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
+"gMM" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt2";
+	name = "Cell 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gMV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -22053,17 +21151,6 @@
 "gOi" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
-"gOl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gOn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -22225,16 +21312,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"gRi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair/office,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "gRp" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -22286,10 +21363,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"gSe" = (
-/obj/machinery/door/airlock/security{
-	req_one_access_txt = "4";
-	name = "Interogation Holding"
+"gSb" = (
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -22303,15 +21383,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"gSy" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "gSE" = (
 /obj/machinery/door/window/westleft{
 	name = "Research Division Deliveries";
@@ -22338,25 +21409,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"gTB" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
-"gTG" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "gTH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -22520,14 +21572,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"gWG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "gWJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
@@ -22719,24 +21763,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"hai" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+"gZX" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
+/area/security/main)
 "hal" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -22764,7 +21800,9 @@
 /area/hallway/primary/fore)
 "haX" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -22902,6 +21940,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"hcJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Education Center";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "hdd" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -22926,16 +21982,6 @@
 "hdz" = (
 /turf/closed/wall,
 /area/science/mixing)
-"hdO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "hdR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22968,15 +22014,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/theatre)
-"hek" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "heC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -23072,8 +22109,8 @@
 /area/engine/atmos)
 "hfx" = (
 /obj/machinery/door/poddoor/shutters{
-	name = "Armoury Access Shutters";
-	id = "armour_exterior"
+	id = "armour_exterior";
+	name = "Armoury Access Shutters"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23166,14 +22203,6 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
-"hhi" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "hhn" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/turf_decal/tile/red{
@@ -23248,6 +22277,22 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"hiD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hiP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/coffee,
@@ -23277,18 +22322,6 @@
 /obj/structure/closet/secure_closet/bar,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"hjj" = (
-/obj/machinery/computer/security/telescreen/interrogation{
-	dir = 1;
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/filingcabinet/security,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "hjo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23419,13 +22452,6 @@
 "hlt" = (
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
-"hlu" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "hlE" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
@@ -23516,7 +22542,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_vest,
 /obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_helmet,
 /turf/open/floor/plasteel,
@@ -23625,6 +22653,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"how" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hox" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -23797,15 +22838,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"hsg" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "hsn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -23917,28 +22949,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"htP" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral,
-/mob/living/simple_animal/hostile/carp/cayenne{
-	desc = "A failed experiment of Nanotrasen to create weaponised carp technology. This less than intimidating carp now serves as an authority figure's pet.";
-	health = 200;
-	icon_dead = "magicarp_dead";
-	icon_gib = "magicarp_gib";
-	icon_living = "magicarp";
-	icon_state = "magicarp";
-	maxHealth = 200;
-	name = "Lia"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "htT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -24088,31 +23098,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
-"hxd" = (
-/obj/machinery/vending/hydroseeds,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hxh" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -24309,12 +23294,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
-"hAA" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hAD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24371,16 +23350,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"hBq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "hBP" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/sign/poster/random{
@@ -24517,17 +23486,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"hEt" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "hEw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -24555,16 +23513,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
-"hER" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/checkpoint/supply)
 "hFs" = (
 /obj/machinery/button/door{
 	id = "cp_west_inner";
@@ -24595,6 +23543,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"hFx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hFA" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery,
@@ -24715,15 +23668,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"hHM" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "hHS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -24975,6 +23919,13 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"hLP" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hLT" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine{
@@ -25199,16 +24150,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
-"hQu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "hQw" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
@@ -25567,16 +24508,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hVU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "hWl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -25644,16 +24575,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"hXA" = (
-/obj/machinery/requests_console{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/checkpoint/supply)
 "hXO" = (
 /obj/machinery/light{
 	dir = 1
@@ -25796,22 +24717,6 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/janitor)
-"hYR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "hYW" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -25946,16 +24851,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ibI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ibO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
 	dir = 5
@@ -25987,6 +24882,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"icl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ict" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -26020,38 +24925,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"icI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "icT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
-"idg" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "idj" = (
 /obj/structure/window/reinforced/spawner{
@@ -26295,6 +25173,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"ihm" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iht" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
@@ -26438,6 +25331,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"ijA" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Head of Security";
+	req_access_txt = "58"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hos)
 "ijB" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -26678,15 +25585,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"ior" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "iot" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26750,13 +25648,6 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
-"ipk" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ipm" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -27000,6 +25891,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"irD" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "irJ" = (
 /obj/structure/chair/fancy/sofa/old{
 	dir = 8
@@ -27106,6 +26009,13 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"itA" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "itT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27165,12 +26075,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"iuV" = (
-/obj/structure/sign/poster/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "iuW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27367,6 +26271,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"izG" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Evidence";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "izP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -27518,15 +26444,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
-"iBM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "iBO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -27892,11 +26809,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"iHZ" = (
-/obj/effect/landmark/start/head_of_security,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "iIe" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -28100,25 +27012,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
-"iMC" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/item/seeds/tea,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "iMR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -28146,6 +27039,18 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"iNK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28256,17 +27161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"iPj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "iPK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -28379,6 +27273,24 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
+"iRC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_one_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iRG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -28493,6 +27405,26 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"iSC" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "iSD" = (
 /obj/structure/transit_tube/curved/flipped,
 /obj/effect/spawner/structure/window/reinforced,
@@ -28792,12 +27724,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"iYj" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "iYq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -28939,6 +27865,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jaf" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/chef_recipes,
+/obj/item/kitchen/rollingpin,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jal" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29267,16 +28203,6 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/maintenance/port)
-"jfU" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "jfW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -29382,12 +28308,6 @@
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jin" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jiP" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -29635,21 +28555,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"jno" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "jnq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29750,22 +28655,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"jph" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_one_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jpk" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jpR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray,
-/obj/item/kitchen/fork,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "jpY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -30186,15 +29100,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"jxp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jxt" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
@@ -30333,16 +29238,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"jAh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jAj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -30357,22 +29252,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"jAA" = (
-/obj/machinery/requests_console{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/balaclava,
-/obj/item/reagent_containers/syringe,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "jAB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -30389,6 +29268,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
+"jAL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jAO" = (
 /obj/machinery/light{
 	dir = 1
@@ -30444,12 +29333,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"jBR" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jBS" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
@@ -30472,16 +29355,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal)
-"jCz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "jCD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -30559,17 +29432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"jDD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "jDF" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/server,
@@ -30614,6 +29476,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jEy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jEF" = (
 /obj/machinery/light{
 	dir = 1
@@ -30628,14 +29496,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"jEM" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jEZ" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -30786,47 +29646,6 @@
 "jGG" = (
 /turf/closed/wall,
 /area/science/robotics)
-"jGM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jGQ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jHc" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jHk" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -30837,19 +29656,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"jHm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jHq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -30950,6 +29756,26 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"jIN" = (
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jIR" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
@@ -31085,13 +29911,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"jKY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jLw" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/freezer,
@@ -31131,18 +29950,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"jLV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jMf" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -31188,16 +29995,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"jNl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "jNq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/green,
@@ -31236,21 +30033,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
-"jOI" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jOL" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -31291,31 +30073,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"jPv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/computer/security/hos{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "jPQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -31386,16 +30143,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
-/area/security/prison)
-"jRv" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "jRY" = (
 /obj/item/kirbyplants/random,
@@ -31492,17 +30239,6 @@
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"jTl" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
 /area/security/brig)
 "jTn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -31650,19 +30386,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"jVs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "jVA" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -31717,31 +30440,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"jWw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/hos,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "hosoffice";
-	name = "Head of Security's Office Shutters";
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "jWy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -31903,16 +30601,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"jYt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "jYC" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -31929,15 +30617,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jZh" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jZm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white{
@@ -31984,19 +30663,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
-"jZD" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "jZG" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -32129,6 +30795,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kci" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kco" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -32178,6 +30851,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kde" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "kdj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
@@ -32251,19 +30930,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"keH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "kff" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -32759,18 +31425,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"kne" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "knn" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -32955,6 +31609,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"kpN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kpP" = (
 /obj/item/radio/intercom{
 	pixel_x = 29;
@@ -32966,7 +31631,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kpR" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow,
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -33187,15 +31854,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kuk" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "kuy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33259,21 +31917,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"kvf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_one_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kvu" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -33549,16 +32192,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"kyC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kyF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -33629,6 +32262,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kAj" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "kAm" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap,
@@ -33672,17 +32314,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"kBt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "kBB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -33743,6 +32374,13 @@
 /obj/structure/marker_beacon,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"kCD" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kCE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -33755,6 +32393,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"kDc" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kDe" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -33762,25 +32409,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"kDf" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kDh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -33799,24 +32427,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/warden)
-"kDo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"kDs" = (
-/obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kDz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -33847,16 +32457,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"kDG" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kDK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -33866,12 +32466,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"kDU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "kEd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -33923,24 +32517,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"kEP" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/seeds/tea,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kEQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/neutral{
@@ -33952,12 +32528,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"kEY" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "kFa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -33976,17 +32546,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"kFE" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/security/sec,
+"kFG" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "kFS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34033,17 +32598,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"kHo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "kHq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34131,21 +32685,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"kJK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Distro to Waste"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "kJL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -34153,6 +32692,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kJU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kKf" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -34208,19 +32757,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
-"kLJ" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "kMb" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine";
@@ -34328,6 +32864,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"kMT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kMU" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 1
@@ -34383,33 +32924,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kNF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"kNI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kNN" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel/dark,
@@ -34428,27 +32942,6 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kOy" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Interrogation room";
-	dir = 4;
-	network = list("interrogation")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kOD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -34468,18 +32961,6 @@
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kPl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kPy" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plasteel,
@@ -34760,18 +33241,6 @@
 /obj/effect/spawner/room/tenxten,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"kVK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kVR" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -35138,6 +33607,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"lbH" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lbJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -35323,20 +33806,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"ldQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Secure Brig";
-	req_one_access_txt = "2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lee" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -35584,15 +34053,6 @@
 "liF" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"ljg" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "ljs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -35609,14 +34069,22 @@
 "lju" = (
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"ljA" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+"ljz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "ljB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35639,26 +34107,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"lkB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/button/ignition{
-	pixel_x = 4;
-	pixel_y = 27
-	},
-/obj/machinery/button/door{
-	desc = "Welcome to your new life, employee.";
-	id = "deathdoor";
-	name = "Transfer Switch";
-	pixel_x = -6;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "lkE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -35739,37 +34187,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"llM" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/toy/figure/qm{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/qm)
 "llQ" = (
 /obj/structure/sign/painting/library{
 	pixel_x = 32
@@ -36087,46 +34504,9 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"lro" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lrx" = (
 /turf/open/floor/circuit/red,
 /area/hallway/secondary/entry)
-"lrA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
-"lrH" = (
-/obj/structure/table/glass,
-/obj/machinery/door/window/eastleft{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
-/obj/effect/spawner/lootdrop/job_scale/medical/medkits,
-/turf/open/floor/plasteel,
-/area/medical/storage)
 "lrJ" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/delivery,
@@ -36412,7 +34792,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lwg" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -36510,34 +34892,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"lxt" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lxu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"lxx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lxA" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -36695,19 +35055,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lzn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "lzw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -36856,10 +35203,24 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"lBZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lCz" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -36916,15 +35277,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
-"lCJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lCK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -37189,37 +35541,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"lHh" = (
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"lHw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "lHx" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -37227,14 +35548,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/library)
-"lHJ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lHM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -37265,60 +35578,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"lHW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lIe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"lIw" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/disabler,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "lIO" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"lJh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/disposal/bin,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "lJl" = (
 /obj/effect/spawner/room/fivexfour,
 /turf/open/floor/plating,
@@ -37522,15 +35789,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"lLS" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "lLT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -37600,13 +35858,6 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"lNv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lNH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37675,21 +35926,6 @@
 /obj/item/storage/box/disks_nanite,
 /turf/open/floor/circuit/green,
 /area/science/nanite)
-"lOC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lOG" = (
 /obj/structure/chair{
 	dir = 8
@@ -38017,33 +36253,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lTA" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lTO" = (
 /obj/effect/landmark/observer_start,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"lTR" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/sugarcane,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lTY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lUa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38119,29 +36344,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/noslip/standard,
 /area/hallway/secondary/service)
-"lUR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lUW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -38326,21 +36528,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"lXS" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "lXT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38379,19 +36566,6 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"lYG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "lYK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -38402,15 +36576,6 @@
 "lYS" = (
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"lYU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lZe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -38557,15 +36722,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
-"maH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "maO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38718,8 +36874,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Armory";
-	security_level = 6;
-	req_one_access_txt = "66;3"
+	req_one_access_txt = "66;3";
+	security_level = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -38772,18 +36928,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"meS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/dark/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "meZ" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -38828,6 +36972,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/central)
+"mfA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mfD" = (
 /obj/machinery/disposal/bin,
 /obj/item/radio/intercom{
@@ -39112,15 +37264,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"mjN" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mjV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -39171,13 +37314,27 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"mkB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"mkC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Briefing Room";
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "mkF" = (
 /turf/closed/wall,
 /area/chapel/main/monastery)
@@ -39296,13 +37453,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
-"mmg" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "mmp" = (
 /obj/machinery/light{
 	dir = 1
@@ -39393,26 +37543,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"mnY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "moe" = (
 /obj/machinery/light{
 	dir = 1
@@ -39438,7 +37568,9 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "moh" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -39516,21 +37648,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mqa" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/command{
-	name = "Head of Security";
-	req_access_txt = "58"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hos)
 "mql" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -39540,21 +37657,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"mqm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mqn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39579,20 +37681,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/education)
-"mqD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "mqE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -39982,18 +38070,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"muO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "muW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -40373,13 +38449,6 @@
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"mBT" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mBU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -40599,19 +38668,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
-"mEM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mEV" = (
 /obj/item/radio/intercom{
 	pixel_x = -28;
@@ -40764,16 +38820,6 @@
 "mHr" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
-"mHw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mHK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -40919,17 +38965,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mKU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall15";
-	location = "hall14"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mKY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40944,18 +38979,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/medical/storage)
-"mLp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mLt" = (
 /obj/structure/table/reinforced,
 /obj/item/nanite_remote,
@@ -40992,18 +39015,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"mLX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "mLY" = (
 /turf/closed/wall,
 /area/science/research)
@@ -41483,18 +39494,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"mTp" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/chef_recipes,
-/obj/item/kitchen/rollingpin,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "mTx" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -41525,6 +39524,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"mUs" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mUv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -41562,16 +39571,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"mUB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "mUF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41652,18 +39651,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"mVY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "mWh" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -41846,16 +39833,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/port)
-"mZR" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "nam" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/structure/cable/yellow{
@@ -41864,24 +39841,6 @@
 /obj/item/xenoartifact/maint,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"nan" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/pickaxe/mini,
-/obj/item/pickaxe/mini,
-/obj/item/storage/bag/ore,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "naw" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -41998,6 +39957,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"ncw" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ncB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
@@ -42235,6 +40202,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"ngl" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ngq" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -42264,19 +40238,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ngF" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ngK" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -42300,16 +40261,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/brig)
-"nhc" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "nhd" = (
 /obj/structure/disposalpipe/segment,
@@ -42367,20 +40318,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"nih" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/computer/card/minor/hos{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "nin" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -42608,28 +40545,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"nnB" = (
-/obj/machinery/cryopod{
+"noa" = (
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/computer/cryopod{
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "nof" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -42864,12 +40789,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
-"nrr" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "nrw" = (
 /obj/machinery/light{
 	dir = 4
@@ -42924,6 +40843,21 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nsv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/detectives_office)
 "nsw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/white,
@@ -43262,18 +41196,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"nyy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nyG" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -43407,18 +41329,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"nzL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "nzM" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -43710,23 +41620,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"nFr" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "nFy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43924,16 +41817,6 @@
 "nIH" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
-"nIJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "nIO" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -44217,21 +42100,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"nMg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nMw" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -44442,6 +42310,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nOC" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "nOF" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner{
@@ -44736,23 +42616,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"nTO" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "nTV" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -44996,6 +42859,17 @@
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"nYf" = (
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nYi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45161,6 +43035,15 @@
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/janitor)
+"oaF" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "oaL" = (
 /turf/closed/wall,
 /area/medical/medbay/aft)
@@ -45314,6 +43197,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ocV" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "odl" = (
 /obj/machinery/requests_console{
 	department = "Arrivals Dock";
@@ -45415,21 +43308,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"oeX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ofc" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -45469,8 +43347,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "Turbine Waste to Thermoelectric Generator";
-	dir = 8
+	dir = 8;
+	name = "Turbine Waste to Thermoelectric Generator"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmospherics_engine)
@@ -45588,20 +43466,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"ois" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -14;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "oiM" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -45669,22 +43533,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"okc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "okw" = (
 /obj/structure/table/glass,
 /obj/structure/sign/poster/random{
@@ -45960,16 +43808,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"oph" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "opq" = (
 /turf/closed/wall,
 /area/science/breakroom)
@@ -46067,21 +43905,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/secondary)
-"oqF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
 "orb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -46091,24 +43914,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"ore" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "org" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -46133,6 +43938,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
+"orJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "orN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -46183,16 +43997,21 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"osL" = (
+"osU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/main)
 "osX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46339,6 +44158,16 @@
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ovS" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ovW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -46355,18 +44184,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"owj" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "owH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -46498,22 +44315,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"oyb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "Cargo Window";
-	pixel_y = 1;
-	req_access_txt = "31"
-	},
-/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
-/obj/structure/desk_bell{
-	pixel_x = -8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "oyn" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_x = -32
@@ -46616,16 +44417,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"oze" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname,
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "ozg" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
@@ -46699,28 +44490,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "oAF" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/item/taperecorder,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"oAG" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "oAH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46789,6 +44567,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"oBD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oBJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -46827,16 +44615,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"oCV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "oCW" = (
 /turf/closed/wall,
 /area/engine/atmospherics_engine)
@@ -46906,6 +44684,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"oDx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Long-Term Cell 1";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oDB" = (
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -47225,23 +45018,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"oHT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Secure Brig";
-	req_one_access_txt = "2;1;4;34;3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "oHU" = (
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -47295,6 +45071,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"oIS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oIU" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -47470,6 +45256,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
+"oNe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oNk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -47530,6 +45331,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"oNY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oOl" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
@@ -47928,21 +45734,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
-"oVN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oWc" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat/cargo,
@@ -48368,6 +46159,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"pfd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "pfu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48558,18 +46358,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"pim" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/holopad{
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pio" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -48694,7 +46482,9 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "pke" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -48722,6 +46512,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"pkS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "plC" = (
 /obj/structure/chair/fancy/sofa/old/right{
 	dir = 8
@@ -48776,6 +46579,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"pmg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "pmj" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -48853,23 +46663,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
-"poQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"poV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "ppd" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -48947,24 +46740,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
-"pqg" = (
-/obj/structure/table/reinforced,
-/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 1;
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "pqj" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -49014,6 +46789,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pqN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2;1;4;34;3"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pqO" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /obj/structure/cable/yellow{
@@ -49117,6 +46910,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"pte" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ptf" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 1
@@ -49246,15 +47053,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"pvo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pvv" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -49287,21 +47085,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"pwc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Briefing Room";
-	req_one_access_txt = "1;4"
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "pwm" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -49336,19 +47119,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"pwA" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pwC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -49385,8 +47155,8 @@
 /area/chapel/main/monastery)
 "pxi" = (
 /obj/machinery/door/airlock/security{
-	req_one_access_txt = "4";
-	name = "Interogation Room"
+	name = "Interogation Room";
+	req_one_access_txt = "4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -49411,15 +47181,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"pxv" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/chef_recipes,
-/obj/item/kitchen/rollingpin,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "pxI" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "dorm1"
@@ -49444,30 +47205,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"pya" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 1;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/qm)
 "pyv" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -49642,13 +47379,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"pAz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pAD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -49691,17 +47421,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pBZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pCa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -49864,16 +47583,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"pEy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "pEC" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -50029,6 +47738,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"pGx" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2;1;4;34;3"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pGV" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -50044,19 +47768,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"pHz" = (
-/obj/structure/table,
-/obj/item/storage/lockbox/loyalty,
-/obj/item/radio,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "pHB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50075,6 +47786,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"pHK" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pHL" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -50210,18 +47936,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"pJm" = (
-/obj/machinery/flasher{
-	id = "PCell 1";
-	pixel_x = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Cell 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "pJt" = (
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
@@ -50314,15 +48028,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"pLn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pLz" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -50408,6 +48113,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
+"pMr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"pMz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pMX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 1
@@ -50437,15 +48159,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
-"pNb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pNe" = (
 /obj/structure/transit_tube/station{
 	dir = 1
@@ -50503,15 +48216,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"pNM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pOd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -50535,37 +48239,21 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"pOG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"pOK" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"pOI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/restraints/handcuffs/cable/zipties,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/crew_quarters/heads/hos)
 "pOL" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -50881,22 +48569,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"pUM" = (
-/obj/structure/chair,
-/obj/item/radio/intercom{
-	frequency = 1423;
-	name = "Interrogation Intercom";
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pUR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -51139,13 +48811,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
-"pYy" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pYz" = (
 /obj/machinery/door/airlock/science{
 	name = "Toxins Lab";
@@ -51240,6 +48905,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qad" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "qay" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -51251,16 +48927,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"qaA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qaC" = (
 /obj/machinery/light{
 	dir = 1
@@ -51371,6 +49037,21 @@
 /obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
+"qcO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qcP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -51415,16 +49096,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"qdv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "qdG" = (
 /obj/item/crowbar/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51802,16 +49473,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
-"qkE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "qkT" = (
 /obj/machinery/light{
 	dir = 4
@@ -52305,6 +49966,18 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"qsV" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/security/detectives_office)
 "qsX" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -52401,15 +50074,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"qug" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "quq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -52475,16 +50139,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"quM" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig Medical";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "quW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -52611,27 +50265,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"qwH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
-"qwL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "qwM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -52810,14 +50443,6 @@
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
-"qAq" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qAF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -52839,25 +50464,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qBa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 15
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
 "qBi" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 8
@@ -53060,6 +50666,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"qDk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qDx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53109,6 +50721,28 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"qDX" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"qEd" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qEg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53350,10 +50984,6 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qId" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qIg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -53517,13 +51147,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qLx" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "qLz" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
@@ -53934,16 +51557,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"qSB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qSI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -53965,22 +51578,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"qTW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/chair,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qUi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54034,15 +51631,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
-"qUF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qUO" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -54061,12 +51649,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"qVf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qVg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -54165,21 +51747,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"qXq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "qXK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54193,34 +51760,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"qXL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"qXX" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qYc" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "qYd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/disposal/bin,
@@ -54555,6 +52094,19 @@
 "rdA" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
+"rdK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rdL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -54779,32 +52331,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"rgB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/table,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "rgH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -54836,19 +52362,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"rhg" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "rhG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 1
@@ -54885,19 +52398,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rhZ" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "rie" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -54922,17 +52422,6 @@
 	dir = 6
 	},
 /area/chapel/main/monastery)
-"riA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "riE" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -55005,22 +52494,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"rkf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Medical";
-	req_access_txt = "34"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "rki" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -55099,6 +52572,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rlr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rlw" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/seclite,
@@ -55154,20 +52633,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"rlR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
 "rmc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55281,16 +52746,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
-"rnG" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rnW" = (
 /mob/living/simple_animal/pet/dog/pug,
 /turf/open/floor/engine,
@@ -55388,18 +52843,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"roW" = (
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "rpc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -55419,6 +52862,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rpl" = (
+/obj/effect/landmark/start/head_of_security,
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rpq" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -55513,6 +52967,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rqt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rqF" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -55855,7 +53322,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rxk" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -56065,16 +53534,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
-"rBh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "rBk" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
@@ -56092,6 +53551,16 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"rBK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "rCa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -56356,17 +53825,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"rFO" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rFR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/siding/wood,
@@ -56616,26 +54074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"rJI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "rJJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -56909,41 +54347,6 @@
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"rOj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rOC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rPk" = (
-/obj/machinery/door/airlock/security{
-	req_one_access_txt = "4";
-	name = "Detective's Office"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/detectives_office)
 "rPn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -57052,6 +54455,25 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"rQl" = (
+/obj/machinery/computer/security/hos{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rQp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -57200,22 +54622,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"rSn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/item/wrench,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "rSB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -57255,7 +54661,9 @@
 /turf/open/floor/carpet/cyan,
 /area/crew_quarters/heads/cmo)
 "rTo" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -57322,22 +54730,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
-"rUL" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "rUN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -57407,23 +54799,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"rWf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/rag,
-/obj/machinery/door/window/brigdoor/eastright{
-	dir = 8;
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "rWj" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
@@ -57518,19 +54893,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
-"rXL" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rXP" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -57640,7 +55002,9 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "rZa" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -57857,12 +55221,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"sdp" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "sdz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -57931,7 +55289,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -58125,21 +55485,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"shz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "shJ" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
+"shK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "shL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -58667,6 +56027,13 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"spJ" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sqh" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -58798,6 +56165,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"ssD" = (
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permabolt1";
+	name = "Cell 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ssI" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -58904,20 +56281,6 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"suf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "suq" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/stripes/corner{
@@ -58945,18 +56308,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"sux" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "suN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -59066,7 +56417,9 @@
 	pixel_x = -2;
 	pixel_y = -3
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -59169,6 +56522,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"syF" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "syX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59178,18 +56540,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_prep)
-"syZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "sze" = (
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -59401,6 +56751,21 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sCf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sCm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59472,35 +56837,28 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics)
-"sEE" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 8
+"sEP" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "sEV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"sFf" = (
+"sFh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sFB" = (
 /obj/structure/chair/fancy/bench/pew/left{
@@ -59721,16 +57079,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"sJH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "sJI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/purple,
@@ -59812,18 +57160,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"sKs" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "sKx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/siding/wood,
@@ -59928,6 +57264,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"sLV" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sLX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -60641,15 +57985,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"sZe" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "sZh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -60667,18 +58002,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/security/courtroom)
-"sZt" = (
-/obj/machinery/flasher{
-	id = "PCell 2";
-	pixel_x = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Cell 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "sZv" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -60781,15 +58104,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"tbe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tbi" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -60889,6 +58203,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tdr" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tdR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60904,12 +58225,6 @@
 "tdY" = (
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
-"ted" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "teD" = (
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
@@ -60924,7 +58239,9 @@
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "teE" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -60985,13 +58302,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"tfC" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+"tfB" = (
+/obj/structure/chair,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tfH" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -61019,12 +58342,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
-"tfY" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "tgs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -61178,12 +58495,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"tiy" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tiJ" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -61235,25 +58546,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"tku" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/interrogation{
-	dir = 1;
-	pixel_y = -30
-	},
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tkA" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -61361,18 +58653,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"tne" = (
-/obj/structure/table,
-/obj/item/phone{
-	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tnA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -61616,6 +58896,17 @@
 "trM" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"tsl" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tss" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
@@ -61633,7 +58924,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "tsz" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
@@ -61648,6 +58941,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
+"tsE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tsG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/disposalpipe/segment{
@@ -61751,13 +59051,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"tva" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "tvk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -61867,13 +59160,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"txB" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "txJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes,
@@ -62201,18 +59487,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"tDh" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tDl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -62427,10 +59701,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"tFU" = (
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "tFX" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
@@ -62673,6 +59943,18 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"tLn" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tLo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -62778,6 +60060,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"tNe" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tNf" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing{
@@ -62905,26 +60197,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"tOG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "tOL" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
@@ -62954,18 +60226,6 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/relay)
-"tPa" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tPm" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -63041,26 +60301,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
+"tQv" = (
+/obj/machinery/flasher{
+	id = "PCell 2";
+	pixel_x = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Cell 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tQE" = (
 /obj/machinery/rnd/production/protolathe/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"tQG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tQH" = (
 /obj/machinery/camera{
-	dir = 1;
-	c_tag = "Armoury Exterior"
+	c_tag = "Armoury Exterior";
+	dir = 1
 	},
 /turf/open/space/basic,
 /area/space)
@@ -63076,6 +60339,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
+"tRg" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tRq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall22";
@@ -63083,18 +60360,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"tRy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tRP" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
@@ -63197,18 +60462,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"tTD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tTH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall23";
@@ -63260,15 +60513,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"tUH" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tUJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 1
@@ -63530,18 +60774,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"tZD" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tZF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -63658,19 +60890,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
-"uaZ" = (
-/obj/machinery/camera{
-	c_tag = "Prison Toilet";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ubm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63681,8 +60900,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
-	name = "Armoury Access Shutters";
-	id = "armour_exterior"
+	id = "armour_exterior";
+	name = "Armoury Access Shutters"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -63721,22 +60940,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"uce" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"uci" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "uco" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -63969,16 +61172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ufp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "ufq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -64061,20 +61254,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uhc" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
-"uhp" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "uhq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -64422,31 +61610,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"umx" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
 "umy" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/hydroponics)
-"umI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "umK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -64460,16 +61627,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"unc" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "und" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
@@ -64552,22 +61709,6 @@
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
-"uoA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/injection,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "uoO" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -64608,15 +61749,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uoZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "upa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -64728,23 +61860,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"uqZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "urg" = (
 /obj/machinery/power/supermatter_crystal/shard/engine{
 	moveable = 1
 	},
 /obj/machinery/mass_driver{
-	armor = list("melee"=10,"bullet"=10,"laser"=10,"energy"=0,"bomb"=0,"bio"=0,"rad"=0,"fire"=100,"acid"=70);
+	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70);
 	critical_machine = 1;
 	dir = 8;
 	id = "smeject";
@@ -64815,16 +61936,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"usn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "usA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -65124,6 +62235,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uxY" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Long-Term Cell 2";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "uxZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -65183,25 +62306,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/medical/storage)
-"uyN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "uyQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -65313,26 +62417,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"uBk" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"uBo" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "uBx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65453,22 +62537,6 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"uDR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "uEf" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -65515,6 +62583,18 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/noslip/white,
 /area/medical/medbay/central)
+"uEv" = (
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "uEx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -65544,6 +62624,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"uEE" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "uEX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -65679,16 +62780,15 @@
 "uGg" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
-"uGk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
+"uGK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uGL" = (
@@ -65920,16 +63020,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"uJI" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "uJJ" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1;
@@ -65948,14 +63038,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
-"uKa" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "uKd" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/stripes/line,
@@ -66164,6 +63246,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"uMN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uMT" = (
 /obj/structure/table,
 /obj/item/phone{
@@ -66336,16 +63423,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"uPF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uPQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66370,6 +63447,15 @@
 	dir = 9
 	},
 /area/medical/surgery)
+"uQv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "uQB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -66452,16 +63538,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"uRO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uRU" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastleft{
@@ -66484,19 +63560,6 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"uSA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "uSJ" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -66535,20 +63598,6 @@
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/maintenance/starboard/secondary)
-"uTp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "uTw" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -66638,6 +63687,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"uUY" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uVh" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -66737,25 +63796,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uWk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
-"uWu" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "uWE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/cargo/request,
@@ -66806,33 +63846,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"uXP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"uXT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "uXX" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Escape Pod Alpha"
@@ -66843,6 +63856,17 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"uYf" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "uYo" = (
 /obj/effect/landmark/start/captain,
 /obj/structure/cable/yellow{
@@ -66962,16 +63986,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"vbr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vbv" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -66979,6 +63993,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"vby" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vbD" = (
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -67058,6 +64085,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vcI" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "vcO" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
@@ -67127,7 +64162,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vdU" = (
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -67197,15 +64234,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"veG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "veI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67361,16 +64389,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"vho" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vhu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -67509,9 +64527,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"vjU" = (
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "vky" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -67557,29 +64572,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
-"vlk" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1423;
-	listening = 0;
-	name = "Interrogation Intercom";
-	pixel_x = 29
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vlr" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -67639,6 +64631,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"vmI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vmQ" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -67648,15 +64648,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen/coldroom)
-"vne" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vno" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -67790,15 +64781,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"vps" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vpH" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -68099,6 +65081,14 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"vuh" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "vum" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68117,24 +65107,6 @@
 "vun" = (
 /turf/closed/wall,
 /area/science/misc_lab/range)
-"vuu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/computer/security/hos{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -5;
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "vuv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -68189,14 +65161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"vuY" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall10";
-	location = "hall9"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "vvb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -68383,6 +65347,20 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"vxq" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vxy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -68484,6 +65462,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"vyt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vyv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -68682,15 +65667,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"vAm" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vAt" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet)
@@ -68801,13 +65777,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"vCi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "vCo" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -68918,14 +65887,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"vEm" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "vEs" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -69062,6 +66023,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"vGx" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vGB" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -69260,13 +66239,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"vIl" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vIx" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Dock Access"
@@ -69280,13 +66252,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"vID" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "vIW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -69327,17 +66292,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"vJp" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "vJu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -69434,21 +66388,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"vKL" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/requests_console{
-	pixel_y = -32
-	},
-/obj/machinery/vending/security,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "vKM" = (
 /obj/machinery/gibber,
 /obj/machinery/requests_console{
@@ -69588,18 +66527,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
-"vNt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "vNz" = (
 /obj/machinery/vending/custom{
 	pixel_y = -1
@@ -69943,7 +66870,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "vTj" = (
@@ -70017,16 +66946,6 @@
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
-"vVK" = (
-/obj/structure/chair,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vVR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
@@ -70068,23 +66987,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
-"vWy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "vWC" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -70262,17 +67164,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"wam" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "waJ" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -70363,6 +67254,21 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"wci" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wcn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -70720,15 +67626,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"wiU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wiV" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/shorts/green,
@@ -70885,38 +67782,12 @@
 "wlP" = (
 /turf/template_noop,
 /area/maintenance/department/crew_quarters/dorms)
-"wlR" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair/office,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wlT" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"wlV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "wlW" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -70939,15 +67810,6 @@
 /obj/structure/closet/cardboard/metal,
 /turf/open/space/basic,
 /area/space)
-"wmg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wmk" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel,
@@ -71014,14 +67876,17 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wnA" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"wnr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/crew_quarters/heads/hos)
 "wnN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -71314,6 +68179,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wsv" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wsI" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -71357,24 +68232,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"wtS" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/radio,
-/obj/item/radio/intercom{
-	pixel_x = -29;
-	pixel_y = -29
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/checkpoint/supply)
 "wul" = (
 /obj/effect/spawner/structure/window/depleteduranium,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -71418,6 +68275,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
+"wuV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wuY" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -71432,18 +68299,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"wvq" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/melee/baton/loaded,
-/obj/item/restraints/handcuffs,
-/obj/item/storage/secure/briefcase,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "wvu" = (
 /obj/machinery/door/airlock/mining{
 	name = "Quartermaster's Office";
@@ -71483,18 +68338,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"wvU" = (
-/obj/structure/table/glass,
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
+"wvQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
-/obj/effect/spawner/lootdrop/job_scale/medical/medkits,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
-/area/medical/storage)
+/area/security/brig)
+"wvW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wwk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -71502,18 +68369,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"wwu" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wwx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -71534,6 +68389,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wwA" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wwI" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -71589,15 +68455,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"wxA" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "wxC" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/airlock_sensor/incinerator_toxmix{
@@ -71630,15 +68487,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"wxY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "wys" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -71782,18 +68630,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"wAz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wAU" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -71804,21 +68640,6 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"wAW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wBb" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -71836,6 +68657,28 @@
 /obj/item/stack/rods,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wBL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wBU" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -71958,16 +68801,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/wood,
 /area/library)
-"wEy" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wEC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light,
@@ -72067,15 +68900,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wGk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "wGl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -72126,19 +68950,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"wHp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "wHB" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/lattice,
@@ -72295,13 +69106,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"wKl" = (
-/obj/machinery/camera/autoname,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wKq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72335,17 +69139,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"wKA" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/lobby)
 "wKJ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/dark,
@@ -72482,15 +69275,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
-"wMC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wMM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72516,24 +69300,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"wNh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_one_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wNi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -72649,16 +69415,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"wPi" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/filingcabinet/security,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "wPn" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -72802,27 +69558,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"wSa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"wSe" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Secure Brig";
-	req_one_access_txt = "2;1;4;34;3"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wSk" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -72855,15 +69590,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"wSB" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -73138,19 +69864,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"wXU" = (
-/obj/structure/table/reinforced,
-/obj/item/coin/antagtoken,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wXZ" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/chair/stool,
@@ -73214,18 +69927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wYo" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "wYq" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -73265,11 +69966,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"wYR" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "wYS" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -73353,6 +70049,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xaC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "xaO" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/scientist,
@@ -73396,17 +70103,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"xdc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "xdj" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -73442,13 +70138,6 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
-"xdF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "xdI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -73665,6 +70354,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"xhZ" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xim" = (
 /obj/effect/landmark/carpspawn,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -73887,13 +70583,6 @@
 	},
 /turf/open/floor/dock/drydock,
 /area/science/shuttle)
-"xmi" = (
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xmq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -74010,40 +70699,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"xoV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"xoW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "HOS's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/item/storage/secure/safe/HoS{
-	pixel_x = 37;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "xpd" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -74162,14 +70817,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/explab)
-"xqF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "xqJ" = (
 /obj/structure/dresser,
 /turf/open/floor/plasteel/dark,
@@ -74631,6 +71278,15 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"xyG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xyJ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -74708,6 +71364,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xzR" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "xzZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -74725,17 +71393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"xAk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xAt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -74781,15 +71438,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"xAP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xAS" = (
 /obj/machinery/door/airlock/virology{
 	name = "Virology Lab";
@@ -74987,21 +71635,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"xCW" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/command)
 "xDj" = (
 /obj/machinery/camera{
 	c_tag = "Prison Main North";
@@ -75073,22 +71706,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"xEI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "xEN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -75187,27 +71804,6 @@
 	},
 /turf/open/floor/circuit,
 /area/gateway)
-"xGM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "xHo" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75226,18 +71822,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"xHC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "xHM" = (
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
@@ -75431,16 +72015,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"xJW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "xKk" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/bananalamp{
@@ -75540,30 +72114,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
-"xLs" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/kitchen/knife/combat/bone,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"xLu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Long-Term Cell 2";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "xLF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -75831,19 +72381,6 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"xPR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/suit_storage_unit/hos,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "xPT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -75853,6 +72390,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xQa" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xQv" = (
 /obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -76151,6 +72701,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"xUq" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xUK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -76265,6 +72827,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xWi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "xXa" = (
 /turf/closed/wall,
 /area/library)
@@ -76296,27 +72864,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"xXy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xXD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -76330,16 +72877,6 @@
 /area/quartermaster/warehouse)
 "xXK" = (
 /turf/open/floor/plasteel,
-/area/security/brig)
-"xXN" = (
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xXS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -76360,32 +72897,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"xYi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/item/storage/secure/briefcase,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "xYm" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
@@ -76408,14 +72919,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"xYK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "xYZ" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -76589,19 +73092,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ydt" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ydu" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -76739,7 +73229,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/item/seeds/tea,
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
@@ -76989,19 +73481,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"ylA" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Long-Term Cell 1";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ylC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -114412,7 +110891,7 @@ iYG
 xyq
 tdf
 oYY
-kgL
+pMz
 kgL
 kgL
 kgL
@@ -115145,8 +111624,8 @@ ujv
 tBd
 skM
 fNy
-uBk
-vsJ
+bjV
+syF
 eyU
 hmy
 ksE
@@ -115402,13 +111881,13 @@ nrw
 mhz
 pCL
 tPB
-uci
-bKF
+gtR
+xhZ
 byP
 hmy
 rAb
 dka
-sdp
+dcj
 nsY
 nXe
 anT
@@ -115659,13 +112138,13 @@ uKT
 uKT
 duF
 ehI
-uoZ
+xUq
 jDl
 mNF
 hmy
 vNG
 vrV
-kEY
+apj
 mMs
 nXe
 aMT
@@ -115904,25 +112383,25 @@ anT
 vyE
 kvB
 uNK
-mjN
+wvW
 oHv
 oHv
-oHv
+dlj
 oHv
 uKT
 pRp
-sZt
-iuV
+tQv
+cqD
 jQz
 duF
 mGW
-wSa
-eaE
+bzN
+kDc
 ikY
 hmy
 fZM
-ckG
-umI
+bul
+nsv
 lPI
 nXe
 aMT
@@ -116161,24 +112640,24 @@ anT
 vyE
 rHY
 lxK
-oEY
-pxv
-aeB
-ePW
-ePW
-bjN
-kDU
-kDU
-kDU
-kDU
-ylA
-wiU
-qYc
-jBR
+how
+jaf
+oAF
+cCI
+uYf
+gMM
+vuh
+ovS
+oBD
+vuh
+oDx
+bdC
+shK
+hLP
 oHg
 hmy
 eqX
-ckG
+qsV
 phE
 tuH
 nXe
@@ -116421,7 +112900,7 @@ lxK
 oEY
 gpE
 oaA
-oHv
+uEv
 bPO
 uKT
 mJk
@@ -116430,12 +112909,12 @@ xqJ
 bNP
 duF
 wFK
-wNh
-kvf
+jph
+iRC
 hmy
 hmy
 hmy
-rPk
+euH
 hmy
 hmy
 duF
@@ -116678,7 +113157,7 @@ ehT
 xsV
 bFY
 aXL
-oHv
+uEv
 tWA
 uKT
 uKT
@@ -116687,12 +113166,12 @@ uKT
 uKT
 duF
 xDM
-ipk
-lJV
+qDX
+ngl
 mug
 duF
-qwL
-tUH
+uQv
+wci
 bKF
 hmy
 usR
@@ -116700,22 +113179,22 @@ niF
 clb
 tMp
 hmy
-gTG
-tPa
-jxp
-kNI
-mHw
-jOI
-jxp
-vps
-jGM
-jxp
-jxp
-eKw
-jxp
-oHT
+bUY
+rqt
+pMr
+xQa
+tRg
+ljz
+ekn
+fjL
+eKV
+ekn
+pMr
+kpN
+pMr
+pqN
 eeC
-qSB
+wvQ
 tJh
 dHi
 mVf
@@ -116935,44 +113414,44 @@ sjC
 qIY
 tGP
 jif
-sjC
+irD
 otJ
 uKT
 pRp
-pJm
-iuV
+dzB
+cqD
 jQz
 duF
 lJV
-wSa
-bKF
+tNe
+mUs
 aqr
 hmy
-wKl
-iYj
+wsv
+aEC
 xtd
 hmy
 frC
-pLn
-usn
+iNK
+eJJ
 axR
 hmy
-cra
-vcZ
-vcZ
-pCL
-fdr
-qhg
-fFa
-qhg
-vcZ
-mBT
-rnG
-vcZ
-fdr
-wSe
-qVf
-rwP
+oIS
+tdr
+eEZ
+kJU
+uUY
+mfA
+nYf
+mfA
+eEZ
+lTA
+dox
+eEZ
+vmI
+pGx
+qDk
+fIg
 hZN
 hmy
 hmy
@@ -116981,7 +113460,7 @@ hmy
 duF
 jwG
 tdf
-kgL
+uMN
 uHq
 gnj
 gks
@@ -117189,38 +113668,38 @@ anT
 vyE
 kad
 xxK
-qUF
-xxK
-xAP
-lxK
-hAA
-djF
-vjU
-vjU
-vjU
-vjU
-xLu
-lJV
-tUH
-qwL
+ahc
+kci
+ocV
+orJ
+sLV
+ssD
+oNY
+pmg
+tsE
+oNY
+uxY
+deq
+bTR
+fNu
 fRY
 hmy
-qwL
-exi
+xyG
+jAL
 lJV
 hmy
 xAZ
-uGk
-mLp
+oNe
+cqr
 jTf
 hmy
-jGQ
-pBZ
+cfK
+gEd
 cSo
 cSo
 cSo
 wqm
-pwc
+mkC
 mqH
 cSo
 cSo
@@ -117229,7 +113708,7 @@ duF
 duF
 duF
 fJO
-aCw
+qEd
 uqu
 rkX
 rgb
@@ -117446,10 +113925,10 @@ anT
 vyE
 dZW
 lxK
-lxK
+giG
 lxK
 pCu
-lxK
+rlr
 drK
 uKT
 cFU
@@ -117458,26 +113937,26 @@ xqJ
 bNP
 duF
 lJV
-tUH
+fbk
 hmy
 hmy
 hmy
-qwL
-iYj
+xyG
+bPW
 lJV
 hmy
 hmy
 hmy
-aIf
+izG
 hmy
 hmy
-shz
-qId
+bBh
+kCD
 cSo
 cOM
 vxE
 qAF
-gTB
+vby
 fCx
 mth
 jhz
@@ -117486,7 +113965,7 @@ erD
 ivK
 hmy
 hmy
-quM
+bmU
 bpE
 hmy
 hmy
@@ -117715,27 +114194,27 @@ uKT
 uKT
 duF
 dEv
-tUH
-ldQ
-iBM
-qwL
-qwL
-iYj
-aIt
-xXN
-dzf
-ior
-tUH
-bKF
-wYR
-bHm
-vcZ
+pHK
+hiD
+wwA
+sFh
+wuV
+ncw
+hFx
+dfy
+nOC
+tsl
+ihm
+kFG
+vyt
+cQT
+awt
 cSo
 rTW
 vxE
-bjv
-ufp
-syZ
+cvC
+ezz
+osU
 xts
 uRG
 oRA
@@ -117743,7 +114222,7 @@ ivK
 ivK
 hmy
 dtI
-tFU
+noa
 oKx
 kWM
 hmy
@@ -117972,12 +114451,12 @@ bpZ
 mQd
 duF
 qve
-wAz
+vGx
 wCB
 qOm
 vEG
-jAg
-dEE
+bfE
+eml
 jYd
 jAg
 jnq
@@ -117986,12 +114465,12 @@ veY
 jAg
 ukc
 kcc
-vcZ
+spJ
 cSo
 ngN
 vxE
 tXe
-uhp
+bvr
 nto
 bQr
 dDa
@@ -118000,7 +114479,7 @@ ivK
 ivK
 hmy
 gjU
-tfY
+xzR
 qOG
 bvE
 hmy
@@ -118224,16 +114703,16 @@ nhn
 naL
 oEb
 cWG
-gHo
+gEu
 gHo
 vCs
 duF
-lJV
-tUH
+kMT
+pkS
 hmy
 hmy
 hmy
-gSe
+ers
 hmy
 hmy
 hmy
@@ -118243,12 +114722,12 @@ hmy
 pxi
 hmy
 rGg
-xmi
+gSb
 cSo
 xlT
 uKd
 tXe
-hhi
+vxq
 nto
 nJT
 kdY
@@ -118257,7 +114736,7 @@ jdN
 ivK
 hmy
 bpE
-rkf
+gEc
 bpE
 hmy
 hmy
@@ -118481,17 +114960,17 @@ mGe
 vpH
 pjQ
 nYi
-nYi
-nYi
-aqN
-dCU
-jAg
-mLX
+pfd
+rBK
+fDi
+hcJ
+sEP
+lbH
 hmy
-vVK
-cCv
-tbe
-gxo
+tfB
+rdK
+sCf
+gDy
 hmy
 ieK
 cKb
@@ -118500,12 +114979,12 @@ bsc
 mSg
 hmy
 vCO
-jKY
+dEQ
 etB
 wcn
 wxW
 tXe
-uhp
+bvr
 nto
 khK
 wcn
@@ -118514,7 +114993,7 @@ cwf
 ivK
 hmy
 uga
-nrr
+oaF
 kEU
 clW
 hmy
@@ -118739,16 +115218,16 @@ naL
 hBg
 naL
 msu
-gHo
+kde
 hfz
 duF
 lJV
-tUH
+fbk
 hmy
-xXK
+jEy
 oQB
 xXK
-bWt
+fkO
 pxi
 tLk
 uMT
@@ -118756,13 +115235,13 @@ ssj
 jjv
 phc
 hmy
-jZh
-jKY
+dVq
+icl
 aUS
 whr
 nms
 msz
-guv
+wBL
 lwX
 lLK
 whr
@@ -118771,8 +115250,8 @@ nst
 trr
 hmy
 sVv
-tfY
-ted
+kAj
+ckw
 wNR
 hmy
 ivK
@@ -118996,11 +115475,11 @@ iiH
 eNA
 mqu
 sVq
-gHo
+xWi
 cWx
 duF
 gTl
-qug
+qcO
 hmy
 hSn
 nTD
@@ -119019,7 +115498,7 @@ cSo
 mTx
 jxw
 vJc
-dcg
+rQl
 wTM
 lJU
 qEw
@@ -119257,7 +115736,7 @@ wFk
 fex
 duF
 vgI
-cgU
+jIN
 hmy
 hmy
 iRh
@@ -119275,9 +115754,9 @@ duF
 cSo
 pSQ
 bQL
-poV
-iHZ
-tfC
+xaC
+rpl
+gZX
 bQL
 pSQ
 fOv
@@ -119514,8 +115993,8 @@ oJx
 cWx
 duF
 qhg
-jin
-tiy
+lBZ
+tLn
 cpB
 ohA
 rnf
@@ -119771,14 +116250,14 @@ vys
 nYj
 duF
 ojK
-qId
-jEM
-lHW
-bQG
-hek
-kVs
-sZe
-dzs
+itA
+pte
+uGK
+ijA
+wnr
+vcI
+qad
+uEE
 ihC
 iRh
 aMT
@@ -120035,7 +116514,7 @@ iRh
 wvD
 eEV
 hig
-nFr
+iSC
 hpD
 iRh
 aMT
@@ -120292,7 +116771,7 @@ iRh
 tbi
 kVs
 pgn
-owj
+pOK
 vxp
 sUf
 anT

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -1175,7 +1175,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "amk" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/airalarm/engine{
@@ -1609,9 +1609,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "asK" = (
@@ -1720,9 +1717,6 @@
 "auC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -2318,6 +2312,17 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
+"aCH" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aCI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -2641,16 +2646,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"aFG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aFH" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -3080,8 +3075,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aKy" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hos)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aKJ" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
@@ -3778,9 +3780,6 @@
 "aSM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aTc" = (
@@ -4581,7 +4580,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bgd" = (
@@ -4734,9 +4732,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -5247,8 +5242,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/security/detectives_office)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "brS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -5452,7 +5449,7 @@
 	},
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "bvI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -5529,15 +5526,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bwG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bwW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/button/door{
@@ -5695,13 +5688,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"bAk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bAn" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -7243,9 +7229,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	name = "Brig Control Desk";
@@ -7721,7 +7704,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/red,
-/area/security/brig)
+/area/security/detectives_office)
 "ckO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -7778,7 +7761,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "cmg" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -8598,7 +8581,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "cBN" = (
 /obj/item/radio/intercom{
 	pixel_x = -28;
@@ -8917,9 +8900,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -10573,7 +10553,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "dky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -10803,8 +10783,11 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "doz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11037,8 +11020,11 @@
 "dtI" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "dtW" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -11699,9 +11685,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "dFu" = (
@@ -12010,9 +11993,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dKv" = (
@@ -12077,12 +12057,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "dLA" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dLB" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -12386,13 +12365,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"dRf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dRg" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -12801,12 +12773,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -13221,9 +13187,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "eeb" = (
@@ -13277,7 +13240,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -13347,9 +13309,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -13975,7 +13934,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/red,
-/area/security/brig)
+/area/security/detectives_office)
 "erm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14049,7 +14008,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
 "etB" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
@@ -14383,12 +14341,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "exZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall12";
+	location = "hall10"
 	},
-/turf/open/floor/plating,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "eya" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -15396,9 +15355,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -15416,15 +15372,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eRv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "eRF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -16388,6 +16338,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "fjx" = (
@@ -16867,6 +16818,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "frA" = (
@@ -16933,7 +16885,6 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fsT" = (
@@ -17808,6 +17759,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
+"fIr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fIx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18597,7 +18558,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "fVN" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -18855,8 +18816,11 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/detective,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /turf/open/floor/carpet/red,
-/area/security/brig)
+/area/security/detectives_office)
 "fZQ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -18869,7 +18833,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
-/area/security/detectives_office)
+/area/security/brig)
 "fZW" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -19000,7 +18964,6 @@
 "gci" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/start/security_officer,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gcn" = (
@@ -19445,8 +19408,11 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "gjY" = (
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -19465,6 +19431,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gkz" = (
@@ -19834,9 +19801,6 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/item/radio/intercom{
 	pixel_y = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -20259,9 +20223,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gyB" = (
@@ -20367,7 +20328,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "gzO" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/delivery,
@@ -20492,9 +20453,6 @@
 	},
 /obj/machinery/recharger{
 	pixel_y = 3
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -20835,12 +20793,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "gHq" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "gHw" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -21621,9 +21581,6 @@
 "gTl" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -23455,6 +23412,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hAa" = (
@@ -23863,6 +23821,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"hHM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hHS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -25053,7 +25020,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -25143,7 +25109,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "idg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -25269,15 +25235,9 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "ieI" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ifc" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
@@ -25803,9 +25763,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ipm" = (
@@ -26110,6 +26067,9 @@
 "isF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -27295,9 +27255,6 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "iPK" = (
@@ -29156,7 +29113,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -29295,9 +29251,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -29504,7 +29457,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
-/area/security/detectives_office)
+/area/security/brig)
 "jDF" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/server,
@@ -30004,10 +29957,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jLw" = (
@@ -30564,9 +30513,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "jVA" = (
@@ -30598,21 +30544,14 @@
 /turf/closed/wall,
 /area/bridge)
 "jWm" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jWp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -30793,6 +30732,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"jYt" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "jYC" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -31190,15 +31139,9 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "kgL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "kgN" = (
 /obj/effect/landmark/start/exploration,
 /obj/machinery/camera/autoname{
@@ -31597,7 +31540,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/security/detectives_office)
+/area/security/brig)
 "knn" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -31699,6 +31642,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "koS" = (
@@ -31906,7 +31850,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "ksO" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -32357,9 +32301,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kyP" = (
@@ -32587,7 +32528,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
-/area/security/detectives_office)
+/area/security/brig)
 "kDs" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/green,
@@ -32634,7 +32575,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kDK" = (
@@ -32733,7 +32673,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "kFa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -32761,9 +32701,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/security/sec,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "kFS" = (
@@ -33169,11 +33106,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -33187,7 +33124,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kNN" = (
@@ -33240,9 +33176,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -33259,6 +33192,7 @@
 /area/space/nearstation)
 "kQI" = (
 /obj/structure/table,
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kRc" = (
@@ -33430,6 +33364,9 @@
 "kTC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -33633,8 +33570,11 @@
 /obj/item/storage/firstaid{
 	pixel_y = 1
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "kXc" = (
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
@@ -34073,7 +34013,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Secure Brig";
@@ -34846,9 +34785,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -35964,9 +35900,6 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "lJl" = (
@@ -36078,18 +36011,6 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
-"lKP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "lKQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -36377,7 +36298,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "lPX" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
@@ -37010,9 +36931,6 @@
 "lYU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -37889,11 +37807,12 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
 "mmg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/starboard)
 "mmp" = (
 /obj/machinery/light{
 	dir = 1
@@ -39097,7 +39016,6 @@
 	pixel_x = -28;
 	pixel_y = -2
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mEV" = (
@@ -39432,7 +39350,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/secure_closet/detective,
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "mMt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40594,6 +40512,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ngK" = (
@@ -40619,9 +40541,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -41221,7 +41140,7 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "nsZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -41455,7 +41374,7 @@
 	name = "Secure Brig Maintenance";
 	req_one_access_txt = "2;1;4;34;3"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/security/brig)
 "nxG" = (
 /obj/machinery/telecomms/server/presets/supply,
@@ -42134,7 +42053,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	pixel_x = -28;
 	pixel_y = -2
@@ -43829,9 +43747,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "okw" = (
@@ -44317,7 +44232,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -44723,9 +44637,6 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname,
 /obj/structure/closet/secure_closet/security/sec,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "ozg" = (
@@ -44820,9 +44731,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -45282,7 +45190,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Secure Brig";
@@ -45454,7 +45361,7 @@
 /obj/item/reagent_containers/blood/random,
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "oKN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -46492,7 +46399,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "phJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -46832,7 +46739,6 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ppd" = (
@@ -47218,7 +47124,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pvv" = (
@@ -47647,9 +47552,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pCa" = (
@@ -47823,7 +47725,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/security/detectives_office)
+/area/security/brig)
 "pEC" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -48433,15 +48335,14 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "pNM" = (
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/start/security_officer,
-/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "pOd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -49067,7 +48968,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pYz" = (
@@ -49159,19 +49059,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "qac" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qay" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -49184,15 +49076,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "qaA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall11";
-	location = "hall10"
+/obj/effect/turf_decal/tile/red,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "qaC" = (
 /obj/machinery/light{
 	dir = 1
@@ -49338,7 +49230,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
-/area/security/detectives_office)
+/area/security/brig)
 "qdG" = (
 /obj/item/crowbar/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49506,9 +49398,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qhk" = (
@@ -50398,7 +50287,9 @@
 	name = "Brig Medical";
 	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "quW" = (
 /obj/machinery/door/airlock/maintenance{
@@ -51778,9 +51669,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qSI" = (
@@ -51815,9 +51703,6 @@
 	dir = 4
 	},
 /obj/structure/chair,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
@@ -51907,7 +51792,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qVg" = (
@@ -52040,31 +51924,20 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qXX" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qYd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/disposal/bin,
@@ -53580,10 +53453,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rwP" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -53774,7 +53643,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "rAw" = (
 /obj/machinery/advanced_airlock_controller/directional/south,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -53828,7 +53697,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -54669,7 +54537,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/detectives_office)
 "rPn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -55532,7 +55400,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "sdz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -55592,7 +55460,7 @@
 "sef" = (
 /obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall,
-/area/security/brig)
+/area/security/detectives_office)
 "sep" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/closed/wall,
@@ -57072,7 +56940,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -57219,12 +57086,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "sHZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/starboard)
 "sIf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -58027,8 +57894,11 @@
 "sVv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/crate/freezer/blood,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "sVB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -58417,9 +58287,11 @@
 /turf/open/floor/carpet/cyan,
 /area/crew_quarters/heads/cmo)
 "tdf" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tdj" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -59206,7 +59078,7 @@
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "tuK" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -59343,9 +59215,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "txB" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "txJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes,
@@ -60301,10 +60176,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall10";
-	location = "hall9"
-	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "tNW" = (
@@ -60584,7 +60455,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tTH" = (
@@ -60889,6 +60759,8 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tZF" = (
@@ -61058,7 +60930,7 @@
 	req_access_txt = "34"
 	},
 /turf/open/floor/plating,
-/area/security/detectives_office)
+/area/security/brig)
 "ubC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -61068,7 +60940,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uco" = (
@@ -61350,7 +61221,7 @@
 /obj/machinery/anesthetic_machine,
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "ugr" = (
 /obj/machinery/power/generator,
 /obj/structure/cable{
@@ -61568,7 +61439,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ukc" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -61755,7 +61625,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/security/brig)
+/area/security/detectives_office)
 "umK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -62160,7 +62030,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -62992,12 +62861,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "uHq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uHw" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4;
@@ -63570,7 +63438,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 26
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uPQ" = (
@@ -63579,9 +63446,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -63678,7 +63542,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uRU" = (
@@ -64163,7 +64026,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vbv" = (
@@ -64265,7 +64127,6 @@
 /area/security/execution/education)
 "vcZ" = (
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vdg" = (
@@ -64498,9 +64359,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vgK" = (
@@ -64970,7 +64828,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vpH" = (
@@ -65094,15 +64951,12 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "vrj" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	sortType = 8
-	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/starboard)
 "vrp" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -65159,7 +65013,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/red,
-/area/security/brig)
+/area/security/detectives_office)
 "vsg" = (
 /obj/machinery/light{
 	dir = 4
@@ -65345,13 +65199,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"vuY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall10";
+	location = "hall9"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vvb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -65599,6 +65458,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vyv" = (
@@ -66544,6 +66404,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vLG" = (
@@ -66673,7 +66534,7 @@
 /obj/item/poster/random_official,
 /obj/item/poster/random_official,
 /turf/open/floor/carpet/red,
-/area/security/brig)
+/area/security/detectives_office)
 "vNJ" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /obj/structure/cable/yellow{
@@ -67313,9 +67174,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -68008,9 +67866,6 @@
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "wnN" = (
@@ -68065,14 +67920,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "wod" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/starboard)
 "won" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68159,9 +68011,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/main)
@@ -68491,9 +68340,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -68922,9 +68768,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wEC" = (
@@ -69032,9 +68875,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -69242,7 +69082,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "wKh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -69301,16 +69141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/lobby)
-"wKG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wKN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -69383,9 +69213,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -69450,7 +69277,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -69497,9 +69323,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wNi" = (
@@ -69539,8 +69362,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/security/detectives_office)
+/area/security/brig)
 "wNW" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -69776,7 +69600,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Secure Brig";
@@ -70214,7 +70037,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wYR" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
@@ -70454,11 +70276,6 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xez" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xeR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -71608,20 +71425,12 @@
 /turf/open/floor/dock/drydock,
 /area/science/shuttle)
 "xzF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xzO" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 4
@@ -71955,11 +71764,6 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"xDV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xDZ" = (
@@ -72850,6 +72654,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xRL" = (
@@ -73086,13 +72893,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "xVp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xVs" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -73476,9 +73281,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -111024,13 +110826,13 @@ ogh
 uWc
 sRa
 xyq
-sqh
-sqh
-sqh
-sqh
-sqh
-sqh
-sqh
+xVp
+qac
+qac
+qXX
+qac
+qac
+qac
 jzx
 ike
 lpT
@@ -111281,13 +111083,13 @@ pID
 fSU
 iYG
 xyq
-sqh
-sqh
-sqh
-sqh
-sqh
-sqh
-sqh
+tdf
+vuY
+kgL
+kgL
+kgL
+kgL
+kgL
 jzx
 vjJ
 hMM
@@ -111538,13 +111340,13 @@ vqG
 wqt
 kNB
 xyq
-sqh
-sqh
-sqh
-sqh
-hzZ
-sqh
-sqh
+tdf
+eRv
+ieI
+ieI
+ieI
+mmg
+ieI
 jzx
 mEx
 rpc
@@ -111764,10 +111566,10 @@ qLx
 vgb
 hmy
 sef
-hmy
-hmy
-hmy
-hmy
+nXe
+nXe
+nXe
+nXe
 tQH
 oXI
 htD
@@ -111787,7 +111589,7 @@ dvq
 iSx
 fAg
 tch
-wod
+rwP
 qZp
 hmy
 hmy
@@ -111795,15 +111597,15 @@ hmy
 hmy
 hmy
 duF
-sqh
-sqh
-gnj
-iaU
+tdf
+uHq
 gnj
 gnj
 iaU
 gnj
 gnj
+gnj
+iaU
 gnj
 mFB
 eWn
@@ -112024,7 +111826,7 @@ ksE
 fVD
 gzH
 amh
-hmy
+nXe
 aMT
 oXI
 hwK
@@ -112044,7 +111846,7 @@ cGF
 qsm
 dDl
 tch
-wod
+rwP
 oHE
 dHi
 xFa
@@ -112052,8 +111854,8 @@ dgP
 uWc
 sRa
 xyq
-sqh
-sqh
+tdf
+uHq
 gnj
 aMT
 aMT
@@ -112281,7 +112083,7 @@ rAb
 dka
 sdp
 nsY
-hmy
+nXe
 anT
 oXI
 dus
@@ -112309,8 +112111,8 @@ pID
 fSU
 iYG
 xyq
-sqh
-sqh
+tdf
+uHq
 iaU
 aMT
 aMT
@@ -112321,7 +112123,7 @@ aMT
 aMT
 iaU
 sNC
-qaA
+tSC
 kEQ
 iDL
 dxz
@@ -112538,7 +112340,7 @@ vNG
 vrV
 kEY
 mMs
-hmy
+nXe
 aMT
 oXI
 oXI
@@ -112558,7 +112360,7 @@ gtV
 rPL
 dDl
 tch
-wod
+rwP
 deS
 dHi
 iUQ
@@ -112566,8 +112368,8 @@ vqG
 wqt
 kNB
 xyq
-sqh
-sqh
+tdf
+uHq
 iaU
 aMT
 aMT
@@ -112795,7 +112597,7 @@ fZM
 ckG
 umI
 lPI
-hmy
+nXe
 aMT
 aMT
 oXI
@@ -112823,8 +112625,8 @@ hmy
 hmy
 hmy
 duF
-sqh
-sqh
+hHM
+uHq
 iaU
 aMT
 aMT
@@ -113052,7 +112854,7 @@ eqX
 ckG
 phE
 tuH
-hmy
+nXe
 aMT
 aMT
 aMT
@@ -113080,8 +112882,8 @@ foZ
 uWc
 sRa
 xyq
-sqh
-sqh
+tdf
+uHq
 gnj
 aMT
 aMT
@@ -113337,8 +113139,8 @@ pID
 fSU
 iYG
 xyq
-sqh
-sqh
+tdf
+uHq
 gnj
 gnj
 fjt
@@ -113565,12 +113367,12 @@ duF
 qwL
 tUH
 bKF
-duF
+hmy
 usR
 wAW
 icI
 tMp
-duF
+hmy
 wwu
 fsF
 pvo
@@ -113594,9 +113396,9 @@ vqG
 wqt
 kNB
 xyq
-sqh
-sqh
-sqh
+tdf
+dLA
+bwG
 gnj
 frx
 tZD
@@ -113818,24 +113620,24 @@ lJV
 wEy
 lTY
 oph
-duF
+hmy
 pAz
 iYj
 eez
-duF
+hmy
 frC
 kVK
 rOC
 axR
-duF
+hmy
 kyC
-xez
 vcZ
-kgL
 vcZ
+pCL
+pYy
 uce
 gci
-vrj
+uce
 vcZ
 poQ
 uPF
@@ -113851,9 +113653,9 @@ hmy
 hmy
 duF
 jwG
-sqh
-sqh
-sqh
+tdf
+kgL
+uHq
 gnj
 gks
 gnj
@@ -114072,19 +113874,19 @@ vjU
 vjU
 xLu
 lJV
-lKP
+tUH
 qwL
 lNv
-duF
+hmy
 qwL
 exi
 lJV
-duF
+hmy
 xAZ
 nMg
 cri
 jTf
-duF
+hmy
 jGQ
 pBZ
 cSo
@@ -114092,7 +113894,7 @@ cSo
 cSo
 wqm
 pwc
-bwG
+mqH
 cSo
 cSo
 oRA
@@ -114108,15 +113910,15 @@ tlU
 eBL
 xBP
 kTC
-sqh
-sqh
-sqh
-sqh
-sqh
+wod
+exZ
+vrj
+sHZ
+qac
 xRF
-sqh
-sqh
-sqh
+qac
+qac
+qac
 jZD
 fkM
 sqh
@@ -114329,24 +114131,24 @@ xqJ
 bNP
 duF
 lJV
-lKP
-duF
-duF
-duF
+tUH
+hmy
+hmy
+hmy
 qwL
 iYj
 lJV
-duF
-duF
-duF
+hmy
+hmy
+hmy
 aIf
-duF
-duF
+hmy
+hmy
 fMJ
 dXV
 cSo
 wam
-pNM
+lLS
 dFt
 wHp
 jVs
@@ -114366,14 +114168,14 @@ aIt
 eZE
 isF
 hzZ
-sqh
-sqh
-sqh
-sqh
-sqh
-sqh
-sqh
-sqh
+ieI
+xzF
+gHq
+kgL
+kgL
+kgL
+kgL
+kgL
 hbK
 tQc
 pIh
@@ -114586,21 +114388,21 @@ uKT
 uKT
 duF
 dEv
-lKP
+tUH
 ldQ
-bAk
-bAk
-dLA
-uHq
-tdf
+pNM
+qwL
+qwL
+iYj
+aIt
 nIJ
 ibI
 wMC
-aFG
-xDV
+qXL
+bKF
 wYR
 bHm
-sHZ
+vcZ
 cSo
 oze
 lLS
@@ -114612,12 +114414,12 @@ jno
 oRA
 ivK
 ivK
-nXe
+hmy
 dtI
 fZQ
 oKx
 kWM
-nXe
+hmy
 hmy
 hmy
 hmy
@@ -114625,12 +114427,12 @@ pqj
 gnj
 rxo
 gnj
+jWm
 vLi
-vLi
-vLi
+aKy
 kQI
-sqh
-sqh
+ieI
+ieI
 gPc
 kEB
 aBD
@@ -114849,32 +114651,32 @@ xoV
 vEG
 jAg
 mUB
-vIl
-ieI
-xVp
+aCH
+jAg
+fIr
 osL
 rBh
-xVp
+jAg
 ukc
 tDh
-sHZ
+vcZ
 cSo
 gqz
 lLS
 hYR
 cWA
-jWm
+asI
 beW
 cbC
 scG
 ivK
 ivK
-nXe
+hmy
 gjU
 kne
 jDD
 bvE
-nXe
+hmy
 ivK
 ivK
 ivK
@@ -115114,24 +114916,24 @@ hmy
 pxi
 hmy
 rGg
-sHZ
+txB
 cSo
 kFE
 gSy
 hYR
 suf
-jWm
+asI
 kBt
 vKL
 fOv
 jdN
 ivK
-nXe
-txB
+hmy
+bpE
 brR
-txB
-nXe
-nXe
+bpE
+hmy
+hmy
 ivK
 ivK
 ivK
@@ -115373,22 +115175,22 @@ hmy
 kNF
 jKY
 etB
-xzF
+uqZ
 bgb
-qXX
-qac
+hYR
+cWA
 asI
 uBo
 uqZ
 fOv
 cwf
 ivK
-nXe
+hmy
 uga
 kDo
 pEy
 clW
-nXe
+hmy
 ivK
 cUA
 hLY
@@ -115613,10 +115415,10 @@ lkB
 gHo
 oCV
 duF
-gHq
-eRv
+lJV
+tUH
 hmy
-mmg
+xXK
 oQB
 xXK
 bWt
@@ -115628,7 +115430,7 @@ oAF
 xYK
 hmy
 lYU
-wKG
+jKY
 aUS
 lrA
 nTO
@@ -115640,12 +115442,12 @@ ajD
 oUZ
 nst
 trr
-nXe
+hmy
 sVv
 kne
 qdv
 wNR
-nXe
+hmy
 ivK
 apD
 ivK
@@ -115884,7 +115686,7 @@ ssj
 vlk
 uSA
 hmy
-dRf
+vcZ
 aSM
 cSo
 wnA
@@ -115893,16 +115695,16 @@ aDh
 jPv
 xYi
 unc
-crC
+jYt
 fOv
 ivK
 cfP
-nXe
+hmy
 dow
 icT
 wKc
 cBK
-nXe
+hmy
 ivK
 apD
 ivK
@@ -116134,16 +115936,16 @@ hmy
 iRh
 iRh
 boQ
-aKy
+iRh
 iRh
 iRh
 iRh
 hmy
-hmy
-hmy
+duF
+duF
 nxz
 duF
-oRA
+cSo
 mZR
 crC
 aDJ
@@ -116154,12 +115956,12 @@ mZR
 fOv
 jdN
 cfP
-nXe
-nXe
+hmy
+hmy
 ubx
-nXe
-nXe
-nXe
+hmy
+hmy
+hmy
 jdN
 vAI
 jdN
@@ -116399,8 +116201,8 @@ aMT
 jdN
 ivK
 ivK
-ivK
-exZ
+nkH
+cSo
 oAG
 gBr
 edV
@@ -116641,7 +116443,7 @@ naL
 rWf
 lzn
 duF
-qhg
+qaA
 mkB
 jTl
 hQu
@@ -116653,7 +116455,7 @@ ore
 htP
 iRh
 aMT
-jdN
+ivy
 ivK
 ivK
 ivK
@@ -116910,11 +116712,11 @@ mnY
 wPi
 iRh
 aMT
-ivy
+jdN
 ivK
 ivK
 ivK
-ivy
+jdN
 aMT
 kQq
 aMT

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -584,16 +584,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"aeH" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "aeN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1529,15 +1519,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aqr" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "aqt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2992,6 +2978,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"aJn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "aJt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -4248,14 +4241,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"aXX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "aYd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
@@ -11524,6 +11509,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
+"dAW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dBG" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -15540,27 +15532,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"eVn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "eVI" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/button/door{
@@ -27796,6 +27767,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"iVI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iVW" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
@@ -28363,13 +28344,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"jdU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "jeb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -31442,12 +31416,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"kky" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "kkP" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -32382,13 +32350,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kya" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kyg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38736,16 +38697,6 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"mAC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research)
 "mAJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -43258,6 +43209,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"nWd" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/research)
 "nWe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -44090,16 +44051,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"okq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "okw" = (
 /obj/structure/table/glass,
 /obj/structure/sign/poster/random{
@@ -48382,6 +48333,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"pJe" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pJf" = (
 /mob/living/simple_animal/pet/hamster/vector,
 /obj/structure/bed/dogbed/vector,
@@ -51363,13 +51325,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"qGG" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qGQ" = (
 /obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced,
@@ -60342,6 +60297,13 @@
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"tHe" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tHs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60612,6 +60574,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_prep)
+"tMg" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tMm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 10
@@ -60916,6 +60888,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
+"tRd" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tRq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hall22";
@@ -71204,6 +71186,27 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"xmd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xmg" = (
 /obj/structure/table,
 /obj/item/shuttle_creator{
@@ -74156,6 +74159,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"yks" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ykK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -102894,7 +102905,7 @@ hZO
 bOW
 qqf
 vBK
-kky
+aqr
 vKb
 iCv
 eey
@@ -103665,7 +103676,7 @@ qvj
 kMZ
 cah
 nAV
-kky
+aqr
 bpq
 anz
 qQo
@@ -103922,7 +103933,7 @@ teE
 mbl
 cah
 fYh
-kky
+aqr
 bpq
 anz
 opS
@@ -104671,7 +104682,7 @@ jHI
 dQx
 fAL
 lpb
-mAC
+nWd
 cft
 mif
 eAm
@@ -113887,7 +113898,7 @@ duF
 qIa
 vVU
 nTY
-kya
+dAW
 hmy
 dpB
 amM
@@ -114166,7 +114177,7 @@ sXL
 wtJ
 bQp
 hwc
-aqr
+tRd
 fRR
 lRh
 aer
@@ -114401,9 +114412,9 @@ nwA
 bRD
 mHW
 pek
-aXX
+yks
 hmy
-okq
+iVI
 sgY
 lJV
 hmy
@@ -114441,7 +114452,7 @@ qPa
 qBd
 wKH
 vov
-afM
+pJe
 sVw
 afM
 cdX
@@ -114692,8 +114703,8 @@ aIt
 aIt
 eZE
 avM
-aeH
-qGG
+tMg
+tHe
 xzF
 gHq
 kgL
@@ -115941,7 +115952,7 @@ feb
 hfz
 duF
 rDK
-eVn
+xmd
 hmy
 xtv
 oQB
@@ -117483,8 +117494,8 @@ naL
 naL
 duF
 duF
-jdU
-jdU
+aJn
+aJn
 duF
 iRh
 tbi

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -395,9 +395,8 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "acn" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -1006,10 +1005,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ajD" = (
-/obj/structure/chair,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "ajI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1157,13 +1155,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "amh" = (
-/obj/machinery/computer/operating{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
 /area/security/brig)
 "amk" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -2277,12 +2273,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aCz" = (
@@ -3060,15 +3050,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aKy" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Head of Security";
-	req_access_txt = "58"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/crew_quarters/heads/hos)
 "aKJ" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -5215,14 +5197,27 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "brR" = (
-/obj/effect/landmark/start/detective,
-/obj/structure/chair/fancy/comfy{
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Medical";
+	req_access_txt = "34"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "brS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -5417,11 +5412,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bvE" = (
-/obj/structure/closet/secure_closet/detective,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/wood,
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "bvI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -7677,37 +7677,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"cki" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "cky" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ckG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/carpet/red,
 /area/security/brig)
 "ckO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -7758,15 +7734,13 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/port)
 "clW" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/computer/operating{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = -24
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "cmg" = (
 /obj/machinery/disposal/bin,
@@ -8580,8 +8554,13 @@
 /turf/open/floor/plating,
 /area/security/nuke_storage)
 "cBK" = (
-/obj/machinery/vending/boozeomat/all_access,
-/turf/open/floor/wood,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/sec/surgery,
+/obj/item/blood_filter,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "cBN" = (
 /obj/item/radio/intercom{
@@ -8918,15 +8897,18 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
 "cJf" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Armoury Access Hallway";
+	req_access_txt = "3";
+	security_level = 6
 	},
+/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/caution,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/security/warden)
 "cJj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9982,15 +9964,22 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "ddE" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	security_level = 6;
+	req_one_access_txt = "66;3"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "ddN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10028,16 +10017,6 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"deP" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "deS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10147,10 +10126,7 @@
 	name = "Armoury Access";
 	pixel_x = 29;
 	pixel_y = 28;
-	req_access_txt = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+	req_access_txt = "3"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -10546,27 +10522,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dka" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Medical";
-	req_access_txt = "34"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/landmark/start/detective,
+/obj/structure/chair/fancy/comfy{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/brig)
 "dky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10793,13 +10756,11 @@
 /turf/closed/wall,
 /area/quartermaster/storage)
 "dow" = (
-/obj/machinery/computer/security{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "doz" = (
 /obj/structure/cable/yellow{
@@ -11031,15 +10992,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "dtI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "detective_shutters";
-	name = "detective's office shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
+/obj/machinery/stasis,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "dtW" = (
 /obj/structure/table/wood,
@@ -12390,9 +12345,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dRg" = (
@@ -13267,11 +13219,9 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "eez" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/warden)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "eeC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13481,12 +13431,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "eit" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/brig)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eiF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -13950,9 +13902,16 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "eqX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/stasis,
-/turf/open/floor/plasteel,
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
 /area/security/brig)
 "erm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15995,12 +15954,21 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fdx" = (
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "fdD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16949,13 +16917,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/quartermaster/office)
-"fub" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
-/area/space)
 "fuh" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -18541,14 +18502,11 @@
 /turf/open/floor/wood,
 /area/library)
 "fVD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/brig)
 "fVN" = (
 /obj/machinery/light_switch{
@@ -18803,31 +18761,24 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fZM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"fZQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_access_txt = "4"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood/end{
+/obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/effect/landmark/start/detective,
+/turf/open/floor/carpet/red,
+/area/security/brig)
+"fZQ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "fZW" = (
 /obj/structure/chair/fancy/comfy{
@@ -19399,19 +19350,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "gjU" = (
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
+/obj/structure/table/glass,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "gjY" = (
 /obj/machinery/camera/autoname{
@@ -20318,16 +20262,21 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "gzH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = -25;
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/button/door{
+	id = "detective_shutters";
+	name = "detective's office shutters control";
+	pixel_x = -26;
+	pixel_y = 6;
+	req_access_txt = "4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/brig)
 "gzO" = (
 /obj/machinery/washing_machine,
@@ -20902,23 +20851,19 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "gIX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "armorydoors";
-	name = "Blast Doors"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	security_level = 6;
-	req_access_txt = "2;66"
-	},
+/obj/effect/spawner/lootdrop/job_scale/armoury/laser_gun,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "gIZ" = (
@@ -22267,18 +22212,20 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "hfx" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/door/poddoor/shutters{
+	name = "Armoury Access Shutters";
+	id = "armour_exterior"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
 "hgm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -23615,19 +23562,12 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "hEt" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hEw" = (
@@ -24072,16 +24012,8 @@
 	},
 /area/holodeck/rec_center)
 "hLY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Interrogation Room";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/closed/wall,
+/area/space/nearstation)
 "hMH" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -24244,9 +24176,6 @@
 /mob/living/simple_animal/pet/dog/bullterrier/walter,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/wood,
 /area/security/warden)
@@ -25006,15 +24935,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ibI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ibO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
@@ -25095,10 +25024,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "icT" = (
-/obj/machinery/computer/secure_data{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "idg" = (
 /obj/effect/turf_decal/tile/red,
@@ -26359,6 +26288,11 @@
 /area/crew_quarters/bar)
 "izC" = (
 /obj/structure/closet/secure_closet/warden,
+/obj/machinery/requests_console{
+	department = "Warden's Office";
+	departmentType = 5;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/security/warden)
 "izP" = (
@@ -26772,18 +26706,9 @@
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "iGm" = (
-/obj/machinery/door/poddoor/shutters{
-	name = "Armoury Access Shutters";
-	id = "armour_exterior"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/structure/rack,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
+/obj/effect/spawner/lootdrop/job_scale/armoury/wt550,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "iGp" = (
@@ -27759,14 +27684,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "iYj" = (
-/obj/structure/table/reinforced,
-/obj/item/defibrillator/loaded,
-/obj/item/wrench/medical,
-/obj/item/wallframe/defib_mount,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/security/brig)
 "iYq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -29116,11 +29035,15 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "jxp" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/job_scale/armoury/riot_shield,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "jxt" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
@@ -29442,24 +29365,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jDD" = (
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/button/door{
-	id = "detective_shutters";
-	name = "detective's office shutters control";
-	pixel_x = -26;
-	pixel_y = 6;
-	req_access_txt = "4"
-	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "jDF" = (
 /obj/machinery/telecomms/server/presets/common,
@@ -31549,19 +31463,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kne" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "knn" = (
 /obj/machinery/ai_slipper{
@@ -31861,10 +31772,13 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "ksE" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/anesthetic_machine,
-/obj/item/tank/internals/anesthetic,
-/turf/open/floor/plasteel,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
 /area/security/brig)
 "ksO" = (
 /obj/structure/chair/office/light{
@@ -32538,13 +32452,14 @@
 /turf/open/floor/wood,
 /area/security/warden)
 "kDo" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/evidence,
-/obj/item/melee/classic_baton/police,
-/obj/item/reagent_containers/food/drinks/flask/det,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "kDs" = (
 /obj/machinery/vending/snack/random,
@@ -32560,6 +32475,9 @@
 	},
 /obj/machinery/computer/security/labor{
 	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/security/warden)
@@ -32684,13 +32602,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kEY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/random,
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/brig)
 "kFa" = (
 /obj/effect/turf_decal/stripes/line{
@@ -33572,22 +33487,15 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal)
 "kWM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/storage/firstaid{
+	pixel_y = 1
 	},
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	security_level = 6;
-	req_access_txt = "2;66"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plasteel,
+/area/security/detectives_office)
 "kXc" = (
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
@@ -33803,15 +33711,10 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "lbl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
 "lbs" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -33899,12 +33802,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lcm" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/job_scale/armoury/riot_shield,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/ai_monitored/security/armory)
 "lcq" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -34026,19 +33928,19 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ldQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "lee" = (
 /obj/structure/extinguisher_cabinet{
@@ -35889,13 +35791,21 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "lIw" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3";
-	security_level = 6
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/warden)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/job_scale/armoury/disabler,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lIO" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -36320,16 +36230,17 @@
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "lPI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/requests_console{
+	department = "Detective's Office";
+	departmentType = 4;
+	pixel_y = -32
 	},
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("aisat")
 	},
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
 /area/security/brig)
 "lPX" = (
 /obj/machinery/door/airlock/command{
@@ -37259,28 +37170,25 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mdT" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Medical";
-	req_one_access_txt = "34;2;1;4"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "armorydoors";
+	name = "Blast Doors"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	security_level = 6;
+	req_one_access_txt = "66;3"
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "mea" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -38654,11 +38562,11 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "mya" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/job_scale/armoury/wt550,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/warden)
 "myf" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -39367,14 +39275,12 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "mMs" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/firealarm{
+	pixel_y = -24
 	},
-/obj/structure/table/glass,
-/obj/item/storage/firstaid{
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/secure_closet/detective,
+/turf/open/floor/wood,
 /area/security/brig)
 "mMt" = (
 /obj/effect/turf_decal/stripes/line{
@@ -39943,6 +39849,9 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "mVY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
@@ -41149,17 +41058,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "nsY" = (
-/obj/structure/chair/fancy/comfy{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/security/detectives_office)
+/area/security/brig)
 "nsZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -41389,21 +41294,12 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "nxz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Secure Brig Maintenance";
+	req_one_access_txt = "2;1;4;34;3"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/security/main)
 "nxG" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/server,
@@ -41475,11 +41371,11 @@
 	},
 /area/hallway/secondary/entry)
 "nyJ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plasteel,
+/area/security/warden)
 "nyS" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -42078,21 +41974,16 @@
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
 "nIJ" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/laser_gun,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nIO" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -44036,11 +43927,8 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "oph" = (
-/obj/machinery/holopad{
-	pixel_y = 16
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/space)
 "opq" = (
 /turf/closed/wall,
 /area/science/breakroom)
@@ -45378,7 +45266,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "oKx" = (
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/random,
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "oKN" = (
 /obj/structure/cable/yellow{
@@ -45830,19 +45724,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "oUZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hosoffice";
-	name = "Head of Security's Office Shutters"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Gear Room Maintenance";
+	req_one_access_txt = "1;4"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
+/area/maintenance/starboard/fore)
 "oVg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -46411,14 +46298,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "phE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/computer/med_data{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood,
 /area/security/brig)
 "phJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -46627,19 +46516,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pkx" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Interrogation Room";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "pkM" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -47249,6 +47125,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pwC" = (
@@ -47743,13 +47620,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "pEy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "pEC" = (
 /turf/open/floor/plasteel/dark,
@@ -48717,16 +48595,19 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "pUM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/chair,
+/obj/item/radio/intercom{
+	frequency = 1423;
+	name = "Interrogation Intercom";
+	pixel_x = -28
 	},
-/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pUR" = (
@@ -49239,11 +49120,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qdv" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/security/detectives_office)
 "qdG" = (
 /obj/item/crowbar/red,
@@ -50302,17 +50186,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "quM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig Medical";
+	req_access_txt = "63"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 30
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "quW" = (
@@ -53669,20 +53547,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rAb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/chair/fancy/comfy{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/brig)
 "rAw" = (
 /obj/machinery/advanced_airlock_controller/directional/south,
@@ -54573,15 +54444,16 @@
 /turf/closed/wall,
 /area/hydroponics/garden)
 "rPn" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3";
+	security_level = 6
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plating,
+/area/security/warden)
 "rPs" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/rack,
@@ -55429,20 +55301,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "sdp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/brig)
 "sdz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -55501,9 +55363,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "sef" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel,
+/obj/machinery/vending/boozeomat/all_access,
+/turf/closed/wall,
 /area/security/brig)
 "sep" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -55895,27 +55756,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"slv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "slH" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -56360,15 +56200,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ssT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ssV" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	filter_type = "n2"
@@ -57000,16 +56836,21 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sFf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3";
-	security_level = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/security/warden)
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sFB" = (
 /obj/structure/chair/fancy/bench/pew/left{
 	dir = 8
@@ -57957,12 +57798,9 @@
 /turf/open/floor/plating,
 /area/science/research)
 "sVv" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/detective,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "sVB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -58881,14 +58719,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"tpt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tpA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59151,14 +58981,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "tuH" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Security Maintenance";
-	req_access_txt = "63"
+/obj/machinery/computer/secure_data{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/security/brig)
 "tuK" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -59296,13 +59125,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "txB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/security/detectives_office)
 "txJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -60051,9 +59875,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tLk" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plasteel,
+/obj/structure/chair,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tLo" = (
 /obj/structure/cable/yellow{
@@ -60633,21 +60456,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tVA" = (
-/obj/structure/chair,
-/obj/item/radio/intercom{
-	frequency = 1423;
-	name = "Interrogation Intercom";
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "tWh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -60972,10 +60780,19 @@
 /area/security/prison)
 "ubm" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	name = "Armoury Access Shutters";
+	id = "armour_exterior"
+	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/ai_monitored/security/armory)
 "ubn" = (
 /obj/machinery/modular_fabricator/exosuit_fab,
 /obj/effect/turf_decal/bot,
@@ -60997,7 +60814,15 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ubx" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Brig Medical Maintenance";
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Brig Medical Maintenance";
+	req_access_txt = "34"
+	},
+/turf/open/floor/plating,
 /area/security/detectives_office)
 "ubC" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -61286,16 +61111,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/customs)
 "uga" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/item/poster/random_official,
-/obj/item/poster/random_official,
-/obj/item/poster/random_official,
-/turf/open/floor/carpet/red,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/anesthetic_machine,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "ugr" = (
 /obj/machinery/power/generator,
@@ -61685,6 +61504,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "umy" = (
@@ -61692,14 +61514,13 @@
 /turf/closed/wall,
 /area/hydroponics)
 "umI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/brig)
 "umK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -61917,9 +61738,6 @@
 "uqu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -63852,20 +63670,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "uVP" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/disabler,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "uVR" = (
 /obj/effect/turf_decal/stripes/line,
@@ -64912,9 +64720,6 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "vps" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -65100,17 +64905,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "vrV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/obj/structure/table/wood,
+/obj/item/storage/box/evidence,
+/obj/item/melee/classic_baton/police,
+/obj/item/reagent_containers/food/drinks/flask/det,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/turf/open/floor/carpet/red,
 /area/security/brig)
 "vsg" = (
 /obj/machinery/light{
@@ -66317,13 +66118,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"vIL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Interrogation Waiting Room";
-	req_one_access_txt = "1;4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vIW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66594,20 +66388,14 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "vNt" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/ai_monitored/security/armory)
 "vNz" = (
 /obj/machinery/vending/custom{
 	pixel_y = -1
@@ -66618,18 +66406,16 @@
 /turf/open/floor/wood,
 /area/library)
 "vNG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/item/poster/random_official,
+/obj/item/poster/random_official,
+/obj/item/poster/random_official,
+/turf/open/floor/carpet/red,
 /area/security/brig)
 "vNJ" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
@@ -67664,17 +67450,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wiI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/ai_monitored/security/armory)
 "wiP" = (
 /obj/machinery/light{
 	dir = 4
@@ -67810,14 +67588,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"wku" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wkz" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/telecomms/server,
@@ -68825,14 +68595,22 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "wCB" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wDn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -69202,16 +68980,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wKc" = (
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/machinery/computer/med_data{
+/obj/structure/table/reinforced,
+/obj/item/defibrillator/loaded,
+/obj/item/wrench/medical,
+/obj/item/wallframe/defib_mount,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "wKh" = (
 /obj/structure/cable/yellow{
@@ -69420,11 +69196,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wMM" = (
@@ -69506,19 +69281,11 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "wNR" = (
-/obj/machinery/requests_console{
-	department = "Detective's Office";
-	departmentType = 4;
-	pixel_y = -32
+/obj/structure/table/optable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("aisat")
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/detectives_office)
 "wNW" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -70187,13 +69954,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wYR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
-/obj/item/blood_filter,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/space/basic,
 /area/security/brig)
 "wYS" = (
 /obj/machinery/telecomms/bus/preset_one,
@@ -73197,14 +72958,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
 "xXK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xXY" = (
@@ -73864,19 +73617,18 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "yma" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3";
+	security_level = 6
 	},
-/obj/machinery/vending/wardrobe/det_wardrobe,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/security/detectives_office)
+/turf/open/floor/plasteel,
+/area/security/warden)
 "ymf" = (
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science/central)
 
 (1,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -74388,11 +74140,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (3,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -74904,11 +74654,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (5,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -75420,11 +75168,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (7,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -75936,11 +75682,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (9,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -76452,11 +76196,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (11,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -76968,11 +76710,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (13,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -77484,11 +77224,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (15,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -78000,11 +77738,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (17,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -78516,11 +78252,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (19,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -79032,11 +78766,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (21,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -79548,11 +79280,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (23,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -79905,7 +79635,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -80068,7 +79797,6 @@ aMT
 xRF
 "}
 (25,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -80420,7 +80148,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aYR
 anT
@@ -80584,7 +80311,6 @@ aMT
 xRF
 "}
 (27,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -80933,7 +80659,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -81100,7 +80825,6 @@ aMT
 xRF
 "}
 (29,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -81448,7 +81172,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 huQ
 anT
@@ -81616,7 +81339,6 @@ aMT
 xRF
 "}
 (31,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -81964,7 +81686,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -82132,7 +81853,6 @@ aMT
 xRF
 "}
 (33,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -82480,7 +82200,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -82648,7 +82367,6 @@ aMT
 xRF
 "}
 (35,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -83000,7 +82718,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 anT
@@ -83164,7 +82881,6 @@ aMT
 xRF
 "}
 (37,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -83516,7 +83232,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 anT
@@ -83680,7 +83395,6 @@ aMT
 xRF
 "}
 (39,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -84026,7 +83740,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -84196,7 +83909,6 @@ aMT
 xRF
 "}
 (41,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -84542,7 +84254,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -84712,7 +84423,6 @@ aMT
 xRF
 "}
 (43,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -85058,7 +84768,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 anT
 aLq
@@ -85228,7 +84937,6 @@ aMT
 xRF
 "}
 (45,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -85574,7 +85282,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aLq
@@ -85744,7 +85451,6 @@ aMT
 xRF
 "}
 (47,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -86087,7 +85793,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 aLq
 aLq
 aLq
@@ -86260,7 +85965,6 @@ aMT
 xRF
 "}
 (49,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -86597,7 +86301,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qBt
 rlm
 oVg
@@ -86776,7 +86479,6 @@ aMT
 xRF
 "}
 (51,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -87097,7 +86799,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oTx
 oTx
 oTx
@@ -87292,7 +86993,6 @@ aMT
 xRF
 "}
 (53,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -87550,7 +87250,6 @@ aMT
 xRF
 "}
 (54,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -87867,7 +87566,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -88066,7 +87764,6 @@ aMT
 xRF
 "}
 (56,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -88382,7 +88079,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 aPf
 vyB
 fye
@@ -88582,7 +88278,6 @@ aMT
 xRF
 "}
 (58,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -88898,7 +88593,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 aPf
 hWq
 vyB
@@ -89098,7 +88792,6 @@ aMT
 xRF
 "}
 (60,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -89410,7 +89103,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oTx
 oTx
 aMT
@@ -89614,7 +89306,6 @@ aMT
 xRF
 "}
 (62,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -89925,7 +89616,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oTx
 aMT
 anT
@@ -90130,7 +89820,6 @@ aMT
 xRF
 "}
 (64,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -90441,7 +90130,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oTx
 aMT
 anT
@@ -90646,7 +90334,6 @@ aMT
 xRF
 "}
 (66,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -90957,7 +90644,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oTx
 aMT
 anT
@@ -91215,7 +90901,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oTx
 aMT
 anT
@@ -91420,7 +91105,6 @@ aMT
 xRF
 "}
 (69,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -91736,7 +91420,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 iaD
@@ -91936,7 +91619,6 @@ aMT
 xRF
 "}
 (71,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -92252,7 +91934,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 anT
 iaD
@@ -92452,7 +92133,6 @@ aMT
 xRF
 "}
 (73,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -92765,7 +92445,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 anT
 anT
@@ -92968,7 +92647,6 @@ aMT
 xRF
 "}
 (75,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -93277,7 +92955,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qiD
 aMT
 aMT
@@ -93484,7 +93161,6 @@ aMT
 xRF
 "}
 (77,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -93800,7 +93476,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 anT
 iaD
@@ -94000,7 +93675,6 @@ aMT
 xRF
 "}
 (79,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -94318,7 +93992,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 anT
 aPf
@@ -94516,7 +94189,6 @@ aMT
 xRF
 "}
 (81,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -94838,7 +94510,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 kqr
 bmR
 bmR
@@ -95096,7 +94767,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 hrK
 aPf
 aPf
@@ -95290,7 +94960,6 @@ aMT
 xRF
 "}
 (84,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -95612,7 +95281,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 hrK
 aPf
 oIN
@@ -95806,7 +95474,6 @@ aMT
 xRF
 "}
 (86,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -96128,7 +95795,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 hrK
 aPf
 aPf
@@ -96322,7 +95988,6 @@ aMT
 xRF
 "}
 (88,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -96643,7 +96308,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oCW
 rpy
 oCW
@@ -96838,7 +96502,6 @@ aMT
 xRF
 "}
 (90,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -97158,7 +96821,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 agE
 oYp
 dXn
@@ -97354,7 +97016,6 @@ aMT
 xRF
 "}
 (92,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -97674,7 +97335,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 agE
 ebm
 cnI
@@ -97870,7 +97530,6 @@ aMT
 xRF
 "}
 (94,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -98190,7 +97849,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 agE
 mAy
 oCW
@@ -98386,7 +98044,6 @@ aMT
 xRF
 "}
 (96,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -98706,7 +98363,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 aBa
 rHW
 aWR
@@ -98902,7 +98558,6 @@ aMT
 xRF
 "}
 (98,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -99211,7 +98866,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 sVT
 aMT
 aMT
@@ -99418,7 +99072,6 @@ aMT
 xRF
 "}
 (100,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -99734,7 +99387,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 anT
@@ -99934,7 +99586,6 @@ aMT
 xRF
 "}
 (102,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -100247,7 +99898,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 anT
 anT
@@ -100450,7 +100100,6 @@ aMT
 xRF
 "}
 (104,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -100763,7 +100412,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 anT
 anT
@@ -100966,7 +100614,6 @@ aMT
 xRF
 "}
 (106,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -101278,7 +100925,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -101482,7 +101128,6 @@ aMT
 xRF
 "}
 (108,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -101799,7 +101444,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tRV
 aMT
 aMT
@@ -101998,7 +101642,6 @@ aMT
 xRF
 "}
 (110,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -102314,7 +101957,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 dun
 uDs
 oIq
@@ -102514,7 +102156,6 @@ aMT
 xRF
 "}
 (112,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -102830,7 +102471,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 dun
 uDs
 oIq
@@ -103030,7 +102670,6 @@ aMT
 xRF
 "}
 (114,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -103312,7 +102951,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qiD
 aMT
 aMT
@@ -103546,7 +103184,6 @@ aMT
 xRF
 "}
 (116,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -103839,7 +103476,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -104062,7 +103698,6 @@ aMT
 xRF
 "}
 (118,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -104343,7 +103978,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tvU
 tvU
 tvU
@@ -104578,7 +104212,6 @@ aMT
 xRF
 "}
 (120,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -104857,7 +104490,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oqj
 uyk
 bJM
@@ -105094,7 +104726,6 @@ aMT
 xRF
 "}
 (122,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -105371,7 +105002,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 byn
 uyk
 bJM
@@ -105610,7 +105240,6 @@ aMT
 xRF
 "}
 (124,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -105887,7 +105516,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 byn
 nVG
 pVz
@@ -106126,7 +105754,6 @@ aMT
 xRF
 "}
 (126,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -106403,7 +106030,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 oqj
 nVG
 hTH
@@ -106642,7 +106268,6 @@ aMT
 xRF
 "}
 (128,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -106918,7 +106543,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 byn
 lNs
 dKU
@@ -107158,7 +106782,6 @@ aMT
 xRF
 "}
 (130,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -107434,7 +107057,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 byn
 lNs
 kDB
@@ -107674,7 +107296,6 @@ aMT
 xRF
 "}
 (132,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -107951,7 +107572,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 hAa
 aUa
 ooo
@@ -108190,7 +107810,6 @@ aMT
 xRF
 "}
 (134,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -108467,7 +108086,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 byn
 aUa
 pVz
@@ -108706,7 +108324,6 @@ aMT
 xRF
 "}
 (136,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -108983,7 +108600,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 byn
 ckQ
 tNy
@@ -109222,7 +108838,6 @@ aMT
 xRF
 "}
 (138,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -109501,7 +109116,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 hAa
 lCz
 tNy
@@ -109738,7 +109352,6 @@ aMT
 xRF
 "}
 (140,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -110019,7 +109632,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xON
 xON
 xON
@@ -110254,7 +109866,6 @@ aMT
 xRF
 "}
 (142,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -110568,7 +110179,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -110770,7 +110380,6 @@ aMT
 xRF
 "}
 (144,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -111084,7 +110693,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -111120,7 +110728,7 @@ aMT
 aMT
 oXI
 oXI
-mya
+iGm
 iYF
 smX
 oXI
@@ -111350,7 +110958,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qBt
 uKT
 uKT
@@ -111371,10 +110978,10 @@ duF
 duF
 duF
 duF
-duF
-duF
-duF
-duF
+wYR
+iYj
+iYj
+iYj
 anT
 oXI
 dMz
@@ -111608,7 +111215,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qBt
 uKT
 gvo
@@ -111628,23 +111234,23 @@ aKK
 wlR
 xQE
 hmy
-tLk
-ubm
 iYj
 wYR
-duF
+iYj
+wYR
+wYR
 aMT
 oXI
 xhX
 ipZ
 fNn
-uVP
+lIw
 vZO
 oXI
 crF
 oXI
-rPn
-acn
+lbl
+lbl
 lpe
 izC
 ghw
@@ -111861,7 +111467,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -111887,25 +111492,25 @@ qLx
 vgb
 hmy
 sef
-ckG
-ddE
-lcm
-duF
+hmy
+hmy
+hmy
+hmy
 tQH
 oXI
 htD
 aae
 lXS
-hEt
+fdx
 jkd
-gIX
+mdT
 sir
-kWM
-cJf
+ddE
+vNt
 mVY
 tNg
 vdg
-vBE
+nyJ
 dvq
 iSx
 fAg
@@ -112118,7 +111723,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 iaD
 anT
@@ -112146,21 +111750,21 @@ muO
 hmy
 ksE
 fVD
-phE
+gzH
 amh
-duF
+hmy
 aMT
 oXI
 hwK
 ipZ
 fNn
-nIJ
+gIX
 jbs
 oXI
 hIC
 oXI
 wYo
-mVY
+hEt
 tNg
 dHN
 vBE
@@ -112377,7 +111981,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -112402,11 +112005,11 @@ dJW
 aFJ
 oeX
 hmy
-bpE
+rAb
 dka
-bpE
+sdp
+nsY
 hmy
-duF
 anT
 oXI
 dus
@@ -112417,12 +112020,12 @@ dMe
 oXI
 aOu
 oXI
-wCB
-mVY
+eit
+ssT
 lpe
 mqN
-eez
-eez
+mya
+mya
 qYB
 tTo
 jDz
@@ -112632,7 +112235,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qiD
 aMT
 aMT
@@ -112664,20 +112266,20 @@ vNG
 vrV
 kEY
 mMs
-duF
+hmy
 aMT
 oXI
 oXI
-jxp
+lcm
 hmQ
 ozu
 oXI
 oXI
 anT
 oXI
-nyJ
-mVY
-tNg
+acn
+ssT
+lpe
 hPv
 gtV
 gtV
@@ -112891,7 +112493,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 anT
 iaD
@@ -112922,7 +112523,7 @@ fZM
 ckG
 umI
 lPI
-duF
+hmy
 aMT
 aMT
 oXI
@@ -112933,14 +112534,14 @@ oXI
 aMT
 aMT
 oXI
-nyJ
-mVY
-tNg
+acn
+ssT
+cJf
 dgh
 hQz
 kDl
 dxw
-sFf
+rPn
 nyy
 uPQ
 sBB
@@ -113149,7 +112750,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -113177,22 +112777,22 @@ hdO
 tRy
 hmy
 eqX
-fVD
+ckG
 phE
-vrV
-duF
+tuH
+hmy
+aMT
+aMT
+aMT
+anT
+aMT
+anT
 aMT
 ams
-aMT
-anT
-aMT
-anT
-aMT
-aMT
-fub
+qiD
 oXI
-nyJ
-mVY
+hfx
+ubm
 lpe
 mXD
 kDz
@@ -113407,7 +113007,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 rKo
 aMT
 aMT
@@ -113435,12 +113034,12 @@ kvf
 hmy
 hmy
 hmy
-mdT
+aIt
+hmy
 hmy
 duF
-duF
-wGS
-wGS
+ssj
+ssj
 duF
 duF
 duF
@@ -113449,12 +113048,12 @@ duF
 duF
 duF
 oXI
-iGm
-iGm
+uVP
+wiI
 lpe
 gBw
 lpe
-lIw
+yma
 lpe
 tTo
 vcF
@@ -113664,7 +113263,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 iaD
 anT
@@ -113691,10 +113289,10 @@ xDM
 ipk
 lJV
 mug
-slv
-ldQ
-cki
-sdp
+duF
+aIt
+aIt
+aIt
 duF
 usR
 wAW
@@ -113706,8 +113304,8 @@ fsF
 pvo
 kNI
 uRO
-rAb
-pvo
+sFf
+jxp
 vps
 mEM
 isF
@@ -113923,7 +113521,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -113949,10 +113546,10 @@ lJV
 wEy
 lTY
 lNv
-gzH
+duF
 aIt
-oph
-ibI
+aIt
+aIt
 duF
 frC
 kVK
@@ -114181,7 +113778,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -114207,10 +113803,10 @@ lJV
 lKP
 qwL
 tdf
-hfx
-lbl
-lbl
-nxz
+duF
+aIt
+aIt
+aIt
 duF
 xAZ
 nMg
@@ -114439,7 +114035,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 anT
 iaD
@@ -114463,12 +114058,12 @@ bNP
 duF
 lJV
 lKP
-hmy
-hmy
-hmy
-hmy
-hmy
-hmy
+duF
+duF
+duF
+aIt
+aIt
+aIt
 duF
 duF
 duF
@@ -114487,13 +114082,13 @@ uTp
 uKa
 oRA
 erD
-vre
-tuH
-tpt
+ivK
+hmy
+hmy
 quM
-fdx
-wku
-ssj
+bpE
+hmy
+hmy
 aIt
 aIt
 eZE
@@ -114699,7 +114294,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -114720,19 +114314,19 @@ uKT
 uKT
 duF
 dEv
-vNt
-hmy
-tVA
-tku
-ssj
-kOy
-hVU
-hmy
-qTW
-mqm
-jLV
-rOj
-hmy
+lKP
+ldQ
+bAk
+bAk
+uHq
+uHq
+uHq
+nIJ
+ibI
+wMC
+aFG
+bAk
+uHq
 bHm
 sHZ
 cSo
@@ -114745,16 +114339,16 @@ gyo
 jno
 oRA
 ivK
-cfP
-ubx
+ivK
+nXe
 dtI
 fZQ
+oKx
+kWM
 nXe
-nXe
-ubx
-duF
-duF
-duF
+hmy
+hmy
+hmy
 pqj
 gnj
 iaU
@@ -114957,7 +114551,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -114978,19 +114571,19 @@ gRi
 jAA
 duF
 lJV
-pUM
-hmy
-ajD
-tne
-ssj
-oAF
-xYK
-hLY
-mmg
-oQB
-pAz
-bWt
-vIL
+lKP
+wCB
+xoV
+vEG
+mUB
+mUB
+kPl
+ieI
+xVp
+xVp
+rBh
+xVp
+ukc
 bHm
 sHZ
 cSo
@@ -115003,13 +114596,13 @@ beW
 cbC
 scG
 ivK
-cfP
-ubx
+ivK
+nXe
 gjU
 kne
 jDD
 bvE
-ubx
+nXe
 ivK
 ivK
 ivK
@@ -115214,7 +114807,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 iaD
 anT
@@ -115238,16 +114830,16 @@ duF
 lJV
 qXL
 hmy
-cim
-hjj
-ssj
-vlk
-uSA
 hmy
-ydt
-ngF
-lHJ
-kDf
+hmy
+xXK
+hmy
+hmy
+hmy
+hmy
+hmy
+hmy
+xXK
 hmy
 rGg
 sHZ
@@ -115262,12 +114854,12 @@ vKL
 fOv
 jdN
 cfP
-ubx
-nsY
+nXe
+txB
 brR
 txB
-yma
-ubx
+nXe
+nXe
 ivK
 ivK
 ivK
@@ -115473,7 +115065,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 iaD
 aMT
 aMT
@@ -115496,16 +115087,16 @@ dCU
 vIl
 eQV
 hmy
-pkx
+qTW
+mqm
+jLV
+rOj
 hmy
-hmy
-hmy
-hmy
-hmy
-hmy
-wFK
-eit
-hmy
+pUM
+tku
+ssj
+kOy
+hVU
 hmy
 kNF
 jKY
@@ -115520,12 +115111,12 @@ uqZ
 fOv
 cwf
 cfP
-ubx
+nXe
 uga
 kDo
 pEy
 clW
-ubx
+nXe
 ivK
 cUA
 lTv
@@ -115736,7 +115327,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qBt
 uKT
 fQS
@@ -115753,18 +115343,18 @@ oCV
 duF
 gHq
 eRv
-ssT
-bAk
-bAk
-wMC
-deP
+hmy
+mmg
+oQB
+pAz
+bWt
 xXK
-bAk
-bAk
-bAk
-aFG
-bAk
-uHq
+tLk
+tne
+ssj
+oAF
+xYK
+hmy
 lYU
 wKG
 aUS
@@ -115775,15 +115365,15 @@ tOG
 rJI
 aBp
 wHp
-fOv
+oUZ
 ivK
 trr
-ubx
+nXe
 sVv
-oKx
+kne
 qdv
 wNR
-ubx
+nXe
 ivK
 nzt
 ivK
@@ -115994,7 +115584,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qBt
 uKT
 uKT
@@ -116011,18 +115600,18 @@ xdF
 duF
 gTl
 qug
-wiI
-xoV
-vEG
-mUB
-mUB
-kPl
-ieI
-xVp
-xVp
-rBh
-xVp
-ukc
+hmy
+ydt
+ngF
+lHJ
+kDf
+hmy
+cim
+hjj
+ssj
+vlk
+uSA
+hmy
 dRf
 aSM
 cSo
@@ -116036,12 +115625,12 @@ crC
 fOv
 ivK
 cfP
-ubx
+nXe
 dow
 icT
 wKc
 cBK
-ubx
+nXe
 ivK
 nzt
 ivK
@@ -116252,7 +115841,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qBt
 iCB
 anT
@@ -116275,13 +115863,13 @@ iRh
 iRh
 boQ
 aKy
-oUZ
 iRh
 iRh
-oRA
-oRA
-mqH
-mqH
+iRh
+cSo
+cSo
+cSo
+nxz
 oRA
 oRA
 mZR
@@ -116294,12 +115882,12 @@ mZR
 fOv
 jdN
 cfP
+nXe
+nXe
 ubx
-ubx
-ubx
-ubx
-ubx
-ubx
+nXe
+nXe
+nXe
 jdN
 vAI
 jdN
@@ -116510,7 +116098,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qBt
 aMT
 aMT
@@ -116537,10 +116124,10 @@ wGk
 lJh
 iRh
 aMT
-anT
-aMT
-aMT
-aMT
+hLY
+oph
+oph
+oph
 exZ
 oAG
 gBr
@@ -116773,7 +116360,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 naL
 nVo
 nVo
@@ -116795,10 +116381,10 @@ ore
 htP
 iRh
 aMT
-anT
-aMT
-aMT
-aMT
+hLY
+oph
+oph
+oph
 oRA
 oRA
 oRA
@@ -117033,7 +116619,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -117053,13 +116638,13 @@ mnY
 wPi
 iRh
 aMT
-anT
-aMT
-aMT
-aMT
+ajD
+oph
+oph
+oph
+eez
 aMT
 kQq
-aMT
 aMT
 aMT
 aMT
@@ -117286,7 +116871,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 qiD
 aMT
 aMT
@@ -117313,7 +116897,7 @@ sUf
 anT
 jdN
 jdN
-jdN
+ivK
 jdN
 jdN
 jdN
@@ -117478,7 +117062,6 @@ aMT
 xRF
 "}
 (170,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -117807,7 +117390,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -117994,7 +117576,6 @@ aMT
 xRF
 "}
 (172,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -118323,7 +117904,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -118510,7 +118090,6 @@ aMT
 xRF
 "}
 (174,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -118768,7 +118347,6 @@ aMT
 xRF
 "}
 (175,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -119097,7 +118675,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -119355,7 +118932,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -119542,7 +119118,6 @@ aMT
 xRF
 "}
 (178,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -119871,7 +119446,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 fOv
@@ -120058,7 +119632,6 @@ aMT
 xRF
 "}
 (180,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -120387,7 +119960,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 ivy
@@ -120574,7 +120146,6 @@ aMT
 xRF
 "}
 (182,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -120903,7 +120474,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 jdN
@@ -121090,7 +120660,6 @@ aMT
 xRF
 "}
 (184,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -121423,7 +120992,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 jdN
 mqG
 jdN
@@ -121606,7 +121174,6 @@ aMT
 xRF
 "}
 (186,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -121939,7 +121506,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 ivy
 rAw
 jdN
@@ -122197,7 +121763,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 jdN
 bQz
 jdN
@@ -122380,7 +121945,6 @@ aMT
 xRF
 "}
 (189,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -122720,7 +122284,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 anT
 anT
@@ -122978,7 +122541,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -123154,7 +122716,6 @@ aMT
 xRF
 "}
 (192,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -123494,7 +123055,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -123752,7 +123312,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -123928,7 +123487,6 @@ aMT
 xRF
 "}
 (195,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -124268,7 +123826,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -124444,7 +124001,6 @@ aMT
 xRF
 "}
 (197,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -124784,7 +124340,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 aMT
@@ -124960,7 +124515,6 @@ aMT
 xRF
 "}
 (199,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -125308,7 +124862,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 nLn
@@ -125476,7 +125029,6 @@ aMT
 xRF
 "}
 (201,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -125826,7 +125378,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 nLn
 qPJ
 nLn
@@ -126084,7 +125635,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 nLn
 qPJ
 fzs
@@ -126250,7 +125800,6 @@ aMT
 xRF
 "}
 (204,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -126600,7 +126149,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 krU
 nLn
 krU
@@ -126858,7 +126406,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 krU
@@ -127024,7 +126571,6 @@ aMT
 xRF
 "}
 (207,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -127374,7 +126920,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 tXx
 krU
@@ -127540,7 +127085,6 @@ aMT
 xRF
 "}
 (209,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -127889,7 +127433,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 tXx
@@ -128056,7 +127599,6 @@ aMT
 xRF
 "}
 (211,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -128404,7 +127946,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 uTo
 uOk
 gHg
@@ -128572,7 +128113,6 @@ aMT
 xRF
 "}
 (213,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -128919,7 +128459,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 baJ
@@ -129177,7 +128716,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 baJ
@@ -129346,7 +128884,6 @@ aMT
 xRF
 "}
 (216,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -129690,7 +129227,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 tXx
@@ -129862,7 +129398,6 @@ aMT
 xRF
 "}
 (218,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -130208,7 +129743,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 kSS
 baJ
@@ -130378,7 +129912,6 @@ aMT
 xRF
 "}
 (220,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -130724,7 +130257,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 kSS
 sBx
@@ -130894,7 +130426,6 @@ aMT
 xRF
 "}
 (222,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -131238,7 +130769,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 anT
 aMT
 tXx
@@ -131410,7 +130940,6 @@ aMT
 xRF
 "}
 (224,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -131757,7 +131286,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 baJ
 baJ
@@ -131926,7 +131454,6 @@ aMT
 xRF
 "}
 (226,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -132273,7 +131800,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 baJ
@@ -132442,7 +131968,6 @@ aMT
 xRF
 "}
 (228,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -132790,7 +132315,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 krU
@@ -132958,7 +132482,6 @@ aMT
 xRF
 "}
 (230,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -133309,7 +132832,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 tXx
@@ -133474,7 +132996,6 @@ aMT
 xRF
 "}
 (232,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -133829,7 +133350,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 tXx
@@ -133990,7 +133510,6 @@ aMT
 xRF
 "}
 (234,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -134349,7 +133868,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 tXx
 tXx
 tXx
@@ -134506,7 +134024,6 @@ aMT
 xRF
 "}
 (236,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -135018,11 +134535,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (238,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -135534,11 +135049,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (240,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -136050,11 +135563,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (242,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -136566,11 +136077,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (244,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -137082,11 +136591,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (246,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -137598,11 +137105,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (248,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -138114,11 +137619,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (250,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -138630,11 +138133,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (252,1,1) = {"
-aMT
 aMT
 aMT
 aMT
@@ -139146,7 +138647,6 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (254,1,1) = {"
@@ -139404,11 +138904,9 @@ aMT
 aMT
 aMT
 aMT
-aMT
 xRF
 "}
 (255,1,1) = {"
-aMT
 aMT
 aMT
 aMT

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -395,20 +395,12 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "acn" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/item/storage/lockbox/loyalty,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "acp" = (
 /obj/structure/rack,
 /obj/item/pet_carrier,
@@ -8815,14 +8807,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cGF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "cHg" = (
 /obj/effect/landmark/start/cargo_technician,
@@ -8929,22 +8918,15 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
 "cJf" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/requests_console{
-	department = "Warden's Office";
-	departmentType = 5;
-	pixel_y = 32
-	},
-/obj/structure/bed/dogbed/walter,
-/mob/living/simple_animal/pet/dog/bullterrier/walter,
+/obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "cJj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10157,14 +10139,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "dgh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/button/door{
+	id = "armour_exterior";
+	name = "Armoury Access";
+	pixel_x = 29;
+	pixel_y = 28;
+	req_access_txt = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood,
 /area/security/warden)
 "dgp" = (
 /obj/effect/turf_decal/stripes/line{
@@ -11117,14 +11108,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dvq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "dvr" = (
 /obj/effect/turf_decal/stripes/line{
@@ -11286,17 +11273,17 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "dxw" = (
-/obj/machinery/photocopier{
-	pixel_x = -2;
-	pixel_y = -3
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/warden)
 "dxz" = (
 /obj/machinery/newscaster{
@@ -11559,12 +11546,7 @@
 /area/quartermaster/storage)
 "dDl" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/security/warden)
 "dDH" = (
@@ -11874,14 +11856,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dHN" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/storage/lockbox/loyalty,
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -13283,11 +13267,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "eez" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/warden)
 "eeC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -17323,19 +17306,18 @@
 /area/medical/surgery)
 "fAg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Brig Control Desk";
-	req_access_txt = "3"
-	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
 	dir = 2;
 	icon_state = "right";
 	name = "Outer Window"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Brig Control Desk";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plating,
 /area/security/warden)
 "fAh" = (
 /obj/structure/chair,
@@ -19263,20 +19245,8 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "ghw" = (
-/obj/structure/table,
-/obj/item/melee/baton/loaded,
-/obj/item/restraints/handcuffs,
-/obj/item/folder/red,
-/obj/item/folder/red,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/storage/box/firingpins,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
 /area/security/warden)
 "ghR" = (
 /turf/open/floor/plasteel/white,
@@ -19992,15 +19962,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "gtV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/flasher/portable,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/warden)
 "gtW" = (
 /obj/structure/cable/yellow{
@@ -20498,11 +20460,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "gBw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Brig Control Desk";
+	req_access_txt = "3"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Outer Window"
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel,
 /area/security/warden)
 "gBI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -20930,16 +20902,25 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "gIX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/gun/energy/laser,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "armorydoors";
+	name = "Blast Doors"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	security_level = 6;
+	req_access_txt = "2;66"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "gIZ" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/drone,
@@ -22684,12 +22665,16 @@
 /area/hallway/primary/fore)
 "hmQ" = (
 /obj/structure/rack,
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 2;
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_vest,
+/obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_helmet,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "hmZ" = (
@@ -23630,21 +23615,21 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "hEt" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Brig Control Desk";
-	req_access_txt = "3"
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Outer Window"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/warden)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "hEw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -24252,13 +24237,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hPv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
 /area/security/warden)
 "hPD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24318,11 +24308,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "hQz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/warden)
 "hQN" = (
 /obj/machinery/light{
@@ -26369,21 +26358,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "izC" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/secure_closet/warden,
+/turf/open/floor/plasteel,
 /area/security/warden)
 "izP" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -26796,28 +26772,19 @@
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "iGm" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/door/poddoor/shutters{
+	name = "Armoury Access Shutters";
+	id = "armour_exterior"
 	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "iGp" = (
 /obj/structure/window/reinforced{
@@ -27492,14 +27459,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "iSx" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/warden,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/button/door{
 	id = "secmain";
 	name = "Security Exterior Blast Doors";
@@ -27507,6 +27466,8 @@
 	pixel_y = -26;
 	req_access_txt = "2"
 	},
+/obj/structure/chair/office,
+/obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "iSD" = (
@@ -29155,18 +29116,11 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "jxp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/job_scale/armoury/riot_shield,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/ai_monitored/security/armory)
 "jxt" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
@@ -32577,14 +32531,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "kDl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/warden)
 "kDo" = (
 /obj/structure/table/wood,
@@ -32604,17 +32555,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kDz" = (
-/obj/structure/chair/office{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/landmark/start/warden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/security/labor{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/warden)
 "kDB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -33625,18 +33572,22 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal)
 "kWM" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 2
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	security_level = 6;
+	req_access_txt = "2;66"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "kXc" = (
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/central)
@@ -34680,19 +34631,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "lpe" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3";
-	security_level = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/warden)
 "lpj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -35950,14 +35889,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "lIw" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3";
+	security_level = 6
+	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/warden)
 "lIO" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -38260,26 +38198,28 @@
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "mqN" = (
-/obj/structure/chair/office{
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 2
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/warden,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/warden)
 "mqY" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
 "mrc" = (
 /obj/machinery/computer/security{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -38714,15 +38654,11 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "mya" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/job_scale/armoury/wt550,
 /turf/open/floor/plasteel,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "myf" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -40007,25 +39943,11 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "mVY" = (
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	req_access_txt = "3";
-	security_level = 6
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "armorydoors";
-	name = "Blast Doors"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "mWh" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
@@ -40114,16 +40036,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "mXD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/machinery/computer/security/labor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/landmark/start/warden,
+/turf/open/floor/wood,
 /area/security/warden)
 "mXH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -41544,6 +41464,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nyG" = (
@@ -41552,14 +41475,11 @@
 	},
 /area/hallway/secondary/entry)
 "nyJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/warden)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "nyS" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -42159,15 +42079,6 @@
 /area/hallway/primary/fore)
 "nIJ" = (
 /obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -42179,6 +42090,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/job_scale/armoury/laser_gun,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "nIO" = (
@@ -44773,20 +44685,9 @@
 /area/maintenance/starboard/central)
 "ozu" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/head/helmet/alt,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/effect/spawner/lootdrop/job_scale/armoury/riot_suit,
+/obj/effect/spawner/lootdrop/job_scale/armoury/riot_helmet,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "ozK" = (
@@ -48134,17 +48035,10 @@
 	},
 /area/science/research)
 "pIW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/warden)
 "pIZ" = (
 /obj/structure/cable/yellow{
@@ -50162,13 +50056,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -52116,6 +52004,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "qYB" = (
+/obj/machinery/light_switch{
+	pixel_x = 1;
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -4;
@@ -52125,20 +52020,11 @@
 	pixel_x = 2;
 	pixel_y = -3
 	},
-/obj/item/wirecutters{
-	pixel_y = 2
+/obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = 1;
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/warden)
 "qYF" = (
 /obj/structure/chair/fancy/comfy{
@@ -53783,14 +53669,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rAb" = (
-/obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rAw" = (
 /obj/machinery/advanced_airlock_controller/directional/south,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -54680,23 +54573,13 @@
 /turf/closed/wall,
 /area/hydroponics/garden)
 "rPn" = (
-/obj/machinery/door/airlock/security{
-	name = "Armory";
-	req_access_txt = "3";
-	security_level = 6
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "armorydoors";
-	name = "Blast Doors"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "rPs" = (
@@ -54737,17 +54620,18 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "rPL" = (
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/rack,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/flashlight/seclite,
 /obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/warden)
 "rPT" = (
 /obj/machinery/door/airlock/external{
@@ -56708,10 +56592,18 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "swK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/photocopier{
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/wood,
 /area/security/warden)
 "swM" = (
 /obj/machinery/light{
@@ -57108,17 +57000,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sFf" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/item/gun/ballistic/automatic/wt550/rubber_loaded{
-	pixel_y = 3
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3";
+	security_level = 6
 	},
-/obj/item/gun/ballistic/automatic/wt550/rubber_loaded,
-/obj/item/gun/ballistic/automatic/wt550/rubber_loaded{
-	pixel_y = -4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plating,
+/area/security/warden)
 "sFB" = (
 /obj/structure/chair/fancy/bench/pew/left{
 	dir = 8
@@ -58096,7 +57987,6 @@
 "sVH" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/nullrod,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -61789,11 +61679,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "umx" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -63636,6 +63525,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uPX" = (
@@ -63960,22 +63852,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "uVP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/button/door{
-	id = "armorydoors";
-	name = "Armory Blast Doors";
-	pixel_x = -28;
-	pixel_y = 28;
-	req_access_txt = "3"
-	},
+/obj/effect/spawner/lootdrop/job_scale/armoury/disabler,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "uVR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -64333,20 +64224,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vdg" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/melee/baton/loaded,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -65937,18 +65819,6 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "vBE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/flasher/portable,
-/obj/item/wrench,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "vBI" = (
@@ -68955,10 +68825,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "wCB" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "wDn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -70265,26 +70139,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wYo" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -110743,7 +110602,6 @@ lXw
 lXw
 lXw
 lXw
-aMT
 aVq
 aMT
 anT
@@ -110752,6 +110610,7 @@ anT
 aMT
 qiD
 aVq
+aMT
 aMT
 mJo
 xUk
@@ -111002,12 +110861,12 @@ aMT
 aMT
 aMT
 aMT
+oXI
+oXI
+oXI
+oXI
+oXI
 aMT
-oXI
-oXI
-oXI
-oXI
-oXI
 aMT
 aMT
 aMT
@@ -111259,16 +111118,16 @@ anT
 aMT
 aMT
 aMT
-aMT
 oXI
 oXI
-sFf
+mya
 iYF
 smX
 oXI
 oXI
 anT
 anT
+aMT
 mJo
 xUk
 xUk
@@ -111517,7 +111376,6 @@ duF
 duF
 duF
 anT
-anT
 oXI
 dMz
 suN
@@ -111526,11 +111384,12 @@ qwN
 nNW
 oXI
 aOu
-aMT
-tTo
-tTo
-tTo
-tTo
+oXI
+oXI
+oXI
+lpe
+lpe
+lpe
 tTo
 tTo
 tTo
@@ -111775,18 +111634,18 @@ iYj
 wYR
 duF
 aMT
-aMT
 oXI
 xhX
 ipZ
 fNn
-nIJ
+uVP
 vZO
 oXI
 crF
-crF
-tTo
-wCB
+oXI
+rPn
+acn
+lpe
 izC
 ghw
 umx
@@ -112032,21 +111891,21 @@ ckG
 ddE
 lcm
 duF
-aMT
 tQH
 oXI
 htD
 aae
 lXS
-wYo
+hEt
 jkd
-rPn
+gIX
 sir
-sir
+kWM
+cJf
 mVY
-uVP
+tNg
 vdg
-nyJ
+vBE
 dvq
 iSx
 fAg
@@ -112291,18 +112150,18 @@ phE
 amh
 duF
 aMT
-aMT
 oXI
 hwK
 ipZ
 fNn
-iGm
+nIJ
 jbs
 oXI
 hIC
-hIC
-tTo
-acn
+oXI
+wYo
+mVY
+tNg
 dHN
 vBE
 cGF
@@ -112549,7 +112408,6 @@ bpE
 hmy
 duF
 anT
-anT
 oXI
 dus
 lSx
@@ -112558,11 +112416,12 @@ ucx
 dMe
 oXI
 aOu
-aMT
-tTo
-rAb
+oXI
+wCB
+mVY
+lpe
 mqN
-mya
+eez
 eez
 qYB
 tTo
@@ -112807,23 +112666,23 @@ kEY
 mMs
 duF
 aMT
-aMT
 oXI
 oXI
+jxp
 hmQ
 ozu
-lIw
 oXI
 oXI
 anT
-anT
-tTo
-kWM
+oXI
+nyJ
+mVY
+tNg
 hPv
 gtV
-eez
+gtV
 rPL
-tNg
+dDl
 tch
 wod
 deS
@@ -113066,7 +112925,6 @@ lPI
 duF
 aMT
 aMT
-aMT
 oXI
 oXI
 oXI
@@ -113074,14 +112932,15 @@ oXI
 oXI
 aMT
 aMT
-aMT
-tTo
-cJf
+oXI
+nyJ
+mVY
+tNg
 dgh
 hQz
 kDl
 dxw
-tNg
+sFf
 nyy
 uPQ
 sBB
@@ -113323,7 +113182,6 @@ phE
 vrV
 duF
 aMT
-aMT
 ams
 aMT
 anT
@@ -113332,9 +113190,10 @@ anT
 aMT
 aMT
 fub
-aMT
-tTo
-gIX
+oXI
+nyJ
+mVY
+lpe
 mXD
 kDz
 pIW
@@ -113589,13 +113448,13 @@ duF
 duF
 duF
 duF
-duF
-duF
-tTo
-tTo
+oXI
+iGm
+iGm
+lpe
 gBw
-hEt
-tTo
+lpe
+lIw
 lpe
 tTo
 vcF
@@ -113847,8 +113706,8 @@ fsF
 pvo
 kNI
 uRO
-vps
-jxp
+rAb
+pvo
 vps
 mEM
 isF

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -248,7 +248,9 @@
 /area/engine/atmos)
 "aaV" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "aaX" = (
@@ -343,7 +345,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/engine/engineering)
 "abL" = (
 /obj/machinery/light_switch{
@@ -374,9 +376,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "ack" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -398,14 +398,15 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = 24
 	},
 /obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "acp" = (
@@ -947,9 +948,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aiU" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -1015,13 +1014,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ajD" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/chair,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "ajI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1046,12 +1042,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"ajU" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "akb" = (
 /obj/machinery/door/airlock/virology/glass{
 	id_tag = "Viro1";
@@ -1175,18 +1165,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "amh" = (
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/computer/operating{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "amk" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/airalarm/engine{
@@ -1297,8 +1283,8 @@
 	name = "Escape Airlock";
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -1598,14 +1584,21 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "asI" = (
-/obj/machinery/door/airlock/external{
-	name = "Labour Shuttle"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/main)
 "asK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
@@ -1925,25 +1918,13 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/hor)
-"axO" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/item/storage/firstaid{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "axR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/structure/closet{
+	name = "Evidence Closet 5"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "axT" = (
 /obj/machinery/vending/coffee,
@@ -2220,17 +2201,21 @@
 /turf/open/space/basic,
 /area/space)
 "aBp" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/security/main)
 "aBq" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -2362,19 +2347,36 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aDh" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/iv_drip,
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/computer/card/minor/hos{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aDm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2444,16 +2446,27 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aDJ" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/security/main)
 "aDM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2617,16 +2630,24 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aFG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/security/main)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aFH" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aFJ" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aFX" = (
@@ -2709,6 +2730,12 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "aGO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/button/door{
 	id = "permacell2";
 	name = "Cell 1 Lockdown";
@@ -2720,9 +2747,6 @@
 	id = "PCell 2";
 	pixel_x = 6;
 	pixel_y = 25
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -2838,16 +2862,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "aIf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/security/glass{
+	name = "Evidence";
+	req_one_access_txt = "1;4"
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "aIi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3042,23 +3071,27 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
 	name = "Head of Security";
 	req_access_txt = "58"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "aKJ" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aKK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/table/reinforced,
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
@@ -3067,9 +3100,6 @@
 	dir = 8
 	},
 /obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aKL" = (
@@ -3742,15 +3772,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "aSM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "aTc" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -3933,9 +3961,13 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "aUS" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "aUT" = (
 /obj/structure/chair{
 	dir = 8
@@ -4039,9 +4071,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aWy" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -4169,14 +4199,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"aYb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aYd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
@@ -4478,14 +4500,15 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "beW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bfc" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -4546,12 +4569,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bgb" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "bgd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4587,6 +4615,13 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "bgw" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "Prison Main North";
 	network = list("ss13","prison")
@@ -4595,9 +4630,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bgy" = (
@@ -4655,14 +4687,10 @@
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
 "bhs" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/security/brig)
 "bhx" = (
 /obj/item/bedsheet/medical,
@@ -4696,17 +4724,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "bhN" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -4771,15 +4797,11 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "biN" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/brig_physician,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "bja" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4842,7 +4864,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bjS" = (
@@ -4872,15 +4893,9 @@
 	},
 /area/chapel/main/monastery)
 "bkH" = (
-/obj/machinery/door/window/brigdoor/eastright{
-	dir = 1;
-	req_access_txt = "2"
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plating,
 /area/security/execution/education)
 "bkS" = (
 /obj/item/radio/intercom{
@@ -5184,19 +5199,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/machinery/firealarm{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "brJ" = (
@@ -5242,8 +5254,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bsi" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -5409,17 +5424,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bvC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "bvE" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/effect/turf_decal/siding/wood{
@@ -5503,9 +5507,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bwG" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "bwW" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/button/door{
@@ -5529,10 +5539,19 @@
 	pixel_y = 32
 	},
 /obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bxE" = (
@@ -5655,12 +5674,12 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "bAk" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bAn" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -6167,12 +6186,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
-"bIU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bIX" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
@@ -6181,8 +6194,16 @@
 /obj/machinery/door/airlock{
 	name = "Toilet Unit"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "bJB" = (
@@ -6246,11 +6267,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/cryo)
-"bKE" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/grass,
-/area/hydroponics/garden)
 "bKR" = (
 /obj/machinery/deepfryer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6616,10 +6632,16 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "bPX" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6860,20 +6882,15 @@
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "bUs" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/igniter{
+	id = "deathroom"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/item/wirecutters,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "bUZ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -6914,21 +6931,9 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "bWt" = (
-/obj/machinery/computer/card/minor/hos{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bWu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Library Maintenance";
@@ -7208,14 +7213,21 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cbC" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "Security Deliveries";
-	req_access_txt = "2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Brig Control Desk";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "cbG" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -7434,9 +7446,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "cfY" = (
@@ -7506,12 +7515,6 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "cgU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
@@ -7521,7 +7524,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "cgZ" = (
 /obj/item/radio/intercom{
@@ -7588,13 +7593,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cim" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "cir" = (
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
@@ -7658,11 +7662,12 @@
 /area/science/robotics/lab)
 "cjA" = (
 /obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -7681,17 +7686,19 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "cki" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "cky" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -7699,14 +7706,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ckG" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "ckO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -7783,7 +7792,16 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "cmm" = (
@@ -8019,23 +8037,25 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cri" = (
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "crC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/main)
 "crF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -8077,15 +8097,17 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "csa" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "csd" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -8366,7 +8388,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "cxY" = (
-/turf/open/floor/grass,
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_home";
+	name = "laborcamp shuttle dock";
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 7
+	},
+/turf/open/space/basic,
 /area/hydroponics/garden)
 "cyg" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8638,14 +8669,24 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "cCR" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
 "cCU" = (
@@ -8729,9 +8770,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
 "cFH" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -8779,10 +8818,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "cHg" = (
@@ -8893,6 +8932,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/requests_console{
 	department = "Warden's Office";
 	departmentType = 5;
@@ -8900,9 +8943,6 @@
 	},
 /obj/structure/bed/dogbed/walter,
 /mob/living/simple_animal/pet/dog/bullterrier/walter,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "cJj" = (
@@ -8956,12 +8996,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"cKK" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "cKR" = (
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
@@ -9021,14 +9055,12 @@
 	pixel_y = 24;
 	prison_radio = 1
 	},
+/obj/machinery/computer/security/wooden_tv{
+	pixel_x = 1;
+	pixel_y = 7
+	},
 /turf/open/floor/carpet,
 /area/security/prison)
-"cLo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cLI" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -9340,11 +9372,8 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
 "cSo" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/closed/wall,
+/area/security/main)
 "cSs" = (
 /turf/closed/wall,
 /area/maintenance/starboard/central)
@@ -9362,16 +9391,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cSy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -9391,23 +9418,6 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"cSR" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "cTD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -9637,21 +9647,24 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "cWA" = (
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
+"cWG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"cWG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "cWH" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
@@ -9699,15 +9712,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cXx" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/hallway/primary/central)
 "cXE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9740,12 +9752,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"cYD" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "cYI" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/circuit/telecomms/server,
@@ -9790,21 +9796,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"cZX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "cZY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -9832,7 +9823,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/engine/engineering)
 "daB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -9895,10 +9886,19 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "dbJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/door/airlock/external/glass{
 	name = "Escape Pod Alpha"
 	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dcn" = (
@@ -9951,18 +9951,15 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "ddl" = (
-/obj/structure/sign/directions/engineering{
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/sign/directions/science{
-	dir = 8;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/medical{
-	pixel_y = -8
-	},
-/turf/closed/wall,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel,
+/area/medical/medbay/lobby)
 "ddt" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -10003,13 +10000,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "ddE" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Gravity Generator Area";
-	req_access_txt = "19; 61"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "ddN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10048,18 +10047,15 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "deP" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 8
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
-/obj/effect/landmark/start/head_of_security,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "deS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10161,8 +10157,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "dgh" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -10401,13 +10401,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"diF" = (
-/obj/effect/landmark/start/brig_physician,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "diN" = (
 /obj/machinery/requests_console{
 	department = "Medical";
@@ -10559,31 +10552,31 @@
 	name = "Cell 2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dka" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Medical";
+	req_access_txt = "34"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "dky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -10633,13 +10626,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"dlj" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "dlk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10695,11 +10681,26 @@
 /turf/open/floor/circuit,
 /area/hallway/secondary/entry)
 "dmz" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/door/airlock/security/glass{
+	name = "Kill Chamber";
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "dmC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -10875,11 +10876,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"dpy" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "dpG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -11086,10 +11082,9 @@
 /area/solar/port/fore)
 "dus" = (
 /obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/temperature/security,
 /obj/effect/turf_decal/delivery,
-/obj/item/beacon/nettingportal,
-/obj/effect/spawner/lootdrop/job_scale/armoury/dragnet,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "duF" = (
@@ -11122,9 +11117,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dvq" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "dvr" = (
@@ -11145,10 +11144,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "dvx" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -11200,13 +11203,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
-"dwd" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "dwj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
@@ -11280,6 +11276,10 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -11290,20 +11290,11 @@
 	pixel_x = -2;
 	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -11529,11 +11520,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dCU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red/opposingcorners{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Education Center";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/security/execution/education)
 "dCW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -11559,7 +11559,12 @@
 /area/quartermaster/storage)
 "dDl" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/security/warden)
 "dDH" = (
@@ -11586,17 +11591,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "dEv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/item/radio/intercom{
+	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dEw" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11701,15 +11700,24 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "dFt" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "dFu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -11735,7 +11743,10 @@
 	pixel_y = -28;
 	prison_radio = 1
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "dFA" = (
@@ -11866,11 +11877,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -11978,17 +11989,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "dJW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -12003,10 +12011,20 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "dKp" = (
-/obj/item/radio/intercom{
-	pixel_y = 32
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dKv" = (
@@ -12382,17 +12400,17 @@
 /area/medical/medbay/central)
 "dRf" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "dRg" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -12600,9 +12618,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dUs" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -12800,14 +12816,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "dXV" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -13157,9 +13174,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "edw" = (
@@ -13201,9 +13216,34 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/secondary)
 "edV" = (
-/obj/machinery/light/small,
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "eeb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -13243,9 +13283,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "eez" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "eeC" = (
@@ -13314,18 +13355,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "eeZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "efi" = (
 /obj/effect/spawner/room/tenxfive,
 /turf/open/floor/plating,
@@ -13342,12 +13389,10 @@
 /area/security/courtroom)
 "efG" = (
 /obj/machinery/advanced_airlock_controller/directional/north,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "efT" = (
@@ -13453,22 +13498,22 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "eit" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "eiF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -13504,9 +13549,26 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "ejo" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ejp" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/flasher{
@@ -13540,11 +13602,15 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /obj/machinery/newscaster{
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -13901,17 +13967,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "eqX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/stasis,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "erm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13930,9 +13989,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "esi" = (
-/obj/effect/turf_decal/tile/green,
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/medical/medbay/lobby)
 "esk" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/royalblue,
@@ -13970,23 +14035,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "etf" = (
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
 "etB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/security/main)
 "etM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14309,17 +14371,12 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "exZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/security/main)
 "eya" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -14352,8 +14409,12 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "ezg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall14";
+	location = "hall13"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -14410,13 +14471,28 @@
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "eAu" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/item/radio/intercom{
 	pixel_y = 24
-	},
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
@@ -14442,13 +14518,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"eAW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "eBp" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -14683,9 +14752,6 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "eEV" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666"
-	},
 /obj/effect/landmark/start/head_of_security,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14707,9 +14773,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -14810,7 +14873,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "eIj" = (
-/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eIv" = (
@@ -14865,13 +14931,16 @@
 /area/hallway/primary/central)
 "eJi" = (
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/reagent_containers/food/drinks/britcup,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "eJz" = (
@@ -14957,9 +15026,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "eLy" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -15015,20 +15082,6 @@
 "eMX" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
-"eNq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "eNt" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -15038,17 +15091,10 @@
 /area/crew_quarters/bar)
 "eNA" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "eNC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15332,14 +15378,19 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "eQV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "eRe" = (
 /obj/effect/turf_decal/stripes/line{
@@ -15353,19 +15404,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eRv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "eRF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -15388,19 +15434,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "eRO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "eSG" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -15461,9 +15512,6 @@
 "eTq" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/spawner/lootdrop/glowstick/lit,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -15562,11 +15610,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall10";
-	location = "hall9"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "eWN" = (
@@ -15725,7 +15775,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "eZE" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -15733,6 +15782,7 @@
 	id = "secmain";
 	name = "Blast Doors"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "faj" = (
@@ -16098,22 +16148,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"ffG" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/closet{
-	name = "Evidence Closet 2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ffH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -16180,14 +16214,24 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "fgB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "fgF" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -16218,8 +16262,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fiw" = (
@@ -16252,21 +16294,23 @@
 	},
 /turf/open/floor/engine/cult,
 /area/library)
-"fiW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
+"fjd" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"fjd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/main)
 "fje" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -16290,18 +16334,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "fjk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"fjt" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "fjx" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -16477,8 +16533,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "flw" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -16763,6 +16825,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"frx" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "frA" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -16776,12 +16847,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "frC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet{
+	name = "Evidence Closet 2"
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "fsa" = (
@@ -16820,17 +16892,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fsT" = (
@@ -16996,9 +17064,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
 "fwf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17267,7 +17334,7 @@
 	icon_state = "right";
 	name = "Outer Window"
 	},
-/obj/item/storage/fancy/donut_box,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "fAh" = (
@@ -17308,21 +17375,8 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "fAE" = (
-/obj/machinery/airalarm/directional/west,
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/closed/wall,
+/area/hallway/secondary/command)
 "fAL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -17744,7 +17798,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -17814,8 +17871,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "fKn" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -17960,16 +18023,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "fMJ" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/mask/balaclava,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/electropack,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fMM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -18031,10 +18095,16 @@
 "fNn" = (
 /obj/vehicle/ridden/secway,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fNA" = (
@@ -18230,18 +18300,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"fPU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "fQa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -18295,13 +18353,16 @@
 /obj/machinery/shower{
 	pixel_y = 16
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "Prison Shower";
 	dir = 9;
 	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -18337,16 +18398,19 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "fRC" = (
-/obj/machinery/power/terminal{
+/obj/effect/landmark/start/head_of_security,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/security/main)
 "fRG" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -18417,16 +18481,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"fTB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "fTR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18505,19 +18559,15 @@
 /turf/open/floor/wood,
 /area/library)
 "fVD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "fVN" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -18570,20 +18620,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"fWZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "fXv" = (
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
@@ -18785,11 +18821,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fZM" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/table/glass,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fZQ" = (
@@ -18937,13 +18975,9 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "gci" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/security_officer,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/start/security_officer,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gcn" = (
@@ -19048,11 +19082,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "geg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "geh" = (
@@ -19127,19 +19164,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
-"gfG" = (
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/bottle/chloralhydrate,
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "gfM" = (
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes{
@@ -19194,11 +19218,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ggy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -19244,8 +19271,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/item/storage/box/firingpins,
-/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ghR" = (
@@ -19265,10 +19295,19 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "gis" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "giA" = (
@@ -19411,6 +19450,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"gks" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "gkz" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable/yellow{
@@ -19550,14 +19602,6 @@
 	},
 /turf/open/floor/circuit/red,
 /area/hallway/secondary/entry)
-"gnb" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "gnj" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
@@ -19779,18 +19823,19 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "gqz" = (
-/obj/machinery/door/airlock/external{
-	name = "Labour Shuttle";
-	req_access_txt = "2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/item/radio/intercom{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/main)
 "gqE" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/brig)
@@ -19812,6 +19857,12 @@
 /area/medical/genetics)
 "grc" = (
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/camera{
 	c_tag = "Prison Main South";
 	dir = 1;
@@ -19819,10 +19870,6 @@
 	},
 /obj/item/radio/intercom{
 	pixel_y = -28
-	},
-/obj/item/coin/antagtoken,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -19945,17 +19992,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "gtV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/warden)
 "gtW" = (
@@ -19991,8 +20035,11 @@
 "guo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -20183,19 +20230,19 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
 "gyo" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "gyr" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
@@ -20285,9 +20332,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "gyZ" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
@@ -20311,17 +20356,16 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "gzH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gzO" = (
 /obj/machinery/washing_machine,
@@ -20377,13 +20421,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"gAE" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
 "gAI" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -20447,15 +20484,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "gBr" = (
-/obj/structure/closet/secure_closet/injection,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "gBw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -20780,22 +20821,14 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "gHo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
+"gHq" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"gHq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
 /area/security/brig)
 "gHw" = (
 /obj/structure/grille,
@@ -20857,15 +20890,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
-"gIv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "gIz" = (
 /obj/machinery/light{
 	dir = 4
@@ -21299,10 +21323,14 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "gOl" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gOn" = (
@@ -21471,9 +21499,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "gRi" = (
-/obj/structure/filingcabinet,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "gRp" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -21536,12 +21570,14 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "gSy" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "gSE" = (
 /obj/machinery/door/window/westleft{
 	name = "Research Division Deliveries";
@@ -21550,12 +21586,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/research)
-"gSR" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "gTe" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
@@ -21570,17 +21600,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "gTl" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/balaclava,
-/obj/item/reagent_containers/syringe,
-/obj/machinery/requests_console{
-	pixel_x = -32
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/brig)
 "gTH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -21840,10 +21867,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "gYK" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/grape,
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "gYM" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -21888,10 +21916,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"gZs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "gZx" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -21973,9 +21997,7 @@
 /area/hallway/primary/fore)
 "haX" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -22113,13 +22135,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"hdb" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "hdd" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -22145,8 +22160,12 @@
 /turf/closed/wall,
 /area/science/mixing)
 "hdO" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -22267,9 +22286,18 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "hfx" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hgm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -22435,14 +22463,17 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "hjj" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "hjo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -22653,14 +22684,12 @@
 /area/hallway/primary/fore)
 "hmQ" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/delivery,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/teargas{
-	pixel_x = 1;
-	pixel_y = -2
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 2;
+	pixel_y = 1
 	},
-/obj/item/storage/box/flashbangs,
-/obj/item/gun/grenadelauncher,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "hmZ" = (
@@ -23035,10 +23064,21 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
+/mob/living/simple_animal/hostile/carp/cayenne{
+	desc = "A failed experiment of Nanotrasen to create weaponised carp technology. This less than intimidating carp now serves as an authority figure's pet.";
+	health = 200;
+	icon_dead = "magicarp_dead";
+	icon_gib = "magicarp_gib";
+	icon_living = "magicarp";
+	icon_state = "magicarp";
+	maxHealth = 200;
+	name = "Lia"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "htT" = (
@@ -23162,12 +23202,10 @@
 /obj/item/ammo_box/magazine/wt550m9,
 /obj/item/ammo_box/magazine/wt550m9,
 /obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/structure/closet/secure_closet{
-	name = "Lethal WT ammunition locker"
-	},
+/obj/structure/closet/secure_closet,
+/obj/item/ammo_box/magazine/wt550m9/rubber,
+/obj/item/ammo_box/magazine/wt550m9/rubber,
+/obj/item/ammo_box/magazine/wt550m9/rubber,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "hwN" = (
@@ -23200,20 +23238,26 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hxh" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/science/shuttle)
 "hxC" = (
 /obj/machinery/newscaster{
@@ -23359,13 +23403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"hzM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plating,
-/area/security/execution/education)
 "hzP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -23381,7 +23418,7 @@
 /turf/closed/wall,
 /area/maintenance/port/central)
 "hzZ" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "hAa" = (
@@ -23447,11 +23484,15 @@
 /turf/open/space/basic,
 /area/space)
 "hBq" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "hBP" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/sign/poster/random{
@@ -23601,7 +23642,7 @@
 	icon_state = "right";
 	name = "Outer Window"
 	},
-/obj/structure/desk_bell,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "hEw" = (
@@ -23632,19 +23673,12 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
 "hER" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/computer/cargo{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Medical";
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/supply)
 "hFs" = (
 /obj/machinery/button/door{
 	id = "cp_west_inner";
@@ -24053,17 +24087,16 @@
 	},
 /area/holodeck/rec_center)
 "hLY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Interrogation Room";
+	req_one_access_txt = "1;4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hMH" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -24219,8 +24252,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hPv" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -24258,16 +24294,12 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
 "hQu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -24286,13 +24318,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "hQz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "hQN" = (
@@ -24425,24 +24454,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
-"hSD" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "hSI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_y = -8
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/sign/directions/supply{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/structure/sign/directions/evac{
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/entry)
 "hSS" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/delivery,
@@ -24630,21 +24654,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "hVU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/legcuffs/bola/energy,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hWl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -24713,9 +24731,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "hXA" = (
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
 /obj/machinery/requests_console{
 	pixel_y = 32
 	},
@@ -24865,14 +24880,21 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "hYR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "hYW" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -24964,17 +24986,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "iaU" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/computer/warrant{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/opposingcorners,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "iaV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -25004,16 +25017,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ibI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ibO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
@@ -25080,15 +25092,16 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "icI" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -25099,10 +25112,16 @@
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "idg" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "idj" = (
@@ -25167,15 +25186,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"idM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ieb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -25226,13 +25236,15 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "ieI" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ifc" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
@@ -25397,20 +25409,10 @@
 /area/ai_monitored/storage/eva)
 "iiH" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_one_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "iiO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -25435,23 +25437,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"iiV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ijb" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/atmospherics,
@@ -25513,14 +25498,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "ike" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -25595,10 +25574,6 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"imf" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "imh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -25613,12 +25588,6 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "imy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "imE" = (
@@ -25793,22 +25762,14 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
 "ipk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ipm" = (
 /obj/machinery/camera/autoname{
@@ -26110,28 +26071,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "isF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "isL" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/grass,
+/turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "isR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -26225,9 +26178,6 @@
 "iuV" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -26344,7 +26294,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ixJ" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/science/shuttle)
 "iyj" = (
 /obj/structure/cable/yellow{
@@ -26428,11 +26378,11 @@
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "izP" = (
@@ -26793,11 +26743,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"iFr" = (
-/obj/machinery/computer/shuttle_flight/labor,
-/obj/machinery/advanced_airlock_controller/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "iFt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -26852,9 +26797,26 @@
 /area/crew_quarters/heads/chief)
 "iGm" = (
 /obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/spawner/lootdrop/job_scale/armoury/laser_gun,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "iGp" = (
@@ -27162,14 +27124,21 @@
 /area/crew_quarters/toilet)
 "iMC" = (
 /obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/item/seeds/tea,
-/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iMR" = (
@@ -27310,10 +27279,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "iPj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "iPK" = (
@@ -27518,15 +27494,18 @@
 "iSx" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/machinery/button/door{
 	id = "secmain";
 	name = "Security Exterior Blast Doors";
 	pixel_x = -28;
 	pixel_y = -26;
 	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -27666,22 +27645,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"iVz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "iVW" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
@@ -27835,16 +27798,15 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "iYj" = (
-/obj/structure/table/glass,
-/obj/item/hatchet,
-/obj/item/cultivator,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/spray/pestspray{
-	pixel_x = 3;
-	pixel_y = 4
+/obj/structure/table/reinforced,
+/obj/item/defibrillator/loaded,
+/obj/item/wrench/medical,
+/obj/item/wallframe/defib_mount,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iYq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -27945,12 +27907,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "iZV" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	pixel_y = 2
 	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
+/turf/open/space/basic,
+/area/space)
 "iZW" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
 /turf/open/floor/engine/air,
@@ -28311,7 +28272,8 @@
 /obj/machinery/shower{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -28400,13 +28362,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jhR" = (
-/obj/structure/lattice,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "jhT" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -28534,10 +28489,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/button/door{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Armory Blast Doors";
 	pixel_x = 26;
 	pixel_y = -26;
@@ -28661,12 +28614,20 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "jno" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/window/reinforced/spawner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "jnD" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -28765,8 +28726,11 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/tray,
 /obj/item/kitchen/fork,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -28974,12 +28938,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jtW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "jum" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/green{
@@ -29197,31 +29155,22 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "jxp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jxt" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"jxK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "jxO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29283,17 +29232,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "jzx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall11";
-	location = "hall10"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hallway/primary/central)
 "jzB" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8
@@ -29342,16 +29282,16 @@
 /turf/open/floor/wood,
 /area/library)
 "jAh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jAp" = (
@@ -29361,11 +29301,21 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "jAA" = (
-/obj/machinery/light_switch{
-	pixel_x = -25
+/obj/machinery/requests_console{
+	pixel_x = -32
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/balaclava,
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "jAB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -29766,20 +29716,31 @@
 /turf/closed/wall,
 /area/science/robotics)
 "jGQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jHc" = (
 /obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jHk" = (
@@ -29793,13 +29754,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "jHm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -30038,29 +30001,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"jKV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown/opposingcorners,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "jKY" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jLw" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/freezer,
@@ -30101,12 +30052,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "jLV" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/quartermaster/storage)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jMf" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -30241,11 +30200,30 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jPv" = (
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/computer/security/hos{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "jPQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -30318,11 +30296,12 @@
 /turf/open/floor/carpet,
 /area/security/prison)
 "jRv" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -30413,26 +30392,24 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "jTf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/closet{
+	name = "Evidence Closet 4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/delivery,
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jTl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jTn" = (
@@ -30582,16 +30559,21 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "jVs" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 24
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
-/turf/open/floor/plasteel,
-/area/medical/medbay/lobby)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "jVA" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -30621,22 +30603,37 @@
 /turf/closed/wall,
 /area/bridge)
 "jWm" = (
-/obj/machinery/advanced_airlock_controller/directional/south,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/main)
 "jWp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "jWw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/closet/secure_closet/hos,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
@@ -30648,15 +30645,6 @@
 	id = "hosoffice";
 	name = "Head of Security's Office Shutters";
 	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -30821,7 +30809,6 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -31024,10 +31011,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kcQ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "kcX" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
@@ -31219,7 +31202,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -31521,9 +31505,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/quartermaster/storage)
 "klU" = (
@@ -31721,6 +31702,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"koR" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "koS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31812,9 +31803,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kpR" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -31918,8 +31907,11 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "ksE" = (
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/anesthetic_machine,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ksO" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -31946,15 +31938,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ktb" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "ktc" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/bridge)
@@ -32105,6 +32088,7 @@
 	req_one_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kvu" = (
@@ -32155,26 +32139,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"kvU" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"kwa" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "kwb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -32267,17 +32231,9 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "kxd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -32301,15 +32257,6 @@
 	},
 /turf/open/floor/wood,
 /area/quartermaster/storage)
-"kxx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kxy" = (
 /obj/machinery/advanced_airlock_controller/directional/south,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -32365,18 +32312,13 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
 "kxN" = (
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/medical/medbay/lobby)
 "kxW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -32413,13 +32355,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kyC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -2
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kyP" = (
@@ -32523,20 +32468,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "kBt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "kBB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -32606,24 +32547,24 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "kDf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kDh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -32636,20 +32577,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "kDl" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/warden)
-"kDn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "kDo" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/evidence,
@@ -32661,7 +32597,10 @@
 /area/security/detectives_office)
 "kDs" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kDz" = (
@@ -32669,11 +32608,11 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/warden,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -32696,20 +32635,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "kDG" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kDK" = (
@@ -32780,11 +32713,20 @@
 /area/solar/port/fore)
 "kEP" = (
 /obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/item/seeds/tea,
-/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kEQ" = (
@@ -32795,18 +32737,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kEY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/random,
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "kFa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -32826,38 +32764,19 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "kFE" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"kFR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Education Center";
-	req_access_txt = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "kFS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -33080,15 +32999,18 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "kLJ" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/computer/security{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "kMb" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine";
@@ -33252,20 +33174,30 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kNF" = (
-/obj/machinery/computer/operating{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "kNI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -33288,27 +33220,40 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kOy" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/machinery/camera{
+	c_tag = "Interrogation room";
+	dir = 4;
+	network = list("interrogation")
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kOS" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "kPl" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kPy" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plasteel,
@@ -33485,16 +33430,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "kTC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/space/basic,
 /area/hallway/primary/starboard)
 "kTL" = (
 /obj/effect/turf_decal/siding/wood{
@@ -33578,13 +33514,8 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "kVs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -33593,9 +33524,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "kVK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33696,9 +33631,10 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "kXc" = (
@@ -33778,15 +33714,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "kYc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "kYu" = (
 /obj/structure/table,
 /obj/machinery/plantgenes{
@@ -33919,35 +33851,16 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/engine/storage)
-"lbc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/gravity_generator";
-	name = "Gravity Generator APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "lbl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Briefing Room";
-	req_one_access_txt = "1;4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "lbs" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -34035,15 +33948,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lcm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
-"lcq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/optable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"lcq" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -34080,7 +33993,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -34163,20 +34075,19 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ldQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lee" = (
 /obj/structure/extinguisher_cabinet{
@@ -34451,8 +34362,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "ljA" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ljB" = (
@@ -34478,12 +34392,25 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "lkB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/button/ignition{
+	pixel_x = 4;
+	pixel_y = 27
+	},
+/obj/machinery/button/door{
+	desc = "Welcome to your new life, employee.";
+	id = "deathdoor";
+	name = "Transfer Switch";
+	pixel_x = -6;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "lkE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -34570,13 +34497,28 @@
 	pixel_x = -1;
 	pixel_y = 11
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
@@ -34749,19 +34691,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/security/warden)
 "lpj" = (
@@ -34911,31 +34841,37 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "lro" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lrx" = (
 /turf/open/floor/circuit/red,
 /area/hallway/secondary/entry)
 "lrA" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/corg;
-	width = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lrH" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/eastleft{
@@ -34968,13 +34904,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lrP" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/yellow,
-/obj/machinery/requests_console{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "lsf" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -34986,7 +34919,9 @@
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
 "lsi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "lsm" = (
@@ -35220,9 +35155,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lwg" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -35324,7 +35257,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "lxx" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35479,16 +35415,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "lzn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "lzw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -35607,10 +35545,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -35640,9 +35575,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -35688,8 +35621,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
 "lCJ" = (
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -35795,16 +35731,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"lEZ" = (
-/obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_y = 32
-	},
-/obj/machinery/igniter{
-	id = "deathroom"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "lFm" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 8;
@@ -35940,9 +35866,23 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "lHh" = (
-/obj/machinery/camera/autoname,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "lHw" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -35950,12 +35890,10 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "lHx" = (
@@ -35966,24 +35904,16 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "lHJ" = (
-/obj/machinery/computer/security/hos{
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lHM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -36021,27 +35951,38 @@
 /area/hallway/primary/fore)
 "lIw" = (
 /obj/structure/rack,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/job_scale/armoury/riot_suit,
-/obj/effect/spawner/lootdrop/job_scale/armoury/riot_helmet,
-/obj/effect/spawner/lootdrop/job_scale/armoury/riot_shield,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "lIO" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "lJh" = (
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/disposal/bin,
 /obj/machinery/firealarm{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "lJl" = (
@@ -36089,7 +36030,6 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/yellow,
-/obj/structure/disposalpipe/segment,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -36115,16 +36055,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "lJV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lKi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -36163,18 +36095,16 @@
 	},
 /area/crew_quarters/heads/hor)
 "lKP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 1;
-	pixel_y = -25
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lKQ" = (
 /obj/structure/cable/yellow{
@@ -36251,14 +36181,14 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "lLS" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "lLT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -36316,17 +36246,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lNv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_one_access_txt = "63"
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lNH" = (
@@ -36398,13 +36321,17 @@
 /turf/open/floor/circuit/green,
 /area/science/nanite)
 "lOC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -36455,15 +36382,17 @@
 /turf/open/floor/grass,
 /area/hallway/primary/fore)
 "lPI" = (
-/obj/machinery/firealarm{
-	pixel_y = -24
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 2
 	},
+/obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "lPX" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
@@ -36706,17 +36635,24 @@
 "lTR" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/sugarcane,
-/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "lTY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lUa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36798,22 +36734,24 @@
 	dir = 1
 	},
 /obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lUS" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lUW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -37001,13 +36939,16 @@
 "lXS" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "lXT" = (
@@ -37072,13 +37013,21 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "lYU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "lZe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -37226,11 +37175,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "maH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -37372,9 +37321,28 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mdT" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Medical";
+	req_one_access_txt = "34;2;1;4"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "mea" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -37807,28 +37775,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"mkA" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/pen/red{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "mkB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mkF" = (
@@ -37927,18 +37878,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"mlY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "mma" = (
 /turf/closed/wall,
 /area/maintenance/fore)
@@ -37965,10 +37904,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mmp" = (
 /obj/machinery/light{
 	dir = 1
@@ -38027,6 +37964,9 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "mnB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock";
 	req_access_txt = "63"
@@ -38057,20 +37997,21 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "mnY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad,
 /obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -38100,9 +38041,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "moh" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -38129,17 +38068,14 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "moS" = (
-/obj/structure/sign/directions/supply{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/evac{
-	pixel_y = 8
-	},
-/turf/closed/wall,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "mpn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -38187,15 +38123,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/machinery/door/airlock/command{
 	name = "Head of Security";
 	req_access_txt = "58"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hos)
 "mql" = (
@@ -38208,14 +38144,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "mqm" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable/yellow,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mqn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38287,23 +38229,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "mqH" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plating,
+/area/security/main)
 "mqJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38333,8 +38264,11 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/warden,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -38584,11 +38518,15 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "muO" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "muW" = (
@@ -38709,9 +38647,6 @@
 /area/hallway/primary/aft)
 "mxb" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
 /turf/open/floor/wood,
 /area/quartermaster/storage)
 "mxf" = (
@@ -38780,14 +38715,11 @@
 /area/science/xenobiology)
 "mya" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
@@ -38806,15 +38738,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"myr" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "myS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -39169,11 +39092,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
 "mEM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -39182,9 +39102,7 @@
 	pixel_x = -28;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mEV" = (
@@ -39234,20 +39152,17 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "mFB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/sign/directions/medical{
+	pixel_y = -8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/sign/directions/engineering{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/sign/directions/science{
+	dir = 8;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/hallway/primary/starboard)
 "mFO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -39307,16 +39222,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"mHo" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "mHr" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -39452,6 +39357,9 @@
 	location = "hall14"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mKY" = (
@@ -39523,9 +39431,15 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "mMs" = (
-/obj/machinery/gravity_generator/main/station,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/storage/firstaid{
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mMt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39758,7 +39672,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "mPy" = (
@@ -39889,18 +39802,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"mST" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/tower,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/requests_console{
-	pixel_x = 32
-	},
-/turf/open/floor/grass,
-/area/hydroponics/garden)
 "mSV" = (
 /obj/structure/closet/crate/goldcrate,
 /obj/machinery/light,
@@ -39948,8 +39849,11 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/chef_recipes,
 /obj/item/kitchen/rollingpin,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -40016,13 +39920,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mUB" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mUF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40116,10 +40019,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Blast Doors"
 	},
 /obj/machinery/door/firedoor,
@@ -40213,11 +40114,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "mXD" = (
-/obj/machinery/computer/security/labor{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/machinery/computer/security/labor{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -40232,9 +40136,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "mXJ" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mYd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40292,8 +40199,14 @@
 /turf/open/floor/wood,
 /area/maintenance/port)
 "mZR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "nam" = (
 /obj/structure/closet/secure_closet/RD,
@@ -40304,12 +40217,21 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "nan" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/table/reinforced,
 /obj/item/pickaxe/mini,
 /obj/item/pickaxe/mini,
 /obj/item/storage/bag/ore,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "naE" = (
@@ -40328,6 +40250,9 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
 "naS" = (
+/obj/item/bedsheet/captain,
+/obj/structure/bed,
+/obj/effect/landmark/start/captain,
 /obj/item/radio/intercom{
 	pixel_x = 29;
 	pixel_y = -2
@@ -40336,9 +40261,6 @@
 	c_tag = "Captain's Quarters";
 	dir = 8
 	},
-/obj/structure/bed/double,
-/obj/item/bedsheet/double/captain,
-/obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "naT" = (
@@ -40680,14 +40602,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ngF" = (
-/obj/machinery/light,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/requests_console{
-	pixel_y = -32
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ngK" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -40708,10 +40630,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nhd" = (
@@ -40761,12 +40686,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "nih" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/computer/card/minor/hos{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "nin" = (
@@ -40983,7 +40913,16 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "nof" = (
@@ -41250,7 +41189,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "nst" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -41531,25 +41469,21 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "nxz" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Briefing Room";
-	req_one_access_txt = "1;4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "nxG" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/server,
@@ -41618,16 +41552,10 @@
 	},
 /area/hallway/secondary/entry)
 "nyJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41755,11 +41683,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "nzL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -42228,9 +42159,26 @@
 /area/hallway/primary/fore)
 "nIJ" = (
 /obj/structure/rack,
+/obj/item/gun/energy/disabler{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/spawner/lootdrop/job_scale/armoury/disabler,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "nIO" = (
@@ -42377,19 +42325,6 @@
 /obj/machinery/announcement_system,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"nKt" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "nKB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -42522,28 +42457,20 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "nMg" = (
-/obj/machinery/button/ignition{
-	pixel_x = 4;
-	pixel_y = 27
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/button/door{
-	desc = "Welcome to your new life, employee.";
-	id = "deathdoor";
-	name = "Transfer Switch";
-	pixel_x = -6;
-	pixel_y = 27
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nMw" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -43000,12 +42927,6 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
-"nTj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nTm" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -43040,17 +42961,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nTO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "nTV" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -43280,15 +43206,11 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "nYi" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/closet{
-	name = "Evidence Closet 3"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "nYw" = (
 /obj/machinery/conveyor{
 	id = "recycling"
@@ -43299,22 +43221,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"nYA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = 1;
-	pixel_y = -25
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "nYH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -43409,9 +43315,6 @@
 "oal" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
 	},
 /turf/open/floor/wood,
 /area/quartermaster/storage)
@@ -43703,6 +43606,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "oeX" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/firealarm{
 	pixel_y = -24
@@ -43710,9 +43617,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -43748,9 +43652,6 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "ofC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "ofE" = (
@@ -43828,21 +43729,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ohA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hos)
 "ohH" = (
 /turf/closed/wall,
 /area/gateway)
@@ -43888,13 +43779,16 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "ois" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -14;
 	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -43956,15 +43850,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "okc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "okw" = (
@@ -44223,12 +44124,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "oph" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/holopad{
+	pixel_y = 16
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "opq" = (
 /turf/closed/wall,
@@ -44355,20 +44254,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -44720,13 +44616,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"oya" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "oyb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -44846,18 +44735,18 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "oze" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ozg" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
@@ -44884,6 +44773,12 @@
 /area/maintenance/starboard/central)
 "ozu" = (
 /obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/head/helmet/alt,
+/obj/item/clothing/head/helmet/alt,
+/obj/item/clothing/head/helmet/alt,
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -44891,11 +44786,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
-/obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_vest,
-/obj/effect/spawner/lootdrop/job_scale/armoury/bulletproof_helmet,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "ozK" = (
@@ -44940,27 +44831,31 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "oAF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/main)
-"oAG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/item/taperecorder,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
+"oAG" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "oAH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -45064,17 +44959,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oCV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall12";
-	location = "hall11"
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oCW" = (
 /turf/closed/wall,
 /area/engine/atmospherics_engine)
@@ -45227,12 +45120,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"oEn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oED" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -45415,6 +45302,24 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"oHT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2;1;4;34;3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oHU" = (
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -45527,14 +45432,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oJx" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oJE" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel,
@@ -45640,17 +45542,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/maintenance/fore)
-"oME" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "oNk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -45852,13 +45743,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "oQB" = (
-/obj/machinery/firealarm{
-	pixel_y = -24
-	},
-/obj/machinery/vending/security,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oQO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45907,15 +45794,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
-"oSf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "oSo" = (
 /obj/machinery/light{
 	dir = 1
@@ -45997,9 +45875,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "oUo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -46054,11 +45929,19 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "oUZ" = (
-/obj/machinery/camera/autoname{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hosoffice";
+	name = "Head of Security's Office Shutters"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "oVg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -46112,11 +45995,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -46251,24 +46137,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
-"oYE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Medical";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "oYK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -46641,25 +46509,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"phx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "phE" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -46731,11 +46587,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pim" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/holopad{
 	pixel_y = 16
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -46851,9 +46710,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "pke" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -46870,10 +46727,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pkx" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/door/airlock/security/glass{
+	name = "Interrogation Room";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "pkM" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -46922,7 +46787,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "pme" = (
@@ -47003,18 +46867,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "poQ" = (
-/obj/machinery/requests_console{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/red,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "ppd" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -47098,12 +46957,15 @@
 /obj/item/reagent_containers/food/condiment/enzyme{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/light_switch{
 	pixel_x = 1;
 	pixel_y = -25
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -47386,24 +47248,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pvo" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pvv" = (
@@ -47439,14 +47290,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pwc" = (
-/obj/effect/turf_decal/tile/brown/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Briefing Room";
+	req_one_access_txt = "1;4"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/main)
 "pwm" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -47573,16 +47430,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "pya" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/machinery/light_switch{
 	pixel_x = 1;
 	pixel_y = 28
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
@@ -47751,12 +47618,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "pAz" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/machinery/camera/autoname,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pAD" = (
@@ -47802,9 +47666,19 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pBZ" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pCa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -47813,17 +47687,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "pCd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "pCr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47845,9 +47713,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "pCu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -47888,6 +47753,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pDg" = (
@@ -48073,18 +47940,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"pFS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "pFY" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -48154,12 +48009,18 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "pHz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/storage/lockbox/loyalty,
+/obj/item/radio,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "pHB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48214,8 +48075,8 @@
 	dir = 1
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall14";
-	location = "hall13"
+	codes_txt = "patrol;next_patrol=hall13";
+	location = "hall12"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -48273,13 +48134,15 @@
 	},
 /area/science/research)
 "pIW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/item/radio/intercom{
 	pixel_x = 29;
 	pixel_y = -2
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -48322,9 +48185,6 @@
 /obj/machinery/flasher{
 	id = "PCell 1";
 	pixel_x = -28
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Cell 2";
@@ -48386,7 +48246,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "pKj" = (
 /obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/science/shuttle)
 "pKn" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -48606,15 +48466,15 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "pNM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/security_officer,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "pOd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -48639,15 +48499,27 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "pOG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "pOI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner,
@@ -48655,9 +48527,6 @@
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/restraints/handcuffs/cable/zipties,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pOL" = (
@@ -48954,16 +48823,17 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "pUM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pUR" = (
 /obj/effect/turf_decal/stripes/line,
@@ -49046,11 +48916,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pWb" = (
-/obj/structure/chair/office{
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/medical/medbay/lobby)
 "pWk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49204,14 +49078,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
 "pYy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pYz" = (
@@ -49241,10 +49112,10 @@
 /area/medical/medbay/central)
 "pYT" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/brown/opposingcorners,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pYY" = (
@@ -49303,11 +49174,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "qac" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "qay" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -49320,16 +49199,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "qaA" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall11";
+	location = "hall10"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -49642,17 +49517,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qhk" = (
@@ -49864,17 +49732,15 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
 "qkE" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "qkT" = (
 /obj/machinery/light{
 	dir = 4
@@ -50062,15 +49928,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"qok" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qop" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -50304,17 +50161,14 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -50483,14 +50337,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "qug" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "quq" = (
 /obj/structure/disposalpipe/segment,
@@ -50691,30 +50547,25 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "qwH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "qwL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qwM" = (
 /obj/effect/turf_decal/tile/red{
@@ -50731,13 +50582,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"qwU" = (
-/obj/effect/turf_decal/tile/brown/opposingcorners,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qxn" = (
 /obj/machinery/light{
 	dir = 8
@@ -50814,16 +50658,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"qyy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "qyz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50863,14 +50697,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
-"qyY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "qzc" = (
 /obj/machinery/computer/rdconsole,
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
@@ -50914,7 +50740,10 @@
 /area/crew_quarters/bar)
 "qAq" = (
 /obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qAG" = (
@@ -51485,21 +51314,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"qJL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "qJN" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -51581,8 +51395,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qLx" = (
-/obj/machinery/gulag_teleporter,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51641,20 +51455,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"qMB" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/delivery,
-/obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -2
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "qMC" = (
 /obj/machinery/requests_console{
 	pixel_x = -32
@@ -52032,16 +51832,24 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "qTW" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qUi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52096,9 +51904,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "qUF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -52259,23 +52064,33 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "qXL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qXX" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "qYd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -52300,20 +52115,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"qYA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "qYB" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -52327,18 +52128,15 @@
 /obj/item/wirecutters{
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_x = 1;
 	pixel_y = -25
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -52452,7 +52250,7 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "rav" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -52663,15 +52461,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ret" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "rez" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -52785,19 +52574,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "rgb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rgc" = (
@@ -52859,14 +52643,28 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rgB" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rgH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -52948,12 +52746,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "rhZ" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet{
-	name = "Evidence Closet 4"
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "rie" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -52979,12 +52783,14 @@
 	},
 /area/chapel/main/monastery)
 "riA" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "riE" = (
@@ -53178,11 +52984,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"rlO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "rlR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -53351,15 +53152,18 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "roQ" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/mask/balaclava,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/electropack,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plating,
+/area/security/execution/education)
 "roV" = (
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen #5";
@@ -53377,18 +53181,17 @@
 /obj/machinery/shower{
 	pixel_y = 16
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "rpc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -53833,9 +53636,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rxk" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -53906,15 +53707,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/crew_quarters/heads/cmo)
-"ryY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "rza" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -53928,14 +53720,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "rzc" = (
-/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rzq" = (
@@ -53989,7 +53777,6 @@
 /area/library)
 "rzV" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -53997,10 +53784,11 @@
 /area/maintenance/starboard/fore)
 "rAb" = (
 /obj/machinery/computer/prisoner/management,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "rAw" = (
@@ -54018,6 +53806,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"rAP" = (
+/turf/closed/wall,
+/area/engine/engineering)
 "rAR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -54049,17 +53840,19 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "rBh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rBk" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
@@ -54333,24 +54126,16 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "rFO" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/prison)
 "rFR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/siding/wood,
@@ -54398,10 +54183,17 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "rGg" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/watermelon,
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rGk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -54570,12 +54362,22 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "rJI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/warden)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rJJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54850,13 +54652,28 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "rOj" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rOC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rPk" = (
@@ -54875,10 +54692,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Blast Doors"
 	},
 /obj/machinery/door/firedoor,
@@ -54926,20 +54741,11 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/flashlight/seclite,
 /obj/item/restraints/handcuffs,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -55088,17 +54894,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rRn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "rRs" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -55117,15 +54912,6 @@
 	dir = 8
 	},
 /area/medical/chemistry)
-"rRD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "rRL" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -55137,20 +54923,21 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "rSn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/item/wrench,
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "rSB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55190,9 +54977,7 @@
 /turf/open/floor/carpet/cyan,
 /area/crew_quarters/heads/cmo)
 "rTo" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -55254,17 +55039,18 @@
 /area/medical/surgery)
 "rUL" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/item/stamp/hos{
-	pixel_x = 13;
-	pixel_y = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "rUN" = (
@@ -55337,20 +55123,22 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "rWf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bottle/chloralhydrate,
+/obj/item/reagent_containers/glass/bottle/chloralhydrate,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 8;
+	req_access_txt = "2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "rWj" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
@@ -55435,11 +55223,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/fitness/recreation)
 "rXL" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -55542,9 +55334,7 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "rZa" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -55720,7 +55510,7 @@
 	},
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/main)
 "scI" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore)
@@ -55755,22 +55545,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "sdp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sdz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -55829,25 +55617,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "sef" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/security/brig)
 "sep" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/engine/engineering)
 "sey" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -56072,8 +55854,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -56175,8 +55955,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "skQ" = (
@@ -56232,21 +56012,25 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "slv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "slH" = (
 /obj/machinery/holopad,
@@ -56267,16 +56051,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"smb" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "smF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56308,16 +56082,14 @@
 /area/quartermaster/exploration_prep)
 "smX" = (
 /obj/structure/rack,
-/obj/item/ammo_box/magazine/wt550m9/rubber{
-	pixel_x = -2;
-	pixel_y = 3
+/obj/item/storage/box/teargas{
+	pixel_x = 1;
+	pixel_y = -2
 	},
-/obj/item/ammo_box/magazine/wt550m9/rubber,
-/obj/item/ammo_box/magazine/wt550m9/rubber{
-	pixel_x = 2;
-	pixel_y = -3
-	},
+/obj/item/storage/box/flashbangs,
 /obj/effect/turf_decal/delivery,
+/obj/item/storage/box/firingpins,
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "snb" = (
@@ -56641,14 +56413,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "ssj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/security/brig)
 "ssm" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -56709,9 +56476,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ssT" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ssV" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	filter_type = "n2"
@@ -56800,20 +56573,19 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "suf" = (
-/obj/structure/table,
-/obj/item/paper/guides/jobs/engi/gravity_gen,
-/obj/item/pen/blue,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/security/main)
 "sut" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -56823,11 +56595,14 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "sux" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -56911,13 +56686,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"svR" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "svX" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -56940,18 +56708,6 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "swK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -57265,19 +57021,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sBI" = (
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "sCm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57365,9 +57108,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sFf" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/job_scale/armoury/wt550,
+/obj/effect/turf_decal/delivery,
+/obj/item/gun/ballistic/automatic/wt550/rubber_loaded{
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/automatic/wt550/rubber_loaded,
+/obj/item/gun/ballistic/automatic/wt550/rubber_loaded{
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "sFB" = (
@@ -57511,10 +57260,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "sHZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sIf" = (
@@ -57681,19 +57430,17 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "sKs" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/plant_analyzer,
-/obj/item/seeds/wheat,
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -2
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/turf/open/floor/grass,
-/area/hydroponics/garden)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "sKx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/siding/wood,
@@ -58049,12 +57796,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/security/brig)
-"sRh" = (
-/obj/structure/table/reinforced,
-/obj/item/defibrillator/loaded,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "sRn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -58138,18 +57879,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"sSr" = (
-/obj/machinery/door/airlock/external{
-	name = "Labour Shuttle"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "sSL" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner{
@@ -58231,13 +57960,6 @@
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"sUe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "sUf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -58397,16 +58119,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"sWx" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "sWE" = (
 /obj/structure/chair{
 	dir = 8
@@ -58482,16 +58194,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"sXZ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/blood_filter,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "sYe" = (
 /obj/machinery/light{
 	dir = 4
@@ -58572,9 +58274,6 @@
 /obj/machinery/flasher{
 	id = "PCell 2";
 	pixel_x = -28
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Cell 1";
@@ -58763,11 +58462,15 @@
 /turf/open/floor/carpet/cyan,
 /area/crew_quarters/heads/cmo)
 "tdf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tdj" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -58803,9 +58506,7 @@
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "teE" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -59087,11 +58788,24 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "tku" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "tkA" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -59200,8 +58914,16 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "tne" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/white,
+/obj/structure/table,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tnA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -59415,10 +59137,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "trC" = (
@@ -59457,9 +59179,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "tsz" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/plasteel/white,
@@ -59548,8 +59268,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/brig)
 "tuK" = (
@@ -59580,24 +59298,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"tuU" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tva" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "tvk" = (
@@ -60018,12 +59723,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "tDh" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/turf/open/floor/plasteel,
+/area/medical/medbay/lobby)
 "tDl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -60202,18 +59907,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"tFu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "tFG" = (
 /obj/machinery/computer/shuttle_flight{
 	dir = 8;
@@ -60250,17 +59943,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"tFW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/plasteel,
-/area/security/main)
 "tFX" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
@@ -60479,14 +60161,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tLk" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tLo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -60552,18 +60230,9 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "tMp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28;
-	pixel_y = -2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/structure/closet/secure_closet/evidence,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tMA" = (
 /obj/machinery/door/poddoor{
@@ -60621,12 +60290,12 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
 "tNg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plating,
+/area/security/warden)
 "tNl" = (
 /obj/machinery/requests_console{
 	department = "Library";
@@ -60696,6 +60365,10 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=hall10";
+	location = "hall9"
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "tNW" = (
@@ -60717,15 +60390,22 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "tOG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "tOL" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch{
@@ -60804,27 +60484,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "tQG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tQH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/camera{
+	dir = 1;
+	c_tag = "Armoury Exterior"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/space/basic,
+/area/space)
 "tQQ" = (
 /obj/machinery/vending/medical,
 /obj/machinery/airalarm/directional/west,
@@ -60845,9 +60522,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "tRy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tRP" = (
@@ -60948,10 +60631,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tTz" = (
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "tTC" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -60960,15 +60639,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tTH" = (
@@ -61023,11 +60700,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "tUH" = (
-/obj/machinery/light_switch{
-	pixel_x = 1;
-	pixel_y = -25
-	},
-/turf/open/floor/grass,
+/turf/open/space/basic,
 /area/hydroponics/garden)
 "tUJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -61071,12 +60744,20 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tVA" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/chair,
+/obj/item/radio/intercom{
+	frequency = 1423;
+	name = "Interrogation Intercom";
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "tWh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -61270,6 +60951,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"tZD" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "tZF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -61384,20 +61072,20 @@
 	c_tag = "Prison Toilet";
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "ubm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ubn" = (
 /obj/machinery/modular_fabricator/exosuit_fab,
 /obj/effect/turf_decal/bot,
@@ -61426,12 +61114,11 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "uce" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/sorting/mail/flip,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uco" = (
@@ -61754,9 +61441,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uhc" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -61867,16 +61552,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/virology)
-"ujp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ujs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -61949,14 +61624,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ukc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/security/main)
+/area/security/brig)
 "ukj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -62116,7 +61792,10 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "umy" = (
@@ -62124,27 +61803,14 @@
 /turf/closed/wall,
 /area/hydroponics)
 "umI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "permacell1";
-	name = "Cell 2 Lockdown";
-	pixel_x = -4;
-	pixel_y = 25;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/flasher{
-	id = "PCell 1";
-	pixel_x = 6;
-	pixel_y = 25
-	},
-/obj/machinery/camera/autoname,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "umK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -62160,12 +61826,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "unc" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "und" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
@@ -62235,12 +61904,21 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "uoA" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet{
-	name = "Evidence Closet 5"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/injection,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "uoO" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -62396,22 +62074,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "uqZ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_one_access_txt = "1;4"
-	},
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/main)
 "urg" = (
 /obj/machinery/power/supermatter_crystal/shard/engine{
 	moveable = 1
@@ -62499,13 +62171,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "usR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/closet{
+	name = "Evidence Closet 3"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = 25
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -62835,11 +62506,24 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "uyN" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uyQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -62952,15 +62636,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "uBo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/item/wrench,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/execution/education)
+/area/security/main)
 "uBx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63082,20 +62767,21 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "uDR" = (
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uEf" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -63307,15 +62993,14 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "uGL" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -63363,14 +63048,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "uHq" = (
-/obj/vehicle/ridden/secway,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uHw" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4;
@@ -63439,23 +63119,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"uIs" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Room";
-	req_access_txt = "19;23"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "uIy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63554,8 +63217,13 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "uJI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uJJ" = (
@@ -63577,11 +63245,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "uKa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/carpet/royalblue,
-/area/crew_quarters/heads/captain/private)
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uKr" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -63946,15 +63616,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "uPF" = (
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/light_switch{
 	pixel_x = 26
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uPQ" = (
@@ -64052,14 +63721,14 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "uRO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uRU" = (
@@ -64085,19 +63754,18 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "uSA" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "uSJ" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -64131,17 +63799,19 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/maintenance/starboard/secondary)
 "uTp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -25
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uTw" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -64263,18 +63933,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uVk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uVo" = (
@@ -64298,17 +63963,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/button/door{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Armory Blast Doors";
 	pixel_x = -28;
 	pixel_y = 28;
 	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -64337,19 +64001,24 @@
 /turf/open/floor/carpet/blue,
 /area/security/brig)
 "uWk" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "uWu" = (
-/obj/structure/table/reinforced,
-/obj/item/wallframe/defib_mount,
-/obj/item/wrench/medical,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/quartermaster/storage)
 "uWE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/cargo/request,
@@ -64404,11 +64073,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -64435,10 +64107,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "uYo" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 1
-	},
 /obj/effect/landmark/start/captain,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -64552,14 +64220,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vbr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vbv" = (
@@ -64654,22 +64322,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vcQ" = (
-/obj/structure/closet/secure_closet/evidence{
-	name = "Secure Evidence Closet 1"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "vcZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vdg" = (
@@ -64679,14 +64339,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64736,9 +64395,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vdU" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -64809,7 +64466,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "veG" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64875,8 +64535,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vgb" = (
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/machinery/gulag_teleporter,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vge" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 1
@@ -64898,10 +64559,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/firealarm{
+	dir = 1;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -64910,13 +64569,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "vgK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vgU" = (
@@ -65083,10 +64749,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "vjU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "vky" = (
@@ -65135,22 +64797,28 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
 "vlk" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 3
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/item/folder/red{
-	pixel_x = -3;
-	pixel_y = 2
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1423;
+	listening = 0;
+	name = "Interrogation Intercom";
+	pixel_x = 29
 	},
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/brig)
 "vlr" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -65220,8 +64888,11 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen/coldroom)
 "vne" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -65359,29 +65030,21 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "vps" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vpH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
 /area/security/execution/education)
 "vpN" = (
 /obj/structure/rack,
@@ -65480,9 +65143,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "vrg" = (
@@ -65503,12 +65163,13 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "vrj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	sortType = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vrp" = (
@@ -65557,8 +65218,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "vrV" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "vsg" = (
 /obj/machinery/light{
 	dir = 4
@@ -65673,9 +65344,14 @@
 /turf/closed/wall,
 /area/science/misc_lab/range)
 "vuu" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/computer/security/hos{
 	dir = 8
 	},
@@ -65683,8 +65359,6 @@
 	pixel_x = -5;
 	pixel_y = -25
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "vuv" = (
@@ -65840,16 +65514,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "vvX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "vwc" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/holopad,
@@ -65990,6 +65659,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/science/shuttle)
+"vyf" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "vyv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -66189,11 +65870,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vAm" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vAt" = (
@@ -66258,21 +65940,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/flasher/portable,
 /obj/item/wrench,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/warden)
 "vBI" = (
@@ -66322,18 +65998,12 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "vCi" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = -28
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "vCo" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -66416,18 +66086,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "vEm" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vEs" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66468,16 +66133,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "vEG" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 3
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vEJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -66764,15 +66428,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "vIl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vIx" = (
 /obj/machinery/door/airlock/public/glass{
@@ -66788,23 +66448,12 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
 "vIL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/security/glass{
+	name = "Interrogation Waiting Room";
+	req_one_access_txt = "1;4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vIW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66831,10 +66480,13 @@
 /area/medical/virology)
 "vJp" = (
 /obj/structure/table/reinforced,
-/obj/item/toy/cards/deck,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/toy/cards/deck,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "vJu" = (
@@ -66934,18 +66586,20 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "vKL" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/vending/security,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vKM" = (
 /obj/machinery/gibber,
 /obj/machinery/requests_console{
@@ -67070,16 +66724,19 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "vNt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vNz" = (
 /obj/machinery/vending/custom{
@@ -67091,9 +66748,19 @@
 /turf/open/floor/wood,
 /area/library)
 "vNG" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "vNJ" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /obj/structure/cable/yellow{
@@ -67288,16 +66955,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"vRC" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "vRY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -67426,9 +67083,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "vTj" = (
@@ -67544,21 +67199,23 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "vWy" = (
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "vWC" = (
@@ -67739,14 +67396,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "wam" = (
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "waJ" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -68101,8 +67763,6 @@
 /area/library)
 "whZ" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wiq" = (
@@ -68134,13 +67794,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wiI" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "wiP" = (
 /obj/machinery/light{
@@ -68313,26 +67976,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"wlN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "wlP" = (
 /turf/template_noop,
 /area/maintenance/department/crew_quarters/dorms)
 "wlR" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair/office,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wlT" = (
@@ -68379,14 +68034,14 @@
 /turf/open/space/basic,
 /area/space)
 "wmg" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wmk" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/plasteel,
@@ -68454,24 +68109,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wnA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wnN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -68588,12 +68235,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "woR" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/closed/wall,
+/area/ai_monitored/storage/eva)
 "wpg" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -68616,12 +68259,18 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "wqm" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/main)
 "wqp" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -68878,13 +68527,14 @@
 /area/science/shuttle)
 "wvq" = (
 /obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/neutral,
 /obj/item/melee/baton/loaded,
 /obj/item/restraints/handcuffs,
 /obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "wvu" = (
@@ -68936,15 +68586,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wwu" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -69024,7 +68676,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "wxA" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -69054,13 +68709,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/customs)
 "wxY" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/security/execution/education)
 "wys" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -69215,12 +68871,17 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "wAW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -69228,16 +68889,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"wBf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "wBw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
@@ -69337,19 +68988,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wDA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "wDG" = (
 /turf/closed/wall,
 /area/maintenance/department/science/central)
@@ -69360,16 +68998,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"wEh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "wEp" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -69378,16 +69006,17 @@
 /turf/open/floor/wood,
 /area/library)
 "wEy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wEC" = (
 /obj/effect/turf_decal/bot,
@@ -69441,15 +69070,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wFk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "wFt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -69493,18 +69118,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wGk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -69559,17 +69183,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "wHp" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "wHB" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/lattice,
@@ -69762,24 +69387,25 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "wKA" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/item/radio/intercom{
+	pixel_y = 24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/medical/medbay/lobby)
 "wKG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "wKN" = (
 /obj/structure/cable/yellow{
@@ -69917,13 +69543,16 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "wMC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wMM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -69959,17 +69588,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
 	req_one_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wNi" = (
@@ -70096,14 +69723,12 @@
 /area/engine/engine_room)
 "wPi" = (
 /obj/machinery/light,
-/obj/machinery/holopad{
-	pixel_y = 16
-	},
-/obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "wPn" = (
@@ -70246,6 +69871,21 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"wSe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Secure Brig";
+	req_one_access_txt = "2;1;4;34;3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wSk" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -70441,12 +70081,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"wVV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "wWb" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -70555,11 +70189,16 @@
 /turf/open/floor/plasteel,
 /area/science/shuttle)
 "wXU" = (
-/obj/machinery/light,
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
+/obj/structure/table/reinforced,
+/obj/item/coin/antagtoken,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wXZ" = (
@@ -70627,11 +70266,26 @@
 /area/hallway/primary/central)
 "wYo" = (
 /obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/effect/spawner/lootdrop/job_scale/armoury/energy_gun,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "wYq" = (
@@ -70674,14 +70328,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wYR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/sec/surgery,
+/obj/item/blood_filter,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wYS" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -70749,13 +70403,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"xab" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
 "xak" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -70862,15 +70509,12 @@
 	},
 /area/crew_quarters/heads/hor)
 "xdF" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/security/execution/education)
 "xdI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -70928,15 +70572,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xez" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xeR" = (
@@ -71042,7 +70679,7 @@
 /area/crew_quarters/heads/hop)
 "xgS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/secondary)
@@ -71430,13 +71067,20 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "xoV" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xoW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "HOS's Desk";
@@ -71444,6 +71088,7 @@
 	name = "Captain RC";
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/bed/pod,
 /obj/item/bedsheet/hos,
 /obj/item/radio/intercom{
@@ -71453,8 +71098,6 @@
 	pixel_x = 37;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "xpd" = (
@@ -71576,15 +71219,13 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "xqF" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=hall13";
-	location = "hall12"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "xqJ" = (
 /obj/structure/dresser,
 /turf/open/floor/plasteel/dark,
@@ -71916,14 +71557,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
-"xxb" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "xxg" = (
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -71939,19 +71572,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"xxh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "xxH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -72078,13 +71698,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/science/central)
-"xzl" = (
-/obj/effect/landmark/start/brig_physician,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "xzr" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -72112,15 +71725,20 @@
 /turf/open/floor/dock/drydock,
 /area/science/shuttle)
 "xzF" = (
-/obj/machinery/door/airlock/external{
-	name = "Labour Shuttle";
-	req_access_txt = "2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/main)
 "xzO" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 4
@@ -72150,8 +71768,11 @@
 "xAk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -72201,10 +71822,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xAP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -72241,11 +71858,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xAZ" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/structure/closet{
+	name = "Evidence Closet 1"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xBa" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -72449,22 +72067,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
 "xDM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 24
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching Prison Wing holding areas.";
-	name = "Prison Monitor";
-	network = list("prison");
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xDZ" = (
 /obj/machinery/airalarm/directional/south,
@@ -72492,15 +72100,21 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "xEI" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/evidence{
-	name = "Secure Evidence Closet 2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/security/execution/education)
 "xEN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -72600,6 +72214,15 @@
 /turf/open/floor/circuit,
 /area/gateway)
 "xGM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -72608,16 +72231,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -72640,14 +72253,14 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "xHC" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -72958,9 +72571,13 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/sugar,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/kitchen/knife/combat/bone,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "xLu" = (
@@ -72971,9 +72588,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xLF" = (
@@ -73248,7 +72862,10 @@
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/hos,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -73273,14 +72890,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "xQE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xQG" = (
 /obj/machinery/camera/autoname{
@@ -73482,9 +73095,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"xTn" = (
-/turf/closed/wall,
-/area/security/execution/education)
 "xTN" = (
 /obj/structure/chair/fancy/comfy{
 	dir = 8
@@ -73584,15 +73194,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "xVp" = (
-/obj/structure/table,
-/obj/item/storage/lockbox/loyalty,
-/obj/item/radio,
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xVs" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -73640,14 +73248,6 @@
 /obj/effect/turf_decal/tile/green/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xVK" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Kill Chamber";
-	req_access_txt = "3"
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/education)
 "xWd" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -73709,6 +73309,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -73717,9 +73323,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -73735,20 +73338,16 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
 "xXK" = (
-/obj/structure/chair/fancy/comfy{
-	color = "#666666";
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/item/radio/intercom{
+	pixel_x = -28;
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xXY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -73756,15 +73355,31 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "xYi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/storage/secure/briefcase,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "xYm" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
@@ -73788,20 +73403,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "xYK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad{
-	pixel_y = 16
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xYZ" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -73976,19 +73584,21 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ydt" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ydu" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -74155,9 +73765,6 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -74380,9 +73987,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ylC" = (
@@ -95157,7 +94761,7 @@ nmi
 gub
 kff
 bBc
-amI
+rAP
 luI
 bxc
 wpL
@@ -95415,7 +95019,7 @@ dZs
 jfW
 kff
 wTq
-amI
+rAP
 ozb
 kNz
 giD
@@ -95673,7 +95277,7 @@ dZs
 gGc
 mfn
 joJ
-amI
+rAP
 jKi
 oDr
 oLv
@@ -95931,7 +95535,7 @@ dZs
 tJs
 kff
 bBc
-amI
+rAP
 hKp
 rtF
 oZt
@@ -96189,7 +95793,7 @@ amI
 kPy
 uUV
 vWF
-amI
+rAP
 pFF
 lXu
 ixJ
@@ -96443,11 +96047,11 @@ lNH
 atw
 aTN
 wej
-amI
-amI
+rAP
+rAP
 qpC
-amI
-amI
+rAP
+rAP
 pFF
 uoO
 ixJ
@@ -96705,7 +96309,7 @@ irc
 rjL
 dBS
 bBc
-amI
+rAP
 kpi
 lXu
 ixJ
@@ -96963,7 +96567,7 @@ qrp
 itv
 hHS
 xfG
-amI
+rAP
 pFF
 lXu
 ixJ
@@ -97221,7 +96825,7 @@ wXZ
 ngu
 hYd
 fKw
-amI
+rAP
 pFF
 lXu
 ixJ
@@ -97479,7 +97083,7 @@ shn
 kSV
 hYd
 bBc
-amI
+rAP
 bvo
 lXu
 jjx
@@ -98511,7 +98115,7 @@ wEN
 iAP
 rMr
 fYp
-amI
+rAP
 jsW
 wuY
 ixJ
@@ -98761,15 +98365,15 @@ cWm
 cWH
 cWH
 cWH
-amI
+rAP
 uRU
-amI
-amI
-amI
+rAP
+rAP
+rAP
 vyX
-amI
-amI
-amI
+rAP
+rAP
+rAP
 fBh
 lXu
 ixJ
@@ -99026,7 +98630,7 @@ abv
 uCF
 iQJ
 ngy
-amI
+rAP
 jJc
 imh
 eHi
@@ -99284,7 +98888,7 @@ sep
 izU
 tFR
 cQe
-amI
+rAP
 ant
 dTm
 sOB
@@ -99542,7 +99146,7 @@ daj
 keC
 oIU
 fdU
-amI
+rAP
 jTo
 pwC
 rLp
@@ -99796,20 +99400,20 @@ cWH
 nFz
 nfv
 nFz
-amI
+rAP
 aMd
 uoX
 aMd
-amI
-nIH
+rAP
+kVl
 aEQ
-nIH
-nIH
-ihY
+kVl
+kVl
+woR
 klB
-ihY
+woR
 lZp
-ihY
+woR
 ihY
 ihY
 ayd
@@ -100579,7 +100183,7 @@ haM
 haM
 haM
 mDG
-ihY
+woR
 dgZ
 vYK
 pZM
@@ -101095,8 +100699,8 @@ msC
 mWw
 haM
 mXH
-ihY
-ihY
+woR
+woR
 kNN
 dhK
 kNN
@@ -101358,7 +100962,7 @@ ayd
 jIi
 qtR
 xJJ
-ihY
+woR
 ciK
 nJu
 xOn
@@ -101612,11 +101216,11 @@ qdm
 aYi
 gET
 oSJ
-ihY
-ihY
+woR
+woR
 fuT
-ihY
-ihY
+woR
+woR
 wDG
 gHw
 gHw
@@ -103911,17 +103515,17 @@ jxO
 jxO
 kVl
 kVl
-nIH
-nIH
-nIH
-scI
+kVl
+kVl
+kVl
+mma
 bja
 bja
 bja
-scI
-scI
-scI
-scI
+mma
+mma
+mma
+mma
 mma
 ioQ
 bxI
@@ -104169,7 +103773,7 @@ aMT
 anT
 aMT
 aMT
-aRL
+jWk
 aMT
 aMT
 aMT
@@ -104179,7 +103783,7 @@ anT
 aMT
 aMT
 aMT
-scI
+mma
 ppu
 qDx
 bxI
@@ -104427,7 +104031,7 @@ aMT
 anT
 aMT
 aMT
-aRL
+jWk
 aMT
 aMT
 azB
@@ -104437,7 +104041,7 @@ azB
 azB
 aMT
 aMT
-scI
+mma
 baK
 wfO
 bxI
@@ -104685,7 +104289,7 @@ anT
 anT
 anT
 aMT
-aRL
+jWk
 aMT
 azB
 azB
@@ -104695,7 +104299,7 @@ rvH
 azB
 azB
 aMT
-scI
+mma
 ccF
 qDx
 bxI
@@ -104943,7 +104547,7 @@ aMT
 anT
 aMT
 aMT
-aRL
+jWk
 eAd
 azB
 arH
@@ -104953,7 +104557,7 @@ aRB
 aif
 azB
 csy
-scI
+mma
 mma
 ioQ
 bxI
@@ -105201,7 +104805,7 @@ fCz
 fCz
 oGY
 xnh
-aRL
+jWk
 aMT
 azB
 csV
@@ -105211,7 +104815,7 @@ aUs
 mSV
 azB
 aMT
-scI
+mma
 aVf
 qDx
 fBQ
@@ -105456,10 +105060,10 @@ anT
 anT
 anT
 anT
-aRL
+jWk
 dmg
 abg
-aRL
+jWk
 aMT
 azB
 eqw
@@ -105469,7 +105073,7 @@ weT
 loq
 azB
 aMT
-scI
+mma
 gpY
 qOM
 wdC
@@ -105714,10 +105318,10 @@ anT
 anT
 anT
 anT
-aRL
+jWk
 tzl
 rdU
-aRL
+jWk
 aMT
 azB
 aRB
@@ -105727,7 +105331,7 @@ aUs
 aRB
 azB
 aMT
-scI
+mma
 mKY
 geF
 wYA
@@ -105971,11 +105575,11 @@ anT
 anT
 alZ
 alZ
-aRL
-aRL
+jWk
+jWk
 pPi
 rGI
-aRL
+jWk
 eAd
 azB
 agS
@@ -105985,7 +105589,7 @@ aRB
 ari
 azB
 csy
-scI
+mma
 mKY
 mma
 qeh
@@ -106233,7 +105837,7 @@ ewm
 reb
 qoK
 sUq
-aRL
+jWk
 aMT
 azB
 azB
@@ -106243,7 +105847,7 @@ azB
 azB
 azB
 aMT
-scI
+mma
 nre
 mma
 ycJ
@@ -106491,7 +106095,7 @@ adI
 aOM
 gva
 xku
-aRL
+jWk
 aMT
 aMT
 ium
@@ -106501,7 +106105,7 @@ ayU
 ium
 aMT
 aMT
-scI
+mma
 mKY
 vlr
 qeh
@@ -106749,7 +106353,7 @@ kIZ
 aor
 uIy
 xTZ
-aRL
+jWk
 aMT
 aMT
 iAd
@@ -106759,7 +106363,7 @@ vEu
 aba
 aMT
 aMT
-scI
+mma
 mKY
 vlr
 jxh
@@ -107007,7 +106611,7 @@ kIZ
 tIm
 cgp
 rTw
-aRL
+jWk
 aMT
 aMT
 aMT
@@ -107017,7 +106621,7 @@ csr
 aMT
 aMT
 aMT
-scI
+mma
 hSo
 pNt
 hoR
@@ -107265,24 +106869,24 @@ qFQ
 tIm
 lVc
 aaX
-aRL
-aRL
-aRL
+jWk
+jWk
+jWk
 jHG
 tsB
 lcr
 tsB
 jHG
-kgE
-kgE
-kgE
-kgE
-kgE
+fAE
+fAE
+fAE
+fAE
+fAE
 xNl
-kgE
-kgE
-kgE
-kgE
+fAE
+fAE
+fAE
+fAE
 kgE
 aob
 oEe
@@ -108305,10 +107909,10 @@ kgE
 bXb
 kgE
 kgE
-kgE
+fAE
 xNl
-kgE
-kgE
+fAE
+fAE
 uGg
 lnb
 uGg
@@ -110356,14 +109960,14 @@ aMT
 aMT
 anT
 aMT
-nJn
+iZV
 dkK
 imy
 lHw
 lXw
 sGH
 uYo
-uKa
+ofC
 hbk
 lXw
 pgG
@@ -110381,7 +109985,7 @@ uGg
 uGg
 xUk
 mJo
-ktc
+mJo
 vRi
 wGS
 npu
@@ -110639,7 +110243,7 @@ fTR
 fTR
 sKA
 jsO
-ktc
+mJo
 cUd
 uln
 aIt
@@ -110872,32 +110476,32 @@ aMT
 aMT
 anT
 anT
-gGa
-vgb
-vgb
-uIs
+anT
+jWk
+jWk
+jWk
 lXw
 nvi
 naS
 qFP
 lXw
 lXw
-ktc
-ktc
-ktc
+mJo
+mJo
+mJo
 xYC
-ktc
-ktc
-ktc
-ktc
-ktc
-ktc
+mJo
+mJo
+mJo
+mJo
+mJo
+mJo
 mJo
 mJo
 mJo
 mJo
 wuJ
-ktc
+mJo
 srD
 uTx
 dYP
@@ -111117,7 +110721,7 @@ anT
 anT
 anT
 anT
-jhR
+anT
 anT
 anT
 anT
@@ -111129,11 +110733,11 @@ aMT
 aMT
 gqE
 aMT
+anT
 aMT
+anT
 aMT
-vgb
-cKK
-cSR
+qBt
 lXw
 lXw
 lXw
@@ -111149,7 +110753,7 @@ aMT
 qiD
 aVq
 aMT
-ktc
+mJo
 xUk
 xUk
 hOZ
@@ -111374,11 +110978,11 @@ aMT
 aMT
 qBt
 iaD
+lrP
 iaD
 iaD
 iaD
-iaD
-iaD
+lrP
 iaD
 qBt
 hmy
@@ -111387,16 +110991,16 @@ aMT
 aMT
 hmy
 aMT
+anT
+aMT
+anT
+aMT
+qBt
+aMT
+anT
 aMT
 aMT
-vgb
-vgb
-uIs
-vgb
-wKA
-suf
-aDJ
-vgb
+aMT
 aMT
 aMT
 oXI
@@ -111407,7 +111011,7 @@ oXI
 aMT
 aMT
 aMT
-ktc
+mJo
 xUk
 xUk
 xUk
@@ -111436,7 +111040,7 @@ srU
 koS
 uaJ
 uaJ
-uaJ
+hSI
 uaJ
 xVx
 xVx
@@ -111633,10 +111237,10 @@ aMT
 qBt
 aMT
 anT
-jPv
+aMT
 anT
 aMT
-aMT
+gYK
 iaD
 qBt
 hmy
@@ -111645,16 +111249,16 @@ aMT
 aMT
 hmy
 aMT
+anT
+aMT
+anT
+aMT
+qBt
+aMT
+anT
 aMT
 aMT
-vgb
-gnb
-vIL
-xxh
-fRC
-mlY
-wxY
-vgb
+aMT
 aMT
 oXI
 oXI
@@ -111665,7 +111269,7 @@ oXI
 oXI
 anT
 anT
-ktc
+mJo
 xUk
 xUk
 xUk
@@ -111681,20 +111285,20 @@ ogh
 uWc
 sRa
 xyq
-wmg
-sef
-wDA
-fPU
-amh
-sef
-qwU
-qYI
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+jzx
 ike
 lpT
 maH
-qOx
+cXx
 jmv
-lSJ
+qOx
 lld
 qOx
 qOx
@@ -111905,19 +111509,19 @@ duF
 duF
 duF
 duF
-vgb
-mkA
-aBp
-vrV
-vrV
-xdF
-lbc
-vgb
+duF
+duF
+duF
+duF
+duF
+duF
+duF
+anT
 anT
 oXI
 dMz
 suN
-tFu
+qwN
 qwN
 nNW
 oXI
@@ -111939,17 +111543,17 @@ pID
 fSU
 iYG
 xyq
-ret
-imf
-aIf
-hdb
-hdb
-xAZ
-lPI
-qYI
-kxx
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+jzx
+rpc
 hMM
-xSH
+cpp
 mKU
 cpp
 cpp
@@ -112152,8 +111756,8 @@ gvo
 ukY
 gaC
 uKT
-aMT
-duF
+opr
+bhs
 anM
 duF
 duF
@@ -112163,14 +111767,14 @@ duF
 pOI
 aKK
 wlR
-vgb
-qMB
+xQE
+hmy
 tLk
 ubm
-ubm
+iYj
 wYR
-lrP
-vgb
+duF
+aMT
 aMT
 oXI
 xhX
@@ -112197,15 +111801,15 @@ vqG
 wqt
 kNB
 xyq
-ret
-poQ
-gnj
-pBZ
-pBZ
-qok
-kEQ
-qYI
-qYI
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+jzx
+jzx
 rpc
 uVk
 uJI
@@ -112411,7 +112015,7 @@ qch
 jRg
 nMU
 aMT
-duF
+vvX
 efG
 mnB
 mug
@@ -112419,17 +112023,17 @@ fKn
 riA
 duF
 flw
-pWb
+aIt
 qLx
 vgb
-vgb
-lcm
-lcm
+hmy
+sef
+ckG
 ddE
 lcm
-lcm
-vgb
+duF
 aMT
+tQH
 oXI
 htD
 aae
@@ -112455,16 +112059,16 @@ hmy
 hmy
 hmy
 duF
-aSM
-oCV
-smb
-pwc
-hSD
-uyN
-ezg
-qwU
+sqh
+sqh
+gnj
+iaU
+gnj
+gnj
+iaU
+gnj
 qYI
-ddl
+qYI
 mFB
 eWn
 tNG
@@ -112668,7 +112272,7 @@ gvo
 xOb
 gaC
 uKT
-jPv
+aMT
 gNo
 lBE
 esZ
@@ -112680,18 +112284,18 @@ lOC
 eiF
 fKn
 muO
-vgb
+hmy
 ksE
-ksE
-ksE
-ksE
-ksE
-vgb
+fVD
+phE
+amh
+duF
+aMT
 aMT
 oXI
 hwK
 ipZ
-uHq
+fNn
 iGm
 jbs
 oXI
@@ -112713,18 +112317,18 @@ dgP
 uWc
 sRa
 xyq
-ret
-dwd
-ujp
-lYU
-fiW
-fiW
-gZs
-tNg
-wFk
-bUs
-pNM
 sqh
+sqh
+gnj
+kTC
+kTC
+kTC
+kTC
+kTC
+kTC
+kTC
+gnj
+uGL
 lch
 nBQ
 mpD
@@ -112934,17 +112538,17 @@ buF
 dvx
 idg
 pCL
-flw
+wmg
 dJW
 aFJ
 oeX
-vgb
-ksE
-vrV
-vrV
-vrV
-ksE
-vgb
+hmy
+bpE
+dka
+bpE
+hmy
+duF
+anT
 anT
 oXI
 dus
@@ -112971,19 +112575,19 @@ pID
 fSU
 iYG
 xyq
-ret
-wBf
-rPk
-tdf
-hzZ
-hzZ
-gSy
 sqh
 sqh
-jzx
+hzZ
+tUH
+tUH
+tUH
+kTC
+kTC
+kTC
+kTC
+iaU
 vLi
-sqh
-tSC
+qaA
 kEQ
 iDL
 dxz
@@ -113170,7 +112774,7 @@ aMT
 aMT
 aMT
 aMT
-aMT
+qiD
 aMT
 aMT
 iaD
@@ -113196,13 +112800,13 @@ dKp
 bhN
 pim
 nan
-vgb
-ksE
+hmy
+vNG
 vrV
-ksE
+kEY
 mMs
-oUZ
-vgb
+duF
+aMT
 aMT
 oXI
 oXI
@@ -113217,9 +112821,9 @@ tTo
 kWM
 hPv
 gtV
-rJI
+eez
 rPL
-dDl
+tNg
 tch
 wod
 deS
@@ -113229,20 +112833,20 @@ vqG
 wqt
 kNB
 xyq
-ret
-dwd
+sqh
+sqh
 hzZ
-cxY
-ssT
-hzZ
-hzZ
-gSy
-hdb
+tUH
+tUH
+tUH
+tUH
 kTC
+kTC
+kTC
+iaU
 fll
-wVV
 vgK
-tuU
+kEQ
 mpD
 mpI
 hFG
@@ -113454,13 +113058,13 @@ aGO
 jAh
 lCJ
 vAm
-vgb
-ksE
-vrV
-vrV
-vrV
-ksE
-vgb
+hmy
+fZM
+ckG
+umI
+lPI
+duF
+aMT
 aMT
 aMT
 oXI
@@ -113477,7 +113081,7 @@ dgh
 hQz
 kDl
 dxw
-dDl
+tNg
 nyy
 uPQ
 sBB
@@ -113487,20 +113091,20 @@ hmy
 hmy
 hmy
 duF
-rFO
-eNq
-hzZ
-cxY
-bKE
-bwG
-hzZ
-tdf
-tdf
-hzZ
-sNC
 sqh
-roQ
-iDL
+sqh
+hzZ
+tUH
+tUH
+tUH
+tUH
+tUH
+tUH
+tUH
+iaU
+sNC
+tSC
+tDh
 iDL
 otY
 hFG
@@ -113704,21 +113308,21 @@ pOG
 pOG
 bjN
 kDU
-ryY
-fTB
-aYb
+kDU
+kDU
+kDU
 ylA
 jHm
 okc
 hdO
 tRy
-vgb
-ksE
-ksE
-ksE
-ksE
-ksE
-vgb
+hmy
+eqX
+fVD
+phE
+vrV
+duF
+aMT
 aMT
 ams
 aMT
@@ -113745,22 +113349,22 @@ foZ
 uWc
 sRa
 xyq
-ret
-dwd
-hzZ
-cxY
-cxY
-cxY
-cxY
+sqh
+sqh
+rPk
+tUH
+tUH
+tUH
+tUH
 cxY
 tUH
-rPk
+tUH
+gnj
 sNC
-sqh
-nKt
+tSC
+esi
 iDL
 jjS
-qac
 vvO
 bOi
 iDL
@@ -113969,15 +113573,15 @@ duF
 wFK
 wNh
 kvf
+hmy
+hmy
+hmy
+mdT
+hmy
 duF
-vgb
-vgb
-vgb
-vgb
-vgb
-vgb
-vgb
 duF
+wGS
+wGS
 duF
 duF
 duF
@@ -114003,22 +113607,22 @@ pID
 fSU
 iYG
 xyq
-ret
-dwd
-hzZ
-cxY
-cxY
-mdT
-cxY
-cxY
-edV
+sqh
+sqh
 rPk
+rPk
+fjt
+rPk
+rPk
+koR
+rPk
+rPk
+gnj
 laR
-vNG
 rzc
+kxN
 iDL
-jVs
-hFG
+wKA
 hFG
 tCk
 ccc
@@ -114226,32 +113830,32 @@ uKT
 duF
 xDM
 ipk
-tQH
-iiH
+lJV
+mug
 slv
 ldQ
 cki
 sdp
-etB
+duF
 usR
 wAW
 icI
 tMp
-bhs
+duF
 wwu
 fsF
-jxp
-kDn
+pvo
+kNI
 uRO
 vps
 jxp
-jxp
+vps
 mEM
 isF
-jxp
+pvo
 vbr
 pvo
-kNI
+oHT
 eeC
 qSB
 tJh
@@ -114261,22 +113865,22 @@ vqG
 wqt
 kNB
 xyq
-ret
-dwd
-rPk
-mST
-iYj
-gYK
-rGg
+sqh
+sqh
 isL
-sKs
+rPk
+frx
+tZD
+rPk
+frx
+tZD
 rPk
 sNC
 sqh
-uGL
+tSC
+pWb
 iDL
 qQT
-btd
 ors
 iHs
 kwG
@@ -114482,34 +114086,34 @@ pJm
 iuV
 jQz
 duF
-umI
+lJV
 wEy
 lTY
 lNv
 gzH
-qwL
+aIt
 oph
 ibI
-cLo
+duF
 frC
 kVK
 rOC
 axR
-rOC
+duF
 kyC
 xez
-rOC
+vcZ
 kgL
-rOC
+vcZ
 uce
 gci
 vrj
-hYR
-axR
+vcZ
+poQ
 uPF
 vcZ
 pYy
-kgL
+wSe
 qVf
 rwP
 pwA
@@ -114519,20 +114123,20 @@ hmy
 hmy
 duF
 jwG
-kYc
-kEY
+sqh
+sqh
+isL
+rPk
+gks
 rPk
 rPk
-hzZ
-hzZ
-hzZ
-iZV
+vyf
 rPk
 rPk
 sNC
 sqh
-sBI
-iDL
+tSC
+ddl
 iDL
 pLN
 uql
@@ -114730,41 +114334,41 @@ vyE
 xXy
 xxK
 qUF
-idM
+xxK
 xAP
-eit
+lxK
 fwf
 djF
-crC
 vjU
-fjd
-crC
+vjU
+vjU
+vjU
 xLu
-jGQ
+lJV
 lKP
-oRA
-oRA
-oRA
-mZR
+qwL
+tdf
+hfx
+lbl
 lbl
 nxz
-mZR
-oRA
-oRA
-oRA
-jTf
-jTf
-hmy
-hmy
-bpE
-bpE
-bpE
-wqm
-hmy
-hmy
-ohA
+duF
+xAZ
+nMg
+cri
 jTf
 duF
+jGQ
+pBZ
+cSo
+cSo
+cSo
+wqm
+pwc
+bwG
+cSo
+cSo
+oRA
 duF
 duF
 duF
@@ -114776,20 +114380,20 @@ rgb
 tlU
 eBL
 xBP
-mqH
-qaA
-dRf
-dka
-iiV
-fVD
-fVD
-fVD
-fWZ
-rRn
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
 jZD
 fkM
 sqh
-rgB
+tSC
 pYT
 wSu
 wSu
@@ -114987,10 +114591,10 @@ anT
 vyE
 uXP
 lxK
-nTj
-oEn
+lxK
+lxK
 pCu
-esi
+lxK
 kDs
 uKT
 cFU
@@ -114998,31 +114602,31 @@ tNa
 xqJ
 bNP
 duF
-qug
-oAG
-oRA
-dpy
-tku
-gSR
-ukc
-pCd
-qXX
-vvX
-dpy
-oRA
-jin
-jin
-jin
+lJV
+lKP
+hmy
+hmy
+hmy
+hmy
+hmy
+hmy
+duF
+duF
+duF
+aIf
+duF
+duF
+fMJ
 dXV
-lUS
+cSo
 wam
-wam
+pNM
 dFt
 wHp
-jin
+jVs
 uTp
-rOj
-duF
+uKa
+oRA
 erD
 vre
 tuH
@@ -115030,15 +114634,15 @@ tpt
 quM
 fdx
 wku
-lkB
+ssj
 aIt
 aIt
 eZE
-jKV
-vKL
-xqF
-oSf
-bIU
+sqh
+sqh
+sqh
+sqh
+sqh
 sqh
 sqh
 sqh
@@ -115047,7 +114651,7 @@ sqh
 hbK
 tQc
 pIh
-tSC
+ezg
 hJO
 wSu
 okw
@@ -115248,29 +114852,29 @@ qAq
 eIj
 cmh
 iMC
-aUS
+eIj
+rFO
 uKT
-duF
-duF
-duF
-duF
-duF
+uKT
+uKT
+uKT
+uKT
 duF
 dEv
 vNt
-oRA
+hmy
 tVA
 tku
 ssj
 kOy
 hVU
-jxK
+hmy
 qTW
 mqm
-oRA
+jLV
 rOj
-fZM
-unc
+hmy
+bHm
 sHZ
 cSo
 oze
@@ -115280,8 +114884,8 @@ uDR
 eeZ
 gyo
 jno
-duF
-hfx
+oRA
+ivK
 cfP
 ubx
 dtI
@@ -115295,13 +114899,13 @@ duF
 pqj
 gnj
 iaU
-wnA
-eNA
-aBD
-kLJ
-aBD
-kvU
-aBD
+gnj
+sqh
+sqh
+sqh
+sqh
+sqh
+sqh
 gPc
 kEB
 aBD
@@ -115508,35 +115112,35 @@ uKT
 uKT
 bJm
 uKT
-vcQ
+uKT
 uoA
 rhZ
 gRi
 jAA
 duF
-xQE
+lJV
 pUM
-oRA
+hmy
 ajD
-tku
-cXx
+tne
+ssj
 oAF
 xYK
 hLY
 mmg
 oQB
-oRA
-duF
-duF
-duF
-duF
-duF
+pAz
+bWt
+vIL
+bHm
+sHZ
+cSo
 gqz
-duF
-lkB
-duF
-sSr
-duF
+lLS
+hYR
+cWA
+jWm
+beW
 cbC
 scG
 ivK
@@ -115552,8 +115156,8 @@ ivK
 ivK
 dAw
 vnF
-dLA
-dLA
+hER
+vnF
 dLA
 dIv
 dIv
@@ -115765,39 +115369,39 @@ wxA
 jfU
 uKT
 uaZ
-uKT
+naL
 lHh
 cWG
-wKG
+gHo
 gHo
 eRO
-uqZ
+duF
 lJV
 qXL
-oRA
+hmy
 cim
 hjj
-wlN
+ssj
 vlk
 uSA
-tFW
+hmy
 ydt
 ngF
-oRA
-aMT
-aMT
-aMT
-duF
-iFr
+lHJ
+kDf
+hmy
+rGg
+sHZ
+cSo
 kFE
-wFK
-aMT
-wFK
+gSy
+hYR
+suf
 jWm
-duF
-duF
+kBt
+vKL
 fOv
-fOv
+jdN
 cfP
 ubx
 nsY
@@ -116023,37 +115627,37 @@ rwF
 jfU
 uKT
 dFy
-uKT
+vpH
 xEI
 nYi
-ffG
-sWx
+nYi
+nYi
 uWk
-duF
+dCU
 vIl
 eQV
-oRA
+hmy
 pkx
-xxb
-cZX
-bWt
-lHJ
-phx
-qYA
-qyY
-aFG
-anT
-anT
-anT
-duF
-duF
+hmy
+hmy
+hmy
+hmy
+hmy
+hmy
+wFK
+eit
+hmy
+hmy
+kNF
+jKY
+etB
 xzF
-wFK
-anT
-wFK
+bgb
+qXX
+qac
 asI
-duF
-aMT
+uBo
+uqZ
 fOv
 cwf
 cfP
@@ -116279,39 +115883,39 @@ uKT
 fQS
 dxu
 jfU
-uKT
-uKT
-uKT
-duF
+naL
+naL
+naL
+dmz
+naL
 lkB
-lkB
-lkB
-duF
+gHo
+oCV
 duF
 gHq
 eRv
-oRA
+ssT
 bAk
-mXJ
+bAk
 wMC
 deP
 xXK
-qyy
-oya
-jKY
+bAk
+bAk
+bAk
 aFG
-aMT
-aMT
-aMT
-aMT
-aMT
+bAk
+uHq
+lYU
+wKG
+aUS
 lrA
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
+nTO
+rgB
+tOG
+rJI
+aBp
+wHp
 fOv
 ivK
 trr
@@ -116537,39 +116141,39 @@ uKT
 uKT
 uKT
 uKT
-uKT
-aMT
-aMT
-anT
-aMT
-aMT
-aMT
-anT
+naL
+pCd
+iiH
+eNA
+mqu
+wxY
+gHo
+xdF
 duF
-gHq
-vNt
-oRA
+gTl
+qug
+wiI
 xoV
 vEG
 mUB
-tTz
+mUB
 kPl
 ieI
 xVp
-mHo
-oRA
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
+xVp
+rBh
+xVp
+ukc
+dRf
+aSM
+cSo
+wnA
+vEm
+aDh
+jPv
+xYi
+unc
+crC
 fOv
 ivK
 cfP
@@ -116795,41 +116399,41 @@ iCB
 anT
 aMT
 aMT
-anT
-aMT
-duF
-duF
-wGS
-wGS
-wGS
-duF
+naL
+kYc
+roQ
+vcQ
+bkH
+csa
+wFk
+xqF
 duF
 vgI
 cgU
-oRA
-oRA
+hmy
+hmy
 iRh
 iRh
 boQ
 aKy
-boQ
+oUZ
 iRh
 iRh
 oRA
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
+oRA
+mqH
+mqH
+oRA
+oRA
+mZR
+crC
+aDJ
+fRC
+fjd
+crC
+mZR
 fOv
-fOv
+jdN
 cfP
 ubx
 ubx
@@ -117049,24 +116653,24 @@ aMT
 aMT
 aMT
 qBt
-oTx
-duF
-duF
-duF
-duF
-duF
-duF
+aMT
+aMT
+aMT
+aMT
+naL
+bUs
+gHo
 biN
-axO
+mqu
 rSn
 oJx
 vCi
-wFK
-gHq
-vNt
+duF
+qhg
+jin
 lxx
 gOl
-iRh
+ohA
 jWw
 xGM
 vWy
@@ -117074,18 +116678,18 @@ wGk
 lJh
 iRh
 aMT
+anT
 aMT
 aMT
 aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
+exZ
+oAG
+gBr
+edV
+uyN
+ejo
+pHz
+kLJ
 fOv
 vre
 lcF
@@ -117308,18 +116912,18 @@ aMT
 aMT
 aMT
 aMT
-duF
-ejo
-oME
-woR
-vEm
-bpE
-diF
-cYD
-exZ
+aMT
+aMT
+aMT
+naL
+nVo
+nVo
+nVo
+naL
+naL
 rWf
 lzn
-oYE
+duF
 qhg
 mkB
 jTl
@@ -117332,20 +116936,20 @@ ore
 htP
 iRh
 aMT
+anT
 aMT
 aMT
 aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
-aMT
+oRA
+oRA
+oRA
+mqH
+mqH
+mqH
+oRA
+oRA
 fOv
-lcq
+cfP
 mbE
 mbE
 mbE
@@ -117566,18 +117170,18 @@ aMT
 aMT
 aMT
 aMT
-duF
-pAz
-xzl
-sUe
-wEh
-hER
-wiI
-rlO
-csa
+aMT
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+naL
 qkE
 hBq
-wFK
+duF
 nhc
 tTD
 kDG
@@ -117590,19 +117194,19 @@ mnY
 wPi
 iRh
 aMT
+anT
 aMT
+aMT
+aMT
+aMT
+kQq
 aMT
 aMT
 aMT
 aMT
 anT
 aMT
-aMT
-anT
-aMT
-aMT
-aMT
-fOv
+jdN
 eTq
 mbE
 llM
@@ -117824,25 +117428,25 @@ aMT
 aMT
 aMT
 aMT
+qiD
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+naL
+naL
+naL
 duF
-sXZ
-dmz
-tne
-beW
-bpE
-phE
-kwa
-xYi
-eAW
-aDh
-hmy
-naL
-naL
-kFR
-naL
+duF
+duF
+duF
+duF
 iRh
 fIJ
-xab
+kVs
 nih
 qwH
 fjk
@@ -117850,18 +117454,18 @@ sUf
 anT
 jdN
 jdN
-fOv
-fOv
-fOv
-fOv
+jdN
+jdN
+jdN
+jdN
 ivy
 ivy
-fOv
-fOv
-fOv
-fOv
-fOv
-lcq
+jdN
+jdN
+jdN
+jdN
+jdN
+cfP
 mbE
 cCR
 dvZ
@@ -118082,22 +117686,22 @@ aMT
 aMT
 aMT
 aMT
-duF
-uWu
-dmz
-kNF
-beW
-hmy
-ckG
-kxN
-svR
-cri
-hmy
-xTn
-gBr
-fAE
-qJL
-gTl
+aMT
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+aMT
 iRh
 xoW
 geg
@@ -118340,22 +117944,22 @@ aMT
 aMT
 aMT
 aMT
-duF
-sRh
-vRC
-bvC
-nYA
-duF
-gAE
-lkB
-hmy
-hmy
-hmy
-cWA
-pHz
-kBt
-pFS
-myr
+aMT
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+aMT
 iRh
 iRh
 itw
@@ -118366,10 +117970,10 @@ iRh
 aMT
 jdN
 erD
-cUA
-lTv
+ivK
+ivK
 whZ
-lTv
+ivK
 kxd
 ivK
 jdN
@@ -118598,23 +118202,23 @@ aMT
 aMT
 aMT
 aMT
-duF
-duF
-duF
-duF
-duF
-duF
 aMT
 aMT
-naL
-naL
-naL
-xVK
-naL
-nMg
-dCU
-ktb
-naL
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+aMT
+aMT
 aMT
 aMT
 aMT
@@ -118624,16 +118228,16 @@ aMT
 aMT
 jdN
 ivK
-nzt
 ivK
 ivK
 ivK
-osX
+ivK
+cfP
 ivK
 jdN
 mxb
 klL
-jLV
+mxb
 aWM
 hSr
 mbE
@@ -118860,41 +118464,41 @@ aMT
 aMT
 aMT
 aMT
-qiD
+aMT
 anT
 aMT
 aMT
-naL
-nTO
-jtW
-rRD
-mqu
-iVz
-eqX
-ajU
-naL
-naL
-naL
+aMT
+aMT
 aMT
 aMT
 anT
 aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
 jdN
 jdN
 jdN
-mxr
+mXJ
 jdN
 jdN
 jdN
-osX
+lcq
 ivK
 jdN
 oal
 cBi
-tYs
+cBi
 wmD
-ozg
-fJL
+sKs
+uWu
 sux
 pno
 nSp
@@ -119122,17 +118726,17 @@ anT
 anT
 anT
 anT
-naL
-hSI
-fMJ
-tOG
-hzM
-kDf
-vpH
-ajU
-gfG
-dlj
-naL
+anT
+anT
+anT
+anT
+anT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
 aMT
 aMT
 anT
@@ -119380,17 +118984,17 @@ aMT
 anT
 aMT
 aMT
-naL
-lEZ
-kcQ
-bgb
-mqu
-uBo
-rBh
-gIv
-bkH
-tDh
-naL
+aMT
+aMT
+aMT
+aMT
+anT
+anT
+anT
+anT
+anT
+anT
+anT
 anT
 anT
 anT
@@ -119638,17 +119242,17 @@ aMT
 anT
 aMT
 aMT
-naL
-nVo
-nVo
-nVo
-naL
-naL
-naL
-naL
-naL
-naL
-naL
+aMT
+aMT
+aMT
+aMT
+anT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
 aMT
 aMT
 anT
@@ -119896,10 +119500,10 @@ aMT
 anT
 aMT
 aMT
-anT
-anT
-anT
-anT
+aMT
+aMT
+aMT
+aMT
 anT
 aMT
 aMT
@@ -120155,10 +119759,10 @@ anT
 aMT
 aMT
 aMT
-anT
+aMT
+aMT
 aMT
 anT
-aMT
 aMT
 aMT
 aMT

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -398,6 +398,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acp" = (
@@ -1005,9 +1008,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ajD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "ajI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1415,6 +1430,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
+"apD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "apW" = (
 /obj/structure/chair{
 	dir = 1
@@ -2202,6 +2229,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aBq" = (
@@ -2619,7 +2649,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aFH" = (
 /obj/structure/table,
@@ -5670,7 +5700,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bAn" = (
 /obj/machinery/camera/autoname{
@@ -6259,6 +6289,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/medical/cryo)
+"bKF" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bKR" = (
 /obj/machinery/deepfryer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -7683,6 +7717,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ckG" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/red,
 /area/security/brig)
 "ckO" = (
@@ -8364,7 +8401,7 @@
 	width = 7
 	},
 /turf/open/space/basic,
-/area/hydroponics/garden)
+/area/space)
 "cyg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -8908,7 +8945,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
-/area/security/warden)
+/area/ai_monitored/security/armory)
 "cJj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9481,6 +9518,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "cUF" = (
@@ -9923,7 +9963,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/lobby)
+/area/hallway/primary/starboard)
 "ddt" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -10528,6 +10568,9 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/security/brig)
@@ -11194,6 +11237,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dxf" = (
@@ -11387,6 +11433,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/room/fivexfour,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dAF" = (
@@ -12028,12 +12077,12 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "dLA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/security/checkpoint/supply)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dLB" = (
 /obj/structure/chair/fancy/comfy{
 	color = "#666666";
@@ -12338,9 +12387,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dRf" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -13219,9 +13265,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "eez" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "eeC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13613,6 +13660,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"elB" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/item/clothing/head/beret/ccguardnavy,
+/obj/item/clothing/head/beret/ccguardnavy,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "elS" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -13939,7 +14002,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/lobby)
+/area/hallway/primary/starboard)
 "esk" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/royalblue,
@@ -14240,6 +14303,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"exi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "exk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -15561,6 +15631,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"eWy" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eWN" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
@@ -15616,6 +15694,9 @@
 	},
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "eYB" = (
@@ -16308,7 +16389,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/starboard)
 "fjx" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -16471,6 +16552,9 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -16784,7 +16868,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/starboard)
 "frA" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -18269,6 +18353,9 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "fQp" = (
@@ -18505,6 +18592,9 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/wood,
 /area/security/brig)
@@ -19376,7 +19466,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/starboard)
 "gkz" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable/yellow{
@@ -21321,10 +21411,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gPn" = (
@@ -21485,6 +21571,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"gSe" = (
+/obj/machinery/door/airlock/security{
+	req_one_access_txt = "4";
+	name = "Interogation Holding"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gSk" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -22891,6 +22984,15 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"hsg" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "hsn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -23350,9 +23452,11 @@
 /turf/closed/wall,
 /area/maintenance/port/central)
 "hzZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hAa" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner{
@@ -23568,6 +23672,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hEw" = (
@@ -23601,6 +23707,9 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/machinery/computer/cargo{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
@@ -24012,8 +24121,13 @@
 	},
 /area/holodeck/rec_center)
 "hLY" = (
-/turf/closed/wall,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hMH" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -24039,9 +24153,7 @@
 	codes_txt = "patrol;next_patrol=hall9";
 	location = "hall8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hMT" = (
@@ -24653,6 +24765,9 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "hXO" = (
@@ -24943,7 +25058,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ibO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
@@ -25161,7 +25276,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ifc" = (
 /obj/structure/table/wood,
@@ -25417,6 +25532,10 @@
 /area/maintenance/starboard/aft)
 "ike" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25989,21 +26108,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "isF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/starboard)
 "isL" = (
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "isR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -27684,8 +27800,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "iYj" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iYq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -29109,6 +29227,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "jzx" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jzB" = (
@@ -29158,6 +29281,13 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"jAg" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "jAh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -29928,9 +30058,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -30735,13 +30862,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jZG" = (
@@ -31576,7 +31700,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/starboard)
 "koS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31777,6 +31901,9 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/wood,
 /area/security/brig)
@@ -32186,7 +32313,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/lobby)
+/area/hallway/primary/starboard)
 "kxW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -33039,14 +33166,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -33108,13 +33235,18 @@
 /area/science/xenobiology)
 "kPl" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "kPy" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -33125,6 +33257,10 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kQI" = (
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "kRc" = (
 /obj/structure/chair{
 	dir = 8
@@ -33292,7 +33428,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "kTC" = (
-/turf/open/space/basic,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kTL" = (
 /obj/effect/turf_decal/siding/wood{
@@ -35750,9 +35889,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lHM" = (
@@ -36296,6 +36432,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
+"lQx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "lQz" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -36862,18 +37008,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "lYU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -37922,7 +38064,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/medical/medbay/lobby)
+/area/hallway/primary/starboard)
 "mpn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38914,6 +39056,15 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"mEx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mEI" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
@@ -39766,7 +39917,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mUF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -39854,6 +40008,9 @@
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -41299,7 +41456,7 @@
 	req_one_access_txt = "2;1;4;34;3"
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/security/brig)
 "nxG" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/server,
@@ -41982,7 +42139,7 @@
 	pixel_x = -28;
 	pixel_y = -2
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "nIO" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -42815,6 +42972,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"nUE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nUY" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -43927,8 +44090,15 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "oph" = (
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "opq" = (
 /turf/closed/wall,
 /area/science/breakroom)
@@ -44142,6 +44312,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"osL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "osX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45728,6 +45909,9 @@
 	name = "Gear Room Maintenance";
 	req_one_access_txt = "1;4"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "oVg" = (
@@ -46758,6 +46942,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "pql" = (
@@ -47162,6 +47349,13 @@
 	dir = 4
 	},
 /area/chapel/main/monastery)
+"pxi" = (
+/obj/machinery/door/airlock/security{
+	req_one_access_txt = "4";
+	name = "Interogation Room"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pxq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47396,10 +47590,11 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "pAz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pAD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -48546,6 +48741,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
+"pTz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pTS" = (
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
@@ -48699,7 +48909,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/lobby)
+/area/hallway/primary/starboard)
 "pWk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50109,9 +50319,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "qug" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -52427,6 +52634,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/table,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "rgH" = (
@@ -52957,6 +53167,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rpi" = (
@@ -53406,6 +53619,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"rxo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "rxq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53607,15 +53827,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rBk" = (
 /turf/open/floor/engine/o2,
@@ -54140,6 +54357,9 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "rJJ" = (
@@ -54441,8 +54661,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rPk" = (
-/turf/closed/wall,
-/area/hydroponics/garden)
+/obj/machinery/door/airlock/security{
+	req_one_access_txt = "4";
+	name = "Detective's Office"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "rPn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -58190,13 +58417,7 @@
 /turf/open/floor/carpet/cyan,
 /area/crew_quarters/heads/cmo)
 "tdf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tdj" = (
@@ -58854,9 +59075,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "trr" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/grille,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -59437,12 +59655,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "tDh" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/medical/medbay/lobby)
+/area/security/brig)
 "tDl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -60117,6 +60340,9 @@
 	dir = 1
 	},
 /obj/machinery/rnd/production/techfab/department/security,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "tOL" = (
@@ -60413,8 +60639,14 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "tUH" = (
-/turf/open/space/basic,
-/area/hydroponics/garden)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "tUJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 1
@@ -60654,8 +60886,11 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/starboard)
 "tZF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -61337,10 +61572,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ukj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -62703,11 +62937,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -62756,7 +62993,10 @@
 /area/maintenance/starboard/fore)
 "uHq" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uHw" = (
 /obj/machinery/porta_turret/ai{
@@ -63643,13 +63883,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uVk" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uVo" = (
@@ -64426,6 +64663,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"vjJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vjN" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
@@ -64911,6 +65155,9 @@
 /obj/item/reagent_containers/food/drinks/flask/det,
 /obj/item/clothing/glasses/hud/security/sunglasses,
 /obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet/red,
 /area/security/brig)
 "vsg" = (
@@ -65353,7 +65600,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/starboard)
 "vyv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -65600,6 +65847,9 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "vAQ" = (
@@ -65811,7 +66061,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vEJ" = (
 /obj/structure/cable/yellow{
@@ -66118,6 +66368,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/chapel/monastery)
+"vID" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vIW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66284,11 +66541,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "vLi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -66393,6 +66647,9 @@
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -66868,9 +67125,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -68113,6 +68367,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "wul" = (
@@ -68776,9 +69033,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -69052,8 +69306,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -69200,7 +69454,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wMM" = (
 /obj/structure/cable/yellow{
@@ -69469,6 +69723,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -69912,6 +70169,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "wYq" = (
@@ -69954,7 +70214,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wYR" = (
-/turf/open/space/basic,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wYS" = (
 /obj/machinery/telecomms/bus/preset_one,
@@ -70694,7 +70957,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xoW" = (
 /obj/effect/turf_decal/tile/red{
@@ -71694,6 +71957,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"xDV" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xDZ" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -72579,7 +72847,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "xRF" = (
-)
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xRL" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -72819,7 +73091,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xVs" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -73883,7 +74155,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (2,1,1) = {"
 aMT
@@ -74140,7 +74412,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (3,1,1) = {"
 aMT
@@ -74397,7 +74669,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (4,1,1) = {"
 aMT
@@ -74654,7 +74926,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (5,1,1) = {"
 aMT
@@ -74911,7 +75183,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (6,1,1) = {"
 aMT
@@ -75168,7 +75440,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (7,1,1) = {"
 aMT
@@ -75425,7 +75697,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (8,1,1) = {"
 aMT
@@ -75682,7 +75954,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (9,1,1) = {"
 aMT
@@ -75939,7 +76211,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (10,1,1) = {"
 aMT
@@ -76196,7 +76468,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (11,1,1) = {"
 aMT
@@ -76453,7 +76725,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (12,1,1) = {"
 aMT
@@ -76710,7 +76982,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (13,1,1) = {"
 aMT
@@ -76967,7 +77239,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (14,1,1) = {"
 aMT
@@ -77224,7 +77496,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (15,1,1) = {"
 aMT
@@ -77481,7 +77753,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (16,1,1) = {"
 aMT
@@ -77738,7 +78010,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (17,1,1) = {"
 aMT
@@ -77995,7 +78267,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (18,1,1) = {"
 aMT
@@ -78252,7 +78524,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (19,1,1) = {"
 aMT
@@ -78509,7 +78781,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (20,1,1) = {"
 aMT
@@ -78766,7 +79038,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (21,1,1) = {"
 aMT
@@ -79023,7 +79295,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (22,1,1) = {"
 aMT
@@ -79280,7 +79552,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (23,1,1) = {"
 aMT
@@ -79537,7 +79809,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (24,1,1) = {"
 aMT
@@ -79794,7 +80066,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (25,1,1) = {"
 aMT
@@ -80051,7 +80323,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (26,1,1) = {"
 aMT
@@ -80308,7 +80580,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (27,1,1) = {"
 aMT
@@ -80565,7 +80837,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (28,1,1) = {"
 aMT
@@ -80822,7 +81094,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (29,1,1) = {"
 aMT
@@ -81079,7 +81351,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (30,1,1) = {"
 aMT
@@ -81336,7 +81608,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (31,1,1) = {"
 aMT
@@ -81593,7 +81865,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (32,1,1) = {"
 aMT
@@ -81850,7 +82122,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (33,1,1) = {"
 aMT
@@ -82107,7 +82379,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (34,1,1) = {"
 aMT
@@ -82364,7 +82636,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (35,1,1) = {"
 aMT
@@ -82621,7 +82893,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (36,1,1) = {"
 aMT
@@ -82878,7 +83150,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (37,1,1) = {"
 aMT
@@ -83135,7 +83407,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (38,1,1) = {"
 aMT
@@ -83392,7 +83664,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (39,1,1) = {"
 aMT
@@ -83649,7 +83921,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (40,1,1) = {"
 aMT
@@ -83906,7 +84178,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (41,1,1) = {"
 aMT
@@ -84163,7 +84435,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (42,1,1) = {"
 aMT
@@ -84420,7 +84692,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (43,1,1) = {"
 aMT
@@ -84677,7 +84949,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (44,1,1) = {"
 aMT
@@ -84934,7 +85206,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (45,1,1) = {"
 aMT
@@ -85191,7 +85463,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (46,1,1) = {"
 aMT
@@ -85448,7 +85720,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (47,1,1) = {"
 aMT
@@ -85705,7 +85977,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (48,1,1) = {"
 aMT
@@ -85962,7 +86234,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (49,1,1) = {"
 aMT
@@ -86219,7 +86491,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (50,1,1) = {"
 aMT
@@ -86476,7 +86748,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (51,1,1) = {"
 aMT
@@ -86733,7 +87005,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (52,1,1) = {"
 aMT
@@ -86990,7 +87262,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (53,1,1) = {"
 aMT
@@ -87247,7 +87519,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (54,1,1) = {"
 aMT
@@ -87504,7 +87776,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (55,1,1) = {"
 aMT
@@ -87761,7 +88033,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (56,1,1) = {"
 aMT
@@ -88018,7 +88290,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (57,1,1) = {"
 aMT
@@ -88275,7 +88547,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (58,1,1) = {"
 aMT
@@ -88532,7 +88804,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (59,1,1) = {"
 aMT
@@ -88789,7 +89061,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (60,1,1) = {"
 aMT
@@ -89046,7 +89318,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (61,1,1) = {"
 aMT
@@ -89303,7 +89575,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (62,1,1) = {"
 aMT
@@ -89560,7 +89832,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (63,1,1) = {"
 aMT
@@ -89817,7 +90089,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (64,1,1) = {"
 aMT
@@ -90074,7 +90346,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (65,1,1) = {"
 aMT
@@ -90331,7 +90603,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (66,1,1) = {"
 aMT
@@ -90588,7 +90860,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (67,1,1) = {"
 aMT
@@ -90845,7 +91117,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (68,1,1) = {"
 aMT
@@ -91102,7 +91374,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (69,1,1) = {"
 aMT
@@ -91359,7 +91631,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (70,1,1) = {"
 aMT
@@ -91616,7 +91888,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (71,1,1) = {"
 aMT
@@ -91873,7 +92145,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (72,1,1) = {"
 aMT
@@ -92130,7 +92402,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (73,1,1) = {"
 aMT
@@ -92387,7 +92659,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (74,1,1) = {"
 aMT
@@ -92644,7 +92916,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (75,1,1) = {"
 aMT
@@ -92901,7 +93173,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (76,1,1) = {"
 aMT
@@ -93158,7 +93430,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (77,1,1) = {"
 aMT
@@ -93415,7 +93687,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (78,1,1) = {"
 aMT
@@ -93672,7 +93944,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (79,1,1) = {"
 aMT
@@ -93929,7 +94201,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (80,1,1) = {"
 aMT
@@ -94186,7 +94458,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (81,1,1) = {"
 aMT
@@ -94443,7 +94715,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (82,1,1) = {"
 aMT
@@ -94700,7 +94972,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (83,1,1) = {"
 aMT
@@ -94957,7 +95229,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (84,1,1) = {"
 aMT
@@ -95214,7 +95486,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (85,1,1) = {"
 aMT
@@ -95471,7 +95743,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (86,1,1) = {"
 aMT
@@ -95728,7 +96000,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (87,1,1) = {"
 aMT
@@ -95985,7 +96257,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (88,1,1) = {"
 aMT
@@ -96242,7 +96514,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (89,1,1) = {"
 aMT
@@ -96499,7 +96771,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (90,1,1) = {"
 aMT
@@ -96756,7 +97028,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (91,1,1) = {"
 aMT
@@ -97013,7 +97285,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (92,1,1) = {"
 aMT
@@ -97270,7 +97542,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (93,1,1) = {"
 aMT
@@ -97527,7 +97799,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (94,1,1) = {"
 aMT
@@ -97784,7 +98056,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (95,1,1) = {"
 aMT
@@ -98041,7 +98313,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (96,1,1) = {"
 aMT
@@ -98298,7 +98570,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (97,1,1) = {"
 aMT
@@ -98555,7 +98827,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (98,1,1) = {"
 aMT
@@ -98812,7 +99084,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (99,1,1) = {"
 aMT
@@ -99069,7 +99341,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (100,1,1) = {"
 aMT
@@ -99326,7 +99598,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (101,1,1) = {"
 aMT
@@ -99583,7 +99855,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (102,1,1) = {"
 aMT
@@ -99840,7 +100112,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (103,1,1) = {"
 aMT
@@ -100097,7 +100369,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (104,1,1) = {"
 aMT
@@ -100354,7 +100626,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (105,1,1) = {"
 aMT
@@ -100611,7 +100883,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (106,1,1) = {"
 aMT
@@ -100868,7 +101140,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (107,1,1) = {"
 aMT
@@ -101125,7 +101397,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (108,1,1) = {"
 aMT
@@ -101382,7 +101654,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (109,1,1) = {"
 aMT
@@ -101639,7 +101911,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (110,1,1) = {"
 aMT
@@ -101896,7 +102168,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (111,1,1) = {"
 aMT
@@ -102153,7 +102425,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (112,1,1) = {"
 aMT
@@ -102410,7 +102682,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (113,1,1) = {"
 aMT
@@ -102667,7 +102939,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (114,1,1) = {"
 aMT
@@ -102924,7 +103196,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (115,1,1) = {"
 aMT
@@ -103181,7 +103453,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (116,1,1) = {"
 aMT
@@ -103438,7 +103710,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (117,1,1) = {"
 aMT
@@ -103695,7 +103967,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (118,1,1) = {"
 aMT
@@ -104209,7 +104481,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (120,1,1) = {"
 aMT
@@ -104466,7 +104738,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (121,1,1) = {"
 aMT
@@ -104723,7 +104995,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (122,1,1) = {"
 aMT
@@ -104980,7 +105252,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (123,1,1) = {"
 aMT
@@ -105237,7 +105509,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (124,1,1) = {"
 aMT
@@ -105494,7 +105766,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (125,1,1) = {"
 aMT
@@ -105751,7 +106023,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (126,1,1) = {"
 aMT
@@ -106008,7 +106280,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (127,1,1) = {"
 aMT
@@ -106265,7 +106537,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (128,1,1) = {"
 aMT
@@ -106522,7 +106794,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (129,1,1) = {"
 aMT
@@ -106779,7 +107051,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (130,1,1) = {"
 aMT
@@ -107036,7 +107308,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (131,1,1) = {"
 aMT
@@ -107293,7 +107565,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (132,1,1) = {"
 aMT
@@ -107550,7 +107822,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (133,1,1) = {"
 aMT
@@ -107807,7 +108079,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (134,1,1) = {"
 aMT
@@ -108064,7 +108336,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (135,1,1) = {"
 aMT
@@ -108321,7 +108593,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (136,1,1) = {"
 aMT
@@ -108578,7 +108850,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (137,1,1) = {"
 aMT
@@ -108835,7 +109107,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (138,1,1) = {"
 aMT
@@ -109092,7 +109364,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (139,1,1) = {"
 aMT
@@ -109349,7 +109621,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (140,1,1) = {"
 aMT
@@ -109606,7 +109878,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (141,1,1) = {"
 aMT
@@ -109863,7 +110135,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (142,1,1) = {"
 aMT
@@ -110120,7 +110392,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (143,1,1) = {"
 aMT
@@ -110377,7 +110649,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (144,1,1) = {"
 aMT
@@ -110634,7 +110906,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (145,1,1) = {"
 aMT
@@ -110891,7 +111163,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (146,1,1) = {"
 aMT
@@ -110978,10 +111250,10 @@ duF
 duF
 duF
 duF
-wYR
-iYj
-iYj
-iYj
+aMT
+anT
+anT
+anT
 anT
 oXI
 dMz
@@ -111017,7 +111289,7 @@ sqh
 sqh
 sqh
 jzx
-rpc
+vjJ
 hMM
 cpp
 mKU
@@ -111148,7 +111420,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (147,1,1) = {"
 aMT
@@ -111234,11 +111506,11 @@ aKK
 wlR
 xQE
 hmy
-iYj
-wYR
-iYj
-wYR
-wYR
+anT
+aMT
+anT
+aMT
+aMT
 aMT
 oXI
 xhX
@@ -111270,11 +111542,11 @@ sqh
 sqh
 sqh
 sqh
-sqh
+hzZ
 sqh
 sqh
 jzx
-jzx
+mEx
 rpc
 uVk
 uJI
@@ -111405,7 +111677,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (148,1,1) = {"
 aMT
@@ -111508,7 +111780,7 @@ sir
 ddE
 vNt
 mVY
-tNg
+lQx
 vdg
 nyJ
 dvq
@@ -111531,8 +111803,8 @@ gnj
 gnj
 iaU
 gnj
-qYI
-qYI
+gnj
+gnj
 mFB
 eWn
 tNG
@@ -111662,7 +111934,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (149,1,1) = {"
 aMT
@@ -111783,13 +112055,13 @@ xyq
 sqh
 sqh
 gnj
-kTC
-kTC
-kTC
-kTC
-kTC
-kTC
-kTC
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
 gnj
 uGL
 lch
@@ -111919,7 +112191,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (150,1,1) = {"
 aMT
@@ -112021,7 +112293,7 @@ oXI
 aOu
 oXI
 eit
-ssT
+eWy
 lpe
 mqN
 mya
@@ -112039,16 +112311,16 @@ iYG
 xyq
 sqh
 sqh
-hzZ
-tUH
-tUH
-tUH
-kTC
-kTC
-kTC
-kTC
 iaU
-vLi
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+iaU
+sNC
 qaA
 kEQ
 iDL
@@ -112176,7 +112448,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (151,1,1) = {"
 aMT
@@ -112278,7 +112550,7 @@ oXI
 anT
 oXI
 acn
-ssT
+hsg
 lpe
 hPv
 gtV
@@ -112296,14 +112568,14 @@ kNB
 xyq
 sqh
 sqh
-hzZ
-tUH
-tUH
-tUH
-tUH
-kTC
-kTC
-kTC
+iaU
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
 iaU
 fll
 vgK
@@ -112433,7 +112705,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (152,1,1) = {"
 aMT
@@ -112534,7 +112806,7 @@ oXI
 aMT
 aMT
 oXI
-acn
+elB
 ssT
 cJf
 dgh
@@ -112553,18 +112825,18 @@ hmy
 duF
 sqh
 sqh
-hzZ
-tUH
-tUH
-tUH
-tUH
-tUH
-tUH
-tUH
+iaU
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
+aMT
 iaU
 sNC
 tSC
-tDh
+kEQ
 iDL
 otY
 hFG
@@ -112690,7 +112962,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (153,1,1) = {"
 aMT
@@ -112810,14 +113082,14 @@ sRa
 xyq
 sqh
 sqh
-rPk
-tUH
-tUH
-tUH
-tUH
+gnj
+aMT
+aMT
+aMT
+aMT
 cxY
-tUH
-tUH
+aMT
+aMT
 gnj
 sNC
 tSC
@@ -112947,7 +113219,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (154,1,1) = {"
 aMT
@@ -113034,12 +113306,12 @@ kvf
 hmy
 hmy
 hmy
-aIt
+rPk
 hmy
 hmy
 duF
-ssj
-ssj
+isL
+isL
 duF
 duF
 duF
@@ -113067,14 +113339,14 @@ iYG
 xyq
 sqh
 sqh
-rPk
-rPk
+gnj
+gnj
 fjt
-rPk
-rPk
+gnj
+gnj
 koR
-rPk
-rPk
+gnj
+gnj
 gnj
 laR
 rzc
@@ -113204,7 +113476,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (155,1,1) = {"
 aMT
@@ -113290,9 +113562,9 @@ ipk
 lJV
 mug
 duF
-aIt
-aIt
-aIt
+qwL
+tUH
+bKF
 duF
 usR
 wAW
@@ -113308,7 +113580,7 @@ sFf
 jxp
 vps
 mEM
-isF
+pvo
 pvo
 vbr
 pvo
@@ -113324,16 +113596,16 @@ kNB
 xyq
 sqh
 sqh
-isL
-rPk
-frx
-tZD
-rPk
-frx
-tZD
-rPk
-sNC
 sqh
+gnj
+frx
+tZD
+gnj
+frx
+tZD
+gnj
+pTz
+nUE
 tSC
 pWb
 iDL
@@ -113461,7 +113733,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (156,1,1) = {"
 aMT
@@ -113545,11 +113817,11 @@ duF
 lJV
 wEy
 lTY
-lNv
+oph
 duF
-aIt
-aIt
-aIt
+pAz
+iYj
+eez
 duF
 frC
 kVK
@@ -113581,14 +113853,14 @@ duF
 jwG
 sqh
 sqh
-isL
-rPk
+sqh
+gnj
 gks
-rPk
-rPk
+gnj
+gnj
 vyf
-rPk
-rPk
+gnj
+gnj
 sNC
 sqh
 tSC
@@ -113718,7 +113990,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (157,1,1) = {"
 aMT
@@ -113802,11 +114074,11 @@ xLu
 lJV
 lKP
 qwL
-tdf
+lNv
 duF
-aIt
-aIt
-aIt
+qwL
+exi
+lJV
 duF
 xAZ
 nMg
@@ -113835,13 +114107,13 @@ rgb
 tlU
 eBL
 xBP
+kTC
 sqh
 sqh
 sqh
 sqh
 sqh
-sqh
-sqh
+xRF
 sqh
 sqh
 sqh
@@ -113975,7 +114247,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (158,1,1) = {"
 aMT
@@ -114061,9 +114333,9 @@ lKP
 duF
 duF
 duF
-aIt
-aIt
-aIt
+qwL
+iYj
+lJV
 duF
 duF
 duF
@@ -114092,8 +114364,8 @@ hmy
 aIt
 aIt
 eZE
-sqh
-sqh
+isF
+hzZ
 sqh
 sqh
 sqh
@@ -114232,7 +114504,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (159,1,1) = {"
 aMT
@@ -114318,15 +114590,15 @@ lKP
 ldQ
 bAk
 bAk
+dLA
 uHq
-uHq
-uHq
+tdf
 nIJ
 ibI
 wMC
 aFG
-bAk
-uHq
+xDV
+wYR
 bHm
 sHZ
 cSo
@@ -114351,12 +114623,12 @@ hmy
 hmy
 pqj
 gnj
-iaU
+rxo
 gnj
-sqh
-sqh
-sqh
-sqh
+vLi
+vLi
+vLi
+kQI
 sqh
 sqh
 gPc
@@ -114489,7 +114761,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (160,1,1) = {"
 aMT
@@ -114570,21 +114842,21 @@ rhZ
 gRi
 jAA
 duF
-lJV
-lKP
+vID
+kPl
 wCB
 xoV
 vEG
+jAg
 mUB
-mUB
-kPl
+vIl
 ieI
 xVp
-xVp
+osL
 rBh
 xVp
 ukc
-bHm
+tDh
 sHZ
 cSo
 gqz
@@ -114610,7 +114882,7 @@ dAw
 vnF
 hER
 vnF
-dLA
+ePs
 dIv
 dIv
 ncB
@@ -114746,7 +115018,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (161,1,1) = {"
 aMT
@@ -114832,14 +115104,14 @@ qXL
 hmy
 hmy
 hmy
-xXK
+gSe
 hmy
 hmy
 hmy
 hmy
 hmy
 hmy
-xXK
+pxi
 hmy
 rGg
 sHZ
@@ -114853,7 +115125,7 @@ kBt
 vKL
 fOv
 jdN
-cfP
+ivK
 nXe
 txB
 brR
@@ -114863,7 +115135,7 @@ nXe
 ivK
 ivK
 ivK
-nzt
+apD
 vnF
 hXA
 ciw
@@ -115003,7 +115275,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (162,1,1) = {"
 aMT
@@ -115110,7 +115382,7 @@ uBo
 uqZ
 fOv
 cwf
-cfP
+ivK
 nXe
 uga
 kDo
@@ -115119,7 +115391,7 @@ clW
 nXe
 ivK
 cUA
-lTv
+hLY
 wQU
 vnF
 eYn
@@ -115260,7 +115532,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (163,1,1) = {"
 aMT
@@ -115346,9 +115618,9 @@ eRv
 hmy
 mmg
 oQB
-pAz
-bWt
 xXK
+bWt
+pxi
 tLk
 tne
 ssj
@@ -115364,9 +115636,9 @@ rgB
 tOG
 rJI
 aBp
-wHp
+ajD
 oUZ
-ivK
+nst
 trr
 nXe
 sVv
@@ -115375,7 +115647,7 @@ qdv
 wNR
 nXe
 ivK
-nzt
+apD
 ivK
 ivK
 vnF
@@ -115517,7 +115789,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (164,1,1) = {"
 aMT
@@ -115632,7 +115904,7 @@ wKc
 cBK
 nXe
 ivK
-nzt
+apD
 ivK
 ivK
 vnF
@@ -115774,7 +116046,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (165,1,1) = {"
 aMT
@@ -115866,11 +116138,11 @@ aKy
 iRh
 iRh
 iRh
-cSo
-cSo
-cSo
+hmy
+hmy
+hmy
 nxz
-oRA
+duF
 oRA
 mZR
 crC
@@ -116031,7 +116303,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (166,1,1) = {"
 aMT
@@ -116124,10 +116396,10 @@ wGk
 lJh
 iRh
 aMT
-hLY
-oph
-oph
-oph
+jdN
+ivK
+ivK
+ivK
 exZ
 oAG
 gBr
@@ -116288,7 +116560,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (167,1,1) = {"
 aMT
@@ -116381,10 +116653,10 @@ ore
 htP
 iRh
 aMT
-hLY
-oph
-oph
-oph
+jdN
+ivK
+ivK
+ivK
 oRA
 oRA
 oRA
@@ -116545,7 +116817,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (168,1,1) = {"
 aMT
@@ -116638,11 +116910,11 @@ mnY
 wPi
 iRh
 aMT
-ajD
-oph
-oph
-oph
-eez
+ivy
+ivK
+ivK
+ivK
+ivy
 aMT
 kQq
 aMT
@@ -116802,7 +117074,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (169,1,1) = {"
 aMT
@@ -116897,7 +117169,7 @@ sUf
 anT
 jdN
 jdN
-ivK
+mXJ
 jdN
 jdN
 jdN
@@ -117059,7 +117331,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (170,1,1) = {"
 aMT
@@ -117316,7 +117588,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (171,1,1) = {"
 aMT
@@ -117573,7 +117845,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (172,1,1) = {"
 aMT
@@ -117830,7 +118102,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (173,1,1) = {"
 aMT
@@ -118087,7 +118359,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (174,1,1) = {"
 aMT
@@ -118344,7 +118616,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (175,1,1) = {"
 aMT
@@ -118601,7 +118873,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (176,1,1) = {"
 aMT
@@ -118858,7 +119130,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (177,1,1) = {"
 aMT
@@ -119115,7 +119387,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (178,1,1) = {"
 aMT
@@ -119372,7 +119644,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (179,1,1) = {"
 aMT
@@ -119629,7 +119901,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (180,1,1) = {"
 aMT
@@ -119886,7 +120158,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (181,1,1) = {"
 aMT
@@ -120143,7 +120415,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (182,1,1) = {"
 aMT
@@ -120400,7 +120672,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (183,1,1) = {"
 aMT
@@ -120657,7 +120929,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (184,1,1) = {"
 aMT
@@ -120914,7 +121186,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (185,1,1) = {"
 aMT
@@ -121171,7 +121443,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (186,1,1) = {"
 aMT
@@ -121428,7 +121700,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (187,1,1) = {"
 aMT
@@ -121685,7 +121957,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (188,1,1) = {"
 aMT
@@ -121942,7 +122214,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (189,1,1) = {"
 aMT
@@ -122199,7 +122471,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (190,1,1) = {"
 aMT
@@ -122456,7 +122728,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (191,1,1) = {"
 aMT
@@ -122713,7 +122985,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (192,1,1) = {"
 aMT
@@ -122970,7 +123242,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (193,1,1) = {"
 aMT
@@ -123227,7 +123499,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (194,1,1) = {"
 aMT
@@ -123484,7 +123756,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (195,1,1) = {"
 aMT
@@ -123741,7 +124013,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (196,1,1) = {"
 aMT
@@ -123998,7 +124270,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (197,1,1) = {"
 aMT
@@ -124255,7 +124527,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (198,1,1) = {"
 aMT
@@ -124512,7 +124784,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (199,1,1) = {"
 aMT
@@ -124769,7 +125041,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (200,1,1) = {"
 aMT
@@ -125026,7 +125298,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (201,1,1) = {"
 aMT
@@ -125283,7 +125555,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (202,1,1) = {"
 aMT
@@ -125540,7 +125812,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (203,1,1) = {"
 aMT
@@ -125797,7 +126069,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (204,1,1) = {"
 aMT
@@ -126054,7 +126326,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (205,1,1) = {"
 aMT
@@ -126311,7 +126583,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (206,1,1) = {"
 aMT
@@ -126568,7 +126840,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (207,1,1) = {"
 aMT
@@ -126825,7 +127097,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (208,1,1) = {"
 aMT
@@ -127082,7 +127354,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (209,1,1) = {"
 aMT
@@ -127339,7 +127611,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (210,1,1) = {"
 aMT
@@ -127596,7 +127868,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (211,1,1) = {"
 aMT
@@ -127853,7 +128125,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (212,1,1) = {"
 aMT
@@ -128110,7 +128382,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (213,1,1) = {"
 aMT
@@ -128367,7 +128639,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (214,1,1) = {"
 aMT
@@ -128624,7 +128896,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (215,1,1) = {"
 aMT
@@ -128881,7 +129153,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (216,1,1) = {"
 aMT
@@ -129138,7 +129410,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (217,1,1) = {"
 aMT
@@ -129395,7 +129667,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (218,1,1) = {"
 aMT
@@ -129652,7 +129924,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (219,1,1) = {"
 aMT
@@ -129909,7 +130181,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (220,1,1) = {"
 aMT
@@ -130166,7 +130438,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (221,1,1) = {"
 aMT
@@ -130423,7 +130695,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (222,1,1) = {"
 aMT
@@ -130680,7 +130952,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (223,1,1) = {"
 aMT
@@ -130937,7 +131209,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (224,1,1) = {"
 aMT
@@ -131194,7 +131466,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (225,1,1) = {"
 aMT
@@ -131451,7 +131723,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (226,1,1) = {"
 aMT
@@ -131708,7 +131980,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (227,1,1) = {"
 aMT
@@ -131965,7 +132237,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (228,1,1) = {"
 aMT
@@ -132222,7 +132494,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (229,1,1) = {"
 aMT
@@ -132479,7 +132751,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (230,1,1) = {"
 aMT
@@ -132736,7 +133008,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (231,1,1) = {"
 aMT
@@ -132993,7 +133265,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (232,1,1) = {"
 aMT
@@ -133250,7 +133522,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (233,1,1) = {"
 aMT
@@ -133507,7 +133779,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (234,1,1) = {"
 aMT
@@ -133764,7 +134036,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (235,1,1) = {"
 aMT
@@ -134021,7 +134293,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (236,1,1) = {"
 aMT
@@ -134278,7 +134550,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (237,1,1) = {"
 aMT
@@ -134535,7 +134807,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (238,1,1) = {"
 aMT
@@ -134792,7 +135064,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (239,1,1) = {"
 aMT
@@ -135049,7 +135321,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (240,1,1) = {"
 aMT
@@ -135306,7 +135578,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (241,1,1) = {"
 aMT
@@ -135563,7 +135835,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (242,1,1) = {"
 aMT
@@ -135820,7 +136092,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (243,1,1) = {"
 aMT
@@ -136077,7 +136349,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (244,1,1) = {"
 aMT
@@ -136334,7 +136606,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (245,1,1) = {"
 aMT
@@ -136591,7 +136863,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (246,1,1) = {"
 aMT
@@ -136848,7 +137120,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (247,1,1) = {"
 aMT
@@ -137105,7 +137377,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (248,1,1) = {"
 aMT
@@ -137362,7 +137634,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (249,1,1) = {"
 aMT
@@ -137619,7 +137891,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (250,1,1) = {"
 aMT
@@ -137876,7 +138148,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (251,1,1) = {"
 aMT
@@ -138133,7 +138405,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (252,1,1) = {"
 aMT
@@ -138390,7 +138662,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (253,1,1) = {"
 aMT
@@ -138647,7 +138919,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (254,1,1) = {"
 aMT
@@ -138904,7 +139176,7 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}
 (255,1,1) = {"
 aMT
@@ -139161,5 +139433,5 @@ aMT
 aMT
 aMT
 aMT
-xRF
+aMT
 "}

--- a/code/modules/atmospherics/machinery/pipes/mapping.dm
+++ b/code/modules/atmospherics/machinery/pipes/mapping.dm
@@ -13,21 +13,26 @@
 	##Fulltype/visible/layer2 {			\
 		piping_layer = 2;				\
 		icon_state = Iconbase + "-2";	\
+		FASTDMM_PROP(pipe_group = "atmos-[piping_layer]-"+Type+"-visible");\
 	}									\
 	##Fulltype/visible/layer4 {			\
 		piping_layer = 4;				\
 		icon_state = Iconbase + "-4";	\
+		FASTDMM_PROP(pipe_group = "atmos-[piping_layer]-"+Type+"-visible");\
 	}									\
 	##Fulltype/hidden {					\
 		hide = TRUE;					\
+		FASTDMM_PROP(pipe_group = "atmos-[piping_layer]-"+Type+"-hidden");\
 	}									\
 	##Fulltype/hidden/layer2 {			\
 		piping_layer = 2;				\
 		icon_state = Iconbase + "-2";	\
+		FASTDMM_PROP(pipe_group = "atmos-[piping_layer]-"+Type+"-hidden");\
 	}									\
 	##Fulltype/hidden/layer4 {			\
 		piping_layer = 4;				\
 		icon_state = Iconbase + "-4";	\
+		FASTDMM_PROP(pipe_group = "atmos-[piping_layer]-"+Type+"-hidden");\
 	}
 
 #define HELPER_PARTIAL_NAMED(Fulltype, Type, Iconbase, Color, Name) \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks CorgStation security.
- Makes armoury accessible from space.
- Makes security less of a single giant hallway and adds some more turns into it.
- Moves the brig medbay area closer to the cells.
- Moves the detective's office deeper into security
- Moves the labour shuttle to a publicly exitable area

TODO:
- [ ] Add gravity generator back in
- [ ] Deconflict the map with new features (This branch was made months ago)

## Why It's Good For The Game

Fixes some of the major critisisms about corgstation armoury being impossible to attack, reworks security to be a more interesting design.

## Testing Photographs and Procedure

Before gravity generator changes:
![2023 05 24-17 07 47](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/c18333ab-bd7d-4c96-bcd1-18ac8f5986aa)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/55b1754c-0258-409f-af2a-1d6521f643e7)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5cd8c7b0-a17d-4f9d-8a4b-382a9f4cd7c8)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/308b6ac4-b54d-442d-ade1-f7e9f2020403)


## Changelog
:cl:
tweak: Reworks CorgStation's security wing, making armoury more accessible from space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
