### PR TITLE
Tourettes can combine with voice of god for an... interesting effect

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -131,7 +131,12 @@
 			if(1)
 				owner.emote("twitch")
 			if(2 to 3)
-				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", forced="tourette's syndrome")
+				var/list/spans = list()
+				if(owner.has_trauma_type(/datum/brain_trauma/special/godwoken) || owner.has_functioning_organ(ORGAN_SLOT_VOICE, /obj/item/organ/vocal_cords/colossus))
+					playsound(get_turf(owner), 'sound/magic/clockwork/invoke_general.ogg', 300, 1, 5)
+					spans = list("colossus", "yell")
+				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]", spans=spans, forced="tourette's syndrome")
+
 		var/x_offset_old = owner.pixel_x
 		var/y_offset_old = owner.pixel_y
 		var/x_offset = owner.pixel_x + rand(-2,2)

--- a/code/modules/surgery/organs/helpers.dm
+++ b/code/modules/surgery/organs/helpers.dm
@@ -45,3 +45,15 @@
 
 /mob/living/carbon/getorganslot(slot)
 	return internal_organs_slot[slot]
+
+/mob/living/carbon/proc/has_functioning_organ(slot, path)
+	if(!slot)
+		return FALSE
+	var/obj/item/organ/organ = getorganslot(slot)
+	if(QDELETED(organ) || !istype(organ))
+		return FALSE
+	if(ispath(path) && !istype(organ, path))
+		return FALSE
+	if(CHECK_BITFIELD(organ.organ_flags, ORGAN_FAILING))
+		return FALSE
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so, if you have tourettes and either godwoken syndrome or the divine vocal cords, your forced swearing will BIG AND LOUD!

VoG tourettes has no actual effect on listeners, it's just loud and has the big red text.

## Why It's Good For The Game

it's mildly annoying in a funny way.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-05-24-1684964902-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/36c427c6-0142-430f-a768-09ddb2b5a500)


</details>

## Changelog
:cl:
add: Tourettes can now combine with voice of god for an... interesting effect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
