### PR TITLE
Fix gender and skin tone DNA not properly applying

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -410,11 +410,11 @@
 		return
 	switch(deconstruct_block(getblock(dna.uni_identity, DNA_GENDER_BLOCK), 3))
 		if(G_MALE)
-			set_gender(MALE, TRUE)
+			set_gender(MALE, TRUE, forced = TRUE)
 		if(G_FEMALE)
-			set_gender(FEMALE, TRUE)
+			set_gender(FEMALE, TRUE, forced = TRUE)
 		else
-			set_gender(PLURAL, TRUE)
+			set_gender(PLURAL, TRUE, forced = TRUE)
 
 /mob/living/carbon/human/updateappearance(icon_update=1, mutcolor_update=0, mutations_overlay_update=0)
 	..()
@@ -427,6 +427,11 @@
 	hair_style = GLOB.hair_styles_list[deconstruct_block(getblock(structure, DNA_HAIR_STYLE_BLOCK), GLOB.hair_styles_list.len)]
 	gradient_color = sanitize_hexcolor(getblock(structure, DNA_HAIR_GRADIENT_COLOR_BLOCK))
 	gradient_style = GLOB.hair_gradients_list[deconstruct_block(getblock(structure, DNA_HAIR_GRADIENT_STYLE_BLOCK), GLOB.hair_gradients_list.len)]
+	// Ensure we update the skin tone of all non-foreign bodyparts
+	for(var/obj/item/bodypart/part in bodyparts)
+		if(part.no_update)
+			continue
+		part.update_limb(dropping_limb = FALSE, source = src, is_creating = TRUE)
 	if(icon_update)
 		update_body()
 		update_hair()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes gender and skin tone not being properly applied when DNA is set. The effect of that was that cloning would _always_ randomize your gender and skin tone, which was unintentional.

the gender bug was, ironically enough, caused by https://github.com/BeeStation/BeeStation-Hornet/pull/8407. that fact isn't really relevant but the irony is kinda funny.

## Why It's Good For The Game

bugs bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-05-26-1685081607-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/69a9ebdf-3355-4657-9190-de94563f9756)
![23-05-26-1685081610-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/20cde3d6-b912-471b-bcc0-1716e17be32a)

</details>

## Changelog
:cl:
fix: Setting DNA (including through cloning) now properly applies the correct gender and skin tone. As a result, cloning will no longer randomize gender and skin tone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
