### PR TITLE
Removes the freebie Incursion radio implant

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -156,17 +156,6 @@
 				<b>Implant Details:</b> Allows user to use an internal radio, useful if user expects equipment loss, or cannot equip conventional radios."}
 	return dat
 
-/obj/item/implant/radio/syndicate/selfdestruct
-	name = "hacked internal radio implant"
-
-/obj/item/implant/radio/syndicate/selfdestruct/on_implanted(mob/living/user)
-	if(!user.mind.has_antag_datum(/datum/antagonist/incursion))
-		user.visible_message("<span class='warning'>[imp_in] starts beeping ominously!</span>", "<span class='userdanger'>You have a sudden feeling of dread. The implant is rigged to explode!</span>")
-		playsound(user, 'sound/items/timer.ogg', 30, 0)
-		explosion(src,0,0,2,2, flame_range = 2)
-		user.gib(1)
-		qdel(src)
-
 /obj/item/implanter/radio
 	name = "implanter (internal radio)"
 	imp_type = /obj/item/implant/radio
@@ -174,7 +163,3 @@
 /obj/item/implanter/radio/syndicate
 	name = "implanter (internal syndicate radio)"
 	imp_type = /obj/item/implant/radio/syndicate
-
-/obj/item/implanter/radio/syndicate/selfdestruct
-	name = "implanter (modified internal syndicate radio)"
-	imp_type = /obj/item/implant/radio/syndicate/selfdestruct

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -92,8 +92,6 @@
 
 /datum/antagonist/incursion/proc/equip(var/silent = FALSE)
 	owner.equip_traitor("The Syndicate", FALSE, src, 15)
-	var/obj/item/implant/radio/syndicate/selfdestruct/syndio = new
-	syndio.implant(owner.current)
 
 /datum/team/incursion
 	name = "syndicate incursion force"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The incursion radio implant is given to all members of the incursion team, as they spawn, which grants them all access to the syndicate radio frequency. Not only does this allow for all members, which can reach 6 people, to communicate right away, but also communicate securely right away. This PR removes that free syndicate radio implant.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We have seen that the Incursion is somewhat powerful when they have enough or competent members. This levels the playing field, requiring them to use the same methods of locating each other as regular traitors do with keywords, at least until they can acquire some secure channel. It will also slow down their progression by forcing them to at least meet in person, adding some additional risk of being found not doing their duties.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Removed the incursion radio implant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
