### PR TITLE
Fixes the "bad proc" SDQL runtime error when calling global procs

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -768,7 +768,6 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 	for(var/arg in arguments)
 		new_args[++new_args.len] = SDQL_expression(source, arg)
 	if(object == GLOB) // Global proc.
-		procname = "/proc/[procname]"
 		return superuser? (call("/proc/[procname]")(new_args)) : (WrapAdminProcCall(GLOBAL_PROC, procname, new_args))
 	return superuser? (call(object, procname)(new_args)) : (WrapAdminProcCall(object, procname, new_args))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Resolves the `bad proc` runtime error when calling global wrapper procs.

```dm
[2023-05-27 03:58:19.694] ## NOTICE: Crossedfall/(Sara Ulery) executed SDQL query(s): "SDQL2-query "UPDATE /obj/machinery/power/apc SET failure_timer=global._rand(10,20)".
[2023-05-27 03:58:19.763] runtime error: bad proc
```

This error was introduced in #4622

## Why It's Good For The Game

Enables more adminbus/debugging

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

### Before:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26130695/de7762ae-e761-4d0d-ad62-3c481b83fc48)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26130695/4daf41b9-ba2a-4940-aff3-1e82e843ec72)

### After
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26130695/e5b583b3-7032-4b03-9e87-f03468a234b6)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26130695/a234de4d-9bd1-456b-b18f-f00194aa009c)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26130695/3d6a8ba5-b4f5-4272-9e0c-1939d657c079)


</details>

## Changelog
:cl:
fix: fixed bad proc runtimes for SDQL queries using global procs (wrappers)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
