### PR TITLE
Abductors now have a smartfridge instead of their old fridge

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3153,7 +3153,7 @@
 	},
 /area/abductor_ship)
 "mt" = (
-/obj/machinery/abductor/gland_dispenser,
+/obj/machinery/smartfridge/abductor,
 /turf/open/floor/plating/abductor,
 /area/abductor_ship)
 "mu" = (

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -23,7 +23,7 @@
 		amounts[i] = rand(1,5)
 
 /obj/machinery/abductor/gland_dispenser/ui_status(mob/user)
-	if(!isabductor(user) && !isobserver(user))
+	if(!isabductor(user) && !user.mind.has_antag_datum(/datum/antagonist) && !isobserver(user))
 		return UI_CLOSE
 	return ..()
 
@@ -78,3 +78,62 @@
 		var/T = gland_types[count]
 		new T(get_turf(src))
 	ui_update()
+
+// -------------------------
+// less flavour, but abductor can see what these are
+/obj/machinery/smartfridge/abductor
+	name = "replacement organ storage"
+	desc = "A tank filled with replacement organs."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "dispenser"
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	density = TRUE
+	idle_power_usage = 0
+	active_power_usage = 0
+	max_n_of_items = 1000
+	var/repair_rate = 0
+	var/allowed_to_everyone = FALSE
+
+/obj/machinery/smartfridge/abductor/Initialize(mapload)
+	. = ..()
+	for(var/each as() in shuffle(subtypesof(/obj/item/organ/heart/gland)))
+		for(var/i in 1 to rand(5)+10)
+			var/obj/item/organ/heart/gland/each_gland = new each
+			each_gland.name = each_gland.true_name
+			each_gland.forceMove(src)
+
+/obj/machinery/smartfridge/abductor/ui_status(mob/user)
+	if(!allowed_to_everyone && (!isabductor(user) && !user.mind.has_antag_datum(/datum/antagonist) && !isobserver(user)))
+		return UI_CLOSE
+	return ..()
+
+/obj/machinery/smartfridge/abductor/ui_state(mob/user)
+	return GLOB.physical_state
+
+/obj/machinery/smartfridge/abductor/accept_check(obj/item/O)
+	if(istype(O, /obj/item/organ/heart/gland))
+		return TRUE
+	return FALSE
+
+/obj/machinery/smartfridge/abductor/load(obj/item/O)
+	. = ..()
+	if(!.)	//if the item loads, clear can_decompose
+		return
+	if(!istype(O, /obj/item/organ/heart/gland))
+		return
+	var/obj/item/organ/heart/gland/organ = O
+	organ.organ_flags |= ORGAN_FROZEN
+	organ.name = organ.true_name
+
+/obj/machinery/smartfridge/abductor/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(!istype(gone, /obj/item/organ/heart/gland))
+		return
+	var/obj/item/organ/heart/gland/organ = gone
+	organ.organ_flags &= ~ORGAN_FROZEN
+	organ.organ_flags &= ~ORGAN_FAILING
+	organ.setOrganDamage(-200)
+	organ.name = initial(organ.name)
+
+/obj/machinery/smartfridge/abductor/update_icon()
+	return

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -94,6 +94,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	max_n_of_items = 1000
+	tgui_theme = "abductor"
 	var/repair_rate = 0
 	var/allowed_to_everyone = FALSE
 
@@ -103,7 +104,7 @@
 
 /obj/machinery/smartfridge/abductor/proc/generate_glands()
 	for(var/each as() in shuffle(subtypesof(/obj/item/organ/heart/gland)))
-		for(var/i in 1 to rand(5)+10)
+		for(var/i in 1 to rand(2, 7))
 			var/obj/item/organ/heart/gland/each_gland = new each
 			each_gland.name = each_gland.true_name
 			each_gland.forceMove(src)

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -99,6 +99,9 @@
 
 /obj/machinery/smartfridge/abductor/Initialize(mapload)
 	. = ..()
+	generate_glands()
+
+/obj/machinery/smartfridge/abductor/proc/generate_glands()
 	for(var/each as() in shuffle(subtypesof(/obj/item/organ/heart/gland)))
 		for(var/i in 1 to rand(5)+10)
 			var/obj/item/organ/heart/gland/each_gland = new each

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -1,3 +1,5 @@
+// This is classic abductor dispenser, but it is awfully identifiable.
+// The actual one abductors are using is after this type (as smartfridge)
 /obj/machinery/abductor/gland_dispenser
 	name = "replacement organ storage"
 	desc = "A tank filled with replacement organs."
@@ -80,7 +82,8 @@
 	ui_update()
 
 // -------------------------
-// less flavour, but abductor can see what these are
+// This is just smartfridge but for abductors.
+// less flavour, but abductor can see what these are at a glance
 /obj/machinery/smartfridge/abductor
 	name = "replacement organ storage"
 	desc = "A tank filled with replacement organs."

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -110,7 +110,7 @@
 			each_gland.forceMove(src)
 
 /obj/machinery/smartfridge/abductor/ui_status(mob/user)
-	if(!allowed_to_everyone && !isabductor(user) && !isobserver(user)))
+	if(!allowed_to_everyone && !isabductor(user) && !isobserver(user))
 		return UI_CLOSE
 	return ..()
 

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -110,7 +110,7 @@
 			each_gland.forceMove(src)
 
 /obj/machinery/smartfridge/abductor/ui_status(mob/user)
-	if(!allowed_to_everyone && (!isabductor(user) && !user.mind.has_antag_datum(/datum/antagonist) && !isobserver(user)))
+	if(!allowed_to_everyone && !isabductor(user) && !isobserver(user)))
 		return UI_CLOSE
 	return ..()
 

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -25,7 +25,7 @@
 		amounts[i] = rand(1,5)
 
 /obj/machinery/abductor/gland_dispenser/ui_status(mob/user)
-	if(!isabductor(user) && !user.mind.has_antag_datum(/datum/antagonist) && !isobserver(user))
+	if(!isabductor(user) && !isobserver(user))
 		return UI_CLOSE
 	return ..()
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -13,7 +13,7 @@
 	active_power_usage = 100
 	circuit = /obj/item/circuitboard/machine/smartfridge
 
-
+	var/tgui_theme = null // default theme as null is Nanotrasen theme.
 
 	var/max_n_of_items = 1500
 	var/allow_ai_retrieve = FALSE
@@ -223,6 +223,7 @@
 	.["contents"] = listofitems
 	.["name"] = name
 	.["isdryer"] = FALSE
+	.["ui_theme"] = tgui_theme
 
 
 /obj/machinery/smartfridge/handle_atom_del(atom/A) // Update the UIs in case something inside gets deleted

--- a/tgui/packages/tgui/interfaces/SmartVend.js
+++ b/tgui/packages/tgui/interfaces/SmartVend.js
@@ -6,10 +6,7 @@ import { Window } from '../layouts';
 export const SmartVend = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-    <Window
-      width={440}
-      height={550}
-      {...(data.ui_theme && { theme: data.ui_theme })}>
+    <Window width={440} height={550} {...(data.ui_theme && { theme: data.ui_theme })}>
       <Window.Content scrollable>
         <Section
           title="Storage"

--- a/tgui/packages/tgui/interfaces/SmartVend.js
+++ b/tgui/packages/tgui/interfaces/SmartVend.js
@@ -6,7 +6,10 @@ import { Window } from '../layouts';
 export const SmartVend = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-    <Window width={440} height={550}>
+    <Window
+      width={440}
+      height={550}
+      {...(data.ui_theme && { theme: data.ui_theme })}>
       <Window.Content scrollable>
         <Section
           title="Storage"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Abductors now have a smartfridge instead of their old fridge
That you don't know which container has which organ is one of reasons why abductors are usually annoying. They just put random shits into people.
This will let them have a choice of what they'll put into people.

Also, buffs gland generation amounts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
removing tedious-ism.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/4fbbf872-6fb0-41c1-a868-3754a80ffb02)

</details>

## Changelog
:cl:
tweak: abductor gland storage now uses smartfridge UI instead of too-alieny-UI.
balance: gland names will be revealed when these are in abductor's new organ storage.
tweak: abductor gland storage now has 2~7 glands per each at starting.
add: broken glands will be restored once you put these into a new storage (old one doesn't work)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
