### PR TITLE
Fixes the recycler not working

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -82,13 +82,6 @@
 		is_powered = FALSE
 	icon_state = icon_name + "[is_powered]" + "[(blood ? "bld" : "")]" // add the blood tag at the end
 
-/obj/machinery/recycler/CanAllowThrough(atom/movable/mover, border_dir)
-	. = ..()
-	if(!anchored)
-		return
-	if(border_dir == eat_dir)
-		return TRUE
-
 /obj/machinery/recycler/Bumped(atom/movable/AM)
 
 	if(machine_stat & (BROKEN|NOPOWER))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#8838 added a CanAllowThrough proc to the trash recycler, allowing objects to pass through its opening. However, since the recycler's behaviour is triggered by objects bumping into it, this stopped it from working at all. This PR removes the recycler's CanAllowThrough proc, restoring functionnality to it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a bug fix, the recycler should work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/781260b9-f236-4b9a-8700-c499b01697c1


</details>

## Changelog
:cl:
fix: Trash recycler now works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
