### PR TITLE
Cult sacrificing no longer ignores DNR

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -333,7 +333,7 @@
 	var/mob/dead/observer/chosen_ghost
 
 	for(var/mob/dead/observer/ghost in GLOB.player_list) //We put them back in their body
-		if(ghost.mind && ghost.mind.current == T && ghost.client)
+		if(ghost.mind && ghost.mind.current == T && ghost.client && ghost.can_reenter_corpse)
 			chosen_ghost = ghost
 			break
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cult sacrificing currently ignores DNR, and forces you into a cult shade anyways. This fixes that, meaning it'll just try to grab a ghost if you sacrifice a DNR body.

Fixes #8765

## Why It's Good For The Game

Because nothing should ignore DNR.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![23-05-29-1685387335-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/d0c63a78-e91a-46f8-999c-9db15c01d9c5)
![23-05-29-1685387344-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ef5cbd97-d114-4484-8f6c-d3d78e961891)

</details>

## Changelog
:cl:
tweak: Sacrificing a DNR corpse will no longer force the unwilling ghost back into their body, and will instead poll ghosts for who wants to be the shade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
