### PR TITLE
Jetpack speed nerf

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -83,7 +83,7 @@
 	var/datum/gas_mixture/__env = loc.return_air();\
 	if(full_speed && __env.return_pressure() < JETPACK_FAST_PRESSURE_MAX) {\
 		var/__proportion = CLAMP01(1 - ((__env.return_pressure() - JETPACK_FAST_PRESSURE_MIN) / (JETPACK_FAST_PRESSURE_MAX - JETPACK_FAST_PRESSURE_MIN)));\
-		user.add_movespeed_modifier(movespeed_id, priority=100, multiplicative_slowdown=speed * __proportion, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK);\
+		user.add_movespeed_modifier(movespeed_id, priority=100, override = TRUE, multiplicative_slowdown=speed * __proportion, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK);\
 	} else {\
 		user.remove_movespeed_modifier(movespeed_id);\
 	}

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -74,5 +74,19 @@
 /// Amount to increase consumption by
 #define JETPACK_COMBUSTION_CONSUMPTION_ADJUSTMENT 500
 
+// The pressure at which jetpacks begin to slowdown
+#define JETPACK_FAST_PRESSURE_MIN 20
+// The pressure at which jetpacks reach their min speed
+#define JETPACK_FAST_PRESSURE_MAX 80
+
+#define JETPACK_SPEED_CHECK(user, movespeed_id, speed, full_speed) \
+	var/datum/gas_mixture/__env = loc.return_air();\
+	if(full_speed && __env.return_pressure() < JETPACK_FAST_PRESSURE_MAX) {\
+		var/__proportion = CLAMP01(1 - ((__env.return_pressure() - JETPACK_FAST_PRESSURE_MIN) / (JETPACK_FAST_PRESSURE_MAX - JETPACK_FAST_PRESSURE_MIN)));\
+		user.add_movespeed_modifier(movespeed_id, priority=100, multiplicative_slowdown=speed * __proportion, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK);\
+	} else {\
+		user.remove_movespeed_modifier(movespeed_id);\
+	}
+
 /// Generic position of user offset for /datum/component/riding
 #define RIDING_OFFSET_ALL "ALL"

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -98,8 +98,8 @@
 	icon_state = "[initial(icon_state)]-on"
 	if(ion_trail)
 		ion_trail.start()
-	if(full_speed)
-		known_user.add_movespeed_modifier(MOVESPEED_ID_JETPACK, priority=100, multiplicative_slowdown=-2, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
+
+	JETPACK_SPEED_CHECK(known_user, MOVESPEED_ID_JETPACK, -1, full_speed)
 
 /obj/item/tank/jetpack/proc/turn_off(mob/user)
 	if(!known_user)
@@ -116,6 +116,8 @@
 	SIGNAL_HANDLER
 	if(on)
 		allow_thrust(THRUST_REQUIREMENT_SPACEMOVE, user)
+		// Update speed according to pressure
+		JETPACK_SPEED_CHECK(known_user, MOVESPEED_ID_JETPACK, -1, full_speed)
 
 /obj/item/tank/jetpack/proc/allow_thrust(num, mob/living/user, use_fuel = TRUE)
 	if(!on || !known_user)

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -154,7 +154,7 @@
 		if(allow_thrust(THRUST_REQUIREMENT_SPACEMOVE))
 			ion_trail.start()
 			RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(move_react))
-			owner.add_movespeed_modifier(MOVESPEED_ID_CYBER_THRUSTER, priority=100, multiplicative_slowdown=-2, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
+			JETPACK_SPEED_CHECK(owner, MOVESPEED_ID_CYBER_THRUSTER, -1, TRUE)
 			if(!silent)
 				to_chat(owner, "<span class='notice'>You turn your thrusters set on.</span>")
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Reduces base jetpack speed up from 2, to 1. (Base movespeed in the config is 2, which means this is a 2x speedup as oppossed to an infinite speedup)
- The jetpacks effectiveness now slowly drops to 0 in pressurised environments. This effect starts at 20 kPA and finishes at 80kPA, with the speed reduction being interpolated in between.

## Why It's Good For The Game

The jetpack speedup is so high that is just reduces the movement speed delay to 0 allowing essentially for teleportation. In addition to this, due to the insane speeds of jetpacks, jetpack based combat in 0g is practically impossible. This lowers jetpacks so that when a user is in an environment where they may experience combat and shouldn't be able to zip away from it as easilly, the station, their movement speed is not boosted.

## Testing Photographs and Procedure


https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f9481c89-d19c-4d63-b478-8ee9d2a4f7d2


https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f9499aa2-4f8d-470b-aa97-aa8c3e16830a



## Changelog
:cl:
balance: Jetpack speedup has been reduced from -2 (100% reduction in move delay) to -1 (50% reduction in move delay).
balance: Jetpacks will no longer provide their speed bonuses in pressurised environments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
