### PR TITLE
Solo abductor is now possible if only one player signs up for abductor

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -540,12 +540,13 @@
 	antag_flag = ROLE_ABDUCTOR
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
 	required_enemies = list(2,2,1,1,1,1,0,0,0,0)
-	required_candidates = 2
+	required_candidates = 1
 	required_applicants = 2
 	weight = 4
 	cost = 7
 	minimum_players = 25
 	repeatable = TRUE
+	var/solo = FALSE
 	var/datum/team/abductor_team/new_team
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/ready(forced = FALSE)
@@ -553,12 +554,19 @@
 		return FALSE
 	return ..()
 
+/datum/dynamic_ruleset/midround/from_ghosts/abductors/review_applications()
+	if(length(candidates) == 1)
+		solo = TRUE
+		required_applicants = 1
+	return ..()
+
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/finish_setup(mob/new_character, index)
-	if (index == 1) // Our first guy is the scientist.  We also initialize the team here as well since this should only happen once per pair of abductors.
+	if (index == 1 || solo) // Our first guy is the scientist.  We also initialize the team here as well since this should only happen once per pair of abductors.
 		new_team = new
 		if(new_team.team_number > ABDUCTOR_MAX_TEAMS)
 			return MAP_ERROR
-		var/datum/antagonist/abductor/scientist/new_role = new
+		var/antag_type = solo ? /datum/antagonist/abductor/scientist/onemanteam : /datum/antagonist/abductor/scientist
+		var/datum/antagonist/abductor/scientist/new_role = new antag_type
 		new_character.mind.add_antag_datum(new_role, new_team)
 	else // Our second guy is the agent, team is already created, don't need to make another one.
 		var/datum/antagonist/abductor/agent/new_role = new

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -546,7 +546,6 @@
 	cost = 7
 	minimum_players = 25
 	repeatable = TRUE
-	var/solo = FALSE
 	var/datum/team/abductor_team/new_team
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/ready(forced = FALSE)
@@ -556,16 +555,15 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/review_applications()
 	if(length(candidates) == 1)
-		solo = TRUE
 		required_applicants = 1
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/finish_setup(mob/new_character, index)
-	if (index == 1 || solo) // Our first guy is the scientist.  We also initialize the team here as well since this should only happen once per pair of abductors.
+	if (index == 1) // Our first guy is the scientist.  We also initialize the team here as well since this should only happen once per pair of abductors.
 		new_team = new
 		if(new_team.team_number > ABDUCTOR_MAX_TEAMS)
 			return MAP_ERROR
-		var/antag_type = solo ? /datum/antagonist/abductor/scientist/onemanteam : /datum/antagonist/abductor/scientist
+		var/antag_type = length(candidates) == 1 ? /datum/antagonist/abductor/scientist/onemanteam : /datum/antagonist/abductor/scientist
 		var/datum/antagonist/abductor/scientist/new_role = new antag_type
 		new_character.mind.add_antag_datum(new_role, new_team)
 	else // Our second guy is the agent, team is already created, don't need to make another one.

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -34,10 +34,6 @@
 	name = "Abductor Solo"
 	outfit = /datum/outfit/abductor/scientist/onemanteam
 
-/datum/antagonist/abductor/scientist/onemanteam
-	name = "Abductor Solo"
-	outfit = /datum/outfit/abductor/scientist/onemanteam
-
 /datum/antagonist/abductor/create_team(datum/team/abductor_team/new_team)
 	if(!new_team)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If only one ghost chooses to say yes to abductor, they get to be a solo abductor, instead of there being no abductors at all.

## Why It's Good For The Game

Because trashing a ruleset because only one person instead of two said yes is dumb.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Solo abductors can now be made if only one ghost signs up to be an abductor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
