### PR TITLE
Fix transformation sting

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -114,7 +114,7 @@
 		if(ismonkey(C))
 			C = C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG | TR_KEEPAI)
 		var/datum/status_effect/ling_transformation/previous_transformation = C.has_status_effect(STATUS_EFFECT_LING_TRANSFORMATION)
-		C.apply_status_effect(STATUS_EFFECT_LING_TRANSFORMATION, new_dna, previous_transformation?.original_dna)
+		C.apply_status_effect(STATUS_EFFECT_LING_TRANSFORMATION, new_dna, (previous_transformation && istype(previous_transformation)) ? previous_transformation.original_dna : null)
 	COOLDOWN_START(src, next_sting, TRANSFORM_STING_COOLDOWN)
 
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -114,7 +114,7 @@
 		if(ismonkey(C))
 			C = C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG | TR_KEEPAI)
 		var/datum/status_effect/ling_transformation/previous_transformation = C.has_status_effect(STATUS_EFFECT_LING_TRANSFORMATION)
-		C.apply_status_effect(STATUS_EFFECT_LING_TRANSFORMATION, new_dna, (previous_transformation && istype(previous_transformation)) ? previous_transformation.original_dna : null)
+		C.apply_status_effect(STATUS_EFFECT_LING_TRANSFORMATION, new_dna, istype(previous_transformation) ? previous_transformation.original_dna : null)
 	COOLDOWN_START(src, next_sting, TRANSFORM_STING_COOLDOWN)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm a dummy and didn't realize `has_status_effect` would return `FALSE` instead of `null` whenever there's no status effect...

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/9112

## Why It's Good For The Game

it's supposed to work

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Changeling transformation sting works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
