### PR TITLE
Fix orbit panel showing invalid job huds

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -29,6 +29,21 @@
 		else
 			return TRUE
 
+/datum/orbit_menu/ui_static_data(mob/user)
+	var/static/list/all_job_huds
+	if(!all_job_huds)
+		all_job_huds = GLOB.command_positions_hud|\
+			GLOB.important_positions_hud|\
+			GLOB.engineering_positions_hud|\
+			GLOB.medical_positions_hud|\
+			GLOB.science_positions_hud|\
+			GLOB.supply_positions_hud|\
+			GLOB.civilian_positions_hud|\
+			GLOB.security_positions_hud
+	return list(
+		"job_huds" = all_job_huds
+	)
+
 /datum/orbit_menu/ui_data(mob/user)
 	var/list/data = list()
 

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -35,7 +35,9 @@ const compareNumberedText = (a, b) => {
 };
 
 const OrbitSection = (props, context) => {
-  const { act } = useBackend(context);
+  const { act, data: {
+    job_huds = [],
+  } } = useBackend(context);
   const { searchText, source, title, color, basic } = props;
   const things = source.filter(searchFor(searchText));
   things.sort(compareNumberedText);
@@ -59,7 +61,7 @@ const OrbitSection = (props, context) => {
             key={thing.name}
             color={color}
             thing={thing}
-            job={thing.role_icon}
+            job={job_huds.includes(thing.role_icon.substring(3)) && thing.role_icon}
             antag={thing.antag_icon}
           />
         )


### PR DESCRIPTION
## About The Pull Request

If an assigned role exists but is not actually a real job hud, it is still shown as a blank box. This will ensure only valid job huds are shown.

## Why It's Good For The Game

Fixes a bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/7b548c6a-2fd3-47e8-8934-b82a73586d20)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/10cb8259-31c8-45e0-886d-c35b694be707)

</details>

## Changelog
:cl:
fix: Fix orbit panel showing invalid job HUDs as blank boxes.
/:cl: