### PR TITLE
Alt fix of "Fix orbit panel showing invalid job huds #9118"

### DIFF
--- a/code/__HELPERS/jobs.dm
+++ b/code/__HELPERS/jobs.dm
@@ -76,7 +76,7 @@
 
 // This returns a hud icon (from `hud.dmi`) by given job name.
 // Some custom title is from `PDApainter.dm`. You neec to check it if you're going to remove custom job.
-/proc/get_hud_by_jobname(jobname)
+/proc/get_hud_by_jobname(jobname, returns_unknown=TRUE)
 	if(!jobname)
 		CRASH("The proc has taken a null value")
 
@@ -153,7 +153,9 @@
 		"Unassigned" = JOB_HUD_UNKNOWN,
 		JOB_NAME_PRISONER = JOB_HUD_PRISONER
 	)
-	return id_to_hud[jobname] || JOB_HUD_UNKNOWN // default: a grey unknown hud
+	if(returns_unknown)
+		return id_to_hud[jobname] || JOB_HUD_UNKNOWN // default: a grey unknown hud
+	return id_to_hud[jobname] // this will return null
 
 // used to determine chat color by HUD in `chatmessage.dm`
 // Note: custom colors are what I really didn't put much attention into. feel free to change its color when you feel off.

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -67,9 +67,9 @@
 					serialized["role_icon"] = "hud[ckey(identification_card.GetJobIcon())]"
 				else
 					//If we have no ID, use the mind job
-					var/datum/job/located_job = SSjob.GetJob(mind.assigned_role)
-					if (located_job)
-						serialized["role_icon"] = "hud[ckey(located_job.title)]"
+					var/located_job_hud = get_hud_by_jobname(mind.assigned_role, returns_unknown=FALSE)
+					if (located_job_hud)
+						serialized["role_icon"] = "hud[ckey(located_job_hud)]"
 
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alternative fix of:
* #9118

the suggested PR also removes the visibility of non-standard huds like raw series, centcom, prisoner, etc
This prevents hudless jobs to be shown but still lets such job huds shown

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d6c37086-be70-4575-bb97-23c1bee1f697)

</details>

## Changelog
:cl:
fix: Fix orbit panel showing invalid job HUDs as blank boxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
