### PR TITLE
Adds a variable in spellbook that can bypass a threat lock for rituals/spell compatible

### DIFF
--- a/code/game/objects/items/debug_items.dm
+++ b/code/game/objects/items/debug_items.dm
@@ -154,7 +154,8 @@
 /obj/item/spellbook/debug
 	name = "\improper Robehator's spell book"
 	uses = 200
-	debug = TRUE
+	everything_robeless = TRUE
+	bypass_lock = TRUE
 
 //Debug suit
 /obj/item/clothing/head/helmet/space/hardsuit/debug


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a variable in spellbook that can bypass a threat lock for rituals/spell compatible

if you set `bypass_lock` TRUE, You'll be capable of casting the crazy rituals.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rituals are actually not possible to happen. Wizards will need to beg admeme so that it can actually happen.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/eb8b21fb-0852-4ddc-b311-5b7970ec2902)


![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d58ddf04-7db6-4a03-bac2-d03ba5320244)

</details>

## Changelog
:cl:
add: spell book now has bypass_lock variable. Admin can set it TRUE to bypass dynamic threat lock for some rituals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
