### PR TITLE
Removes yet another xenobio exploit

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/crystalized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/crystalized.dm
@@ -6,18 +6,14 @@
 	effect_desc = "Use to place a pylon."
 	var/obj/structure/slime_crystal/crystal_type
 
-/obj/item/slimecross/crystalline/proc/check_for_crystals(user)
-	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
-	if(C)
-		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
-	return C
 /obj/item/slimecross/crystalline/attack_self(mob/user)
 	. = ..()
 
 	// Check before the progress bar so they don't wait for nothing
 	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
 
-	if(check_for_crystals(user))
+	if(locate(/obj/structure/slime_crystal) in range(6,get_turf(user)))
+		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
 		return
 
 	var/user_turf = get_turf(user)
@@ -26,7 +22,8 @@
 		return
 
 	// check after in case someone placed a crystal in the meantime (im watching you aramix)
-	if(check_for_crystals(user))
+	if(locate(/obj/structure/slime_crystal) in range(6,get_turf(user)))
+		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
 		return
 
 	new crystal_type(user_turf)

--- a/code/modules/research/xenobiology/crossbreeding/crystalized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/crystalized.dm
@@ -5,14 +5,19 @@
 	icon_state = "crystalline"
 	effect_desc = "Use to place a pylon."
 	var/obj/structure/slime_crystal/crystal_type
+
+/obj/item/slimecross/crystalline/proc/check_for_crystals(user)
+	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
+	if(C)
+		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
+	return C
 /obj/item/slimecross/crystalline/attack_self(mob/user)
 	. = ..()
 
 	// Check before the progress bar so they don't wait for nothing
 	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
 
-	if(C)
-		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
+	if(check_for_crystals(user))
 		return
 
 	var/user_turf = get_turf(user)
@@ -21,9 +26,7 @@
 		return
 
 	// check after in case someone placed a crystal in the meantime (im watching you aramix)
-	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
-	if(C)
-		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
+	if(check_for_crystals(user))
 		return
 
 	new crystal_type(user_turf)

--- a/code/modules/research/xenobiology/crossbreeding/crystalized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/crystalized.dm
@@ -10,8 +10,6 @@
 	. = ..()
 
 	// Check before the progress bar so they don't wait for nothing
-	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
-
 	if(locate(/obj/structure/slime_crystal) in range(6,get_turf(user)))
 		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
 		return

--- a/code/modules/research/xenobiology/crossbreeding/crystalized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/crystalized.dm
@@ -5,10 +5,10 @@
 	icon_state = "crystalline"
 	effect_desc = "Use to place a pylon."
 	var/obj/structure/slime_crystal/crystal_type
-
 /obj/item/slimecross/crystalline/attack_self(mob/user)
 	. = ..()
 
+	// Check before the progress bar so they don't wait for nothing
 	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
 
 	if(C)
@@ -17,7 +17,13 @@
 
 	var/user_turf = get_turf(user)
 
-	if(!do_after(user, 15 SECONDS, user_turf, timed_action_flags = IGNORE_HELD_ITEM))
+	if(!do_after(user, 15 SECONDS, src))
+		return
+
+	// check after in case someone placed a crystal in the meantime (im watching you aramix)
+	var/obj/structure/slime_crystal/C = locate(/obj/structure/slime_crystal) in range(6,get_turf(user))
+	if(C)
+		to_chat(user,"<span class='notice'>You can't build crystals that close to each other!</span>")
 		return
 
 	new crystal_type(user_turf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
extract do_after was attached to the turf player was on instead of the extract so it didn't cancel when extract was deleted resulting in a lot of pylons if spammed. This PR fixes it.
Also someone could place another pylon while yours was being constructed because it checked for pylons only before the progress bar
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xenobio exploits bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
- Try to spam xenobio crystalline pylons
- Progressbars vanish/cancel when one pylon gets created
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Current master behavior:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/411a4b7f-4ff0-43fa-a2bf-659103502cc8)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/6be59778-b99c-488b-afba-ea109fa0739d)

This PR behavior:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/74c5a400-ca90-44c8-8bef-7a76001e1cb2)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/d8f8297b-cc0d-4053-ad9e-6153cdd9aabf)

</details>

## Changelog
:cl:
fix: Fixed xenobio infinite pylons exploit that could potentially crash the server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
