### PR TITLE
Improve TGUI ui_data sleeping + Cache metabalance locally

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -69,7 +69,7 @@
 		body += "<a href='?_src_=holder;[HrefToken()];modantagtokens=subtract;mob=[REF(M)]'>-</a> "
 		body += "<a href='?_src_=holder;[HrefToken()];modantagtokens=set;mob=[REF(M)]'>=</a> "
 		body += "<a href='?_src_=holder;[HrefToken()];modantagtokens=zero;mob=[REF(M)]'>0</a>"
-		var/metabalance = M.client.get_metabalance()
+		var/metabalance = M.client.get_metabalance_db()
 		body += "<br><b>[CONFIG_GET(string/metacurrency_name)]s</b>: [metabalance] "
 		var/full_version = "Unknown"
 		if(M.client.byond_version)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -63,7 +63,7 @@
 		body += "<a href='?_src_=holder;[HrefToken()];modantagrep=subtract;mob=[REF(M)]'>-</a> "
 		body += "<a href='?_src_=holder;[HrefToken()];modantagrep=set;mob=[REF(M)]'>=</a> "
 		body += "<a href='?_src_=holder;[HrefToken()];modantagrep=zero;mob=[REF(M)]'>0</a>"
-		var/antag_tokens = M.client.get_antag_token_count()
+		var/antag_tokens = M.client.get_antag_token_count_db()
 		body += "<br><b>Antag Tokens</b>: [antag_tokens] "
 		body += "<a href='?_src_=holder;[HrefToken()];modantagtokens=add;mob=[REF(M)]'>+</a> "
 		body += "<a href='?_src_=holder;[HrefToken()];modantagtokens=subtract;mob=[REF(M)]'>-</a> "

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -114,8 +114,8 @@
 					for(var/entry in log)
 						log_type_data[entry] += html_decode(log[entry])
 					data_entry["log_client"][log_type] = log_type_data
-				data_entry["metacurrency_balance"] = player.client.get_metabalance()
-				data_entry["antag_tokens"] = player.client.get_antag_token_count()
+				data_entry["metacurrency_balance"] = player.client.get_metabalance_unreliable()
+				data_entry["antag_tokens"] = player.client.get_antag_token_count_unreliable()
 				data_entry["register_date"] = player.client.account_join_date
 				data_entry["first_seen"] = player.client.player_join_date
 				data_entry["ip"] = player.client.address

--- a/code/modules/client/antag_tokens.dm
+++ b/code/modules/client/antag_tokens.dm
@@ -4,7 +4,7 @@
 /// Never-blocking method to retrieve cached antag token count. This CAN be null and runtimes if it is.
 /// Use get_antag_token_count_db() for a more accurate measure. Never use this in modifying calculations.
 /// The cached antag token count is initialized during client/Login()
-/client/proc/get_antag_token_count()
+/client/proc/get_antag_token_count_unreliable()
 	SHOULD_NOT_SLEEP(TRUE)
 	if(antag_token_count_cached == null)
 		CRASH("Antag token amount fetched before value initialized")
@@ -26,7 +26,9 @@
 	else
 		token_count = query_get_antag_tokens.item[1]
 	qdel(query_get_antag_tokens)
-	return text2num(token_count)
+	var/count = text2num(token_count)
+	antag_token_count_cached = count
+	return count
 
 /// Sets antag token count in the local cache, then invokes a database update.
 /// token_count: Amount to increment the antag token count by

--- a/code/modules/client/antag_tokens.dm
+++ b/code/modules/client/antag_tokens.dm
@@ -1,7 +1,20 @@
+/// Cached antag token count, pulled just before prefs initialization.
+/client/var/antag_token_count_cached = null
+
+/// Never-blocking method to retrieve cached antag token count. This CAN be null and runtimes if it is.
+/// Use get_antag_token_count_db() for a more accurate measure. Never use this in modifying calculations.
+/// The cached antag token count is initialized during client/Login()
 /client/proc/get_antag_token_count()
+	SHOULD_NOT_SLEEP(TRUE)
+	if(antag_token_count_cached == null)
+		CRASH("Antag token amount fetched before value initialized")
+	return antag_token_count_cached
+
+/// Gets the user's antag token count from the DB. Blocking.
+/client/proc/get_antag_token_count_db()
 	var/datum/DBQuery/query_get_antag_tokens = SSdbcore.NewQuery(
 		"SELECT antag_tokens FROM [format_table_name("player")] WHERE ckey = :ckey",
-		list("ckey" = ckey)	
+		list("ckey" = ckey)
 	)
 	var/token_count = 0
 	if(!query_get_antag_tokens.warn_execute())
@@ -15,7 +28,37 @@
 	qdel(query_get_antag_tokens)
 	return text2num(token_count)
 
+/// Sets antag token count in the local cache, then invokes a database update.
+/// token_count: Amount to increment the antag token count by
 /client/proc/set_antag_token_count(token_count)
+	SHOULD_NOT_SLEEP(TRUE)
+	if(antag_token_count_cached == null)
+		to_chat(usr, "<span class='warning'>Error adjusting antag tokens!</span>")
+		CRASH("Antag token amount adjusted before value initialized")
+	antag_token_count_cached = token_count
+	INVOKE_ASYNC(src, PROC_REF(db_set_antag_token_count), token_count)
+
+/// Increases antag token count in the local cache, then invokes a database update.
+/// token_count: Amount to increment the antag token count by
+/client/proc/inc_antag_token_count(token_count)
+	SHOULD_NOT_SLEEP(TRUE)
+	if(antag_token_count_cached == null)
+		to_chat(usr, "<span class='warning'>Error adjusting antag tokens!</span>")
+		CRASH("Antag token amount adjusted before value initialized")
+	antag_token_count_cached += token_count
+	INVOKE_ASYNC(src, PROC_REF(db_inc_antag_token_count), token_count)
+
+/client/proc/db_inc_antag_token_count(token_count)
+	var/datum/DBQuery/query_inc_antag_tokens = SSdbcore.NewQuery(
+		"UPDATE [format_table_name("player")] SET antag_tokens = antag_tokens + :token_count WHERE ckey = :ckey",
+		list("token_count" = token_count, "ckey" = ckey)
+	)
+	if(!query_inc_antag_tokens.warn_execute())
+		qdel(query_inc_antag_tokens)
+		return
+	qdel(query_inc_antag_tokens)
+
+/client/proc/db_set_antag_token_count(token_count)
 	var/datum/DBQuery/query_set_antag_tokens = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET antag_tokens = :token_count WHERE ckey = :ckey",
 		list("token_count" = token_count, "ckey" = ckey)
@@ -24,13 +67,3 @@
 		qdel(query_set_antag_tokens)
 		return
 	qdel(query_set_antag_tokens)
-
-/client/proc/inc_antag_token_count(token_count)
-	var/datum/DBQuery/query_inc_antag_tokens = SSdbcore.NewQuery(
-		"UPDATE [format_table_name("player")] SET antag_tokens = antag_tokens + :token_count WHERE ckey = :ckey",
-		list("token_count" = token_count, "ckey" = ckey)	
-	)
-	if(!query_inc_antag_tokens.warn_execute())
-		qdel(query_inc_antag_tokens)
-		return
-	qdel(query_inc_antag_tokens)

--- a/code/modules/client/antag_tokens.dm
+++ b/code/modules/client/antag_tokens.dm
@@ -17,14 +17,9 @@
 		list("ckey" = ckey)
 	)
 	var/token_count = 0
-	if(!query_get_antag_tokens.warn_execute())
-		qdel(query_get_antag_tokens)
-		return text2num(token_count)
-	if(!query_get_antag_tokens.NextRow())
-		qdel(query_get_antag_tokens)
-		return text2num(token_count)
-	else
+	if(query_get_antag_tokens.warn_execute() && query_get_antag_tokens.NextRow())
 		token_count = query_get_antag_tokens.item[1]
+
 	qdel(query_get_antag_tokens)
 	var/count = text2num(token_count)
 	antag_token_count_cached = count

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -248,6 +248,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 				to_chat_immediate(src, "<span class='userdanger'>Debugger enabled. Make sure you untick \"Runtime errors\" in the bottom left of VSCode's Run and Debug tab.</span>")
 			var/datum/admin_rank/localhost_rank = new("!localhost!", R_EVERYTHING, R_DBRANKS, R_EVERYTHING) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
+	metabalance_cached = get_metabalance_db()
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]
 	if(prefs)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -250,6 +250,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			new /datum/admins(localhost_rank, ckey, 1, 1)
 	// Retrieve cached metabalance
 	metabalance_cached = get_metabalance_db()
+	// Retrieve cached antag token count
+	antag_token_count_cached = get_antag_token_count_db()
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]
 	if(prefs)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -249,9 +249,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			var/datum/admin_rank/localhost_rank = new("!localhost!", R_EVERYTHING, R_DBRANKS, R_EVERYTHING) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
 	// Retrieve cached metabalance
-	metabalance_cached = get_metabalance_db()
+	get_metabalance_db()
 	// Retrieve cached antag token count
-	antag_token_count_cached = get_antag_token_count_db()
+	get_antag_token_count_db()
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]
 	if(prefs)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -248,6 +248,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 				to_chat_immediate(src, "<span class='userdanger'>Debugger enabled. Make sure you untick \"Runtime errors\" in the bottom left of VSCode's Run and Debug tab.</span>")
 			var/datum/admin_rank/localhost_rank = new("!localhost!", R_EVERYTHING, R_DBRANKS, R_EVERYTHING) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
+	// Retrieve cached metabalance
 	metabalance_cached = get_metabalance_db()
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1034,6 +1034,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return FALSE
 		if (NAMEOF(src, cached_badges))
 			return FALSE
+		if (NAMEOF(src, metabalance_cached))
+			return FALSE
 		if (NAMEOF(src, view))
 			view_size.setDefault(var_value)
 			return TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1332,7 +1332,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(TG.sort_category == "Donator")
 				if(CONFIG_GET(flag/donator_items) && alert(parent, "This item is only accessible to our patrons. Would you like to subscribe?", "Patron Locked", "Yes", "No") == "Yes")
 					parent.donate()
-			else if(TG.cost < user.client.get_metabalance_db())
+			else if(TG.cost <= user.client.get_metabalance_db())
 				purchased_gear += TG.id
 				TG.purchase(user.client)
 				user.client.inc_metabalance((TG.cost * -1), TRUE, "Purchased [TG.display_name].")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -770,7 +770,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "</center>"
 
 			var/fcolor =  "#3366CC"
-			var/metabalance = user.client.get_metabalance()
+			var/metabalance = user.client.get_metabalance_db()
 			dat += "<table align='center' width='100%'>"
 			dat += "<tr><td colspan=4><center><b>Current balance: <font color='[fcolor]'>[metabalance]</font> [CONFIG_GET(string/metacurrency_name)]s.</b> \[<a href='?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
 			dat += "<tr><td colspan=4><center><b>"
@@ -1332,7 +1332,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(TG.sort_category == "Donator")
 				if(CONFIG_GET(flag/donator_items) && alert(parent, "This item is only accessible to our patrons. Would you like to subscribe?", "Patron Locked", "Yes", "No") == "Yes")
 					parent.donate()
-			else if(TG.cost < user.client.get_metabalance())
+			else if(TG.cost < user.client.get_metabalance_db())
 				purchased_gear += TG.id
 				TG.purchase(user.client)
 				user.client.inc_metabalance((TG.cost * -1), TRUE, "Purchased [TG.display_name].")

--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -23,10 +23,9 @@
 
 	var/list/play_records = owner.prefs.exp
 	if (!play_records.len)
-		owner.set_exp_from_db()
-		play_records = owner.prefs.exp
-		if (!play_records.len)
-			return list("failReason" = JOB_REPORT_MENU_FAIL_REASON_NO_RECORDS)
+		// We can't invoke this directly right now, since it's blocking, but this will ensure a cache hit next time.
+		INVOKE_ASYNC(owner, TYPE_PROC_REF(/client, set_exp_from_db))
+		return list("failReason" = JOB_REPORT_MENU_FAIL_REASON_NO_RECORDS)
 
 	var/list/data = list()
 	data["jobPlaytimes"] = list()

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -40,9 +40,8 @@
 		list("ckey" = ckey)
 	)
 	var/mc_count = 0
-	if(query_get_metacoins.warn_execute())
-		if(query_get_metacoins.NextRow())
-			mc_count = query_get_metacoins.item[1]
+	if(query_get_metacoins.warn_execute() && query_get_metacoins.NextRow())
+		mc_count = query_get_metacoins.item[1]
 
 	qdel(query_get_metacoins)
 	var/count = text2num(mc_count)

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -1,18 +1,22 @@
+/// Cached metabalance, pulled just before prefs initialization.
+/client/var/metabalance_cached = null
+
 /client/proc/process_endround_metacoin()
-    if(!mob)    return
-    var/mob/M = mob
-    if(M.mind && !isnewplayer(M))
-        if(M.stat != DEAD && !isbrain(M))
-            if(EMERGENCY_ESCAPED_OR_ENDGAMED)
-                if(!M.onCentCom() && !M.onSyndieBase())
-                    var/reward_type = ((isAI(M)|| iscyborg(M) ? METACOIN_ESCAPE_REWARD : METACOIN_SURVIVE_REWARD))
-                    inc_metabalance(reward_type, reason="Survived the shift.")
-                else
-                    inc_metabalance(METACOIN_ESCAPE_REWARD, reason="Survived the shift and escaped!")
-            else
-                inc_metabalance(METACOIN_ESCAPE_REWARD, reason="Survived the shift.")
-        else
-            inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
+	if(!mob)
+		return
+	var/mob/M = mob
+	if(M.mind && !isnewplayer(M))
+		if(M.stat != DEAD && !isbrain(M))
+			if(EMERGENCY_ESCAPED_OR_ENDGAMED)
+				if(!M.onCentCom() && !M.onSyndieBase())
+					var/reward_type = ((isAI(M)|| iscyborg(M) ? METACOIN_ESCAPE_REWARD : METACOIN_SURVIVE_REWARD))
+					inc_metabalance(reward_type, reason="Survived the shift.")
+				else
+					inc_metabalance(METACOIN_ESCAPE_REWARD, reason="Survived the shift and escaped!")
+			else
+				inc_metabalance(METACOIN_ESCAPE_REWARD, reason="Survived the shift.")
+		else
+			inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
 
 /client/proc/process_greentext()
 	src.give_award(/datum/award/achievement/misc/greentext, src.mob)
@@ -21,6 +25,12 @@
 	inc_metabalance(METACOIN_TENMINUTELIVING_REWARD, FALSE)
 
 /client/proc/get_metabalance()
+	SHOULD_NOT_SLEEP(TRUE)
+	if(metabalance_cached == null)
+		CRASH("Metacoin amount fetched before value initialized")
+	return metabalance_cached
+
+/client/proc/get_metabalance_db()
 	var/datum/DBQuery/query_get_metacoins = SSdbcore.NewQuery(
 		"SELECT metacoins FROM [format_table_name("player")] WHERE ckey = :ckey",
 		list("ckey" = ckey)
@@ -34,26 +44,32 @@
 	return text2num(mc_count)
 
 /client/proc/set_metacoin_count(mc_count, ann=TRUE)
-	var/datum/DBQuery/query_set_metacoins = SSdbcore.NewQuery(
-		"UPDATE [format_table_name("player")] SET metacoins = :mc_count WHERE ckey = :ckey",
-		list("mc_count" = mc_count, "ckey" = ckey)
-	)
-	query_set_metacoins.warn_execute()
-	qdel(query_set_metacoins)
+	SHOULD_NOT_SLEEP(TRUE)
+	if(metabalance_cached == null)
+		CRASH("Metacoin amount adjusted before value initialized")
+	metabalance_cached = mc_count
 	if(ann)
 		to_chat(src, "<span class='rose bold'>Your new metacoin balance is [mc_count]!</span>")
+	INVOKE_ASYNC(src, PROC_REF(db_set_metabalance), metabalance_cached)
 
 /client/proc/inc_metabalance(mc_count, ann=TRUE, reason=null)
+	SHOULD_NOT_SLEEP(TRUE)
 	if(mc_count >= 0 && !CONFIG_GET(flag/grant_metacurrency))
 		return
-	var/datum/DBQuery/query_inc_metacoins = SSdbcore.NewQuery(
-		"UPDATE [format_table_name("player")] SET metacoins = metacoins + :mc_count WHERE ckey = :ckey",
-		list("mc_count" = mc_count, "ckey" = ckey)
-	)
-	query_inc_metacoins.warn_execute()
-	qdel(query_inc_metacoins)
+	if(metabalance_cached == null)
+		CRASH("Metacoin amount adjusted before value initialized")
+	metabalance_cached += mc_count
 	if(ann)
 		if(reason)
 			to_chat(src, "<span class='rose bold'>[abs(mc_count)] [CONFIG_GET(string/metacurrency_name)]\s have been [mc_count >= 0 ? "deposited to" : "withdrawn from"] your account! Reason: [reason]</span>")
 		else
 			to_chat(src, "<span class='rose bold'>[abs(mc_count)] [CONFIG_GET(string/metacurrency_name)]\s have been [mc_count >= 0 ? "deposited to" : "withdrawn from"] your account!</span>")
+	INVOKE_ASYNC(src, PROC_REF(db_set_metabalance), metabalance_cached)
+
+/client/proc/db_set_metabalance(mc_count)
+	var/datum/DBQuery/query_set_metacoins = SSdbcore.NewQuery(
+		"UPDATE [format_table_name("player")] SET metacoins = metacoins + :mc_count WHERE ckey = :ckey",
+		list("mc_count" = mc_count, "ckey" = ckey)
+	)
+	query_set_metacoins.warn_execute()
+	qdel(query_set_metacoins)

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -25,7 +25,7 @@
 	inc_metabalance(METACOIN_TENMINUTELIVING_REWARD, FALSE)
 
 /// Never-blocking method to retrieve cached metabalance. This CAN be null and runtimes if it is.
-/// Use get_metabalance_db() for a more accurate measure. Never use this in modifynig calculations.
+/// Use get_metabalance_db() for a more accurate measure. Never use this in modifying calculations.
 /// The cached metabalance is initialized during client/Login()
 /client/proc/get_metabalance()
 	SHOULD_NOT_SLEEP(TRUE)

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -27,7 +27,7 @@
 /// Never-blocking method to retrieve cached metabalance. This CAN be null and runtimes if it is.
 /// Use get_metabalance_db() for a more accurate measure. Never use this in modifying calculations.
 /// The cached metabalance is initialized during client/Login()
-/client/proc/get_metabalance()
+/client/proc/get_metabalance_unreliable()
 	SHOULD_NOT_SLEEP(TRUE)
 	if(metabalance_cached == null)
 		CRASH("Metacoin amount fetched before value initialized")
@@ -45,7 +45,9 @@
 			mc_count = query_get_metacoins.item[1]
 
 	qdel(query_get_metacoins)
-	return text2num(mc_count)
+	var/count = text2num(mc_count)
+	metabalance_cached = count
+	return count
 
 /// Sets metabalance in the local cache, then invokes a database update.
 /// mc_count: Amount to increment the metabalance by

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -50,6 +50,7 @@
  * return list Data to be sent to the UI.
  */
 /datum/proc/ui_data(mob/user)
+	SHOULD_NOT_SLEEP(TRUE) // Optional, but good code practice. Remove this if you have a valid use case.
 	return list() // Not implemented.
 
 /**
@@ -67,6 +68,7 @@
  * return list Statuic Data to be sent to the UI.
  */
 /datum/proc/ui_static_data(mob/user)
+	SHOULD_NOT_SLEEP(TRUE) // Optional, but good code practice. Remove this if you have a valid use case.
 	return list()
 
 /**

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -259,13 +259,13 @@
 	var/data = custom_data || with_data && src_object.ui_data(user)
 	if(data)
 		json_data["data"] = data
-	// ui_data can sleep, protect against that
+	// if ui_data sleeps, prevent errors
 	if(!user?.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
 		return
 	var/static_data = with_static_data && src_object.ui_static_data(user)
 	if(static_data)
 		json_data["static_data"] = static_data
-	// ui_static_data can sleep, protect against that
+	// if ui_static_data sleeps, prevent errors
 	if(!user?.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
 		return
 	if(src_object.tgui_shared_states)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -257,9 +257,13 @@
 	var/data = custom_data || with_data && src_object.ui_data(user)
 	if(data)
 		json_data["data"] = data
+	// ui_data can sleep, protect against that
+	if(!user?.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
+		return
 	var/static_data = with_static_data && src_object.ui_static_data(user)
 	if(static_data)
 		json_data["static_data"] = static_data
+	// ui_static_data can sleep, protect against that
 	if(!user?.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
 		return
 	if(src_object.tgui_shared_states)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -215,12 +215,14 @@
  * optional force bool Send an update even if UI is not interactive.
  */
 /datum/tgui/proc/send_update(custom_data, force)
-	if(!user.client || !initialized || closing)
+	if(!user.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
 		return
 	var/should_update_data = force || status >= UI_UPDATE
-	window.send_message("update", get_payload(
+	var/payload = get_payload(
 		custom_data,
-		with_data = should_update_data))
+		with_data = should_update_data)
+	if(payload)
+		window.send_message("update", payload)
 
 /**
  * private
@@ -258,6 +260,8 @@
 	var/static_data = with_static_data && src_object.ui_static_data(user)
 	if(static_data)
 		json_data["static_data"] = static_data
+	if(!user?.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
+		return
 	if(src_object.tgui_shared_states)
 		json_data["shared"] = src_object.tgui_shared_states
 	return json_data

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -260,13 +260,13 @@
 	if(data)
 		json_data["data"] = data
 	// if ui_data sleeps, prevent errors
-	if(!user?.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
+	if(!user?.client || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
 		return
 	var/static_data = with_static_data && src_object.ui_static_data(user)
 	if(static_data)
 		json_data["static_data"] = static_data
 	// if ui_static_data sleeps, prevent errors
-	if(!user?.client || !initialized || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
+	if(!user?.client || closing || QDELETED(src_object) || QDELETED(user) || QDELETED(window))
 		return
 	if(src_object.tgui_shared_states)
 		json_data["shared"] = src_object.tgui_shared_states

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -200,11 +200,13 @@
 		return
 	refreshing = FALSE
 	var/should_update_data = force || status >= UI_UPDATE
-	window.send_message("update", get_payload(
+	var/payload = get_payload(
 		custom_data,
 		with_data = should_update_data,
-		with_static_data = TRUE))
-	COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
+		with_static_data = TRUE)
+	if(payload)
+		window.send_message("update", payload)
+		COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
 
 /**
  * public


### PR DESCRIPTION
## About The Pull Request

When the player panel was closed, it would sometimes trigger a bluescreen with "config" being null. This was caused by get_payload runtiming with `null.tgui_shared_states`. This is a really patch on fix for src_object randomly becoming null in the middle of this proc. ~~I'm not sure why or how, but it does indeed fix the bug.~~

~~My guess is it's a race condition caused by a ui_act from the search bar when it's closed, since it gets unfocused and then updates the text inside. This action message is sent at the same time the suspend message is sent, meaning two concurrent executions of ui updating and ui closing occur. This means that while the UI is closing, it's building a message to be sent, and then the UI finishes closing and sets src_object to null, causing said runtime. I'm not sure how or why, or how to properly fix this, but this solution works well enough that I'm just gonna leave it there and hope TG fixes it upstream or something. I did search for related PRs or changes but found nothing of the sort.~~

If ui_static_data or ui_data sleep at all, they can become null during the proc, so this should be handled.

ui_data and ui_static_data now also enforce SHOULD_NOT_SLEEP. In order to meet this I added a local metabalance cache, but it's only used for display purposes and not involved in balance calculations. Admins also cannot edit it.

Antag tokens were also cached locally.

Fixes a bug where you can only purchase items that are less than your metabalance rather than less than or equal to.

## Why It's Good For The Game

Fixes a bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/54de23b8-61cd-47ff-acae-7310ec6bfe04)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/74d75f45-78f7-4939-a7a3-0977451b1411)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/8a59aa4d-73b3-4208-ab02-74dc561e7078)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/47da0c71-0ae4-409b-9788-d67eeed6a910)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/aaadf4a1-2fd6-4719-a223-7cd7e0d90bec)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/85bb7f29-fbe7-440d-8323-92568ef5a939)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/8d7aa0fb-e0f0-4ec7-9b9e-3ea7eb7ca932)

</details>

## Changelog
:cl:
fix: Fixed admin player panel bluescreening/runtiming when closed.
tweak: Metabalance is now cached on the player's client datum to reduce database use.
fix: You can now purchase items that cost exactly your metabalance.
tweak: Antag token count is now cached on the player's client datum to reduce database use.
/:cl:
