### PR TITLE
[s] Fixes a mhelp/ahelp XSS.

### DIFF
--- a/code/modules/admin/verbs/_help.dm
+++ b/code/modules/admin/verbs/_help.dm
@@ -559,7 +559,7 @@
 		claim_ticket = CLAIM_OVERRIDE
 	return claim_ticket
 
-/datum/help_ticket/proc/MessageNoRecipient(msg)
+/datum/help_ticket/proc/MessageNoRecipient(msg, sanitized = FALSE)
 	return
 
 /datum/help_ticket/proc/key_name_ticket(mob/user)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -193,11 +193,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/help_tickets/admin, new)
 /datum/help_ticket/admin/message_ticket_managers(msg)
 	message_admins(msg)
 
-/datum/help_ticket/admin/MessageNoRecipient(msg, add_to_ticket = TRUE)
+/datum/help_ticket/admin/MessageNoRecipient(msg, add_to_ticket = TRUE, sanitized = FALSE)
 	var/ref_src = "[REF(src)]"
+	var/sanitized_msg = sanitized ? msg : sanitize(msg)
 
 	//Message to be sent to all admins
-	var/admin_msg = "<span class='adminnotice'><span class='adminhelp'>Ticket [TicketHref("#[id]", ref_src)]</span><b>: [LinkedReplyName(ref_src)] [FullMonty(ref_src)]:</b> <span class='linkify'>[keywords_lookup(msg)]</span></span>"
+	var/admin_msg = "<span class='adminnotice'><span class='adminhelp'>Ticket [TicketHref("#[id]", ref_src)]</span><b>: [LinkedReplyName(ref_src)] [FullMonty(ref_src)]:</b> <span class='linkify'>[keywords_lookup(sanitized_msg)]</span></span>"
 
 	if(add_to_ticket)
 		AddInteraction("red", msg, initiator_key_name, claimee_key_name, "You", "Administrator")
@@ -216,7 +217,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/help_tickets/admin, new)
 	if(add_to_ticket)
 		to_chat(initiator,
 			type = message_type,
-			html = "<span class='adminnotice'>PM to-<b>Admins</b>: <span class='linkify'>[msg]</span></span>")
+			html = "<span class='adminnotice'>PM to-<b>Admins</b>: <span class='linkify'>[sanitized_msg]</span></span>")
 
 
 /datum/help_ticket/admin/proc/FullMonty(ref_src)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -128,7 +128,7 @@
 					to_chat(src, msg)
 				return
 			else if(msg) // you want to continue if there's no message instead of returning now
-				current_adminhelp_ticket.MessageNoRecipient(msg)
+				current_adminhelp_ticket.MessageNoRecipient(msg, sanitized = html_encoded)
 				return
 
 		//get message text, limit it's length.and clean/escape html
@@ -148,7 +148,7 @@
 				if(holder)
 					to_chat(src, "<span class='danger'>Error: Admin-PM: Client not found.</span>", type = MESSAGE_TYPE_ADMINPM)
 				else
-					current_adminhelp_ticket.MessageNoRecipient(msg)
+					current_adminhelp_ticket.MessageNoRecipient(msg, sanitized = html_encoded)
 				return
 
 	if (src.handle_spam_prevention(msg,MUTE_ADMINHELP))

--- a/code/modules/admin/verbs/mentorhelp.dm
+++ b/code/modules/admin/verbs/mentorhelp.dm
@@ -137,7 +137,7 @@ GLOBAL_DATUM_INIT(mhelp_tickets, /datum/help_tickets/mentor, new)
 /datum/help_ticket/mentor/NewFrom(datum/help_ticket/old_ticket)
 	if(!..())
 		return FALSE
-	MessageNoRecipient(initial_msg, FALSE)
+	MessageNoRecipient(initial_msg, add_to_ticket = FALSE, sanitized = TRUE) // initial_msg is sanitized already
 	return TRUE
 
 /datum/help_ticket/mentor/TimeoutVerb()
@@ -150,11 +150,12 @@ GLOBAL_DATUM_INIT(mhelp_tickets, /datum/help_tickets/mentor, new)
 /datum/help_ticket/mentor/message_ticket_managers(msg)
 	message_mentors(msg)
 
-/datum/help_ticket/mentor/MessageNoRecipient(msg, add_to_ticket = TRUE)
+/datum/help_ticket/mentor/MessageNoRecipient(msg, add_to_ticket = TRUE, sanitized = FALSE)
 	var/ref_src = "[REF(src)]"
+	var/sanitized_msg = sanitized ? msg : sanitize(msg)
 
 	//Message to be sent to all admins
-	var/admin_msg = "<span class='mentornotice'><span class='mentorhelp'>Mentor Ticket [TicketHref("#[id]", ref_src)]</span>: [LinkedReplyName(ref_src)] [ClosureLinks(ref_src)]: <span class='linkify'>[msg]</span></span>"
+	var/admin_msg = "<span class='mentornotice'><span class='mentorhelp'>Mentor Ticket [TicketHref("#[id]", ref_src)]</span>: [LinkedReplyName(ref_src)] [ClosureLinks(ref_src)]: <span class='linkify'>[sanitized_msg]</span></span>"
 
 	if(add_to_ticket)
 		AddInteraction("red", msg, initiator_key_name, claimee_key_name, "You", "Mentor")
@@ -169,7 +170,7 @@ GLOBAL_DATUM_INIT(mhelp_tickets, /datum/help_tickets/mentor, new)
 
 	//show it to the person adminhelping too
 	if(add_to_ticket)
-		to_chat(initiator, "<span class='mentornotice'>PM to-<b>Mentors</b>: <span class='linkify'>[msg]</span></span>", type = message_type)
+		to_chat(initiator, "<span class='mentornotice'>PM to-<b>Mentors</b>: <span class='linkify'>[sanitized_msg]</span></span>", type = message_type)
 
 /datum/help_ticket/mentor/proc/ClosureLinks(ref_src)
 	if(state > TICKET_ACTIVE)

--- a/code/modules/mentor/mentorpm.dm
+++ b/code/modules/mentor/mentorpm.dm
@@ -48,7 +48,7 @@
 			if(holder)
 				to_chat(src, "<span class='danger'>Error: Mentor-PM: Client not found.</span>", type = MESSAGE_TYPE_MENTORPM)
 			else
-				current_mentorhelp_ticket.MessageNoRecipient(msg)
+				current_mentorhelp_ticket.MessageNoRecipient(msg, sanitized = TRUE)
 			return
 
 	if (src.handle_spam_prevention(msg,MUTE_MHELP))

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -322,7 +322,7 @@
 				if(world.time > client.last_adminhelp_reply + 10 SECONDS)
 					client.last_adminhelp_reply = world.time
 					if(client.current_adminhelp_ticket)
-						client.current_adminhelp_ticket.MessageNoRecipient(message)
+						client.current_adminhelp_ticket.MessageNoRecipient(message, sanitized = TRUE)
 					else
 						to_chat(src, "<span class='warning'>Your issue has already been resolved!</span>")
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Initial ahelps and mhelps were vulnerable to XSS injection, as ticket handling code sent the first message of a ticket to the chat of admins/mentors _unsanitized_.

## Why It's Good For The Game

SECURITY FIX WEE WOO WEE WOO

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

before:
![23-06-01-1685613499-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/63f7b2d1-1ade-4a43-9af4-d48c7a497446)

after:
![23-06-01-1685614327-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/96da3bb0-4d80-4039-82c6-67495033e860)
![23-06-01-1685614334-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/be5a7be0-7986-4533-b27c-51570a16a8f7)



</details>

## Changelog
:cl:
fix: Fixed an exploit with mentorhelps and adminhelps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
