### PR TITLE
Fix some unfairness in the heretic sacrifice minigame

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -19,13 +19,18 @@
 	return ..()
 
 /datum/status_effect/unholy_determination/on_apply()
+	initial_heal()
 	ADD_TRAIT(owner, TRAIT_NOCRITDAMAGE, type)
 	ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, type)
+	ADD_TRAIT(owner, TRAIT_NOBREATH, type)
+	ADD_TRAIT(owner, TRAIT_NOHUNGER, type)
 	return TRUE
 
 /datum/status_effect/unholy_determination/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_NOCRITDAMAGE, type)
 	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, type)
+	REMOVE_TRAIT(owner, TRAIT_NOBREATH, type)
+	REMOVE_TRAIT(owner, TRAIT_NOHUNGER, type)
 
 /datum/status_effect/unholy_determination/tick()
 	// The amount we heal of each damage type per tick. If we're missing legs we heal better because we can't dodge.
@@ -53,6 +58,27 @@
 	adjust_all_damages(healing_amount)
 	adjust_temperature()
 	adjust_bleed_wounds()
+
+/*
+ * Initially heals the owner a bit, ensuring they have no suffocation and no immobility.
+*/
+/datum/status_effect/unholy_determination/proc/initial_heal()
+	owner.ExtinguishMob()
+	// catch your breath
+	owner.losebreath = 0
+	owner.setOxyLoss(0, updating_health = FALSE)
+	// get back on your feet
+	owner.resting = FALSE
+	owner.setStaminaLoss(0)
+	owner.SetSleeping(0)
+	owner.SetUnconscious(0)
+	owner.SetAllImmobility(0, updating = TRUE)
+	// who cares about how hungry or fat you are when you're fighting for your life???
+	owner.set_nutrition(clamp(owner.nutrition, NUTRITION_LEVEL_STARVING + 10, NUTRITION_LEVEL_FAT - 10))
+	REMOVE_TRAIT(owner, TRAIT_FAT, OBESITY)
+	owner.overeatduration = 0
+	owner.remove_movespeed_modifier(MOVESPEED_ID_FAT, update = FALSE)
+	owner.remove_movespeed_modifier(MOVESPEED_ID_HUNGRY)
 
 /*
  * Heals up all the owner a bit, fire stacks and losebreath included.

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -23,14 +23,12 @@
 	ADD_TRAIT(owner, TRAIT_NOCRITDAMAGE, type)
 	ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, type)
 	ADD_TRAIT(owner, TRAIT_NOBREATH, type)
-	ADD_TRAIT(owner, TRAIT_NOHUNGER, type)
 	return TRUE
 
 /datum/status_effect/unholy_determination/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_NOCRITDAMAGE, type)
 	REMOVE_TRAIT(owner, TRAIT_NOSOFTCRIT, type)
 	REMOVE_TRAIT(owner, TRAIT_NOBREATH, type)
-	REMOVE_TRAIT(owner, TRAIT_NOHUNGER, type)
 
 /datum/status_effect/unholy_determination/tick()
 	// The amount we heal of each damage type per tick. If we're missing legs we heal better because we can't dodge.
@@ -73,12 +71,6 @@
 	owner.SetSleeping(0)
 	owner.SetUnconscious(0)
 	owner.SetAllImmobility(0, TRUE)
-	// who cares about how hungry or fat you are when you're fighting for your life???
-	owner.set_nutrition(clamp(owner.nutrition, NUTRITION_LEVEL_STARVING + 10, NUTRITION_LEVEL_FAT - 10))
-	REMOVE_TRAIT(owner, TRAIT_FAT, OBESITY)
-	owner.overeatduration = 0
-	owner.remove_movespeed_modifier(MOVESPEED_ID_FAT, FALSE)
-	owner.remove_movespeed_modifier(MOVESPEED_ID_HUNGRY)
 
 /*
  * Heals up all the owner a bit, fire stacks and losebreath included.

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_buff.dm
@@ -66,18 +66,18 @@
 	owner.ExtinguishMob()
 	// catch your breath
 	owner.losebreath = 0
-	owner.setOxyLoss(0, updating_health = FALSE)
+	owner.setOxyLoss(0, FALSE)
 	// get back on your feet
 	owner.resting = FALSE
 	owner.setStaminaLoss(0)
 	owner.SetSleeping(0)
 	owner.SetUnconscious(0)
-	owner.SetAllImmobility(0, updating = TRUE)
+	owner.SetAllImmobility(0, TRUE)
 	// who cares about how hungry or fat you are when you're fighting for your life???
 	owner.set_nutrition(clamp(owner.nutrition, NUTRITION_LEVEL_STARVING + 10, NUTRITION_LEVEL_FAT - 10))
 	REMOVE_TRAIT(owner, TRAIT_FAT, OBESITY)
 	owner.overeatduration = 0
-	owner.remove_movespeed_modifier(MOVESPEED_ID_FAT, update = FALSE)
+	owner.remove_movespeed_modifier(MOVESPEED_ID_FAT, FALSE)
 	owner.remove_movespeed_modifier(MOVESPEED_ID_HUNGRY)
 
 /*


### PR DESCRIPTION
## About The Pull Request

This adds some healing to the sacrifice minigame to ensure that the sacrifice victim is actually up and able to move by the time the hands start.

## Why It's Good For The Game

Because this minigame should be _somewhat_ fair.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/2eeac242-70b1-4573-b04e-7643b2692590



</details>

## Changelog
:cl:
balance: The heretic sacrifice minigame now heals fire, suffocation, sleep, stamina, and stun before the hands start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
