### PR TITLE
Fixes Xenobio gentle crossbreed exploit

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -465,7 +465,7 @@
 		return
 
 	if(species.current_extract)
-		species.extract_cooldown = world.time + 100
+		species.extract_cooldown = world.time + 10 SECONDS
 		var/cooldown = species.current_extract.activate(H, species, activation_type)
 		species.extract_cooldown = world.time + cooldown
 

--- a/code/modules/research/xenobiology/crossbreeding/gentle.dm
+++ b/code/modules/research/xenobiology/crossbreeding/gentle.dm
@@ -21,14 +21,14 @@
 	extract.forceMove(src)
 
 /obj/item/slimecross/gentle/attack_self(mob/living/carbon/user)
-	if(activate_core(user))
+	if(preactivate_core(user))
 		COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR))
 
 /obj/item/slimecross/gentle/AltClick(mob/living/carbon/user, obj/item/I)
-	if(activate_core(user))
+	if(preactivate_core(user))
 		COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR))
 
-/obj/item/slimecross/gentle/proc/activate_core(mob/living/carbon/user)
+/obj/item/slimecross/gentle/proc/preactivate_core(mob/living/carbon/user)
 	if(user.incapacitated() || !iscarbon(user))
 		return FALSE
 	if(!COOLDOWN_FINISHED(src, use_cooldown))

--- a/code/modules/research/xenobiology/crossbreeding/gentle.dm
+++ b/code/modules/research/xenobiology/crossbreeding/gentle.dm
@@ -21,18 +21,21 @@
 	extract.forceMove(src)
 
 /obj/item/slimecross/gentle/attack_self(mob/living/carbon/user)
-	if(user.incapacitated() || !iscarbon(user))
-		return
-	if(!COOLDOWN_FINISHED(src, use_cooldown))
-		return
-	COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR))
+	if(activate_core(user))
+		COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR))
 
 /obj/item/slimecross/gentle/AltClick(mob/living/carbon/user, obj/item/I)
+	if(activate_core(user))
+		COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR))
+
+/obj/item/slimecross/gentle/proc/activate_core(mob/living/carbon/user)
 	if(user.incapacitated() || !iscarbon(user))
-		return
+		return FALSE
 	if(!COOLDOWN_FINISHED(src, use_cooldown))
-		return
-	COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR))
+		to_chat(user, "<span class='notice'>[src] isn't ready yet!</span>")
+		return FALSE
+	COOLDOWN_START(src, use_cooldown, 10 SECONDS) //This will be overwritten depending on exact activation, but prevents bypassing cooldowns on extracts with a do_after.
+	return TRUE
 
 /obj/item/slimecross/gentle/grey
 	extract_type = /obj/item/slime_extract/grey


### PR DESCRIPTION
## About The Pull Request

Luminescent abilities go on a 10 second cooldown upon activation - for most of them this is immediately overridden by a new, proper cooldown depending on exactly which ability was used, but some abilities have a `do_after` and the cooldown isn't updated immediately. This 10 second pseudo cooldown prevents spamming those few abilties.

Gentle extracts were missing that 10 second failsafe and this PR fixes that, preventing players from bypassing/negating cooldowns and otherwise spamming abilities that weren't meant to be spammed. 

Also cleans up a couple of minor things, adding a `SECONDS` where it needed to be + cutting down on some duplicate code. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Exploit bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/7790451c-0e53-475e-88cd-bdbcf726c4ab)

</details>

## Changelog
:cl:
fix: fixed an exploit that allowed for gentle crossbreed cooldowns to be bypassed. They now properly mirror luminescent behavior.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
