### PR TITLE
Nanites now copy cloud ID and such when syncing

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -126,7 +126,7 @@
 	qdel(src)
 
 //Syncs the nanite component to another, making it so programs are the same with the same programming (except activation status)
-/datum/component/nanites/proc/sync(datum/signal_source, datum/component/nanites/source, full_overwrite = TRUE, copy_activation = FALSE)
+/datum/component/nanites/proc/sync(datum/signal_source, datum/component/nanites/source, full_overwrite = TRUE, copy_settings = TRUE, copy_activation = FALSE)
 	SIGNAL_HANDLER
 
 	var/list/programs_to_remove = programs.Copy()
@@ -143,6 +143,10 @@
 	if(full_overwrite)
 		for(var/X in programs_to_remove)
 			qdel(X)
+	if(copy_settings)
+		cloud_active = source.cloud_active
+		cloud_id = source.cloud_id
+		safety_threshold = source.safety_threshold
 	for(var/X in programs_to_add)
 		var/datum/nanite_program/SNP = X
 		add_program(null, SNP.copy())
@@ -153,7 +157,7 @@
 		if(backup)
 			var/datum/component/nanites/cloud_copy = backup.nanites
 			if(cloud_copy)
-				sync(null, cloud_copy)
+				sync(source = cloud_copy)
 				return
 	//Without cloud syncing nanites can accumulate errors and/or defects
 	if(prob(8) && programs.len)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -138,7 +138,7 @@
 		//copying over nanite programs/cloud sync with 50% saturation in host and spare
 		owner_nanites.nanite_volume *= 0.5
 		spare.AddComponent(/datum/component/nanites, owner_nanites.nanite_volume)
-		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner_nanites, TRUE, TRUE) //The trues are to copy activation as well
+		SEND_SIGNAL(spare, COMSIG_NANITE_SYNC, owner_nanites, TRUE, TRUE, TRUE) //The trues are to copy activation as well
 
 	H.blood_volume *= 0.45
 	H.notransform = 0

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -261,7 +261,7 @@
 	SSblackbox.record_feedback("tally", "slime_babies_born", 1, M.colour)
 	if(original_nanites)
 		M.AddComponent(/datum/component/nanites, original_nanites.nanite_volume*0.25)
-		SEND_SIGNAL(M, COMSIG_NANITE_SYNC, original_nanites, TRUE, TRUE) //The trues are to copy activation as well
+		SEND_SIGNAL(M, COMSIG_NANITE_SYNC, original_nanites, TRUE, TRUE, TRUE) //The trues are to copy activation as well
 	return M
 
 /mob/living/simple_animal/slime/proc/teleport()

--- a/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -57,6 +57,7 @@
 
 	var/datum/nanite_cloud_backup/backup = new(src)
 	var/datum/component/nanites/cloud_copy = backup.AddComponent(/datum/component/nanites)
+	cloud_copy.cloud_id = cloud_id
 	backup.cloud_id = cloud_id
 	backup.nanites = cloud_copy
 	investigate_log("[key_name(user)] created a new nanite cloud backup with id #[cloud_id]", INVESTIGATE_NANITES)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes `COMSIG_NANITE_SYNC`, by default, copy the cloud ID and such of the source nanites into the target nanites. This means that slimes/slimepeople will keep their cloud ID when splitting, and nanite sting/infective exo-locomotion (which barely works btw, which I plan to fix in another PR)

**Note**: this is a part of a series of PRs porting individual parts of a nanite rework I was working on.

## Why It's Good For The Game

Allows for more !!!FUN!!! shenanigans to occur with nanites. Also just a mild convenience for slimepeople.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/979f4977-0568-4a8e-ac70-d68bde954850)

</details>

## Changelog
:cl:
tweak: Forceful nanite syncs (slime/person splitting, nanite sting, infective exo-locomotion) now copy settings such as cloud ID.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
