### PR TITLE
Syndicate teleporter rework

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -7,7 +7,7 @@
 // asoundout: soundfile to play after teleportation
 // no_effects: disable the default effectin/effectout of sparks
 // forced: whether or not to ignore no_teleport
-/proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE, teleport_mode = TELEPORT_MODE_DEFAULT)
+/proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE, teleport_mode = TELEPORT_MODE_DEFAULT, commit = TRUE)
 	// teleporting most effects just deletes them
 	var/static/list/delete_atoms = typecacheof(list(
 		/obj/effect,
@@ -26,7 +26,7 @@
 	if(channel != TELEPORT_CHANNEL_FREE && channel != TELEPORT_CHANNEL_WORMHOLE)
 		for (var/obj/machinery/bluespace_anchor/anchor as() in GLOB.active_bluespace_anchors)
 			//Not nearby
-			if (anchor.get_virtual_z_level() != teleatom.get_virtual_z_level() || get_dist(teleatom, anchor) > anchor.range)
+			if (anchor.get_virtual_z_level() != teleatom.get_virtual_z_level() || (get_dist(teleatom, anchor) > anchor.range && get_dist(destination, anchor) > anchor.range))
 				continue
 			//Check it
 			if(!anchor.try_activate())
@@ -85,6 +85,9 @@
 
 	if(isobserver(teleatom))
 		teleatom.abstract_move(destturf)
+		return TRUE
+
+	if (!commit)
 		return TRUE
 
 	tele_play_specials(teleatom, curturf, effectin, asoundin)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -247,7 +247,7 @@
 	var/charges = 4
 	//The maximum number of stored uses
 	var/max_charges = 4
-	var/minimum_teleport_distance = 4
+	var/minimum_teleport_distance = 6
 	var/maximum_teleport_distance = 8
 	//How far the emergency teleport checks for a safe position
 	var/parallel_teleport_distance = 3
@@ -308,78 +308,58 @@
 
 	var/mob/living/carbon/C = user
 	var/teleport_distance = rand(minimum_teleport_distance,maximum_teleport_distance)
-	var/turf/destination = get_teleport_loc(current_location,C,teleport_distance,0,0,0,0,0,0)
 	var/list/bagholding = user.GetAllContents(/obj/item/storage/backpack/holding)
+	var/direction = (EMP_D || length(bagholding)) ? pick(GLOB.cardinals) : user.dir
 
-	if(isclosedturf(destination))
-		if(!EMP_D && !(bagholding.len))
-			panic_teleport(user, destination) //We're in a wall, engage emergency parallel teleport.
-		else
-			get_fragged(user, destination) //EMP teleported you into a wall? Wearing a BoH? You're dead.
-	else
-		telefrag(destination, user)
-		do_teleport(C, destination, channel = TELEPORT_CHANNEL_BLINK)
-		charges--
-		check_charges()
-		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(current_location)
-		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(destination)
-		playsound(destination, 'sound/effects/phasein.ogg', 25, 1)
-		playsound(destination, "sparks", 50, 1)
+	for (var/i in 1 to teleport_distance)
+		// Step forward
+		var/turf/previous = current_location
+		current_location = get_step(current_location, direction)
 
-/obj/item/teleporter/proc/panic_teleport(mob/user, turf/destination)
-	var/mob/living/carbon/C = user
-	var/turf/mobloc = get_turf(C)
-	var/turf/emergency_destination = get_teleport_loc(destination,C,0,0,1,parallel_teleport_distance,0,0,0)
+		// Check if we can move here
+		current_area = current_location.loc
+		if(!current_location || current_area.teleport_restriction || is_away_level(current_location.z) || is_centcom_level(current_location.z) || !isturf(user.loc))//If turf was not found or they're on z level 2 or >7 which does not currently exist. or if user is not located on a turf
+			current_location = previous
+			break
+		// If it contains objects, try to break it
+		for (var/obj/object in current_location.contents)
+			if (object.density)
+				object.take_damage(150)
+		if (current_location.is_blocked_turf(TRUE))
+			current_location = previous
+			break
 
-	if(emergency_destination)
-		telefrag(emergency_destination, user)
-		do_teleport(C, emergency_destination, channel = TELEPORT_CHANNEL_BLINK)
-		charges--
-		check_charges()
-		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(mobloc)
-		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(emergency_destination)
-		playsound(emergency_destination, 'sound/effects/phasein.ogg', 25, 1)
-		playsound(emergency_destination, "sparks", 50, 1)
-	else //We tried to save. We failed. Death time.
-		get_fragged(user, destination)
+		// Telefrag this location
+		if (!telefrag(current_location, user))
+			current_location = previous
+			break
 
-/obj/item/teleporter/proc/get_fragged(mob/user, turf/destination)
-	var/turf/mobloc = get_turf(user)
-	if(do_teleport(user, destination, channel = TELEPORT_CHANNEL_BLINK, no_effects = TRUE))
-		playsound(mobloc, "sparks", 50, TRUE)
-		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(mobloc)
-		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(destination)
-		playsound(destination, "sparks", 50, TRUE)
-		playsound(destination, "sound/magic/disintegrate.ogg", 50, TRUE)
-		to_chat(user, "<span class='userdanger'>You teleport into the wall, the teleporter tries to save you, but-</span>")
-		destination.ex_act(2) //Destroy the wall
-		user.gib()
+	new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(get_turf(user))
+	new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(current_location)
+	do_teleport(C, current_location, channel = TELEPORT_CHANNEL_BLINK)
+	charges--
+	check_charges()
+	playsound(current_location, 'sound/effects/phasein.ogg', 25, 1)
+	playsound(current_location, "sparks", 50, 1)
 
 /obj/item/teleporter/proc/telefrag(turf/fragging_location, mob/user)
-	for(var/mob/living/M in fragging_location)//Hit everything in the turf
-		M.apply_damage(20, BRUTE)
-		M.Paralyze(30)
-		to_chat(M, "<span class='userdanger'>[user] teleports into you, knocking you to the floor with the bluespace wave!</span>")
-
-/obj/item/paper/teleporter
-	name = "Teleporter Guide"
-	icon_state = "paper"
-	default_raw_text = {"<b>Instructions on your new prototype syndicate teleporter:</b><br>
-	<br>
-	This experimental teleporter will teleport the user 4-8 meters in the direction they are facing. Anything you are pulling will not be teleported with you.<br>
-	<br>
-	It has 4 charges, and will recharge over time. No, sticking the teleporter into the tesla, an APC, a microwave, or an electrified door will not make it charge faster.<br>
-	<br>
-	<b>Warning:</b> Teleporting into walls will activate a failsafe teleport parallel up to 3 meters, but the user will be ripped apart and gibbed in the wall if it fails to find a safe location.<br>
-	<br>
-	Do not expose the teleporter to electromagnetic pulses, or possess a bag of holding while operating it. Unwanted malfunctions may occur.
-"}
-/obj/item/storage/box/syndie_kit/teleporter
-	name = "syndicate teleporter kit"
-
-/obj/item/storage/box/syndie_kit/teleporter/PopulateContents()
-	new /obj/item/teleporter(src)
-	new /obj/item/paper/teleporter(src)
+	for(var/mob/living/target in fragging_location)//Hit everything in the turf
+		// Skip any mobs that aren't standing, or aren't dense
+		if (!(target.mobility_flags & MOBILITY_STAND) || !target.density)
+			continue
+		// Run armour checks and apply damage
+		var/armor_block = target.run_armor_check(BODY_ZONE_CHEST, MELEE)
+		target.apply_damage(25, BRUTE, blocked = armor_block)
+		target.Paralyze(10 * (100 - armor_block) / 100)
+		target.Knockdown(40 * (100 - armor_block) / 100)
+		// Check if we successfully knocked them down
+		if (!(target.mobility_flags & MOBILITY_STAND))
+			to_chat(target, "<span class='userdanger'>[user] teleports into you, knocking you to the floor with the bluespace wave!</span>")
+		else
+			to_chat(user, "<span class='userdanger'>[target] resists the force of your jaunt's wake, bringing you to stop!</span>")
+			to_chat(target, "<span class='userdanger'>[user] slams into you, falling out of their bluespace jaunt tunnel!</span>")
+			return FALSE
+	return TRUE
 
 /obj/effect/temp_visual/teleport_abductor/syndi_teleporter
 	duration = 5

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -320,7 +320,7 @@
 
 		// Check if we can move here
 		current_area = current_location.loc
-		if(!current_location || current_area.teleport_restriction || is_away_level(current_location.z) || is_centcom_level(current_location.z) || !isturf(user.loc))//If turf was not found or they're on z level 2 or >7 which does not currently exist. or if user is not located on a turf
+		if(!do_teleport(C, current_location, no_effects = TRUE, channel = TELEPORT_CHANNEL_BLINK))//If turf was not found or they're on z level 2 or >7 which does not currently exist. or if user is not located on a turf
 			current_location = previous
 			break
 		// If it contains objects, try to break it
@@ -338,7 +338,6 @@
 
 	new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(get_turf(user))
 	new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(current_location)
-	do_teleport(C, current_location, channel = TELEPORT_CHANNEL_BLINK)
 	charges--
 	check_charges()
 	playsound(current_location, 'sound/effects/phasein.ogg', 25, 1)
@@ -347,7 +346,7 @@
 /obj/item/teleporter/proc/telefrag(turf/fragging_location, mob/user)
 	for(var/mob/living/target in fragging_location)//Hit everything in the turf
 		// Skip any mobs that aren't standing, or aren't dense
-		if (!(target.mobility_flags & MOBILITY_STAND) || !target.density)
+		if (!(target.mobility_flags & MOBILITY_STAND) || !target.density || user == target)
 			continue
 		// Run armour checks and apply damage
 		var/armor_block = target.run_armor_check(BODY_ZONE_CHEST, MELEE)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -320,7 +320,7 @@
 
 		// Check if we can move here
 		current_area = current_location.loc
-		if(!do_teleport(C, current_location, no_effects = TRUE, channel = TELEPORT_CHANNEL_BLINK))//If turf was not found or they're on z level 2 or >7 which does not currently exist. or if user is not located on a turf
+		if(!do_teleport(C, current_location, no_effects = TRUE, channel = TELEPORT_CHANNEL_BLINK, commit = FALSE))//If turf was not found or they're on z level 2 or >7 which does not currently exist. or if user is not located on a turf
 			current_location = previous
 			break
 		// If it contains objects, try to break it
@@ -335,6 +335,8 @@
 		if (!telefrag(current_location, user))
 			current_location = previous
 			break
+
+	do_teleport(C, current_location, channel = TELEPORT_CHANNEL_BLINK)
 
 	new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(get_turf(user))
 	new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(current_location)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -231,8 +231,10 @@
  */
 
 /obj/item/teleporter
-	name = "syndicate teleporter"
-	desc = "A Syndicate reverse-engineered version of the Nanotrasen portable handheld teleporter. It uses bluespace technology to translocate users, but lacks the advanced safety features of its counterpart. Warranty voided if exposed to an electromagnetic pulse."
+	name = "syndicate jaunter"
+	desc = "A device created by the syndicate in order to mimic the effects of the hand teleporter, using reverse-engineered jaunters obtained from captured miners. \
+		While it fails to allow for long-range teleportation and teleportation through matter, the combat potential of the bluespace wake created as a result of \
+		using the device far exceeds that of what Nanotrasen has been able to produce, mainly due to the fact that the Syndicate don't see it as an unwanted side effect."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "syndi_tele"
 	item_state = "electronic"

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -232,8 +232,8 @@
 
 /obj/item/teleporter
 	name = "syndicate jaunter"
-	desc = "A device created by the syndicate in order to mimic the effects of the hand teleporter, using reverse-engineered jaunters obtained from captured miners. \
-		While it fails to allow for long-range teleportation and teleportation through matter, the combat potential of the bluespace wake created as a result of \
+	desc = "A device created by the Syndicate in order to mimic the effects of the hand teleporter which uses reverse-engineered jaunters obtained from captured miners. \
+		While it fails to allow for long-range teleportation and teleportation through solid matter, the combat potential of the bluespace wake created as a result of \
 		using the device far exceeds that of what Nanotrasen has been able to produce, mainly due to the fact that the Syndicate don't see it as an unwanted side effect."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "syndi_tele"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1639,13 +1639,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	illegal_tech = FALSE
 
 /datum/uplink_item/device_tools/syndicate_teleporter
-	name = "Experimental Syndicate Teleporter"
-	desc = "The Syndicate teleporter is a handheld device that teleports the user 4-8 meters forward. \
-			Beware, teleporting into a wall will make the teleporter do a parallel emergency teleport, \
-			but if that emergency teleport fails, it will kill you instantly. \
-			Has 4 charges, recharges automatically. Warranty voided if exposed to EMP."
-	item = /obj/item/storage/box/syndie_kit/teleporter
-	cost = 8
+	name = "Experimental Syndicate Jaunter"
+	desc = "The Syndicate jaunter is a handheld device that jaunts the user 4-8 meters forward. \
+		Anyone caught in the wake of the jaunter will be knocked off their feet and recieve minor damage. \
+		Due to the Syndicate's more limited research of teleportation technologies, it is incapable of phasing the user \
+		through solid matter nor is it capable of teleporting them across longer ranges."
+	item = /obj/item/teleporter
+	cost = 7
 
 /datum/uplink_item/device_tools/frame
 	name = "F.R.A.M.E. PDA Disk"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- The syndicate teleporter now costs 7 TC instead of 8 TC
- The syndicate teleporter can no longer teleport through solid objects or walls
  - The syndicate teleporter will deal 150 structural damage to any solid objects, if it is broken, then you can travel through them.
- The syndicate teleporter's damage has been upped to 25, however it now respects armour blocking
- The syndicate teleporter's paralysis time has been reduced to 1 seconds from 3, but now deals 4 seconds of knockdown additionally, which will be reduced proportional to the armour rating of the target
- Wearing a BOH or being EMPed will now result in a random direction teleport rather than allowing the user to be gibbed.

## Why It's Good For The Game

The syndicate teleporter was created as an item to be used in combat, however it has significant design flaws:
- Gameplay issues: The syndicate teleporter can be used as a stealth item, which has the positives of an emag (free entry to almost all locations) without leaving behind any evidence. This has lead to them being severely over-used on lowpop rounds in order to quickly break into the captain's office without anyway to stop it.
- 'Insta-win' combat issues: The syndicate teleporter can randomly gib its user if the (really bad) emergency teleport fails to save the user. This is surprisingly common and a source of frustration for the users.
- Useless in combat: you have to land exactly on the target in order to get the weak telefrag effect to apply. This is surprisingly difficult when the teleport distance is entirely random.
- Lore continuity issues: The syndicate only have access to worse, stolen, or remodified nanotrasen tech and not their own teleportation devices (otherwise why would they be stealing them).

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8a6d4dd3-e209-4f38-9981-e89285fc4f6d

## Changelog
:cl:
balance: Syndicate teleporter has been reworked. It will no longer teleport through solid walls but will be more effective at knocking down targets in a combat scenario, as it will knock down any targets passed through during a teleport. It can be used to jump through windows without being shocked. The price has been reduced from 8 TC to 7.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
