### PR TITLE
Blood filtering tweaks and fixes

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -59,9 +59,12 @@
 /datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/tox_loss = target.getToxLoss()
 	if(target.reagents.total_volume || (tox_heal_factor > 0 && tox_loss > 0))
-		for(var/blood_chem in target.reagents.reagent_list)
-			var/datum/reagent/chem = blood_chem
-			target.reagents.remove_reagent(chem.type, min(chem.volume * chem_purge_factor, 10)) //Removes more reagent for higher amounts
+		if(target.reagents.total_volume <= 2)
+			target.reagents.clear_reagents()
+		else
+			for(var/blood_chem in target.reagents.reagent_list)
+				var/datum/reagent/chem = blood_chem
+				target.reagents.remove_reagent(chem.type, min(chem.volume * chem_purge_factor, 10)) //Removes more reagent for higher amounts
 		if(tox_heal_factor > 0)
 			if(tox_loss <= 2)
 				target.setToxLoss(0)

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -73,7 +73,7 @@
 				remaining += "<font color='[COLOR_GREEN]'>[round(tox_loss, 0.1)]</font> toxin"
 			if(target.reagents.total_volume)
 				remaining += "<font color='[COLOR_MAGENTA]'>[round(target.reagents.total_volume, 0.1)]u</font> of reagents"
-		var/umsg = length(remaining) ? " [english_list(remaining)]" : ""
+		var/umsg = length(remaining) ? " [english_list(remaining)] remaining." : ""
 		display_results(user, target, "<span class='notice'>[tool] pings as it filters [target]'s blood.[umsg]</span>",
 				"<span class='notice'>[user] pumps [target]'s blood with [tool].</span>",
 				"[tool] pings as it pumps.")

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -79,7 +79,7 @@
 				"[tool] pings as it pumps.")
 	else
 		display_results(user, target, "<span class='notice'>[tool] flashes, [target]'s blood is clean.</span>",
-			"<span class='notice'>[user] finishes pumping [target]s' blood with [tool]</span>",
+			"<span class='notice'>[user] finishes pumping [target]'s blood with [tool]</span>",
 			"[tool] has no chemicals or toxins to filter.")
 	if(istype(surgery, /datum/surgery/blood_filter))
 		var/datum/surgery/blood_filter/the_surgery = surgery

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -59,12 +59,9 @@
 /datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/tox_loss = target.getToxLoss()
 	if(target.reagents.total_volume || (tox_heal_factor > 0 && tox_loss > 0))
-		if(target.reagents.total_volume <= 2)
-			target.reagents.clear_reagents()
-		else
-			for(var/blood_chem in target.reagents.reagent_list)
-				var/datum/reagent/chem = blood_chem
-				target.reagents.remove_reagent(chem.type, min(chem.volume * chem_purge_factor, 10)) //Removes more reagent for higher amounts
+		for(var/blood_chem in target.reagents.reagent_list)
+			var/datum/reagent/chem = blood_chem
+			target.reagents.remove_reagent(chem.type, min(chem.volume * chem_purge_factor, 10)) //Removes more reagent for higher amounts
 		if(tox_heal_factor > 0)
 			if(tox_loss <= 2)
 				target.setToxLoss(0)

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -57,20 +57,30 @@
 				break
 
 /datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
-	if(target.reagents.total_volume || (tox_heal_factor > 0 && target.getToxLoss() > 0))
+	var/tox_loss = target.getToxLoss()
+	if(target.reagents.total_volume || (tox_heal_factor > 0 && tox_loss > 0))
 		for(var/blood_chem in target.reagents.reagent_list)
 			var/datum/reagent/chem = blood_chem
 			target.reagents.remove_reagent(chem.type, min(chem.volume * chem_purge_factor, 10)) //Removes more reagent for higher amounts
 		if(tox_heal_factor > 0)
-			var/healing_amount = target.getToxLoss() <= 1 ? 0.5 : (target.getToxLoss() * tox_heal_factor)
-			target.adjustToxLoss(-healing_amount, forced=TRUE) //forced so this will actually heal oozelings too
-		display_results(user, target, "<span class='notice'>[tool] pings as it finishes filtering [target]'s blood.</span>",
-			"<span class='notice'>[tool] pings as it stops pumping your blood.</span>",
-			"[tool] pings as it stops pumping.")
+			if(tox_loss <= 2)
+				target.setToxLoss(0)
+			else
+				target.adjustToxLoss(-(tox_loss * tox_heal_factor), forced=TRUE) //forced so this will actually heal oozelings too
+		var/list/remaining = list()
+		if(locate(/obj/item/healthanalyzer) in user.held_items)
+			if(tox_heal_factor > 0 && tox_loss > 0)
+				remaining += "<font color='[COLOR_GREEN]'>[round(tox_loss, 0.1)]</font> toxin"
+			if(target.reagents.total_volume)
+				remaining += "<font color='[COLOR_MAGENTA]'>[round(target.reagents.total_volume, 0.1)]u</font> of reagents"
+		var/umsg = length(remaining) ? " [english_list(remaining)]" : ""
+		display_results(user, target, "<span class='notice'>[tool] pings as it filters [target]'s blood.[umsg]</span>",
+				"<span class='notice'>[user] pumps [target]'s blood with [tool].</span>",
+				"[tool] pings as it pumps.")
 	else
 		display_results(user, target, "<span class='notice'>[tool] flashes, [target]'s blood is clean.</span>",
-			"<span class='notice'>[tool] flashes, your blood is clean.</span>",
-			"[tool] has no chemcials to filter.")
+			"<span class='notice'>[user] finishes pumping [target]s' blood with [tool]</span>",
+			"[tool] has no chemicals or toxins to filter.")
 	if(istype(surgery, /datum/surgery/blood_filter))
 		var/datum/surgery/blood_filter/the_surgery = surgery
 		the_surgery.antispam = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes a few tweaks and fixes to blood filtering:
- Blood filtering won't take forever trying to wean off the last 1 toxin damage in someone
- Holding a health analyzer in your other hand will show the tox damage + reagent volume left, similar to wound tending surgery.
- Tweaked the surgery messages for filtering blood so that they appear properly to third party observers.

## Why It's Good For The Game

QoL feature

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-06-03-1685766399-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/31ace098-1118-4676-8ce9-3c8bf5f0e470)


</details>

## Changelog
:cl:
fix: Blood filtering won't take forever trying to wean off the last 1 toxin damage in someone
add: Holding a health analyzer in your other hand during blood filtering surgery will show the remaining toxin damage and reagent volume, similar to wound tending surgery.
tweak: Tweaked the surgery messages for filtering blood so that they appear properly to third party observers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
