### PR TITLE
Ghosts can now see normally hidden implants and viruses when health scanning someone

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -439,7 +439,11 @@ GENE SCANNER
 
 	for(var/thing in M.diseases)
 		var/datum/disease/D = thing
-		if(!(D.visibility_flags & HIDDEN_SCANNER))
+		if(isobserver(user) || !(D.visibility_flags & HIDDEN_SCANNER))
+			if(istype(D, /datum/disease/advance))
+				var/datum/disease/advance/advance_disease = D
+				if(advance_disease.dormant)
+					continue
 			message += "<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text]</span>"
 
 	// Blood Level
@@ -468,7 +472,7 @@ GENE SCANNER
 
 		var/list/cyberimp_detect = list()
 		for(var/obj/item/organ/cyberimp/CI in C.internal_organs)
-			if(CI.status == ORGAN_ROBOTIC && !CI.syndicate_implant)
+			if(CI.status == ORGAN_ROBOTIC && (isobserver(user) || !CI.syndicate_implant))
 				cyberimp_detect += CI.name
 		if(length(cyberimp_detect))
 			message += "<span class='notice'>Detected cybernetic modifications:</span>"


### PR DESCRIPTION


## About The Pull Request

This makes it so ghosts can see hidden (but not dormant) viruses and hidden cybernetic implants when health scanning someone.

## Why It's Good For The Game

QoL for ghosts that makes it easier for ghosts to know when shenanigans are happening.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-06-03-1685767831-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/59d46aea-6e75-4b1f-88cf-d7c1044b4b4b)

</details>

## Changelog
:cl:
add: Ghosts can now see stealthy viruses and hidden cybernetic implants when health scanning someone. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
