### PR TITLE
Fixes an already-initialized mind is being initialized again to get antag datum

### DIFF
--- a/code/controllers/configuration/entries/policies.dm
+++ b/code/controllers/configuration/entries/policies.dm
@@ -3,3 +3,6 @@
 
 /datum/config_entry/string/policy_polymorph
 	config_entry_value = "<span class='boldannounce'>Even if you take the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>"
+
+/datum/config_entry/string/non_antag_mind
+	config_entry_value = "<span class='boldannounce'>You're playing a character that is known as an antagonist, but your mind IS NOT antagonist. Please avoid antagonism.</span>"

--- a/code/controllers/configuration/entries/policies.dm
+++ b/code/controllers/configuration/entries/policies.dm
@@ -6,3 +6,11 @@
 
 /datum/config_entry/string/non_antag_mind
 	config_entry_value = "<span class='boldannounce'>You're playing a character that is known as an antagonist, but your mind IS NOT antagonist. Please avoid antagonism.</span>"
+
+/// announces the policy as long as their mind is not antag
+/proc/announce_non_antag_mind_policy(mob/living/target_user)
+	var/datum/mind/mind = target_user.mind
+	if(!mind.has_antag_datum(/datum/antagonist, TRUE))
+		var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
+		if(non_antag_mind_msg)
+			to_chat(target_user, non_antag_mind_msg)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -776,9 +776,11 @@
 /mob/dead/observer/sync_mind()
 	return
 
-//Initialisation procs
+/// This is also called by `sync_mind()`.
+/// skip_initialization parameter is used to prevent a transformed player (person -> xeno) getting a bad mind init.
+/// For example, if a crew becomes a morph, a xenomorph, they're really not an antag, but they get antag datum...
 /mob/proc/mind_initialize(skip_initialization=FALSE)
-	if(!skip_initialization)
+	if(skip_initialization) // they have mind already. No need to make a new one.
 		mind.key = key
 	else
 		mind = new /datum/mind(key)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -762,7 +762,7 @@
 				return TRUE
 
 /mob/proc/sync_mind()
-	mind_initialize()	//updates the mind (or creates and initializes one if one doesn't exist)
+	mind_initialize(already_initialized = (mind ? TRUE : FALSE))	//updates the mind (or creates and initializes one if one doesn't exist)
 	mind.active = 1		//indicates that the mind is currently synced with a client
 
 /datum/mind/proc/has_martialart(var/string)
@@ -777,10 +777,9 @@
 	return
 
 //Initialisation procs
-/mob/proc/mind_initialize()
-	if(mind)
+/mob/proc/mind_initialize(already_initialized=FALSE)
+	if(already_initialized)
 		mind.key = key
-
 	else
 		mind = new /datum/mind(key)
 		SSticker.minds += mind
@@ -788,28 +787,28 @@
 		mind.name = real_name
 	mind.set_current(src)
 
-/mob/living/carbon/mind_initialize()
+/mob/living/carbon/mind_initialize(already_initialized=FALSE)
 	..()
 	last_mind = mind
 
 //HUMAN
-/mob/living/carbon/human/mind_initialize()
+/mob/living/carbon/human/mind_initialize(already_initialized=FALSE)
 	..()
 	if(!mind.assigned_role)
 		mind.assigned_role = "Unassigned" //default
 
 //AI
-/mob/living/silicon/ai/mind_initialize()
+/mob/living/silicon/ai/mind_initialize(already_initialized=FALSE)
 	..()
 	mind.assigned_role = JOB_NAME_AI
 
 //BORG
-/mob/living/silicon/robot/mind_initialize()
+/mob/living/silicon/robot/mind_initialize(already_initialized=FALSE)
 	..()
 	mind.assigned_role = JOB_NAME_CYBORG
 
 //PAI
-/mob/living/silicon/pai/mind_initialize()
+/mob/living/silicon/pai/mind_initialize(already_initialized=FALSE)
 	..()
 	mind.assigned_role = ROLE_PAI
 	mind.special_role = ""

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -762,7 +762,7 @@
 				return TRUE
 
 /mob/proc/sync_mind()
-	mind_initialize(already_initialized = (mind ? TRUE : FALSE))	//updates the mind (or creates and initializes one if one doesn't exist)
+	mind_initialize(skip_initialization = mind)	//updates the mind (or creates and initializes one if one doesn't exist)
 	mind.active = 1		//indicates that the mind is currently synced with a client
 
 /datum/mind/proc/has_martialart(var/string)
@@ -777,8 +777,8 @@
 	return
 
 //Initialisation procs
-/mob/proc/mind_initialize(already_initialized=FALSE)
-	if(already_initialized)
+/mob/proc/mind_initialize(skip_initialization=FALSE)
+	if(!skip_initialization)
 		mind.key = key
 	else
 		mind = new /datum/mind(key)
@@ -787,28 +787,28 @@
 		mind.name = real_name
 	mind.set_current(src)
 
-/mob/living/carbon/mind_initialize(already_initialized=FALSE)
+/mob/living/carbon/mind_initialize(skip_initialization=FALSE)
 	..()
 	last_mind = mind
 
 //HUMAN
-/mob/living/carbon/human/mind_initialize(already_initialized=FALSE)
+/mob/living/carbon/human/mind_initialize(skip_initialization=FALSE)
 	..()
 	if(!mind.assigned_role)
 		mind.assigned_role = "Unassigned" //default
 
 //AI
-/mob/living/silicon/ai/mind_initialize(already_initialized=FALSE)
+/mob/living/silicon/ai/mind_initialize(skip_initialization=FALSE)
 	..()
 	mind.assigned_role = JOB_NAME_AI
 
 //BORG
-/mob/living/silicon/robot/mind_initialize(already_initialized=FALSE)
+/mob/living/silicon/robot/mind_initialize(skip_initialization=FALSE)
 	..()
 	mind.assigned_role = JOB_NAME_CYBORG
 
 //PAI
-/mob/living/silicon/pai/mind_initialize(already_initialized=FALSE)
+/mob/living/silicon/pai/mind_initialize(skip_initialization=FALSE)
 	..()
 	mind.assigned_role = ROLE_PAI
 	mind.special_role = ""

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -290,9 +290,12 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		forceMove(NewLoc)
 		return TRUE
 
-/mob/camera/blob/mind_initialize(already_initialized=FALSE)
+/mob/camera/blob/mind_initialize(skip_initialization=FALSE)
 	. = ..()
-	if(already_initialized) // for some reason, they transformed into a blob...
-		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	if(skip_initialization)
+		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
+			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
+			if(non_antag_mind_msg)
+				to_chat(src, non_antag_mind_msg)
 	else if(!mind.has_antag_datum(/datum/antagonist/blob))
 		mind.add_antag_datum(/datum/antagonist/blob)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -290,8 +290,9 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		forceMove(NewLoc)
 		return TRUE
 
-/mob/camera/blob/mind_initialize()
+/mob/camera/blob/mind_initialize(already_initialized=FALSE)
 	. = ..()
-	var/datum/antagonist/blob/B = mind.has_antag_datum(/datum/antagonist/blob)
-	if(!B)
+	if(already_initialized) // for some reason, they transformed into a blob...
+		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	else if(!mind.has_antag_datum(/datum/antagonist/blob))
 		mind.add_antag_datum(/datum/antagonist/blob)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -292,10 +292,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /mob/camera/blob/mind_initialize(skip_initialization=FALSE)
 	. = ..()
-	if(skip_initialization)
-		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
-			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
-			if(non_antag_mind_msg)
-				to_chat(src, non_antag_mind_msg)
-	else if(!mind.has_antag_datum(/datum/antagonist/blob))
+	if(!skip_initialization && !mind.has_antag_datum(/datum/antagonist/blob))
 		mind.add_antag_datum(/datum/antagonist/blob)
+
+	announce_non_antag_mind_policy(src)

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -263,11 +263,14 @@
 	else
 		..()
 
-/mob/living/simple_animal/hostile/morph/mind_initialize(already_initialized=FALSE)
+/mob/living/simple_animal/hostile/morph/mind_initialize(skip_initialization=FALSE)
 	. = ..()
 	to_chat(src, playstyle_string)
-	if(already_initialized)
-		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	if(skip_initialization)
+		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
+			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
+			if(non_antag_mind_msg)
+				to_chat(src, non_antag_mind_msg)
 	else if(!mind.has_antag_datum(/datum/antagonist/morph))
 		mind.add_antag_datum(/datum/antagonist/morph)
 

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -266,13 +266,10 @@
 /mob/living/simple_animal/hostile/morph/mind_initialize(skip_initialization=FALSE)
 	. = ..()
 	to_chat(src, playstyle_string)
-	if(skip_initialization)
-		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
-			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
-			if(non_antag_mind_msg)
-				to_chat(src, non_antag_mind_msg)
-	else if(!mind.has_antag_datum(/datum/antagonist/morph))
+	if(!skip_initialization && !mind.has_antag_datum(/datum/antagonist/morph))
 		mind.add_antag_datum(/datum/antagonist/morph)
+
+	announce_non_antag_mind_policy(src)
 
 //Spawn Event
 /datum/round_event_control/morph

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -263,18 +263,15 @@
 	else
 		..()
 
-/mob/living/simple_animal/hostile/morph/mind_initialize()
+/mob/living/simple_animal/hostile/morph/mind_initialize(already_initialized=FALSE)
 	. = ..()
 	to_chat(src, playstyle_string)
-	// sometimes the datum is not added for a bit
-	addtimer(CALLBACK(src, PROC_REF(notify_non_antag)), 3 SECONDS)
-
-/mob/living/simple_animal/hostile/morph/proc/notify_non_antag()
-	if(!mind.has_antag_datum(/datum/antagonist/morph))
+	if(already_initialized)
 		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	else if(!mind.has_antag_datum(/datum/antagonist/morph))
+		mind.add_antag_datum(/datum/antagonist/morph)
 
 //Spawn Event
-
 /datum/round_event_control/morph
 	name = "Spawn Morph"
 	typepath = /datum/round_event/ghost_role/morph

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -107,10 +107,13 @@
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
 
-/mob/living/simple_animal/hostile/swarmer/mind_initialize()
+/mob/living/simple_animal/hostile/swarmer/mind_initialize(already_initialized=FALSE)
 	. = ..()
-	var/datum/antagonist/swarmer/S = new()
-	mind.add_antag_datum(S)
+	if(already_initialized)
+		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	else if(!mind.has_antag_datum(/datum/antagonist/swarmer))
+		var/datum/antagonist/swarmer/S = new()
+		mind.add_antag_datum(S)
 
 /mob/living/simple_animal/hostile/swarmer/med_hud_set_health()
 	var/image/holder = hud_list[DIAG_HUD]

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -109,13 +109,10 @@
 
 /mob/living/simple_animal/hostile/swarmer/mind_initialize(skip_initialization=FALSE)
 	. = ..()
-	if(skip_initialization)
-		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
-			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
-			if(non_antag_mind_msg)
-				to_chat(src, non_antag_mind_msg)
-	else if(!mind.has_antag_datum(/datum/antagonist/swarmer))
+	if(!skip_initialization && !mind.has_antag_datum(/datum/antagonist/swarmer))
 		mind.add_antag_datum(/datum/antagonist/swarmer)
+
+	announce_non_antag_mind_policy(src)
 
 /mob/living/simple_animal/hostile/swarmer/med_hud_set_health()
 	var/image/holder = hud_list[DIAG_HUD]

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -107,10 +107,13 @@
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
 
-/mob/living/simple_animal/hostile/swarmer/mind_initialize(already_initialized=FALSE)
+/mob/living/simple_animal/hostile/swarmer/mind_initialize(skip_initialization=FALSE)
 	. = ..()
-	if(already_initialized)
-		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	if(skip_initialization)
+		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
+			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
+			if(non_antag_mind_msg)
+				to_chat(src, non_antag_mind_msg)
 	else if(!mind.has_antag_datum(/datum/antagonist/swarmer))
 		mind.add_antag_datum(/datum/antagonist/swarmer)
 

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -112,8 +112,7 @@
 	if(already_initialized)
 		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
 	else if(!mind.has_antag_datum(/datum/antagonist/swarmer))
-		var/datum/antagonist/swarmer/S = new()
-		mind.add_antag_datum(S)
+		mind.add_antag_datum(/datum/antagonist/swarmer)
 
 /mob/living/simple_animal/hostile/swarmer/med_hud_set_health()
 	var/image/holder = hud_list[DIAG_HUD]

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -53,10 +53,13 @@
 
 
 //XENO
-/mob/living/carbon/alien/mind_initialize(already_initialized=FALSE)
+/mob/living/carbon/alien/mind_initialize(skip_initialization=FALSE)
 	..()
-	if(already_initialized)
-		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	if(skip_initialization)
+		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
+			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
+			if(non_antag_mind_msg)
+				to_chat(src, non_antag_mind_msg)
 	else if(!mind.has_antag_datum(/datum/antagonist/xeno))
 		mind.add_antag_datum(/datum/antagonist/xeno)
 

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -57,6 +57,6 @@
 	..()
 	if(already_initialized)
 		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
-	else
+	else 	if(!mind.has_antag_datum(/datum/antagonist/xeno))
 		mind.add_antag_datum(/datum/antagonist/xeno)
 

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -53,7 +53,10 @@
 
 
 //XENO
-/mob/living/carbon/alien/mind_initialize()
+/mob/living/carbon/alien/mind_initialize(already_initialized=FALSE)
 	..()
-	if(!mind.has_antag_datum(/datum/antagonist/xeno))
+	if(already_initialized)
+		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	else
 		mind.add_antag_datum(/datum/antagonist/xeno)
+

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -55,11 +55,7 @@
 //XENO
 /mob/living/carbon/alien/mind_initialize(skip_initialization=FALSE)
 	..()
-	if(skip_initialization)
-		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
-			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
-			if(non_antag_mind_msg)
-				to_chat(src, non_antag_mind_msg)
-	else if(!mind.has_antag_datum(/datum/antagonist/xeno))
+	if(!skip_initialization && !mind.has_antag_datum(/datum/antagonist/xeno))
 		mind.add_antag_datum(/datum/antagonist/xeno)
 
+	announce_non_antag_mind_policy(src)

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -57,6 +57,6 @@
 	..()
 	if(already_initialized)
 		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
-	else 	if(!mind.has_antag_datum(/datum/antagonist/xeno))
+	else if(!mind.has_antag_datum(/datum/antagonist/xeno))
 		mind.add_antag_datum(/datum/antagonist/xeno)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -710,7 +710,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 //We don't want to update the current var
 //But we will still carry a mind.
-/mob/dead/observer/mind_initialize()
+/mob/dead/observer/mind_initialize(already_initialized=FALSE)
 	return
 
 /mob/dead/observer/proc/show_ai_hud()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -710,7 +710,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 //We don't want to update the current var
 //But we will still carry a mind.
-/mob/dead/observer/mind_initialize(already_initialized=FALSE)
+/mob/dead/observer/mind_initialize(skip_initialization=FALSE)
 	return
 
 /mob/dead/observer/proc/show_ai_hud()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -80,9 +80,11 @@
 	lesserwrap = new
 	AddAbility(lesserwrap)
 
-/mob/living/simple_animal/hostile/poison/giant_spider/mind_initialize()
+/mob/living/simple_animal/hostile/poison/giant_spider/mind_initialize(already_initialized=FALSE)
 	. = ..()
-	if(!mind.has_antag_datum(/datum/antagonist/spider))
+	if(already_initialized)
+		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	else if(!mind.has_antag_datum(/datum/antagonist/spider))
 		var/datum/antagonist/spider/spooder = new
 		if(!spider_team)
 			spooder.create_team()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -80,10 +80,13 @@
 	lesserwrap = new
 	AddAbility(lesserwrap)
 
-/mob/living/simple_animal/hostile/poison/giant_spider/mind_initialize(already_initialized=FALSE)
+/mob/living/simple_animal/hostile/poison/giant_spider/mind_initialize(skip_initialization=FALSE)
 	. = ..()
-	if(already_initialized)
-		to_chat(src, "<span class='boldwarning'>If you were not an antagonist before you did not become one now. You still retain your retain your original loyalties and mind!</span>")
+	if(skip_initialization)
+		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
+			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
+			if(non_antag_mind_msg)
+				to_chat(src, non_antag_mind_msg)
 	else if(!mind.has_antag_datum(/datum/antagonist/spider))
 		var/datum/antagonist/spider/spooder = new
 		if(!spider_team)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -82,17 +82,14 @@
 
 /mob/living/simple_animal/hostile/poison/giant_spider/mind_initialize(skip_initialization=FALSE)
 	. = ..()
-	if(skip_initialization)
-		if(!mind.has_antag_datum(/datum/antagonist, TRUE))
-			var/non_antag_mind_msg = CONFIG_GET(string/non_antag_mind)
-			if(non_antag_mind_msg)
-				to_chat(src, non_antag_mind_msg)
-	else if(!mind.has_antag_datum(/datum/antagonist/spider))
+	if(!skip_initialization && !mind.has_antag_datum(/datum/antagonist/spider))
 		var/datum/antagonist/spider/spooder = new
 		if(!spider_team)
 			spooder.create_team()
 			spider_team = spooder.spider_team
 		mind.add_antag_datum(spooder, spider_team)
+
+	announce_non_antag_mind_policy(src)
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Destroy()
 	RemoveAbility(lesserwrap)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an already-initialized mind is being initialized again to get antag datum
that a crew who became xenomorph gets a xeno antag is because their mind is re-initialized again, but their mind doesn't have to be initialized unless we want something specific.
This variously fixes most a mind-that-already-exist becomes an antag because of the mind init

~~NOTE: this fix is highly encouraged to be merged after job refactor is merged.~~ Nevermind this

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixing awful logics

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/01f87e77-8937-4f00-9bb9-5b3a0bd5193d)

they're not a xenomorph

</details>

## Changelog
:cl:
fix: most cases getting a random antag status because you're transformed are now fixed. You won't get a xeno antag datum because youi're somehow transformed into xeno by transformation magic & disease, or etc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
