### PR TITLE
Ghosts are now yoinked at revival instead of five seconds ahead of it. 

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -476,10 +476,8 @@
 
 	if((!req_defib && grab_ghost) || (req_defib && defib.grab_ghost))
 		H.notify_ghost_cloning("Your heart is being defibrillated!")
-		H.grab_ghost() // Shove them back in their body.
 	else if(can_defib(H))
-		H.notify_ghost_cloning("Your heart is being defibrillated. Re-enter your corpse if you want to be revived!", source = src)
-
+		H.notify_ghost_cloning("Your heart is being defibrillated!", source = src)
 	do_help(H, user)
 
 /obj/item/shockpaddles/proc/can_defib(mob/living/carbon/H)
@@ -626,8 +624,6 @@
 					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's heart too damaged.</span>"
 				else if(total_burn >= MAX_REVIVE_FIRE_DAMAGE || total_brute >= MAX_REVIVE_BRUTE_DAMAGE || HAS_TRAIT(H, TRAIT_HUSK))
 					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Severe tissue damage makes recovery of patient impossible via defibrillator. Further attempts futile.</span>"
-				else if(H.get_ghost())
-					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - No activity in patient's brain. Further attempts may be successful.</span>"
 				else
 					var/obj/item/organ/brain/BR = H.getorgan(/obj/item/organ/brain)
 					if(BR)
@@ -635,6 +631,8 @@
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain tissue is damaged making recovery of patient impossible via defibrillator. Further attempts futile.</span>"
 						if(BR.suicided || BR.brainmob?.suiciding)
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - No intelligence pattern can be detected in patient's brain. Further attempts futile.</span>"
+						if(H.get_ghost())
+							H.grab_ghost() // Shove them back in their body now, revival is possible.
 					else
 						failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain is missing. Further attempts futile.</span>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Instead of being pulled back into the body five seconds before revival, ghosts are now pulled back into their body just ahead of the revival step to prevent ghosts from selectively refusing revivals without the use of DNR.

This ghost is still notified of every attempt to revive five seconds ahead of time, even if the revival will fail, but will only be forced back into their body if the revival passes all of its checks and will be successful. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Before this PR ghosts are pulled back to their bodies five seconds before revival, which gives them time to move back out of the body to refuse revival without actually going DNR. This has been used in combination with early ghosting to refuse to play with antagonists and then accept safe revivals by the station:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/cf73aaf3-cde6-4eb5-b7f5-cf75a8c0258d)

DNR exists for players who do not wish to be revived, and players should not be able to selectively decide who gets to revive them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_szHXTPABDK](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/82efa550-5e65-46f0-9f2d-71523de7ae5b)


## Changelog
:cl:
fix: Removes the ability for players to selectively refuse revivals by quickly leaving their body after being forced back into it. DNR will still prevent resuscitations, this only applies to players who have not enabled this. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
