### PR TITLE
Revert "removes the incusion implant (#9090)"

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -156,6 +156,17 @@
 				<b>Implant Details:</b> Allows user to use an internal radio, useful if user expects equipment loss, or cannot equip conventional radios."}
 	return dat
 
+/obj/item/implant/radio/syndicate/selfdestruct
+	name = "hacked internal radio implant"
+
+/obj/item/implant/radio/syndicate/selfdestruct/on_implanted(mob/living/user)
+	if(!user.mind.has_antag_datum(/datum/antagonist/incursion))
+		user.visible_message("<span class='warning'>[imp_in] starts beeping ominously!</span>", "<span class='userdanger'>You have a sudden feeling of dread. The implant is rigged to explode!</span>")
+		playsound(user, 'sound/items/timer.ogg', 30, 0)
+		explosion(src,0,0,2,2, flame_range = 2)
+		user.gib(1)
+		qdel(src)
+
 /obj/item/implanter/radio
 	name = "implanter (internal radio)"
 	imp_type = /obj/item/implant/radio
@@ -163,3 +174,7 @@
 /obj/item/implanter/radio/syndicate
 	name = "implanter (internal syndicate radio)"
 	imp_type = /obj/item/implant/radio/syndicate
+
+/obj/item/implanter/radio/syndicate/selfdestruct
+	name = "implanter (modified internal syndicate radio)"
+	imp_type = /obj/item/implant/radio/syndicate/selfdestruct

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -92,6 +92,8 @@
 
 /datum/antagonist/incursion/proc/equip(var/silent = FALSE)
 	owner.equip_traitor("The Syndicate", FALSE, src, 15)
+	var/obj/item/implant/radio/syndicate/selfdestruct/syndio = new
+	syndio.implant(owner.current)
 
 /datum/team/incursion
 	name = "syndicate incursion force"


### PR DESCRIPTION
## About The Pull Request

This reverts commit 8a072c686646d7c963eb63501172887a5b4b308a of PR #9090, adding back the Incursion radio implant

## Why It's Good For The Game

This PR was merged within 12 hours with zero discussion or review, and I don't think time was taken to consider the repercussions of doing so.

- Incursions now rely entirely on finding each other in person / with tracking, forcing communication with radio frequencies, or using insecure PDA messaging which could easily be identified as suspicious by security.
- Incursionists cannot purchase syndicate keys.
- Incursions still receive only 15TC despite losing at least 3TC in value.
- Incursionists don't receive codewords, and even if they did they would be useless since they're only used to identify other agents, and they already know who the other incursionists are.

Incursions while powerful vary heavily in their ability to get things done. Meeting each other in person is also strictly advantageous if that's what we're trying to accomplish. Many incursions establish a hideout. However, having a way to communicate while apart is VITAL to an incursion's function, otherwise you just get huge teamwork blunders, especially as many players are not willing to stick around and elaborate on a plan. If you need help in the moment, there is NO way to call for it. Being arrested? Tough luck. This forces incursions into stealth and they cannot rely on teammates in combat.

In conclusion, having the comms allows incursions to avoid using as much stealth, driving round conflict, and better locate members who are worse at communicating or sticking with the group. It also allows on-the-fly coordination that is not possible otherwise, as they cannot purchase radio keys anyway.

Antagonists being powerful gives sec a worthy challenge - without effective communications an incursion is no better than a collection of random traitors with less TC, and sharing objectives. This is supposed to be a tight-knit team who have infiltrated the station, a real threat to security. While it is true that incursions could reasonably stomp sec and take over, a radio uplink gives them little extra combat advantage other than organizing. They already have plenty of TC to gain effective murder devices should they wish to eliminate sec.

## Testing Photographs and Procedure

N/A

## Changelog
:cl:
balance: Re-added incursion's radio keys.
/:cl: