### PR TITLE
Manually makes the CL for #9103

### DIFF
--- a/html/changelogs/ManualChangelog-pr-9103.yml
+++ b/html/changelogs/ManualChangelog-pr-9103.yml
@@ -1,0 +1,4 @@
+author: Absolucy
+delete-after: true
+changes:
+  - tweak: Sacrificing a DNR corpse will no longer force the unwilling ghost back into their body, and will instead poll ghosts for who wants to be the shade.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some reason the action never ran to make the CL entry for #9103. I don't see any reason _why_ it wasn't triggered, but it wasn't. Maybe because the original merge queue failed? But even then, it was still a push to master which is the only trigger.