### PR TITLE
Adjusts basic shuttle tech requisites

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -685,7 +685,7 @@
 		"shuttle_creator",
 		"wingpack",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/nullspacebreaching

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -676,7 +676,7 @@
 	description = "Research the technology required to create and use basic shuttles."
 	prereq_ids = list(
 		"adv_engi",
-		"bluespace_travel",
+		"adv_plasma",
 	)
 	design_ids = list(
 		"engine_heater",
@@ -685,7 +685,7 @@
 		"shuttle_creator",
 		"wingpack",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 5000
 
 /datum/techweb_node/nullspacebreaching

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -676,7 +676,7 @@
 	description = "Research the technology required to create and use basic shuttles."
 	prereq_ids = list(
 		"adv_engi",
-		"adv_plasma",
+		"basic_plasma",
 	)
 	design_ids = list(
 		"engine_heater",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers a single requirement for the "Basic Shuttle Research" tech, and lowers its cost slightly.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

"Basic Shuttle Research" is a tier 3 tech, locked behind the most advanced bluespace tech, "Bluespace Travel", a tier 5 tech. This progression simply doesn't make sense. 

The shuttle construction technology IC already exists on station, in the form of the Aux Base constructor, and the roundstart shuttle constructorion bases in Fland and Corg.

If we want to make it so players explore our codebase's unique features, like supercruise, we need to make it more readily available, and congruent with what exists roundstart.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/2be87003-28bd-42b5-a2d5-9ddf806049d7)

</details>

## Changelog
:cl: RKz
tweak: tweaked "Basic Shuttle Research" tech to be easier to research
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
