### PR TITLE
Prevents persistent rulesets from rolling for more than 2 rounds in a row

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -192,8 +192,9 @@
 			if(istype(DR, type))
 				weight = max(weight-repeatable_weight_decrease,1)
 	var/list/repeated_mode_adjust = CONFIG_GET(number_list/repeated_mode_adjust)
-	if(CHECK_BITFIELD(flags, PERSISTENT_RULESET) && LAZYLEN(repeated_mode_adjust))
+	if(CHECK_BITFIELD(flags, PERSISTENT_RULESET) && length(repeated_mode_adjust))
 		var/adjustment = 0
+		var/occurances = 0
 		for(var/rounds_ago = 1 to min(length(SSpersistence.saved_dynamic_rulesets), length(repeated_mode_adjust)))
 			var/list/round = SSpersistence.saved_dynamic_rulesets[rounds_ago]
 			if(!round)
@@ -202,6 +203,13 @@
 				round = list(round)
 			if(name in round)
 				adjustment += repeated_mode_adjust[rounds_ago]
+				occurances += 1
+		if(occurances >= 2)
+			if(!logged_repeated_mode_adjust)
+				log_game("DYNAMIC: [src] has been disabled due to happening twice within the last [length(repeated_mode_adjust)] rounds")
+				logged_repeated_mode_adjust = TRUE
+			weight = 0
+			return weight
 		if(adjustment)
 			var/old_weight = weight
 			weight *= ((100 - adjustment) / 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This ensures dynamic rulesets with the persistent flag will be DISABLED if they occur 2+ times in the persistence ruleset memory (which is around 3 rounds)

## Why It's Good For The Game

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ad514123-61e8-4d99-9945-54543b7ebf93)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Persistent dynamic rulesets (blood/clock cult, nukies, aliens, etc) will no longer roll more than 2 times within a span of 3-4 rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
