### PR TITLE
Adds an eye examine message for brainwashed victims

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -80,6 +80,8 @@
 			. += "[t_He] [t_has] [glasses.get_examine_string(user)] covering [t_his] eyes."
 		else if(eye_color == BLOODCULT_EYE && iscultist(src) && HAS_TRAIT(src, CULT_EYES))
 			. += "<span class='warning'><B>[t_His] eyes are glowing an unnatural red!</B></span>"
+		else if(mind?.has_antag_datum(/datum/antagonist/brainwashed))
+			. += "<span class='warning'>[t_His] gaze seems distant and unfocused.</span>"
 
 	//ears
 	if(ears && !(obscured & ITEM_SLOT_EARS) && !(ears.item_flags & EXAMINE_SKIP))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a new examine message to brainwashed victims, if their eyes are uncovered: "_Their gaze seems distant and unfocused_"

tbh, brainwashing needs more balancing, but this should help with one of its biggest issues for now.

## Why It's Good For The Game

Brainwashing is currently undetectable, which kinda sucks for balance. This makes it possible to actually check if someone's brainwashed or not, without being able to "drive-by" scan people like you can with a health analyzer and hypnosis (just wear glasses!)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-06-08-1686201382-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/d739727a-d656-4d0c-8aac-e784098852d1)

</details>

## Changelog
:cl:
add: Nanotrasen has instructed its employees on how to recognize if someone has been brainwashed - a victim of brainwashing will have a unique gaze that can be described as "distant and unfocused" upon close inspection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
