### PR TITLE
Fix transform sting reversion being broken if you're monkeyized

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_carbon.dm
@@ -10,4 +10,4 @@
 #define COMSIG_CARBON_EMBED_RIP "item_embed_start_rip"						// defined twice, in carbon and human's topics, fired when interacting with a valid embedded_object to pull it out (mob/living/carbon/target, /obj/item, /obj/item/bodypart/L)
 #define COMSIG_CARBON_EMBED_REMOVAL "item_embed_remove_safe"		// called when removing a given item from a mob, from mob/living/carbon/remove_embedded_object(mob/living/carbon/target, /obj/item)
 #define COMSIG_CARBON_CUFF_ATTEMPTED "carbon_attempt_cuff"			///Called when someone attempts to cuff a carbon
-
+#define COMSIG_CARBON_TRANSFORMED	"carbon_transformed"			//! Called whenever a carbon is transformed into another carbon, i.e monkeyize/humanize (mob/living/carbon/new_body)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1118,8 +1118,10 @@
 	/// How much "charge" the transformation has left. It's randomly set upon creation,
 	/// and ticks down every second if there's mutadone in the target's system.
 	var/charge_left
+	/// Whether the
+	var/already_applied = FALSE
 
-/datum/status_effect/ling_transformation/on_creation(mob/living/new_owner, datum/dna/target_dna, datum/dna/original_dna)
+/datum/status_effect/ling_transformation/on_creation(mob/living/new_owner, datum/dna/target_dna, datum/dna/original_dna, already_applied = FALSE)
 	if(!iscarbon(new_owner) || QDELETED(target_dna))
 		qdel(src)
 		return
@@ -1129,6 +1131,7 @@
 	if(original_dna)
 		src.original_dna = new original_dna.type
 		original_dna.copy_dna(src.original_dna)
+	src.already_applied = already_applied
 	return ..()
 
 /datum/status_effect/ling_transformation/on_apply()
@@ -1143,8 +1146,10 @@
 	else if(!original_dna)
 		original_dna = new carbon_owner.dna.type
 		carbon_owner.dna.copy_dna(original_dna)
-	apply_dna(target_dna)
-	to_chat(owner, "<span class='warning'>You don't feel like yourself anymore...</span>")
+	RegisterSignal(owner, COMSIG_CARBON_TRANSFORMED, PROC_REF(on_transformation))
+	if(!already_applied)
+		apply_dna(target_dna)
+		to_chat(owner, "<span class='warning'>You don't feel like yourself anymore...</span>")
 
 /datum/status_effect/ling_transformation/on_remove()
 	. = ..()
@@ -1152,6 +1157,7 @@
 		return
 	apply_dna(original_dna)
 	to_chat(owner, "<span class='notice'>You feel like yourself again!</span>")
+	UnregisterSignal(owner, COMSIG_CARBON_TRANSFORMED)
 
 /datum/status_effect/ling_transformation/tick()
 	. = ..()
@@ -1170,3 +1176,11 @@
 	carbon_owner.real_name = carbon_owner.dna.real_name
 	carbon_owner.updateappearance(mutcolor_update = TRUE)
 	carbon_owner.domutcheck()
+
+/datum/status_effect/ling_transformation/proc/on_transformation(mob/living/carbon/source, mob/living/carbon/new_body)
+	SIGNAL_HANDLER
+	if(!istype(source) || !istype(new_body))
+		return
+	var/datum/status_effect/ling_transformation/new_effect = new_body.apply_status_effect(/datum/status_effect/ling_transformation, target_dna, original_dna, TRUE)
+	if(new_effect)
+		new_effect.charge_left = charge_left

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1118,7 +1118,7 @@
 	/// How much "charge" the transformation has left. It's randomly set upon creation,
 	/// and ticks down every second if there's mutadone in the target's system.
 	var/charge_left
-	/// Whether the
+	/// Whether the transformation has already been applied or not (i.e is this a new transformation, or an old one being transferred?)
 	var/already_applied = FALSE
 
 /datum/status_effect/ling_transformation/on_creation(mob/living/new_owner, datum/dna/target_dna, datum/dna/original_dna, already_applied = FALSE)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -140,6 +140,7 @@
 
 	if (tr_flags & TR_DEFAULTMSG)
 		to_chat(O, "<B>You are now a monkey.</B>")
+	SEND_SIGNAL(src, COMSIG_CARBON_TRANSFORMED, O)
 
 	for(var/A in loc.vars)
 		if(loc.vars[A] == src)
@@ -282,6 +283,8 @@
 
 	if (tr_flags & TR_DEFAULTMSG)
 		to_chat(O, "<B>You are now a living teratoma.</B>")
+
+	SEND_SIGNAL(src, COMSIG_CARBON_TRANSFORMED, O)
 
 	for(var/A in loc.vars)
 		if(loc.vars[A] == src)
@@ -450,6 +453,8 @@
 	O.a_intent = INTENT_HELP
 	if (tr_flags & TR_DEFAULTMSG)
 		to_chat(O, "<B>You are now \a [O.dna.species]].</B>")
+
+	SEND_SIGNAL(src, COMSIG_CARBON_TRANSFORMED, O)
 
 	transfer_observers_to(O)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, if you ever turn into a monkey or something (and back) after transform stung, you will no longer be able to 'fix' the transformation sting.

## Why It's Good For The Game

bug fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/127a1431-cc65-4076-87da-c6882f3162e2)

</details>

## Changelog
:cl:
fix: Transformation sting is no longer unfixable if you're monkeyized after being stung.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
