### PR TITLE
New botany trait: Richer juice - doubles chem result

### DIFF
--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -171,7 +171,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_grow = "lime-grow"
 	icon_dead = "lime-dead"
-	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/orange)
+	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/orange, /datum/plant_gene/trait/richer_juice)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/citrus/orange_3d

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -25,7 +25,7 @@
 	yield = 2
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/stinging)
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.25)
+	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.12)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/nettle // "snack"

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -526,7 +526,7 @@
 /datum/plant_gene/trait/richer_juice
 	name = "Richer Juice"
 	rate = 2
-	trait_id = "chem_boots"
+	trait_id = "chem_boost"
 
 /datum/plant_gene/trait/plant_type // Parent type
 	name = "you shouldn't see this"

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -393,6 +393,7 @@
 	// 2x to max reagents volume.
 	name = "Densified Chemicals"
 	rate = 2
+	trait_id = "chem_boots"
 
 /datum/plant_gene/trait/maxchem/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
 	..()
@@ -520,6 +521,12 @@
 			HY.pestlevel = 0 // Reset
 			HY.update_icon()
 			HY.visible_message("<span class='warning'>The [H.myseed.plantname] spreads!</span>")
+
+// It boosts chemical output of a plant by rate
+/datum/plant_gene/trait/richer_juice
+	name = "Richer Juice"
+	rate = 2
+	trait_id = "chem_boots"
 
 /datum/plant_gene/trait/plant_type // Parent type
 	name = "you shouldn't see this"

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -393,7 +393,7 @@
 	// 2x to max reagents volume.
 	name = "Densified Chemicals"
 	rate = 2
-	trait_id = "chem_boots"
+	trait_id = "chem_boost"
 
 /datum/plant_gene/trait/maxchem/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
 	..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -191,12 +191,17 @@
 	return result
 
 
-/obj/item/seeds/proc/prepare_result(var/obj/item/T)
+/obj/item/seeds/proc/prepare_result(obj/item/T)
 	if(!T.reagents)
 		CRASH("[T] has no reagents.")
 
+	var/output_multiply = 1
+	var/datum/plant_gene/trait/richer_juice/richer_juice = locate(/datum/plant_gene/trait/richer_juice) in genes
+	if(richer_juice)
+		output_multiply = richer_juice.rate
+
 	for(var/rid in reagents_add)
-		var/amount = 1 + round(potency * reagents_add[rid], 1)
+		var/amount = 1 + round(potency * reagents_add[rid] * output_multiply, 1)
 
 		var/list/data = null
 		if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -201,7 +201,7 @@
 		output_multiply = richer_juice.rate
 
 	for(var/rid in reagents_add)
-		var/amount = 1 + round(potency * reagents_add[rid] * output_multiply, 1)
+		var/amount = (1 + round(potency * reagents_add[rid], 1)) * output_multiply
 
 		var/list/data = null
 		if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Adds a new botany trait: Richer Juice
Doubles 2x chem results.
blocks Densified Chemicals. You can't take both.
available from 3D orange

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
new thing + nerf death nettle

This is primarily to nerf death nettle acid.
Basically, botany-spam plants shouldn't do much things in a single throw.
That's why we accepted the old botany nerf (flu-acid 50% to 25% => maximum 26u)

Now, flu-acid effect is so below:
26u of flu-acid is enough to remove `Captain's hat + PDA + jumpsuit`
13u of flu-acid is enough to remove `Jumpsuit` only

This means they wouldn't get the wanted result very quickly because they made a successful throw of a plant.

If botanist wants to get the original power level of acid, they should use this new trait.
but the new trait also blocks Densified Chemicals, which means the chem maximum will be limited to 50u.


### Wouldn't 2x chems be too powerful to other chems?
Every chem in botany is already too much. Toxins are like 8u, 20u, or something more.
but also toxins have very low metabolisation rate. Toxins will do its thing already with only 1u.

With consideration of this, having 2x means the example units become 16u, 40u, but it wouldn't make any big difference because it does the thing already.

and if they want to make very poisonous plant, they should use multiple toxins, not using this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/f1b162e3-5c54-4fb5-836f-fb31fece1238)

</details>

## Changelog
:cl:
add: Added a new botany trait: Richer Juice. Doubles 2x chem results. Not compatible with Densified Chemicals. You can't take both. available from 3D orange
balance: deathnettle now has 12% Fluorosulfuric acid
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
