### PR TITLE
[BUGFIX]: PAI phasing out of sealed spaces

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -25,6 +25,9 @@
 		if(!L.temporarilyRemoveItemFromInventory(card))
 			to_chat(src, "<span class='warning'>Error: Unable to expand to mobile form. Chassis is restrained by some device or person.</span>")
 			return FALSE
+	if(istype(card.loc, /obj/structure) || istype(card.loc, /obj/machinery))
+		to_chat(src, "<span class='warning'>Error: Unable to expand to mobile form. Chassis is restrained by some device or person.</span>")
+		return FALSE
 	forceMove(get_turf(card))
 	card.forceMove(src)
 	if(client)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #9151 by adding a check for when a PAI is inside of a `/obj/structure` (and `/obj/machinery`, just in case)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Even though most PAI are harmless, they shouldn't be allowed to break general logic, such as escaping a welded locker.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/79a91724-4a32-44a5-ac1e-ce9a2170951f
</details>

## Changelog
:cl:
fix: PAI can no longer phase out of solid structures and machines such as closets (even when they were welded) and disposal pipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
