### PR TITLE
Makes the mask re-skin action use a radial menu rather than a list

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -78,7 +78,6 @@
 /obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated())
 		return
-	message_admins("UI action click detected")
 	var/list/options = list()
 	options["True Form"] = "clown"
 	options["The Feminist"] = "sexyclown"
@@ -87,10 +86,8 @@
 	options["The Jester"] ="chaos" //Nepeta33Leijon is holding me captive and forced me to help with this please send help
 	options["The Lunatic"] = "trickymask"
 
-	//var/choice = input(user,"To what form do you wish to Morph this mask?","Morph Mask") in sort_list(options)
 	var/choice = show_radial_menu(user, user, mask_designs, custom_check = FALSE, radius = 40)
 	if(!choice)
-		message_admins("No choice detected, returning")
 		return FALSE
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))
@@ -120,7 +117,14 @@
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
+	var/list/mask_designs = list()
 
+/obj/item/clothing/mask/gas/mime/Initialize(mapload)
+	.=..()
+	mask_designs["Blanc"] = image(icon = src.icon, icon_state = "mime")
+	mask_designs["Triste"] = image(icon = src.icon, icon_state = "sadmime")
+	mask_designs["Effrayé"] = image(icon = src.icon, icon_state = "scaredmime")
+	mask_designs["Excité"] = image(icon = src.icon, icon_state = "sexymime")
 
 /obj/item/clothing/mask/gas/mime/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated())
@@ -132,7 +136,9 @@
 	options["Effrayé"] = "scaredmime"
 	options["Excité"] ="sexymime"
 
-	var/choice = input(user,"To what form do you wish to Morph this mask?","Morph Mask") in sort_list(options)
+	var/choice = show_radial_menu(user, user, mask_designs, custom_check = FALSE, radius = 40)
+	if(!choice)
+		return FALSE
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))
 		icon_state = options[choice]
@@ -194,7 +200,14 @@
 	max_integrity = 100
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = null
+	var/list/mask_designs = list()
 
+/obj/item/clothing/mask/gas/tiki_mask/Initialize(mapload)
+	.=..()
+	mask_designs["Original Tiki"] = image(icon = src.icon, icon_state = "tiki_eyebrow")
+	mask_designs["Happy Tikie"] = image(icon = src.icon, icon_state = "tiki_happy")
+	mask_designs["Confused Tiki"] = image(icon = src.icon, icon_state = "tiki_confused")
+	mask_designs["Angry Tiki"] = image(icon = src.icon, icon_state = "tiki_angry")
 
 /obj/item/clothing/mask/gas/tiki_mask/ui_action_click(mob/user)
 	var/mob/M = usr
@@ -204,7 +217,9 @@
 	options["Confused Tiki"] = "tiki_confused"
 	options["Angry Tiki"] ="tiki_angry"
 
-	var/choice = input(M,"To what form do you wish to change this mask?","Morph Mask") in sort_list(options)
+	var/choice = show_radial_menu(user, user, mask_designs, custom_check = FALSE, radius = 40)
+	if(!choice)
+		return FALSE
 
 	if(src && choice && !M.stat && in_range(M,src))
 		icon_state = options[choice]

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -67,17 +67,18 @@
 	var/list/mask_designs = list()
 
 /obj/item/clothing/mask/gas/clown_hat/Initialize(mapload)
+	.=..()
 	mask_designs["True Form"] = image(icon = src.icon, icon_state = "clown")
 	mask_designs["The Feminist"] = image(icon = src.icon, icon_state = "sexyclown")
 	mask_designs["The Madman"] = image(icon = src.icon, icon_state = "joker")
-	mask_designs["The Rainbow Color"] = image(icon = src.icon, icon_state = "color")
+	mask_designs["The Rainbow Color"] = image(icon = src.icon, icon_state = "rainbow")
 	mask_designs["The Jester"] = image(icon = src.icon, icon_state = "chaos")
 	mask_designs["The Lunatic"] = image(icon = src.icon, icon_state = "trickymask")
 
 /obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated())
 		return
-
+	message_admins("UI action click detected")
 	var/list/options = list()
 	options["True Form"] = "clown"
 	options["The Feminist"] = "sexyclown"
@@ -87,8 +88,9 @@
 	options["The Lunatic"] = "trickymask"
 
 	//var/choice = input(user,"To what form do you wish to Morph this mask?","Morph Mask") in sort_list(options)
-	var/choice = show_radial_menu(user, src, mask_designs, custom_check = FALSE, radius = 40, require_near = TRUE)
+	var/choice = show_radial_menu(user, user, mask_designs, custom_check = FALSE, radius = 40)
 	if(!choice)
+		message_admins("No choice detected, returning")
 		return FALSE
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -64,6 +64,15 @@
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = /datum/dog_fashion/head/clown
+	var/list/mask_designs = list()
+
+/obj/item/clothing/mask/gas/clown_hat/Initialize(mapload)
+	mask_designs["True Form"] = image(icon = src.icon, icon_state = "clown")
+	mask_designs["The Feminist"] = image(icon = src.icon, icon_state = "sexyclown")
+	mask_designs["The Madman"] = image(icon = src.icon, icon_state = "joker")
+	mask_designs["The Rainbow Color"] = image(icon = src.icon, icon_state = "color")
+	mask_designs["The Jester"] = image(icon = src.icon, icon_state = "chaos")
+	mask_designs["The Lunatic"] = image(icon = src.icon, icon_state = "trickymask")
 
 /obj/item/clothing/mask/gas/clown_hat/ui_action_click(mob/user)
 	if(!istype(user) || user.incapacitated())
@@ -77,7 +86,10 @@
 	options["The Jester"] ="chaos" //Nepeta33Leijon is holding me captive and forced me to help with this please send help
 	options["The Lunatic"] = "trickymask"
 
-	var/choice = input(user,"To what form do you wish to Morph this mask?","Morph Mask") in sort_list(options)
+	//var/choice = input(user,"To what form do you wish to Morph this mask?","Morph Mask") in sort_list(options)
+	var/choice = show_radial_menu(user, src, mask_designs, custom_check = FALSE, radius = 40, require_near = TRUE)
+	if(!choice)
+		return FALSE
 
 	if(src && choice && !user.incapacitated() && in_range(user,src))
 		icon_state = options[choice]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the reskin menus for the Clown, Mime and Tiki masks use a radial menu rather than a list.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It looks better and allows you to see what you'll make the mask look like before you pick it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/5fc15faa-334d-4441-a2f0-a1ddbb54869e)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/78be904c-9129-4a16-b6f7-e59ea7162cd2)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/e1672606-a577-49eb-b7c2-d772e6c9648e)

</details>

## Changelog
:cl:
tweak: Made the skin selection for the Clown, Mime and Tiki masks use a radial menu rather than a list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
