### PR TITLE
Brings back forced hits on failed surgery steps

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -60,10 +60,14 @@
 	SEND_SIGNAL(M, COMSIG_MOB_ITEM_ATTACKBY, user, src)
 
 	var/nonharmfulhit = FALSE
-	if(item_flags & NOBLUDGEON)
-		nonharmfulhit = TRUE
 
 	if(user.a_intent == INTENT_HELP && !(item_flags & ISWEAPON))
+		nonharmfulhit = TRUE
+	for(var/datum/surgery/S in M.surgeries)
+		if(S.failed_step)
+			nonharmfulhit = FALSE //No freebies, if you fail a surgery step you should hit your patient
+
+	if(item_flags & NOBLUDGEON)
 		nonharmfulhit = TRUE
 
 	if(force && HAS_TRAIT(user, TRAIT_PACIFISM) && !nonharmfulhit)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -66,7 +66,7 @@
 	for(var/datum/surgery/S in M.surgeries)
 		if(S.failed_step)
 			nonharmfulhit = FALSE //No freebies, if you fail a surgery step you should hit your patient
-			failed_step = FALSE //In theory the hit should only happen once, upon failing the step
+			S.failed_step = FALSE //In theory the hit should only happen once, upon failing the step
 
 	if(item_flags & NOBLUDGEON)
 		nonharmfulhit = TRUE

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -66,6 +66,7 @@
 	for(var/datum/surgery/S in M.surgeries)
 		if(S.failed_step)
 			nonharmfulhit = FALSE //No freebies, if you fail a surgery step you should hit your patient
+			failed_step = FALSE //In theory the hit should only happen once, upon failing the step
 
 	if(item_flags & NOBLUDGEON)
 		nonharmfulhit = TRUE

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -67,6 +67,7 @@
 		if(S.failed_step)
 			nonharmfulhit = FALSE //No freebies, if you fail a surgery step you should hit your patient
 			S.failed_step = FALSE //In theory the hit should only happen once, upon failing the step
+			break
 
 	if(item_flags & NOBLUDGEON)
 		nonharmfulhit = TRUE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -19,6 +19,7 @@
 	var/self_operable = FALSE										//Can the surgery be performed on yourself.
 	var/requires_tech = FALSE										//handles techweb-oriented surgeries, previously restricted to the /advanced subtype (You still need to add designs)
 	var/replaced_by													//type; doesn't show up if this type exists. Set to /datum/surgery if you want to hide a "base" surgery (useful for typing parents IE healing.dm just make sure to null it out again)
+	var/failed_step = FALSE											//used for bypassing the 'poke on help intent' on failing a surgery step and forcing the doctor to damage the patient
 
 /datum/surgery/New(surgery_target, surgery_location, surgery_bodypart)
 	..()
@@ -97,6 +98,7 @@
 
 
 /datum/surgery/proc/next_step(mob/user, intent)
+	failed_step = FALSE
 	if(step_in_progress)
 		return TRUE
 
@@ -110,6 +112,7 @@
 			return TRUE
 		if(iscyborg(user) && user.a_intent != INTENT_HARM) //to save asimov borgs a LOT of heartache
 			return TRUE
+	failed_step = TRUE
 	return FALSE
 
 /datum/surgery/proc/get_surgery_step()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you fail a surgery step, you will hit your patient with your current tool, even if you are on help intent.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was an unintended consequence of the 'Makes non-weapon items poke people on help intent' PR.
Bringing back the forced hits makes failing a surgery step have more consequences.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/a7207d24-e428-40b8-bf50-651505e9cfba

</details>

## Changelog
:cl:
fix: Fixed failed surgery steps not hitting the patient
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
