### PR TITLE
Fixes projectile blocking

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -590,6 +590,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(block_flags & BLOCKING_PROJECTILE)
 			if(P.movement_type & PHASING) //you can't block piercing rounds!
 				return 0
+			// Recalculate the relative_dir based on the projectile angle
+			relative_dir = dir2angle(angle2dir(P.Angle)) - dir2angle(owner.dir)
 		else
 			return 0
 	if(owner.m_intent == MOVE_INTENT_WALK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #9193
Change the way that projectiles calculate their attack direction. I believe the issue was that in certain conditions, the projectile would be on the same turf as the player which would result in the offset being 0 instead of an actual value.

## Why It's Good For The Game

Fixes projectiles sometimes failing.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8e9c0ffb-79aa-4e0b-a294-492727939e44)

## Changelog
:cl:
fix: Fixes projectiles sometimes failing to be blocked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
