### PR TITLE
Mining and exploration vendors now vend into hand

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -132,7 +132,9 @@
 				flick(icon_deny, src)
 				return
 			to_chat(usr, "<span class='notice'>[src] clanks to life briefly before vending [prize.equipment_name]!</span>")
-			new prize.equipment_path(loc)
+			var/obj/created = new prize.equipment_path(loc)
+			if (M.CanReach(src))
+				M.put_in_hands(created)
 			SSblackbox.record_feedback("nested tally", "mining_equipment_bought", 1, list("[type]", "[prize.equipment_path]"))
 			. = TRUE
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1024,6 +1024,10 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					if(compartmentLoadAccessCheck(usr))
 						vending_machine_input[N] = max(vending_machine_input[N] - 1, 0)
 						S.forceMove(drop_location())
+						if (usr.CanReach(src) && usr.put_in_hands(S))
+							to_chat(usr, "<span class='notice'>You take [S.name] out of the slot.</span>")
+						else
+							to_chat(usr, "<span class='warning'>[capitalize(S.name)] falls onto the floor!</span>")
 						loaded_items--
 						use_power(5)
 						vend_ready = TRUE
@@ -1036,6 +1040,10 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 							SSblackbox.record_feedback("amount", "vending_spent", S.custom_price)
 						vending_machine_input[N] = max(vending_machine_input[N] - 1, 0)
 						S.forceMove(drop_location())
+						if (usr.CanReach(src) && usr.put_in_hands(S))
+							to_chat(usr, "<span class='notice'>You take [S.name] out of the slot.</span>")
+						else
+							to_chat(usr, "<span class='warning'>[capitalize(S.name)] falls onto the floor!</span>")
 						loaded_items--
 						use_power(5)
 						if(last_shopper != REF(usr) || purchase_message_cooldown < world.time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #9072
Mining and exploration vendors now vend into the hand
Custom vendors will now vend into the hand.

## Why It's Good For The Game

Normal vendors vend into the hand.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/54c63c2a-91f0-4149-bd49-efbac2380d65)

## Changelog
:cl:
fix: Vendors now vend into hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
