### PR TITLE
+10 minutes for meteor preperation

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -18,7 +18,7 @@
 	var/start_x
 	var/start_y
 	var/datum/orbital_object/station_target
-	var/meteor_time = 15 MINUTES
+	var/meteor_time = 25 MINUTES
 
 /datum/round_event/meteor_wave/New()
 	..()
@@ -80,7 +80,7 @@
 			kill()
 
 /datum/round_event/meteor_wave/announce(fake)
-	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: 10 MINUTES. Anti-meteor point defense is available for purchase via the station's cargo shuttle.", "Meteor Alert", ANNOUNCER_METEORS)
+	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: 20 MINUTES. Anti-meteor point defense is available for purchase via the station's cargo shuttle.", "Meteor Alert", ANNOUNCER_METEORS)
 
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds ten extra minutes for meteor preparation for the crew to get their act together.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

How many shifts have ended in the station taking the full brunt of the meteors?

![dreamseeker_CXkWxWHX32](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/99b5801e-3b8c-4b80-be8c-3b39ebf88d2b)

I'm not an admin now so I can't tell you, but I feel as if this is way too common of an occurrence that leads to the same predicable outcome. A full comfy station meteor defense requires **about** 10 meteor sat crates (each sat covers 29x29 unobstructed space), costing 30,000 credits and a full crew response with optimal positioning. This is not going to happen in 10 minutes, and even if this event is meant to be a grave threat to the station and requires players to determine what they want to protect, I feel its a boring way to end a round. (On the plus side, this will also nerf the most common admin *nudge* for the round to end, get more creative :trollface:)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

</details>

## Changelog
:cl:
balance: Meteors now take twice as long to reach the station (+10 extra minutes)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
