### PR TITLE
Exploration VIP's *now* have the same flavor text as their memory

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -54,7 +54,6 @@
 				but it would take another one of the miracles that kept you alive to get you home."
 			created_human.equipOutfit(/datum/outfit/vip_target/greytide)
 			antag_elligable = TRUE
-	created_human.mind.store_memory(created_human.flavor_text)
 	if(antag_elligable)
 		if(prob(7))
 			created_human.mind.make_Traitor()
@@ -64,6 +63,7 @@
 			created_human.mind.make_Changeling()
 			created_human.flavor_text += " - Or so's the cover story we've curated to sway the hearts of the hapless souls who, one day, may stumble upon \
 			our miserable, eeked out existence here... And inadvertently begin the hunt anew." //Ditto
+	created_human.mind.store_memory(created_human.flavor_text)
 	mob_to_recover = created_human
 	//Give them space-worthy suit and other equipment
 	var/turf/open/T = locate() in shuffle(view(1, created_human))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -74,7 +74,6 @@
 		new belt_type(T)
 	generated = TRUE
 
-
 //=====================
 // BASE VIP Outfit
 //=====================

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -74,6 +74,7 @@
 		new belt_type(T)
 	generated = TRUE
 
+
 //=====================
 // BASE VIP Outfit
 //=====================


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a thing that's been botched up since it was added by an older PR (around a year ago)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps avoid confusion like this, which just happened last night:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/707ee102-e403-4100-91d8-e6f4faf8413c)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Before and After</summary>

**BEFORE**:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/7f5447af-1d8d-4790-ab50-2a0cadc23b44)

**AFTER:**
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/8c7f3151-72fa-4ec1-b82d-18874d12b319)


</details>
<details>
<summary>How I tested it</summary>

I implemented the following temp code.

Mandatory VIP Mission:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/3e464ae2-8ec2-4edb-bd45-38b5db7ed313)

Mandatory Traitor VIP
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/0d6ba1bc-740a-4b17-adc5-57aa876e95ed)

Started up a test server, joined exploration, selected the mission, and took the shuttle on my way
Then I ghosted and jumped into the newly created antagonistic VIP

</details>

## Changelog
:cl:
fix: Exploration VIP targets now memorize why they have strange abilities, or an uplink in their head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
