### PR TITLE
All Carps must be named

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -245,7 +245,9 @@
 
 /mob/living/simple_animal/hostile/carp/advanced/examine(mob/user)
 	. = ..()
-	if(!isnull(client))
+	if(mind)
 		. += "<span class='notice'>This one seems to be self-aware.</span>"
+	else if(!isnull(client))
+		. += "<span class='notice'>This one seems to be self-aware, but distant.</span>"
 
 #undef REGENERATION_DELAY

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -247,7 +247,5 @@
 	. = ..()
 	if(mind)
 		. += "<span class='notice'>This one seems to be self-aware.</span>"
-	else if(!isnull(client))
-		. += "<span class='notice'>This one seems to be self-aware, but distant.</span>"
 
 #undef REGENERATION_DELAY

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -3,6 +3,7 @@
 /mob/living/simple_animal/hostile/carp
 	name = "space carp"
 	desc = "A ferocious, fang-bearing creature that resembles a fish."
+	unique_name = TRUE
 	icon = 'icons/mob/carp.dmi'
 	icon_state = "base"
 	icon_living = "base"
@@ -105,6 +106,7 @@
 	icon = 'icons/mob/broadMobs.dmi'
 	name = "Mega Space Carp"
 	desc = "A ferocious, fang bearing creature that resembles a shark. This one seems especially ticked off."
+	unique_name = FALSE
 	icon_state = "megacarp"
 	icon_living = "megacarp"
 	icon_dead = "megacarp_dead"
@@ -142,6 +144,7 @@
 	name = "Cayenne"
 	desc = "A failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
 	gender = FEMALE
+	unique_name = FALSE
 	speak_emote = list("squeaks")
 	gold_core_spawnable = NO_SPAWN
 	faction = list("carp", ROLE_SYNDICATE)
@@ -219,6 +222,7 @@
 	real_name = "Lia"
 	desc = "A failed experiment of Nanotrasen to create weaponised carp technology. This less than intimidating carp now serves as the Head of Security's pet."
 	gender = FEMALE
+	unique_name = FALSE
 	speak_emote = list("squeaks")
 	gold_core_spawnable = NO_SPAWN
 	faction = list("neutral")
@@ -233,10 +237,15 @@
 
 /mob/living/simple_animal/hostile/carp/advanced
 	name = "advanced space carp"
-	desc = "A ferocious, fang-bearing creature that resembles a fish. This one seems to be self-aware."
+	desc = "A ferocious, fang-bearing creature that resembles a fish."
 	maxHealth = 40
 	health = 40
 	gold_core_spawnable = NO_SPAWN
 	obj_damage = 15
+
+/mob/living/simple_animal/hostile/carp/advanced/examine(mob/user)
+	. = ..()
+	if(!isnull(client))
+		. += "<span class='notice'>This one seems to be self-aware.</span>"
 
 #undef REGENERATION_DELAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the 3 digit unique number `space carp (123)` to all carps, except for those whose name is determined through some other unqiue-enough mechanism (Lia, Cayenne, and Mega Space Carps).

Changes the advanced space carp examine to now tell if you're dealing with a player or ai bot, as I believed the previous examine text was misleading.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Observed a round with a bad dragon carp, so I think its best for logging and administrative situations that carps, which players may frequently control, receive unique names to differentiate each other, just like monkeys. Players especially can now know and attribute actions to a singular player, and admins can immediately identify a single player in reports rather than comb through all the carps of the round.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

examinations
![dreamseeker_2ZGXinjRM3](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/88c7c97f-759c-4c2e-918e-65bca16ef2ff)

advanced space carp with examine flavor
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/af42b03c-fa3e-49c3-909d-57c87c119282)

</details>

## Changelog
:cl:
tweak: All carps (besides those with unique names) now are numbered uniquely
add: Examine flavor for advanced carps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
