### PR TITLE
Fixes armblades not hurting people on help intent

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -1,5 +1,5 @@
 /obj/item/melee
-	item_flags = NEEDS_PERMIT | ISWEAPON | ISWEAPON
+	item_flags = NEEDS_PERMIT | ISWEAPON
 
 /obj/item/melee/proc/check_martial_counter(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	if(target.check_block())

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -1,5 +1,5 @@
 /obj/item/melee
-	item_flags = NEEDS_PERMIT | ISWEAPON
+	item_flags = NEEDS_PERMIT | ISWEAPON | ISWEAPON
 
 /obj/item/melee/proc/check_martial_counter(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	if(target.check_block())

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -150,7 +150,7 @@
 	item_state = "arm_blade"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
-	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
+	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL | ISWEAPON
 	w_class = WEIGHT_CLASS_HUGE
 	force = 20 //this is an undroppable melee weapon. should not be better than the fireaxe
 	throwforce = 0 //Just to be on the safe side


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes https://github.com/BeeStation/BeeStation-Hornet/issues/9237

The following items will now hurt people on help intent:
- /obj/item/melee/arm_blade
- /obj/item/melee/arm_blade/false
- /obj/item/melee/arm_blade/slime

## Why It's Good For The Game

These items are distinctly weapons and cannot be used as non-weapons.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8e13f148-1881-487a-a50b-74dfd7644606)

## Changelog
:cl:
tweak: Armblades will now damage targets on help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
