### PR TITLE
Improved issue reporter

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2482,6 +2482,7 @@
 #include "code\modules\instruments\songs\play_synthesized.dm"
 #include "code\modules\interview\interview.dm"
 #include "code\modules\interview\interview_manager.dm"
+#include "code\modules\issue_reporter\issue_reporter.dm"
 #include "code\modules\jobs\access.dm"
 #include "code\modules\jobs\job_exp.dm"
 #include "code\modules\jobs\job_mail.dm"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -225,7 +225,13 @@
 /datum/config_entry/string/githuburl
 	config_entry_value = "https://github.com/BeeStation/BeeStation-Hornet"
 
-/datum/config_entry/string/issue_label
+/datum/config_entry/string/default_issue_label
+
+/datum/config_entry/string/regression_issue_label
+
+/datum/config_entry/string/issue_template
+	config_entry_value = "config/issue_template.txt"
+	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/string/donateurl
 	config_entry_value = "https://www.patreon.com/user?u=10639001"

--- a/code/modules/issue_reporter/issue_reporter.dm
+++ b/code/modules/issue_reporter/issue_reporter.dm
@@ -91,7 +91,7 @@
 	var/regression_label = CONFIG_GET(string/regression_issue_label)
 	if (regression_label && isRegression)
 		labels += regression_label
-	DIRECT_OUTPUT(owner, link("[githuburl]/issues/new?body=[rustg_url_encode(body)][length(labels) ? "&labels=[rustg_url_encode(jointext(labels, ","))]" : ""]"))
+	DIRECT_OUTPUT(owner, link("[githuburl]/issues/new?title=[rustg_url_encode(title)]&body=[rustg_url_encode(body)][length(labels) ? "&labels=[rustg_url_encode(jointext(labels, ","))]" : ""]"))
 
 /datum/issue_reporter/ui_close(mob/user, datum/tgui/tgui)
 	. = ..()

--- a/code/modules/issue_reporter/issue_reporter.dm
+++ b/code/modules/issue_reporter/issue_reporter.dm
@@ -98,4 +98,6 @@
 	terminate_reporter()
 
 /datum/issue_reporter/proc/terminate_reporter()
+	if (QDELETED(src))
+		return
 	qdel(src)

--- a/code/modules/issue_reporter/issue_reporter.dm
+++ b/code/modules/issue_reporter/issue_reporter.dm
@@ -1,0 +1,101 @@
+
+/datum/issue_reporter
+	var/client/owner
+
+/datum/issue_reporter/New(client/user)
+	if (!user)
+		terminate_reporter()
+		CRASH("Issue reporter created with no client.")
+	. = ..()
+	owner = user
+	ui_interact(user.mob)
+	// Clear references to the client
+	RegisterSignal(user, COMSIG_PARENT_QDELETING, PROC_REF(terminate_reporter))
+
+/datum/issue_reporter/Destroy(force, ...)
+	owner = null
+	return ..()
+
+/datum/issue_reporter/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/issue_reporter/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "IssueReporter")
+		ui.open()
+
+/datum/issue_reporter/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	// This could result in some horrible exploits if there is another exploit involved
+	if (usr.client != owner)
+		return
+	if (action != "submit")
+		return
+	var/githuburl = CONFIG_GET(string/githuburl)
+	if (!githuburl)
+		tgui_alert_async(usr, "The Github URL is not set in the server configuration.", "Configuration Error")
+		return
+	// This will open on the users own browser.
+	var/isRegression = params["isRegression"]
+	var/title = params["title"]
+	var/expected = params["expected"]
+	var/actual = params["actual"]
+	var/replicationSteps = params["replicationSteps"]
+	var/template_path = CONFIG_GET(string/issue_template)
+	var/body = rustg_file_read(template_path)
+	if (!body)
+		// /Default body
+		body = @{"## Occurance Details
+
+**Round Date:** %DATE%
+
+**Round ID:** %ROUNDID%
+
+**Testmerges**:
+%TESTMERGES%
+
+## Bug Details
+
+### Expected Behaviour:
+
+%EXPECTED%
+
+### Actual Behaviour:
+
+%ACTUAL%
+
+### Reproduction:
+
+%REPRODUCTION%
+"}
+	var/servername = CONFIG_GET(string/servername)
+	body = replacetext(body, "%DATE%", time2text(world.timeofday,"DD-MM-YYYY hh:mm:ss"))
+	body = replacetext(body, "%ROUNDID%", "[GLOB.round_id ? " Round ID: [GLOB.round_id][servername ? " ([servername])" : ""]" : servername]")
+	body = replacetext(body, "%EXPECTED%", expected)
+	body = replacetext(body, "%ACTUAL%", actual)
+	body = replacetext(body, "%REPRODUCTION%", replicationSteps)
+	// Fetch testmerge info
+	var/testmerge_info = "- None"
+	if (length(GLOB.revdata.testmerge))
+		var/list/testmerge_line = list()
+		for (var/datum/tgs_revision_information/test_merge/tm in GLOB.revdata.testmerge)
+			testmerge_line += "- #[tm.number] commit [tm.head_commit]"
+		testmerge_info = jointext(testmerge_line, "\n")
+	body = replacetext(body, "%TESTMERGES%", testmerge_info)
+
+	var/issue_label = CONFIG_GET(string/default_issue_label)
+	var/list/labels = list()
+	if (issue_label)
+		labels += issue_label
+	var/regression_label = CONFIG_GET(string/regression_issue_label)
+	if (regression_label && isRegression)
+		labels += regression_label
+	DIRECT_OUTPUT(owner, link("[githuburl]/issues/new?body=[rustg_url_encode(body)][length(labels) ? "&labels=[rustg_url_encode(jointext(labels, ","))]" : ""]"))
+
+/datum/issue_reporter/ui_close(mob/user, datum/tgui/tgui)
+	. = ..()
+	terminate_reporter()
+
+/datum/issue_reporter/proc/terminate_reporter()
+	qdel(src)

--- a/code/modules/issue_reporter/issue_reporter.dm
+++ b/code/modules/issue_reporter/issue_reporter.dm
@@ -70,7 +70,7 @@
 %REPRODUCTION%
 "}
 	var/servername = CONFIG_GET(string/servername)
-	body = replacetext(body, "%DATE%", time2text(world.timeofday,"DD-MM-YYYY hh:mm:ss"))
+	body = replacetext(body, "%DATE%", time2text(world.timeofday,"YYYY-MM-DD hh:mm:ss"))
 	body = replacetext(body, "%ROUNDID%", "[GLOB.round_id ? " Round ID: [GLOB.round_id][servername ? " ([servername])" : ""]" : servername]")
 	body = replacetext(body, "%EXPECTED%", expected)
 	body = replacetext(body, "%ACTUAL%", actual)

--- a/config/config.txt
+++ b/config/config.txt
@@ -274,9 +274,14 @@ RULESURL https://beestation13.com/rules
 ## Github address
 GITHUBURL https://www.github.com/beestation/beestation-hornet
 
-## Label to tag ingame-registered issues with.
-## Uncomment this to enable them.
-#ISSUE_LABEL Ingame Issue Report
+## The default labels to apply to issues reported in game, seperated by commas
+DEFAULT_ISSUE_LABEL Bug
+
+## The label to apply to regression PRs
+REGRESSION_ISSUE_LABEL Regression
+
+## The filepath that the issue template to use is stored at
+ISSUE_TEMPLATE config/issue_template.txt
 
 ## Donation URL
 DONATEURL https://www.patreon.com/user?u=10639001

--- a/config/issue_template.txt
+++ b/config/issue_template.txt
@@ -1,0 +1,22 @@
+## Occurance Details
+
+**Round Date:** %DATE%
+
+**Round ID:** %ROUNDID%
+
+**Testmerges**:
+%TESTMERGES%
+
+## Bug Details
+
+### Expected Behaviour:
+
+%EXPECTED%
+
+### Actual Behaviour:
+
+%ACTUAL%
+
+### Reproduction:
+
+%REPRODUCTION%

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -57,6 +57,10 @@
 	set name = "report-issue"
 	set desc = "Report an issue"
 	set hidden = 1
+
+	if(tgalert(src, message, "What kind of issue are you facing?","TGUI","Other")!="TGUI")
+		new /datum/issue_reporter(src)
+		return
 	var/githuburl = CONFIG_GET(string/githuburl)
 	if(githuburl)
 		var/message = "This will open the Github issue reporter in your browser. Are you sure?"
@@ -76,7 +80,6 @@
 		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[rustg_url_encode(url_params)][issue_label ? "&labels=[rustg_url_encode(issue_label)]" : ""]"))
 	else
 		to_chat(src, "<span class='danger'>The Github URL is not set in the server configuration.</span>")
-	return
 
 /client/verb/hotkeys_help()
 	set name = "hotkeys-help"

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -58,7 +58,7 @@
 	set desc = "Report an issue"
 	set hidden = 1
 
-	if(tgalert(src, message, "What kind of issue are you facing?","TGUI","Other")!="TGUI")
+	if(tgalert(src, "What kind of issue are you facing?", "Report Issue", "In-game Bug", "UI issue", "Other") != "UI issue")
 		new /datum/issue_reporter(src)
 		return
 	var/githuburl = CONFIG_GET(string/githuburl)

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -58,7 +58,7 @@
 	set desc = "Report an issue"
 	set hidden = 1
 
-	if(tgalert(src, "What kind of issue are you facing?", "Report Issue", "In-game Bug", "UI issue", "Other") != "UI issue")
+	if(alert(src, "What kind of issue are you facing?", "Report Issue", "In-game Bug", "UI issue", "Other") != "UI issue")
 		new /datum/issue_reporter(src)
 		return
 	var/githuburl = CONFIG_GET(string/githuburl)
@@ -76,7 +76,7 @@
 		var/url_params = "Reporting client version: [byond_version].[byond_build]\n\n[issue_template]"
 		if(GLOB.round_id || servername)
 			url_params = "Issue reported from [GLOB.round_id ? " Round ID: [GLOB.round_id][servername ? " ([servername])" : ""]" : servername]\n\n[url_params]"
-		var/issue_label = CONFIG_GET(string/issue_label)
+		var/issue_label = CONFIG_GET(string/default_issue_label)
 		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[rustg_url_encode(url_params)][issue_label ? "&labels=[rustg_url_encode(issue_label)]" : ""]"))
 	else
 		to_chat(src, "<span class='danger'>The Github URL is not set in the server configuration.</span>")

--- a/tgui/packages/tgui/interfaces/IssueReporter.js
+++ b/tgui/packages/tgui/interfaces/IssueReporter.js
@@ -1,0 +1,226 @@
+import { Window } from '../layouts';
+import { useBackend, useLocalState } from '../backend';
+import { ButtonCheckbox } from 'tgui/components/Button';
+import { Box, Section, Button, Flex, TextArea, Input } from '../components';
+
+export const IssueReporter = (props, context) => {
+
+  const {
+    act,
+  } = useBackend(context);
+
+  const [
+    isRegression,
+    setIsRegression,
+  ] = useLocalState(context, 'isRegression', false);
+  const [
+    issueName,
+    setIssueName,
+  ] = useLocalState(context, 'issueName', '');
+  const [
+    replicationSteps,
+    setReplicationSteps,
+  ] = useLocalState(context, 'replicationSteps', '');
+  const [
+    expected,
+    setExpected,
+  ] = useLocalState(context, 'expected', '');
+  const [
+    actual,
+    setActual,
+  ] = useLocalState(context, 'actual', '');
+
+  const [
+    stage,
+    setStage,
+  ] = useLocalState(context, 'stage', 1);
+
+  let content = "The issue reporter is currently facing issues.";
+  let windowHeight = 480;
+
+  switch (stage)
+  {
+    case 1:
+      content = (<Regression
+        isRegression={isRegression}
+        setIsRegression={setIsRegression}
+        issueName={issueName}
+        setIssueName={setIssueName} />);
+      windowHeight = 294;
+      break;
+      case 2:
+        content = (<ExpectedBehaviours
+          expected={expected}
+          setExpected={setExpected}
+          actual={actual}
+          setActual={setActual} />);
+        windowHeight = 494;
+        break;
+      case 3:
+        content = (<ReplicationSteps
+          replicationSteps={replicationSteps}
+          setReplicationSteps={setReplicationSteps} />);
+        windowHeight = 362;
+        break;
+  }
+
+  return (
+    <Window
+      width={340}
+      height={windowHeight}
+      overflow="auto"
+      theme="generic"
+      title={"Issue reporter " + stage + "/3"}>
+      <Window.Content>
+        <Flex direction="column" height="100%">
+          <Flex.Item
+            grow={1}>
+            {content}
+          </Flex.Item>
+          <Flex.Item
+            alignSelf="flex-end">
+            <Section>
+              <Flex direction="row" width="100%">
+                {stage !== 1 ? (
+                <Flex.Item
+                  grow={1}>
+                  <Button
+                    fontSize={1.5}
+                    onClick={() => {
+                      if (stage === 1)
+                      {
+                        return;
+                      }
+                      setStage(stage - 1);
+                    }}>
+                    Previous
+                  </Button>
+                </Flex.Item>) : (
+                  <Flex.Item grow={1} />
+                )}
+                <Flex.Item
+                  alignSelf="flex-end">
+                  <Button
+                    fontSize={1.5}
+                    onClick={() => {
+                      if (stage === 3)
+                      {
+                        // Submit the report and close
+                        act('submit', {
+                          title: issueName,
+                          expected: expected,
+                          actual: actual,
+                          replicationSteps: replicationSteps,
+                          isRegression: isRegression,
+                        });
+                        return;
+                      }
+                      setStage(stage + 1);
+                    }}>
+                    {stage === 3 ? "Submit in browser" : "Continue"}
+                  </Button>
+                </Flex.Item>
+              </Flex>
+            </Section>
+          </Flex.Item>
+        </Flex>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const Regression = (props, context) => {
+
+  const {
+    isRegression,
+    setIsRegression,
+    issueName,
+    setIssueName,
+  } = props;
+
+  return (
+    <>
+      <Section title="Issue Title">
+        Please enter a concise name for the issue
+        <Input
+          mt={1}
+          width="100%"
+          value={issueName}
+          onInput={(e, text) => setIssueName(text)} />
+      </Section>
+      <Section title="Issue Type">
+        Was the issue being reported previously functioning as intended?
+        <i>(Please select &#39;No&#39; if unknown).</i>
+        <Box
+          mt={1}
+          mb={1}
+          width="100%">
+          <ButtonCheckbox
+            overflowX="wrap"
+            ml={1}
+            style={{ 'font-weight': 'normal', 'font-size': '12px' }}
+            content={isRegression
+              ? "Yes - This is a new issue"
+              : "No - This hasn't been known to work"}
+            checked={isRegression}
+            onClick={() => {
+              setIsRegression(!isRegression);
+            }} />
+        </Box>
+      </Section>
+    </>
+  );
+};
+
+const ExpectedBehaviours = (props, context) => {
+
+  const {
+    expected,
+    setExpected,
+    actual,
+    setActual,
+  } = props;
+
+  return (
+    <>
+      <Section title="Expected Behaviour">
+        Please describe the expected behaviour of the issue that you are reporting.
+        <TextArea
+          mt={1}
+          height="120px"
+          value={expected}
+          onInput={(e, text) => setExpected(text)} />
+      </Section>
+      <Section title="Actual Behaviour">
+        Please describe the actual behaviour exhibited.
+        <TextArea
+          mt={1}
+          height="120px"
+          value={actual}
+          onInput={(e, text) => setActual(text)} />
+      </Section>
+    </>
+  );
+};
+
+
+const ReplicationSteps = (props, context) => {
+
+  const {
+    replicationSteps,
+    setReplicationSteps,
+  } = props;
+
+  return (
+    <Section title="Replication Steps">
+      Please describe the steps that you performed in order to cause the
+      bug to happen. Issues that have steps to replicate 100% of the time
+      are more likely to be solved.
+      <TextArea
+        mt={1}
+        height="150px"
+        value={replicationSteps}
+        onInput={(e, text) => setReplicationSteps(text)} />
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/IssueReporter.js
+++ b/tgui/packages/tgui/interfaces/IssueReporter.js
@@ -40,7 +40,7 @@ export const IssueReporter = (props, context) => {
   }
 
   return (
-    <Window width={340} height={windowHeight} overflow="auto" theme="generic" title={'Issue reporter ' + stage + '/3'}>
+    <Window width={340} height={windowHeight} overflow="auto" theme="generic" title={`Issue reporter (${stage}/3)`}>
       <Window.Content>
         <Flex direction="column" height="100%">
           <Flex.Item grow={1}>{content}</Flex.Item>
@@ -109,7 +109,7 @@ const Regression = (props, context) => {
             overflowX="wrap"
             ml={1}
             style={{ 'font-weight': 'normal', 'font-size': '12px' }}
-            content={isRegression ? 'Yes - This is a new issue' : "No - This hasn't been known to work"}
+            content={'Yes - This is a new issue'}
             checked={isRegression}
             onClick={() => {
               setIsRegression(!isRegression);

--- a/tgui/packages/tgui/interfaces/IssueReporter.js
+++ b/tgui/packages/tgui/interfaces/IssueReporter.js
@@ -4,107 +4,70 @@ import { ButtonCheckbox } from 'tgui/components/Button';
 import { Box, Section, Button, Flex, TextArea, Input } from '../components';
 
 export const IssueReporter = (props, context) => {
+  const { act } = useBackend(context);
 
-  const {
-    act,
-  } = useBackend(context);
+  const [isRegression, setIsRegression] = useLocalState(context, 'isRegression', false);
+  const [issueName, setIssueName] = useLocalState(context, 'issueName', '');
+  const [replicationSteps, setReplicationSteps] = useLocalState(context, 'replicationSteps', '');
+  const [expected, setExpected] = useLocalState(context, 'expected', '');
+  const [actual, setActual] = useLocalState(context, 'actual', '');
 
-  const [
-    isRegression,
-    setIsRegression,
-  ] = useLocalState(context, 'isRegression', false);
-  const [
-    issueName,
-    setIssueName,
-  ] = useLocalState(context, 'issueName', '');
-  const [
-    replicationSteps,
-    setReplicationSteps,
-  ] = useLocalState(context, 'replicationSteps', '');
-  const [
-    expected,
-    setExpected,
-  ] = useLocalState(context, 'expected', '');
-  const [
-    actual,
-    setActual,
-  ] = useLocalState(context, 'actual', '');
+  const [stage, setStage] = useLocalState(context, 'stage', 1);
 
-  const [
-    stage,
-    setStage,
-  ] = useLocalState(context, 'stage', 1);
-
-  let content = "The issue reporter is currently facing issues.";
+  let content = 'The issue reporter is currently facing issues.';
   let windowHeight = 480;
 
-  switch (stage)
-  {
+  switch (stage) {
     case 1:
-      content = (<Regression
-        isRegression={isRegression}
-        setIsRegression={setIsRegression}
-        issueName={issueName}
-        setIssueName={setIssueName} />);
+      content = (
+        <Regression
+          isRegression={isRegression}
+          setIsRegression={setIsRegression}
+          issueName={issueName}
+          setIssueName={setIssueName}
+        />
+      );
       windowHeight = 294;
       break;
-      case 2:
-        content = (<ExpectedBehaviours
-          expected={expected}
-          setExpected={setExpected}
-          actual={actual}
-          setActual={setActual} />);
-        windowHeight = 494;
-        break;
-      case 3:
-        content = (<ReplicationSteps
-          replicationSteps={replicationSteps}
-          setReplicationSteps={setReplicationSteps} />);
-        windowHeight = 362;
-        break;
+    case 2:
+      content = <ExpectedBehaviours expected={expected} setExpected={setExpected} actual={actual} setActual={setActual} />;
+      windowHeight = 494;
+      break;
+    case 3:
+      content = <ReplicationSteps replicationSteps={replicationSteps} setReplicationSteps={setReplicationSteps} />;
+      windowHeight = 362;
+      break;
   }
 
   return (
-    <Window
-      width={340}
-      height={windowHeight}
-      overflow="auto"
-      theme="generic"
-      title={"Issue reporter " + stage + "/3"}>
+    <Window width={340} height={windowHeight} overflow="auto" theme="generic" title={'Issue reporter ' + stage + '/3'}>
       <Window.Content>
         <Flex direction="column" height="100%">
-          <Flex.Item
-            grow={1}>
-            {content}
-          </Flex.Item>
-          <Flex.Item
-            alignSelf="flex-end">
+          <Flex.Item grow={1}>{content}</Flex.Item>
+          <Flex.Item alignSelf="flex-end">
             <Section>
               <Flex direction="row" width="100%">
                 {stage !== 1 ? (
-                <Flex.Item
-                  grow={1}>
-                  <Button
-                    fontSize={1.5}
-                    onClick={() => {
-                      if (stage === 1)
-                      {
-                        return;
-                      }
-                      setStage(stage - 1);
-                    }}>
-                    Previous
-                  </Button>
-                </Flex.Item>) : (
+                  <Flex.Item grow={1}>
+                    <Button
+                      fontSize={1.5}
+                      onClick={() => {
+                        if (stage === 1) {
+                          return;
+                        }
+                        setStage(stage - 1);
+                      }}>
+                      Previous
+                    </Button>
+                  </Flex.Item>
+                ) : (
                   <Flex.Item grow={1} />
                 )}
-                <Flex.Item
-                  alignSelf="flex-end">
+                <Flex.Item alignSelf="flex-end">
                   <Button
                     fontSize={1.5}
                     onClick={() => {
-                      if (stage === 3)
-                      {
+                      if (stage === 3) {
                         // Submit the report and close
                         act('submit', {
                           title: issueName,
@@ -117,7 +80,7 @@ export const IssueReporter = (props, context) => {
                       }
                       setStage(stage + 1);
                     }}>
-                    {stage === 3 ? "Submit in browser" : "Continue"}
+                    {stage === 3 ? 'Submit in browser' : 'Continue'}
                   </Button>
                 </Flex.Item>
               </Flex>
@@ -130,42 +93,28 @@ export const IssueReporter = (props, context) => {
 };
 
 const Regression = (props, context) => {
-
-  const {
-    isRegression,
-    setIsRegression,
-    issueName,
-    setIssueName,
-  } = props;
+  const { isRegression, setIsRegression, issueName, setIssueName } = props;
 
   return (
     <>
       <Section title="Issue Title">
         Please enter a concise name for the issue
-        <Input
-          mt={1}
-          width="100%"
-          value={issueName}
-          onInput={(e, text) => setIssueName(text)} />
+        <Input mt={1} width="100%" value={issueName} onInput={(e, text) => setIssueName(text)} />
       </Section>
       <Section title="Issue Type">
         Was the issue being reported previously functioning as intended?
         <i>(Please select &#39;No&#39; if unknown).</i>
-        <Box
-          mt={1}
-          mb={1}
-          width="100%">
+        <Box mt={1} mb={1} width="100%">
           <ButtonCheckbox
             overflowX="wrap"
             ml={1}
             style={{ 'font-weight': 'normal', 'font-size': '12px' }}
-            content={isRegression
-              ? "Yes - This is a new issue"
-              : "No - This hasn't been known to work"}
+            content={isRegression ? 'Yes - This is a new issue' : "No - This hasn't been known to work"}
             checked={isRegression}
             onClick={() => {
               setIsRegression(!isRegression);
-            }} />
+            }}
+          />
         </Box>
       </Section>
     </>
@@ -173,54 +122,30 @@ const Regression = (props, context) => {
 };
 
 const ExpectedBehaviours = (props, context) => {
-
-  const {
-    expected,
-    setExpected,
-    actual,
-    setActual,
-  } = props;
+  const { expected, setExpected, actual, setActual } = props;
 
   return (
     <>
       <Section title="Expected Behaviour">
         Please describe the expected behaviour of the issue that you are reporting.
-        <TextArea
-          mt={1}
-          height="120px"
-          value={expected}
-          onInput={(e, text) => setExpected(text)} />
+        <TextArea mt={1} height="120px" value={expected} onInput={(e, text) => setExpected(text)} />
       </Section>
       <Section title="Actual Behaviour">
         Please describe the actual behaviour exhibited.
-        <TextArea
-          mt={1}
-          height="120px"
-          value={actual}
-          onInput={(e, text) => setActual(text)} />
+        <TextArea mt={1} height="120px" value={actual} onInput={(e, text) => setActual(text)} />
       </Section>
     </>
   );
 };
 
-
 const ReplicationSteps = (props, context) => {
-
-  const {
-    replicationSteps,
-    setReplicationSteps,
-  } = props;
+  const { replicationSteps, setReplicationSteps } = props;
 
   return (
     <Section title="Replication Steps">
-      Please describe the steps that you performed in order to cause the
-      bug to happen. Issues that have steps to replicate 100% of the time
-      are more likely to be solved.
-      <TextArea
-        mt={1}
-        height="150px"
-        value={replicationSteps}
-        onInput={(e, text) => setReplicationSteps(text)} />
+      Please describe the steps that you performed in order to cause the bug to happen. Issues that have steps to replicate 100%
+      of the time are more likely to be solved.
+      <TextArea mt={1} height="150px" value={replicationSteps} onInput={(e, text) => setReplicationSteps(text)} />
     </Section>
   );
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #8857

Updates the issue reporter to allow for more comprehensive in game reports from players.
It will now ask the player to fill out the issue before directing them to github where they can review and submit the issue.
This introduces new config variables:
- Filepath of the default issue template (New system only)
- The default labels to apply to issues
- The name of the regression label to apply to regression issues

## Why It's Good For The Game

Players in game will now be given the boxes required to fill out an issue report, making the actual issue filed from these reports a lot more useful. When we do get issues from the old system, there is a lot of information missing due to not filling out the template. This new method will also fill out the bug label automatically, and regression if ticked.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5e5ff205-b57d-4d2e-8385-e6b8e761f45b)
(UI issue will use the old reporting system rather than the new one)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/a2b4fec7-7e25-4156-acd1-37266e95bf7b)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/cc1a4ec0-7c8c-4949-922e-5c72f8b6f7f7)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5b8366c0-a4ec-4981-b095-08ab28aa00bb)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/b223406a-57a5-4d02-9374-666fd734501a)


## Changelog
:cl:
add: Adds a new issue reporter which is more comprehensive than before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
