### PR TITLE
Removes chainsaw from barber

### DIFF
--- a/_maps/RandomRooms/10x5/sk_rdm011_barbershop.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm011_barbershop.dmm
@@ -82,7 +82,6 @@
 	amount = 2
 	},
 /obj/item/stack/sheet/iron/ten,
-/obj/item/chainsaw,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/clothing/head/wig/random,
 /obj/item/reagent_containers/medspray/spraytan,

--- a/_maps/RandomRooms/10x5/sk_rdm011_barbershop.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm011_barbershop.dmm
@@ -82,6 +82,7 @@
 	amount = 2
 	},
 /obj/item/stack/sheet/iron/ten,
+/obj/item/hatchet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/clothing/head/wig/random,
 /obj/item/reagent_containers/medspray/spraytan,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the chainsaw from barber supplies, replacing it with a hatchet to fulfil the same function for ghetto surgery

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Barbers cannot wrap their heads around the fact they shouldn't be valid-hunting. 
It serves *almost* no legitimate purpose for barbers that are not murder-hobos, when compared to the far less lethal hatchet.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/c1c55ab9-20d4-48de-8192-2f1e4c1f46ff)

## Changelog
:cl:
del: Replaces the barber's chainsaw with a hatchet because the baboons won't stop valid-hunting with the chainsaw. 
/:cl:
