### PR TITLE
Sleek titanium tiles fix

### DIFF
--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -141,21 +141,21 @@
 
 /turf/open/floor/mineral/titanium/alt/blue
 	icon_state = "titanium_blue_alt"
-	floor_tile = /obj/item/stack/tile/mineral/titanium/alt/yellow
+	floor_tile = /obj/item/stack/tile/mineral/titanium/alt/blue
 
 /turf/open/floor/mineral/titanium/alt/blue/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/mineral/titanium/alt/white
 	icon_state = "titanium_white_alt"
-	floor_tile = /obj/item/stack/tile/mineral/titanium/alt/yellow
+	floor_tile = /obj/item/stack/tile/mineral/titanium/alt/white
 
 /turf/open/floor/mineral/titanium/alt/white/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/mineral/titanium/alt/purple
 	icon_state = "titanium_purple_alt"
-	floor_tile = /obj/item/stack/tile/mineral/titanium/alt/yellow
+	floor_tile = /obj/item/stack/tile/mineral/titanium/alt/purple
 
 /turf/open/floor/mineral/titanium/alt/purple/airless
 	initial_gas_mix = AIRLESS_ATMOS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
*  Closes https://github.com/BeeStation/BeeStation-Hornet/issues/9251

Makes sleek titanium tiles drop their respective tile items when crowbarred.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/8345cd82-31ca-4fd0-9b5d-8d2c63ac7eee)

</details>

## Changelog
:cl:
fix: Made sleek titanium tiles create the tile items of their respective color when removed with a crowbar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
