### PR TITLE
Prevent dynamic midrounds from rolling if the shuttle is called or docked

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -13,7 +13,7 @@
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
-#define EMERGENCY_ALMOST_HERE (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL) && (SSshuttle.emergency.timeLeft() <= 2 MINUTES))
+#define EMERGENCY_ALMOST_HERE (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL) && (SSshuttle.emergency.timeLeft(1) <= 2 MINUTES))
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -13,7 +13,7 @@
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
-#define EMERGENCY_ALMOST_HERE (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL) && (SSshuttle.emergency.timeLeft(1) <= 2 MINUTES))
+#define EMERGENCY_ALMOST_HERE (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL) && (SSshuttle.emergency.timeLeft(1) <= 10 MINUTES))
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -13,7 +13,7 @@
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
-#define EMERGENCY_ALMOST_HERE (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL) && (SSshuttle.emergency.timeLeft(1) <= 10 MINUTES))
+#define EMERGENCY_CALLED (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL))
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -13,6 +13,7 @@
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
+#define EMERGENCY_ALMOST_HERE (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL) && (SSshuttle.emergency.timeLeft() <= 2 MINUTES))
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -23,8 +23,8 @@
 	if (GLOB.dynamic_forced_extended)
 		return
 
-	if(!forced_injection && (EMERGENCY_AT_LEAST_DOCKED || EMERGENCY_ALMOST_HERE))
-		dynamic_log("Not rolling a midround because the shuttle is almost here or already here.")
+	if(!forced_injection && (EMERGENCY_AT_LEAST_DOCKED || EMERGENCY_CALLED))
+		dynamic_log("Not rolling a midround because the shuttle is called or already here.")
 		return
 
 	if (EMERGENCY_ESCAPED_OR_ENDGAMED)

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -23,6 +23,9 @@
 	if (GLOB.dynamic_forced_extended)
 		return
 
+	if(!forced_injection && (EMERGENCY_AT_LEAST_DOCKED || EMERGENCY_ALMOST_HERE))
+		return
+
 	if (EMERGENCY_ESCAPED_OR_ENDGAMED)
 		return
 

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -24,6 +24,7 @@
 		return
 
 	if(!forced_injection && (EMERGENCY_AT_LEAST_DOCKED || EMERGENCY_ALMOST_HERE))
+		dynamic_log("Not rolling a midround because the shuttle is almost here or left.")
 		return
 
 	if (EMERGENCY_ESCAPED_OR_ENDGAMED)

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -24,7 +24,7 @@
 		return
 
 	if(!forced_injection && (EMERGENCY_AT_LEAST_DOCKED || EMERGENCY_ALMOST_HERE))
-		dynamic_log("Not rolling a midround because the shuttle is almost here or left.")
+		dynamic_log("Not rolling a midround because the shuttle is almost here or already here.")
 		return
 
 	if (EMERGENCY_ESCAPED_OR_ENDGAMED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents dynamic midrounds from rolling if the emergency shuttle is docked or if the shuttle is less than or equal to ~~two~~ ten minutes away from docking. **Admin-forced midrounds are unaffected.**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I initially wanted to make it a variable which can be toggled for **certain** midrounds, but after looking at the list of midrounds I decided to expand it to **ALL MIDROUNDS**. If the shuttle is almost here or docked, there is nothing of value a pirate, or xeno larvae, or fugitives, or obsessed or any midround can add to the experience this late into the round. This mainly targets that situation where a blob spawns and just effectively delays the round and force a possibly already-exhausted crew to fight it who knows how long into the round, let the round come to a close.

The two minutes has been determined somewhat arbitrarily, as the shuttle will take ~~two~~ ten minutes to leave, and I do not want to block midrounds if the shuttle gets recalled super late, open for suggestions on what should constitute "Almost here".

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/dc3f9348-c958-4f44-892f-83171470c3bf)

</details>

## Changelog
:cl:
tweak: Dynamic midrounds can no longer roll if the shuttle is called or docked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
