### PR TITLE
Dynamic brakes - Midround threat limitations based on a chaos heuristic

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -919,6 +919,7 @@
 #include "code\game\gamemodes\devil\objectives.dm"
 #include "code\game\gamemodes\devil\devil agent\devil_agent.dm"
 #include "code\game\gamemodes\dynamic\dynamic.dm"
+#include "code\game\gamemodes\dynamic\dynamic_danger.dm"
 #include "code\game\gamemodes\dynamic\dynamic_hijacking.dm"
 #include "code\game\gamemodes\dynamic\dynamic_logging.dm"
 #include "code\game\gamemodes\dynamic\dynamic_midround_rolling.dm"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -710,6 +710,14 @@ SUBSYSTEM_DEF(ticker)
 
 	world.Reboot()
 
+/datum/controller/subsystem/ticker/get_metrics()
+	. = ..()
+	if (mode)
+		var/list/game_mode_info = mode?.get_metrics()
+		if (length(game_mode_info))
+			.["custom"] = game_mode_info
+	return .
+
 /datum/controller/subsystem/ticker/Shutdown()
 	gather_newscaster() //called here so we ensure the log is created even upon admin reboot
 	save_admin_data()

--- a/code/game/gamemodes/dynamic/dynamic_danger.dm
+++ b/code/game/gamemodes/dynamic/dynamic_danger.dm
@@ -1,0 +1,81 @@
+/// The threat growth for new antagonists
+#define ANTAGONIST_THREAT 2
+/// The time it takes for new antagonist threats to decay
+#define ANTAG_THREAT_DECAY (15 MINUTES)
+/// The threat increase from a crewmember dying
+#define DEAD_THREAT 3
+/// How long it takes for the threat from a mob dying to decay
+#define DEAD_THREAT_DECAY (30 MINUTES)
+/// Time based decay of threat gives a threat trajectory over the course of the round.
+/// This determines how much danger will be reduced by every hour.
+/// A value of 10 would mean that at the 1 hour mark, calculate_danger()'s output will
+/// be reduced by 10.
+#define HOURLY_THREAT_DECREASE 10
+
+/datum/game_mode/dynamic/admin_stat_info()
+	. = list()
+	if (world.time < previous_cache_heuristic_time + 30 SECONDS)
+		.["Danger Heuristic"] = GENERATE_STAT_TEXT("[previous_cache_heuristic]")
+		return
+	.["Danger Heuristic"] = GENERATE_STAT_TEXT("[calculate_danger()]")
+
+/datum/game_mode/dynamic/get_metrics()
+	. = list()
+	.["dynamic"] = list(
+		"danger_heuristic" = calculate_danger()
+	)
+
+/// Calculate the amount of 'danger' on the station.
+/// This will be subtracted from the amount of threat that is spendable, so in intense situations
+/// dynamic will be throttled on how much it can spawn to allow for the station to recover.
+/// This heuristic should not be overly complicated and have its calculation based on complex
+/// factors, otherwise it is less likely to work well as a heuristic for the chaos going on.
+/// We allow dynamic to handle population by having higher pops give higher threat levels, so this
+/// doesn't scale based on the population.
+/datum/game_mode/dynamic/proc/calculate_danger()
+	. = 0
+	// Increase the danger level based on the proportion of new antagonists
+	// We don't care about how many antagonists there are, since active ones causing chaos
+	// will likely continuously trip the dead player heuristic, we only care about
+	// new antagonists as there needs to be a safe zone that allows antagonists
+	// to get active.
+	// This specifically targets antagonist growth.
+	for (var/datum/antagonist/antagonist in GLOB.antagonists)
+		if (!antagonist.is_station_threat)
+			continue
+		if (!antagonist.owner || !antagonist.owner.current)
+			continue
+		// Ignore dead antagonists, since they are no threat
+		if (antagonist.owner.current.stat == DEAD)
+			continue
+		var/threat_for = world.time - antagonist.created_at
+		. += (1 - CLAMP01(threat_for / ANTAG_THREAT_DECAY)) * ANTAGONIST_THREAT
+	// Increase the danger level for every player that can be revived
+	// Ignore players that cannot be recovered as they are considered
+	for (var/mob/living/L in GLOB.mob_list)
+		// Ignore players in the wrong place
+		if (!is_station_level(L.z))
+			continue
+		// Ignore dead players
+		if (L.stat != DEAD)
+			continue
+		// Ignore dead crew with no ghosts
+		if (!L.get_ghost(FALSE, TRUE))
+			continue
+		// We can't handle this
+		if (!L.timeofdeath)
+			continue
+		var/dead_for = world.time - L.timeofdeath
+		// The danger decays as people stay dead for 30 minutes
+		. += (1 - CLAMP01(dead_for / DEAD_THREAT_DECAY)) * DEAD_THREAT
+	// Decrease threat over time to create a threat trajectory that increases the allowed chaos
+	// over time.
+	. -= (world.time / (1 HOURS)) * HOURLY_THREAT_DECREASE
+	// Do not allow threat increases
+	. = max(., 0)
+	previous_cache_heuristic = .
+	previous_cache_heuristic_time = world.time
+
+/// Get the amount of threat that we are allowed to spend
+/datum/game_mode/dynamic/proc/get_allowed_midround_budget()
+	return mid_round_budget - calculate_danger()

--- a/code/game/gamemodes/dynamic/dynamic_logging.dm
+++ b/code/game/gamemodes/dynamic/dynamic_logging.dm
@@ -87,6 +87,8 @@
 	serialized["threat_level"] = threat_level
 	serialized["round_start_budget"] = initial_round_start_budget
 	serialized["mid_round_budget"] = threat_level - initial_round_start_budget
+	serialized["current_danger"] = calculate_danger()
+	serialized["allowed_budget"] = get_allowed_midround_budget()
 
 	var/list/serialized_snapshots = list()
 	for (var/_snapshot in snapshots)

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -48,8 +48,8 @@
 			log_game("DYNAMIC: FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len], threat level: [threat_level]")
 			continue
 
-		if (mid_round_budget < ruleset.cost)
-			log_game("DYNAMIC: FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], ruleset cost: [ruleset.cost]")
+		if (get_allowed_midround_budget() < ruleset.cost)
+			log_game("DYNAMIC: FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], Midround reduction: [calculate_danger()], Final midround budget: [get_allowed_midround_budget()], ruleset cost: [ruleset.cost]")
 			continue
 
 		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -894,3 +894,9 @@
 		round_credits += list("<center><h2>The station was free of <s>greytide</s> assistance!</h2>", "<center><h2>Not a single Assistant showed up on the station today!</h2>")
 
 	return round_credits
+
+/datum/game_mode/proc/admin_stat_info()
+	return list()
+
+/datum/game_mode/proc/get_metrics()
+	return list()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -29,6 +29,23 @@ GLOBAL_LIST(admin_antag_list)
 	var/antagpanel_category = "Uncategorized"	//Antagpanel will display these together, REQUIRED
 	var/show_name_in_check_antagonists = FALSE //Will append antagonist name in admin listings - use for categories that share more than one antag type
 	var/show_to_ghosts = FALSE // Should this antagonist be shown as antag to ghosts? Shouldn't be used for stealthy antagonists like traitors
+	/// Should this antagonist count towards the station threat heuristic
+	var/is_station_threat = TRUE
+	/// The time that this antagonist was created at
+	var/created_at
+
+/datum/antagonist/New()
+	. = ..()
+	GLOB.antagonists += src
+	typecache_datum_blacklist = typecacheof(typecache_datum_blacklist)
+	created_at = world.time
+
+/datum/antagonist/Destroy()
+	GLOB.antagonists -= src
+	if(owner)
+		LAZYREMOVE(owner.antag_datums, src)
+	owner = null
+	return ..()
 
 /datum/antagonist/proc/show_tips(fileid)
 	if(!owner || !owner.current || !owner.current.client)
@@ -43,17 +60,6 @@ GLOBAL_LIST(admin_antag_list)
 
 /datum/antagonist/proc/get_asset_url_from(match)
 	return SSassets.transport.get_asset_url(match)
-
-/datum/antagonist/New()
-	GLOB.antagonists += src
-	typecache_datum_blacklist = typecacheof(typecache_datum_blacklist)
-
-/datum/antagonist/Destroy()
-	GLOB.antagonists -= src
-	if(owner)
-		LAZYREMOVE(owner.antag_datums, src)
-	owner = null
-	return ..()
 
 /datum/antagonist/proc/can_be_owned(datum/mind/new_owner)
 	. = TRUE

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -11,6 +11,7 @@
 	antagpanel_category = "Ash Walkers"
 	delay_roundend = FALSE
 	count_against_dynamic_roll_chance = FALSE
+	is_station_threat = FALSE
 	var/datum/team/ashwalkers/ashie_team
 
 /datum/antagonist/ashwalker/create_team(datum/team/team)

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -22,6 +22,7 @@
 	show_to_ghosts = TRUE
 	antag_moodlet = /datum/mood_event/focused
 	count_against_dynamic_roll_chance = FALSE
+	is_station_threat = FALSE
 
 /datum/antagonist/ert/on_gain()
 	if(random_names)

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -7,6 +7,7 @@
 	show_to_ghosts = TRUE
 	prevent_roundtype_conversion = FALSE
 	count_against_dynamic_roll_chance = FALSE
+	is_station_threat = FALSE
 	var/datum/team/fugitive/fugitive_team
 	var/is_captured = FALSE
 	var/living_on_capture = TRUE

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -7,6 +7,7 @@
 	show_to_ghosts = TRUE
 	prevent_roundtype_conversion = FALSE
 	count_against_dynamic_roll_chance = FALSE
+	is_station_threat = FALSE
 	var/datum/team/fugitive_hunters/hunter_team
 	var/datum/fugitive_type/hunter/backstory
 

--- a/code/modules/antagonists/official/official.dm
+++ b/code/modules/antagonists/official/official.dm
@@ -3,6 +3,7 @@
 	show_name_in_check_antagonists = TRUE
 	show_in_antagpanel = FALSE
 	can_elimination_hijack = ELIMINATION_PREVENT
+	is_station_threat = FALSE
 	var/datum/objective/mission
 	var/datum/team/ert/ert_team
 	show_to_ghosts = TRUE

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -78,6 +78,7 @@
 	show_name_in_check_antagonists = FALSE
 	prevent_roundtype_conversion = FALSE
 	delay_roundend = FALSE
+	is_station_threat = FALSE
 
 /datum/antagonist/special/proc/equip()
 	return

--- a/code/modules/antagonists/santa/santa.dm
+++ b/code/modules/antagonists/santa/santa.dm
@@ -3,6 +3,7 @@
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
+	is_station_threat = FALSE
 
 /datum/antagonist/santa/on_gain()
 	. = ..()

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -165,11 +165,19 @@
 	if(SSticker.round_start_time)
 		tab_data["Security Level"] = GENERATE_STAT_TEXT("[capitalize(get_security_level())]")
 
-	tab_data["divider_3"] = GENERATE_STAT_DIVIDER
 	if(SSshuttle.emergency)
+		tab_data["divider_3"] = GENERATE_STAT_DIVIDER
 		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
+
+	// Admin information
+	if (check_rights_for(client, R_ADMIN | R_DEBUG))
+		var/list/admin_tab_data = list()
+		admin_tab_data += SSticker.mode?.admin_stat_info() || list()
+		if (length(admin_tab_data))
+			tab_data["divider_4"] = GENERATE_STAT_DIVIDER
+			tab_data += admin_tab_data
 	return tab_data
 
 /mob/proc/get_stat_tab_master_controller()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a heuristic for tracking the overall chaos going down in a dynamic round. This heuristic will limit the availability of the midround budget when the chaos level is too high.
The heuristic tracks:
- New antagonists (After 15 minutes, the danger added to the heuristic by the antagonist decreases to 0)
- New deaths (After 30 minutes the danger added to the heuristic by a dead player decreases to 0)
Over time the heuristic decreases, with a rate of -10 every hour.

For every point of danger calculated by the heuristic, a point will be taken off of the dynamic midround budget meaning that in chaotic situations, dynamic will be prevented from spawning even more chaos driving events. The decrease over time provides a "danger trajectory" which allows for the game to introduce more chaos as the time goes on.

The heuristic tracks basic elements, it doesn't and shouldn't track complex things such as station damage, individual antagonist impact or projected chaos as that would decrease the accuracy of the system and make it more likely to not have the intended results.

This heuristic logs itself to metrics, so that it can be tracked. I don't expect this to be perfect first try and it might not work at all. This entire idea is entirely hypothetical. The main argument against this I see coming is that the heuristic will be too inaccurate and won't be able to accurately predict the chaos level of the game, however we don't need an accurate determination of the current level of chaos, only something that strongly correlates to how the players percieve the chaos of the round.

I was thinking about trying to calculate projected future impacts of rulesets by doing some statistical analysis however after doing this on the whiteboard I just reached the basis of machine learning and I really don't want to code any machine learning systems into the game right now.

## Why It's Good For The Game

In a pretty good portion of dynamic rounds I have played, midrounds have been spawning when the station is already in chaos often resulting in frustrating rather than interesting gameplay. There is a fine balance we need to achieve between midround spawning creating interesting instead of frustrating scenarios. Some kind basic heuristic is necessary in order to achieve this.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/fdd063ce-69d5-4dc0-9e51-4699fad7c283)

More to come soon.

## Changelog
:cl:
add: Adds a heuristic which performs a basic calculation of how chaotic the current game is and decreases the dynamic threat spawning rate based on that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
