### PR TITLE
Fix headmin not being able to ban 3 admins

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -557,7 +557,8 @@
 		if(query_check_adminban_count.NextRow())
 			var/adminban_count = text2num(query_check_adminban_count.item[1])
 			var/max_adminbans = MAX_ADMINBANS_PER_ADMIN
-			if(R_EVERYTHING && !(R_EVERYTHING & rank.can_edit_rights)) //edit rights are a more effective way to check hierarchical rank since many non-headmins have R_PERMISSIONS now
+			//edit rights are a more effective way to check hierarchical rank since many non-headmins have R_PERMISSIONS
+			if(rank.can_edit_rights == R_EVERYTHING)
 				max_adminbans = MAX_ADMINBANS_PER_HEADMIN
 			if(adminban_count >= max_adminbans)
 				to_chat(usr, "<span class='danger'>You've already logged [max_adminbans] admin ban(s) or more. Do not abuse this function!</span>")


### PR DESCRIPTION
## About The Pull Request

The check that was originally there is broken, this fixes said check.

## Why It's Good For The Game

Headmins should be able to ban more than 1 admin.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Tested as local debug user which has R_EVERYTHING and can edit all perms

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/fdd7b88a-006d-4173-a51a-e62ad3184647)

</details>

## Changelog
:cl:
fix: Headmins can now ban more than 1 admin.
/:cl:
