### PR TITLE
Janitor QoL

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,11 @@
 					"DM_EXE": "${config:dreammaker.byondPath}"
 				}
 			},
-			"problemMatcher": ["$dreammaker", "$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": {
 				"kind": "build",
 				"isDefault": true
@@ -23,7 +27,9 @@
 		{
 			"type": "dreammaker",
 			"dme": "beestation.dme",
-			"problemMatcher": ["$dreammaker"],
+			"problemMatcher": [
+				"$dreammaker"
+			],
 			"group": "build",
 			"label": "dm: build - beestation.dme"
 		},
@@ -33,7 +39,10 @@
 			"windows": {
 				"command": ".\\bin\\test.cmd"
 			},
-			"problemMatcher": ["$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": "build",
 			"label": "Run All Tests"
 		},
@@ -43,7 +52,10 @@
 			"windows": {
 				"command": ".\\bin\\temp-fast-test.cmd"
 			},
-			"problemMatcher": ["$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": "build",
 			"label": "dm: find hard deletes"
 		},
@@ -58,7 +70,10 @@
 			"windows": {
 				"command": ".\\bin\\tgui-build.cmd"
 			},
-			"problemMatcher": ["$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": "build",
 			"label": "tgui: build"
 		},
@@ -68,7 +83,10 @@
 			"windows": {
 				"command": ".\\bin\\tgui-dev.cmd"
 			},
-			"problemMatcher": ["$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": "build",
 			"label": "tgui: dev server"
 		},
@@ -78,7 +96,10 @@
 			"windows": {
 				"command": ".\\bin\\tgui-bench.cmd"
 			},
-			"problemMatcher": ["$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": "build",
 			"label": "tgui: bench"
 		},
@@ -88,7 +109,10 @@
 			"windows": {
 				"command": ".\\bin\\tgui-sonar.cmd"
 			},
-			"problemMatcher": ["$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": "build",
 			"label": "tgui: sonar"
 		},
@@ -98,9 +122,21 @@
 			"windows": {
 				"command": ".\\bin\\tgui-prettier.cmd"
 			},
-			"problemMatcher": ["$tsc", "$eslint-stylish"],
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
 			"group": "build",
 			"label": "tgui: prettier-formatter"
+		},
+		{
+			"type": "dreammaker",
+			"dme": "beestation.m.dme",
+			"problemMatcher": [
+				"$dreammaker"
+			],
+			"group": "build",
+			"label": "dm: build - beestation.m.dme"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,11 +12,7 @@
 					"DM_EXE": "${config:dreammaker.byondPath}"
 				}
 			},
-			"problemMatcher": [
-				"$dreammaker",
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$dreammaker", "$tsc", "$eslint-stylish"],
 			"group": {
 				"kind": "build",
 				"isDefault": true
@@ -27,9 +23,7 @@
 		{
 			"type": "dreammaker",
 			"dme": "beestation.dme",
-			"problemMatcher": [
-				"$dreammaker"
-			],
+			"problemMatcher": ["$dreammaker"],
 			"group": "build",
 			"label": "dm: build - beestation.dme"
 		},
@@ -39,10 +33,7 @@
 			"windows": {
 				"command": ".\\bin\\test.cmd"
 			},
-			"problemMatcher": [
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$tsc", "$eslint-stylish"],
 			"group": "build",
 			"label": "Run All Tests"
 		},
@@ -52,10 +43,7 @@
 			"windows": {
 				"command": ".\\bin\\temp-fast-test.cmd"
 			},
-			"problemMatcher": [
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$tsc", "$eslint-stylish"],
 			"group": "build",
 			"label": "dm: find hard deletes"
 		},
@@ -70,10 +58,7 @@
 			"windows": {
 				"command": ".\\bin\\tgui-build.cmd"
 			},
-			"problemMatcher": [
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$tsc", "$eslint-stylish"],
 			"group": "build",
 			"label": "tgui: build"
 		},
@@ -83,10 +68,7 @@
 			"windows": {
 				"command": ".\\bin\\tgui-dev.cmd"
 			},
-			"problemMatcher": [
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$tsc", "$eslint-stylish"],
 			"group": "build",
 			"label": "tgui: dev server"
 		},
@@ -96,10 +78,7 @@
 			"windows": {
 				"command": ".\\bin\\tgui-bench.cmd"
 			},
-			"problemMatcher": [
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$tsc", "$eslint-stylish"],
 			"group": "build",
 			"label": "tgui: bench"
 		},
@@ -109,10 +88,7 @@
 			"windows": {
 				"command": ".\\bin\\tgui-sonar.cmd"
 			},
-			"problemMatcher": [
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$tsc", "$eslint-stylish"],
 			"group": "build",
 			"label": "tgui: sonar"
 		},
@@ -122,21 +98,9 @@
 			"windows": {
 				"command": ".\\bin\\tgui-prettier.cmd"
 			},
-			"problemMatcher": [
-				"$tsc",
-				"$eslint-stylish"
-			],
+			"problemMatcher": ["$tsc", "$eslint-stylish"],
 			"group": "build",
 			"label": "tgui: prettier-formatter"
-		},
-		{
-			"type": "dreammaker",
-			"dme": "beestation.m.dme",
-			"problemMatcher": [
-				"$dreammaker"
-			],
-			"group": "build",
-			"label": "dm: build - beestation.m.dme"
 		}
 	]
 }

--- a/code/datums/elements/cleaning.dm
+++ b/code/datums/elements/cleaning.dm
@@ -48,6 +48,12 @@
 	var/toggled = TRUE
 	var/atom/movable/toggle_target = null
 
+/datum/action/cleaning_toggle/maid
+	name = "Floor Polish Toggle"
+	desc = "Toggles the automatic floor polishing"
+	icon_icon = 'icons/obj/clothing/gloves.dmi'
+	button_icon_state = "maid_arms"
+
 /datum/action/cleaning_toggle/Grant(mob/M)
 	. = ..()
 	if(isnull(toggle_target))

--- a/code/datums/elements/cleaning.dm
+++ b/code/datums/elements/cleaning.dm
@@ -10,7 +10,6 @@
 
 /datum/element/cleaning/proc/Clean(datum/source)
 	SIGNAL_HANDLER
-
 	var/atom/movable/AM = source
 	var/turf/tile = AM.loc
 	if(!isturf(tile))
@@ -40,3 +39,31 @@
 				SEND_SIGNAL(cleaned_human, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRENGTH_BLOOD)
 				cleaned_human.regenerate_icons()
 				to_chat(cleaned_human, "<span class='danger'>[AM] cleans your face!</span>")
+
+/datum/action/cleaning_toggle
+	name = "Floor Cleaning Toggle"
+	desc = "Toggles the automatic floor cleaning"
+	icon_icon = 'icons/obj/vehicles.dmi'
+	button_icon_state = "upgrade"
+	var/toggled = TRUE
+	var/atom/movable/toggle_target = null
+
+/datum/action/cleaning_toggle/Grant(mob/M)
+	. = ..()
+	if(isnull(toggle_target))
+		toggle_target = M
+
+/datum/action/cleaning_toggle/Trigger()
+	. = ..()
+	if(!toggle_target)
+		log_runtime("Floor Cleaning Toggle action triggered without a target.")
+		return
+	if(toggled)
+		toggle_target.RemoveElement(/datum/element/cleaning)
+		toggled = FALSE
+	else
+		toggle_target.AddElement(/datum/element/cleaning)
+		toggled = TRUE
+	owner.balloon_alert(owner, "Auto-cleaning is [toggled ? "ON" : "OFF"]")
+	to_chat(owner, "<span class='notice'>The auto-cleaning is now [toggled ? "ON" : "OFF"].</span>")
+

--- a/code/datums/elements/cleaning.dm
+++ b/code/datums/elements/cleaning.dm
@@ -48,6 +48,10 @@
 	var/toggled = TRUE
 	var/atom/movable/toggle_target = null
 
+/datum/action/cleaning_toggle/Remove(mob/M)
+	toggle_target = null
+	. = ..()
+
 /datum/action/cleaning_toggle/maid
 	name = "Floor Polish Toggle"
 	desc = "Toggles the automatic floor polishing"

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -77,7 +77,7 @@
 	name = "advanced mop"
 	mopcap = 10
 	icon_state = "advmop"
-	item_state = "mop"
+	item_state = "advmop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	force = 12

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -100,7 +100,22 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(!isturf(target) || !isobj(target))
-		return
-	if(target.color != initial(target.color))
-		target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+	if(isclothing(target) && HAS_TRAIT(target, TRAIT_SPRAYPAINTED) || target.color != initial(target.color))
+		user.visible_message("[user] begins to clean \the [target.name] with [src]...", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
+		if(!do_after(user, 10, target = target))
+			to_chat(user, "<span class='notice'>You fail to clean \the [target.name]!.</span>")
+			return
+		to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
+		if(isclothing(target) && HAS_TRAIT(target, TRAIT_SPRAYPAINTED))
+			var/obj/item/clothing/C = target
+			var/mob/living/carbon/human/H = user
+			C.flash_protect -= 1
+			C.tint -= 2
+			H.update_tint()
+			REMOVE_TRAIT(target, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
+		if(istype(target, /obj/structure/window))
+			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+			target.set_opacity(initial(target.opacity))
+		if(target.color != initial(target.color))
+			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
+			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -167,7 +167,7 @@
 			balloon_alert(user, "Removed [mybroom]")
 			to_chat(user, "<span class='notice'>You take [mybroom] from [src].</span>")
 			user.put_in_hands(mybroom)
-			mymop = null
+			mybroom = null
 		if("Spray bottle")
 			if(!myspray)
 				return
@@ -225,7 +225,6 @@
 				continue //we'll do this after.
 			. += "\t[icon2html(thing, user)] \a [thing]"
 		if(signs > 0)
-			//var/obj/item/caution/object = new /obj/item/caution/object
 			var/obj/item/clothing/suit/caution/object = locate() in src
 			if(signs > 1)
 				. += "\t[icon2html(object, user)] [signs] [object.name]\s"

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -15,7 +15,6 @@
 	var/signs = 0
 	var/max_signs = 4
 
-
 /obj/structure/janitorialcart/Initialize(mapload)
 	. = ..()
 	create_reagents(100, OPENCONTAINER)
@@ -32,6 +31,7 @@
 	else
 		var/obj/item/mop/M = mop
 		reagents.trans_to(mop, M.mopcap, transfered_by = user)
+		balloon_alert(user, "Wet the [mop]")
 		to_chat(user, "<span class='notice'>You wet [mop] in [src].</span>")
 		playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		return 1
@@ -40,12 +40,19 @@
 	if(!user.transferItemToLoc(I, src))
 		return
 	updateUsrDialog()
+	balloon_alert(user, "Put [I] into [src]")
 	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 	return
 
+/obj/structure/janitorialcart/AltClick(mob/user)
+	if(!mymop)
+		return
+	balloon_alert(user, "Removed [mymop]")
+	user.put_in_hands(mymop)
+	mymop = null
+	update_icon()
 
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user, params)
-	var/fail_msg = "<span class='warning'>There is already one of those in [src]!</span>"
 
 	if(istype(I, /obj/item/mop))
 		var/obj/item/mop/m=I
@@ -55,118 +62,142 @@
 		if(!mymop)
 			m.janicart_insert(user, src)
 		else
-			to_chat(user, fail_msg)
+			balloon_alert(user, "Already has \a [mymop]!")
+			to_chat(user, "<span class='notice'>There is already \a [mymop] in [src]!</span>")
 	else if(istype(I, /obj/item/pushbroom))
 		if(!mybroom)
 			var/obj/item/pushbroom/b=I
 			b.janicart_insert(user,src)
 		else
-			to_chat(user, fail_msg)
+			balloon_alert(user, "Already has \a [mybroom]!")
+			to_chat(user, "<span class='notice'>There is already \a [mybroom] in [src]!</span>")
 	else if(istype(I, /obj/item/storage/bag/trash))
 		if(!mybag)
 			var/obj/item/storage/bag/trash/t=I
 			t.janicart_insert(user, src)
 		else
-			to_chat(user,  fail_msg)
+			balloon_alert(user, "Already has \a [mybag]!")
+			to_chat(user, "<span class='notice'>There is already \a [mybag] in [src]!</span>")
 	else if(istype(I, /obj/item/reagent_containers/spray/cleaner))
 		if(!myspray)
 			put_in_cart(I, user)
 			myspray=I
 			update_icon()
 		else
-			to_chat(user, fail_msg)
+			balloon_alert(user, "Already has \a [myspray]!")
+			to_chat(user, "<span class='notice'>There is already \a [myspray] in [src]!</span>")
 	else if(istype(I, /obj/item/lightreplacer))
 		if(!myreplacer)
 			var/obj/item/lightreplacer/l=I
 			l.janicart_insert(user,src)
 		else
-			to_chat(user, fail_msg)
+			balloon_alert(user, "Already has \a [myreplacer]!")
+			to_chat(user, "<span class='notice'>There is already \a [myreplacer] in [src]!</span>")
 	else if(istype(I, /obj/item/clothing/suit/caution))
 		if(signs < max_signs)
 			put_in_cart(I, user)
 			signs++
 			update_icon()
 		else
-			to_chat(user, "<span class='warning'>[src] can't hold any more signs!</span>")
+			balloon_alert(user, "The sign rack is full!")
+			to_chat(user, "<span class='notice'>The [src] can't hold any more signs!</span>")
 	else if(mybag)
 		mybag.attackby(I, user)
 	else if(I.tool_behaviour == TOOL_CROWBAR)
-		user.visible_message("[user] begins to empty the contents of [src].", "<span class='notice'>You begin to empty the contents of [src]...</span>")
+		user.balloon_alert_to_viewers("Starts dumping [src]...", "Started dumping [src]...")
+		user.visible_message("[user] begins to dump the contents of [src].", "<span class='notice'>You begin to dump the contents of [src]...</span>")
 		if(I.use_tool(src, user, 30))
-			to_chat(usr, "<span class='notice'>You empty the contents of [src]'s bucket onto the floor.</span>")
+			balloon_alert(user, "Dumped [src]")
+			to_chat(usr, "<span class='notice'>You dump the contents of [src]'s bucket onto the floor.</span>")
 			reagents.reaction(src.loc)
 			src.reagents.clear_reagents()
 	else
 		return ..()
+
+/obj/structure/janitorialcart/proc/check_menu(mob/living/user)
+	return istype(user) && !user.incapacitated()
 
 /obj/structure/janitorialcart/attack_hand(mob/user)
 	. = ..()
 	if(.)
 		return
 	user.set_machine(src)
-	var/dat
+	var/list/items = list()
 	if(mybag)
-		dat += "<a href='?src=[REF(src)];garbage=1'>[mybag.name]</a><br>"
+		items += list("Trash bag" = image(icon = mybag.icon, icon_state = mybag.icon_state))
 	if(mymop)
-		dat += "<a href='?src=[REF(src)];mop=1'>[mymop.name]</a><br>"
+		items += list("Mop" = image(icon = mymop.icon, icon_state = mymop.icon_state))
 	if(mybroom)
-		dat += "<a href='?src=[REF(src)];broom=1'>[mybroom.name]</a><br>"
+		items += list("Broom" = image(icon = mybroom.icon, icon_state = mybroom.icon_state))
 	if(myspray)
-		dat += "<a href='?src=[REF(src)];spray=1'>[myspray.name]</a><br>"
+		items += list("Spray bottle" = image(icon = myspray.icon, icon_state = myspray.icon_state))
 	if(myreplacer)
-		dat += "<a href='?src=[REF(src)];replacer=1'>[myreplacer.name]</a><br>"
-	if(signs)
-		dat += "<a href='?src=[REF(src)];sign=1'>[signs] sign\s</a><br>"
-	var/datum/browser/popup = new(user, "janicart", name, 240, 160)
-	popup.set_content(dat)
-	popup.open()
+		items += list("Light replacer" = image(icon = myreplacer.icon, icon_state = myreplacer.icon_state))
+	if(signs > 0)
+		var/obj/item/clothing/suit/caution/sign = locate() in src
+		items += list("Sign" = image(icon = sign.icon, icon_state = sign.icon_state))
 
+	if(!length(items))
+		return
 
-/obj/structure/janitorialcart/Topic(href, href_list)
-	if(!in_range(src, usr))
+	var/pick = items[1]
+	if(length(items) > 1)
+		items = sort_list(items)
+		pick = show_radial_menu(user, src, items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), radius = 38, require_near = TRUE)
+	if(!pick)
 		return
-	if(!isliving(usr))
-		return
-	var/mob/living/user = usr
-	if(href_list["garbage"])
-		if(mybag)
-			user.put_in_hands(mybag)
+	switch(pick)
+		if("Trash bag")
+			if(!mybag)
+				return
+			balloon_alert(user, "Detached [mybag]")
 			to_chat(user, "<span class='notice'>You take [mybag] from [src].</span>")
+			user.put_in_hands(mybag)
 			mybag = null
-	if(href_list["mop"])
-		if(mymop)
-			user.put_in_hands(mymop)
+		if("Mop")
+			if(!mymop)
+				return
+			balloon_alert(user, "Removed [mymop]")
 			to_chat(user, "<span class='notice'>You take [mymop] from [src].</span>")
+			user.put_in_hands(mymop)
 			mymop = null
-	if(href_list["broom"])
-		if(mybroom)
-			user.put_in_hands(mybroom)
+		if("Broom")
+			if(!mybroom)
+				return
+			balloon_alert(user, "Removed [mybroom]")
 			to_chat(user, "<span class='notice'>You take [mybroom] from [src].</span>")
-			mybroom = null
-	if(href_list["spray"])
-		if(myspray)
-			user.put_in_hands(myspray)
+			user.put_in_hands(mybroom)
+			mymop = null
+		if("Spray bottle")
+			if(!myspray)
+				return
+			balloon_alert(user, "Removed [myspray]")
 			to_chat(user, "<span class='notice'>You take [myspray] from [src].</span>")
+			user.put_in_hands(myspray)
 			myspray = null
-	if(href_list["replacer"])
-		if(myreplacer)
-			user.put_in_hands(myreplacer)
+		if("Light replacer")
+			if(!myreplacer)
+				return
+			balloon_alert(user, "Removed [myreplacer]")
 			to_chat(user, "<span class='notice'>You take [myreplacer] from [src].</span>")
+			user.put_in_hands(myreplacer)
 			myreplacer = null
-	if(href_list["sign"])
-		if(signs)
+		if("Sign")
+			if(signs <= 0)
+				return
 			var/obj/item/clothing/suit/caution/Sign = locate() in src
-			if(Sign)
+			if(signs > 1)
+				balloon_alert(user, "Removed \a [Sign]")
 				user.put_in_hands(Sign)
-				to_chat(user, "<span class='notice'>You take \a [Sign] from [src].</span>")
 				signs--
 			else
-				WARNING("Signs ([signs]) didn't match contents")
+				balloon_alert(user, "Removed [Sign]")
+				user.put_in_hands(Sign)
 				signs = 0
-
+			to_chat(user, "<span class='notice'>You take \a [Sign] from [src].</span>")
+		else
+			return
 	update_icon()
-	updateUsrDialog()
-
 
 /obj/structure/janitorialcart/update_icon()
 	cut_overlays()
@@ -184,4 +215,23 @@
 		add_overlay("cart_sign[signs]")
 	if(reagents.total_volume > 0)
 		add_overlay("cart_water")
+
+/obj/structure/janitorialcart/examine(mob/user)
+	. = ..()
+	if(contents.len)
+		. += ("<span class='notice'><b>\nIt is carrying:</b></span>")
+		for(var/thing in sort_names(contents))
+			if(istype(thing, /obj/item/clothing/suit/caution))
+				continue //we'll do this after.
+			. += "\t[icon2html(thing, user)] \a [thing]"
+		if(signs > 0)
+			//var/obj/item/caution/object = new /obj/item/caution/object
+			var/obj/item/clothing/suit/caution/object = locate() in src
+			if(signs > 1)
+				. += "\t[icon2html(object, user)] [signs] [object.name]\s"
+			else
+				. += "\t[icon2html(object, user)] \a [object]"
+		. += "<span class='notice'>\n<b>Left-click</b> to [contents.len > 1 ? "search [src]" : "remove [contents[1]]"].</span>"
+		if(mymop)
+			. += "<span class='notice'><b>Alt-click</b> to quickly remove [mymop].</span>"
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -27,6 +27,8 @@
 	var/obj/item/clockwork/clockwork_slab/internal_clock_slab = null
 	var/ratvar = FALSE
 
+	var/datum/action/cleaning_toggle/autoclean_toggle
+
 //Hud stuff
 
 	var/atom/movable/screen/inv1 = null
@@ -234,6 +236,9 @@
 		if(T && istype(radio) && istype(radio.keyslot))
 			radio.keyslot.forceMove(T)
 			radio.keyslot = null
+	if(autoclean_toggle)
+		autoclean_toggle.Remove(usr)
+	QDEL_NULL(autoclean_toggle)
 	QDEL_NULL(wires)
 	QDEL_NULL(eye_lights)
 	QDEL_NULL(inv1)
@@ -1084,8 +1089,14 @@
 
 	if(module.clean_on_move)
 		AddElement(/datum/element/cleaning)
+		autoclean_toggle = new()
+		autoclean_toggle.toggle_target = usr
+		autoclean_toggle.Grant(usr)
 	else
 		RemoveElement(/datum/element/cleaning)
+		if(autoclean_toggle)
+			autoclean_toggle.Remove(usr)
+			QDEL_NULL(autoclean_toggle)
 
 	hat_offset = module.hat_offset
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -173,6 +173,11 @@
 	autoclean_toggle = new()
 	autoclean_toggle.Grant(usr)
 
+/mob/living/simple_animal/hostile/alien/maid/Destroy()
+	. = ..()
+	autoclean_toggle.Remove(usr)
+	QDEL_NULL(autoclean_toggle)
+
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()
 	if(ismovable(target))
 		if(istype(target, /obj/effect/decal/cleanable))

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -165,15 +165,12 @@
 	icon_state = "maid"
 	icon_living = "maid"
 	icon_dead = "maid_dead"
-	var/datum/action/cleaning_toggle/autoclean_toggle
+	var/datum/action/cleaning_toggle/maid/autoclean_toggle
 
 /mob/living/simple_animal/hostile/alien/maid/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/cleaning)
 	autoclean_toggle = new()
-	autoclean_toggle.icon_icon = 'icons/obj/clothing/gloves.dmi'
-	autoclean_toggle.button_icon_state = "maid_arms"
-	autoclean_toggle.toggle_target = usr
 	autoclean_toggle.Grant(usr)
 
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -165,10 +165,16 @@
 	icon_state = "maid"
 	icon_living = "maid"
 	icon_dead = "maid_dead"
+	var/datum/action/cleaning_toggle/autoclean_toggle
 
 /mob/living/simple_animal/hostile/alien/maid/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/cleaning)
+	autoclean_toggle = new()
+	autoclean_toggle.icon_icon = 'icons/obj/clothing/gloves.dmi'
+	autoclean_toggle.button_icon_state = "maid_arms"
+	autoclean_toggle.toggle_target = usr
+	autoclean_toggle.Grant(usr)
 
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()
 	if(ismovable(target))

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -87,6 +87,12 @@
 		autoclean_toggle.Remove(buckled_mob)
 		QDEL_NULL(autoclean_toggle)
 
+/obj/vehicle/ridden/janicart/Destroy()
+	. = ..()
+	if(floorbuffer)
+		autoclean_toggle.toggle_target = null
+		QDEL_NULL(autoclean_toggle)
+
 /obj/vehicle/ridden/janicart/upgraded
 	floorbuffer = TRUE
 

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -6,6 +6,7 @@
 	key_type = /obj/item/key/janitor
 	var/obj/item/storage/bag/trash/mybag = null
 	var/floorbuffer = FALSE
+	var/datum/action/cleaning_toggle/autoclean_toggle
 
 /obj/vehicle/ridden/janicart/Initialize(mapload)
 	. = ..()
@@ -72,6 +73,19 @@
 		user.put_in_hands(mybag)
 		mybag = null
 		update_icon()
+
+/obj/vehicle/ridden/janicart/buckle_mob(mob/living/M, force, check_loc)
+	. = ..()
+	if(floorbuffer)
+		autoclean_toggle = new()
+		autoclean_toggle.toggle_target = src
+		autoclean_toggle.Grant(M)
+
+/obj/vehicle/ridden/janicart/unbuckle_mob(mob/living/buckled_mob, force)
+	. = ..()
+	if(floorbuffer)
+		autoclean_toggle.Remove(buckled_mob)
+		QDEL_NULL(autoclean_toggle)
 
 /obj/vehicle/ridden/janicart/upgraded
 	floorbuffer = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the janicart use a radial menu rather than a browser for item retrieval, allows for quick mop retrieval with Alt-Click, gives the janicart a more detailed description on examine and allows for the Pimping Ride/Janibot/Xenomaid to toggle their automatic floor cleaning on movement.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is honestly a pretty big quality of life change as it makes playing Janitor more smooth without needing to rely on the clunky browser menu. This also makes one of the roles that's commonly recommended to new players a lot more accessible.
And the floor autoclean toggle allows for people to pass over floor art/graffiti without erasing it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Detailed examine

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/edcb3249-fb8b-4cdb-a576-897a527c0520)

Mop 'quickdraw' with alt click

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/071abb4b-70bc-48f1-8c6a-c0c4fd2ffe14

New janicart item retrieval radial menu

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/4e26cee5-5cd6-4a4f-b079-2b28f42e02d2

Janicart floor buffer toggle

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/5fc4842a-1dc4-4cf1-b14a-fd427df7216d

Janibot floor autoclean toggle

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/e7cbd702-8997-424a-b6e6-08e8abda742a

Xenomaid autopolish toggle

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/cac0e62d-69b4-42a5-a70f-22768780513b

</details>

## Changelog
:cl:
add: Added a more detailed description to the Janicart
add: Added the ability to quickdraw a mop from the Janicart
add: Replaced the old windows menu for the janicart with a radial menu
add: Added the ability to toggle auto floor cleaning for pimping rides, janibots and xeno maids
fix: Fixed the advanced mop having the same inhand icon as the normal mop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
