### PR TITLE
Makes the 'crew manifest' a default PDA app.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -6,7 +6,9 @@
 	extended_desc = "Program for viewing and printing the current crew manifest"
 	transfer_access = list(ACCESS_HEADS)
 	requires_ntnet = FALSE
-	size = 4
+	size = 0
+	undeletable = TRUE // It comes by default in PDAs, can't be downloaded, takes no space and should obviously not be able to be deleted.
+	available_on_ntnet = FALSE
 	tgui_id = "NtosCrewManifest"
 	program_icon = "clipboard-list"
 

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -181,6 +181,7 @@
 /obj/item/computer_hardware/hard_drive/small/pda/install_default_programs()
 	store_file(new /datum/computer_file/program/messenger(src))
 	store_file(new /datum/computer_file/program/notepad(src))
+	store_file(new/datum/computer_file/program/crew_manifest(src))
 	store_file(new/datum/computer_file/program/databank_uplink(src))	// Wiki Uplink, allows the user to access the Wiki from in-game!
 	..()
 

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -34,9 +34,6 @@
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
 
-	if(disk_flags & DISK_MANIFEST)
-		progs_to_store += new /datum/computer_file/program/crew_manifest(src)
-
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the 'crew manifest' a default PDA app.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
The Messenger app already serves as an alternative for seeing who's on the crew manifest, and there's no real reason to restrict this app only to command/security.
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Installed by default

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/4a2a5d2f-2234-4539-8aad-d915e98d98a6)

Not downloadable

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/a65170f3-905b-454f-b6c2-6150daf80935)


</details>

## Changelog
:cl:
tweak: Added the 'Crew Manifest' program to the list of default PDA apps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
