### PR TITLE
Fixes some item pickup overtime

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1130,6 +1130,7 @@
 #include "code\game\objects\effects\effects.dm"
 #include "code\game\objects\effects\forcefields.dm"
 #include "code\game\objects\effects\glowshroom.dm"
+#include "code\game\objects\effects\icons.dm"
 #include "code\game\objects\effects\info.dm"
 #include "code\game\objects\effects\landmarks.dm"
 #include "code\game\objects\effects\mainttraps.dm"

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -367,12 +367,16 @@
 	for(var/client/C in show_to)
 		C.images -= I
 
+/// Shows an image to all clients, then removes that image after the duration.
+/// If you want an overlay applied to the object which will show to all clients, use
+/// flick_overlay_static
 /proc/flick_overlay(image/I, list/show_to, duration)
 	for(var/client/C in show_to)
 		C.images += I
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_images_from_clients), I, show_to), duration, TIMER_CLIENT_TIME)
 
-/proc/flick_overlay_view(image/I, atom/target, duration) //wrapper for the above, flicks to everyone who can see the target atom
+/// Displays an image to clients that can see a target object.
+/proc/flick_overlay_view(image/I, atom/target, duration)
 	var/list/viewing = list()
 	for(var/mob/M as() in viewers(target))
 		if(M.client)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -833,39 +833,40 @@
 
 /atom/movable/proc/do_item_attack_animation(atom/A, visual_effect_icon, obj/item/used_item)
 	var/image/I
+	var/obj/effect/icon/temp/attack_animation_object
 	if(visual_effect_icon)
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
+		attack_animation_object = new(A.loc, I, 10)
 	else if(used_item)
 		I = image(icon = used_item, loc = A, layer = A.layer + 0.1)
 		I.plane = GAME_PLANE
-
-		// Scale the icon.
-		I.transform *= pick(0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55)
-		// The icon should not rotate.
-		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		I.appearance_flags = NO_CLIENT_COLOR | PIXEL_SCALE
+		attack_animation_object = new(A.loc, I, 10)
 
 		// Set the direction of the icon animation.
 		var/direction = get_dir(src, A)
 		if(direction & NORTH)
-			I.pixel_y = rand(-15,-11)
+			attack_animation_object.pixel_y = rand(-15,-11)
 		else if(direction & SOUTH)
-			I.pixel_y = rand(11,15)
+			attack_animation_object.pixel_y = rand(11,15)
 
 		if(direction & EAST)
-			I.pixel_x = rand(-15,-11)
+			attack_animation_object.pixel_x = rand(-15,-11)
 		else if(direction & WEST)
-			I.pixel_x = rand(11,15)
+			attack_animation_object.pixel_x = rand(11,15)
 
 		if(!direction) // Attacked self?!
-			I.pixel_z = 16
+			attack_animation_object.pixel_z = 16
 
 	if(!I)
 		return
 
-	flick_overlay(I, GLOB.clients, 10) // 10 ticks/a whole second
+	// Scale the icon.
+	if (used_item)
+		attack_animation_object.transform *= pick(0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55)
 
 	// And animate the attack!
-	animate(I, alpha = 175, transform = matrix() * 0.75, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
+	animate(attack_animation_object, alpha = 175, transform = matrix() * 0.75, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
 	animate(time = 1)
 	animate(alpha = 0, time = 3, easing = CIRCULAR_EASING|EASE_OUT)
 
@@ -1050,8 +1051,7 @@
 		return
 	var/image/pickup_animation = image(icon = src, loc = loc, layer = layer + 0.1)
 	pickup_animation.plane = GAME_PLANE
-	pickup_animation.transform *= 0.75
-	pickup_animation.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	pickup_animation.appearance_flags = NO_CLIENT_COLOR | PIXEL_SCALE
 	var/turf/current_turf = get_turf(src)
 	var/direction = get_dir(current_turf, target)
 	var/to_x = target.base_pixel_x
@@ -1069,12 +1069,13 @@
 		to_y += 10
 		pickup_animation.pixel_x += 6 * (prob(50) ? 1 : -1) //6 to the right or left, helps break up the straight upward move
 
-	flick_overlay(pickup_animation, GLOB.clients, 6)
-	var/matrix/animation_matrix = new(pickup_animation.transform)
+	var/obj/effect/icon/temp/pickup_animation_object = new(loc, pickup_animation, 4)
+	pickup_animation_object.transform *= 0.75
+	var/matrix/animation_matrix = new(pickup_animation_object.transform)
 	animation_matrix.Turn(pick(-30, 30))
 	animation_matrix.Scale(0.65)
 
-	animate(pickup_animation, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
+	animate(pickup_animation_object, alpha = 175, pixel_x = to_x, pixel_y = to_y, time = 3, transform = animation_matrix, easing = CUBIC_EASING)
 	animate(alpha = 0, transform = matrix().Scale(0.7), time = 1)
 
 /obj/item/proc/do_drop_animation(atom/moving_from)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -843,6 +843,9 @@
 		I.appearance_flags = NO_CLIENT_COLOR | PIXEL_SCALE
 		attack_animation_object = new(A.loc, I, 10)
 
+		// Scale the icon.
+		attack_animation_object.transform *= pick(0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55)
+
 		// Set the direction of the icon animation.
 		var/direction = get_dir(src, A)
 		if(direction & NORTH)
@@ -860,10 +863,6 @@
 
 	if(!I)
 		return
-
-	// Scale the icon.
-	if (used_item)
-		attack_animation_object.transform *= pick(0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55)
 
 	// And animate the attack!
 	animate(attack_animation_object, alpha = 175, transform = matrix() * 0.75, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)

--- a/code/game/objects/effects/icons.dm
+++ b/code/game/objects/effects/icons.dm
@@ -1,0 +1,7 @@
+/obj/effect/icon/Initialize(mapload, icon/render_source)
+	. = ..()
+	overlays = list(render_source)
+
+/obj/effect/icon/temp/Initialize(mapload, icon/render_source, duration)
+	. = ..()
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), src), duration, TIMER_STOPPABLE | TIMER_CLIENT_TIME)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

flick_overlay with a target of GLOB.clients is expensive. Rather than sending the icon to all clients in the game, we will just create an atom with an overlay and let byond handle it for us.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/33569b0c-c568-4d9b-a58c-6692da000916)

## Why It's Good For The Game

Optimisation.

## Testing Photographs and Procedure

### Testing Behaviour

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/18474379-304c-4d38-a1dc-2c8812fc33b5

### Testing Performance

Testing performance is a bit tricky for this, since it requires a server with players on it which I don't have locally.

## Changelog
:cl:
fix: Changes the way item pickup works in order to reduce overtime from sending images to all clients in the game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
