### PR TITLE
Fix self-highlighting with new highlighting

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -306,9 +306,9 @@ const TextHighlightSetting = (props, context) => {
         </Flex.Item>
         <Flex.Item>
           <Button.Checkbox
-            content="Case"
+            content="Self"
             tooltip="If this option is selected, your own messages will be highlighted too."
-            checked={matchCase}
+            checked={highlightSelf}
             onClick={() =>
               dispatch(
                 updateHighlightSetting({


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I messed up this button due to poor copy-paste work. I have now fixed it.

## Why It's Good For The Game

bug fix

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-06-21-1687374709-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/5687c904-41ec-442e-b3e8-61897b0a02c4)


</details>

## Changelog
:cl:
fix: The option to highlight your own chat messages works once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
