### PR TITLE
Slightly optimises turf_decal initialisation [1500 blips]

### DIFF
--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -37,7 +37,7 @@
 	layer = TURF_DECAL_LAYER
 
 /obj/effect/turf_decal/Initialize(mapload)
-	..()
+	ComponentInitialize()
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/turf_decal/ComponentInitialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Slightly optimises the initialisation time of decals, in my very brief tests I saved ~1500 blips of init time out of 28500.
This won't be a huge improvement, but every little helps. Note that these counts include /obj/effect/decal which is unchanged but that shouldn't make a difference.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/7358d3cf-a493-415b-a907-6ca3162fe01d)

The left is the blips that it took before, the 2 in green are the blips that it took afterwards. The reason the middle one is higher is because my computer only has 8GB of ram and discord and some stupid windows biometric services randomly started using all my ram for no reason. (I ran the middle one first, its in the middle because of excel csv weirdness)

Comparing the original run to the run with similar running conditions, I got:
|Decal|Before|After|
|-|-|-|
|/obj/effect/turf_decal/stripes/line|921.169|520.505|
|/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted|379.969|215.455|

Some things that didn't get optimised (Bit of a control test):
|Decal|Before|After|
|-|-|-|
|/obj/effect/decal/cleanable/blood/gibs/old|7.36312|5.57381|
|/obj/effect/decal/cleanable/blood/old|145.332|137.753|
|/obj/effect/decal/cleanable/dirt/dust|36.8641|30.8901|

Okay, so maybe my computer was running slightly faster in the second test, but the difference in the optimised thing is much better.

I'm not too worried about comprehensively proving this is better, since looking at the code clearly shows it is faster and it is impossible that it wouldn't be.

## Why It's Good For The Game

Slightly faster init times.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/cb5b3000-6c9e-47be-83cc-918a79e396ab)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/cde1f69e-123e-46af-a3d3-65b42d5532f1)

Spawned decals still work

## Changelog
:cl:
tweak: Optimises turf decal init time slightly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
