### PR TITLE
Optimises closet init times [2700 blips]

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3736,6 +3736,7 @@
 #include "code\modules\tgui_panel\tgui_panel.dm"
 #include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\unit_tests\_unit_tests.dm"
+#include "code\modules\unit_tests\closets.dm"
 #include "code\modules\uplink\uplink_devices.dm"
 #include "code\modules\uplink\uplink_items.dm"
 #include "code\modules\uplink\uplink_purchase_log.dm"

--- a/beestation.dme
+++ b/beestation.dme
@@ -3736,7 +3736,6 @@
 #include "code\modules\tgui_panel\tgui_panel.dm"
 #include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\unit_tests\_unit_tests.dm"
-#include "code\modules\unit_tests\closets.dm"
 #include "code\modules\uplink\uplink_devices.dm"
 #include "code\modules\uplink\uplink_items.dm"
 #include "code\modules\uplink\uplink_purchase_log.dm"

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -7,6 +7,8 @@
 	var/list/excludefromjob = list()				//If you don't want a job to get a certain objective (no captain stealing his own medal, etcetc)
 	var/list/altitems = list()				//Items which can serve as an alternative to the objective (darn you blueprints)
 	var/list/special_equipment = list()
+	/// Require that the target item is spawned at roundstart by closets.
+	var/require_item_spawns_at_roundstart = TRUE
 
 /datum/objective_item/proc/check_special_completion() //for objectives with special checks (is that slime extract unused? does that intellicard have an ai in it? etcetc)
 	return 1
@@ -246,6 +248,7 @@
 	name = "5 cardboard."
 	targetitem = /obj/item/stack/sheet/cardboard
 	difficulty = 9001
+	require_item_spawns_at_roundstart = FALSE
 
 /datum/objective_item/stack/check_special_completion(obj/item/stack/S)
 	var/target_amount = text2num(name)

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -228,9 +228,11 @@
 	switch(rand(1,10))
 
 		if(1,2)
-			name = special_name ? junk_names[junk] : "[initial(name)] for [pick(GLOB.alive_mob_list)]" //LETTER FOR IAN / BUBBLEGUM / MONKEY(420)
+			if (length(GLOB.alive_mob_list))
+				name = special_name ? junk_names[junk] : "[initial(name)] for [pick(GLOB.alive_mob_list)]" //LETTER FOR IAN / BUBBLEGUM / MONKEY(420)
 		if(3,4)
-			name = special_name ? junk_names[junk] : "[initial(name)] for [pick(GLOB.player_list)]" //Letter for ANYONE, even that wizard rampaging through the station.
+			if (length(GLOB.player_list))
+				name = special_name ? junk_names[junk] : "[initial(name)] for [pick(GLOB.player_list)]" //Letter for ANYONE, even that wizard rampaging through the station.
 		if(5)
 			name = special_name ? junk_names[junk] : "DO NOT OPEN"
 		else

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -13,7 +13,7 @@
 	throw_speed = 3
 	throw_range = 7
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 250)
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/active = FALSE
 	var/atom/movable/target //The thing we're searching for
 	var/minimum_range = 0 //at what range the pinpointer declares you to be at your destination

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -8,6 +8,7 @@
 	max_integrity = 200
 	integrity_failure = 50
 	armor = list(MELEE = 20,  BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 70, ACID = 60, STAMINA = 0)
+	var/contents_initialised = FALSE
 	var/icon_door = null
 	var/icon_door_override = FALSE //override to have open overlay use icon different to its base's
 	var/secure = FALSE //secure locker or not, also used if overriding a non-secure locker with a secure door overlay to add fancy lights
@@ -42,12 +43,12 @@
 	var/door_anim_angle = 136
 	var/door_hinge = -6.5
 	var/door_anim_time = 2.0 // set to 0 to make the door not animate at all
+
 /obj/structure/closet/Initialize(mapload)
 	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
 		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
 	. = ..()
 	update_icon()
-	PopulateContents()
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()
@@ -166,6 +167,10 @@
 	return TRUE
 
 /obj/structure/closet/proc/dump_contents()
+	// Generate the contents if we haven't already
+	if (!contents_initialised)
+		PopulateContents()
+		contents_initialised = TRUE
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
 		AM.forceMove(L)
@@ -524,6 +529,10 @@
 				req_access |= pick(get_all_accesses())
 
 /obj/structure/closet/contents_explosion(severity, target)
+	// Generate the contents if we haven't already
+	if (!contents_initialised)
+		PopulateContents()
+		contents_initialised = TRUE
 	for(var/thing in contents)
 		switch(severity)
 			if(EXPLODE_DEVASTATE)
@@ -566,6 +575,10 @@
 		T1.visible_message("<span class='warning'>[user] dives into [src]!</span>")
 
 /obj/structure/closet/on_object_saved(var/depth = 0)
+	// Generate the contents if we haven't already
+	if (!contents_initialised)
+		PopulateContents()
+		contents_initialised = TRUE
 	if(depth >= 10)
 		return ""
 	var/dat = ""

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -48,7 +48,13 @@
 	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
 		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
 	. = ..()
+	populate_contents_immediate()
 	update_icon()
+
+/// Used to immediately fill a closet on spawn.
+/// Use this if you are spawning any items which can be tracked inside the closet.
+/obj/structure/closet/proc/populate_contents_immediate()
+	return
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -3,6 +3,10 @@
 	req_access = list(ACCESS_QM)
 	icon_state = "qm"
 
+/obj/structure/closet/secure_closet/quartermaster/populate_contents_immediate()
+	..()
+	new /obj/item/card/id/departmental_budget/car(src)
+
 /obj/structure/closet/secure_closet/quartermaster/PopulateContents()
 	..()
 	new /obj/item/clothing/neck/cloak/qm(src)
@@ -24,5 +28,4 @@
 	new /obj/item/circuitboard/machine/techfab/department/cargo(src)
 	new /obj/item/storage/photo_album/QM(src)
 	new /obj/item/circuitboard/machine/ore_silo(src)
-	new /obj/item/card/id/departmental_budget/car(src)
 	new /obj/item/storage/box/radiokey/car(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -3,6 +3,10 @@
 	req_access = list(ACCESS_CE)
 	icon_state = "ce"
 
+/obj/structure/closet/secure_closet/engineering_chief/populate_contents_immediate()
+	new /obj/item/card/id/departmental_budget/eng(src)
+	new /obj/item/areaeditor/blueprints(src)
+
 /obj/structure/closet/secure_closet/engineering_chief/PopulateContents()
 	..()
 	new /obj/item/storage/box/suitbox/ce(src)
@@ -25,8 +29,6 @@
 	new /obj/item/circuitboard/machine/techfab/department/engineering(src)
 
 	// prioritized items
-	new /obj/item/card/id/departmental_budget/eng(src)
-	new /obj/item/areaeditor/blueprints(src)
 	new /obj/item/storage/toolbox/mechanical(src)
 	new /obj/item/clothing/neck/cloak/ce(src)
 	new /obj/item/door_remote/chief_engineer(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -4,6 +4,7 @@
 	icon_state = "ce"
 
 /obj/structure/closet/secure_closet/engineering_chief/populate_contents_immediate()
+	..()
 	new /obj/item/card/id/departmental_budget/eng(src)
 	new /obj/item/areaeditor/blueprints(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -78,6 +78,11 @@
 	req_access = list(ACCESS_CMO)
 	icon_state = "cmo"
 
+/obj/structure/closet/secure_closet/CMO/populate_contents_immediate()
+	..()
+	new /obj/item/card/id/departmental_budget/med(src)
+	new /obj/item/reagent_containers/hypospray/CMO(src)
+
 /obj/structure/closet/secure_closet/CMO/PopulateContents()
 	..()
 	new /obj/item/storage/box/suitbox/cmo(src)
@@ -103,8 +108,6 @@
 
 	// prioritized items
 	new /obj/item/door_remote/chief_medical_officer(src)
-	new /obj/item/card/id/departmental_budget/med(src)
-	new /obj/item/reagent_containers/hypospray/CMO(src)
 	new /obj/item/autosurgeon/cmo(src)
 	new /obj/item/extrapolator(src)
 	new /obj/item/storage/belt/medical(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
@@ -4,11 +4,14 @@
 	req_access = list(ACCESS_CENT_CAPTAIN)
 	icon_state = "cap"
 
+/obj/structure/closet/secure_closet/ertCom/populate_contents_immediate()
+	..()
+	new /obj/item/aicard(src)
+
 /obj/structure/closet/secure_closet/ertCom/PopulateContents()
 	..()
 	new /obj/item/storage/firstaid/regular(src)
 	new /obj/item/storage/box/handcuffs(src)
-	new /obj/item/aicard(src)
 	new /obj/item/assembly/flash/handheld(src)
 	if(prob(50))
 		new /obj/item/ammo_box/magazine/m50(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -3,10 +3,15 @@
 	req_access = list(ACCESS_RD)
 	icon_state = "rd"
 
+/obj/structure/closet/secure_closet/RD/populate_contents_immediate()
+	..()
+	new /obj/item/clothing/suit/armor/reactive/teleport(src)
+	new /obj/item/laser_pointer(src)
+	new /obj/item/card/id/departmental_budget/sci(src)
+
 /obj/structure/closet/secure_closet/RD/PopulateContents()
 	..()
 	new /obj/item/storage/box/suitbox/rd(src)
-	new /obj/item/clothing/suit/armor/reactive/teleport(src)
 	new /obj/item/clothing/suit/toggle/labcoat/research_director(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/radio/headset/heads/research_director(src)
@@ -24,11 +29,9 @@
 	new /obj/item/megaphone/command(src)
 	new /obj/item/computer_hardware/hard_drive/role/rd(src)
 	new /obj/item/storage/lockbox/medal/sci(src)
-	new /obj/item/laser_pointer(src)
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 
 	// prioritized items
-	new /obj/item/card/id/departmental_budget/sci(src)
 	new /obj/item/clothing/neck/cloak/rd(src)
 	new /obj/item/clothing/gloves/color/latex(src)
 	new /obj/item/clothing/glasses/hud/diagnostic(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -3,6 +3,10 @@
 	req_access = list(ACCESS_CAPTAIN)
 	icon_state = "cap"
 
+/obj/structure/closet/secure_closet/captains/populate_contents_immediate()
+	..()
+	new /obj/item/card/id/departmental_budget/civ(src)
+
 /obj/structure/closet/secure_closet/captains/PopulateContents()
 	..()
 	new /obj/item/storage/box/suitbox/cap(src)
@@ -31,7 +35,6 @@
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
 
 	// prioritized items
-	new /obj/item/card/id/departmental_budget/civ(src)
 	new /obj/item/clothing/neck/cloak/cap(src)
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/storage/belt/sabre(src)
@@ -55,6 +58,10 @@
 	req_access = list(ACCESS_HOP)
 	icon_state = "hop"
 
+/obj/structure/closet/secure_closet/hop/populate_contents_immediate()
+	..()
+	new /obj/item/card/id/departmental_budget/srv(src)
+
 /obj/structure/closet/secure_closet/hop/PopulateContents()
 	..()
 	new /obj/item/storage/box/suitbox/hop(src)
@@ -73,7 +80,6 @@
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
 
 	// prioritized items
-	new /obj/item/card/id/departmental_budget/srv(src)
 	new /obj/item/clothing/neck/cloak/hop(src)
 	new /obj/item/door_remote/civillian(src)
 	new /obj/item/assembly/flash/handheld(src)
@@ -119,6 +125,12 @@
 	req_access = list(ACCESS_HOS)
 	icon_state = "hos"
 
+/obj/structure/closet/secure_closet/hos/populate_contents_immediate()
+	..()
+	new /obj/item/card/id/departmental_budget/sec(src)
+	new /obj/item/gun/energy/e_gun/hos(src)
+	new /obj/item/pinpointer/nuke(src)
+
 /obj/structure/closet/secure_closet/hos/PopulateContents()
 	..()
 	new /obj/item/storage/box/suitbox/hos(src)
@@ -145,14 +157,11 @@
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
 
 	// prioritized items
-	new /obj/item/card/id/departmental_budget/sec(src)
 	new /obj/item/clothing/neck/cloak/hos(src)
 	new /obj/item/clothing/suit/armor/hos(src)
 	new /obj/item/clothing/suit/armor/hos/trenchcoat(src)
 	new /obj/item/shield/riot/tele(src)
 	new /obj/item/storage/belt/security/full(src)
-	new /obj/item/gun/energy/e_gun/hos(src)
-	new /obj/item/pinpointer/nuke(src)
 
 /obj/item/storage/box/suitbox/hos
 	name = "compression box of head of security outfits"
@@ -334,9 +343,12 @@
 	req_access = list(ACCESS_ARMORY)
 	icon_state = "armory"
 
-/obj/structure/closet/secure_closet/armory1/PopulateContents()
+/obj/structure/closet/secure_closet/armory1/populate_contents_immediate()
 	..()
 	new /obj/item/clothing/suit/armor/laserproof(src)
+
+/obj/structure/closet/secure_closet/armory1/PopulateContents()
+	..()
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/suit/armor/riot(src)
 	for(var/i in 1 to 3)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -20,13 +20,18 @@
 /obj/structure/closet/emcloset/anchored
 	anchored = TRUE
 
+/obj/structure/closet/emcloset/Initialize(mapload)
+	if (prob(1))
+		return INITIALIZE_HINT_QDEL
+	return ..()
+
 /obj/structure/closet/emcloset/PopulateContents()
 	..()
 
 	if (prob(40))
 		new /obj/item/storage/toolbox/emergency(src)
 
-	switch (pick_weight(list("small" = 40, "aid" = 25, "tank" = 20, "both" = 10, "nothing" = 4, "delete" = 1)))
+	switch (pick_weight(list("small" = 40, "aid" = 25, "tank" = 20, "both" = 10, "nothing" = 4)))
 		if ("small")
 			new /obj/item/tank/internals/emergency_oxygen(src)
 			new /obj/item/tank/internals/emergency_oxygen(src)
@@ -52,10 +57,6 @@
 			new /obj/item/tank/internals/emergency_oxygen(src)
 			new /obj/item/clothing/mask/breath(src)
 			new /obj/item/clothing/suit/space/hardsuit/skinsuit(src)
-
-		// teehee
-		if ("delete")
-			qdel(src)
 
 /*
  * Fire Closet

--- a/code/modules/antagonists/nukeop/equipment/pinpointer.dm
+++ b/code/modules/antagonists/nukeop/equipment/pinpointer.dm
@@ -1,4 +1,5 @@
 /obj/item/pinpointer/nuke
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/mode = TRACK_NUKE_DISK
 
 /obj/item/pinpointer/nuke/examine(mob/user)
@@ -61,6 +62,7 @@
 	name = "syndicate pinpointer"
 	desc = "A handheld tracking device that locks onto certain signals. It's configured to switch tracking modes once it detects the activation signal of a nuclear device."
 	icon_state = "pinpointer_syndicate"
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/pinpointer/syndicate_cyborg // Cyborg pinpointers just look for a random operative.
 	name = "cyborg syndicate pinpointer"

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -278,6 +278,7 @@
 	name = "contractor pinpointer"
 	desc = "A handheld tracking device that locks onto certain signals. Ignores suit sensors, but is much less accurate."
 	icon_state = "pinpointer_syndicate"
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	minimum_range = 25
 	has_owner = TRUE
 	ignore_suit_sensor_level = TRUE

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -46,6 +46,7 @@
 #include "achievement_validation.dm"
 #include "anchored_mobs.dm"
 #include "check_adjustable_clothing.dm"
+#include "closets.dm"
 #include "component_tests.dm"
 #include "connect_loc.dm"
 #include "crafting_tests.dm"

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -31,4 +31,4 @@
 			if (item.resistance_flags & INDESTRUCTIBLE)
 				failures += "[closet_type] contains the indestructible item, [item.type], in PopulateContents(). This should be in populate_contents_immediate() instead."
 	if (length(failures))
-		Fail(jointext(failures, ", "))
+		Fail(jointext(failures, "\n"))

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -11,7 +11,7 @@
 	var/list/obj_item_paths = list()
 
 	for (var/datum/objective_item/objective_item_path as() in subtypesof(/datum/objective_item))
-		if (initial(objective_item_path.require_item_spawns_at_roundstart))
+		if (!initial(objective_item_path.require_item_spawns_at_roundstart))
 			continue
 		obj_item_paths |= initial(objective_item_path.targetitem)
 

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -8,6 +8,11 @@
 	all_closets -= typesof(/obj/structure/closet/supplypod)
 	var/list/failures = list()
 
+	var/list/obj_item_paths = list()
+
+	for (var/datum/objective_item/objective_item_path as() in subtypesof(/datum/objective_item))
+		obj_item_paths |= initial(objective_item_path.targetitem)
+
 	for(var/closet_type in all_closets)
 		var/obj/structure/closet/closet = allocate(closet_type)
 
@@ -21,7 +26,7 @@
 			failures += "Initial Contents of [closet.type] ([contents_len]) exceed its storage capacity ([closet.storage_capacity])."
 
 		for (var/obj/item/item in closet.contents - immediate_contents)
-			if (item.type in GLOB.steal_item_handler.objectives_by_path)
+			if (item.type in obj_item_paths)
 				failures += "[closet_type] contains a steal objective [item.type] in PopulateContents(). Move it to populate_contents_immediate()."
 			if (item.resistance_flags & INDESTRUCTIBLE)
 				failures += "[closet_type] contains the indestructible item, [item.type], in PopulateContents(). This should be in populate_contents_immediate() instead."

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -1,0 +1,29 @@
+/// Checks that the length of the initial contents of a closet doesn't exceed its storage capacity.
+/// Also checks that nothing inside that isn't immediate is a steal objective.
+/datum/unit_test/closets
+
+/datum/unit_test/closets/Run()
+	var/list/all_closets = subtypesof(/obj/structure/closet)
+	//Supply pods. They are sent, crashed, opened and never closed again. They also cause exceptions in nullspace.
+	all_closets -= typesof(/obj/structure/closet/supplypod)
+	var/list/failures = list()
+
+	for(var/closet_type in all_closets)
+		var/obj/structure/closet/closet = allocate(closet_type)
+
+		// Copy is necessary otherwise closet.contents - immediate_contents returns an empty list
+		var/list/immediate_contents = closet.contents.Copy()
+
+		closet.PopulateContents()
+		var/contents_len = length(closet.contents)
+
+		if(contents_len > closet.storage_capacity)
+			failures += "Initial Contents of [closet.type] ([contents_len]) exceed its storage capacity ([closet.storage_capacity])."
+
+		for (var/obj/item/item in closet.contents - immediate_contents)
+			if (item.type in GLOB.steal_item_handler.objectives_by_path)
+				failures += "[closet_type] contains a steal objective [item.type] in PopulateContents(). Move it to populate_contents_immediate()."
+			if (item.resistance_flags & INDESTRUCTIBLE)
+				failures += "[closet_type] contains the indestructible item, [item.type], in PopulateContents(). This should be in populate_contents_immediate() instead."
+	if (length(failures))
+		Fail(jointext(failures, ", "))

--- a/code/modules/unit_tests/closets.dm
+++ b/code/modules/unit_tests/closets.dm
@@ -11,6 +11,8 @@
 	var/list/obj_item_paths = list()
 
 	for (var/datum/objective_item/objective_item_path as() in subtypesof(/datum/objective_item))
+		if (initial(objective_item_path.require_item_spawns_at_roundstart))
+			continue
 		obj_item_paths |= initial(objective_item_path.targetitem)
 
 	for(var/closet_type in all_closets)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Kind of ports tgstation/tgstation/issues/69587 although I only really looked at the code afterwards and stole populate_contents_immediate().
Edit: I have now stolen the unit test too.

Makes it so that closets will not initialise their contents until the contents variable has an attempt to access it (If only we had C# getters and setters to make this easier and safer).

**After**
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/ac3e832d-11b0-46f1-bac3-5340aa865fec)

**Before**
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/305ca606-72c4-4c3a-98ed-7b77736fa9cf)

Wow thats like 2700 blips of difference.

## Why It's Good For The Game

Init time with closets will be faster.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/b025f17a-821e-4456-bc00-285bda062227)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/c68e9ccc-ff1c-4166-846a-7c7ebfd26b3a)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/9ca51ed1-d976-4685-bb52-700a592606a9)


## Changelog
:cl: PowerfulBacon, MothBlocks
tweak: Speeds up the initialisation times of closets.
tweak: Crew pinpointers are no longer indestructible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
