### PR TITLE
Adds a line to log_world that which subsystem is being initialized

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -212,6 +212,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	for (var/datum/controller/subsystem/SS in subsystems)
 		if (SS.flags & SS_NO_INIT || SS.initialized) //Don't init SSs with the correspondig flag or if they already are initialzized
 			continue
+		log_world("Initializing [SS.name] subsystem.")
 		SS.Initialize(REALTIMEOFDAY)
 		CHECK_TICK
 	current_ticklimit = TICK_LIMIT_RUNNING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a line to log_world that which subsystem is being initialized
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's better to give us better recognition.
Although you'll believe `CRASH()` or `stack_trace()` will be sufficient to track which subsystem an error belongs to, as far as I've debugging some shits these days, no. We need this.
Check the logs below, then you'll recognise things better for errors we have currently.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
```DM
[2023-06-23 00:46:45.911] Starting up round ID .
 - -------------------------
[2023-06-23 00:46:45.914] Running /tg/ revision: 2023-06-23
[2023-06-23 00:46:50.096] Initializing Fail2Topic subsystem.
[2023-06-23 00:46:50.101] Initialized Fail2Topic subsystem within 0 seconds!
[2023-06-23 00:46:50.102] Initializing Profiler subsystem.
[2023-06-23 00:46:50.104] Initialized Profiler subsystem within 0 seconds!
[2023-06-23 00:46:50.106] Initializing Title Screen subsystem.
[2023-06-23 00:46:50.282] Initialized Title Screen subsystem within 0.1 seconds!
[2023-06-23 00:46:50.284] Initializing Database subsystem.
[2023-06-23 00:46:50.286] Initialized Database subsystem within 0 seconds!
[2023-06-23 00:46:50.292] Initializing Blackbox subsystem.
[2023-06-23 00:46:50.294] Initialized Blackbox subsystem within 0 seconds!
[2023-06-23 00:46:50.295] Initializing Server Tasks subsystem.
[2023-06-23 00:46:50.297] Initialized Server Tasks subsystem within 0 seconds!
[2023-06-23 00:46:50.299] Initializing Input subsystem.
[2023-06-23 00:46:50.301] Initialized Input subsystem within 0 seconds!
[2023-06-23 00:46:50.302] Initializing Topic subsystem.
[2023-06-23 00:46:50.303] Initialized Topic subsystem within 0 seconds!
[2023-06-23 00:46:50.305] Initializing Sound Channels subsystem.
[2023-06-23 00:46:50.306] Initialized Sound Channels subsystem within 0 seconds!
[2023-06-23 00:46:50.307] Initializing Instruments subsystem.
[2023-06-23 00:46:50.318] Initialized Instruments subsystem within 0 seconds!
[2023-06-23 00:46:50.320] Initializing Greyscale subsystem.
[2023-06-23 00:46:50.523] Initialized Greyscale subsystem within 0.2 seconds!
[2023-06-23 00:46:50.525] Initializing Vis contents overlays subsystem.
[2023-06-23 00:46:50.527] Initialized Vis contents overlays subsystem within 0 seconds!
[2023-06-23 00:46:50.529] Initializing Achievements subsystem.
[2023-06-23 00:46:50.530] Initialized Achievements subsystem within 0 seconds!
[2023-06-23 00:46:50.531] Initializing Materials subsystem.
[2023-06-23 00:46:50.533] Initialized Materials subsystem within 0 seconds!
[2023-06-23 00:46:50.534] Initializing Research subsystem.
[2023-06-23 00:46:50.570] Initialized Research subsystem within 0 seconds!
[2023-06-23 00:46:50.572] Initializing Orbits subsystem.
[2023-06-23 00:46:50.573] Initialized Orbits subsystem within 0 seconds!
[2023-06-23 00:46:50.575] Initializing Station subsystem.
[2023-06-23 00:46:50.577] Initialized Station subsystem within 0 seconds!
[2023-06-23 00:46:50.578] Initializing Jobs subsystem.
[2023-06-23 00:46:50.583] Initialized Jobs subsystem within 0 seconds!
[2023-06-23 00:46:50.584] Initializing Events subsystem.
[2023-06-23 00:46:50.587] Initialized Events subsystem within 0 seconds!
[2023-06-23 00:46:50.588] Initializing Quirks subsystem.
[2023-06-23 00:46:50.590] Initialized Quirks subsystem within 0 seconds!
[2023-06-23 00:46:50.592] Initializing AI movement subsystem.
[2023-06-23 00:46:50.593] Initialized AI movement subsystem within 0 seconds!
[2023-06-23 00:46:50.594] Initializing Ticker subsystem.
[2023-06-23 00:46:50.601] Initialized Ticker subsystem within 0.1 seconds!
[2023-06-23 00:46:50.603] Initializing AI Behavior Ticker subsystem.
[2023-06-23 00:46:50.605] Initialized AI Behavior Ticker subsystem within 0 seconds!
[2023-06-23 00:46:50.606] Initializing AI Controller Ticker subsystem.
[2023-06-23 00:46:50.607] Initialized AI Controller Ticker subsystem within 0 seconds!
[2023-06-23 00:46:50.608] Initializing Mapping subsystem.
[2023-06-23 00:46:50.611] Loading Runtime Station...
[2023-06-23 00:46:50.718] Loaded Station in 0.1s!
[2023-06-23 00:46:50.869] Loaded Random Rooms in 0s!
[2023-06-23 00:46:51.464] Initialized Mapping subsystem within 0.8 seconds!
[2023-06-23 00:46:51.467] Initializing Time Tracking subsystem.
[2023-06-23 00:46:51.470] Initialized Time Tracking subsystem within 0 seconds!
[2023-06-23 00:46:51.473] Initializing Networks subsystem.
[2023-06-23 00:46:51.477] Initialized Networks subsystem within 0 seconds!
[2023-06-23 00:46:51.479] Initializing Economy subsystem.
[2023-06-23 00:46:51.493] runtime error: Oh no, crashed! (This is test crash)
 - proc name: Initialize (/datum/controller/subsystem/economy/Initialize)
 -   source file: economy.dm,44
 -   usr: null
 -   src: Economy (/datum/controller/subsystem/economy)
 -   call stack:
 - Economy (/datum/controller/subsystem/economy): Initialize(28114)
 - Master (/datum/controller/master): Initialize(10, 0, 1)
 - 
[2023-06-23 00:46:51.494] Initializing Atoms subsystem.
[2023-06-23 00:46:53.803] ## WARNING: docking port 'pod_lavaland1' could not be randomly placed in /area/lavaland/surface/outdoors: of 0 turfs, none were suitable. in code/modules/shuttle/emergency.dm at line 659 src: the lavaland usr: .
[2023-06-23 00:46:56.089] Initialized Atoms subsystem within 4.6 seconds!
[2023-06-23 00:46:56.091] Initializing Language subsystem.
[2023-06-23 00:46:56.099] Initialized Language subsystem within 0 seconds!
[2023-06-23 00:46:56.100] Initializing Machines subsystem.
[2023-06-23 00:46:56.105] Initialized Machines subsystem within 0 seconds!
[2023-06-23 00:46:56.107] Initializing Atmos Adjacency subsystem.
[2023-06-23 00:46:56.108] Initialized Atmos Adjacency subsystem within 0 seconds!
[2023-06-23 00:46:56.117] Initializing Autotransfer Vote subsystem.
[2023-06-23 00:46:56.119] Initialized Autotransfer Vote subsystem within 0 seconds!
[2023-06-23 00:46:56.121] Initializing Circuit Components subsystem.
[2023-06-23 00:46:56.122] Initialized Circuit Components subsystem within 0 seconds!
[2023-06-23 00:46:56.124] Initializing Disease subsystem.
[2023-06-23 00:46:56.127] Initialized Disease subsystem within 0 seconds!
[2023-06-23 00:46:56.129] Initializing Metrics subsystem.
[2023-06-23 00:46:56.130] Initialized Metrics subsystem within 0 seconds!
[2023-06-23 00:46:56.132] Initializing Night Shift subsystem.
[2023-06-23 00:46:56.134] Initialized Night Shift subsystem within 0 seconds!
[2023-06-23 00:46:56.136] Initializing Parallax subsystem.
[2023-06-23 00:46:56.137] Initialized Parallax subsystem within 0 seconds!
[2023-06-23 00:46:56.139] Initializing Supply subsystem.
[2023-06-23 00:46:56.142] Initialized Supply subsystem within 0 seconds!
[2023-06-23 00:46:56.144] Initializing Traumas subsystem.
[2023-06-23 00:46:56.147] Initialized Traumas subsystem within 0 seconds!
[2023-06-23 00:46:56.148] Initializing Weather subsystem.
[2023-06-23 00:46:56.150] Initialized Weather subsystem within 0 seconds!
[2023-06-23 00:46:56.152] Initializing Zfall subsystem.
[2023-06-23 00:46:56.153] Initialized Zfall subsystem within 0 seconds!
[2023-06-23 00:46:56.155] Initializing Atmospherics subsystem.
[2023-06-23 00:46:57.041] Initialized Atmospherics subsystem within 0.9 seconds!
[2023-06-23 00:46:57.043] Initializing Persistence subsystem.
[2023-06-23 00:46:57.045] Loaded 0 engraved messages on map Runtime Station
[2023-06-23 00:46:57.048] Initialized Persistence subsystem within 0 seconds!
[2023-06-23 00:46:57.049] Initializing Assets subsystem.
[2023-06-23 00:46:57.667] ## WARNING: design /datum/design/leftarm with icon 'icons/mob/human_parts_greyscale.dmi' missing state 'default_human_l_arm'
[2023-06-23 00:46:57.669] ## WARNING: design /datum/design/rightarm with icon 'icons/mob/human_parts_greyscale.dmi' missing state 'default_human_r_arm'
[2023-06-23 00:46:57.671] ## WARNING: design /datum/design/leftleg with icon 'icons/mob/human_parts_greyscale.dmi' missing state 'default_human_l_leg'
[2023-06-23 00:46:57.673] ## WARNING: design /datum/design/rightleg with icon 'icons/mob/human_parts_greyscale.dmi' missing state 'default_human_r_leg'
[2023-06-23 00:46:57.698] ## WARNING: design /datum/design/borg_chest with icon '' missing state 'borg_chest'
[2023-06-23 00:46:57.700] ## WARNING: design /datum/design/borg_head with icon '' missing state 'borg_head'
[2023-06-23 00:46:57.702] ## WARNING: design /datum/design/borg_l_arm with icon '' missing state 'borg_l_arm'
[2023-06-23 00:46:57.703] ## WARNING: design /datum/design/borg_r_arm with icon '' missing state 'borg_r_arm'
[2023-06-23 00:46:57.705] ## WARNING: design /datum/design/borg_l_leg with icon '' missing state 'borg_l_leg'
[2023-06-23 00:46:57.707] ## WARNING: design /datum/design/borg_r_leg with icon '' missing state 'borg_r_leg'
[2023-06-23 00:46:59.877] Initialized Assets subsystem within 2.8 seconds!
[2023-06-23 00:46:59.925] Initializing Icon Smoothing subsystem.
[2023-06-23 00:47:00.061] Initialized Icon Smoothing subsystem within 0.1 seconds!
[2023-06-23 00:47:00.064] Initializing Overlay subsystem.
[2023-06-23 00:47:00.136] Initialized Overlay subsystem within 0.1 seconds!
[2023-06-23 00:47:00.139] Initializing XKeyScore subsystem.
[2023-06-23 00:47:00.141] Initialized XKeyScore subsystem within 0 seconds!
[2023-06-23 00:47:00.143] Initializing PRISM subsystem.
[2023-06-23 00:47:00.146] Initialized PRISM subsystem within 0 seconds!
[2023-06-23 00:47:00.147] Initializing Lighting subsystem.
[2023-06-23 00:47:00.720] Initialized Lighting subsystem within 0.6 seconds!
[2023-06-23 00:47:00.721] Initializing Shuttle subsystem.
[2023-06-23 00:47:00.844] ## WARNING: No /obj/docking_port/mobile/arrivals placed on the map! in code/controllers/subsystem/shuttle.dm at line 69 src: Shuttle usr: .
[2023-06-23 00:47:00.846] ## WARNING: No /obj/docking_port/mobile/emergency placed on the map! in code/controllers/subsystem/shuttle.dm at line 71 src: Shuttle usr: .
[2023-06-23 00:47:00.848] ## WARNING: No /obj/docking_port/mobile/emergency/backup placed on the map! in code/controllers/subsystem/shuttle.dm at line 73 src: Shuttle usr: .
[2023-06-23 00:47:00.849] ## WARNING: No /obj/docking_port/mobile/supply placed on the map! in code/controllers/subsystem/shuttle.dm at line 75 src: Shuttle usr: .
[2023-06-23 00:47:00.851] Initialized Shuttle subsystem within 0.1 seconds!
[2023-06-23 00:47:00.853] Initializing Minor Mapping subsystem.
[2023-06-23 00:47:00.889] Initialized Minor Mapping subsystem within 0 seconds!
[2023-06-23 00:47:00.891] Initializing Pathfinder subsystem.
[2023-06-23 00:47:00.893] Initialized Pathfinder subsystem within 0 seconds!
[2023-06-23 00:47:00.895] Initializing Elevator Controller subsystem.
[2023-06-23 00:47:00.896] Initialized Elevator Controller subsystem within 0 seconds!
[2023-06-23 00:47:00.898] Initializing Chat subsystem.
[2023-06-23 00:47:00.899] Initialized Chat subsystem within 0 seconds!
[2023-06-23 00:47:00.901] Initializations complete within 10.9 seconds!
```

## Changelog
:cl:
code: runtime.log file provides more information - it now reports which subsystem is being initialized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
