### PR TITLE
[s] Require affirmative input from the admin to run sdql2 verbs

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -194,12 +194,20 @@
 		state = SDQL2_STATE_ERROR;\
 		CRASH("SDQL2 fatal error");};
 
-/client/proc/SDQL2_query(query_text as message)
+/client/proc/SDQL2_query(requested_query as message)
 	set category = "Debug"
 	if(!check_rights(R_DEBUG))  //Shouldn't happen... but just to be safe.
 		message_admins("<span class='danger'>ERROR: Non-admin [key_name(usr)] attempted to execute a SDQL query!</span>")
 		log_admin("Non-admin [key_name(usr)] attempted to execute a SDQL query!")
 		return FALSE
+	var/query_text = requested_query
+	if (query_text)
+		if (alert(src, "Are you sure you want to execute the following query?\n[query_text]", "SDQL Query", "Yes", "No") != "Yes")
+			return
+	else
+		query_text = input("Run SDQL2 query:", "SDQL2", null) as message|null
+		if (!length(query_text))
+			return
 	var/list/results = world.SDQL2_query(query_text, key_name_admin(usr), "[key_name(usr)]")
 	if(length(results) == 3)
 		for(var/I in 1 to 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Idea port of https://github.com/tgstation/tgstation/pull/76276

- SDQL queries requires a yes/no alert in order to execute, or require the admin to type the query if no text was provided.

## Why It's Good For The Game

If an attacker manages to find a javascript HTML injection exploit, then they will be able to execute SDQL queries without the victim acknowledging the request.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/b38b6e32-8b0f-4c97-8e1f-ed8c08f16b75)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/6b6f3c6d-d7ca-4409-8b59-860f579fe665)

Pressing "no" does nothing.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/48476c31-5571-4978-9c48-ea71254406d4)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/a6b60335-6122-45aa-839a-c3c7d98d5b5b)

Pressing cancel does nothing.

## Changelog
:cl: PowerfulBacon, MrStonedOne
tweak: Admins making SDQL requests from the command line will need to confirm their action before running it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
