### PR TITLE
Cloning now respects Size and Eye Color

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -432,6 +432,10 @@
 		if(part.no_update)
 			continue
 		part.update_limb(dropping_limb = FALSE, source = src, is_creating = TRUE)
+	var/obj/item/organ/eyes/organ_eyes = getorgan(/obj/item/organ/eyes)
+	if(organ_eyes)
+		organ_eyes.eye_color = eye_color
+		organ_eyes.old_eye_color = eye_color
 	if(icon_update)
 		update_body()
 		update_hair()

--- a/code/modules/client/preferences2/character_save.dm
+++ b/code/modules/client/preferences2/character_save.dm
@@ -493,5 +493,3 @@
 		character.update_body()
 		character.update_hair()
 		character.update_body_parts(TRUE)
-
-	character.dna.update_body_size()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -60,6 +60,7 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_body()
 	remove_overlay(BODY_LAYER)
 	dna.species.handle_body(src)
+	dna.update_body_size()
 
 /mob/living/carbon/human/update_fire()
 	..((fire_stacks > HUMAN_FIRE_STACK_ICON_NUM) ? "Standing" : "Generic_mob_burning")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #9279 

Apparently body size was something only updated from preference code of all places, meaning that it had zero effect outside of players joining the round. This moves that bit of code into `human/update_body`, where it really should've been this entire time.

In addition, apparently eye color wasn't done right either random when cloned. This was found to be due to the eyes organ being removed, then reinserted during cloning, setting the rendered eye color to the color of the organ. This exposed the fact that the eye color wasn't ever being copied to the organ in the first place!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A bugfix. Need I say more?

Okay, I will anyways; DNA is meant to be representative of your character's features; this improves consistency in regards to that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![sized-cloners](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/973f58f6-84d6-4239-a6ef-2c781ff704b3)
It was after this that I noticed that eyes weren't keeping their color properly, so I also fixed that:

![sized-cloners_eye-color](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/fc899309-58cd-4904-a71a-269cea8c5e9d)

</details>

## Changelog
:cl:
fix: Eye Color and Body Size are now respected when cloning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
