### PR TITLE
Fixes biodome turf sprite errors

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -133,6 +133,9 @@
 		return ..()
 	var/old_dir = dir
 	var/turf/open/floor/W = ..()
+	if (flags & CHANGETURF_SKIP)
+		dir = old_dir
+		return W
 	W.setDir(old_dir)
 	W.update_icon()
 	return W


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes it so that if CHANGETURF_SKIP is an active flag in ChangeTurf, then update_icon and setDir will not be called, instead opting to change the dir var directly.
These behaviours should not be called before turfs are initialised as they can do things which depend on initialisation.

fixes #9276

## Why It's Good For The Game

This should fix the black turf tiles inside the biodome.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/26f554aa-406e-4e0e-a39d-fa122be71cc6)


## Changelog
:cl:
fix: Fixes some icon failures related to maploading, fixing the biodomes black floor tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
