### PR TITLE
Basepixel hotfix + cleanup

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -378,7 +378,7 @@
 			if (WEST)
 				animate(M, pixel_x = M.pixel_x - 3, time = 1, loop = 0)
 		sleep(1)
-	animate(M, pixel_x = M.get_standard_pixel_x_offset(), pixel_y = M.get_standard_pixel_y_offset(), time = 1, loop = 0)
+	animate(M, pixel_x = M.body_position_pixel_x_offset, pixel_y = M.body_position_pixel_y_offset, time = 1, loop = 0)
 
 /obj/machinery/jukebox/disco/proc/dance4(var/mob/living/M)
 	var/speed = rand(1,3)
@@ -412,7 +412,7 @@
 			if (WEST)
 				animate(M, pixel_x = M.pixel_x - 3, time = 1, loop = 0)
 		sleep(1)
-	animate(M, transform = matrix(M.transform).Scale(-1), pixel_x = M.get_standard_pixel_x_offset(), pixel_y = M.get_standard_pixel_y_offset(), time = 1, loop = 0) //dance end
+	animate(M, transform = matrix(M.transform).Scale(-1), pixel_x = M.body_position_pixel_x_offset, pixel_y = M.body_position_pixel_y_offset, time = 1, loop = 0) //dance end
 
 /obj/machinery/jukebox/proc/dance_over()
 	for(var/mob/living/L in rangers)

--- a/code/game/objects/noose.dm
+++ b/code/game/objects/noose.dm
@@ -50,9 +50,9 @@
 	else
 		layer = initial(layer)
 		STOP_PROCESSING(SSobj, src)
-		M.pixel_x = initial(M.pixel_x)
-		pixel_x = initial(pixel_x)
-		M.pixel_y = M.get_standard_pixel_y_offset(M.lying)
+		M.pixel_x = M.base_pixel_x
+		pixel_x = base_pixel_x
+		M.pixel_y = M.body_position_pixel_y_offset
 
 /obj/structure/chair/noose/user_unbuckle_mob(mob/living/M,mob/living/user)
 	if(has_buckled_mobs())
@@ -79,8 +79,8 @@
 		unbuckle_all_mobs(force=1)
 		M.pixel_z = initial(M.pixel_z)
 		pixel_z = initial(pixel_z)
-		M.pixel_x = initial(M.pixel_x)
-		pixel_x = initial(pixel_x)
+		M.pixel_x = M.base_pixel_x
+		pixel_x = base_pixel_x
 		add_fingerprint(user)
 
 /obj/structure/chair/noose/user_buckle_mob(mob/living/carbon/human/M, mob/user, check_loc = TRUE)

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -75,8 +75,8 @@
 	add_overlay(nest_overlay)
 
 /obj/structure/bed/nest/post_unbuckle_mob(mob/living/M)
-	M.pixel_x = M.base_pixel_x + M.get_standard_pixel_x_offset(M.lying)
-	M.pixel_y = M.base_pixel_y + M.get_standard_pixel_y_offset(M.lying)
+	M.pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset
+	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
 	M.layer = initial(M.layer)
 	cut_overlay(nest_overlay)
 

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -92,6 +92,7 @@
 /obj/structure/bed/roller/post_buckle_mob(mob/living/M)
 	set_density(TRUE)
 	icon_state = "up"
+	//Push them up from the normal lying position
 	M.pixel_y = M.base_pixel_y
 
 /obj/structure/bed/roller/Moved()
@@ -102,8 +103,8 @@
 /obj/structure/bed/roller/post_unbuckle_mob(mob/living/M)
 	set_density(FALSE)
 	icon_state = "down"
-	M.pixel_x = M.base_pixel_x + M.get_standard_pixel_x_offset(M.lying)
-	M.pixel_y = M.base_pixel_y + M.get_standard_pixel_y_offset(M.lying)
+	//Set them back down to the normal lying position
+	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
 
 /obj/item/roller
 	name = "roller bed"
@@ -243,12 +244,12 @@
 
 /obj/structure/bed/double/post_buckle_mob(mob/living/M)
 	if(buckled_mobs.len > 1 && !goldilocks) //Push the second buckled mob a bit higher from the normal lying position, also, if someone can figure out the same thing for plushes, i'll be really glad to know how to
-		M.pixel_y = initial(M.pixel_y) + 6
+		M.pixel_y = M.base_pixel_y + 6
 		goldilocks = M
 		RegisterSignal(goldilocks, COMSIG_PARENT_QDELETING, PROC_REF(goldilocks_deleted))
 
 /obj/structure/bed/double/post_unbuckle_mob(mob/living/M)
-	M.pixel_y = initial(M.pixel_y) + M.get_standard_pixel_y_offset(M.lying)
+	M.pixel_y = base_pixel_y + M.body_position_pixel_y_offset
 	if(M == goldilocks)
 		UnregisterSignal(goldilocks, COMSIG_PARENT_QDELETING)
 		goldilocks = null

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -83,7 +83,7 @@
 			var/matrix/m180 = matrix(L.transform)
 			m180.Turn(180)
 			animate(L, transform = m180, time = 3)
-			L.pixel_y = L.get_standard_pixel_y_offset(TRUE)
+			L.pixel_y = L.base_pixel_y + PIXEL_Y_OFFSET_LYING
 	else if (has_buckled_mobs())
 		for(var/mob/living/L in buckled_mobs)
 			user_unbuckle_mob(L, user)
@@ -128,7 +128,7 @@
 	var/matrix/m180 = matrix(M.transform)
 	m180.Turn(180)
 	animate(M, transform = m180, time = 3)
-	M.pixel_y = M.base_pixel_y + M.get_standard_pixel_y_offset(TRUE)
+	M.pixel_y = M.base_pixel_y + PIXEL_Y_OFFSET_LYING
 	M.adjustBruteLoss(30)
 	src.visible_message("<span class='danger'>[M] falls free of [src]!</span>")
 	unbuckle_mob(M,force=1)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -118,9 +118,6 @@ Des: Removes all infected images from the alien.
 /mob/living/carbon/alien/canBeHandcuffed()
 	return TRUE
 
-/mob/living/carbon/alien/get_standard_pixel_y_offset(lying = 0)
-	return initial(pixel_y)
-
 /mob/living/carbon/alien/proc/alien_evolve(mob/living/carbon/alien/new_xeno)
 	to_chat(src, "<span class='noticealien'>You begin to evolve!</span>")
 	visible_message("<span class='alertalien'>[src] begins to twist and contort!</span>")

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -42,6 +42,9 @@
 		return
 
 	leaping = TRUE
+	//Because the leaping sprite is bigger than the normal one
+	body_position_pixel_x_offset = -32
+	body_position_pixel_y_offset = -32
 	weather_immunities += "lava"
 	update_icons()
 	throw_at(A, MAX_ALIEN_LEAP_DIST, 1, src, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end)))
@@ -50,6 +53,8 @@
 
 /mob/living/carbon/alien/humanoid/hunter/proc/leap_end()
 	leaping = FALSE
+	body_position_pixel_x_offset = 0
+	body_position_pixel_y_offset = 0
 	weather_immunities -= "lava"
 	update_icons()
 
@@ -78,11 +83,6 @@
 		else if(hit_atom.density && !hit_atom.CanPass(src, get_dir(hit_atom, src)))
 			visible_message("<span class ='danger'>[src] smashes into [hit_atom]!</span>", "<span class ='alertalien'>[src] smashes into [hit_atom]!</span>")
 			Paralyze(40, 1, 1)
-
-		if(leaping)
-			leaping = FALSE
-			update_icons()
-			update_mobility()
 
 /mob/living/carbon/alien/humanoid/float(on)
 	if(leaping)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -74,7 +74,7 @@
 			if(!blocked)
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
 				L.Paralyze(100)
-				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
+				sleep(0.2 SECONDS)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src, L)
 			else
 				Paralyze(40, 1, 1)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -84,6 +84,11 @@
 			visible_message("<span class ='danger'>[src] smashes into [hit_atom]!</span>", "<span class ='alertalien'>[src] smashes into [hit_atom]!</span>")
 			Paralyze(40, 1, 1)
 
+		if(leaping) //check that toggles out of leaping mode if the alien gets hit or otherwise interrupted
+			leaping = FALSE
+			update_icons()
+			update_mobility()
+
 /mob/living/carbon/alien/humanoid/float(on)
 	if(leaping)
 		return

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -13,8 +13,6 @@
 	var/alt_icon = 'icons/mob/alienleap.dmi' //used to switch between the two alien icon files.
 	var/leap_on_click = FALSE
 	COOLDOWN_DECLARE(pounce_cooldown)
-	var/custom_pixel_x_offset = 0 //for admin fuckery.
-	var/custom_pixel_y_offset = 0
 	var/sneaking = FALSE //For sneaky-sneaky mode and appropriate slowdown
 	var/drooling = FALSE //For Neurotoxic spit overlays
 
@@ -42,22 +40,6 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 						"<span class='danger'>You break free of [pulledby]'s grip!</span>")
 	pulledby.stop_pulling()
 	. = 0
-
-/mob/living/carbon/alien/humanoid/get_standard_pixel_y_offset(lying = 0)
-	if(leaping)
-		return -32
-	else if(custom_pixel_y_offset)
-		return custom_pixel_y_offset
-	else
-		return initial(pixel_y)
-
-/mob/living/carbon/alien/humanoid/get_standard_pixel_x_offset(lying = 0)
-	if(leaping)
-		return -32
-	else if(custom_pixel_x_offset)
-		return custom_pixel_x_offset
-	else
-		return initial(pixel_x)
 
 /mob/living/carbon/alien/humanoid/get_permeability_protection()
 	return 0.8

--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -41,8 +41,8 @@
 			var/old_icon = icon
 			icon = alt_icon
 			alt_icon = old_icon
-		pixel_x = base_pixel_x + get_standard_pixel_x_offset(mobility_flags & MOBILITY_STAND)
-		pixel_y = base_pixel_y + get_standard_pixel_y_offset(mobility_flags & MOBILITY_STAND)
+	pixel_x = base_pixel_x + body_position_pixel_x_offset
+	pixel_y = base_pixel_y + body_position_pixel_y_offset
 	update_inv_hands()
 	update_inv_handcuffed()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -357,12 +357,6 @@
 			dropItemToGround(I)
 			return
 
-/mob/living/carbon/get_standard_pixel_y_offset(lying = 0)
-	if(lying)
-		return -6
-	else
-		return initial(pixel_y)
-
 /mob/living/carbon/proc/accident(obj/item/I)
 	if(!I || (I.item_flags & ABSTRACT) || HAS_TRAIT(I, TRAIT_NODROP))
 		return

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -8,11 +8,11 @@
 		changed++
 		ntransform.TurnTo(lying_prev , lying)
 		if(!lying) //Lying to standing
-			final_pixel_y = get_standard_pixel_y_offset()
+			final_pixel_y = base_pixel_y
 		else //if(lying != 0)
 			if(lying_prev == 0) //Standing to lying
-				pixel_y = base_pixel_y + get_standard_pixel_y_offset()
-				final_pixel_y = base_pixel_y + get_standard_pixel_y_offset(lying)
+				pixel_y = base_pixel_y
+				final_pixel_y = base_pixel_y + PIXEL_Y_OFFSET_LYING
 				if(dir & (EAST|WEST)) //Facing east or west
 					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
 	if(resize != RESIZE_DEFAULT_SIZE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -878,7 +878,7 @@
 		animate(pixel_y = base_pixel_y - 2, time = 10, loop = -1, flags = ANIMATION_RELATIVE)
 		setMovetype(movement_type | FLOATING)
 	else if(((!on || fixed) && (movement_type & FLOATING)))
-		animate(src, pixel_y = base_pixel_y + get_standard_pixel_y_offset(lying), time = 1 SECONDS)
+		animate(src, pixel_y = base_pixel_y + body_position_pixel_y_offset, time = 1 SECONDS)
 		setMovetype(movement_type & ~FLOATING)
 
 // The src mob is trying to strip an item from someone
@@ -944,8 +944,8 @@
 	var/amplitude = min(4, (jitteriness/100) + 1)
 	var/pixel_x_diff = rand(-amplitude, amplitude)
 	var/pixel_y_diff = rand(-amplitude/3, amplitude/3)
-	var/final_pixel_x = base_pixel_x + get_standard_pixel_x_offset(lying)
-	var/final_pixel_y = base_pixel_y + get_standard_pixel_y_offset(lying)
+	var/final_pixel_x = base_pixel_x + body_position_pixel_x_offset
+	var/final_pixel_y = base_pixel_y + body_position_pixel_y_offset
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff , time = 2, loop = 6)
 	animate(pixel_x = final_pixel_x , pixel_y = final_pixel_y , time = 2)
 	setMovetype(movement_type & ~FLOATING) // If we were without gravity, the bouncing animation got stopped, so we make sure to restart it in next life().
@@ -961,13 +961,6 @@
 		var/turf/heat_turf = get_turf(src)
 		loc_temp = heat_turf.return_temperature()
 	return loc_temp
-
-/mob/living/proc/get_standard_pixel_x_offset(lying = 0)
-	return initial(pixel_x)
-
-/mob/living/proc/get_standard_pixel_y_offset(lying = 0)
-	return initial(pixel_y)
-
 
 /mob/living/proc/can_track(mob/living/user)
 	//basic fast checks go first. When overriding this proc, I recommend calling ..() at the end.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -135,8 +135,8 @@
 	var/flavor_text = FLAVOR_TEXT_NONE
 	var/role //Used for determining whether a player is banned from taking control of a given mob, if it is assigned to a category.
 
-	///Default X offset
-	var/body_pixel_x_offset = 0
-	///Default Y offset
-	var/body_pixel_y_offset = 0
+	///The y amount a mob's sprite should be offset due to the current position they're in (e.g. lying down moves your sprite down)
+	var/body_position_pixel_x_offset = 0
+	///The x amount a mob's sprite should be offset due to the current position they're in
+	var/body_position_pixel_y_offset = 0
 


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/54706

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #9290 

This PR fixes a few things I noticed with basepixels, and ports a fix from tg.

This fix involves some rectifying improper offsets of xenos, making more stuff basepixels that should be, and changed a getter to a var

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

less weird basepixels behavior

This is a minor atomization of #8965 , which I was requested to cut down on a bit. 

Its important that this be merged, as I will be able to work on atomizing the lying_angle portion of that PR, which specifically sets var/lying to a protected var, and purifies many calls.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

correct Leaping offset
![leapers](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/e2bc48cb-d3ef-4079-9798-5240d49d521c)

correct Normal offset
![slashers](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/0a0486f7-37c0-4a39-b101-22995a519df6)

jittering demonstration

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/295226e6-08b4-4007-8252-e991c6337ffd


</details>

## Changelog
:cl: RKz, Yenwodyah
add: more things properly utilize basepixels, instead of the old `pixel_x = initial(pixel_x)`
fix: xeno offsets dont get messed up again
code: made pixel offsets a var, instead of a getter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
