### PR TITLE
Optimises /datum/gas_mixture/copy_from_turf

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -254,8 +254,15 @@ we use a hook instead
 	return copy
 
 /datum/gas_mixture/copy_from_turf(turf/model)
+	var/static/list/gas_templates = list()
+	// Attempt to find prototype to copy fromf
+	var/datum/gas_mixture/template = gas_templates[model.initial_gas_mix]
+	if (!template)
+		template = new
+		template.parse_gas_string(model.initial_gas_mix)
+		gas_templates[model.initial_gas_mix] = src
 	set_temperature(initial(model.initial_temperature))
-	parse_gas_string(model.initial_gas_mix)
+	copy_from(template)
 	return 1
 
 /datum/gas_mixture/proc/__auxtools_parse_gas_string(gas_string)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates copy_from_turf so that instead of using the expensive parse_gas_string method, it instead creates a gas template from the string and copies that using the much faster rust_g implementation of copy_from.

This isn't going to make an enourmous impact, especially if you have a fast PC, but it is an improvement none the less.

## Why It's Good For The Game

**Previous:**
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f18d3f0e-f6ac-4886-8020-31970b38e2d6)
As you can see, the majority of CPU usage on this proc was from child calls, which was the call to parse_gas_string.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/ec6120c2-8f07-46c6-b4b9-49a5cd736617)

This call is very expensive. With the new method, the profile looks like this:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/59af1732-ce76-449a-b8da-602dff6e6c09)
It is more expensive if we don't consider the child calls as we are doing more work inside the proc, however we avoid calls to the very expensive gas parse proc so the overall total CPU usage is lower.

Master initialisation took a total of 69.922 CPU, this new copy_from_turf implementation saves around 1 total CPU.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f7f7caf6-b09f-41d3-b3cf-b64d9f5c1d6b)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/0868a3fc-150c-4582-a5a8-9c09f70933ed)

Note that self CPU should be consistent across both of these as nothing specific to it has changed. That means for whatever reason, or due to slight inaccuracies, my computer was running slower in the second example however we still observe a non-insignificant improvement.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e6d56126-d7c7-48a4-8fbe-da0cd7e3f753)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/994a4e8e-a549-4aa7-ae50-637e40106c94)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/d4f70a4d-ade6-4b7c-821a-4d78027fb90e)


## Changelog
:cl:
tweak: Optimises copy_from_turf to use the faster rust_g implementation of copy_from. This should slightly improve initialisation times of open turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
