### PR TITLE
Exports init_times to CSV instead of JSON

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -78,7 +78,11 @@ SUBSYSTEM_DEF(atoms)
 		created_atoms = null
 
 #ifdef PROFILE_MAPLOAD_INIT_ATOM
-	rustg_file_write(json_encode(mapload_init_times), "[GLOB.log_directory]/init_times.json")
+	var/csv = ""
+	for (var/atom_type in mapload_init_times)
+		var/time = mapload_init_times[atom_type]
+		csv += "[atom_type],[time]\n"
+	rustg_file_write(csv, "[GLOB.log_directory]/init_times.csv")
 #endif
 
 /// Actually creates the list of atoms. Exists soley so a runtime in the creation logic doesn't cause initalized to totally break

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -78,11 +78,12 @@ SUBSYSTEM_DEF(atoms)
 		created_atoms = null
 
 #ifdef PROFILE_MAPLOAD_INIT_ATOM
-	var/csv = ""
+	var/list/lines = list()
+	lines += "Atom Path,Initialisation Time (ms)"
 	for (var/atom_type in mapload_init_times)
 		var/time = mapload_init_times[atom_type]
-		csv += "[atom_type],[time]\n"
-	rustg_file_write(csv, "[GLOB.log_directory]/init_times.csv")
+		lines += "[atom_type],[time]"
+	rustg_file_write(jointext(lines, "\n"), "[GLOB.log_directory]/init_times.csv")
 #endif
 
 /// Actually creates the list of atoms. Exists soley so a runtime in the creation logic doesn't cause initalized to totally break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've been using this for all of my init time tests already, thought I would publish the code since it makes it significantly easier to actually analyse the data in software like excel and google sheets, since those are specifically designed to deal with CSVs and not JSONs. Json is not a very nice format for processing data in this style.

## Why It's Good For The Game

This makes it significantly easier to load init time data into excel and perform operations on it, without the need for prior conversion.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/26d9f38e-64f0-49fc-9431-b7a7f565bdb3)


## Changelog
:cl:
tweak: Atom init times now export to CSV instead of JSON if you compile the game with the PROFILE_MAPLOAD_INIT_ATOM flag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
