### PR TITLE
[s] Fix fax machine href exploit

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -334,7 +334,7 @@
 			if(!loaded)
 				return
 			if(istype(loaded, /obj/item/paper))
-				if(send_to_additional_faxes(loaded, usr, params["name"], params["color"]))
+				if(send_to_additional_faxes(loaded, usr, params["name"], sanitize_hexcolor(params["color"], 6, TRUE, "#0000ff")))
 					loaded_item_ref = null
 					update_icon()
 					return TRUE

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -334,7 +334,7 @@
 			if(!loaded)
 				return
 			if(istype(loaded, /obj/item/paper))
-				if(send_to_additional_faxes(loaded, usr, params["name"], sanitize_hexcolor(params["color"], 6, TRUE, "#0000ff")))
+				if(send_to_additional_faxes(loaded, usr, sanitize(params["name"]), sanitize_hexcolor(params["color"], 6, TRUE, "#0000ff")))
 					loaded_item_ref = null
 					update_icon()
 					return TRUE

--- a/code/modules/paperwork/fax_manager.dm
+++ b/code/modules/paperwork/fax_manager.dm
@@ -129,7 +129,7 @@ GLOBAL_DATUM_INIT(fax_manager, /datum/fax_manager, new)
 	message.copy_properties(paper)
 	request["paper"] = message
 	requests += list(request)
-	var/msg = "<span class='adminnotice'><b><font color=[receiver_color]>[sanitize(receiver_fax_name)] fax</font> received a message from [sanitize(sender_fax.fax_name)][ADMIN_FLW(sender)][ADMIN_JMP(sender_fax)]/[ADMIN_FULLMONTY(sender)]</b></span>"
+	var/msg = "<span class='adminnotice'><b><font color=[receiver_color]>[receiver_fax_name] fax</font> received a message from [sanitize(sender_fax.fax_name)][ADMIN_FLW(sender)][ADMIN_JMP(sender_fax)]/[ADMIN_FULLMONTY(sender)]</b></span>"
 	to_chat(GLOB.admins, msg)
 
 	for(var/obj/machinery/fax/fax as anything in GLOB.fax_machines)


### PR DESCRIPTION
## About The Pull Request

Fixes an href exploit on the color field.

Name sanitization is moved earlier in the call chain. nothing else calls these functions but ideally they should be removed.

TG closed https://github.com/tgstation/tgstation/pull/70072 which is the PR that causes this problem.

It was replaced with https://github.com/tgstation/tgstation/pull/71129 ... which fun enough had its own XSS https://github.com/tgstation/tgstation/pull/71491

Fucking faxes man

## Why It's Good For The Game

Security fix

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/bf432c28-0417-4bcf-a2a2-de4f05b54a53)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/5fd47f0e-04db-485c-970f-4b4405c41614)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/cffa672e-9bf1-4fde-a601-71754cfe1520)


</details>

## Changelog
:cl:
fix: Fixed exploit in CentCom faxes
/:cl:
