### PR TITLE
Wig adjustments

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -42,6 +42,7 @@
 			return
 		else
 			attached_wig = W
+			attached_wig.hat_attached_to = src
 			W.forceMove(src)
 			add_verb(/obj/item/clothing/head/verb/unattach_wig)
 			update_icon()
@@ -57,6 +58,7 @@
 	usr.put_in_hands(attached_wig)
 	if (usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
 		attached_wig.dropped(usr)
+	attached_wig.hat_attached_to = null
 	attached_wig = null
 	update_icon()
 	remove_verb(/obj/item/clothing/head/verb/unattach_wig)

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -30,17 +30,6 @@
 		if(H.head == src)
 			H.update_inv_head()
 	attached_wig?.dropped(user)
-/*
-/obj/item/clothing/head/update_icon(updates)
-	. = ..()
-	if(attached_wig)
-		var/datum/sprite_accessory/S = GLOB.hair_styles_list[attached_wig.hair_style]
-		if(S)
-			var/mutable_appearance/M = mutable_appearance(S.icon,S.icon_state)
-			M.appearance_flags |= RESET_COLOR
-			M.color = attached_wig.hair_color
-			underlays += M
-*/
 
 /obj/item/clothing/head/attackby(obj/item/W, mob/user, params)
 	. = ..()

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -8,12 +8,89 @@
 	dynamic_hair_suffix = "+generic"
 	///Is the person wearing this trackable by the AI?
 	var/blockTracking = FALSE
+	var/obj/item/clothing/head/wig/attached_wig
 
 /obj/item/clothing/head/Initialize(mapload)
 	. = ..()
 	if(ishuman(loc) && dynamic_hair_suffix)
 		var/mob/living/carbon/human/H = loc
 		H.update_hair()
+
+/obj/item/clothing/head/equipped(mob/user, slot)
+	. = ..()
+	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
+		var/mob/living/carbon/human/H = user
+		H.update_inv_head()
+	attached_wig?.equipped(user, slot)
+
+/obj/item/clothing/head/dropped(mob/user)
+	..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.head == src)
+			H.update_inv_head()
+	attached_wig?.dropped(user)
+/*
+/obj/item/clothing/head/update_icon(updates)
+	. = ..()
+	if(attached_wig)
+		var/datum/sprite_accessory/S = GLOB.hair_styles_list[attached_wig.hair_style]
+		if(S)
+			var/mutable_appearance/M = mutable_appearance(S.icon,S.icon_state)
+			M.appearance_flags |= RESET_COLOR
+			M.color = attached_wig.hair_color
+			underlays += M
+*/
+
+/obj/item/clothing/head/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	if(istype(W, /obj/item/clothing/head/wig))
+		if(flags_inv && HIDEHAIR)
+			to_chat(user, "<span class='notice'>You can't attach a wig to [src]!</span>")
+			return
+		if(attached_wig)
+			to_chat(user,"<span class='notice'>[src] already has a wig attached!</span>")
+			return
+		else
+			attached_wig = W
+			W.forceMove(src)
+			add_verb(/obj/item/clothing/head/verb/unattach_wig)
+			update_icon()
+			strip_delay = 10 //The fake hair makes it really easy to swipe the hat off the head
+			attached_wig.equipped(user, ITEM_SLOT_HEAD)
+
+
+/obj/item/clothing/head/verb/unattach_wig()
+	set name = "Remove Wig"
+	set category = "Object"
+	set src in usr
+
+	usr.put_in_hands(attached_wig)
+	if (usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
+		attached_wig.dropped(usr)
+	attached_wig = null
+	update_icon()
+	remove_verb(/obj/item/clothing/head/verb/unattach_wig)
+	strip_delay = initial(strip_delay)
+	if(ishuman(usr))
+		var/mob/living/carbon/human/H = usr
+		if(H.head == src)
+			H.update_inv_head()
+
+/obj/item/clothing/head/Destroy()
+	if (attached_wig)
+		if (attached_wig.resistance_flags & INDESTRUCTIBLE)
+			attached_wig.forceMove(get_turf(src))
+		else
+			QDEL_NULL(attached_wig)
+	..()
+
+/obj/item/clothing/head/examine(mob/user)
+	. = ..()
+	if(attached_wig)
+		. += "<span class='notice'>There's \a [attached_wig.name] attached, which can be removed through the context menu.</span>"
+	else if(!(flags_inv && HIDEHAIR))
+		. += "<span class='notice'>A wig can be attached to the [src].</span>"
 
 ///Special throw_impact for hats to frisbee hats at people to place them on their heads/attempt to de-hat them.
 /obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -238,10 +238,16 @@
 	var/gradient_color = "000"
 	var/adjustablecolor = TRUE //can color be changed manually?
 	strip_delay = 10 //It's fake hair, can't be too hard to just grab and pull it off
+	var/obj/item/clothing/head/hat_attached_to = null
 
 /obj/item/clothing/head/wig/Initialize(mapload)
 	. = ..()
 	update_icon()
+
+/obj/item/clothing/head/wig/Destroy()
+	. = ..()
+	if(hat_attached_to)
+		hat_attached_to.attached_wig = null
 
 /obj/item/clothing/head/wig/dropped(mob/user)
 	..()

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -260,30 +260,7 @@
 		M.appearance_flags |= RESET_COLOR
 		M.color = hair_color
 		add_overlay(M)
-		/*
-		if(gradient_style)
-			var/mutable_appearance/gradient_overlay
-			var/datum/sprite_accessory/gradient = GLOB.hair_gradients_list[gradient_style]
-			var/icon/temp = icon(gradient.icon, gradient.icon_state)
-			var/icon/temp_hair = icon(S.icon, S.icon_state)
-			temp.Blend(temp_hair, ICON_ADD)
-			gradient_overlay.icon = temp
-			gradient_overlay.color = "#" + gradient_color
-			add_overlay(gradient_overlay)
-		*/
 
-/*
-/obj/item/clothing/head/wig/worn_overlays(mutable_appearance/standing, isinhands = FALSE, file2use)
-	. = list()
-	if(!isinhands)
-		var/datum/sprite_accessory/S = GLOB.hair_styles_list[hair_style]
-		if(!S)
-			return
-		var/mutable_appearance/M = mutable_appearance(S.icon, S.icon_state,layer = -HAIR_LAYER)
-		M.appearance_flags |= RESET_COLOR
-		M.color = hair_color
-		. += M
-*/
 /obj/item/clothing/head/wig/attack_self(mob/user)
 	var/new_style = input(user, "Select a hair style", "Wig Styling")  as null|anything in (GLOB.hair_styles_list - "Bald")
 	if(!user.canUseTopic(src, BE_CLOSE))

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -228,14 +228,27 @@
 	icon = 'icons/mob/human_face.dmi'	  // default icon for all hairs
 	icon_state = "hair_vlong"
 	item_state = "pwig"
-	flags_inv = HIDEHAIR
+	flags_inv = HIDEHAIR	//Instead of being handled as a clothing item, it overrides the hair values in /datum/species/proc/handle_hair
+	slot_flags = ITEM_SLOT_HEAD
+	worn_icon = 'icons/mob/human_face.dmi'
+	worn_icon_state = "bald"
 	var/hair_style = "Very Long Hair"
 	var/hair_color = "#000"
+	var/gradient_style = "None"
+	var/gradient_color = "000"
 	var/adjustablecolor = TRUE //can color be changed manually?
+	strip_delay = 10 //It's fake hair, can't be too hard to just grab and pull it off
 
 /obj/item/clothing/head/wig/Initialize(mapload)
 	. = ..()
 	update_icon()
+
+/obj/item/clothing/head/wig/dropped(mob/user)
+	..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.head == src)
+			H.update_inv_head()
 
 /obj/item/clothing/head/wig/update_icon()
 	cut_overlays()
@@ -247,7 +260,19 @@
 		M.appearance_flags |= RESET_COLOR
 		M.color = hair_color
 		add_overlay(M)
+		/*
+		if(gradient_style)
+			var/mutable_appearance/gradient_overlay
+			var/datum/sprite_accessory/gradient = GLOB.hair_gradients_list[gradient_style]
+			var/icon/temp = icon(gradient.icon, gradient.icon_state)
+			var/icon/temp_hair = icon(S.icon, S.icon_state)
+			temp.Blend(temp_hair, ICON_ADD)
+			gradient_overlay.icon = temp
+			gradient_overlay.color = "#" + gradient_color
+			add_overlay(gradient_overlay)
+		*/
 
+/*
 /obj/item/clothing/head/wig/worn_overlays(mutable_appearance/standing, isinhands = FALSE, file2use)
 	. = list()
 	if(!isinhands)
@@ -258,7 +283,7 @@
 		M.appearance_flags |= RESET_COLOR
 		M.color = hair_color
 		. += M
-
+*/
 /obj/item/clothing/head/wig/attack_self(mob/user)
 	var/new_style = input(user, "Select a hair style", "Wig Styling")  as null|anything in (GLOB.hair_styles_list - "Bald")
 	if(!user.canUseTopic(src, BE_CLOSE))
@@ -268,6 +293,19 @@
 		user.visible_message("<span class='notice'>[user] changes \the [src]'s hairstyle to [new_style].</span>", "<span class='notice'>You change \the [src]'s hairstyle to [new_style].</span>")
 	if(adjustablecolor)
 		hair_color = input(usr,"","Choose Color",hair_color) as color|null
+		var/picked_gradient_style
+		picked_gradient_style = input(usr, "", "Choose Gradient")  as null|anything in GLOB.hair_gradients_list
+		if(picked_gradient_style)
+			gradient_style = picked_gradient_style
+			var/picked_hair_gradient = input(user, "", "Choose Gradient Color", "#" + gradient_color) as color|null
+			if(picked_hair_gradient)
+				gradient_color = sanitize_hexcolor(picked_hair_gradient)
+			else
+				gradient_color = "000"
+		else
+			gradient_style = "None"
+			gradient_color = "000"
+
 	update_icon()
 
 /obj/item/clothing/head/wig/random/Initialize(mapload)
@@ -288,10 +326,12 @@
 	. = ..()
 
 /obj/item/clothing/head/wig/natural/equipped(mob/living/carbon/human/user, slot)
-	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
+	. = ..()
+	if(ishuman(user) && (slot == ITEM_SLOT_HEAD || slot == ITEM_SLOT_NECK))
 		hair_color = "#[user.hair_color]"
+		gradient_style = user.gradient_style
+		gradient_color = "#[user.gradient_color]"
 		update_icon()
-		user.update_inv_head()
 
 /obj/item/clothing/head/bronze
 	name = "bronze hat"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -449,9 +449,18 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 	var/dynamic_hair_suffix = "" //if this is non-null, and hair+suffix matches an iconstate, then we render that hair instead
 	var/dynamic_fhair_suffix = ""
+	var/obj/item/clothing/head/wig/worn_wig
+
+	if(H.head)// Wig stuff
+		if(istype(H.head, /obj/item/clothing/head/wig))
+			worn_wig = H.head
+		if(istype(H.head, /obj/item/clothing/head))
+			var/obj/item/clothing/head/hat = H.head
+			if(hat.attached_wig)
+				worn_wig = hat.attached_wig
 
 	//for augmented heads
-	if(!IS_ORGANIC_LIMB(HD))
+	if(!IS_ORGANIC_LIMB(HD) && !worn_wig) //Wig overrides mechanical heads not having hair
 		return
 
 	//we check if our hat or helmet hides our facial hair.
@@ -531,8 +540,17 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				hair_overlay.icon = 'icons/mob/human_face.dmi'
 				hair_overlay.icon_state = "debrained"
 
-		else if(H.hair_style && (HAIR in species_traits))
-			S = GLOB.hair_styles_list[H.hair_style]
+		else if((H.hair_style && (HAIR in species_traits)) || worn_wig)
+			var/current_hair_style = H.hair_style
+			var/current_hair_color = H.hair_color
+			var/current_gradient_style = H.gradient_style
+			var/current_gradient_color = H.gradient_color
+			if(worn_wig)
+				current_hair_style = worn_wig.hair_style
+				current_hair_color = worn_wig.hair_color
+				current_gradient_style = worn_wig.gradient_style
+				current_gradient_color = worn_wig.gradient_color
+			S = GLOB.hair_styles_list[current_hair_style]
 			if(S)
 
 				//List of all valid dynamic_hair_suffixes
@@ -563,11 +581,12 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 						else
 							hair_overlay.color = "#" + hair_color
 					else
-						hair_overlay.color = "#" + H.hair_color
-
+						hair_overlay.color = "#" + current_hair_color
+					if(worn_wig)//Total override
+						hair_overlay.color = current_hair_color
 					//Gradients
-					var/gradient_style = H.gradient_style
-					var/gradient_color = H.gradient_color
+					var/gradient_style = current_gradient_style
+					var/gradient_color = current_gradient_color
 					if(gradient_style)
 						var/datum/sprite_accessory/gradient = GLOB.hair_gradients_list[gradient_style]
 						var/icon/temp = icon(gradient.icon, gradient.icon_state)
@@ -580,13 +599,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					hair_overlay.color = forced_colour
 
 				hair_overlay.alpha = hair_alpha
+				if(worn_wig)
+					hair_overlay.alpha = 255
 				if(OFFSET_FACE in H.dna.species.offset_features)
 					hair_overlay.pixel_x += H.dna.species.offset_features[OFFSET_FACE][1]
 					hair_overlay.pixel_y += H.dna.species.offset_features[OFFSET_FACE][2]
-		if(H.wear_neck && istype(H.wear_neck, /obj/item/clothing/head/wig))
-			hair_overlay = H.wear_neck.appearance
-		if(H.head && istype(H.head, /obj/item/clothing/head/wig))
-			hair_overlay = H.head.appearance
 		if(hair_overlay.icon)
 			standing += hair_overlay
 			standing += gradient_overlay

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -583,6 +583,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				if(OFFSET_FACE in H.dna.species.offset_features)
 					hair_overlay.pixel_x += H.dna.species.offset_features[OFFSET_FACE][1]
 					hair_overlay.pixel_y += H.dna.species.offset_features[OFFSET_FACE][2]
+		if(H.wear_neck && istype(H.wear_neck, /obj/item/clothing/head/wig))
+			hair_overlay = H.wear_neck.appearance
+		if(H.head && istype(H.head, /obj/item/clothing/head/wig))
+			hair_overlay = H.head.appearance
 		if(hair_overlay.icon)
 			standing += hair_overlay
 			standing += gradient_overlay

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -277,6 +277,7 @@ There are several things that need to be remembered:
 
 /mob/living/carbon/human/update_inv_neck()
 	remove_overlay(NECK_LAYER)
+
 	if(client && hud_used)
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_NECK) + 1]
 		inv.update_icon()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -277,12 +277,11 @@ There are several things that need to be remembered:
 
 /mob/living/carbon/human/update_inv_neck()
 	remove_overlay(NECK_LAYER)
-
 	if(client && hud_used)
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_NECK) + 1]
 		inv.update_icon()
 
-	if(wear_neck && !istype(wear_neck, /obj/item/clothing/head/wig)) //Wigs don't get rendered, they override hair instead
+	if(wear_neck)
 		wear_neck.screen_loc = ui_neck
 		if(client && hud_used && hud_used.hud_shown)
 			if(hud_used.inventory_shown)			//if the inventory is open
@@ -367,13 +366,13 @@ There are several things that need to be remembered:
 
 	if(!get_bodypart(BODY_ZONE_HEAD)) //Decapitated
 		return
-
+	update_hair()
 	if(client && hud_used && hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_HEAD) + 1])
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_HEAD) + 1]
 		inv.update_icon()
 
 	update_mutant_bodyparts()
-	if(head && !istype(head, /obj/item/clothing/head/wig)) //Wigs don't get rendered, they override hair instead
+	if(head)
 		update_hud_head(head)
 		var/icon_file = 'icons/mob/clothing/head.dmi'
 		if(istype(head, /obj/item/clothing/head))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -282,7 +282,7 @@ There are several things that need to be remembered:
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_NECK) + 1]
 		inv.update_icon()
 
-	if(wear_neck)
+	if(wear_neck && !istype(wear_neck, /obj/item/clothing/head/wig)) //Wigs don't get rendered, they override hair instead
 		wear_neck.screen_loc = ui_neck
 		if(client && hud_used && hud_used.hud_shown)
 			if(hud_used.inventory_shown)			//if the inventory is open
@@ -373,7 +373,7 @@ There are several things that need to be remembered:
 		inv.update_icon()
 
 	update_mutant_bodyparts()
-	if(head)
+	if(head && !istype(head, /obj/item/clothing/head/wig)) //Wigs don't get rendered, they override hair instead
 		update_hud_head(head)
 		var/icon_file = 'icons/mob/clothing/head.dmi'
 		if(istype(head, /obj/item/clothing/head))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the wig use hair code for rendering its looks, as well as allowing wigs to have gradients.
Allows for any hat that doesn't hide hair to have a wig attached. This also tremendously reduces the time it takes to strip the hat off.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for more player self-expression and customization, as well as shenanigans relating to easily strippable hats.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/25d7b229-9c49-440d-9eb0-c5d728b7249a

</details>

## Changelog
:cl:
add: Added the ability to attach and detach wigs from hats that don't hide hair
add: Added the ability for wigs to choose hair gradients and gradient colors
balance: Hats with attached wigs, and wigs themselves, only take one second to be stripped off
code: Made the wigs force the handle_hair species proc to use the hair values of the wig
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
