### PR TITLE
Forces cooldowns on martial arts items

### DIFF
--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -11,7 +11,7 @@
 	return 1
 
 /datum/martial_art/boxing/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-
+	A.changeNext_move(CLICK_CD_MELEE)
 	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 
 	var/atk_verb = pick("left hook","right hook","straight punch")

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -125,6 +125,7 @@
 	return TRUE
 
 /datum/martial_art/cqc/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(!can_use(A))
 		return FALSE
 	if(A==D)
@@ -145,6 +146,7 @@
 	return TRUE
 
 /datum/martial_art/cqc/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	var/def_check = D.getarmor(BODY_ZONE_CHEST, MELEE)
 	if(!can_use(A))
 		return FALSE
@@ -176,6 +178,7 @@
 	return TRUE
 
 /datum/martial_art/cqc/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	var/def_check = D.getarmor(BODY_ZONE_CHEST, MELEE)
 	if(!can_use(A))
 		return FALSE

--- a/code/datums/martial/karate.dm
+++ b/code/datums/martial/karate.dm
@@ -93,18 +93,21 @@
 	return basic_hit(A,D)
 
 /datum/martial_art/karate/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return 1
 	return ..()
 
 /datum/martial_art/karate/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return 1
 	return ..()
 
 /datum/martial_art/karate/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return 1

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -121,12 +121,14 @@
 	return 1
 
 /datum/martial_art/krav_maga/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(check_streak(A,D))
 		return 1
 	log_combat(A, D, "grabbed (Krav Maga)")
 	..()
 
 /datum/martial_art/krav_maga/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(check_streak(A,D))
 		return 1
 	log_combat(A, D, "punched")
@@ -150,6 +152,7 @@
 	return 1
 
 /datum/martial_art/krav_maga/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(check_streak(A,D))
 		return 1
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -61,6 +61,7 @@
 	return
 
 /datum/martial_art/plasma_fist/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return 1
@@ -68,6 +69,7 @@
 	return 1
 
 /datum/martial_art/plasma_fist/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return 1
@@ -75,6 +77,7 @@
 	return 1
 
 /datum/martial_art/plasma_fist/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return 1

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -111,6 +111,7 @@
 	return basic_hit(A,D)
 
 /datum/martial_art/the_sleeping_carp/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(A==D)
 		return 0 //prevents grabbing yourself
 	if(A.a_intent == INTENT_GRAB)
@@ -129,6 +130,7 @@
 	return 1
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	var/def_check = D.getarmor(BODY_ZONE_CHEST, MELEE)
 	add_to_streak("H",D)
 	if(check_streak(A,D))
@@ -144,6 +146,7 @@
 
 
 /datum/martial_art/the_sleeping_carp/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return 1

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -80,18 +80,21 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 		D.silent = CLAMP(D.silent + 10, 0, 10)
 
 /datum/martial_art/tribal_claw/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return TRUE
 	return FALSE
 
 /datum/martial_art/tribal_claw/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return TRUE
 	return FALSE
 
 /datum/martial_art/tribal_claw/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return TRUE

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -120,6 +120,7 @@
 	strike.Remove(H)
 
 /datum/martial_art/wrestling/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(check_streak(A,D))
 		return 1
 	log_combat(A, D, "punched with wrestling")
@@ -433,12 +434,14 @@
 	return
 
 /datum/martial_art/wrestling/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(check_streak(A,D))
 		return 1
 	log_combat(A, D, "wrestling-disarmed")
 	..()
 
 /datum/martial_art/wrestling/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.changeNext_move(CLICK_CD_MELEE)
 	if(check_streak(A,D))
 		return 1
 	if(A.pulling == D)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -79,8 +79,8 @@
 
 	else if(M.a_intent == INTENT_HARM)
 		for(var/mob/living/L in oview(1, M))
-			L.attack_hand(M)
 			M.changeNext_move(CLICK_CD_RAPID)
+			L.attack_hand(M)
 			if(warcry)
 				M.say("[warcry]", ignore_spam = TRUE, forced = "north star warcry")
 			break

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -80,6 +80,7 @@
 	else if(M.a_intent == INTENT_HARM)
 		for(var/mob/living/L in oview(1, M))
 			M.changeNext_move(CLICK_CD_RAPID)
+			// Attack must be after the cooldown as martial arts resets the cooldown for clicking
 			L.attack_hand(M)
 			if(warcry)
 				M.say("[warcry]", ignore_spam = TRUE, forced = "north star warcry")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Martial arts will now force click cooldowns, preventing them from being sped up when combined with gloves of the north star or the DNA vault attack speed improvements.

## Why It's Good For The Game

This combo is incredibly powerful and impossible to deal with, these items were not made with the idea of them being combined since sleeping carp gives you insanely high damage per attack and north star gives you almost no attack cooldown and aimlock.
Note that you will still get the aimlock from north star gloves when combined with sleeping carp, but not 0 cooldown.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/53edae3c-1f6d-4b1a-94c7-0811a93ff43a

## Changelog
:cl:
balance: Martial art attacks now force a click cooldown which cannot be overriden by gloves of the north star. (No more gloves of the north star + sleeping carp combo)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
