### PR TITLE
Admins without R_ADMIN perm are sorted in another section in staff_who

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -124,7 +124,7 @@
 			msg += each
 		if(length(non_admin_list)) // notifying the absence of non-admins has no point
 			msg += "<b>Current Maintainers:</b>\n"
-			msg += "\t(Note: non-admin staff are unable to handle adminhelp tickets.)\n"
+			msg += "\t<span class='info'>Non-admin staff are unable to handle adminhelp tickets.</span>\n"
 			for(var/each in non_admin_list)
 				msg += each
 		msg += "<b>Current Mentors:</b>\n"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -123,7 +123,7 @@
 		for(var/each in admin_list)
 			msg += each
 		if(length(non_admin_list)) // notifying the absence of non-admins has no point
-			msg += "<b>Current Non-admin staffs:</b>\n"
+			msg += "<b>Current Maintainers:</b>\n"
 			msg += "\t(Note: non-admin staff are unable to handle adminhelp tickets.)\n"
 			for(var/each in non_admin_list)
 				msg += each

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -118,14 +118,13 @@
 				else // admins without R_ADMIN perm should be sorted in different area, so that people won't believe coders will handle ahelp
 					var/rank = "\improper [C.holder.rank]"
 					non_admin_list += "\t[C] is \a [rank]\n"
-		admin_list += "\trandomckey1234 is an Admin\n"
-		non_admin_list += "\trandomckey6789 is a Coder\n"
+
 		msg = "<b>Current Admins:</b>\n"
 		for(var/each in admin_list)
 			msg += each
 		if(length(non_admin_list)) // notifying the absence of non-admins has no point
 			msg += "<b>Current Non-admin staffs:</b>\n"
-			msg += "\t<span class='info'>Please be aware that non-admin staffs can't handle adminhelp tickets.</span>\n"
+			msg += "\t(Note: non-admin staffs can't handle adminhelp tickets.)\n"
 			for(var/each in non_admin_list)
 				msg += each
 		msg += "<b>Current Mentors:</b>\n"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -124,7 +124,7 @@
 			msg += each
 		if(length(non_admin_list)) // notifying the absence of non-admins has no point
 			msg += "<b>Current Non-admin staffs:</b>\n"
-			msg += "\t(Note: non-admin staffs can't handle adminhelp tickets.)\n"
+			msg += "\t(Note: non-admin staff are unable to handle adminhelp tickets.)\n"
 			for(var/each in non_admin_list)
 				msg += each
 		msg += "<b>Current Mentors:</b>\n"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -112,7 +112,7 @@
 			if(C.is_afk())
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
-				if(check_rights_for(C, R_ADMIN)) // ahelp needs R_ADMIN. If they don't have this perm, it means they're not admin
+				if(check_rights_for(C, R_ADMIN)) // ahelp needs R_ADMIN. If they have R_ADMIN, they'll be listed in admin list.
 					var/rank = "\improper [C.holder.rank]"
 					admin_list += "\t[C] is \a [rank]\n"
 				else // admins without R_ADMIN perm should be sorted in different area, so that people won't believe coders will handle ahelp

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -67,8 +67,11 @@
 	staff_who("Mentorwho")
 
 /client/proc/staff_who(via)
-	var/msg = "<b>Current Admins:</b>\n"
+	var/msg
+
+	// when you are admin
 	if(holder)
+		msg = "<b>Current Admins:</b>\n"
 		for(var/client/C in GLOB.admins)
 			var/rank = "\improper [C.holder.rank]"
 			msg += "\t[C] is \a [rank]"
@@ -100,13 +103,31 @@
 			if(C.is_afk())
 				msg += " (AFK)"
 			msg += "\n"
+
+	// for standard players
 	else
+		var/list/admin_list = list()
+		var/list/non_admin_list = list()
 		for(var/client/C in GLOB.admins)
 			if(C.is_afk())
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
-				var/rank = "\improper [C.holder.rank]"
-				msg += "\t[C] is \a [rank]\n"
+				if(check_rights_for(C, R_ADMIN)) // ahelp needs R_ADMIN. If they don't have this perm, it means they're not admin
+					var/rank = "\improper [C.holder.rank]"
+					admin_list += "\t[C] is \a [rank]\n"
+				else // admins without R_ADMIN perm should be sorted in different area, so that people won't believe coders will handle ahelp
+					var/rank = "\improper [C.holder.rank]"
+					non_admin_list += "\t[C] is \a [rank]\n"
+		admin_list += "\trandomckey1234 is an Admin\n"
+		non_admin_list += "\trandomckey6789 is a Coder\n"
+		msg = "<b>Current Admins:</b>\n"
+		for(var/each in admin_list)
+			msg += each
+		if(length(non_admin_list)) // notifying the absence of non-admins has no point
+			msg += "<b>Current Non-admin staffs:</b>\n"
+			msg += "\t<span class='info'>Please be aware that non-admin staffs can't handle adminhelp tickets.</span>\n"
+			for(var/each in non_admin_list)
+				msg += each
 		msg += "<b>Current Mentors:</b>\n"
 		for(var/client/C in GLOB.mentors)
 			if(C.is_afk())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Admins without R_ADMIN perm are sorted in another section in staff_who
See the test evidence
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
some people think I can handle tickets

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/857e49ad-4ce9-4ade-981f-392426d7bc26)

## Changelog
:cl:
admin: Admins without R_ADMIN perm are sorted in another section in staff_who, so that people will not believe coders can handle adminhelps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
