### PR TITLE
Enables medkits to be equipped to belt slot

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -18,7 +18,8 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	throw_speed = 3
 	throw_range = 7
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_BELT
 	var/skin_type = MEDBOT_SKIN_DEFAULT
 	var/empty = FALSE
 	var/damagetype_healed //defines damage type of the medkit. General ones stay null. Used for medibot healing bonuses
@@ -64,7 +65,6 @@
 	item_state = "firstaid-surgery"
 	desc = "A high capacity aid kit for doctors, full of medical supplies and basic surgical equipment"
 	skin_type = MEDBOT_SKIN_SURGERY
-	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/firstaid/medical/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -64,6 +64,7 @@
 	item_state = "firstaid-surgery"
 	desc = "A high capacity aid kit for doctors, full of medical supplies and basic surgical equipment"
 	skin_type = MEDBOT_SKIN_SURGERY
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/firstaid/medical/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -18,7 +18,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	throw_speed = 3
 	throw_range = 7
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	var/skin_type = MEDBOT_SKIN_DEFAULT
 	var/empty = FALSE
 	var/damagetype_healed //defines damage type of the medkit. General ones stay null. Used for medibot healing bonuses


### PR DESCRIPTION
## About The Pull Request

Enables medkits to be equipped to the belt slot

## Why It's Good For The Game

With the changes in self-care people don't really take meds with them anymore, as they cannot self-heal more then once.
Plus I have been seeing some discarded med-kits on the floors after the content has been transferred to a cardboard box.

Edit: Also gives medical players more options in clothing to wear, as the first aid kit can only be slotted on the back of medical labcoats.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/8070319/f7fc3fe9-7a22-4e74-8cd1-77aa6b093b79)


</details>

## Changelog
:cl:
tweak: Medkits can now be attacked to the belt
/:cl:

