### PR TITLE
Healing holoparasites no longer kill toxinlovers

### DIFF
--- a/code/modules/guardian/abilities/major/healing.dm
+++ b/code/modules/guardian/abilities/major/healing.dm
@@ -30,7 +30,7 @@
 			L.adjustBruteLoss(heals)
 			L.adjustFireLoss(heals)
 			L.adjustOxyLoss(heals)
-			L.adjustToxLoss(heals)
+			L.adjustToxLoss(heals, forced = TRUE)
 			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(L))
 			H.color = guardian.guardiancolor
 			if(L == guardian.summoner?.current)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Healing holoparas heal through like, magic or some shit, not through like chemicals, so it should just... heal, whether you like toxins or not

## Why It's Good For The Game

Healing holopara should heal

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Healing holoparasites will no longer damage toxinlovers (oozelings, etc) when healing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
