### PR TITLE
Makes miscelanious crossbreeds more viable

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -306,7 +306,7 @@
 #define SLIME_EVOLUTION_THRESHOLD 10
 
 //Slime extract crossing. Controls how many extracts is required to feed to a slime to core-cross.
-#define SLIME_EXTRACT_CROSSING_REQUIRED 10
+#define SLIME_EXTRACT_CROSSING_REQUIRED 5
 
 //Slime commands defines
 #define SLIME_FRIENDSHIP_FOLLOW 			3 //! Min friendship to order it to follow


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers the required slime cores for crossbreeding from 10 to 5 which allows for more crossbreed projects to be made in the same amount of time.
It also brings the crossbreeds a bit closer in terms of resources to normal slime cores that are sometimes more powerful than some crossbreeds.

## Why It's Good For The Game

Most crossbreeds are actually quite wacky and not that powerful.
Then what's the point of keeping them overpriced? 
Let's calculate the price (in cores) of a crossbreed regardless of colour.

In the case without upgrades to the slime processor:
- One adult slime = 2 baby slimes = 2 cores
- 10 cores = 10 baby slimes
So in the case, of not upgrading equipment, one crossbreed costs 12 baby slimes, or 12 cores.

In the case of maximum upgrades:
- One adult slime = 2 baby slimes = 8 cores
- 10 cores = 2.5 baby slimes
In this case, we are getting a single crossbreed for 4.5 baby slimes, or 18 cores of which 6 are wasted as the adult slime is not subject to processing.

Both seem like a fair price for a crossbreed that lets you cheat death (Chilling Cerulean), fabricate infinite resources (Stabilized Metal), or get free teleportation for both short-range and a recall spell (Gentle Bluespace). 
However, the price seems to be stupidly high for cookies that change your colour (Consuming Pyrite), a Zippo lighter factory (Industrial Orange), Barrier Grenades (Chilling Grey), corgi maker (Chilling Pink), paintbrushes (Any Prismatic), Janitor Job Stealer (Crystalline Dark Blue), A nudist experience for 20 seconds or so (Chilling Cerulean), a glorified microbomb implant (Stabilized Oil), or a plasma fart (Burning Dark Purple).
Regenerative extracts probably can fall in either category, as 50 healing of each damage is very sweet, but the ridiculous core requirements make them stupidly inefficient to mass-produce.
This may (or may not) give us a chance to see whether it is possible to make xenobio actually useful to the station if we soften the factor that makes them say "I spent this much time and resources for this inconsequential thing I made that I would rather hold onto it than give it out to someone."

## Testing Photographs and Procedure

<details>


https://github.com/BeeStation/BeeStation-Hornet/assets/34888552/1c66661d-675b-4ee4-ac3f-064acb5a435c



</details>

## Changelog
:cl:
balance: Xenobiology crossbreeds are now twice as cheap.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
