### PR TITLE
[Bugfix] Full storage objects are no longer immune to melee attacks

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -519,9 +519,6 @@
 	if(iscyborg(M))
 		return
 	if(!can_be_inserted(I, FALSE, M))
-		var/atom/real_location = real_location()
-		if(real_location.contents.len >= max_items) //don't use items on the backpack if they don't fit
-			return TRUE
 		return FALSE
 	handle_item_insertion(I, FALSE, M)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #8731
which was a bug made prevalent by #8643 's effects on captain spare safes

Found that items would not attack storage boxes if they were full; which made absolutely no sense. Now they'll be able to

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/a52ff46a-5e3f-4167-bf01-c405c60a53ad)
Even the captain's spare safe shouldn't be immune to a sword made of supermatter.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/3a3b45d8-2b27-4636-85d3-f05d77888e5d)

Now with 100% more death by supermatter.

</details>

## Changelog
:cl:
fix: You are no longer blocked from attacking a storage object that is full. e.g. hitting the captain's spare safe with a supermatter sword.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
