### PR TITLE
Fixes Escape Pods

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -75,12 +75,10 @@
 							locate(min(T.x+width-1, world.maxx), min(T.y+height-1, world.maxy), T.z))
 	for(var/turf/turf in turfs)
 		turfs[turf] = turf.loc
-	keep_cached_map = TRUE //We need to access some stuff here below for shuttle skipovers
 	. = ..(T, centered, init_atmos, finalize, register, turfs)
 
-/datum/map_template/shuttle/on_placement_completed(datum/map_generator/map_gen, turf/T, init_atmos, datum/parsed_map/parsed, finalize = TRUE, register = TRUE, list/turfs)
+/datum/map_template/shuttle/on_placement_completed(datum/map_generator/map_place/map_gen, turf/T, init_atmos, datum/parsed_map/parsed, finalize = TRUE, register = TRUE, list/turfs)
 	. = ..(map_gen, T, TRUE, parsed, FALSE)
-	keep_cached_map = initial(keep_cached_map)
 	if(!.)
 		log_runtime("Failed to load shuttle [map_gen.get_name()].")
 		return
@@ -140,7 +138,7 @@
 			line = gset.gridLines[length(gset.gridLines) - y_offset] //Y goes from top to bottom
 			if((gset.xcrd - 1 < x_offset) || (gset.xcrd + (length(line)/cached_map.key_len) - 2 > x_offset)) ///Our x coord isn't in the bounds
 				continue
-			cache = cached_map.modelCache[copytext(line, 1+((x_offset-gset.xcrd+1)*cached_map.key_len), 1+((x_offset-gset.xcrd+2)*cached_map.key_len))]
+			cache = map_gen.placing_template.modelCache[copytext(line, 1+((x_offset-gset.xcrd+1)*cached_map.key_len), 1+((x_offset-gset.xcrd+2)*cached_map.key_len))]
 			break
 		if(!cache) //Our turf isn't in the cached map, something went very wrong
 			continue
@@ -164,14 +162,13 @@
 
 	//If this is a superfunction call, we don't want to initialize atoms here, let the subfunction handle that
 	if(finalize)
+		maps_loading --
+
 		//initialize things that are normally initialized after map load
 		initTemplateBounds(., init_atmos)
 
 		log_game("[name] loaded at [T.x],[T.y],[T.z]")
 
-	maps_loading --
-	if (!maps_loading)
-		cached_map = keep_cached_map ? cached_map : null
 
 //Whatever special stuff you want
 /datum/map_template/shuttle/proc/post_load(obj/docking_port/mobile/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Escape pods now have floors again!

All maps from the same map file sharing a single map template datum caused some issues when trying to load multiple of the same map at a same time, specifically the cached_map var only stores the most recent and therefore most likely to not be finished yet map parser. This caused issues when placing skipover turfs on shuttles that expected that cache to not be still generating. I changed it so that each map now uses its assigned map parser instead of the most recent one of its type to use for shuttle skipover placement.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Escape pods should help you escape alive, not cause you to fall into space 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Pods working on MetaStation</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/51838176/e68834a8-8c47-4360-a656-8be1cb4a660a


</details>

## Changelog
:cl:
fix: Escape pods are fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
