### PR TITLE
Minor deployable item fix + Meteor shield sat is now deployable

### DIFF
--- a/code/game/objects/items/deployable/bodybag.dm
+++ b/code/game/objects/items/deployable/bodybag.dm
@@ -5,6 +5,7 @@
 	icon_state = "bodybag_folded"
 	w_class = WEIGHT_CLASS_SMALL
 	deployed_object = /obj/structure/closet/body_bag
+	ignores_mob_density = TRUE
 
 /obj/item/deployable/bodybag/suicide_act(mob/user)
 	if(isopenturf(user.loc))

--- a/code/game/objects/items/deployable/bot.dm
+++ b/code/game/objects/items/deployable/bot.dm
@@ -3,6 +3,7 @@
 	desc = "if you're seeing this contact coders ASAP"
 	dense_deployment = TRUE
 	w_class = WEIGHT_CLASS_BULKY
+	ignores_mob_density = TRUE
 	//All other variables are set within living/simple_animal/bot/MouseDrop()
 
 /obj/item/deployable/bot/Initialize(mapload)

--- a/code/game/objects/items/deployable/deployable.dm
+++ b/code/game/objects/items/deployable/deployable.dm
@@ -14,6 +14,8 @@
 	var/time_to_deploy
 	///Set to true to allow deployment on top of dense objects
 	var/dense_deployment = FALSE
+	/// even if 'dense_deployment' is FALSE, if this is TRUE, it can be deployed onto your position
+	var/ignores_mob_density = FALSE
 
 /obj/item/deployable/attack_self(mob/user)
 	try_deploy(user, user.loc)
@@ -36,13 +38,17 @@
 		else
 			var/dense_location
 			for(var/atom/movable/AM in location)
-				if(AM.density)
-					dense_location = TRUE
-					break
+				if(!AM.density || (ignores_mob_density && ismob(AM)))
+					continue
+				dense_location = TRUE
+				break
 			if(!dense_location)
 				return deploy_after(user, location)
 	if(user)
-		to_chat(user, "<span class='warning'>[src] can only be deployed in an open area!</span>")
+		if(ignores_mob_density)
+			to_chat(user, "<span class='warning'>[src] can only be deployed in an open area!</span>")
+		else
+			to_chat(user, "<span class='warning'>[src] can only be deployed in an open area! Click an open area where has no dense object.</span>")
 	visible_message("<span class='warning'>[src] fails to deploy!</span>")
 	return FALSE
 

--- a/code/game/objects/items/deployable/rollerbed.dm
+++ b/code/game/objects/items/deployable/rollerbed.dm
@@ -5,6 +5,7 @@
 	icon_state = "folded"
 	w_class = WEIGHT_CLASS_NORMAL // No more excuses, stop getting blood everywhere
 	deployed_object = /obj/structure/bed/roller
+	ignores_mob_density = TRUE
 
 /obj/item/deployable/rollerbed/robo //ROLLER ROBO DA!
 	name = "roller bed dock"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1112,14 +1112,18 @@
 
 /datum/supply_pack/engineering/shield_sat
 	name = "Shield Generator Satellite"
-	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains three Shield Generator Satellites."
-	cost = 3000
-	max_supply = 5
+	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains seven bluespace capsules which a single unit of Shield Generator Satellite is compressed within each."
+	cost = 7000
+	max_supply = 2
 	access_budget = ACCESS_HEADS
 	contains = list(
-					/obj/machinery/satellite/meteor_shield,
-					/obj/machinery/satellite/meteor_shield,
-					/obj/machinery/satellite/meteor_shield
+					/obj/item/deployable/meteor_shield,
+					/obj/item/deployable/meteor_shield,
+					/obj/item/deployable/meteor_shield,
+					/obj/item/deployable/meteor_shield,
+					/obj/item/deployable/meteor_shield,
+					/obj/item/deployable/meteor_shield,
+					/obj/item/deployable/meteor_shield,
 					)
 	crate_name= "shield sat crate"
 

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -127,6 +127,12 @@
 	to_chat(user, "<span class='notice'>// NTSAT-[id] // Mode : [active ? "PRIMARY" : "STANDBY"] //[(obj_flags & EMAGGED) ? "DEBUG_MODE //" : ""]</span>")
 	return TRUE
 
+/obj/item/deployable/meteor_shield
+	name = "\improper Meteor Shield Satellite Deploy Capsule"
+	desc = "A bluespace capsule which a single unit of meteor shield satellite is compressed within. If you activate this capsule, a meteor shield satellite will pop out. You still need to install these."
+	deployed_object = /obj/machinery/satellite/meteor_shield
+	time_to_deploy = 10 SECONDS
+
 /obj/machinery/satellite/meteor_shield
 	name = "\improper Meteor Shield Satellite"
 	desc = "A meteor point-defense satellite."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Minor deployable item fix + Meteor shield sat is now deployable
* Deployable item can be placed onto a turf where a mob eixsts onto (which has density)
a deployable item will have `ignore_mob_density` variable to ignore mobs
* Meteor shield sat is now:
  * 7 items (as deployable capsule) 
  * 7000 credits, 7 items
  * total 2 cargo stocks
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix
also, meteor preparation is really really tedious because meteor sat item is too big and it that makes us difficult to set meteor shields.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/56879981-5299-4827-9c26-55ebd50c927c)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/f276d64b-c154-41fb-b918-6e6991a684b6)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/5f46258c-298c-4811-991b-2b0345fa3996)

</details>

## Changelog
:cl:
fix: bodybag, rollerbed, deployable bot can be placed onto a turf you're on
tweak: if a deployable item can not be placed onto a turf you're on, it will notify you that you need to click an open area.
tweak: meteor shield sat is now a deployable item. This will make preparing and installing meteor shield sat less tedious than before.
tweak: meteor shield cargo order is now max 2 stocks, and each supply contains 7 capsules. Now costs 7,000 credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
