### PR TITLE
[Mapping Bugfix: Corg] That shouldn't be there at all.

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -37560,8 +37560,8 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
 "mgs" = (
-/obj/structure/reagent_dispensers,
 /obj/effect/turf_decal/delivery,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "mgw" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
An invalid `reagent_dispenser` was present in Corg Station in place of what should've been the subtype `reagent_dispenser/watertank`. As the type of PR this is suggests- this fixes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/d2ed3669-64d8-4318-83e8-0838c24d77c7)
No, just no.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/cf771088-3d10-4ae4-93f6-1cd6d91b6733)

I also checked every map using StrongDMM's search feature to ensure there were no more erroneous tanks.

</details>

## Changelog
:cl:
fix: Removed an anomalous "Dispenser" present on CorgStation, replacing it with a proper NT approved water tank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
