### PR TITLE
Fixes a container crafting duplication exploit

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -137,5 +137,21 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 /proc/cmp_mob_realname_dsc(mob/A,mob/B)
 	return sorttext(A.real_name,B.real_name)
 
+/**
+  * Sorts crafting recipe requirements before the crafting recipe is inserted into GLOB.crafting_recipes
+  *
+  * Prioritises [/datum/reagent] to ensure reagent requirements are always processed first when crafting.
+  * This prevents any reagent_containers from being consumed before the reagents they contain, which can
+  * lead to runtimes and item duplication when it happens.
+  */
+/proc/cmp_crafting_req_priority(var/A, var/B)
+	var/lhs
+	var/rhs
+
+	lhs = ispath(A, /datum/reagent) ? 0 : 1
+	rhs = ispath(B, /datum/reagent) ? 0 : 1
+
+	return lhs - rhs
+
 /proc/cmp_heretic_knowledge(datum/heretic_knowledge/knowledge_a, datum/heretic_knowledge/knowledge_b)
 	return initial(knowledge_b.priority) - initial(knowledge_a.priority)

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -77,7 +77,15 @@
 		GLOB.keybinding_list_by_key[key] = sort_list(GLOB.keybinding_list_by_key[key])
 
 
-	init_subtypes(/datum/crafting_recipe, GLOB.crafting_recipes)
+	init_crafting_recipes(GLOB.crafting_recipes)
+
+/// Inits the crafting recipe list, sorting crafting recipe requirements in the process.
+/proc/init_crafting_recipes(list/crafting_recipes)
+	for(var/path in subtypesof(/datum/crafting_recipe))
+		var/datum/crafting_recipe/recipe = new path()
+		recipe.reqs = sort_list(recipe.reqs, /proc/cmp_crafting_req_priority)
+		crafting_recipes += recipe
+	return crafting_recipes
 
 /proc/make_datum_references_lists_late_setup()
 	// this should be done lately because it needs something pre-setup

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -329,6 +329,14 @@
 	while(Deletion.len)
 		var/DL = Deletion[Deletion.len]
 		Deletion.Cut(Deletion.len)
+		// Snowflake handling of reagent containers and storage atoms.
+		// If we consumed them in our crafting, we should dump their contents out before qdeling them.
+		if(istype(DL, /obj/item/reagent_containers))
+			var/obj/item/reagent_containers/container = DL
+			container.reagents.reaction(container.loc, TOUCH)
+		else if(istype(DL, /obj/item/storage))
+			var/obj/item/storage/container = DL
+			container.emptyStorage()
 		qdel(DL)
 
 /datum/component/personal_crafting/proc/component_ui_interact(atom/movable/screen/craft/image, location, control, params, user)


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/54330

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #9379 

This PR fixes an item dupe possible with crafting. For details about it, check out the issue or the tg pr itself.

> First issue: Certain crafting recipes (for example, Hooch) require a bottle, 100u hooch and a paper bag. If the 100u of hooch is in the bottle, because the crafting recipe has the bottle before the hooch in the requirements list, the craft will runtime as the bottle is "consumed" along with all its reagents.
> 
> To remedy this, I've created a simple sorter proc that runs when the global recipe list is inited. Before each recipe is added to the global recipe list, it now sorts the crafting requirements so that reagents are always processed first.
> 
> It's not exactly pretty, but it solves having to either refactor crafting code (please God no) or to go through every recipe datum and manually reorder the req list or create a unit test to ensure all recipe reqs are in the appropriate order.
> 
> Second issue: When crafting consumes a container, it qdels it and thus qdels all the items inside of it.
> 
> I've added two snowflake checks to empty the contents of reagent_containers and storage items before they are qdel'd. No more accidentally deleting items through crafting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Duplication bad. Runtime bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure


Before

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/71e1f908-f0cc-4f87-b472-25988e32e7e0

After

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/dd68b2f9-e59a-4e85-a185-5c5381966417


## Changelog
:cl: RKz, Timberpoes
fix: Crafting recipes that require both bottles and reagents now craft properly when the bottle contains the reagent, without duplicating items.
fix: Crafting that consumes items that have some sort of inventory should now dump the inventory contents out instead of deleting them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
