### PR TITLE
Changes 'recipes' variable to 'get_recipes()' proc

### DIFF
--- a/code/game/objects/items/stacks/ores/ore_type.dm
+++ b/code/game/objects/items/stacks/ores/ore_type.dm
@@ -46,9 +46,8 @@ STACKSIZE_MACRO(/obj/item/stack/ore/iron)
 	refined_type = /obj/item/stack/sheet/glass
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/stack/ore/glass/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.sand_recipes
-	. = ..()
+/obj/item/stack/ore/glass/get_recipes()
+	return GLOB.sand_recipes
 
 /obj/item/stack/ore/glass/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(..() || !ishuman(hit_atom))

--- a/code/game/objects/items/stacks/rods/rods.dm
+++ b/code/game/objects/items/stacks/rods/rods.dm
@@ -22,12 +22,14 @@
 	user.visible_message("<span class='suicide'>[user] begins to stuff \the [src] down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")//it looks like theyre ur mum
 	return BRUTELOSS
 
+/obj/item/stack/rods/get_recipes()
+	return GLOB.rod_recipes
+
 /obj/item/stack/rods/Initialize(mapload, new_amount, merge = TRUE, mob/user = null)
 	. = ..()
 	if(QDELETED(src)) // we can be deleted during merge, check before doing stuff
 		return
 
-	recipes = GLOB.rod_recipes
 	update_icon()
 	AddElement(/datum/element/openspace_item_click_handler)
 

--- a/code/game/objects/items/stacks/sheets/mineral/exotics.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/exotics.dm
@@ -19,9 +19,8 @@ Exotic mineral Sheets
 	point_value = 50
 	merge_type = /obj/item/stack/sheet/mineral/bananium
 
-/obj/item/stack/sheet/mineral/bananium/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.bananium_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/bananium/get_recipes()
+	return GLOB.bananium_recipes
 
 
 /* Adamantine */
@@ -34,9 +33,8 @@ Exotic mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/adamantine
 	grind_results = list(/datum/reagent/liquidadamantine = 10)
 
-/obj/item/stack/sheet/mineral/adamantine/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.adamantine_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/adamantine/get_recipes()
+	return GLOB.adamantine_recipes
 
 /* Alien Alloy */
 
@@ -49,6 +47,5 @@ Exotic mineral Sheets
 	sheettype = "abductor"
 	merge_type = /obj/item/stack/sheet/mineral/abductor
 
-/obj/item/stack/sheet/mineral/abductor/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.abductor_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/abductor/get_recipes()
+	return GLOB.abductor_recipes

--- a/code/game/objects/items/stacks/sheets/mineral/glass.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/glass.dm
@@ -28,9 +28,8 @@
 	user.visible_message("<span class='suicide'>[user] begins to slice [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return BRUTELOSS
 
-/obj/item/stack/sheet/glass/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.glass_recipes
-	return ..()
+/obj/item/stack/sheet/glass/get_recipes()
+	return GLOB.glass_recipes
 
 /obj/item/stack/sheet/glass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
@@ -94,9 +93,8 @@
 	source.add_charge(amount * metcost)
 	glasource.add_charge(amount * glacost)
 
-/obj/item/stack/sheet/rglass/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.reinforced_glass_recipes
-	return ..()
+/obj/item/stack/sheet/rglass/get_recipes()
+	return GLOB.reinforced_glass_recipes
 
 /* Plasma glass */
 
@@ -113,9 +111,8 @@
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10)
 	tableVariant = /obj/structure/table/glass/plasma
 
-/obj/item/stack/sheet/plasmaglass/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.pglass_recipes
-	return ..()
+/obj/item/stack/sheet/plasmaglass/get_recipes()
+	return GLOB.pglass_recipes
 
 /obj/item/stack/sheet/plasmaglass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
@@ -150,9 +147,8 @@
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10, /datum/reagent/iron = 10)
 	point_value = 23
 
-/obj/item/stack/sheet/plasmarglass/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.prglass_recipes
-	return ..()
+/obj/item/stack/sheet/plasmarglass/get_recipes()
+	return GLOB.prglass_recipes
 
 /* Titanium glass */
 
@@ -167,9 +163,8 @@
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/titaniumglass
 
-/obj/item/stack/sheet/titaniumglass/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.titaniumglass_recipes
-	return ..()
+/obj/item/stack/sheet/titaniumglass/get_recipes()
+	return GLOB.titaniumglass_recipes
 
 /* Plastitanium glass */
 
@@ -184,9 +179,8 @@
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/plastitaniumglass
 
-/obj/item/stack/sheet/plastitaniumglass/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.plastitaniumglass_recipes
-	return ..()
+/obj/item/stack/sheet/plastitaniumglass/get_recipes()
+	return GLOB.plastitaniumglass_recipes
 
 /*SHARDS FROM HERE ONWARD, NOT A STACK, MOVE IT AS THE PROPHECY FORETOLD*/
 /obj/item/shard

--- a/code/game/objects/items/stacks/sheets/mineral/materials.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/materials.dm
@@ -34,9 +34,8 @@ Mineral Sheets
 	sheettype = "sandstone"
 	merge_type = /obj/item/stack/sheet/mineral/sandstone
 
-/obj/item/stack/sheet/mineral/sandstone/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.sandstone_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/sandstone/get_recipes()
+	return GLOB.sandstone_recipes
 
 /* Diamond */
 
@@ -51,9 +50,8 @@ Mineral Sheets
 	point_value = 25
 	merge_type = /obj/item/stack/sheet/mineral/diamond
 
-/obj/item/stack/sheet/mineral/diamond/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.diamond_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/diamond/get_recipes()
+	return GLOB.diamond_recipes
 
 /* Uranium */
 
@@ -68,9 +66,8 @@ Mineral Sheets
 	point_value = 20
 	merge_type = /obj/item/stack/sheet/mineral/uranium
 
-/obj/item/stack/sheet/mineral/uranium/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.uranium_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/uranium/get_recipes()
+	return GLOB.uranium_recipes
 
 /* Plasma */
 
@@ -91,9 +88,8 @@ Mineral Sheets
 	user.visible_message("<span class='suicide'>[user] begins licking \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return TOXLOSS//dont you kids know that stuff is toxic?
 
-/obj/item/stack/sheet/mineral/plasma/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.plasma_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/plasma/get_recipes()
+	return GLOB.plasma_recipes
 
 /obj/item/stack/sheet/mineral/plasma/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(W.is_hot() > 300)//If the temperature of the object is over 300, then ignite
@@ -123,9 +119,8 @@ Mineral Sheets
 	point_value = 20
 	merge_type = /obj/item/stack/sheet/mineral/gold
 
-/obj/item/stack/sheet/mineral/gold/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.gold_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/gold/get_recipes()
+	return GLOB.gold_recipes
 
 /* Silver */
 
@@ -141,9 +136,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/silver
 	tableVariant = /obj/structure/table/optable
 
-/obj/item/stack/sheet/mineral/silver/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.silver_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/silver/get_recipes()
+	return GLOB.silver_recipes
 
 /* Copper */
 
@@ -159,9 +153,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/copper
 
 
-/obj/item/stack/sheet/mineral/copper/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.copper_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/copper/get_recipes()
+	return GLOB.copper_recipes
 
 /* Titanium */
 
@@ -181,9 +174,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/titanium
 
 
-/obj/item/stack/sheet/mineral/titanium/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.titanium_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/titanium/get_recipes()
+	return GLOB.titanium_recipes
 
 /* Plastitanium */
 
@@ -202,9 +194,8 @@ Mineral Sheets
 	point_value = 45
 	merge_type = /obj/item/stack/sheet/mineral/plastitanium
 
-/obj/item/stack/sheet/mineral/plastitanium/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.plastitanium_recipes
-	. = ..()
+/obj/item/stack/sheet/mineral/plastitanium/get_recipes()
+	return GLOB.plastitanium_recipes
 
 /* Coal */
 

--- a/code/game/objects/items/stacks/sheets/mineral/metals.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/metals.dm
@@ -37,9 +37,8 @@ Metals Sheets
 	new /obj/item/stack/sheet/runed_metal(loc, amount)
 	qdel(src)
 
-/obj/item/stack/sheet/iron/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.metal_recipes
-	return ..()
+/obj/item/stack/sheet/iron/get_recipes()
+	return GLOB.metal_recipes
 
 /obj/item/stack/sheet/iron/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins whacking [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -63,9 +62,8 @@ Metals Sheets
 	point_value = 23
 	tableVariant = /obj/structure/table/reinforced
 
-/obj/item/stack/sheet/plasteel/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.plasteel_recipes
-	return ..()
+/obj/item/stack/sheet/plasteel/get_recipes()
+	return GLOB.plasteel_recipes
 
 /* Runed Metal */
 
@@ -95,9 +93,8 @@ Metals Sheets
 		return FALSE
 	return ..()
 
-/obj/item/stack/sheet/runed_metal/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.runed_metal_recipes
-	return ..()
+/obj/item/stack/sheet/runed_metal/get_recipes()
+	return GLOB.runed_metal_recipes
 
 
 /* Brass - the cult one */
@@ -127,9 +124,11 @@ Metals Sheets
 	else
 		return ..()
 
+/obj/item/stack/sheet/brass/get_recipes()
+	return GLOB.brass_recipes
+
 /obj/item/stack/sheet/brass/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()
-	recipes = GLOB.brass_recipes
 	pixel_x = 0
 	pixel_y = 0
 
@@ -157,8 +156,10 @@ Metals Sheets
 	else
 		return ..()
 
+/obj/item/stack/sheet/bronze/get_recipes()
+	return GLOB.bronze_recipes
+
 /obj/item/stack/sheet/bronze/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.bronze_recipes
 	. = ..()
 	pixel_x = 0
 	pixel_y = 0

--- a/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
+++ b/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
@@ -21,9 +21,8 @@ Miscellaneous material sheets
 	grind_results = list(/datum/reagent/consumable/honey = 20)
 	merge_type = /obj/item/stack/sheet/wax
 
-/obj/item/stack/sheet/wax/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.wax_recipes
-	. = ..()
+/obj/item/stack/sheet/wax/get_recipes()
+	return GLOB.wax_recipes
 
 /* Sandbags */
 
@@ -40,9 +39,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	new/datum/stack_recipe("sandbags", /obj/structure/barricade/sandbags, 1, one_per_turf = TRUE, on_floor = TRUE, time = 2.5 SECONDS), \
 	))
 
-/obj/item/stack/sheet/sandbags/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.sandbag_recipes
-	. = ..()
+/obj/item/stack/sheet/sandbags/get_recipes()
+	return GLOB.sandbag_recipes
 
 /obj/item/emptysandbag
 	name = "empty sandbag"
@@ -76,9 +74,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	grind_results = list(/datum/reagent/consumable/ice = 20)
 	merge_type = /obj/item/stack/sheet/snow
 
-/obj/item/stack/sheet/snow/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.snow_recipes
-	. = ..()
+/obj/item/stack/sheet/snow/get_recipes()
+	return GLOB.snow_recipes
 
 /* Plastic */
 
@@ -92,9 +89,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	throwforce = 7
 	merge_type = /obj/item/stack/sheet/plastic
 
-/obj/item/stack/sheet/plastic/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.plastic_recipes
-	. = ..()
+/obj/item/stack/sheet/plastic/get_recipes()
+	return GLOB.plastic_recipes
 
 /* Cardboard */
 
@@ -110,9 +106,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	throwforce = 0
 	merge_type = /obj/item/stack/sheet/cardboard
 
-/obj/item/stack/sheet/cardboard/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.cardboard_recipes
-	return ..()
+/obj/item/stack/sheet/cardboard/get_recipes()
+	return GLOB.cardboard_recipes
 
 
 /obj/item/stack/sheet/cardboard/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/stacks/sheets/organic/cloths.dm
+++ b/code/game/objects/items/stacks/sheets/organic/cloths.dm
@@ -37,9 +37,8 @@ Various Cloths
 	pull_effort = 50
 	loom_result = /obj/item/stack/sheet/silk
 
-/obj/item/stack/sheet/cotton/cloth/Initialize(mapload, new_amount, merge = TRUE)
-	. = ..()
-	recipes = GLOB.cloth_recipes
+/obj/item/stack/sheet/cotton/cloth/get_recipes()
+	return GLOB.cloth_recipes
 
 /* Durathread cloth */
 
@@ -66,9 +65,8 @@ Various Cloths
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'
 
-/obj/item/stack/sheet/cotton/cloth/durathread/Initialize(mapload, new_amount, merge = TRUE)
-	. = ..()
-	recipes = GLOB.durathread_recipes
+/obj/item/stack/sheet/cotton/cloth/durathread/get_recipes()
+	return GLOB.durathread_recipes
 
 /* Silk */
 
@@ -84,6 +82,5 @@ Various Cloths
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'
 
-/obj/item/stack/sheet/silk/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.silk_recipes
-	return ..()
+/obj/item/stack/sheet/silk/get_recipes()
+	return GLOB.silk_recipes

--- a/code/game/objects/items/stacks/sheets/organic/hides.dm
+++ b/code/game/objects/items/stacks/sheets/organic/hides.dm
@@ -24,9 +24,8 @@
 	singular_name = "human skin piece"
 	novariants = FALSE
 
-/obj/item/stack/sheet/animalhide/human/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.human_recipes
-	return ..()
+/obj/item/stack/sheet/animalhide/human/get_recipes()
+	return GLOB.human_recipes
 
 /* Corgi hide */
 
@@ -37,9 +36,8 @@
 	icon_state = "sheet-corgi"
 	item_state = "sheet-corgi"
 
-/obj/item/stack/sheet/animalhide/corgi/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.corgi_recipes
-	return ..()
+/obj/item/stack/sheet/animalhide/corgi/get_recipes()
+	return GLOB.corgi_recipes
 
 /* Mothroach hide */
 
@@ -59,9 +57,8 @@
 	icon_state = "sheet-gondola"
 	item_state = "sheet-gondola"
 
-/obj/item/stack/sheet/animalhide/gondola/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.gondola_recipes
-	return ..()
+/obj/item/stack/sheet/animalhide/gondola/get_recipes()
+	return GLOB.gondola_recipes
 
 /* Cot hide */
 
@@ -81,9 +78,8 @@
 	icon_state = "sheet-monkey"
 	icon_state = "sheet-monkey"
 
-/obj/item/stack/sheet/animalhide/monkey/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.monkey_recipes
-	return ..()
+/obj/item/stack/sheet/animalhide/monkey/get_recipes()
+	return GLOB.monkey_recipes
 
 /* Lizard hide */
 
@@ -103,9 +99,8 @@
 	icon_state = "sheet-xeno"
 	item_state = "sheet-xeno"
 
-/obj/item/stack/sheet/animalhide/xeno/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.xeno_recipes
-	return ..()
+/obj/item/stack/sheet/animalhide/xeno/get_recipes()
+	return GLOB.xeno_recipes
 
 /* Ashdrake hide */
 

--- a/code/game/objects/items/stacks/sheets/organic/leather.dm
+++ b/code/game/objects/items/stacks/sheets/organic/leather.dm
@@ -9,9 +9,8 @@
 	icon = 'icons/obj/stacks/organic.dmi'
 
 
-/obj/item/stack/sheet/leather/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.leather_recipes
-	return ..()
+/obj/item/stack/sheet/leather/get_recipes()
+	return GLOB.leather_recipes
 
 /obj/item/stack/sheet/leather/hairlesshide
 	name = "hairless hide"

--- a/code/game/objects/items/stacks/sheets/organic/miscellaneous_organics.dm
+++ b/code/game/objects/items/stacks/sheets/organic/miscellaneous_organics.dm
@@ -52,7 +52,6 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	new/datum/stack_recipe("sinew restraints", /obj/item/restraints/handcuffs/cable/sinew, 1), \
 ))
 
-/obj/item/stack/sheet/sinew/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.sinew_recipes
-	return ..()
+/obj/item/stack/sheet/sinew/get_recipes()
+	return GLOB.sinew_recipes
 

--- a/code/game/objects/items/stacks/sheets/organic/wood.dm
+++ b/code/game/objects/items/stacks/sheets/organic/wood.dm
@@ -22,9 +22,8 @@ Woods Sheets
 	merge_type = /obj/item/stack/sheet/wood
 	grind_results = list(/datum/reagent/carbon = 20)
 
-/obj/item/stack/sheet/wood/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.wood_recipes
-	return ..()
+/obj/item/stack/sheet/wood/get_recipes()
+	return GLOB.wood_recipes
 
 /* Bamboo */
 
@@ -43,14 +42,13 @@ Woods Sheets
 	merge_type = /obj/item/stack/sheet/bamboo
 	grind_results = list("carbon" = 5)
 
-/obj/item/stack/sheet/bamboo/Initialize(mapload, new_amount, merge = TRUE)
-	recipes = GLOB.bamboo_recipes
-	return ..()
+/obj/item/stack/sheet/bamboo/get_recipes()
+	return GLOB.bamboo_recipes
 
 /obj/item/stack/sheet/bamboo/Topic(href, href_list)
 	. = ..()
 	if(href_list["make"])
-		var/list/recipes_list = recipes
+		var/list/recipes_list = get_recipes()
 		var/datum/stack_recipe/R = recipes_list[text2num(href_list["make"])]
 		if(R.result_type == /obj/structure/punji_sticks)
 			var/turf/T = get_turf(src)
@@ -69,6 +67,5 @@ Woods Sheets
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/paperframes
 
-/obj/item/stack/sheet/paperframes/Initialize(mapload)
-	recipes = GLOB.paperframe_recipes
-	. = ..()
+/obj/item/stack/sheet/paperframes/get_recipes()
+	return GLOB.paperframe_recipes

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -18,8 +18,6 @@
 /obj/item/stack
 	icon = 'icons/obj/stacks/minerals.dmi'
 	gender = PLURAL
-	///The list recipes you can make with the stack
-	var/list/datum/stack_recipe/recipes
 	///The name of the thing when it's singular
 	var/singular_name
 	///The amount of thing in the stack
@@ -52,6 +50,10 @@
 		to_chat(usr, "<span class='danger'>[src] is electronically synthesized in your chassis and can't be ground up!</span>")
 		return
 	return TRUE
+
+/obj/item/stack/proc/get_recipes()
+	SHOULD_CALL_PARENT(FALSE)
+	return
 
 /obj/item/stack/Initialize(mapload, new_amount, merge = TRUE, mob/user = null)
 	. = ..()
@@ -197,7 +199,7 @@
 
 /obj/item/stack/ui_static_data(mob/user)
 	var/list/data = list()
-	data["recipes"] = recursively_build_recipes(recipes)
+	data["recipes"] = recursively_build_recipes(get_recipes())
 	return data
 
 /obj/item/stack/ui_act(action, params)
@@ -211,7 +213,7 @@
 				qdel(src)
 				return
 			var/datum/stack_recipe/R = locate(params["ref"])
-			if(!is_valid_recipe(R, recipes)) //href exploit protection
+			if(!is_valid_recipe(R, get_recipes())) //href exploit protection
 				return
 			var/multiplier = text2num(params["multiplier"])
 			if(!isnum_safe(multiplier) || (multiplier <= 0)) //href exploit protection

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -514,6 +514,9 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 		user.visible_message("<span class='suicide'>[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return(OXYLOSS)
 
+/obj/item/stack/cable_coil/get_recipes()
+	return GLOB.cable_coil_recipes
+
 /obj/item/stack/cable_coil/Initialize(mapload, new_amount = null, param_color = null)
 	. = ..()
 
@@ -525,7 +528,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	pixel_x = base_pixel_x + rand(-2,2)
 	pixel_y = base_pixel_y + rand(-2,2)
 	update_icon()
-	recipes = GLOB.cable_coil_recipes
 
 ///////////////////////////////////
 // General procedures


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes 'recipes' variable to 'get_recipes()' proc
* a variable that can possibly be overridable by improper order of Init() proc is not good. (we had a case of durathread uses silk recipe)
* the variable takes a list, but the variable is a type variable - this is bad.
*  you should be capable of accessing the dedicated list when a material is not initialized yet but created newly.
* We really shouldn't let this be a variable which can be dynamically changed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
better logic
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/b55c2a67-0ba3-4a6c-ac3f-60e3020f4664)## Changelog
:cl:
code: recipes variable in materials is removed. It now uses get_recipes() proc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
