### PR TITLE
Fixes orbit transfer function + some orbit code improvement

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -629,7 +629,7 @@ so as to remain in compliance with the most up-to-date laws."
 		if(NOTIFY_ATTACK)
 			target.attack_ghost(ghost_owner)
 		if(NOTIFY_ORBIT)
-			ghost_owner.ManualFollow(target)
+			ghost_owner.check_orbitable(target)
 
 //OBJECT-BASED
 

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -9,7 +9,7 @@
 
 	// Things you might plausibly want to follow
 	if(ismovable(A))
-		ManualFollow(A)
+		check_orbitable(A)
 
 	// Otherwise jump
 	else if(A.loc)

--- a/code/controllers/subsystem/augury.dm
+++ b/code/controllers/subsystem/augury.dm
@@ -48,7 +48,7 @@ SUBSYSTEM_DEF(augury)
 			watchers -= W
 			continue
 		if(biggest_doom && (!W.orbiting || W.orbiting.parent != biggest_doom))
-			W.ManualFollow(biggest_doom)
+			W.check_orbitable(biggest_doom)
 
 /datum/action/innate/augury
 	name = "Auto Follow Debris"

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -1,7 +1,7 @@
 /datum/component/orbiter
 	can_transfer = TRUE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	var/list/orbiters
+	var/list/current_orbiters
 	var/datum/movement_detector/tracker
 
 //radius: range to orbit at, radius of the circle formed by orbiting (in pixels)
@@ -13,7 +13,7 @@
 	if(!istype(orbiter) || !isatom(parent) || isarea(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	orbiters = list()
+	current_orbiters = list()
 
 	begin_orbit(orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 
@@ -33,9 +33,9 @@
 	var/atom/master = parent
 	if(master?.orbiters == src)
 		master.orbiters = null
-	for(var/i in orbiters)
+	for(var/i in current_orbiters)
 		end_orbit(i)
-	orbiters = null
+	current_orbiters = null
 	return ..()
 
 /datum/component/orbiter/InheritComponent(datum/component/orbiter/newcomp, original, atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
@@ -43,14 +43,14 @@
 		begin_orbit(arglist(args.Copy(3)))
 		return
 	// The following only happens on component transfers
-	for(var/o in newcomp.orbiters)
+	for(var/o in newcomp.current_orbiters)
 		var/atom/movable/incoming_orbiter = o
 		incoming_orbiter.orbiting = src
 		// It is important to transfer the signals so we don't get locked to the new orbiter component for all time
 		newcomp.UnregisterSignal(incoming_orbiter, COMSIG_MOVABLE_MOVED)
 		RegisterSignal(incoming_orbiter, COMSIG_MOVABLE_MOVED, PROC_REF(orbiter_move_react))
-	orbiters += newcomp.orbiters
-	newcomp.orbiters = null
+	current_orbiters += newcomp.current_orbiters
+	newcomp.current_orbiters = null
 
 /datum/component/orbiter/PostTransfer()
 	if(!isatom(parent) || isarea(parent) || !get_turf(parent))
@@ -63,12 +63,12 @@
 			orbiter.orbiting.end_orbit(orbiter, TRUE)
 		else
 			orbiter.orbiting.end_orbit(orbiter)
-	orbiters[orbiter] = TRUE
+	current_orbiters[orbiter] = TRUE
 	orbiter.orbiting = src
 	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, PROC_REF(orbiter_move_react))
 	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_BEGIN, orbiter)
 	var/matrix/initial_transform = matrix(orbiter.transform)
-	orbiters[orbiter] = initial_transform
+	current_orbiters[orbiter] = initial_transform
 
 	// Head first!
 	if(pre_rotation)
@@ -89,18 +89,44 @@
 	to_chat(orbiter, "<span class='notice'>Now orbiting [parent].</span>")
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
-	if(!orbiters[orbiter])
+	if(!current_orbiters[orbiter])
 		return
 	UnregisterSignal(orbiter, COMSIG_MOVABLE_MOVED)
 	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_STOP, orbiter)
 	orbiter.SpinAnimation(0, 0)
-	if(istype(orbiters[orbiter],/matrix)) //This is ugly.
-		orbiter.transform = orbiters[orbiter]
-	orbiters -= orbiter
+	if(istype(current_orbiters[orbiter],/matrix)) //This is ugly.
+		orbiter.transform = current_orbiters[orbiter]
+	current_orbiters -= orbiter
 	orbiter.stop_orbit(src)
 	orbiter.orbiting = null
-	if(!refreshing && !length(orbiters) && !QDELING(src))
+	if(!refreshing && !length(current_orbiters) && !QDELING(src))
 		qdel(src)
+
+/**
+ * [Proc Behavior]
+ * 		If target_orbited is null, incoming_orbiter will stop orbiting and start to orbit the new target.
+ * 			-> This is because 'check_orbitable()' makes an orbit component properly.
+ * 		If original_orbited.current_orbiters has one orbiter, incoming_orbiter will stop orbiting and start to orbit the new target.
+ * 			-> This is beacuse 'end_orbit()' removes an orbit component properly.
+ * 		If target_orbited is not null, manually control signals (send, register, unregister), then transfer to the new target.
+ * 			-> We can keep ghosts' orbit animation without glitching theirs.
+ */
+/datum/component/orbiter/proc/transfer_orbiter_to(atom/movable/incoming_orbiter, atom/new_target)
+	if(!new_target || !incoming_orbiter)
+		return
+	if(!new_target.orbiters || length(current_orbiters)==1) // if target has no orbiters or original orbit has only one orbiter
+		end_orbit(incoming_orbiter)
+		incoming_orbiter.check_orbitable(new_target)
+		return
+
+	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_STOP, incoming_orbiter)
+	UnregisterSignal(incoming_orbiter, COMSIG_MOVABLE_MOVED)
+	new_target.orbiters.RegisterSignal(incoming_orbiter, COMSIG_MOVABLE_MOVED, PROC_REF(orbiter_move_react))
+	SEND_SIGNAL(new_target, COMSIG_ATOM_ORBIT_BEGIN, incoming_orbiter)
+
+	incoming_orbiter.orbiting = new_target.orbiters
+	new_target.orbiters.current_orbiters[incoming_orbiter] = current_orbiters[incoming_orbiter]
+	current_orbiters -= incoming_orbiter
 
 // This proc can receive signals by either the thing being directly orbited or anything holding it
 /datum/component/orbiter/proc/move_react(atom/movable/master, atom/mover, atom/oldloc, direction)
@@ -114,7 +140,7 @@
 		qdel(src)
 
 	var/atom/curloc = master.loc
-	for(var/atom/movable/movable_orbiter as anything in orbiters)
+	for(var/atom/movable/movable_orbiter as anything in current_orbiters)
 		if(QDELETED(movable_orbiter) || movable_orbiter.loc == newturf)
 			continue
 		movable_orbiter.abstract_move(newturf)
@@ -132,6 +158,16 @@
 
 /////////////////////
 
+/atom/movable/proc/check_orbitable(atom/A)
+	if(!isatom(A))
+		return
+	if(A.orbiters?.parent == A) // orbiting what you're orbiting causes runtime
+		return
+	var/icon/I = icon(A.icon, A.icon_state, A.dir)
+	var/orbitsize = (I.Width()+I.Height())*0.5
+	orbitsize -= (orbitsize/world.icon_size)*(world.icon_size*0.25)
+	orbit(A, orbitsize)
+
 /atom/movable/proc/orbit(atom/A, radius = 10, clockwise = FALSE, rotation_speed = 20, rotation_segments = 36, pre_rotation = TRUE)
 	if(!istype(A) || !get_turf(A) || A == src)
 		return
@@ -141,7 +177,15 @@
 /atom/movable/proc/stop_orbit(datum/component/orbiter/orbits)
 	return // We're just a simple hook
 
-/atom/proc/transfer_observers_to(atom/target)
+/// includes_everyone=FALSE: when an orbitted mob is a camera eye or something. That shouldn't transfer revenants.
+/// includes_everyone=TRUE: when an orbitted mob is a mob who is being transformed(monkeyize). They should keep orbiters.
+/atom/proc/transfer_observers_to(atom/target, includes_everyone=FALSE)
 	if(!orbiters || !istype(target) || !get_turf(target) || target == src)
 		return
-	target.TakeComponent(orbiters)
+	if(includes_everyone)
+		target.TakeComponent(orbiters)
+		return
+	for(var/each in orbiters.current_orbiters)
+		if(!isobserver(each))
+			continue
+		orbiters.transfer_orbiter_to(each, target)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -126,7 +126,7 @@
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud//we need this because leave_hud() will clear this list
 	var/mob/living/old_current = current
 	if(current)
-		current.transfer_observers_to(new_character)	//transfer anyone observing the old character to the new one
+		current.transfer_observers_to(new_character, TRUE)	//transfer anyone observing the old character to the new one
 	set_current(new_character)								//associate ourself with our new body
 	new_character.mind = src							//and associate our new body with ourself
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -66,7 +66,7 @@
 	var/custom_premium_price
 
 	//List of datums orbiting this atom
-	var/datum/component/orbiter/orbiters
+	var/datum/component/orbiter/orbit_datum
 
 	/// Will move to flags_1 when i can be arsed to (2019, has not done so)
 	var/rad_flags = NONE
@@ -279,7 +279,7 @@
 	if(reagents)
 		QDEL_NULL(reagents)
 
-	orbiters = null // The component is attached to us normaly and will be deleted elsewhere
+	orbit_datum = null // The component is attached to us normaly and will be deleted elsewhere
 
 	LAZYCLEARLIST(overlays)
 	LAZYNULL(managed_overlays)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -38,6 +38,13 @@
 		if(lock_override & CAMERA_LOCK_CENTCOM)
 			z_lock |= SSmapping.levels_by_trait(ZTRAIT_CENTCOM)
 
+/obj/machinery/computer/camera_advanced/attack_ghost(mob/dead/observer/ghost)
+	. = ..()
+	if(.)
+		return
+	if(current_user && eyeobj)
+		ghost.check_orbitable(eyeobj) // ghost QoL
+
 /obj/machinery/computer/camera_advanced/syndie
 	icon_keyboard = "syndie_key"
 	circuit = /obj/item/circuitboard/computer/advanced_camera

--- a/code/modules/admin/admin_follow.dm
+++ b/code/modules/admin/admin_follow.dm
@@ -10,4 +10,4 @@
 	if(!can_ghost)
 		return
 	var/mob/dead/observer/A = C.mob
-	A.ManualFollow(AM)
+	A.check_orbitable(AM)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -40,7 +40,7 @@
 	..()
 
 // Orbit: literally obrits people like how ghosts do
-/mob/living/simple_animal/revenant/proc/check_orbitable(atom/A)
+/mob/living/simple_animal/revenant/check_orbitable(atom/A)
 	if(revealed)
 		to_chat(src, "<span class='revenwarning'>You can't orbit while you're revealed!</span>")
 		return
@@ -52,10 +52,7 @@
 		return
 	if(notransform || inhibited || !incorporeal_move_check(A))
 		return
-	var/icon/I = icon(A.icon, A.icon_state, A.dir)
-	var/orbitsize = (I.Width()+I.Height())*0.5
-	orbitsize -= (orbitsize/world.icon_size)*(world.icon_size*0.25)
-	orbit(A, orbitsize)
+	..()
 
 /mob/living/simple_animal/revenant/orbit(atom/target)
 	setDir(SOUTH) // reset dir so the right directional sprites show up

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -86,7 +86,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(href_list["orbit"])
 		var/mob/dead/observer/ghost = usr
 		if(istype(ghost))
-			ghost.ManualFollow(src)
+			ghost.check_orbitable(src)
 
 /obj/effect/immovablerod/Moved()
 	if(!loc)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -866,7 +866,7 @@
 		var/atom/A = thing
 		A.transfer_observers_to(src)
 
-	for(var/i in orbiters?.current_orbiters)
+	for(var/i in orbit_datum?.current_orbiters)
 		if(!isobserver(i))
 			continue
 		var/mob/dead/observer/G = i

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -852,7 +852,7 @@
 	if(href_list["orbit"])
 		var/mob/dead/observer/ghost = usr
 		if(istype(ghost))
-			ghost.ManualFollow(src)
+			ghost.check_orbitable(src)
 
 /obj/item/melee/ghost_sword/process()
 	ghost_check()
@@ -866,7 +866,7 @@
 		var/atom/A = thing
 		A.transfer_observers_to(src)
 
-	for(var/i in orbiters?.orbiters)
+	for(var/i in orbiters?.current_orbiters)
 		if(!isobserver(i))
 			continue
 		var/mob/dead/observer/G = i

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -448,8 +448,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	orbit_menu.ui_interact(src)
 
+
 // This is the ghost's follow verb with an argument
-/mob/dead/observer/proc/ManualFollow(atom/movable/target)
+/mob/dead/observer/check_orbitable(atom/movable/target)
 	if (!istype(target))
 		return
 
@@ -694,7 +695,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(href_list["follow"])
 			var/atom/movable/target = locate(href_list["follow"])
 			if(istype(target) && (target != src))
-				ManualFollow(target)
+				check_orbitable(target)
 				return
 		if(href_list["x"] && href_list["y"] && href_list["z"])
 			var/tx = text2num(href_list["x"])

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -57,7 +57,7 @@
 			else if (M.mind == null)
 				npcs += list(serialized)
 			else
-				var/number_of_orbiters = M.orbiters?.current_orbiters?.len
+				var/number_of_orbiters = M.orbit_datum?.current_orbiters?.len
 				if (number_of_orbiters)
 					serialized["orbiters"] = number_of_orbiters
 

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -25,7 +25,7 @@
 		var/ref = params["ref"]
 		var/atom/movable/poi = (locate(ref) in GLOB.mob_list) || (locate(ref) in GLOB.poi_list)
 		if (poi != null)
-			owner.ManualFollow(poi)
+			owner.check_orbitable(poi)
 		else
 			return TRUE
 
@@ -57,7 +57,7 @@
 			else if (M.mind == null)
 				npcs += list(serialized)
 			else
-				var/number_of_orbiters = M.orbiters?.orbiters?.len
+				var/number_of_orbiters = M.orbiters?.current_orbiters?.len
 				if (number_of_orbiters)
 					serialized["orbiters"] = number_of_orbiters
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -147,7 +147,7 @@
 			loc.vars[A] = O
 
 	O.update_sight()
-	transfer_observers_to(O)
+	transfer_observers_to(O, TRUE)
 
 	. = O
 
@@ -290,7 +290,7 @@
 		if(loc.vars[A] == src)
 			loc.vars[A] = O
 
-	transfer_observers_to(O)
+	transfer_observers_to(O, TRUE)
 
 	. = O
 
@@ -456,7 +456,7 @@
 
 	SEND_SIGNAL(src, COMSIG_CARBON_TRANSFORMED, O)
 
-	transfer_observers_to(O)
+	transfer_observers_to(O, TRUE)
 
 	. = O
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -291,7 +291,7 @@
 	if(poly_msg)
 		to_chat(new_mob, poly_msg)
 
-	M.transfer_observers_to(new_mob)
+	M.transfer_observers_to(new_mob, TRUE)
 
 	qdel(M)
 	return new_mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* improved orbit related codes
* Fixed a case where orbiting mobs transference shouldn't transfer ingame-player-spirits as well. (Revenant orbiting a xeno-scientist can let them orbit camera eye)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Spiritual beings orbiting people are nice, and ghosts QoL of auto-transference is nice too.
but ingame spirits shouldn't take the all benefits of ghosts QoL stuff.

Also, Lucy is planning holopara rework, especially scouter holopara.
We had an idea to let scouter holopara can orbit their target, so this PR supports that in
* orbit code is more general as atom proc
* Auto-transference feature will not cause glitch transfering holopara to camera mob

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/3eb5fed4-df58-44a2-ab5d-7b5f9505bcb5)

## Changelog
:cl:
code: improved orbit related code (orbitter var name is now 'orbit_datum')
fix: orbiting player mobs (i.e. Revenant) are no longer automatically transferred to an unintended new orbit target. For example, if a revenant is orbiting a scientist and they start using xenobio console, revenant will not be transferred to the camera eye mob - they will still orbit the scientist.
tweak: a ghost clicking a camera console that's being used already will automatically orbit the camera eye
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
