### PR TITLE
Adds a no-threat roundstart dynamic ruleset

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -17,6 +17,9 @@
 /// This ruleset will be logged in persistence, to reduce the chances of it repeatedly rolling several rounds in a row.
 #define PERSISTENT_RULESET (1 << 5)
 
+/// This ruleset will be able to roll with no canidates selected
+#define ALLOW_NO_CANIDATES (1 << 6)
+
 /// This is a "heavy" midround ruleset, and should be run later into the round
 #define MIDROUND_RULESET_STYLE_HEAVY "Heavy"
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -544,7 +544,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (rule.acceptable(roundstart_pop_ready, threat_level) && round_start_budget >= rule.cost)	// If we got the population and threat required
 			rule.candidates = candidates.Copy()
 			rule.trim_candidates()
-			if (rule.ready(roundstart_pop_ready) && rule.candidates.len > 0)
+			if (rule.ready(roundstart_pop_ready) && (rule.candidates.len > 0 || (rule.flags & ALLOW_NO_CANIDATES)))
 				drafted_rules[rule] = rule.get_weight()
 
 	var/list/rulesets_picked = list()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -9,7 +9,7 @@
 	name = "Nothing Bad Yet"
 	required_candidates = 0
 	minimum_players = 0
-	weight = 100
+	weight = 3
 	cost = 0.1
 	requirements = list(0,0,0,0,0,0,0,0,0,0)
 	flags = NO_OTHER_ROUNDSTARTS_RULESET | ALLOW_NO_CANIDATES

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -1,6 +1,30 @@
 
 //////////////////////////////////////////////
 //                                          //
+//            NOTHING BAD YET               //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/roundstart/nothing
+	name = "Nothing Bad Yet"
+	required_candidates = 0
+	minimum_players = 0
+	weight = 100
+	cost = 0.1
+	requirements = list(0,0,0,0,0,0,0,0,0,0)
+	flags = NO_OTHER_ROUNDSTARTS_RULESET | ALLOW_NO_CANIDATES
+
+/datum/dynamic_ruleset/roundstart/nothing/execute(forced = FALSE)
+	return TRUE
+
+/datum/dynamic_ruleset/roundstart/nothing/ready(forced = FALSE)
+	return TRUE
+
+/datum/dynamic_ruleset/roundstart/nothing/check_candidates()
+	return TRUE
+
+//////////////////////////////////////////////
+//                                          //
 //           SYNDICATE TRAITORS             //
 //                                          //
 //////////////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds "Nothing Bad Yet" roundstart dynamic ruleset, with a cost of 0.1 threat level, which doesn't spawn any antagonists and blocks any other roundstart ruleset from being picked, causing all threat to go towards midrounds.

From: [This Thread](https://discord.com/channels/427337870844362753/1126036809634304020)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This will give the crew some breather time (at least in the beginning), and add some variation in rounds where there are just a whole bunch of midrounds and latejoins.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_M3Wj9Zmvs8](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/37ffe862-6b57-4f1b-9512-1f3c81ac79a6)

![dreamseeker_aFUtjJ1BKD](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/dd64cd18-7edb-4890-af28-e940ab145606)

</details>

## Changelog
:cl:
add: New dynamic roundstart rule, "Nothing Bad Yet", which just donates all threat to midrounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
