### PR TITLE
Add unique saymods for felinids

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -5,6 +5,7 @@
 		verb_ask = pick(T.ask_mod)
 		verb_yell = pick(T.yell_mod)
 		verb_exclaim = pick(T.exclaim_mod)
+		verb_whisper = pick(T.whisper_mod)
 	if(slurring || !T)
 		return "slurs"
 	else

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -10,6 +10,7 @@
 	var/ask_mod = "asks"
 	var/yell_mod = "yells"
 	var/exclaim_mod = "exclaims"
+	var/whisper_mod = "whispers"
 	var/liked_food = JUNKFOOD | FRIED
 	var/disliked_food = GROSS | RAW | CLOTH | GORE
 	var/toxic_food = TOXIC
@@ -324,6 +325,10 @@
 	name = "cat tongue"
 	desc = "A rough tongue, full of small, boney spines all over it's surface."
 	say_mod = "meows"
+	ask_mod = "trills"
+	yell_mod = "chirrups"
+	exclaim_mod = "yowls"
+	whisper_mod = "purrs"
 	disliked_food = GROSS | VEGETABLES | SUGAR | CLOTH
 	liked_food = DAIRY | MEAT | GORE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds the following saymods to felinids (well, cat tongues)
- **Ask**: trills
- **Yell**: chirrups
- **Exclaim**: yowls
- **Whisper**: purrs

Based off of discussion [here](https://forums.beestation13.com/t/custom-say-modifiers-for-different-tongues/22866/2?u=absolucy) and [here](https://forums.beestation13.com/t/custom-say-modifiers-for-different-tongues/22866/16?u=absolucy).

## Why It's Good For The Game

Makes species more unique

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-07-12-1689180806-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/a88c52b6-3d90-41bb-85de-dfc8015b4717)

</details>

## Changelog
:cl:
add: Added new say emotes to felinids: they will now trill, chirrup, yowl, and purr!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
