### PR TITLE
Sleepy pen nerf

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -198,7 +198,7 @@
 	if(reagents?.total_volume && M.reagents)
 		// Obvious message to other people, so that they can call out suspicious activity.
 		user.visible_message("<span class='warning'>[user] stabs [M] with [src]!</span>", "<span class='notice'>You prepare to engage the sleepy pen's internal mechanism!</span>", vision_distance = 4, ignored_mobs = list(M))
-		if (!do_after(user, 2 SECONDS, M) || !..())
+		if (!do_after(user, 5, M) || !..())
 			to_chat(user, "<span class='warning'>You fail to engage the sleepy pen mechanism!</span>")
 			return
 		reagents.trans_to(M, reagents.total_volume, transfered_by = user, method = INJECT)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -189,15 +189,24 @@
  * Sleepypens
  */
 
+/obj/item/pen/sleepy
+
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
 	if(!istype(M))
 		return
 
-	if(..())
-		if(reagents.total_volume)
-			if(M.reagents)
-				reagents.trans_to(M, reagents.total_volume, transfered_by = user, method = INJECT)
-
+	if(reagents?.total_volume && M.reagents)
+		// Obvious message to other people, so that they can call out suspicious activity.
+		user.visible_message("<span class='warning'>[user] stabs [M] with [src]!</span>", "<span class='notice'>You prepare to engage the sleepy pen's internal mechanism!</span>", vision_distance = 4, ignored_mobs = list(M))
+		if (!do_after(user, 2 SECONDS, M) || !..())
+			to_chat(user, "<span class='warning'>You fail to engage the sleepy pen mechanism!</span>")
+			return
+		reagents.trans_to(M, reagents.total_volume, transfered_by = user, method = INJECT)
+		// Looks like a normal pen once it has been used
+		qdel(reagents)
+		reagents = null
+	else
+		return ..()
 
 /obj/item/pen/sleepy/Initialize(mapload)
 	. = ..()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -198,7 +198,7 @@
 	if(reagents?.total_volume && M.reagents)
 		// Obvious message to other people, so that they can call out suspicious activity.
 		to_chat(user, "<span class='notice'>You prepare to engage the sleepy pen's internal mechanism!</span>")
-		if (!do_after(user, 5, M) || !..())
+		if (!do_after(user, 0.5 SECONDS, M) || !..())
 			to_chat(user, "<span class='warning'>You fail to engage the sleepy pen mechanism!</span>")
 			return
 		reagents.trans_to(M, reagents.total_volume, transfered_by = user, method = INJECT)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -197,11 +197,12 @@
 
 	if(reagents?.total_volume && M.reagents)
 		// Obvious message to other people, so that they can call out suspicious activity.
-		user.visible_message("<span class='warning'>[user] stabs [M] with [src]!</span>", "<span class='notice'>You prepare to engage the sleepy pen's internal mechanism!</span>", vision_distance = 4, ignored_mobs = list(M))
+		to_chat(user, "<span class='notice'>You prepare to engage the sleepy pen's internal mechanism!</span>")
 		if (!do_after(user, 5, M) || !..())
 			to_chat(user, "<span class='warning'>You fail to engage the sleepy pen mechanism!</span>")
 			return
 		reagents.trans_to(M, reagents.total_volume, transfered_by = user, method = INJECT)
+		user.visible_message("<span class='warning'>[user] stabs [M] with [src]!</span>", "<span class='notice'>You successfully inject [M] with the pen's contents!</span>", vision_distance = 4, ignored_mobs = list(M))
 		// Looks like a normal pen once it has been used
 		qdel(reagents)
 		reagents = null

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -202,7 +202,7 @@
 			to_chat(user, "<span class='warning'>You fail to engage the sleepy pen mechanism!</span>")
 			return
 		reagents.trans_to(M, reagents.total_volume, transfered_by = user, method = INJECT)
-		user.visible_message("<span class='warning'>[user] stabs [M] with [src]!</span>", "<span class='notice'>You successfully inject [M] with the pen's contents!</span>", vision_distance = 4, ignored_mobs = list(M))
+		user.visible_message("<span class='warning'>[user] stabs [M] with [src]!</span>", "<span class='notice'>You successfully inject [M] with the pen's contents!</span>", vision_distance = COMBAT_MESSAGE_RANGE, ignored_mobs = list(M))
 		// Looks like a normal pen once it has been used
 		qdel(reagents)
 		reagents = null

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -810,10 +810,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"
-	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
+	desc = "A spring loaded, single-use syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
 			strong anesthetic and a chemical that prevents the target from speaking. \
-			The pen holds one dose of the mixture, and can be refilled with any chemicals. Note that before the target \
-			falls asleep, they will be able to move and act."
+			The mixture that the pen comes with can be replaced as long as the pen hasn't been used already. Note that the mechanism takes time to \
+			trigger, is obvious to anyone nearby (excluding the target) and the victim may still be able to move and act for a brief period of time before falling unconcious."
 	item = /obj/item/pen/sleepy
 	cost = 5
 	purchasable_from = ~UPLINK_NUKE_OPS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs the sleepy pen by making it single use as well as requiring a two second delay to inject its reagents as well as it making a message that's visible to everyone but the target.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A silent, infinitely reusable tool that instantly injects 45u of reagents and only for 5 TC is simply too good, and has seen plenty of abuse thorough the years. This PR allows it to retain the intended quiet takedown functionality of it, while removing the ability to use it to spam inject people with anything you want.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/fc71923e-fa70-498c-9b4d-94e6ed219920

</details>

## Changelog
:cl:PowerfulBacon
balance: The sleepy pen now becomes a regular pen after a single use, requires a 0.5 second progress bar to inject its reagents and shows a visible message to everyone except the target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
