### PR TITLE
Buffs the Poisoned Knife

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -146,7 +146,7 @@
 	throwforce = 15
 	throw_speed = 5
 	throw_range = 7
-	var/amount_per_transfer_from_this = 5
+	var/amount_per_transfer_from_this = 20
 	var/list/possible_transfer_amounts
 	desc = "An infamous knife of syndicate design, it has a tiny hole going through the blade to the handle which stores toxins."
 	materials = null
@@ -154,7 +154,7 @@
 /obj/item/kitchen/knife/poison/Initialize(mapload)
 	. = ..()
 	create_reagents(40,OPENCONTAINER)
-	possible_transfer_amounts = list(3,5)
+	possible_transfer_amounts = list(5,10,20)
 
 /obj/item/kitchen/knife/poison/attack_self(mob/user)
 	if(possible_transfer_amounts.len)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -146,7 +146,7 @@
 	throwforce = 15
 	throw_speed = 5
 	throw_range = 7
-	var/amount_per_transfer_from_this = 20
+	var/amount_per_transfer_from_this = 10
 	var/list/possible_transfer_amounts
 	desc = "An infamous knife of syndicate design, it has a tiny hole going through the blade to the handle which stores toxins."
 	materials = null
@@ -154,7 +154,7 @@
 /obj/item/kitchen/knife/poison/Initialize(mapload)
 	. = ..()
 	create_reagents(40,OPENCONTAINER)
-	possible_transfer_amounts = list(5,10,20)
+	possible_transfer_amounts = list(5, 10)
 
 /obj/item/kitchen/knife/poison/attack_self(mob/user)
 	if(possible_transfer_amounts.len)
@@ -166,6 +166,7 @@
 					amount_per_transfer_from_this = possible_transfer_amounts[i+1]
 				else
 					amount_per_transfer_from_this = possible_transfer_amounts[1]
+				balloon_alert(user, "Transferring [amount_per_transfer_from_this]u.")
 				to_chat(user, "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>")
 				return
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -446,7 +446,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/dangerous/poisonknife
 	name = "Poisoned Knife"
-	desc = "A knife that is made of two razor sharp blades, it has a secret compartment in the handle to store liquids which are injected when stabbing something. Can hold up to fourty units of reagents but comes empty."
+	desc = "A knife that is made of two razor sharp blades, it has a secret compartment in the handle to store liquids which are injected when stabbing something. Can hold up to forty units of reagents but comes empty."
 	item = /obj/item/kitchen/knife/poison
 	cost = 6 // all in all it's not super stealthy and you have to get some chemicals yourself
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -446,9 +446,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/dangerous/poisonknife
 	name = "Poisoned Knife"
-	desc = "A knife that is made of two razor sharp blades, it has a secret compartment in the handle to store liquids which are injected when stabbing something."
+	desc = "A knife that is made of two razor sharp blades, it has a secret compartment in the handle to store liquids which are injected when stabbing something. Can hold up to fourty units of reagents but comes empty."
 	item = /obj/item/kitchen/knife/poison
-	cost = 8 // all in all it's not super stealthy and you have to get some chemicals yourself
+	cost = 6 // all in all it's not super stealthy and you have to get some chemicals yourself
 
 /datum/uplink_item/dangerous/rawketlawnchair
 	name = "84mm Rocket Propelled Grenade Launcher"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs the poisoned Knife by decreasing its TC cost and increasing it's reagent transfer amount to 5 or 10.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The poisoned combat knife barely sees any use due to it being an extremely subpar tool for injecting chemicals. Partially because it's heavily overshadowed by the sleepy pen, but that's another issue.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/b7a47e96-2ae8-4ea6-a9ee-796a7ee65379)
This PR aims to make the knife a more appealing option for the traitors who wish to engage in chemical warfare.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/08fe1c28-c967-4d2a-b322-2b2ceb7e0ab0


</details>

## Changelog
:cl:
balance: Decreased the price of the Poisoned Knife from 8 TC to 6
balance: Increased the maximum amount of reagents the poisoned knife can transfer per hit to 10
add: Added baloon alerts to changing the poison knife's transfer amounts, visible only to the user
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
