### PR TITLE
Patch up the jankiness of LOOC

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -41,6 +41,7 @@
 #include "code\__DEFINES\atmospherics.dm"
 #include "code\__DEFINES\atom_hud.dm"
 #include "code\__DEFINES\balloon_alert.dm"
+#include "code\__DEFINES\bans.dm"
 #include "code\__DEFINES\bitfields.dm"
 #include "code\__DEFINES\blood.dm"
 #include "code\__DEFINES\bodyparts.dm"

--- a/code/__DEFINES/bans.dm
+++ b/code/__DEFINES/bans.dm
@@ -1,0 +1,1 @@
+#define BAN_OOC "OOC"

--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -1,104 +1,86 @@
 // LOOC ported from Citadel, styling in stylesheet.dm and browseroutput.css
 
-GLOBAL_VAR_INIT(looc_allowed, 1)
+GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
 /client/verb/looc(msg as text)
-    set name = "LOOC"
-    set desc = "Local OOC, seen only by those in view."
-    set category = "OOC"
+	set name = "LOOC"
+	set desc = "Local OOC, seen only by those in view."
+	set category = "OOC"
 
-    if(GLOB.say_disabled)    //This is here to try to identify lag problems
-        to_chat(usr, "<span class='danger'> Speech is currently admin-disabled.</span>")
-        return
+	if(GLOB.say_disabled)    //This is here to try to identify lag problems
+		to_chat(usr, "<span class='danger'> Speech is currently admin-disabled.</span>")
+		return
 
-    if(!mob)        return
-    if(!mob.ckey)   return
+	if(!mob?.ckey)
+		return
 
-    msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
-    var/raw_msg = msg
+	msg = trim(sanitize(msg), MAX_MESSAGE_LEN)
+	if(!length(msg))
+		return
 
-    if(!msg)
-        return
+	var/raw_msg = msg
 
-    if(!(prefs.toggles & CHAT_OOC))
-        to_chat(src, "<span class='danger'>You have OOC (and therefore LOOC) muted.</span>")
-        return
+	if(!(prefs.toggles & CHAT_OOC))
+		to_chat(src, "<span class='danger'>You have OOC (and therefore LOOC) muted.</span>")
+		return
 
-    if(is_banned_from(mob.ckey, "OOC"))
-        to_chat(src, "<span class='danger'>You have been banned from OOC and LOOC.</span>")
-        return
+	if(is_banned_from(mob.ckey, "OOC"))
+		to_chat(src, "<span class='danger'>You have been banned from OOC and LOOC.</span>")
+		return
 
-    if(!holder)
-        if(!CONFIG_GET(flag/looc_enabled))
-            to_chat(src, "<span class='danger'>LOOC is disabled.</span>")
-            return
-        if(!GLOB.dooc_allowed && (mob.stat == DEAD))
-            to_chat(usr, "<span class='danger'>LOOC for dead mobs has been turned off.</span>")
-            return
-        if(prefs.muted & MUTE_OOC)
-            to_chat(src, "<span class='danger'>You cannot use LOOC (muted).</span>")
-            return
-        if(handle_spam_prevention(msg,MUTE_OOC))
-            return
-        if(findtext(msg, "byond://"))
-            to_chat(src, "<B>Advertising other servers is not allowed.</B>")
-            log_admin("[key_name(src)] has attempted to advertise in LOOC: [msg]")
-            return
-        if(mob.stat)
-            to_chat(src, "<span class='danger'>You cannot salt in LOOC while unconscious or dead.</span>")
-            return
-        if(istype(mob, /mob/dead))
-            to_chat(src, "<span class='danger'>You cannot use LOOC while ghosting.</span>")
-            return
+	if(!holder)
+		if(!CONFIG_GET(flag/looc_enabled))
+			to_chat(src, "<span class='danger'>LOOC is disabled.</span>")
+			return
+		if(!GLOB.dooc_allowed && (mob.stat == DEAD))
+			to_chat(usr, "<span class='danger'>LOOC for dead mobs has been turned off.</span>")
+			return
+		if(prefs.muted & MUTE_OOC)
+			to_chat(src, "<span class='danger'>You cannot use LOOC (muted).</span>")
+			return
+		if(handle_spam_prevention(msg, MUTE_OOC))
+			return
+		if(findtext(msg, "byond://"))
+			to_chat(src, "<B>Advertising other servers is not allowed.</B>")
+			log_admin("[key_name(src)] has attempted to advertise in LOOC: [msg]")
+			return
+		if(mob.stat)
+			to_chat(src, "<span class='danger'>You cannot salt in LOOC while unconscious or dead.</span>")
+			return
+		if(isdead(mob))
+			to_chat(src, "<span class='danger'>You cannot use LOOC while ghosting.</span>")
+			return
+		if(OOC_FILTER_CHECK(raw_msg))
+			to_chat(src, "<span class='warning'>That message contained a word prohibited in OOC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ooc_chat'>\"[raw_msg]\"</span></span>")
+			return
 
-        if(OOC_FILTER_CHECK(raw_msg))
-            to_chat(src, "<span class='warning'>That message contained a word prohibited in OOC chat! Consider reviewing the server rules.\n<span replaceRegex='show_filtered_ooc_chat'>\"[raw_msg]\"</span></span>")
-            return
+	msg = emoji_parse(msg)
 
-    msg = emoji_parse(msg)
+	mob.log_talk(raw_msg, LOG_OOC, tag="LOOC")
 
-    mob.log_talk(raw_msg, LOG_OOC, tag="LOOC")
+	// Search everything in the view for anything that might be a mob, or contain a mob.
+	var/list/client/targets = list()
+	for(var/atom/movable/thingymajig in view(get_turf(mob)))
+		var/list/mob/mobs_here = list()
+		if(ismob(thingymajig))
+			LAZYADD(mobs_here, thingymajig)
+		for(var/mob/inner_mob_target in thingymajig.GetAllContents())
+			LAZYOR(mobs_here, inner_mob_target)
+		for(var/mob/target as() in mobs_here)
+			var/client/client = target.client
+			if(!client || !(client.prefs.toggles & CHAT_OOC))
+				continue
+			targets |= client
+			// Admins get handled on their own later.
+			if(!(client in GLOB.admins))
+				to_chat(client, "<span class='looc'><span class='prefix'>LOOC:</span> <EM><span class='name'>[mob.name]</span>:</EM> <span class='message'>[msg]</span></span>")
 
-    var/list/heard = hearers(7, get_top_level_mob(src.mob))
-    for(var/mob/M as() in heard)
-        if(!M.client)
-            continue
-        var/client/C = M.client
-        if (C in GLOB.admins)
-            continue //they are handled after that
-
-        if (isobserver(M))
-            continue //Also handled later.
-
-        if(C.prefs.toggles & CHAT_OOC)
-//            var/display_name = src.key
-//            if(holder)
-//                if(holder.fakekey)
-//                    if(C.holder)
-//                        display_name = "[holder.fakekey]/([src.key])"
-//                else
-//                    display_name = holder.fakekey
-            to_chat(C,"<span class='looc'><span class='prefix'>LOOC:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></span>")
-
-    for(var/client/C in GLOB.admins)
-        if(C.prefs.toggles & CHAT_OOC)
-            var/prefix = "(R)LOOC"
-            if (C.mob in heard)
-                prefix = "LOOC"
-            to_chat(C,"<span class='looc'>[ADMIN_FLW(usr)]<span class='prefix'>[prefix]:</span> <EM>[src.key]/[src.mob.name]:</EM> <span class='message'>[msg]</span></span>")
+	for(var/client/client in GLOB.admins)
+		if(!(client.prefs.toggles & CHAT_OOC))
+			continue
+		var/prefix = "[(client in targets) ? "" : "(R)"]LOOC"
+		to_chat(client, "<span class='looc'><span class='prefix'>[prefix]:</span> <EM>[ADMIN_LOOKUPFLW(client)]:</EM> <span class='message'>[msg]</span></span>")
 
 /proc/log_looc(text)
-    if (CONFIG_GET(flag/log_ooc))
-        WRITE_FILE(GLOB.world_game_log, "\[[time_stamp()]]LOOC: [text]")
-
-/mob/proc/get_top_level_mob()
-    if(istype(src.loc,/mob)&&src.loc!=src)
-        var/mob/M=src.loc
-        return M.get_top_level_mob()
-    return src
-
-/proc/get_top_level_mob(var/mob/S)
-    if(istype(S.loc,/mob)&&S.loc!=S)
-        var/mob/M=S.loc
-        return M.get_top_level_mob()
-    return S
+	if (CONFIG_GET(flag/log_ooc))
+		WRITE_FILE(GLOB.world_game_log, "\[[time_stamp()]]LOOC: [text]")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -34,7 +34,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 					return
 				if("Always yes for this round")
 					holder.ooc_confirmation_enabled = FALSE
-	if(is_banned_from(ckey, "OOC"))
+	if(is_banned_from(ckey, BAN_OOC))
 		to_chat(src, "<span class='danger'>You have been banned from OOC.</span>")
 		return
 	if(QDELETED(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This patches up jankiness with LOOC, such as mobs inside containers (lockers, split personalities, recalled holoparas, etc etc) being unable to hear or talk on LOOC, and observers also being completely unable to hear LOOC.

## Why It's Good For The Game

jank bad. work good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-07-14-1689367359-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/d6bc4d6b-9381-4d61-94c9-8ab226e64383)


</details>

## Changelog
:cl:
fix: LOOC is much less janky now. You can properly both hear LOOC as a ghost, and both hear and talk on LOOC while inside another object (including cases such as split personalities, recalled holoparasites, desynchronized mobs, jaunting mobs)!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
