### PR TITLE
Fix the inability to put capped spraycans into storage, disposals, or closets

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -575,6 +575,8 @@
 
 //Spraycan stuff
 
+GLOBAL_LIST_INIT(spraycan_touch_normally, typecacheof(list(/obj/machinery/modular_fabricator/autolathe, /obj/structure/closet, /obj/machinery/disposal)))
+
 /obj/item/toy/crayon/spraycan
 	name = "spray can"
 	icon_state = "spraycan"
@@ -651,14 +653,13 @@
 
 /obj/item/toy/crayon/spraycan/pre_attack(atom/target, mob/user, proximity, params)
 	if(!proximity)
-		return
+		return ..()
 
 	if(is_capped)
-		if(istype(target, /obj/machinery/modular_fabricator/autolathe))
+		if(is_type_in_typecache(target, GLOB.spraycan_touch_normally) || target.GetComponent(/datum/component/storage))
 			return ..()
-		else
-			to_chat(user, "<span class='warning'>Take the cap off first!</span>")
-			return
+		to_chat(user, "<span class='warning'>Take the cap off first!</span>")
+		return
 
 	if(check_empty(user))
 		return

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -575,8 +575,6 @@
 
 //Spraycan stuff
 
-GLOBAL_LIST_INIT(spraycan_touch_normally, typecacheof(list(/obj/machinery/modular_fabricator/autolathe, /obj/structure/closet, /obj/machinery/disposal)))
-
 /obj/item/toy/crayon/spraycan
 	name = "spray can"
 	icon_state = "spraycan"
@@ -603,6 +601,13 @@ GLOBAL_LIST_INIT(spraycan_touch_normally, typecacheof(list(/obj/machinery/modula
 
 	pre_noise = TRUE
 	post_noise = FALSE
+
+	var/static/list/spraycan_touch_normally
+
+/obj/item/toy/crayon/spraycan/Initialize()
+	. = ..()
+	if(!spraycan_touch_normally)
+		spraycan_touch_normally = typecacheof(list(/obj/machinery/modular_fabricator/autolathe, /obj/structure/closet, /obj/machinery/disposal))
 
 /obj/item/toy/crayon/spraycan/isValidSurface(surface)
 	return (istype(surface, /turf/open/floor) || istype(surface, /turf/closed/wall))
@@ -656,7 +661,7 @@ GLOBAL_LIST_INIT(spraycan_touch_normally, typecacheof(list(/obj/machinery/modula
 		return ..()
 
 	if(is_capped)
-		if(is_type_in_typecache(target, GLOB.spraycan_touch_normally) || target.GetComponent(/datum/component/storage))
+		if(is_type_in_typecache(target, spraycan_touch_normally) || target.GetComponent(/datum/component/storage))
 			return ..()
 		to_chat(user, "<span class='warning'>Take the cap off first!</span>")
 		return


### PR DESCRIPTION
## About The Pull Request

This allows spraycans to actually be put into closets, disposals, and any storage item whenever the cap is on.

## Why It's Good For The Game

bugfix, it is currently very annoying to try to put a spray can in my backpack or something, and you have to throw it to try to put it down disposals

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/a80f706d-e999-4549-84bb-7708f2ef6219

</details>

## Changelog
:cl:
fix: You can now properly put spray cans into storage items and objects whenever the cap is on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
