### PR TITLE
Fix crowbaring open windoors and firelocks

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -196,7 +196,7 @@
 		update_icon()
 
 
-/obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
+/obj/machinery/door/firedoor/try_to_crowbar(obj/item/crowbar, mob/user)
 	if(welded || operating)
 		return
 
@@ -207,12 +207,12 @@
 				access_log.Remove(access_log[1])
 			to_chat(user, "<span class='warning'>You begin forcing open \the [src], the motors whine...</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
-			if(!do_after(user, 10 SECONDS, src))
+			if(!crowbar.use_tool(src, user, 10 SECONDS))
 				return
 		else
 			to_chat(user, "<span class='notice'>You begin forcing open \the [src], the motors don't resist...</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
-			if(!do_after(user, 1 SECONDS, TRUE, src))
+			if(!crowbar.use_tool(src, user, 1 SECONDS))
 				return
 		if(!check_safety(user))
 			log_game("[key_name(user)] has opened a firelock with a pressure difference or a fire alarm at [AREACOORD(loc)], using a crowbar")

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -313,18 +313,18 @@
 	if(..())
 		autoclose = FALSE
 
-/obj/machinery/door/window/try_to_crowbar(obj/item/I, mob/user)
+/obj/machinery/door/window/try_to_crowbar(obj/item/crowbar, mob/user)
 	if(density)
-		if(!HAS_TRAIT(I, TRAIT_DOOR_PRYER) && hasPower())
+		if(!HAS_TRAIT(crowbar, TRAIT_DOOR_PRYER) && hasPower())
 			to_chat(user, "<span class='warning'>The windoor's motors resist your efforts to force it!</span>")
 			return
 		else if(!hasPower())
 			to_chat(user, "<span class='warning'>You begin forcing open \the [src], the motors don't resist...</span>")
-			if(!do_after(user, 1 SECONDS, TRUE, src))
+			if(!crowbar.use_tool(src, user, 1 SECONDS))
 				return
 		else
 			to_chat(user, "<span class='warning'>You begin forcing open \the [src]...</span>")
-			if(!do_after(user, 5 SECONDS, TRUE, src))
+			if(!crowbar.use_tool(src, user, 5 SECONDS))
 				return
 		open(2)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yea someone mixed up the arguments lol.

also i made the prying use `use_tool`, because consistency or something i guess?

## Why It's Good For The Game

this hasn't worked for _months_

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/c9a03929-63a3-4e40-8392-c825e3cae06b



</details>

## Changelog
:cl:
fix: Prying open unpowered firelocks and windoors with a crowbar FINALLY works again.
tweak: Prying open firelocks and windoors now respects tool speed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
