### PR TITLE
Adds alien variants of the toolset and surgical arm implants

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -302,6 +302,17 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+/datum/design/cyberimp_surgical_alien
+	name = "Alien Surgical Arm Implant"
+	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
+	id = "ci-alien-surgery"
+	build_type = PROTOLATHE | MECHFAB
+	materials = list (/datum/material/iron = 5000, /datum/material/plasma = 4500, /datum/material/silver = 3000, /datum/material/titanium = 3000, /datum/material/diamond = 3000)
+	construction_time = 500
+	build_path = /obj/item/organ/cyberimp/arm/alien_surgery
+	category = list("Implants", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/cyberimp_toolset
 	name = "Toolset Arm Implant"
 	desc = "A stripped-down version of engineering cyborg toolset, designed to be installed on subject's arm."
@@ -310,6 +321,17 @@
 	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1500, /datum/material/silver = 1500, /datum/material/copper = 200)
 	construction_time = 200
 	build_path = /obj/item/organ/cyberimp/arm/toolset
+	category = list("Implants", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/cyberimp_surgical_alien
+	name = "Alien Toolset Arm Implant"
+	desc = "A stripped-down version of the engineering cyborg toolset, recreated using alien technology, designed to be installed on subject's arm."
+	id = "ci-alien-toolset"
+	build_type = PROTOLATHE | MECHFAB
+	materials = list (/datum/material/iron = 5000, /datum/material/plasma = 4500, /datum/material/silver = 3000, /datum/material/titanium = 3000, /datum/material/diamond = 3000)
+	construction_time = 500
+	build_path = /obj/item/organ/cyberimp/arm/alien_toolset
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -324,7 +324,7 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/cyberimp_surgical_alien
+/datum/design/cyberimp_toolset_alien
 	name = "Alien Toolset Arm Implant"
 	desc = "A stripped-down version of the engineering cyborg toolset, recreated using alien technology, designed to be installed on subject's arm."
 	id = "ci-alien-toolset"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1414,6 +1414,36 @@
 	export_price = 10000
 	hidden = TRUE
 
+/datum/techweb_node/alien_surgery_cyberimp
+	id = "alien_surgery_cyberimp"
+	tech_tier = 5
+	display_name = "Alien Surgical Toolset Implant"
+	description = "A full array of alien surgical tools, now available from the convienence of your arm!"
+	prereq_ids = list(
+		"adv_cyber_implants",
+		"alien_bio"
+	)
+	design_ids = list(
+		"ci-alien-surgery"
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
+	export_price = 12500
+
+/datum/techweb_node/alien_toolset_cyberimp
+	id = "alien_toolset_cyberimp"
+	tech_tier = 5
+	display_name = "Integrated Alien Toolset Implant"
+	description = "A full array of alien toolsets, now available from the convienence of your arm!"
+	prereq_ids = list(
+		"adv_cyber_implants",
+		"alien_engi"
+	)
+	design_ids = list(
+		"ci-alien-toolset"
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 15000)
+	export_price = 12500
+
 ////////////////////////Tools////////////////////////
 /datum/techweb_node/basic_mining
 	id = "basic_mining"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -312,6 +312,12 @@
 	to_chat(user, "<span class='notice'>You unlock [src]'s integrated blade!</span>")
 	items_list += WEAKREF(new /obj/item/melee/hydraulic_blade(src))
 
+/obj/item/organ/cyberimp/arm/alien_toolset
+	name = "integrated alien toolset implant"
+	desc = "A stripped-down version of the engineering cyborg toolset, recreated using alien technology, designed to be installed on subject's arm."
+	items_to_create = list(/obj/item/screwdriver/abductor, /obj/item/wrench/abductor, /obj/item/weldingtool/abductor,
+		/obj/item/crowbar/abductor, /obj/item/wirecutters/abductor, /obj/item/multitool/abductor)
+
 /obj/item/organ/cyberimp/arm/esword
 	name = "arm-mounted energy blade"
 	desc = "An illegal and highly dangerous cybernetic implant that can project a deadly blade of concentrated energy."
@@ -371,6 +377,11 @@
 	name = "surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
 	items_to_create = list(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment, /obj/item/surgical_drapes)
+
+/obj/item/organ/cyberimp/arm/alien_surgery
+	name = "alien surgical toolset implant"
+	desc = "A set of alien surgical tools hidden behind a concealed panel on the user's arm."
+	items_to_create = list(/obj/item/retractor/alien, /obj/item/hemostat/alien, /obj/item/cautery/alien, /obj/item/surgicaldrill/alien, /obj/item/scalpel/alien, /obj/item/circular_saw/alien, /obj/item/surgical_drapes)
 
 /obj/item/organ/cyberimp/arm/power_cord
 	name = "power cord implant"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds alien tech variants of the surgical toolset arm and integrated toolset arm implants. They are both locked behind research which require their respective alien node (Alien Biological Tools and Alien Engineering, respectively), in addition to the Advanced Cybernetic Implants node.

Also, building them is pretty resource-hungry, I think... I'm not very familiar with ore/material balance, tbh.


... plus, I don't think I've _ever_ seen Alien Engineering actually be researched, as it requires you to yoink a tool from an actual abductor agent.

## Why It's Good For The Game

late-game skilled doctors/engis go brrrr :3

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-07-15-1689398444-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/250ed513-d902-4610-9e80-08021fa8dea6)
![23-07-15-1689398468-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/750699fc-cfa4-440f-b2d2-22b501c37fce)


</details>

## Changelog
:cl:
add: Adds alien variants of the toolset and surgical arm implants, locked behind late-game alien research.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
