### PR TITLE
Adds the Chain of Command to Boxstation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -53436,6 +53436,7 @@
 /obj/item/flashlight/lamp/green{
 	pixel_x = -7
 	},
+/obj/item/melee/chainofcommand,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "tnN" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the Chain of Command to Captain's office, it was quite sad when a Captain wanted to legitimately use it, but it was nowhere to be found.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This map used to have it like all others, however during the Command rework of the station it seems to have been forgotten.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot_1680](https://github.com/BeeStation/BeeStation-Hornet/assets/53474257/74b1684c-874e-4cc8-9cdf-965f04cdd051)


</details>

## Changelog
:cl:
add: Added the Chain of Command to boxstation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
