### PR TITLE
[Janitor Buff] More things can clean cult runes

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -92,11 +92,22 @@
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn
 	if(user.client && ((target in user.client.screen) && !user.is_holding(target)))
 		to_chat(user, "<span class='warning'>You need to take that [target.name] off before cleaning it!</span>")
-	else if(istype(target, /obj/effect/decal/cleanable))
+
+	else if(is_cleanable(target))
 		user.visible_message("[user] begins to scrub \the [target.name] out with [src].", "<span class='warning'>You begin to scrub \the [target.name] out with [src]...</span>")
 		if(do_after(user, src.cleanspeed, target = target))
 			to_chat(user, "<span class='notice'>You scrub \the [target.name] out.</span>")
 			qdel(target)
+			decreaseUses(user)
+
+	else if(type(target, /turf))
+		user.visible_message("[user] begins to scrub [target] with [src].", "<span class='warning'>You begin to scrub [target] with [src]...</span>")
+		if(do_after(user, src.cleanspeed, target = target))
+			var/turf/tile = target
+			for(var/obj/effect/O in tile)
+				if(is_cleanable(O))
+					qdel(O)
+			to_chat(user, "<span class='notice'>You cleaned [target].</span>")
 			decreaseUses(user)
 
 	else if(ishuman(target) && user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
@@ -105,7 +116,7 @@
 		H.lip_style = null //removes lipstick
 		H.update_body()
 		decreaseUses(user)
-		return
+
 	else if(istype(target, /obj/structure/window))
 		user.visible_message("[user] begins to clean \the [target.name] with [src]...", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
 		if(do_after(user, src.cleanspeed, target = target))
@@ -113,6 +124,7 @@
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			target.set_opacity(initial(target.opacity))
 			decreaseUses(user)
+
 	else
 		user.visible_message("[user] begins to clean \the [target.name] with [src]...", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
 		if(do_after(user, src.cleanspeed, target = target))
@@ -124,13 +136,12 @@
 				C.tint -= 2
 				H.update_tint()
 				REMOVE_TRAIT(target, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
-			for(var/obj/effect/decal/cleanable/C in target)
-				qdel(C)
+			for(var/obj/effect/C in target)
+				if(is_cleanable(C))
+					qdel(C)
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 			SEND_SIGNAL(target, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 			decreaseUses(user)
-	return
-
 
 /*
  * Bike Horns

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -100,7 +100,7 @@
 			qdel(target)
 			decreaseUses(user)
 
-	else if(type(target, /turf))
+	else if(istype(target, /turf))
 		user.visible_message("[user] begins to scrub [target] with [src].", "<span class='warning'>You begin to scrub [target] with [src]...</span>")
 		if(do_after(user, src.cleanspeed, target = target))
 			var/turf/tile = target

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -132,6 +132,9 @@
 	if(!target) //Search for decals then.
 		target = scan(/obj/effect/decal/cleanable)
 
+	if(!target) //Search for runes
+		target = scan(/obj/effect/rune)
+
 	if(!target) //Checks for remains
 		target = scan(/obj/effect/decal/remains)
 
@@ -210,7 +213,7 @@
 	target_types = typecacheof(target_types)
 
 /mob/living/simple_animal/bot/cleanbot/UnarmedAttack(atom/A)
-	if(istype(A, /obj/effect/decal/cleanable))
+	if(is_cleanable(A))
 		anchored = TRUE
 		icon_state = "cleanbot-c"
 		visible_message("<span class='notice'>[src] begins to clean up [A].</span>")
@@ -260,7 +263,7 @@
 		return
 	if(A && isturf(A.loc))
 		var/atom/movable/AM = A
-		if(istype(AM, /obj/effect/decal/cleanable))
+		if(is_cleanable(AM))
 			for(var/obj/effect/decal/cleanable/C in A.loc)
 				qdel(C)
 	anchored = FALSE
@@ -324,7 +327,7 @@
 	bot_core.updateUsrDialog()
 
 /mob/living/simple_animal/bot/cleanbot/larry/UnarmedAttack(atom/A)
-	if(istype(A, /obj/effect/decal/cleanable))
+	if(is_cleanable(A))
 		anchored = TRUE
 		icon_state = "larry-c"
 		visible_message("<span class='notice'>[src] begins to clean up [A].</span>")
@@ -374,7 +377,7 @@
 		return
 	if(A && isturf(A.loc))
 		var/atom/movable/AM = A
-		if(istype(AM, /obj/effect/decal/cleanable))
+		if(is_cleanable(AM))
 			for(var/obj/effect/decal/cleanable/C in A.loc)
 				qdel(C)
 	anchored = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -172,7 +172,7 @@
 
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()
 	if(ismovable(target))
-		if(istype(target, /obj/effect/decal/cleanable))
+		if(is_cleanable(target))
 			visible_message("[src] cleans up \the [target].")
 			qdel(target)
 			return TRUE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1113,7 +1113,7 @@
 	return TRUE
 
 /datum/reagent/space_cleaner/reaction_obj(obj/O, reac_volume)
-	if(istype(O, /obj/effect/decal/cleanable))
+	if(is_cleanable(O))
 		qdel(O)
 	else
 		if(O)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes more things use `is_cleanable()` instead of a typecheck for `/obj/effect/decal/cleanable`. These include:
- Soap
- Cleaner Spraybottles
- Cleanbots

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I feel that if we have a whole `is_cleanable()` define which INCLUDES cult runes, more things should use this check instead of checking for cleanable decals? Additionally code-wise this allows us to add more cleanable objects instead of making it a subtype of the cleanable decals.

The cultist runes are not magically protected in any way, they are made of blood, they should be able to be cleaned. This may also encourage crewmembers/security/janitors to go out of their way to fully destroy cultist positions instead of leaving teleport or empower runes on the floor.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/998338cc-35a9-416c-a6b2-72e07ebf2ccc

</details>

## Changelog
:cl:
balance: soap, cleaner spray bottles/grenades, and cleanbots can now clean cult runes (previously just mops, janiborgs, and showers)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
