### PR TITLE
Sound synthesizer now has a proper cooldown

### DIFF
--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -73,10 +73,7 @@
 	if(has_cooldown && !COOLDOWN_FINISHED(src, play_cooldown))
 		to_chat(user, "<span class='warning'>You must wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, play_cooldown))] before you can play another sound!</span>")
 		return
-	for(var/mob/target in hearers(user))
-		if(!target.client || !(target.client.prefs.toggles & PREFTOGGLE_SOUND_INSTRUMENTS))
-			continue
-		target.playsound_local(src, selected_sound, volume, shiftpitch)
+	playsound(user, selected_sound, volume, shiftpitch)
 	SSblackbox.record_feedback("tally", "synth_sound_played", 1, selected_sound_name)
 	if(has_cooldown)
 		COOLDOWN_START(src, play_cooldown, added_cooldown + get_sound_length(user))
@@ -96,8 +93,7 @@
 	if(has_cooldown && !COOLDOWN_FINISHED(src, play_cooldown))
 		to_chat(user, "<span class='warning'>You must wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, play_cooldown))] before you can play another sound!</span>")
 		return
-	if(target.client && (target.client.prefs.toggles & PREFTOGGLE_SOUND_INSTRUMENTS))
-		target.playsound_local(get_turf(src), selected_sound, volume, shiftpitch)
+	target.playsound_local(get_turf(src), selected_sound, volume, shiftpitch)
 	SSblackbox.record_feedback("tally", "synth_sound_played", 1, selected_sound_name)
 	if(has_cooldown)
 		COOLDOWN_START(src, play_cooldown, added_cooldown + get_sound_length(target))

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -1,79 +1,121 @@
 /*
-        Ported from /vg/station:
-        https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/game/objects/items/devices/sound_synth.dm
+		Ported from /vg/station:
+		https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/game/objects/items/devices/sound_synth.dm
 */
 
 /obj/item/soundsynth
-    name = "sound synthesizer"
-    desc = "A device that is able to create sounds."
-    icon = 'icons/obj/radio.dmi'
-    icon_state = "radio"
-    item_state = "radio"
-    w_class = WEIGHT_CLASS_TINY
-    siemens_coefficient = 1
+	name = "sound synthesizer"
+	desc = "A device that is able to create sounds."
+	icon = 'icons/obj/radio.dmi'
+	icon_state = "radio"
+	item_state = "radio"
+	w_class = WEIGHT_CLASS_TINY
+	siemens_coefficient = 1
 
-    var/tmp/spam_flag = 0 //To prevent mashing the button to cause annoyance like a huge idiot.
-    var/selected_sound = "sound/items/bikehorn.ogg"
-    var/shiftpitch = 1
-    var/volume = 50
+	var/selected_sound_name = "Honk" // just so we can select it by default in the input list
+	var/sound/selected_sound = sound('sound/items/bikehorn.ogg')
+	var/shiftpitch = 1
+	var/volume = 50
+	var/has_cooldown = TRUE
+	var/added_cooldown = 1 SECONDS
+	COOLDOWN_DECLARE(play_cooldown)
 
-    var/list/sound_list = list( //How I would like to add tabbing to make this not as messy, but BYOND doesn't like that.
-    "Honk" = "selected_sound=sound/items/bikehorn.ogg&shiftpitch=1&volume=50",
-    "Applause" = "selected_sound=sound/effects/applause.ogg&shiftpitch=1&volume=65",
-    "Laughter" = "selected_sound=sound/effects/laughtrack.ogg&shiftpitch=1&volume=65",
-    "Rimshot" = "selected_sound=sound/effects/rimshot.ogg&shiftpitch=1&volume=65",
-    "Trombone" = "selected_sound=sound/misc/sadtrombone.ogg&shiftpitch=1&volume=50",
-    "Airhorn" = "selected_sound=sound/items/airhorn.ogg&shiftpitch=1&volume=50",
-    "Alert" = "selected_sound=sound/effects/alert.ogg&shiftpitch=1&volume=50",
-    "Boom" = "selected_sound=sound/effects/explosion1.ogg&shiftpitch=1&volume=50",
-    "Boom from Afar" = "selected_sound=sound/effects/explosionfar.ogg&shiftpitch=1&volume=50",
-    "Bubbles" = "selected_sound=sound/effects/bubbles.ogg&shiftpitch=1&volume=50",
-    "Countdown" = "selected_sound=sound/ambience/countdown.ogg&shiftpitch=0&volume=55",
-    "Creepy Whisper" = "selected_sound=sound/hallucinations/turn_around1.ogg&shiftpitch=1&volume=50",
-    "Ding" = "selected_sound=sound/machines/ding.ogg&shiftpitch=1&volume=50",
-    "Bwoink" = "selected_sound=sound/effects/adminhelp.ogg&shiftpitch=1&volume=50",
-    "Double Beep" = "selected_sound=sound/machines/twobeep.ogg&shiftpitch=1&volume=50",
-    "Flush" = "selected_sound=sound/machines/disposalflush.ogg&shiftpitch=1&volume=40",
-    "Kawaii" = "selected_sound=sound/ai/default/animes.ogg&shiftpitch=0&volume=60",
-    "Startup" = "selected_sound=sound/mecha/nominal.ogg&shiftpitch=0&volume=50",
-    "Welding Noises" = "selected_sound=sound/items/welder.ogg&shiftpitch=1&volume=55",
-    "Short Slide Whistle" = "selected_sound=sound/effects/slide_whistle_short.ogg&shiftpitch=1&volume=50",
-    "Long Slide Whistle" = "selected_sound=sound/effects/slide_whistle_long.ogg&shiftpitch=1&volume=50",
-    "YEET" = "selected_sound=sound/effects/yeet.ogg&shiftpitch=1&volume=50",
-    "Time Stop" = "selected_sound=sound/magic/timeparadox2.ogg&shiftpitch=0&volume=80",
-    "Click" = "selected_sound=sound/machines/click.ogg&shiftpitch=0&volume=80",
-    "Booing" = "selected_sound=sound/effects/audience-boo.ogg&shiftpitch=0&volume=80",
-    "Awwing" = "selected_sound=sound/effects/audience-aww.ogg&shiftpitch=0&volume=80",
-    "Gasping" = "selected_sound=sound/effects/audience-gasp.ogg&shiftpitch=0&volume=80",
-    "Oohing" = "selected_sound=sound/effects/audience-ooh.ogg&shiftpitch=0&volume=80"
-    )
+	var/static/list/sound_list = list(
+		"Honk" = "selected_sound=sound/items/bikehorn.ogg&shiftpitch=1&volume=50",
+		"Applause" = "selected_sound=sound/effects/applause.ogg&shiftpitch=1&volume=65",
+		"Laughter" = "selected_sound=sound/effects/laughtrack.ogg&shiftpitch=1&volume=65",
+		"Rimshot" = "selected_sound=sound/effects/rimshot.ogg&shiftpitch=1&volume=65",
+		"Trombone" = "selected_sound=sound/misc/sadtrombone.ogg&shiftpitch=1&volume=50",
+		"Airhorn" = "selected_sound=sound/items/airhorn.ogg&shiftpitch=1&volume=50",
+		"Alert" = "selected_sound=sound/effects/alert.ogg&shiftpitch=1&volume=50",
+		"Boom" = "selected_sound=sound/effects/explosion1.ogg&shiftpitch=1&volume=50",
+		"Boom from Afar" = "selected_sound=sound/effects/explosionfar.ogg&shiftpitch=1&volume=50",
+		"Bubbles" = "selected_sound=sound/effects/bubbles.ogg&shiftpitch=1&volume=50",
+		"Countdown" = "selected_sound=sound/ambience/countdown.ogg&shiftpitch=0&volume=55",
+		"Creepy Whisper" = "selected_sound=sound/hallucinations/turn_around1.ogg&shiftpitch=1&volume=50",
+		"Ding" = "selected_sound=sound/machines/ding.ogg&shiftpitch=1&volume=50",
+		"Bwoink" = "selected_sound=sound/effects/adminhelp.ogg&shiftpitch=1&volume=50",
+		"Double Beep" = "selected_sound=sound/machines/twobeep.ogg&shiftpitch=1&volume=50",
+		"Flush" = "selected_sound=sound/machines/disposalflush.ogg&shiftpitch=1&volume=40",
+		"Kawaii" = "selected_sound=sound/ai/default/animes.ogg&shiftpitch=0&volume=60",
+		"Startup" = "selected_sound=sound/mecha/nominal.ogg&shiftpitch=0&volume=50",
+		"Welding Noises" = "selected_sound=sound/items/welder.ogg&shiftpitch=1&volume=55",
+		"Short Slide Whistle" = "selected_sound=sound/effects/slide_whistle_short.ogg&shiftpitch=1&volume=50",
+		"Long Slide Whistle" = "selected_sound=sound/effects/slide_whistle_long.ogg&shiftpitch=1&volume=50",
+		"YEET" = "selected_sound=sound/effects/yeet.ogg&shiftpitch=1&volume=50",
+		"Time Stop" = "selected_sound=sound/magic/timeparadox2.ogg&shiftpitch=0&volume=80",
+		"Click" = "selected_sound=sound/machines/click.ogg&shiftpitch=0&volume=80",
+		"Booing" = "selected_sound=sound/effects/audience-boo.ogg&shiftpitch=0&volume=80",
+		"Awwing" = "selected_sound=sound/effects/audience-aww.ogg&shiftpitch=0&volume=80",
+		"Gasping" = "selected_sound=sound/effects/audience-gasp.ogg&shiftpitch=0&volume=80",
+		"Oohing" = "selected_sound=sound/effects/audience-ooh.ogg&shiftpitch=0&volume=80"
+	)
+	var/static/list/sound_lengths = list()
 
 /obj/item/soundsynth/verb/pick_sound()
-    set category = "Object"
-    set name = "Select Sound Playback"
-    var/thesoundthatwewant = input("Pick a sound:", null) as null|anything in sound_list
-    if(!thesoundthatwewant)
-        return
-    to_chat(usr, "Sound playback set to: [thesoundthatwewant]!")
-    var/list/assblast = params2list(sound_list[thesoundthatwewant])
-    selected_sound = assblast["selected_sound"]
-    shiftpitch = text2num(assblast["shiftpitch"])
-    volume = text2num(assblast["volume"])
+	set category = "Object"
+	set name = "Select Sound Playback"
+	var/new_sound = tgui_input_list(usr, "Pick a sound!", "Sound Synthesizer", sound_list, default = selected_sound_name)
+	if(!new_sound || !sound_list[new_sound])
+		return
+	to_chat(usr, "<span class='notice'>Sound playback set to: <b>[new_sound]</b>!</span>")
+	selected_sound_name = new_sound
+	var/list/assblast = params2list(sound_list[new_sound])
+	selected_sound = sound(assblast["selected_sound"])
+	shiftpitch = text2num(assblast["shiftpitch"])
+	volume = text2num(assblast["volume"])
+	SSblackbox.record_feedback("tally", "synth_sound_selected", 1, selected_sound_name)
 
-/obj/item/soundsynth/attack_self(mob/user as mob)
-    if(spam_flag + 2 SECONDS < world.timeofday)
-        playsound(src, selected_sound, volume, shiftpitch)
-        spam_flag = world.timeofday
+/obj/item/soundsynth/attack_self(mob/user)
+	if(!selected_sound || !selected_sound_name)
+		to_chat(user, "<span class='warning'>No sound has been selected!</span>")
+		return
+	if(has_cooldown && !COOLDOWN_FINISHED(src, play_cooldown))
+		to_chat(user, "<span class='warning'>You must wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, play_cooldown))] before you can play another sound!</span>")
+		return
+	for(var/mob/target in hearers(user))
+		if(!target.client || !(target.client.prefs.toggles & PREFTOGGLE_SOUND_INSTRUMENTS))
+			continue
+		target.playsound_local(src, selected_sound, volume, shiftpitch)
+	SSblackbox.record_feedback("tally", "synth_sound_played", 1, selected_sound_name)
+	if(has_cooldown)
+		COOLDOWN_START(src, play_cooldown, added_cooldown + get_sound_length(user))
 
 /obj/item/soundsynth/AltClick(mob/living/carbon/user)
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	pick_sound()
 
-/obj/item/soundsynth/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
-    if(M == user)
-        pick_sound()
-    else if(spam_flag + 2 SECONDS < world.timeofday)
-        M.playsound_local(get_turf(src), selected_sound, volume, shiftpitch)
-        spam_flag = world.timeofday
-        //to_chat(M, selected_sound) //this doesn't actually go to their chat very much at all.
+/obj/item/soundsynth/attack(mob/living/target, mob/living/user, def_zone)
+	if(target == user)
+		pick_sound()
+		return
+	if(!selected_sound || !selected_sound_name)
+		to_chat(user, "<span class='warning'>No sound has been selected!</span>")
+		return
+	if(has_cooldown && !COOLDOWN_FINISHED(src, play_cooldown))
+		to_chat(user, "<span class='warning'>You must wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, play_cooldown))] before you can play another sound!</span>")
+		return
+	if(target.client && (target.client.prefs.toggles & PREFTOGGLE_SOUND_INSTRUMENTS))
+		target.playsound_local(get_turf(src), selected_sound, volume, shiftpitch)
+	SSblackbox.record_feedback("tally", "synth_sound_played", 1, selected_sound_name)
+	if(has_cooldown)
+		COOLDOWN_START(src, play_cooldown, added_cooldown + get_sound_length(target))
+
+// WHY BYOND WHYYYYY, WHY DO I HAVE THE QUERY THE CLIENT FOR THE SOUND, CAN'T YOU JUST FILL OUT LEN WHENEVER I MAKE A SOUND DATUM?!
+/obj/item/soundsynth/proc/get_sound_length(mob/living/hearer)
+	. = 0
+	if(!selected_sound?.file || !hearer?.client)
+		return
+	if(sound_lengths[selected_sound.file])
+		return sound_lengths[selected_sound.file]
+	var/list/sound/sounds = hearer.client.SoundQuery()
+	for(var/sound/sound as() in sounds)
+		if(sound.file == selected_sound.file)
+			// Just in case something goes fucky wucky, don't cache a bad  reuslt.
+			if(!isnum_safe(sound.len) || sound.len <= 0)
+				return
+			var/sound_len = CEILING(sound.len * 10, 1)
+			sound_lengths[selected_sound.file] = sound_len
+			return sound_len
+

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -112,7 +112,7 @@
 	var/list/sound/sounds = hearer.client.SoundQuery()
 	for(var/sound/sound as() in sounds)
 		if(sound.file == selected_sound.file)
-			// Just in case something goes fucky wucky, don't cache a bad  reuslt.
+			// Just in case something goes fucky wucky, don't cache a bad result.
 			if(!isnum_safe(sound.len) || sound.len <= 0)
 				return
 			var/sound_len = CEILING(sound.len * 10, 1)


### PR DESCRIPTION
## About The Pull Request

This does a few things to the sound synthesizer:
- Adds a proper cooldown to it: (currently, it's the length of the sound + 1 second, although this can be varedited to both change the 'extra' cooldown and to remove the cooldown entirely)
- Modernized the code _slightly_
- Changed the sound selection to use tgui input
- Adds some SSblackbox metrics to it, because stats are nice.

## Why It's Good For The Game

Because overlapping sound synth spam can get _incredibly annoying OOCly_.


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-07-16-1689515552](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/2435dd25-8928-482c-a518-d4425ec8139e)
![23-07-16-1689515562-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/74c2cdf1-7090-42b8-8e4b-936438e2fee8)


</details>

## Changelog
:cl:
tweak: Sound synthesizers now have a proper cooldown, preventing them from playing overlapping sounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
