### PR TITLE
You can no longer waste materials by RPED upgrading stasis beds or self-sustaining botany trays.

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -54,6 +54,10 @@
 			playsound(src, 'sound/machines/synth_no.ogg', 50, TRUE, frequency = sound_freq)
 		last_stasis_sound = _running
 
+/obj/machinery/stasis/exchange_parts(mob/user, obj/item/storage/part_replacer/W)
+	to_chat(user, "<span class='warning'>There's no reason to upgrade the parts in [src], it'd just be a waste!</span>")
+	return FALSE
+
 /obj/machinery/stasis/AltClick(mob/user)
 	if(world.time >= stasis_can_toggle && user.canUseTopic(src, !issilicon(user)))
 		stasis_enabled = !stasis_enabled

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -46,6 +46,12 @@
 	maxwater = tmp_capacity * 50 // Up to 300
 	maxnutri = tmp_capacity * 5 // Up to 30
 
+/obj/machinery/hydroponics/constructable/exchange_parts(mob/user, obj/item/storage/part_replacer/W)
+	if(self_sustaining)
+		to_chat(user, "<span class='warning'>There's no reason to upgrade the parts in [src], it's already self-sustaining!</span>")
+		return FALSE
+	return ..()
+
 /obj/machinery/hydroponics/constructable/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This prevents RPEDs from being used on finished stasis beds, which is just a waste of mats, as stasis beds _do not from higher tier parts in any way whatsoever_... Many people don't realize this, there's just... no reason the game should let you RPED it.

## Why It's Good For The Game

stop wasting mats

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-07-18-1689653001-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/2b9ac451-73aa-4268-b2e4-61bdd14d19cf)


</details>

## Changelog
:cl:
tweak: You can no longer waste materials by upgrading a (finished) stasis bed or a self-sustaining botany tray with an RPED.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
