### PR TITLE
[Map Tweak: Lavaland] Airlocks: Tiny Fan Boogaloo

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -596,14 +596,11 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "eD" = (
-/obj/machinery/door/airlock{
-	name = "Labor Camp External Access"
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/techmaint,
+/turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -800,6 +797,14 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"fV" = (
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station EVA";
+	req_access_txt = "54"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/eva)
 "fX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -1896,13 +1901,12 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "mH" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/eva)
+/obj/machinery/light/small,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/mine/laborcamp)
 "mK" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -1948,11 +1952,14 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "mW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/mine/science)
+/obj/machinery/door/airlock/glass{
+	name = "Labor Camp External Access"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "nf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -2667,9 +2674,10 @@
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "sM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/structure/ore_box,
 /turf/open/floor/plating/lavaland,
-/area/mine/laborcamp)
+/area/lavaland/surface/outdoors/explored)
 "sR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -2912,13 +2920,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
-"uJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp)
 "uK" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -2935,12 +2936,6 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plasteel,
 /area/mine/science)
-"uQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "uR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -3177,11 +3172,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wv" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland,
 /area/mine/laborcamp)
 "wz" = (
 /obj/effect/spawner/structure/window,
@@ -3737,6 +3729,12 @@
 /obj/structure/fence,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"Br" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "Bx" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile{
@@ -4042,6 +4040,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"DE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/science)
 "DF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4388,12 +4392,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
-"Gg" = (
-/obj/machinery/door/airlock{
-	name = "Labor Camp External Access"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "Gh" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/external{
@@ -4801,10 +4799,9 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "IZ" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
-/turf/open/floor/plating/lavaland,
-/area/lavaland/surface/outdoors/explored)
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "Je" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -4971,6 +4968,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
+"JZ" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/eva)
 "Kb" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -5685,13 +5690,13 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
 "PJ" = (
+/obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_access_txt = "54"
+/obj/machinery/door/airlock/glass{
+	name = "Labor Camp External Access"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/mine/eva)
+/area/mine/laborcamp)
 "PK" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "mining relay room";
@@ -6172,7 +6177,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "Te" = (
-/obj/structure/ore_box,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "Th" = (
@@ -6985,6 +6992,9 @@
 	network = list("labor")
 	},
 /obj/structure/closet/emcloset,
+/mob/living/simple_animal/bot/atmosbot{
+	name = "Officer Fastmosky"
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "YC" = (
@@ -7103,12 +7113,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
-"Zi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "Zl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -29568,10 +29572,10 @@ Vd
 bz
 Vb
 Vb
-uJ
+mH
 rw
-sM
-sM
+wv
+wv
 rw
 xT
 xT
@@ -29826,7 +29830,7 @@ qg
 fM
 fM
 fM
-Gg
+PJ
 tL
 YB
 rw
@@ -30080,12 +30084,12 @@ xT
 xT
 Vd
 qg
-IZ
-ID
-ID
 sM
+ID
+ID
+wv
 tL
-uQ
+Br
 BZ
 BZ
 CL
@@ -30341,7 +30345,7 @@ CL
 BZ
 BZ
 BZ
-eD
+mW
 BZ
 BZ
 jK
@@ -30599,7 +30603,7 @@ NQ
 By
 np
 DB
-wv
+eD
 ZC
 np
 DB
@@ -39068,16 +39072,16 @@ Zd
 Zd
 Zd
 Zd
-mH
+JZ
 gM
 wa
-PJ
+fV
 Sf
 iu
 Sf
 Sf
 Rr
-PJ
+fV
 CF
 gf
 Yq
@@ -39586,10 +39590,10 @@ Fd
 qi
 PR
 Fd
-Te
+IZ
 SE
 Mi
-Zi
+Te
 kK
 Zt
 CF
@@ -51145,7 +51149,7 @@ OE
 rL
 Gh
 iU
-mW
+DE
 KR
 mp
 Jt

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -6952,7 +6952,7 @@
 	},
 /obj/structure/closet/emcloset,
 /mob/living/simple_animal/bot/atmosbot{
-	name = "Seargent Airhead";
+	name = "Sergeant Airhead";
 	on = 0
 	},
 /turf/open/floor/plasteel/techmaint,

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -596,21 +596,13 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "eD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock{
 	name = "Labor Camp External Access"
 	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "eK" = (
@@ -2674,6 +2666,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
+"sM" = (
+/obj/machinery/camera{
+	c_tag = "Labor Camp External";
+	dir = 9;
+	network = list("labor")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/mine/laborcamp)
 "sR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -3172,6 +3175,12 @@
 /obj/structure/stone_tile/slab,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"wv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp)
 "wz" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -3422,15 +3431,6 @@
 	},
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
-"yL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "yN" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3583,12 +3583,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/laborcamp)
-"Aa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/explored)
 "Ah" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -3608,19 +3602,6 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/mine/laborcamp)
-"Au" = (
-/obj/machinery/advanced_airlock_controller/lavaland{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "AA" = (
 /obj/structure/table,
@@ -4071,14 +4052,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"DG" = (
-/obj/machinery/camera{
-	c_tag = "Labor Camp External";
-	dir = 9;
-	network = list("labor")
-	},
-/turf/open/floor/plating/lavaland,
-/area/mine/laborcamp)
 "DJ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -4481,15 +4454,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"GO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "GQ" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -5303,10 +5267,6 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
-"LQ" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/lavaland,
-/area/mine/laborcamp)
 "LW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5727,12 +5687,6 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
-"PB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/explored)
 "PJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -7043,20 +6997,8 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "YB" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Labor Camp External Access"
-	},
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 8
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
+/turf/open/floor/plating,
+/area/lavaland/surface/outdoors/explored)
 "YC" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -29376,11 +29318,11 @@ xT
 xT
 xT
 xT
-bz
-Vb
-Vb
-Vb
-mW
+xT
+xT
+xT
+xT
+xT
 xT
 xT
 xT
@@ -29633,11 +29575,11 @@ xT
 bz
 Vb
 Vb
-PB
-fM
-fM
-DG
-Aa
+Vb
+Vb
+Vb
+mW
+xT
 xT
 xT
 xT
@@ -29890,11 +29832,11 @@ xT
 qg
 fM
 fM
-LQ
-rw
+fM
 YB
-rw
-Aa
+YB
+sM
+xT
 xT
 xT
 xT
@@ -30148,8 +30090,8 @@ qg
 ID
 ID
 ID
-CL
-Au
+wv
+YB
 BZ
 BZ
 CL
@@ -30663,7 +30605,7 @@ NQ
 By
 np
 mH
-yL
+np
 ZC
 np
 DB
@@ -30920,7 +30862,7 @@ WX
 Sc
 Sc
 uR
-GO
+np
 fK
 Hd
 Rp

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1580,6 +1580,14 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ku" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/glass{
+	name = "Labor Camp External Access"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "kw" = (
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
@@ -1893,13 +1901,11 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "mH" = (
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_access_txt = "54"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/eva)
+/turf/open/floor/plasteel,
+/area/mine/science)
 "mK" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -1945,10 +1951,9 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "mW" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/ore_box,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/lavaland,
-/area/lavaland/surface/outdoors/explored)
+/area/mine/laborcamp)
 "nf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -2140,13 +2145,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ow" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp)
 "oN" = (
 /obj/machinery/shower{
 	dir = 8
@@ -2194,18 +2192,6 @@
 /obj/item/storage/firstaid/medical/doctorbag,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
-"pg" = (
-/obj/machinery/camera{
-	c_tag = "Labor Camp External";
-	dir = 10;
-	network = list("labor")
-	},
-/obj/structure/closet/emcloset,
-/mob/living/simple_animal/bot/atmosbot{
-	name = "Seargent Airhead"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "pj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2348,7 +2334,8 @@
 /area/lavaland/surface/outdoors/explored)
 "qi" = (
 /mob/living/simple_animal/bot/atmosbot{
-	name = "Officer Fastmosky"
+	name = "Officer Fastmosky";
+	on = 0
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -2682,8 +2669,11 @@
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "sM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/lavaland,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
 "sR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3179,12 +3169,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wv" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/glass{
-	name = "Labor Camp External Access"
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/techmaint,
+/turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "wz" = (
 /obj/effect/spawner/structure/window,
@@ -3400,6 +3389,15 @@
 "yv" = (
 /turf/closed/mineral/random/labormineral/volcanic,
 /area/lavaland/surface/outdoors/explored)
+"yC" = (
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Labor Camp External Access"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "yE" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -4630,10 +4628,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
-"HI" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "HO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -4802,14 +4796,13 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "IZ" = (
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Labor Camp External Access"
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station EVA";
+	req_access_txt = "54"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
+/area/mine/eva)
 "Je" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -5691,11 +5684,10 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
 "PJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/science)
+/obj/effect/turf_decal/bot,
+/obj/structure/ore_box,
+/turf/open/floor/plating/lavaland,
+/area/lavaland/surface/outdoors/explored)
 "PK" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "mining relay room";
@@ -6176,12 +6168,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "Te" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station"
-	},
-/turf/open/floor/plasteel/techmaint,
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
 /area/mine/eva)
 "Th" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -6352,13 +6340,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
-"UF" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "UI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -6628,6 +6609,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Wl" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/eva)
 "Wm" = (
 /obj/item/cigbutt{
 	pixel_x = 1;
@@ -7039,6 +7028,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
+"YG" = (
+/obj/machinery/camera{
+	c_tag = "Labor Camp External";
+	dir = 10;
+	network = list("labor")
+	},
+/obj/structure/closet/emcloset,
+/mob/living/simple_animal/bot/atmosbot{
+	name = "Seargent Airhead";
+	on = 0
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "YM" = (
 /turf/closed/wall/mineral/wood,
 /area/mine/living_quarters)
@@ -29574,10 +29576,10 @@ Vd
 bz
 Vb
 Vb
-ow
+sM
 rw
-sM
-sM
+mW
+mW
 rw
 xT
 xT
@@ -29832,9 +29834,9 @@ qg
 fM
 fM
 fM
-wv
+ku
 tL
-pg
+YG
 rw
 xT
 xT
@@ -30086,10 +30088,10 @@ xT
 xT
 Vd
 qg
+PJ
+ID
+ID
 mW
-ID
-ID
-sM
 tL
 YB
 BZ
@@ -30347,7 +30349,7 @@ CL
 BZ
 BZ
 BZ
-IZ
+yC
 BZ
 BZ
 jK
@@ -30605,7 +30607,7 @@ NQ
 By
 np
 DB
-UF
+wv
 ZC
 np
 DB
@@ -39074,16 +39076,16 @@ Zd
 Zd
 Zd
 Zd
-Te
+Wl
 gM
 wa
-mH
+IZ
 Sf
 iu
 Sf
 Sf
 Rr
-mH
+IZ
 CF
 gf
 Yq
@@ -39592,7 +39594,7 @@ Fd
 qi
 PR
 Fd
-HI
+Te
 SE
 Mi
 eD
@@ -51151,7 +51153,7 @@ OE
 rL
 Gh
 iU
-PJ
+mH
 KR
 mp
 Jt

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -596,9 +596,11 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "eD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/lavaland,
-/area/mine/laborcamp)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -1891,10 +1893,10 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "mH" = (
-/obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station"
+	name = "Mining Station EVA";
+	req_access_txt = "54"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
@@ -1943,11 +1945,10 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "mW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/science)
+/obj/effect/turf_decal/bot,
+/obj/structure/ore_box,
+/turf/open/floor/plating/lavaland,
+/area/lavaland/surface/outdoors/explored)
 "nf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -2139,6 +2140,13 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ow" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/mine/laborcamp)
 "oN" = (
 /obj/machinery/shower{
 	dir = 8
@@ -2186,6 +2194,18 @@
 /obj/item/storage/firstaid/medical/doctorbag,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
+"pg" = (
+/obj/machinery/camera{
+	c_tag = "Labor Camp External";
+	dir = 10;
+	network = list("labor")
+	},
+/obj/structure/closet/emcloset,
+/mob/living/simple_animal/bot/atmosbot{
+	name = "Seargent Airhead"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "pj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2662,11 +2682,9 @@
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "sM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/eva)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland,
+/area/mine/laborcamp)
 "sR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -3161,11 +3179,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wv" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/glass{
+	name = "Labor Camp External Access"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "wz" = (
 /obj/effect/spawner/structure/window,
@@ -3580,15 +3599,6 @@
 "Am" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
-"An" = (
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Labor Camp External Access"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "Ap" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -4620,6 +4630,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
+"HI" = (
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "HO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -4788,18 +4802,14 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "IZ" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/closeup,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
 /obj/machinery/door/airlock/glass{
 	name = "Labor Camp External Access"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
-"Ja" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/ore_box,
-/turf/open/floor/plating/lavaland,
-/area/lavaland/surface/outdoors/explored)
 "Je" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -5408,18 +5418,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/carpet/blue,
 /area/mine/living_quarters)
-"Nv" = (
-/obj/machinery/camera{
-	c_tag = "Labor Camp External";
-	dir = 10;
-	network = list("labor")
-	},
-/obj/structure/closet/emcloset,
-/mob/living/simple_animal/bot/atmosbot{
-	name = "Officer Fastmosky"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "Nz" = (
 /obj/machinery/rnd/experimentor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5693,12 +5691,11 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
 "PJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp)
+/turf/open/floor/plasteel,
+/area/mine/science)
 "PK" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "mining relay room";
@@ -6179,10 +6176,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "Te" = (
+/obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_access_txt = "54"
+	name = "Mining Station"
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
@@ -6355,6 +6352,13 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
+"UF" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
 "UI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -7228,10 +7232,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"ZR" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "ZT" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/grid/steel,
@@ -29574,10 +29574,10 @@ Vd
 bz
 Vb
 Vb
-PJ
+ow
 rw
-eD
-eD
+sM
+sM
 rw
 xT
 xT
@@ -29832,9 +29832,9 @@ qg
 fM
 fM
 fM
-IZ
+wv
 tL
-Nv
+pg
 rw
 xT
 xT
@@ -30086,10 +30086,10 @@ xT
 xT
 Vd
 qg
-Ja
+mW
 ID
 ID
-eD
+sM
 tL
 YB
 BZ
@@ -30347,7 +30347,7 @@ CL
 BZ
 BZ
 BZ
-An
+IZ
 BZ
 BZ
 jK
@@ -30605,7 +30605,7 @@ NQ
 By
 np
 DB
-wv
+UF
 ZC
 np
 DB
@@ -39074,16 +39074,16 @@ Zd
 Zd
 Zd
 Zd
-mH
+Te
 gM
 wa
-Te
+mH
 Sf
 iu
 Sf
 Sf
 Rr
-Te
+mH
 CF
 gf
 Yq
@@ -39592,10 +39592,10 @@ Fd
 qi
 PR
 Fd
-ZR
+HI
 SE
 Mi
-sM
+eD
 kK
 Zt
 CF
@@ -51151,7 +51151,7 @@ OE
 rL
 Gh
 iU
-mW
+PJ
 KR
 mp
 Jt

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -30862,7 +30862,7 @@ WX
 Sc
 Sc
 uR
-np
+Hd
 fK
 Hd
 Rp

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -225,12 +225,10 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "bT" = (
@@ -845,13 +843,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/production)
 "gl" = (
@@ -929,13 +927,11 @@
 /turf/open/floor/plasteel/checker,
 /area/mine/living_quarters)
 "gH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
 	id = "labor";
 	name = "labor camp blast door"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "gL" = (
@@ -995,17 +991,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "hb" = (
-/obj/machinery/advanced_airlock_controller/lavaland{
-	dir = 8;
-	pixel_x = 26
-	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/production)
 "hd" = (
@@ -1431,15 +1419,12 @@
 /turf/open/floor/plasteel/checker,
 /area/mine/living_quarters)
 "jG" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Security Airlock";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "jJ" = (
@@ -1933,10 +1918,10 @@
 	name = "Mining Shuttle Airlock";
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/production)
 "mR" = (
@@ -1996,6 +1981,10 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
+"nE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
 "nI" = (
 /mob/living/simple_animal/turtle{
 	dir = 4
@@ -2378,16 +2367,11 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
 "qJ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Security Airlock";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "qM" = (
@@ -2575,13 +2559,6 @@
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"sf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "sh" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -2603,13 +2580,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"sp" = (
-/obj/machinery/advanced_airlock_controller/lavaland{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "ss" = (
 /obj/docking_port/stationary{
 	dwidth = 6;
@@ -3236,14 +3206,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"wZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer4,
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "xl" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -4346,15 +4308,10 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
 "FR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "FS" = (
@@ -4413,11 +4370,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
-"Gx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "GB" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -4589,9 +4541,6 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/production)
 "HC" = (
@@ -4849,12 +4798,6 @@
 /obj/item/target/clown,
 /turf/open/floor/plasteel,
 /area/mine/science)
-"Jk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "Jm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -5138,17 +5081,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"KU" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Security Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "KX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
@@ -5427,9 +5359,13 @@
 /turf/closed/wall/r_wall,
 /area/mine/production)
 "NE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "NF" = (
@@ -5768,15 +5704,9 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "Qj" = (
-/obj/machinery/advanced_airlock_controller/lavaland{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer4,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "Qm" = (
@@ -5988,9 +5918,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp/security)
 "RN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Security Airlock";
 	req_access_txt = "2"
@@ -6137,7 +6064,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/production)
 "SY" = (
@@ -6818,14 +6744,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/eva)
 "Xy" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "Xz" = (
@@ -6902,11 +6825,6 @@
 "XX" = (
 /turf/closed/wall,
 /area/mine/storage)
-"XY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
 "XZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6959,8 +6877,6 @@
 /turf/open/floor/plasteel/checker,
 /area/mine/living_quarters)
 "Yq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
@@ -32661,7 +32577,7 @@ Xy
 Qj
 FR
 gH
-XY
+np
 NE
 rw
 jA
@@ -33686,11 +33602,11 @@ fM
 fM
 fM
 jG
-wZ
+Qj
 qJ
-Jk
-sf
-Gx
+uI
+np
+Cb
 rw
 VM
 Iq
@@ -33942,11 +33858,11 @@ fM
 fM
 fM
 fM
-KU
-sp
+jG
+tL
 RN
 uI
-qZ
+nE
 bO
 CL
 zc

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -596,11 +596,8 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "eD" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland,
 /area/mine/laborcamp)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -797,14 +794,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"fV" = (
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_access_txt = "54"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/eva)
 "fX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -1746,10 +1735,11 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "lu" = (
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/poddoor/shutters{
 	id = "lavasci"
 	},
+/obj/effect/turf_decal/stripes/closeup,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/science)
 "lv" = (
@@ -1901,12 +1891,13 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "mH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp)
+/turf/open/floor/plasteel/techmaint,
+/area/mine/eva)
 "mK" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -1952,14 +1943,11 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "mW" = (
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Labor Camp External Access"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
+/turf/open/floor/plasteel,
+/area/mine/science)
 "nf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -2674,10 +2662,11 @@
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "sM" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/ore_box,
-/turf/open/floor/plating/lavaland,
-/area/lavaland/surface/outdoors/explored)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "sR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -3172,8 +3161,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/lavaland,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "wz" = (
 /obj/effect/spawner/structure/window,
@@ -3588,6 +3580,15 @@
 "Am" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
+"An" = (
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Labor Camp External Access"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "Ap" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -3729,12 +3730,6 @@
 /obj/structure/fence,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"Br" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/laborcamp)
 "Bx" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile{
@@ -4040,12 +4035,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"DE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/science)
 "DF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4799,9 +4788,18 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "IZ" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/glass{
+	name = "Labor Camp External Access"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
+"Ja" = (
+/obj/effect/turf_decal/bot,
 /obj/structure/ore_box,
-/turf/open/floor/plasteel,
-/area/mine/eva)
+/turf/open/floor/plating/lavaland,
+/area/lavaland/surface/outdoors/explored)
 "Je" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -4968,14 +4966,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"JZ" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/eva)
 "Kb" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -5418,6 +5408,18 @@
 /obj/machinery/light/small,
 /turf/open/floor/carpet/blue,
 /area/mine/living_quarters)
+"Nv" = (
+/obj/machinery/camera{
+	c_tag = "Labor Camp External";
+	dir = 10;
+	network = list("labor")
+	},
+/obj/structure/closet/emcloset,
+/mob/living/simple_animal/bot/atmosbot{
+	name = "Officer Fastmosky"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "Nz" = (
 /obj/machinery/rnd/experimentor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5673,6 +5675,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/science)
 "Pm" = (
@@ -5690,12 +5693,11 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
 "PJ" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/glass{
-	name = "Labor Camp External Access"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/techmaint,
+/obj/machinery/light/small,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/laborcamp)
 "PK" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -6177,10 +6179,12 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "Te" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station EVA";
+	req_access_txt = "54"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
 "Th" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -6986,14 +6990,8 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "YB" = (
-/obj/machinery/camera{
-	c_tag = "Labor Camp External";
-	dir = 10;
-	network = list("labor")
-	},
-/obj/structure/closet/emcloset,
-/mob/living/simple_animal/bot/atmosbot{
-	name = "Officer Fastmosky"
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
@@ -7230,6 +7228,10 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ZR" = (
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "ZT" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/grid/steel,
@@ -29572,10 +29574,10 @@ Vd
 bz
 Vb
 Vb
-mH
+PJ
 rw
-wv
-wv
+eD
+eD
 rw
 xT
 xT
@@ -29830,9 +29832,9 @@ qg
 fM
 fM
 fM
-PJ
+IZ
 tL
-YB
+Nv
 rw
 xT
 xT
@@ -30084,12 +30086,12 @@ xT
 xT
 Vd
 qg
-sM
+Ja
 ID
 ID
-wv
+eD
 tL
-Br
+YB
 BZ
 BZ
 CL
@@ -30345,7 +30347,7 @@ CL
 BZ
 BZ
 BZ
-mW
+An
 BZ
 BZ
 jK
@@ -30603,7 +30605,7 @@ NQ
 By
 np
 DB
-eD
+wv
 ZC
 np
 DB
@@ -39072,16 +39074,16 @@ Zd
 Zd
 Zd
 Zd
-JZ
+mH
 gM
 wa
-fV
+Te
 Sf
 iu
 Sf
 Sf
 Rr
-fV
+Te
 CF
 gf
 Yq
@@ -39590,10 +39592,10 @@ Fd
 qi
 PR
 Fd
-IZ
+ZR
 SE
 Mi
-Te
+sM
 kK
 Zt
 CF
@@ -51149,7 +51151,7 @@ OE
 rL
 Gh
 iU
-DE
+mW
 KR
 mp
 Jt

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -950,9 +950,11 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "gM" = (
-/obj/structure/ore_box,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
@@ -1285,8 +1287,6 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "iU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/mine/science)
 "iV" = (
@@ -1321,8 +1321,8 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Station"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
 "jd" = (
@@ -1336,12 +1336,14 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "je" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "jh" = (
@@ -1614,12 +1616,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
+/obj/structure/table,
+/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "kL" = (
@@ -1892,15 +1896,13 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "mH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station"
 	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
-/area/mine/laborcamp)
+/turf/open/floor/plasteel/techmaint,
+/area/mine/eva)
 "mK" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -1946,11 +1948,11 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "mW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/explored)
+/turf/open/floor/plasteel,
+/area/mine/science)
 "nf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -2330,15 +2332,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "qi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
 /mob/living/simple_animal/bot/atmosbot{
 	name = "Officer Fastmosky"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
 "qj" = (
@@ -2587,11 +2587,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "sj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
@@ -2667,15 +2667,8 @@
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
 "sM" = (
-/obj/machinery/camera{
-	c_tag = "Labor Camp External";
-	dir = 9;
-	network = list("labor")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/lavaland,
 /area/mine/laborcamp)
 "sR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2728,12 +2721,12 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
 "ty" = (
-/obj/machinery/door/airlock/external{
-	name = "Science Outpost Airlock";
-	req_access_txt = "47"
-	},
 /obj/effect/turf_decal/stripes/closeup,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	req_access_txt = "47";
+	name = "Science Outpost Airlock"
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/science)
 "tz" = (
@@ -2919,6 +2912,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/laborcamp)
+"uJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/mine/laborcamp)
 "uK" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -2935,6 +2935,12 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plasteel,
 /area/mine/science)
+"uQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "uR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -3051,11 +3057,7 @@
 /turf/open/floor/wood,
 /area/mine/living_quarters)
 "vL" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
 "vM" = (
@@ -3117,11 +3119,10 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "wa" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
 	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
@@ -3176,10 +3177,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "wv" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "wz" = (
 /obj/effect/spawner/structure/window,
@@ -3190,9 +3192,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "wB" = (
@@ -3886,14 +3886,13 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/storage)
 "CD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "CF" = (
@@ -4389,16 +4388,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)
+"Gg" = (
+/obj/machinery/door/airlock{
+	name = "Labor Camp External Access"
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "Gh" = (
+/obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/external{
 	name = "Science Outpost Airlock";
 	req_access_txt = "47"
-	},
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/mine/science)
@@ -4801,10 +4801,10 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "IZ" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/techmaint,
-/area/mine/science)
+/obj/effect/turf_decal/bot,
+/obj/structure/ore_box,
+/turf/open/floor/plating/lavaland,
+/area/lavaland/surface/outdoors/explored)
 "Je" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -5260,11 +5260,9 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "LP" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
 "LW" = (
@@ -5560,7 +5558,6 @@
 	created_name = "Fastmosky Senior";
 	name = "old atmosbot assembly"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/science)
 "OH" = (
@@ -5688,11 +5685,12 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/mine/laborcamp)
 "PJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station EVA";
+	req_access_txt = "54"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
 "PK" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -5737,10 +5735,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/machinery/advanced_airlock_controller/lavaland{
-	dir = 8;
-	pixel_x = 26
 	},
 /turf/open/floor/noslip/dark,
 /area/mine/eva)
@@ -5940,11 +5934,6 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "Rr" = (
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
@@ -6183,11 +6172,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "Te" = (
-/obj/machinery/advanced_airlock_controller/lavaland{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/mine/science)
+/obj/structure/ore_box,
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "Th" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -6534,11 +6521,6 @@
 	name = "Mining Station EVA";
 	req_access_txt = "54"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/plasteel/techmaint,
 /area/mine/eva)
@@ -6997,8 +6979,14 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "YB" = (
-/turf/open/floor/plating,
-/area/lavaland/surface/outdoors/explored)
+/obj/machinery/camera{
+	c_tag = "Labor Camp External";
+	dir = 10;
+	network = list("labor")
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/techmaint,
+/area/mine/laborcamp)
 "YC" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -7093,10 +7081,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "Zd" = (
@@ -7115,6 +7103,12 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
+"Zi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/mine/eva)
 "Zl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -29571,14 +29565,14 @@ xT
 xT
 xT
 Vd
-xT
 bz
 Vb
 Vb
-Vb
-Vb
-Vb
-mW
+uJ
+rw
+sM
+sM
+rw
 xT
 xT
 xT
@@ -29828,14 +29822,14 @@ xT
 xT
 xT
 Vd
-xT
 qg
 fM
 fM
 fM
+Gg
+tL
 YB
-YB
-sM
+rw
 xT
 xT
 xT
@@ -30085,13 +30079,13 @@ xT
 xT
 xT
 Vd
-xT
 qg
+IZ
 ID
 ID
-ID
-wv
-YB
+sM
+tL
+uQ
 BZ
 BZ
 CL
@@ -30347,8 +30341,8 @@ CL
 BZ
 BZ
 BZ
-BZ
 eD
+BZ
 BZ
 jK
 ZK
@@ -30604,8 +30598,8 @@ mB
 NQ
 By
 np
-mH
-np
+DB
+wv
 ZC
 np
 DB
@@ -39074,16 +39068,16 @@ Zd
 Zd
 Zd
 Zd
-Fd
+mH
 gM
 wa
-Fd
+PJ
+Sf
 iu
 Sf
 Sf
-Sf
 Rr
-Zt
+PJ
 CF
 gf
 Yq
@@ -39335,7 +39329,7 @@ jb
 LP
 vL
 VK
-PJ
+Sf
 CD
 YX
 je
@@ -39592,10 +39586,10 @@ Fd
 qi
 PR
 Fd
-Sf
+Te
 SE
 Mi
-Sf
+Zi
 kK
 Zt
 CF
@@ -50889,7 +50883,7 @@ Zd
 Zd
 Zd
 Zd
-jh
+mp
 rL
 pI
 jh
@@ -51148,10 +51142,10 @@ Zd
 Zd
 ty
 OE
-IZ
+rL
 Gh
 iU
-kk
+mW
 KR
 mp
 Jt
@@ -51403,8 +51397,8 @@ Zd
 Zd
 Zd
 Zd
-jh
-Te
+mp
+rL
 BC
 jh
 NB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes all the airlocks on the lavaland mining base to use tiny fans, and adds a second set of doors to mining's EVA access.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It resolves #9419, which shows the issue of prisoners being exposed to 0kPa pressures.

Plus, makes it so that miners are less likely to break the glass due to the airlock cycling impeding in their job.

Additionally, due to the limited atmospherics setup of the base, the airlocks would also consume all the air in the base distro after only a few uses of the airlock- this mitigates that

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots: Mining EVA</summary>

- Now double wide
- Changed over from AC to tiny fan!
   - Should discourage miners from breaking the glass every single round just to do their job.

![Mining EVA](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/0c811e24-dc32-46e3-bd9e-7506f4428af0)

</details>
<details>
<summary>Screenshot: Mining Shuttle Dock</summary>

- Changed over from AC to tiny fan!
![Mining Shuttle Dock](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/d8aaa954-e711-4e24-a235-ddd6daa5276e)

</details>
<details>
<summary>Screenshots: Labor Camp External Access</summary>

- Expanded and made more open.
- Also now has its own atmosbot Seargent Airhead.
- Changed over from AC to tiny fan!
![Labor Camp External Access](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/b9206554-40d6-49a1-8666-1f3207595704)

</details>
<details>
<summary>Screenshot: Labor Shuttle Dock</summary>

- Changed over from AC to tiny fan!
- Also changed the decal under the lockdown door from stripes to "Stand Clear"

![Labor Shuttle Dock](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/db1e0979-0f61-4b03-8cb2-1de7846710b2)

</details>
<details>
<summary>Screenshots: Science Outpost Airlock</summary>

- Added glass to the exterior side
- Changed over from AC to tiny fan!
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/e7ab535b-d029-4696-a822-6cfb205d9ef0)
(Yes, this spider would get aggressive if I used glass on the inside airlock door)
![Science Outpost Airlock](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/9563dc14-ffdc-4170-9bc7-43dd1b0e0d93)

</details>
<details>
<summary>Screenshot: Science Shuttle Dock</summary>

- Added fans under the shutters, since apparently there wasn't any under those before.

![Science Shuttle Dock](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/f82fc9d9-5d30-4a1b-98e6-14d305d86e91)

</details>

More details of the map change available from MapDiffBot2 below

## Changelog
:cl:
tweak: Reworked all of Lavaland Mining Station Airlocks to use Tiny Fans instead of Airlock Controllers.
tweak: Mining EVA now has wider doorways, and moved Officer Fastmosky to inside the emergency locker.
tweak: Lavaland's Laborcamp External Access now has its own atmosbot (Sergeant Airhead) inside an emergency locker.
tweak: Put tiny fans under the shutters at the Science Shuttle Dock on Lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
