### PR TITLE
Morph UI search + food digesting

### DIFF
--- a/code/modules/antagonists/morph/morph_stomach.dm
+++ b/code/modules/antagonists/morph/morph_stomach.dm
@@ -1,8 +1,14 @@
+/// The max amount of health a morph can heal from food, as a percentage of the morph's maximum health.
+#define MORPH_MAX_HEALING_FROM_FOOD		0.2
+/// How long it takes for "food healed amt" to decay.
+#define MORPH_FOOD_HEALING_DECAY_TIME	2.5 MINUTES
+
 /datum/morph_stomach
 	var/name = "morph stomach"
 	var/mob/living/simple_animal/hostile/morph/morph
 	var/list/base64_cache = list()
 	var/list/favorites = list()
+	var/food_healed = 0
 
 /datum/morph_stomach/New(my_morph)
 	. = ..()
@@ -12,8 +18,11 @@
 	morph = null
 	. = ..()
 
+/datum/morph_stomach/ui_host(mob/user)
+	return morph
+
 /datum/morph_stomach/ui_state(mob/user)
-	return GLOB.always_state
+	return GLOB.self_state
 
 /datum/morph_stomach/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, morph, ui)
@@ -26,33 +35,33 @@
 	var/list/data_contents = list()
 	var/list/data_living = list()
 	var/list/data_items = list()
-	for(var/atom/movable/A in morph.contents)
-		if(!isliving(A) && !isitem(A))
+	for(var/atom/movable/consumed in morph.contents)
+		if(!isliving(consumed) && !isitem(consumed))
 			continue
 		var/list/element = list()
-		element["living"] = isliving(A)
-		element["name"] = A.name
-		element["id"] = REF(A)
+		element["living"] = isliving(consumed)
+		element["name"] = consumed.name
+		element["id"] = REF(consumed)
 		element["favorite"] = favorites.Find(element["id"])
 		element["digestable"] = TRUE
 		var/base64 = null
-		var/icon_state_temp = A.icon_state_preview || A.icon_state
+		var/icon_state_temp = consumed.icon_state_preview || consumed.icon_state
 		if(icon_state_temp == "" || icon_state_temp == null)
-			if("[A.icon]" == "icons/mob/human.dmi")
+			if("[consumed.icon]" == "icons/mob/human.dmi")
 				icon_state_temp = "ghost"
 		if(icon_state_temp != "" && icon_state_temp != null)
-			var/icon_key = "[A.icon]-[icon_state_temp]"
+			var/icon_key = "[consumed.icon]-[icon_state_temp]"
 			if(base64_cache[icon_key] != null)
 				base64 = base64_cache[icon_key]
 			else
-				base64 = icon2base64(icon(A.icon, icon_state_temp, frame=1, dir=SOUTH))
+				base64 = icon2base64(icon(consumed.icon, icon_state_temp, frame=1, dir=SOUTH))
 				base64_cache[icon_key] = base64
 			element["img"] = base64
-		if(isliving(A))
+		if(isliving(consumed))
 			data_living[element["id"]] = element
-		else if(isitem(A))
-			var/obj/item/I = A
-			element["digestable"] = !(I.resistance_flags & UNACIDABLE) && !(I.resistance_flags & ACID_PROOF) && !(I.resistance_flags & INDESTRUCTIBLE)
+		else if(isitem(consumed))
+			var/obj/item/item = consumed
+			element["digestable"] = !(item.resistance_flags & (UNACIDABLE | ACID_PROOF | INDESTRUCTIBLE))
 			data_items[element["id"]] = element
 	data_contents["living"] = data_living
 	data_contents["items"] = data_items
@@ -64,25 +73,21 @@
 	if(..())
 		return
 	var/ref = params["id"]
-	var/atom/movable/target = null
-	for(var/atom/movable/A in morph.contents)
-		if(REF(A) == ref)
-			target = A
-			break
-	if(target == null || (!isliving(target) && !isitem(target)))
+	var/atom/movable/target = locate(ref) in morph.contents
+	if(!target || (!isliving(target) && !isitem(target)))
 		return
 	switch(action)
 		if("drop")
 			morph.RemoveContents(target)
-			morph.visible_message("<span class='warning'>[morph] spits [target] out!</span>")
-			playsound(morph, 'sound/effects/splat.ogg', 50, 1)
+			morph.visible_message("<span class='warning'>[morph] spits <span class='name'>[target]</span> out!</span>")
+			playsound(morph, 'sound/effects/splat.ogg', vol = 50, vary = TRUE)
 			return TRUE
 		if("disguise")
 			morph.ShiftClickOn(target)
 			return FALSE
 		if("throw")
 			morph.throwatom = target
-			to_chat(morph, "<span class='danger'>You prepare to throw [target]</span>")
+			to_chat(morph, "<span class='danger'>You prepare to throw <span class='name'>[target]</span></span>")
 			return TRUE
 		if("unthrow")
 			morph.throwatom = null
@@ -94,53 +99,76 @@
 				favorites += ref
 			return TRUE
 	if(isliving(target))
-		var/mob/living/L = target
+		var/mob/living/living_target = target
 		switch(action)
 			if("digest")
-				if(HAS_TRAIT(L, TRAIT_HUSK))
-					to_chat(morph, "<span class='warning'>[L] has already been stripped of all nutritional value!</span>")
+				if(HAS_TRAIT(living_target, TRAIT_HUSK))
+					to_chat(morph, "<span class='warning'><span class='name'>[living_target]</span> has already been stripped of all nutritional value!</span>")
 					return FALSE
-				if(morph.throwatom == L)
+				if(morph.throwatom == living_target)
 					morph.throwatom = null
-				to_chat(morph, "<span class='danger'>You begin digesting [L]</span>")
-				if(do_after(morph, L.maxHealth))
-					if(ishuman(L) || ismonkey(L) || isalienadult(L) || istype(L, /mob/living/simple_animal/pet/dog) || istype(L, /mob/living/simple_animal/parrot))
+				to_chat(morph, "<span class='danger'>You begin digesting <span class='name'>[living_target]</span></span>")
+				if(do_after(morph, living_target.maxHealth))
+					if(ishuman(living_target) || ismonkey(living_target) || isalienadult(living_target) || istype(living_target, /mob/living/simple_animal/pet/dog) || istype(living_target, /mob/living/simple_animal/parrot))
 						var/list/turfs_to_throw = view(2, morph)
-						for(var/obj/item/I in L.contents)
-							L.dropItemToGround(I, TRUE)
-							if(QDELING(I))
+						for(var/obj/item/item in living_target.contents)
+							living_target.dropItemToGround(item, TRUE)
+							if(QDELING(item))
 								continue //skip it
-							I.throw_at(pick(turfs_to_throw), 3, 1, spin = FALSE)
-							I.pixel_x = rand(-10, 10)
-							I.pixel_y = rand(-10, 10)
-					morph.RemoveContents(L)
-					L.death(0)
-					L.apply_damage(50, BURN)
-					L.become_husk()
-					morph.adjustHealth(-(L.maxHealth / 2))
-					to_chat(morph, "<span class='danger'>You digest [L], restoring some health</span>")
-					playsound(morph, 'sound/effects/splat.ogg', 50, 1)
+							item.throw_at(pick(turfs_to_throw), 3, 1, spin = FALSE)
+							item.pixel_x = rand(-10, 10)
+							item.pixel_y = rand(-10, 10)
+					morph.RemoveContents(living_target)
+					living_target.death(FALSE)
+					living_target.take_overall_damage(burn = 50)
+					living_target.become_husk("burn") // Digested bodies can be fixed with synthflesh.
+					morph.adjustHealth(-(living_target.maxHealth * 0.5))
+					to_chat(morph, "<span class='danger'>You digest <span class='name'>[living_target]</span>, restoring some health</span>")
+					playsound(morph, 'sound/effects/splat.ogg', vol = 50, vary = TRUE)
 					return TRUE
 	else if(isitem(target))
-		var/obj/item/I = target
+		var/obj/item/item = target
 		switch(action)
 			if("use")
-				I.attack_self(morph)
+				item.attack_self(morph)
 			if("usethrow")
-				morph.throwatom = I
-				to_chat(morph, "<span class='danger'> You prepare to throw [I]</span>")
-				I.attack_self(morph)
+				morph.throwatom = item
+				to_chat(morph, "<span class='danger'>You prepare to throw [item]</span>")
+				item.attack_self(morph)
 				return TRUE
 			if("digest")
-				if(morph.throwatom == I)
+				if(morph.throwatom == item)
 					morph.throwatom = null
-				if((I.resistance_flags & UNACIDABLE) || (I.resistance_flags & ACID_PROOF) || (I.resistance_flags & INDESTRUCTIBLE))
-					to_chat(morph, "<span class='danger'>[I] cannot be digested.</span>")
+				if(item.resistance_flags & (ACID_PROOF | UNACIDABLE | INDESTRUCTIBLE))
+					to_chat(morph, "<span class='danger'>[item] cannot be digested.</span>")
 				else
-					playsound(morph, 'sound/items/welder.ogg', 150, 1)
-					qdel(I)
-					to_chat(morph, "<span class='danger'>You digest [I].</span>")
+					if(item.reagents?.total_volume)
+						var/nutriment_healing = clamp(CEILING(item.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment) * 0.4, 1), 0, 5)
+						var/vitamin_healing = clamp(CEILING(item.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment/vitamin) * 0.6, 1), 0, 5)
+						if(max(nutriment_healing, vitamin_healing) <= 0)
+							to_chat(morph, "<span class='warning'>There are not enough nutrients in [item] to heal from it!</span>")
+						else
+							var/max_heal_amt = round(morph.maxHealth * MORPH_MAX_HEALING_FROM_FOOD)
+							var/left_to_heal = max_heal_amt - food_healed
+							if(left_to_heal <= 0)
+								to_chat(morph, "<span class='warning'>You cannot heal any more from food at the moment!</span>")
+								return TRUE
+							var/amt_healed = min(nutriment_healing + vitamin_healing, left_to_heal)
+							if(amt_healed > 0)
+								morph.adjustHealth(-amt_healed)
+								food_healed += amt_healed
+								addtimer(CALLBACK(src, PROC_REF(food_healing_decay_timer), amt_healed), MORPH_FOOD_HEALING_DECAY_TIME)
+								playsound(morph, 'sound/items/eatfood.ogg', vol = 150, vary = TRUE)
+								qdel(item)
+								to_chat(morph, "<span class='danger'>You digest [item], regaining a small bit of health from its nutrients!</span>")
+								return TRUE
+					playsound(morph, 'sound/items/welder.ogg', vol = 150, vary = TRUE)
+					qdel(item)
+					to_chat(morph, "<span class='danger'>You digest [item].</span>")
 					return TRUE
+
+/datum/morph_stomach/proc/food_healing_decay_timer(amt)
+	food_healed = max(food_healed - amt, 0)
 
 /datum/action/innate/morph_stomach
 	name = "Stomach Contents"
@@ -158,3 +186,6 @@
 
 /datum/action/innate/morph_stomach/Activate()
 	morph_stomach.ui_interact(owner)
+
+#undef MORPH_FOOD_HEALING_DECAY_TIME
+#undef MORPH_MAX_HEALING_FROM_FOOD

--- a/tgui/packages/tgui/interfaces/Morph.js
+++ b/tgui/packages/tgui/interfaces/Morph.js
@@ -1,7 +1,7 @@
 import { createSearch } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
-import { Input, Button, Section, Tabs, LabeledList } from '../components';
+import { Input, Button, Section, Tabs, LabeledList, Box, Icon } from '../components';
 
 export const Morph = (_props, _context) => {
   return (
@@ -26,7 +26,16 @@ const MorphContents = (_props, context) => {
   return (
     <Section
       title="Morph Stomach"
-      buttons={<Input value={searchText} onInput={(_, value) => setSearchText(value)} placeholder={'Search...'} mr={1} />}>
+      buttons={
+        <>
+          <Box inline>
+            <Icon name="search" mr={1} />
+          </Box>
+          <Box inline>
+            <Input placeholder="Search..." width="200px" value={searchText} onInput={(_, value) => setSearchText(value)} />
+          </Box>
+        </>
+      }>
       <Tabs>
         <Tabs.Tab selected={tab === 'living'} onClick={() => setTab('living')}>
           Mobs ({Object.keys(data.contents.living).length})

--- a/tgui/packages/tgui/interfaces/Morph.js
+++ b/tgui/packages/tgui/interfaces/Morph.js
@@ -3,7 +3,7 @@ import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
 import { Input, Button, Section, Tabs, LabeledList, Box, Icon } from '../components';
 
-export const Morph = (_props, _context) => {
+export const Morph = () => {
   return (
     <Window theme="generic" width={650} height={650}>
       <Window.Content scrollable>
@@ -64,7 +64,7 @@ const MorphContents = (_props, context) => {
   );
 };
 
-const MorphItem = ({ name, id, img, living, favorite, digestable, throw_ref }, context) => {
+const MorphItem = ({ name, id, img, living, favorite, digestable, throw_ref }) => {
   return (
     <LabeledList.Item
       label={

--- a/tgui/packages/tgui/interfaces/Morph.js
+++ b/tgui/packages/tgui/interfaces/Morph.js
@@ -1,8 +1,9 @@
+import { createSearch } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
-import { Box, Button, Section, Tabs, LabeledList } from '../components';
+import { Input, Button, Section, Tabs, LabeledList } from '../components';
 
-export const Morph = (props, context) => {
+export const Morph = (_props, _context) => {
   return (
     <Window theme="generic" width={650} height={650}>
       <Window.Content scrollable>
@@ -12,14 +13,20 @@ export const Morph = (props, context) => {
   );
 };
 
-const MorphContents = (props, context) => {
+const MorphContents = (_props, context) => {
   const { data } = useBackend(context);
   const [tab, setTab] = useLocalState(context, 'tab', 'living');
+  const [searchText, setSearchText] = useLocalState(context, 'searchText', '');
   const favorites = Object.values(data.contents.living)
     .concat(Object.values(data.contents.items))
     .filter((A) => A.favorite);
+  const stomachSearch = createSearch(searchText, (item) => {
+    return item.name;
+  });
   return (
-    <Section title="Morph Stomach">
+    <Section
+      title="Morph Stomach"
+      buttons={<Input value={searchText} onInput={(_, value) => setSearchText(value)} placeholder={'Search...'} mr={1} />}>
       <Tabs>
         <Tabs.Tab selected={tab === 'living'} onClick={() => setTab('living')}>
           Mobs ({Object.keys(data.contents.living).length})
@@ -33,9 +40,11 @@ const MorphContents = (props, context) => {
       </Tabs>
       <LabeledList>
         {tab === 'favorites' ? (
-          favorites.map((A) => <MorphItem key={A.id} throw_ref={data.throw_ref} {...A} />)
+          favorites.filter(stomachSearch).map((A) => <MorphItem key={A.id} throw_ref={data.throw_ref} {...A} />)
         ) : data.contents[tab] ? (
-          Object.values(data.contents[tab]).map((A) => <MorphItem key={A.id} throw_ref={data.throw_ref} {...A} />)
+          Object.values(data.contents[tab])
+            .filter(stomachSearch)
+            .map((A) => <MorphItem key={A.id} throw_ref={data.throw_ref} {...A} />)
         ) : (
           <span>
             <strong>Your stomach is empty!</strong>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a search bar to the morph stomach UI, and allows morphs to digest food items for small amounts of healing. Said healing is rather small, and is _capped_ - a morph can only heal 20% of its max health over the course of 2.5 minutes using food (this can be nerfed further if needed).

Also, morph digestion victims can now be properly fixed with synthflesh or rezadone.

## Why It's Good For The Game

Searching through items is _very_ useful when you've eaten like 500 things.

Food digesting gives morphs a way to patch minor wounds without having to waste a monkey or station pet on it.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/6b8037e0-5d11-4161-8261-6ab5983a0abf)


**[VIDEO HAS OLD SEARCH BAR]**
https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/77650c7a-211e-42cf-894d-c667f7c49842



</details>

## Changelog
:cl:
add: Added a search bar to the morph stomach UI.
add: Morphs can now digest nutritious food to recover small amounts of health, however this healing is capped - a morph can only recover up to 20% of its health over the course of 2.5 minutes by digesting food.
tweak: Being husked by morph digestion is now considered a burn husk, meaning that synthflesh or rezadone can fix morph digestion victims.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
