### PR TITLE
[CRITICAL BUGFIX] You can no longer get stuck upon late join: Antag Rollers edition

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -669,9 +669,10 @@ SUBSYSTEM_DEF(job)
 	M.forceMove(get_turf(src))
 
 /obj/structure/chair/JoinPlayerHere(mob/M, buckle)
-	// Placing a mob in a chair will attempt to buckle it
+	// Placing a mob in a chair will attempt to buckle it if buckle is set
 	..()
-	buckle_mob(M, FALSE, FALSE)
+	if (buckle)
+		buckle_mob(M, TRUE, FALSE)
 
 /datum/controller/subsystem/job/proc/SendToLateJoin(mob/M, buckle = TRUE)
 	var/atom/destination

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -672,7 +672,7 @@ SUBSYSTEM_DEF(job)
 	// Placing a mob in a chair will attempt to buckle it if buckle is set
 	..()
 	if (buckle)
-		buckle_mob(M, TRUE, FALSE)
+		buckle_mob(M, FALSE, FALSE)
 
 /datum/controller/subsystem/job/proc/SendToLateJoin(mob/M, buckle = TRUE)
 	var/atom/destination

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -669,10 +669,9 @@ SUBSYSTEM_DEF(job)
 	M.forceMove(get_turf(src))
 
 /obj/structure/chair/JoinPlayerHere(mob/M, buckle)
-	// Placing a mob in a chair will attempt to buckle it, or else fall back to default.
-	if (buckle && isliving(M) && buckle_mob(M, FALSE, FALSE))
-		return
+	// Placing a mob in a chair will attempt to buckle it
 	..()
+	buckle_mob(M, FALSE, FALSE)
 
 /datum/controller/subsystem/job/proc/SendToLateJoin(mob/M, buckle = TRUE)
 	var/atom/destination


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This resolves the longstanding issue of people being trapped in the lobby as a living mob.


The title of #9399 describes the issue- however it details a runtime that seems to be possible happen when joining (so this by no mean closes that)

**A great deal of thanks to `potentiallytaylor` on the bee-cord for helping find the cause of this issue!**



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Other people shouldn't suffer because someone didn't roll an antag they wanted.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->



## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Apparently, all you need to do is this to block anyone from making it on the shuttle:

Just put a bunch of naked people on the shuttle :trollface:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/a8587aa2-eb6f-426e-a1c3-5d163c7b102f)
**Note: All occupants must be unbuckled, and on top of a seat for this to happen.**

And the fix? ~~Removing an `if` statement~~ Moving some code around which results in even simpler code, because sanity checks are already handled lower down.

This is a video of the fix working in action:

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/54ce89d6-7e3e-4bdd-939c-86b63a32751c

</details>

## Changelog
:cl:
fix: You can no longer get stuck in the lobby upon latejoining if someone unbuckled and stayed on top of a seat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
