### PR TITLE
You can milk anything.

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -636,6 +636,7 @@
 #include "code\datums\components\tether.dm"
 #include "code\datums\components\thermite.dm"
 #include "code\datums\components\twohanded.dm"
+#include "code\datums\components\udder.dm"
 #include "code\datums\components\uplink.dm"
 #include "code\datums\components\waddling.dm"
 #include "code\datums\components\wearertargeting.dm"

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -130,7 +130,7 @@
 		return
 	if(udder_mob.gender == FEMALE)
 		START_PROCESSING(SSobj, src)
-	RegisterSignal(udder_mob, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, PROC_REF(on_mob_attacking))
+	RegisterSignal(udder_mob, COMSIG_HOSTILE_ATTACKINGTARGET, PROC_REF(on_mob_attacking))
 
 /obj/item/udder/gutlunch/Destroy()
 	. = ..()

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -1,0 +1,164 @@
+/**
+ * Udder component; for farm animals to generate milk.
+ *
+ * Used for cows, goats, gutlunches. neat!
+ */
+/datum/component/udder
+	///abstract item for managing reagents (further down in this file)
+	var/obj/item/udder/udder
+	///optional proc to callback to when the udder is milked
+	var/datum/callback/on_milk_callback
+
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, on_milk_callback, on_generate_callback)
+	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
+		return COMPONENT_INCOMPATIBLE
+	udder = new udder_type(null, parent)
+	src.on_milk_callback = on_milk_callback
+
+/datum/component/udder/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/on_attackby)
+
+/datum/component/udder/UnregisterFromParent()
+	QDEL_NULL(udder)
+	UnregisterSignal(parent, list(COMSIG_PARENT_EXAMINE, COMSIG_PARENT_ATTACKBY))
+
+///signal called on parent being examined
+/datum/component/udder/proc/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	var/mob/living/milked = parent
+	if(milked.stat != CONSCIOUS)
+		return //come on now
+
+	var/udder_filled_percentage = PERCENT(udder.reagents.total_volume / udder.reagents.maximum_volume)
+	switch(udder_filled_percentage)
+		if(0 to 10)
+			examine_list += "<span class='notice'>[parent]'s [udder] is dry.</span>"
+		if(11 to 99)
+			examine_list += "<span class='notice'>[parent]'s [udder] can be milked if you have something to contain it.</span>"
+		if(100)
+			examine_list += "<span class='notice'>[parent]'s [udder] is round and full, and can be milked if you have something to contain it.</span>"
+
+
+///signal called on parent being attacked with an item
+/datum/component/udder/proc/on_attackby(datum/source, obj/item/milking_tool, mob/user)
+	SIGNAL_HANDLER
+
+	var/mob/living/milked = parent
+	if(milked.stat == CONSCIOUS && istype(milking_tool, /obj/item/reagent_containers/glass))
+		udder.milk(milking_tool, user)
+		if(on_milk_callback)
+			on_milk_callback.Invoke(udder.reagents.total_volume, udder.reagents.maximum_volume)
+		return COMPONENT_NO_AFTERATTACK
+
+/**
+ * # udder item
+ *
+ * Abstract item that is held in nullspace and manages reagents. Created by udder component.
+ * While perhaps reagents created by udder component COULD be managed in the mob, it would be somewhat finnicky and I actually like the abstract udders.
+ */
+/obj/item/udder
+	name = "udder"
+	///how much the udder holds
+	var/size = 50
+	///mob that has the udder component
+	var/mob/living/udder_mob
+	///optional proc to callback to when the udder generates milk
+	var/datum/callback/on_generate_callback
+
+/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback)
+	src.udder_mob = udder_mob
+	src.on_generate_callback = on_generate_callback
+	create_reagents(size/*, REAGENT_HOLDER_ALIVE*/)
+	initial_conditions()
+	. = ..()
+
+/obj/item/udder/Destroy()
+	. = ..()
+	STOP_PROCESSING(SSobj, src)
+
+/obj/item/udder/process(delta_time)
+	if(udder_mob.stat != DEAD)
+		generate() //callback is on generate() itself as sometimes generate does not add new reagents, or is not called via process
+
+/**
+ * # initial_conditions
+ *
+ * Proc called on creation separate from the reagent datum creation to allow for signalled milk generation instead of processing milk generation
+ * also useful for changing initial amounts in reagent holder (cows start with milk, gutlunches start empty)
+ */
+/obj/item/udder/proc/initial_conditions()
+	reagents.add_reagent(/datum/reagent/consumable/milk, 20)
+	START_PROCESSING(SSobj, src)
+
+/**
+ * # generate
+ *
+ * Proc called every 2 seconds from SSMobs to add whatever reagent the udder is generating.
+ */
+/obj/item/udder/proc/generate()
+	if(prob(5))
+		reagents.add_reagent(/datum/reagent/consumable/milk, rand(5, 10))
+		if(on_generate_callback)
+			on_generate_callback.Invoke(reagents.total_volume, reagents.maximum_volume)
+
+/**
+ * # milk
+ *
+ * Proc called from attacking the component parent with the correct item, moves reagents into the glass basically.
+ */
+/obj/item/udder/proc/milk(obj/item/reagent_containers/glass/milk_holder, mob/user)
+	if(milk_holder.reagents.total_volume >= milk_holder.volume)
+		to_chat(user, "<span class='warning'>[milk_holder] is full.</span>")
+		return
+	var/transfered = reagents.trans_to(milk_holder, rand(5,10))
+	if(transfered)
+		user.visible_message("<span class='notice'>[user] milks [src] using \the [milk_holder].</span>", "<span class='notice'>You milk [src] using \the [milk_holder].</span>")
+	else
+		to_chat(user, "<span class='warning'>The udder is dry. Wait a bit longer...</span>")
+
+/**
+ * # gutlunch udder subtype
+ *
+ * Used by gutlunches, and generates healing reagents instead of milk on eating gibs instead of a process. Starts empty!
+ * Female gutlunches (ahem, guthens if you will) make babies when their udder is full under processing, instead of milk generation
+ */
+/obj/item/udder/gutlunch
+	name = "nutrient sac"
+
+/obj/item/udder/gutlunch/initial_conditions()
+	if(udder_mob.gender == FEMALE)
+		START_PROCESSING(SSobj, src)
+	RegisterSignal(udder_mob, COMSIG_HOSTILE_ATTACKINGTARGET, .proc/on_mob_attacking)
+
+/obj/item/udder/gutlunch/Destroy()
+	. = ..()
+	UnregisterSignal(udder_mob, COMSIG_HOSTILE_ATTACKINGTARGET)
+
+/obj/item/udder/gutlunch/process(delta_time)
+	var/mob/living/simple_animal/hostile/asteroid/gutlunch/gutlunch = udder_mob
+	if(reagents.total_volume != reagents.maximum_volume)
+		return
+	if(gutlunch.make_babies())
+		reagents.clear_reagents()
+		//usually this would be a callback but this is a specifically gutlunch feature so fuck it, gutlunch specific proccall
+		gutlunch.regenerate_icons(reagents.total_volume, reagents.maximum_volume)
+
+///signal called on parent attacking an atom
+/obj/item/udder/proc/on_mob_attacking(mob/living/simple_animal/hostile/gutlunch, atom/target)
+	if(is_type_in_typecache(target, gutlunch.wanted_objects)) //we eats
+		generate()
+		gutlunch.visible_message("<span class='notice'>[src] slurps up [target].</span>")
+		qdel(target)
+
+/obj/item/udder/gutlunch/generate()
+	var/made_something = FALSE
+	if(prob(60))
+		reagents.add_reagent(/datum/reagent/consumable/cream, rand(2, 5))
+		made_something = TRUE
+	if(prob(45))
+		reagents.add_reagent(/datum/reagent/medicine/salglu_solution, rand(2,5))
+		made_something = TRUE
+	if(made_something && on_generate_callback)
+		on_generate_callback.Invoke(reagents.total_volume, reagents.maximum_volume)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -30,7 +30,6 @@
 	. = ..()
 
 	AddComponent(/datum/component/personal_crafting)
-	AddComponent(/datum/component/udder)
 	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_blood))
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -30,6 +30,7 @@
 	. = ..()
 
 	AddComponent(/datum/component/personal_crafting)
+	AddComponent(/datum/component/udder)
 	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_blood))
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -29,19 +29,13 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	stop_automated_movement_when_pulled = 1
 	blood_volume = BLOOD_VOLUME_NORMAL
-	var/obj/item/udder/udder = null
 	chat_color = "#B2CEB3"
 
 	do_footstep = TRUE
 
 /mob/living/simple_animal/hostile/retaliate/goat/Initialize(mapload)
-	udder = new()
+	AddComponent(/datum/component/udder)
 	. = ..()
-
-/mob/living/simple_animal/hostile/retaliate/goat/Destroy()
-	qdel(udder)
-	udder = null
-	return ..()
 
 /mob/living/simple_animal/hostile/retaliate/goat/Life()
 	. = ..()
@@ -54,15 +48,18 @@
 			clear_enemies()
 			LoseTarget()
 			src.visible_message("<span class='notice'>[src] calms down.</span>")
-	if(stat == CONSCIOUS)
-		udder.generateMilk()
-		eat_plants()
-		if(!pulledby)
-			for(var/direction in shuffle(list(1,2,4,8,5,6,9,10)))
-				var/step = get_step(src, direction)
-				if(step)
-					if(locate(/obj/structure/spacevine) in step || locate(/obj/structure/glowshroom) in step)
-						Move(step, get_dir(src, step))
+	if(stat != CONSCIOUS)
+		return
+
+	eat_plants()
+	if(pulledby)
+		return
+
+	for(var/direction in shuffle(list(1,2,4,8,5,6,9,10)))
+		var/step = get_step(src, direction)
+		if(step)
+			if(locate(/obj/structure/spacevine) in step || locate(/obj/structure/glowshroom) in step)
+				Move(step, get_dir(src, step))
 
 /mob/living/simple_animal/hostile/retaliate/goat/Retaliate()
 	..()
@@ -87,14 +84,6 @@
 
 	if(eaten && prob(10))
 		INVOKE_ASYNC(src, /atom/movable/proc/say, "Nom")
-
-/mob/living/simple_animal/hostile/retaliate/goat/attackby(obj/item/O, mob/user, params)
-	if(stat == CONSCIOUS && istype(O, /obj/item/reagent_containers/glass))
-		udder.milkAnimal(O, user)
-		return 1
-	else
-		return ..()
-
 
 /mob/living/simple_animal/hostile/retaliate/goat/AttackingTarget()
 	. = ..()
@@ -131,33 +120,16 @@
 	attack_sound = 'sound/weapons/punch1.ogg'
 	health = 50
 	maxHealth = 50
-	var/obj/item/udder/udder = null
 	gold_core_spawnable = FRIENDLY_SPAWN
 	blood_volume = BLOOD_VOLUME_NORMAL
 	chat_color = "#FFFFFF"
 
 	do_footstep = TRUE
 
+/*
 /mob/living/simple_animal/cow/Initialize(mapload)
-	udder = new()
 	. = ..()
-
-/mob/living/simple_animal/cow/Destroy()
-	qdel(udder)
-	udder = null
-	return ..()
-
-/mob/living/simple_animal/cow/attackby(obj/item/O, mob/user, params)
-	if(stat == CONSCIOUS && istype(O, /obj/item/reagent_containers/glass))
-		udder.milkAnimal(O, user)
-		return 1
-	else
-		return ..()
-
-/mob/living/simple_animal/cow/Life()
-	. = ..()
-	if(stat == CONSCIOUS)
-		udder.generateMilk()
+*/
 
 /mob/living/simple_animal/cow/attack_hand(mob/living/carbon/M)
 	if(!stat && M.a_intent == INTENT_DISARM && icon_state != icon_dead)
@@ -380,26 +352,3 @@
 	validColors = list("plain")
 	gold_core_spawnable = FRIENDLY_SPAWN
 	chat_color = "#FFDC9B"
-
-/obj/item/udder
-	name = "udder"
-
-/obj/item/udder/Initialize(mapload)
-	create_reagents(50)
-	reagents.add_reagent(/datum/reagent/consumable/milk, 20)
-	. = ..()
-
-/obj/item/udder/proc/generateMilk()
-	if(prob(5))
-		reagents.add_reagent(/datum/reagent/consumable/milk, rand(5, 10))
-
-/obj/item/udder/proc/milkAnimal(obj/O, mob/user)
-	var/obj/item/reagent_containers/glass/G = O
-	if(G.reagents.total_volume >= G.volume)
-		to_chat(user, "<span class='danger'>[O] is full.</span>")
-		return
-	var/transfered = reagents.trans_to(O, rand(5,10))
-	if(transfered)
-		user.visible_message("[user] milks [src] using \the [O].", "<span class='notice'>You milk [src] using \the [O].</span>")
-	else
-		to_chat(user, "<span class='danger'>The udder is dry. Wait a bit longer...</span>")

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -126,10 +126,9 @@
 
 	do_footstep = TRUE
 
-/*
 /mob/living/simple_animal/cow/Initialize(mapload)
+	AddComponent(/datum/component/udder)
 	. = ..()
-*/
 
 /mob/living/simple_animal/cow/attack_hand(mob/living/carbon/M)
 	if(!stat && M.a_intent == INTENT_DISARM && icon_state != icon_dead)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -44,7 +44,7 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Initialize(mapload)
 	. = ..()
 	if(wanted_objects.len)
-		AddComponent(/datum/component/udder, /obj/item/udder/gutlunch, /mob.proc/regenerate_icons, /mob.proc/regenerate_icons)
+		AddComponent(/datum/component/udder, /obj/item/udder/gutlunch, CALLBACK(src, PROC_REF(regenerate_icons)), CALLBACK(src, PROC_REF(regenerate_icons)))
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/CanAttack(atom/the_target) // Gutlunch-specific version of CanAttack to handle stupid stat_exclusive = true crap so we don't have to do it for literally every single simple_animal/hostile except the two that spawn in lavaland
 	if(isturf(the_target) || !the_target || the_target.type == /atom/movable/lighting_object) // bail out on invalids

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -40,11 +40,11 @@
 	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch = 100)
 
 	wanted_objects = list(/obj/effect/decal/cleanable/xenoblood/xgibs, /obj/effect/decal/cleanable/blood/gibs/, /obj/item/organ)
-	var/obj/item/udder/gutlunch/udder = null
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Initialize(mapload)
-	udder = new()
 	. = ..()
+	if(wanted_objects.len)
+		AddComponent(/datum/component/udder, /obj/item/udder/gutlunch, /mob.proc/regenerate_icons, /mob.proc/regenerate_icons)
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/CanAttack(atom/the_target) // Gutlunch-specific version of CanAttack to handle stupid stat_exclusive = true crap so we don't have to do it for literally every single simple_animal/hostile except the two that spawn in lavaland
 	if(isturf(the_target) || !the_target || the_target.type == /atom/movable/lighting_object) // bail out on invalids
@@ -68,31 +68,14 @@
 
 	return FALSE
 
-/mob/living/simple_animal/hostile/asteroid/gutlunch/Destroy()
-	reagents = null
-	QDEL_NULL(udder)
-	return ..()
-
-/mob/living/simple_animal/hostile/asteroid/gutlunch/regenerate_icons()
+/mob/living/simple_animal/hostile/asteroid/gutlunch/regenerate_icons(new_udder_volume, max_udder_volume)
 	cut_overlays()
-	if(udder.reagents.total_volume == udder.reagents.maximum_volume)
-		add_overlay("gl_full")
+	var/static/gutlunch_full_overlay
+	if(isnull(gutlunch_full_overlay))
+		gutlunch_full_overlay = iconstate2appearance(icon, "gl_full")
+	if(new_udder_volume == max_udder_volume)
+		add_overlay(gutlunch_full_overlay)
 	..()
-
-/mob/living/simple_animal/hostile/asteroid/gutlunch/attackby(obj/item/O, mob/user, params)
-	if(stat == CONSCIOUS && istype(O, /obj/item/reagent_containers/glass))
-		udder.milkAnimal(O, user)
-		regenerate_icons()
-	else
-		..()
-
-/mob/living/simple_animal/hostile/asteroid/gutlunch/AttackingTarget()
-	if(is_type_in_typecache(target,wanted_objects)) //we eats
-		udder.generateMilk()
-		regenerate_icons()
-		visible_message("<span class='notice'>[src] slurps up [target].</span>")
-		qdel(target)
-	return ..()
 
 //Male gutlunch. They're smaller and more colorful!
 /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck
@@ -110,17 +93,6 @@
 	name = "guthen"
 	gender = FEMALE
 
-/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/Life()
-	..()
-	if(udder.reagents.total_volume == udder.reagents.maximum_volume && next_scan_time <= world.time) //Only breed when we're full.
-		make_babies()
-
-/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/make_babies()
-	. = ..()
-	if(.)
-		udder.reagents.clear_reagents()
-		regenerate_icons()
-
 /mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch
 	name = "grublunch"
 	wanted_objects = list() //They don't eat.
@@ -137,7 +109,7 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/Life()
 	..()
 	growth++
-	if(growth > 50) //originally used a timer for this but was more problem that it's worth.
+	if(growth > 50) //originally used a timer for this, but it became more of a problem than it was worth.
 		growUp()
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/proc/growUp()
@@ -152,18 +124,3 @@
 	L.Stun(20, ignore_canstun = TRUE)
 	visible_message("<span class='notice'>[src] grows up into [L].</span>")
 	Destroy()
-
-//Gutlunch udder
-/obj/item/udder/gutlunch
-	name = "nutrient sac"
-
-/obj/item/udder/gutlunch/Initialize(mapload)
-	. = ..()
-	reagents = new(50)
-	reagents.my_atom = src
-
-/obj/item/udder/gutlunch/generateMilk()
-	if(prob(60))
-		reagents.add_reagent(/datum/reagent/consumable/cream, rand(2, 5))
-	if(prob(45))
-		reagents.add_reagent(/datum/reagent/medicine/salglu_solution, rand(2,5))


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/58910

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~You can milk anything!~~

Well, in reality, just stuff that has `AddComponent(/datum/component/udder)`

Adds the components to cows, goats, gutlunch, and gutlunch's wife.

~~Coincidentally, unrelated entirely to #7833~~

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Components are cool. Makes it easy to add functionality to anything without extra code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![buzzella](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/fdb7020b-e653-40b9-8c96-73e6789f90b1)

![cow](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/c1a3c71e-8cb8-430f-a6db-3bfa4c37f262)


</details>

## Changelog
:cl: RKz, tralezab
code: you can milk anything! Componentizes milking.
code: just kidding, only stuff that coders define as milkable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
