### PR TITLE
Updates the CI to use MariaDB not MySQL

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -82,6 +82,8 @@ jobs:
       mariadb:
         image: mariadb:latest
         env:
+          MYSQL_USER: user
+          MYSQL_PASSWORD: password
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -79,8 +79,8 @@ jobs:
   run_all_tests:
     runs-on: ubuntu-20.04
     services:
-      mysql:
-        image: mysql:latest
+      mariadb:
+        image: mariadb:latest
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -82,12 +82,10 @@ jobs:
       mariadb:
         image: mariadb:latest
         env:
-          MYSQL_USER: user
-          MYSQL_PASSWORD: password
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v3
       - name: Cache BYOND


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have no idea how this wasn't noticed until now.

## Why It's Good For The Game

Makes for more reliable CI testing. We _technically_ don't support MySQL, so, the fact that this hasn't caused problems is definitely something.

## Changelog
:cl:
fix: The CI will correctly use MariaDB instead of MySQL, similar to the actual server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
