### PR TITLE
Kills obj/item/projectile in favour of obj/projectile

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -14,9 +14,9 @@
 "e" = (
 /obj/machinery/porta_turret/syndicate{
 	desc = "A ballistic machine gun auto-turret that fires bluespace bullets.";
-	lethal_projectile = /obj/item/projectile/magic/teleport;
+	lethal_projectile = /obj/projectile/magic/teleport;
 	name = "displacement turret";
-	stun_projectile = /obj/item/projectile/magic/teleport
+	stun_projectile = /obj/projectile/magic/teleport
 	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"

--- a/_maps/RuinGeneration/13x13_hilberttest.dmm
+++ b/_maps/RuinGeneration/13x13_hilberttest.dmm
@@ -33,9 +33,9 @@
 "r" = (
 /obj/machinery/porta_turret/syndicate{
 	desc = "A ballistic machine gun auto-turret that fires bluespace bullets.";
-	lethal_projectile = /obj/item/projectile/magic/teleport;
+	lethal_projectile = /obj/projectile/magic/teleport;
 	name = "displacement turret";
-	stun_projectile = /obj/item/projectile/magic/teleport
+	stun_projectile = /obj/projectile/magic/teleport
 	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"

--- a/code/__DEFINES/dcs/signals/signals_atom.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom.dm
@@ -62,7 +62,7 @@
 #define COMSIG_ATOM_EMP_ACT "atom_emp_act"
 ///! from base of atom/fire_act(): (exposed_temperature, exposed_volume)
 #define COMSIG_ATOM_FIRE_ACT "atom_fire_act"
-///! from base of atom/bullet_act(): (/obj/item/projectile, def_zone)
+///! from base of atom/bullet_act(): (/obj/projectile, def_zone)
 #define COMSIG_ATOM_BULLET_ACT "atom_bullet_act"
 ///from base of atom/CheckParts(): (list/parts_list, datum/crafting_recipe/R)
 #define COMSIG_ATOM_CHECKPARTS "atom_checkparts"

--- a/code/__DEFINES/dcs/signals/signals_obj/signals_projectile.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_projectile.dm
@@ -2,10 +2,10 @@
 // When the signal is called: (signal arguments)
 // All signals send the source datum of the signal as the first argument
 
-// /obj/item/projectile signals (sent to the firer)
-#define COMSIG_PROJECTILE_SELF_ON_HIT "projectile_self_on_hit"			// from base of /obj/item/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
-#define COMSIG_PROJECTILE_ON_HIT "projectile_on_hit"			// from base of /obj/item/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
-#define COMSIG_PROJECTILE_BEFORE_FIRE "projectile_before_fire" 			// from base of /obj/item/projectile/proc/fire(): (obj/item/projectile, atom/original_target)
+// /obj/projectile signals (sent to the firer)
+#define COMSIG_PROJECTILE_SELF_ON_HIT "projectile_self_on_hit"			// from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
+#define COMSIG_PROJECTILE_ON_HIT "projectile_on_hit"			// from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
+#define COMSIG_PROJECTILE_BEFORE_FIRE "projectile_before_fire" 			// from base of /obj/projectile/proc/fire(): (obj/projectile, atom/original_target)
 #define COMSIG_PROJECTILE_PREHIT "com_proj_prehit"				// sent to targets during the process_hit proc of projectiles
 #define COMSIG_PROJECTILE_RANGE_OUT "projectile_range_out"				// sent to targets during the process_hit proc of projectiles
 #define COMSIG_EMBED_TRY_FORCE "item_try_embed"					// sent when trying to force an embed (mainly for projectiles, only used in the embed element)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_INIT(pointed_types, typecacheof(list(
 
 #define isbodypart(A) (istype(A, /obj/item/bodypart))
 
-#define isprojectile(A) (istype(A, /obj/item/projectile))
+#define isprojectile(A) (istype(A, /obj/projectile))
 
 #define isgun(A) (istype(A, /obj/item/gun))
 

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -9,7 +9,7 @@
 		/obj/effect,
 		/obj/docking_port,
 		/atom/movable/lighting_object,
-		/obj/item/projectile,
+		/obj/projectile,
 		/obj/structure/chisel_message,
 		/mob/living/simple_animal/eminence
 		))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -385,7 +385,7 @@
 /mob/living/LaserEyes(atom/A, params)
 	changeNext_move(CLICK_CD_RANGE)
 
-	var/obj/item/projectile/beam/LE = new /obj/item/projectile/beam( loc )
+	var/obj/projectile/beam/LE = new /obj/projectile/beam( loc )
 	LE.icon = 'icons/effects/genetics.dmi'
 	LE.icon_state = "eyelasers"
 	playsound(usr.loc, 'sound/weapons/taser2.ogg', 75, 1)

--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -10,7 +10,7 @@ PROCESSING_SUBSYSTEM_DEF(projectiles)
 /datum/controller/subsystem/processing/projectiles/proc/set_pixel_speed(new_speed)
 	global_pixel_speed = new_speed
 	for(var/i in processing)
-		var/obj/item/projectile/P = i
+		var/obj/projectile/P = i
 		if(istype(P))			//there's non projectiles on this too.
 			P.set_pixel_speed(new_speed)
 

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -200,10 +200,10 @@ have ways of interacting with a specific mob and control it.
 	if(prob(MONKEY_RETALIATE_PROB))
 		retaliate(user)
 
-/datum/ai_controller/monkey/proc/on_bullet_act(datum/source, obj/item/projectile/Proj)
+/datum/ai_controller/monkey/proc/on_bullet_act(datum/source, obj/projectile/Proj)
 	SIGNAL_HANDLER
 	var/mob/living/living_pawn = pawn
-	if(istype(Proj , /obj/item/projectile/beam)||istype(Proj, /obj/item/projectile/bullet))
+	if(istype(Proj , /obj/projectile/beam)||istype(Proj, /obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < living_pawn.health && isliving(Proj.firer))
 				retaliate(Proj.firer)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -12,7 +12,7 @@
 		/obj/docking_port,
 		/obj/structure/lattice,
 		/obj/structure/stone_tile,
-		/obj/item/projectile,
+		/obj/projectile,
 		/obj/effect/projectile,
 		/obj/effect/portal,
 		/obj/effect/abstract,

--- a/code/datums/components/mirv.dm
+++ b/code/datums/components/mirv.dm
@@ -32,7 +32,7 @@
 	var/turf/target_turf = get_turf(target)
 	for(var/turf/shootat_turf in RANGE_TURFS(radius, target) - RANGE_TURFS(radius-1, target))
 
-		var/obj/item/projectile/P = new projectile_type(target_turf)
+		var/obj/projectile/P = new projectile_type(target_turf)
 		//Shooting Code:
 		P.range = radius+1
 		if(override_projectile_range)

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -189,7 +189,7 @@
 			break
 
 ///One of our pellets hit something, record what it was and check if we're done (terminated == num_pellets)
-/datum/component/pellet_cloud/proc/pellet_hit(obj/item/projectile/P, atom/movable/firer, atom/target, Angle)
+/datum/component/pellet_cloud/proc/pellet_hit(obj/projectile/P, atom/movable/firer, atom/target, Angle)
 	SIGNAL_HANDLER
 
 	pellets -= P
@@ -203,7 +203,7 @@
 		finalize()
 
 ///One of our pellets disappeared due to hitting their max range (or just somehow got qdel'd), remove it from our list and check if we're done (terminated == num_pellets)
-/datum/component/pellet_cloud/proc/pellet_range(obj/item/projectile/P)
+/datum/component/pellet_cloud/proc/pellet_range(obj/projectile/P)
 	SIGNAL_HANDLER
 
 	pellets -= P
@@ -214,7 +214,7 @@
 
 /// Minor convenience function for creating each shrapnel piece with circle explosions, mostly stolen from the MIRV component
 /datum/component/pellet_cloud/proc/pew(atom/target, spread=0)
-	var/obj/item/projectile/P = new projectile_type(get_turf(parent))
+	var/obj/projectile/P = new projectile_type(get_turf(parent))
 
 	//Shooting Code:
 	P.spread = spread
@@ -231,7 +231,7 @@
 
 ///All of our pellets are accounted for, time to go target by target and tell them how many things they got hit by.
 /datum/component/pellet_cloud/proc/finalize()
-	var/obj/item/projectile/P = projectile_type
+	var/obj/projectile/P = projectile_type
 	var/proj_name = initial(P.name)
 
 	for(var/atom/target in targets_hit)

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -161,7 +161,7 @@
 	consume(source, user)
 
 // Will there be an impact? Who knows.  Will we see it? No.
-/datum/component/singularity/proc/consume_bullets(obj/item/projectile/projectile)
+/datum/component/singularity/proc/consume_bullets(obj/projectile/projectile)
 	SIGNAL_HANDLER
 	qdel(projectile)
 

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -75,8 +75,8 @@
 		var/obj/item/I = arrived
 		if(I.item_flags & ABSTRACT)
 			return
-		else if(istype(arrived, /obj/item/projectile))
-			var/obj/item/projectile/P = arrived
+		else if(istype(arrived, /obj/projectile))
+			var/obj/projectile/P = arrived
 			if(P.original != parent)
 				return
 	if(istype(arrived, /obj/effect/dummy/phased_mob)) //don't squeek if they're in a phased/jaunting container.

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -504,19 +504,19 @@ Thresholds
 
 /obj/item/ammo_casing/caseless/pimple
 	variance = 120
-	projectile_type = /obj/item/projectile/pimple
+	projectile_type = /obj/projectile/pimple
 	var/list/diseases
 
 /obj/item/ammo_casing/caseless/pimple/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/fired_from)
 	. = ..()
 	if(!BB)
 		return
-	if(istype(BB, /obj/item/projectile/pimple))
-		var/obj/item/projectile/pimple/P = BB
+	if(istype(BB, /obj/projectile/pimple))
+		var/obj/projectile/pimple/P = BB
 		P.diseases = diseases
 
 
-/obj/item/projectile/pimple
+/obj/projectile/pimple
 	name = "high-velocity pustule"
 	damage = 4 //and very easily blocked with some bio armor
 	range = 5
@@ -526,7 +526,7 @@ Thresholds
 	armor_flag = BIO
 	var/list/diseases
 
-/obj/item/projectile/pimple/on_hit(atom/target, blocked)
+/obj/projectile/pimple/on_hit(atom/target, blocked)
 	. = ..()
 	var/turf/T = get_turf(target)
 	playsound(T, 'sound/effects/splat.ogg', 50, 1)

--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -146,7 +146,7 @@
   * If we hit a valid target, we create the shrapnel_type object and immediately call tryEmbed() on it, targeting what we impacted. That will lead
   *	it to call tryForceEmbed() on its own embed element (it's out of our hands here, our projectile is done), where it will run through all the checks it needs to.
   */
-/datum/element/embed/proc/checkEmbedProjectile(obj/item/projectile/P, atom/movable/firer, atom/hit, angle, hit_zone)
+/datum/element/embed/proc/checkEmbedProjectile(obj/projectile/P, atom/movable/firer, atom/hit, angle, hit_zone)
 	SIGNAL_HANDLER
 
 	if(!iscarbon(hit))

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -103,7 +103,7 @@
 	charge_max = 600
 	clothes_req = FALSE
 	range = 20
-	projectile_type = /obj/item/projectile/magic/fireball/firebreath
+	projectile_type = /obj/projectile/magic/fireball/firebreath
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
 	sound = 'sound/magic/demon_dies.ogg' //horrifying lizard noises
@@ -121,14 +121,14 @@
 			to_chat(C,"<span class='warning'>Something in front of your mouth caught fire!</span>")
 			return FALSE
 
-/obj/effect/proc_holder/spell/aimed/firebreath/ready_projectile(obj/item/projectile/P, atom/target, mob/user, iteration)
-	if(!istype(P, /obj/item/projectile/magic/fireball))
+/obj/effect/proc_holder/spell/aimed/firebreath/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)
+	if(!istype(P, /obj/projectile/magic/fireball))
 		return
-	var/obj/item/projectile/magic/fireball/F = P
+	var/obj/projectile/magic/fireball/F = P
 	F.exp_light = strength-1
 	F.exp_fire += strength
 
-/obj/item/projectile/magic/fireball/firebreath
+/obj/projectile/magic/fireball/firebreath
 	name = "fire breath"
 	exp_heavy = 0
 	exp_light = 0

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -50,7 +50,7 @@
 	cooldown_min = 150
 	clothes_req = FALSE
 	range = 3
-	projectile_type = /obj/item/projectile/temp/cryo
+	projectile_type = /obj/projectile/temp/cryo
 	base_icon_state = "icebeam"
 	action_icon_state = "icebeam"
 	active_msg = "You focus your cryokinesis!"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -493,7 +493,7 @@
 	new/obj/effect/temp_visual/dir_setting/curse/grasp_portal(spawn_turf, owner.dir)
 	playsound(spawn_turf, 'sound/effects/curse2.ogg', 80, 1, -1)
 	var/turf/ownerloc = get_turf(owner)
-	var/obj/item/projectile/curse_hand/C = new (spawn_turf)
+	var/obj/projectile/curse_hand/C = new (spawn_turf)
 	C.preparePixelProjectile(ownerloc, spawn_turf)
 	C.fire()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -295,7 +295,7 @@
 
 	return ..()
 
-/atom/proc/handle_ricochet(obj/item/projectile/P)
+/atom/proc/handle_ricochet(obj/projectile/P)
 	var/turf/p_turf = get_turf(P)
 	var/face_direction = get_dir(src, p_turf)
 	var/face_angle = dir2angle(face_direction)
@@ -535,7 +535,7 @@
  * def_zone - zone hit
  * piercing_hit - is this hit piercing or normal?
  */
-/atom/proc/bullet_act(obj/item/projectile/P, def_zone, piercing_hit = FALSE)
+/atom/proc/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, P, def_zone)
 	. = P.on_hit(src, 0, def_zone, piercing_hit)
 

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -30,7 +30,7 @@ GLOBAL_VAR_INIT(hsboxspawn, TRUE)
 	var/static/list/spawn_forbidden = list(
 		/obj/item/tk_grab, /obj/item/implant, // not implanter, the actual thing that is inside you
 		/obj/item/assembly, /obj/item/robot_module,
-		/obj/item/small_delivery, /obj/item/projectile,
+		/obj/item/small_delivery, /obj/projectile,
 		/obj/item/borg/sight, /obj/item/borg/stun
 	)
 

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -226,7 +226,7 @@
 		if(plasma_ignition(6))
 			PlasmaBurn()
 
-/obj/machinery/door/airlock/plasma/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/door/airlock/plasma/bullet_act(obj/projectile/Proj)
 	if(!(Proj.nodamage) && Proj.damage_type == BURN)
 		if(plasma_ignition(6, Proj?.firer))
 			PlasmaBurn()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -573,7 +573,7 @@
 					break
 
 	update_icon()
-	var/obj/item/projectile/A
+	var/obj/projectile/A
 	//any emagged turrets drains 2x power and uses a different projectile?
 	if(mode == TURRET_STUN)
 		use_power(reqpower)
@@ -675,8 +675,8 @@
 	req_access = list(ACCESS_SYNDICATE)
 	uses_stored = FALSE
 	mode = TURRET_LETHAL
-	stun_projectile = /obj/item/projectile/bullet
-	lethal_projectile = /obj/item/projectile/bullet
+	stun_projectile = /obj/projectile/bullet
+	lethal_projectile = /obj/projectile/bullet
 	lethal_projectile_sound = 'sound/weapons/gunshot.ogg'
 	stun_projectile_sound = 'sound/weapons/gunshot.ogg'
 	icon_state = "syndie_off"
@@ -697,9 +697,9 @@
 /obj/machinery/porta_turret/syndicate/energy
 	icon_state = "standard_lethal"
 	base_icon_state = "standard"
-	stun_projectile = /obj/item/projectile/energy/electrode
+	stun_projectile = /obj/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
-	lethal_projectile = /obj/item/projectile/beam/laser
+	lethal_projectile = /obj/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	desc = "An energy blaster auto-turret."
 
@@ -708,14 +708,14 @@
 	desc = "A heavy laser auto-turret."
 	icon_state = "standard_lethal"
 	base_icon_state = "standard"
-	stun_projectile = /obj/item/projectile/energy/electrode
+	stun_projectile = /obj/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
-	lethal_projectile = /obj/item/projectile/beam/laser/heavylaser
+	lethal_projectile = /obj/projectile/beam/laser/heavylaser
 	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 	desc = "An energy blaster auto-turret."
 
 /obj/machinery/porta_turret/syndicate/energy/raven
-	stun_projectile =  /obj/item/projectile/beam/laser
+	stun_projectile =  /obj/projectile/beam/laser
 	stun_projectile_sound = 'sound/weapons/laser.ogg'
 	faction = list("neutral","silicon","turret")
 
@@ -725,16 +725,16 @@
 	desc = "A ballistic semi-automatic auto-turret."
 	integrity_failure = 20
 	max_integrity = 40
-	stun_projectile = /obj/item/projectile/bullet/syndicate_turret
-	lethal_projectile = /obj/item/projectile/bullet/syndicate_turret
+	stun_projectile = /obj/projectile/bullet/syndicate_turret
+	lethal_projectile = /obj/projectile/bullet/syndicate_turret
 
 /obj/machinery/porta_turret/syndicate/shuttle
 	name = "syndicate penetrator turret"
 	desc = "A ballistic penetrator auto-turret."
 	scan_range = 9
 	shot_delay = 3
-	stun_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
-	lethal_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
+	stun_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
+	lethal_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile_sound = 'sound/weapons/gunshot_smg.ogg'
 	stun_projectile_sound = 'sound/weapons/gunshot_smg.ogg'
 	armor = list(MELEE = 50,  BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 80, BIO = 0, RAD = 0, FIRE = 90, ACID = 90, STAMINA = 0)
@@ -765,8 +765,8 @@
 	desc = "A plasma beam turret calibrated to defend outposts against non-humanoid fauna. It is more effective when exposed to the environment."
 	installation = null
 	uses_stored = FALSE
-	stun_projectile = /obj/item/projectile/plasma/turret
-	lethal_projectile = /obj/item/projectile/plasma/turret
+	stun_projectile = /obj/projectile/plasma/turret
+	lethal_projectile = /obj/projectile/plasma/turret
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	mode = TURRET_LETHAL //It would be useless in stun mode anyway
 	faction = list("neutral","silicon","turret") //Minebots, medibots, etc that should not be shot.
@@ -792,8 +792,8 @@
 	use_power = NO_POWER_USE
 	has_cover = 0
 	scan_range = 9
-	stun_projectile = /obj/item/projectile/beam/laser
-	lethal_projectile = /obj/item/projectile/beam/laser
+	stun_projectile = /obj/projectile/beam/laser
+	lethal_projectile = /obj/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	stun_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	icon_state = "syndie_off"
@@ -816,8 +816,8 @@
 	integrity_failure = 60
 	name = "Old Laser Turret"
 	desc = "A turret built with substandard parts and run down further with age. Still capable of delivering lethal lasers to the odd space carp, but not much else."
-	stun_projectile = /obj/item/projectile/beam/weak/penetrator
-	lethal_projectile = /obj/item/projectile/beam/weak/penetrator
+	stun_projectile = /obj/projectile/beam/weak/penetrator
+	lethal_projectile = /obj/projectile/beam/weak/penetrator
 	faction = list("neutral","silicon","turret")
 
 ////////////////////////
@@ -1062,16 +1062,16 @@
 
 /obj/item/gun/energy/laser/bluetag/get_turret_properties()
 	. = ..()
-	.["stun_projectile"] = /obj/item/projectile/beam/lasertag/bluetag
-	.["lethal_projectile"] = /obj/item/projectile/beam/lasertag/bluetag
+	.["stun_projectile"] = /obj/projectile/beam/lasertag/bluetag
+	.["lethal_projectile"] = /obj/projectile/beam/lasertag/bluetag
 	.["base_icon_state"] = "blue"
 	.["shot_delay"] = 30
 	.["team_color"] = "blue"
 
 /obj/item/gun/energy/laser/redtag/get_turret_properties()
 	. = ..()
-	.["stun_projectile"] = /obj/item/projectile/beam/lasertag/redtag
-	.["lethal_projectile"] = /obj/item/projectile/beam/lasertag/redtag
+	.["stun_projectile"] = /obj/projectile/beam/lasertag/redtag
+	.["lethal_projectile"] = /obj/projectile/beam/lasertag/redtag
 	.["base_icon_state"] = "red"
 	.["shot_delay"] = 30
 	.["team_color"] = "red"
@@ -1137,14 +1137,14 @@
 	installation = /obj/item/gun/energy/laser/bluetag
 	team_color = "blue"
 
-/obj/machinery/porta_turret/lasertag/bullet_act(obj/item/projectile/P)
+/obj/machinery/porta_turret/lasertag/bullet_act(obj/projectile/P)
 	. = ..()
 	if(on)
 		if(team_color == "blue")
-			if(istype(P, /obj/item/projectile/beam/lasertag/redtag))
+			if(istype(P, /obj/projectile/beam/lasertag/redtag))
 				toggle_on(FALSE)
 				addtimer(CALLBACK(src, PROC_REF(toggle_on), TRUE), 10 SECONDS)
 		else if(team_color == "red")
-			if(istype(P, /obj/item/projectile/beam/lasertag/bluetag))
+			if(istype(P, /obj/projectile/beam/lasertag/bluetag))
 				toggle_on(FALSE)
 				addtimer(CALLBACK(src, PROC_REF(toggle_on), TRUE), 10 SECONDS)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -469,5 +469,5 @@
 	if(istype(mover) && (mover.pass_flags & PASSTRANSPARENT))
 		return prob(20)
 	else
-		if(istype(mover, /obj/item/projectile))
+		if(istype(mover, /obj/projectile))
 			return prob(10)

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -67,7 +67,7 @@
 	SEND_SIGNAL(shield, COMSIG_MECHA_ACTION_ACTIVATE, source, signal_args)
 
 //Redirects projectiles to the shield if defense_check decides they should be blocked and returns true.
-/obj/mecha/combat/durand/proc/prehit(obj/item/projectile/source, list/signal_args)
+/obj/mecha/combat/durand/proc/prehit(obj/projectile/source, list/signal_args)
 	SIGNAL_HANDLER
 
 	if(defense_check(source.loc) && shield)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -37,7 +37,7 @@
 
 	set_ready_state(0)
 	for(var/i=1 to get_shot_amount())
-		var/obj/item/projectile/A = new projectile(curloc)
+		var/obj/projectile/A = new projectile(curloc)
 		A.firer = chassis.occupant
 		A.original = target
 		if(!A.suppressed && firing_effect_type)
@@ -81,7 +81,7 @@
 	desc = "A weapon for combat exosuits. Shoots basic lasers."
 	icon_state = "mecha_laser"
 	energy_drain = 30
-	projectile = /obj/item/projectile/beam/laser
+	projectile = /obj/projectile/beam/laser
 	fire_sound = 'sound/weapons/laser.ogg'
 	harmful = TRUE
 
@@ -91,13 +91,13 @@
 	desc = "A weapon for combat exosuits. Shoots basic disablers."
 	icon_state = "mecha_disabler"
 	energy_drain = 30
-	projectile = /obj/item/projectile/beam/disabler
+	projectile = /obj/projectile/beam/disabler
 	fire_sound = 'sound/weapons/taser2.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler/on_emag(mob/user)
 	..()
 	to_chat(user, "<span class='notice'>You disable [src]'s safety procedures, making it shoot harmful lasers.</span>")
-	projectile = /obj/item/projectile/beam/laser
+	projectile = /obj/projectile/beam/laser
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
@@ -106,7 +106,7 @@
 	desc = "A weapon for combat exosuits. Shoots heavy lasers."
 	icon_state = "mecha_laser"
 	energy_drain = 60
-	projectile = /obj/item/projectile/beam/laser/heavylaser
+	projectile = /obj/projectile/beam/laser/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
@@ -115,7 +115,7 @@
 	desc = "A weapon for combat exosuits. Shoots technology-disabling ion beams. Don't catch yourself in the blast!"
 	icon_state = "mecha_ion"
 	energy_drain = 120
-	projectile = /obj/item/projectile/ion
+	projectile = /obj/projectile/ion
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla
@@ -124,7 +124,7 @@
 	desc = "A weapon for combat exosuits. Fires bolts of electricity similar to the experimental tesla engine."
 	icon_state = "mecha_ion"
 	energy_drain = 500
-	projectile = /obj/item/projectile/energy/tesla/cannon
+	projectile = /obj/projectile/energy/tesla/cannon
 	fire_sound = 'sound/magic/lightningbolt.ogg'
 	harmful = TRUE
 
@@ -134,7 +134,7 @@
 	desc = "A weapon for combat exosuits. Shoots powerful destructive blasts capable of demolishing obstacles."
 	icon_state = "mecha_pulse"
 	energy_drain = 120
-	projectile = /obj/item/projectile/beam/pulse/heavy
+	projectile = /obj/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
 	harmful = TRUE
 
@@ -147,7 +147,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	energy_drain = 30
-	projectile = /obj/item/projectile/plasma/adv/mech
+	projectile = /obj/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	harmful = TRUE
 
@@ -164,7 +164,7 @@
 	icon_state = "mecha_taser"
 	energy_drain = 20
 	equip_cooldown = 8
-	projectile = /obj/item/projectile/energy/electrode
+	projectile = /obj/projectile/energy/electrode
 	fire_sound = 'sound/weapons/taser.ogg'
 
 
@@ -271,7 +271,7 @@
 	desc = "A weapon for combat exosuits. Shoots incendiary bullets."
 	icon_state = "mecha_carbine"
 	equip_cooldown = 10
-	projectile = /obj/item/projectile/bullet/incendiary/fnx99
+	projectile = /obj/projectile/bullet/incendiary/fnx99
 	projectiles = 24
 	projectile_energy_cost = 15
 	harmful = TRUE
@@ -282,7 +282,7 @@
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'
 	icon_state = "mecha_mime"
 	equip_cooldown = 30
-	projectile = /obj/item/projectile/bullet/mime
+	projectile = /obj/projectile/bullet/mime
 	projectiles = 6
 	projectile_energy_cost = 50
 	harmful = TRUE
@@ -292,7 +292,7 @@
 	desc = "A weapon for combat exosuits. Shoots a spread of pellets."
 	icon_state = "mecha_scatter"
 	equip_cooldown = 20
-	projectile = /obj/item/projectile/bullet/scattershot
+	projectile = /obj/projectile/bullet/scattershot
 	projectiles = 40
 	projectile_energy_cost = 25
 	projectiles_per_shot = 4
@@ -304,7 +304,7 @@
 	desc = "A weapon for combat exosuits. Shoots a rapid, three shot burst."
 	icon_state = "mecha_uac2"
 	equip_cooldown = 10
-	projectile = /obj/item/projectile/bullet/lmg
+	projectile = /obj/projectile/bullet/lmg
 	projectiles = 300
 	projectile_energy_cost = 20
 	projectiles_per_shot = 3
@@ -317,7 +317,7 @@
 	name = "\improper SRM-8 missile rack"
 	desc = "A weapon for combat exosuits. Shoots light explosive missiles."
 	icon_state = "mecha_missilerack"
-	projectile = /obj/item/projectile/bullet/a84mm_he
+	projectile = /obj/projectile/bullet/a84mm_he
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
 	projectiles = 8
 	projectile_energy_cost = 1000

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -111,7 +111,7 @@
 	. = ..()
 
 
-/obj/mecha/bullet_act(obj/item/projectile/Proj) //wrapper
+/obj/mecha/bullet_act(obj/projectile/Proj) //wrapper
 	if (!enclosed && occupant && !silicon_pilot && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit the pilot of open-canopy mechs
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -141,7 +141,7 @@
 		else
 			triggered = 1
 			triggermine(target)
-					
+
 
 /obj/effect/mine/proc/triggermine(mob/living/victim)
 	visible_message("<span class='danger'>[victim] sets off [icon2html(src, viewers(src))] [src]!</span>")
@@ -220,7 +220,7 @@
 
 /obj/effect/mine/shrapnel
 	name = "shrapnel mine"
-	var/shrapnel_type = /obj/item/projectile/bullet/shrapnel
+	var/shrapnel_type = /obj/projectile/bullet/shrapnel
 	var/shrapnel_magnitude = 3
 
 /obj/effect/mine/shrapnel/mineEffect(mob/victim)
@@ -228,7 +228,7 @@
 
 /obj/effect/mine/shrapnel/sting
 	name = "stinger mine"
-	shrapnel_type = /obj/item/projectile/bullet/pellet/stingball
+	shrapnel_type = /obj/projectile/bullet/pellet/stingball
 
 /obj/effect/mine/kickmine
 	name = "kick mine"

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -158,7 +158,7 @@
 	var/turf/real_target = get_link_target_turf()
 	if(!istype(real_target))
 		return FALSE
-	if(!force && (!ismecha(M) && !istype(M, /obj/item/projectile) && M.anchored && !allow_anchored))
+	if(!force && (!ismecha(M) && !istype(M, /obj/projectile) && M.anchored && !allow_anchored))
 		return
 	if(ismegafauna(M))
 		message_admins("[M] has used a portal at [ADMIN_VERBOSEJMP(src)] made by [usr].")
@@ -168,8 +168,8 @@
 	else
 		last_effect = world.time
 	if(do_teleport(M, real_target, innate_accuracy_penalty, no_effects = no_effect, channel = teleport_channel))
-		if(istype(M, /obj/item/projectile))
-			var/obj/item/projectile/P = M
+		if(istype(M, /obj/projectile))
+			var/obj/projectile/P = M
 			P.ignore_source_check = TRUE
 		return TRUE
 	return FALSE

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -58,7 +58,7 @@
 
 /obj/structure/spider/stickyweb/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(istype(mover, /obj/item/projectile))
+	if(istype(mover, /obj/projectile))
 		return prob(30)
 
 /obj/structure/spider/eggcluster

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -166,7 +166,7 @@
 		if(EAST)
 			icon_state = "beam_splash_e"
 
-/obj/item/projectile/curse_hand/update_icon()
+/obj/projectile/curse_hand/update_icon()
 	icon_state = "[icon_state][handedness]"
 
 /obj/effect/temp_visual/wizard

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -166,9 +166,6 @@
 		if(EAST)
 			icon_state = "beam_splash_e"
 
-/obj/projectile/curse_hand/update_icon()
-	icon_state = "[icon_state][handedness]"
-
 /obj/effect/temp_visual/wizard
 	name = "water"
 	icon = 'icons/mob/mob.dmi'

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -586,7 +586,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(block_flags & BLOCKING_ACTIVE && owner.get_active_held_item() != src) //you can still parry with the offhand
 		return 0
 	if(isprojectile(hitby)) //fucking bitflags broke this when coded in other ways
-		var/obj/item/projectile/P = hitby
+		var/obj/projectile/P = hitby
 		if(block_flags & BLOCKING_PROJECTILE)
 			if(P.movement_type & PHASING) //you can't block piercing rounds!
 				return 0
@@ -633,7 +633,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		else
 			blockhand = BODY_ZONE_L_ARM
 	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
+		var/obj/projectile/P = hitby
 		if(P.damage_type != STAMINA)// disablers dont do shit to shields
 			attackforce = (P.damage)
 	else if(isitem(hitby))

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -65,8 +65,8 @@
 		if(prob(I.force))
 			push_over()
 
-/obj/item/cardboard_cutout/bullet_act(obj/item/projectile/P, def_zone, piercing_hit = FALSE)
-	if(istype(P, /obj/item/projectile/bullet/reusable))
+/obj/item/cardboard_cutout/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
+	if(istype(P, /obj/projectile/bullet/reusable))
 		P.on_hit(src, 0, piercing_hit)
 	visible_message("<span class='danger'>[src] is hit by [P]!</span>")
 	playsound(src, 'sound/weapons/slice.ogg', 50, 1)

--- a/code/game/objects/items/chrono_eraser.dm
+++ b/code/game/objects/items/chrono_eraser.dm
@@ -120,24 +120,24 @@
 		TED.pass_mind(M)
 
 
-/obj/item/projectile/energy/chrono_beam
+/obj/projectile/energy/chrono_beam
 	name = "eradication beam"
 	icon_state = "chronobolt"
 	range = CHRONO_BEAM_RANGE
 	nodamage = TRUE
 	var/obj/item/gun/energy/chrono_gun/gun = null
 
-/obj/item/projectile/energy/chrono_beam/Initialize(mapload)
+/obj/projectile/energy/chrono_beam/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/chrono_beam/C = loc
 	if(istype(C))
 		gun = C.gun
 
-/obj/item/projectile/energy/chrono_beam/Destroy()
+/obj/projectile/energy/chrono_beam/Destroy()
 	gun = null
 	return ..()
 
-/obj/item/projectile/energy/chrono_beam/on_hit(atom/target)
+/obj/projectile/energy/chrono_beam/on_hit(atom/target)
 	if(target && gun && isliving(target))
 		var/obj/structure/chrono_field/F = new(target.loc, target, gun)
 		gun.field_connect(F)
@@ -145,7 +145,7 @@
 
 /obj/item/ammo_casing/energy/chrono_beam
 	name = "eradication beam"
-	projectile_type = /obj/item/projectile/energy/chrono_beam
+	projectile_type = /obj/projectile/energy/chrono_beam
 	icon_state = "chronobolt"
 	e_cost = 0
 	var/obj/item/gun/energy/chrono_gun/gun
@@ -248,9 +248,9 @@
 	else
 		qdel(src)
 
-/obj/structure/chrono_field/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy/chrono_beam))
-		var/obj/item/projectile/energy/chrono_beam/beam = P
+/obj/structure/chrono_field/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/energy/chrono_beam))
+		var/obj/projectile/energy/chrono_beam/beam = P
 		var/obj/item/gun/energy/chrono_gun/Pgun = beam.gun
 		if(Pgun && istype(Pgun))
 			Pgun.field_connect(src)

--- a/code/game/objects/items/deployable/barricade.dm
+++ b/code/game/objects/items/deployable/barricade.dm
@@ -81,10 +81,10 @@
 	. = ..()
 	if(locate(/obj/structure/barricade) in get_turf(mover))
 		return TRUE
-	else if(istype(mover, /obj/item/projectile))
+	else if(istype(mover, /obj/projectile))
 		if(!anchored)
 			return TRUE
-		var/obj/item/projectile/proj = mover
+		var/obj/projectile/proj = mover
 		if(proj.firer && Adjacent(proj.firer))
 			return TRUE
 		if(prob(proj_pass_rate))

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -242,7 +242,7 @@
 	create_with_tank = TRUE
 
 /obj/item/flamethrower/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/obj/item/projectile/P = hitby
+	var/obj/projectile/P = hitby
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(15))
 		owner.visible_message("<span class='danger'>\The [attack_text] hits the fuel tank on [owner]'s [name], rupturing it! What a shot!</span>")
 		var/turf/target_turf = get_turf(owner)

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -157,7 +157,7 @@
 	return attack_hand(user)
 
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/obj/item/projectile/P = hitby
+	var/obj/projectile/P = hitby
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(15))
 		owner.visible_message("<span class='danger'>[attack_text] hits [owner]'s [src], setting it off! What a shot!</span>")
 		var/turf/T = get_turf(src)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -66,13 +66,13 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 1 //how many tiles away the mob will be stunned.
-	shrapnel_type = /obj/item/projectile/bullet/pellet/stingball
+	shrapnel_type = /obj/projectile/bullet/pellet/stingball
 	shrapnel_radius = 5
 	custom_premium_price = 700 // mostly gotten through cargo, but throw in one for the sec vendor ;)
 
 /obj/item/grenade/stingbang/mega
 	name = "mega stingbang"
-	shrapnel_type = /obj/item/projectile/bullet/pellet/stingball/mega
+	shrapnel_type = /obj/projectile/bullet/pellet/stingball/mega
 	shrapnel_radius = 12
 
 /obj/item/grenade/stingbang/prime(mob/living/lanced_by)
@@ -133,7 +133,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/rots_per_mag = 3 /// how many times we need to "rotate" the charge in hand per extra tile of magnitude
-	shrapnel_type = /obj/item/projectile/bullet/shrapnel
+	shrapnel_type = /obj/projectile/bullet/shrapnel
 	var/rots = 1 /// how many times we've "rotated" the charge
 
 /obj/item/grenade/primer/attack_self(mob/user)
@@ -156,4 +156,4 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	rots_per_mag = 2
-	shrapnel_type = /obj/item/projectile/bullet/pellet/stingball
+	shrapnel_type = /obj/projectile/bullet/pellet/stingball

--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -28,7 +28,7 @@
 	name = "frag grenade"
 	desc = "An anti-personnel fragmentation grenade, this weapon excels at killing soft targets by shredding them with metal shrapnel."
 	icon_state = "frag"
-	shrapnel_type = /obj/item/projectile/bullet/shrapnel
+	shrapnel_type = /obj/projectile/bullet/shrapnel
 	shrapnel_radius = 4
 	ex_heavy = 1
 	ex_light = 3
@@ -37,7 +37,7 @@
 /obj/item/grenade/frag/mega
 	name = "\improper FRAG grenade"
 	desc = "An anti-everything fragmentation grenade, this weapon excels at killing anything any everything by shredding them with metal shrapnel."
-	shrapnel_type = /obj/item/projectile/bullet/shrapnel/mega
+	shrapnel_type = /obj/projectile/bullet/shrapnel/mega
 	shrapnel_radius = 12
 
 /obj/item/grenade/frag/prime(mob/living/lanced_by)

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -40,7 +40,7 @@
 			if (prob(50))
 				qdel(src)
 
-/obj/item/latexballon/bullet_act(obj/item/projectile/P)
+/obj/item/latexballon/bullet_act(obj/projectile/P)
 	if(!P.nodamage)
 		burst()
 	return ..()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -656,7 +656,7 @@
 	"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 	consume_everything()
 
-/obj/item/melee/supermatter_sword/bullet_act(obj/item/projectile/P)
+/obj/item/melee/supermatter_sword/bullet_act(obj/projectile/P)
 	visible_message("<span class='danger'>[P] smacks into [src] and rapidly flashes to ash.</span>",\
 	"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 	consume_everything(P)

--- a/code/game/objects/items/mjolnir.dm
+++ b/code/game/objects/items/mjolnir.dm
@@ -51,7 +51,7 @@
 /obj/item/mjolnir/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, quickstart)
 	thrower.visible_message("<span class='warning'>[thrower] throws [src] with impossible strength!</span>", "<span class='notice'>You lightly throw [src] and it accelerates out of your hand!</span>")
 	//Create the mjolnir projectile
-	var/obj/item/projectile/created = new /obj/item/projectile/mjolnir(get_turf(src), src)
+	var/obj/projectile/created = new /obj/projectile/mjolnir(get_turf(src), src)
 	created.preparePixelProjectile(target, thrower)
 	created.firer = thrower
 	created.fire()
@@ -127,7 +127,7 @@
 		user.visible_message("<span class='notice'>[user] attempts to lift [contained], but its too heavy!</span>", "<span class='userdanger'>[contained] is too heavy!</span>")
 
 
-/obj/item/projectile/mjolnir
+/obj/projectile/mjolnir
 	name = "mjolnir"
 	desc = "A weapon worthy of a god, able to strike with the force of a lightning bolt. It crackles with barely contained energy."
 	icon_state = "mjollnir"
@@ -139,19 +139,19 @@
 	speed = 0.3
 	var/obj/item/mjolnir/contained
 
-/obj/item/projectile/mjolnir/Initialize(mapload, obj/item/mjolnir/contained_hammer)
+/obj/projectile/mjolnir/Initialize(mapload, obj/item/mjolnir/contained_hammer)
 	. = ..()
 	contained = contained_hammer
 	if (contained_hammer)
 		contained_hammer.forceMove(src)
 
-/obj/item/projectile/mjolnir/Destroy()
+/obj/projectile/mjolnir/Destroy()
 	if (contained)
 		new /obj/structure/anchored_mjolnir(loc, contained)
 		contained = null
 	. = ..()
 
-/obj/item/projectile/mjolnir/on_hit(atom/target, blocked, pierce_hit)
+/obj/projectile/mjolnir/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()
 	if (isobj(target))
 		var/obj/hit_structure = target

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -582,17 +582,17 @@
 /obj/item/ammo_casing/caseless/gumball
 	name = "Gumball"
 	desc = "Why are you seeing this?!"
-	projectile_type = /obj/item/projectile/bullet/reusable/gumball
+	projectile_type = /obj/projectile/bullet/reusable/gumball
 
 
-/obj/item/projectile/bullet/reusable/gumball
+/obj/projectile/bullet/reusable/gumball
 	name = "gumball"
 	desc = "Oh noes! A fast-moving gumball!"
 	icon_state = "gumball"
 	ammo_type = /obj/item/reagent_containers/food/snacks/gumball/cyborg
 	nodamage = TRUE
 
-/obj/item/projectile/bullet/reusable/gumball/handle_drop()
+/obj/projectile/bullet/reusable/gumball/handle_drop()
 	if(!dropped)
 		var/turf/T = get_turf(src)
 		var/obj/item/reagent_containers/food/snacks/gumball/S = new ammo_type(T)
@@ -602,9 +602,9 @@
 /obj/item/ammo_casing/caseless/lollipop	//NEEDS RANDOMIZED COLOR LOGIC.
 	name = "Lollipop"
 	desc = "Why are you seeing this?!"
-	projectile_type = /obj/item/projectile/bullet/reusable/lollipop
+	projectile_type = /obj/projectile/bullet/reusable/lollipop
 
-/obj/item/projectile/bullet/reusable/lollipop
+/obj/projectile/bullet/reusable/lollipop
 	name = "lollipop"
 	desc = "Oh noes! A fast-moving lollipop!"
 	icon_state = "lollipop_1"
@@ -612,7 +612,7 @@
 	var/color2 = rgb(0, 0, 0)
 	nodamage = TRUE
 
-/obj/item/projectile/bullet/reusable/lollipop/Initialize(mapload)
+/obj/projectile/bullet/reusable/lollipop/Initialize(mapload)
 	. = ..()
 	var/obj/item/reagent_containers/food/snacks/lollipop/S = new ammo_type(src)
 	color2 = S.headcolor
@@ -620,7 +620,7 @@
 	head.color = color2
 	add_overlay(head)
 
-/obj/item/projectile/bullet/reusable/lollipop/handle_drop()
+/obj/projectile/bullet/reusable/lollipop/handle_drop()
 	if(!dropped)
 		var/turf/T = get_turf(src)
 		var/obj/item/reagent_containers/food/snacks/lollipop/S = new ammo_type(T)
@@ -648,7 +648,7 @@
 	var/projectile_damage_tick_ecost_coefficient = 10
 	var/projectile_speed_coefficient = 1.5		//Higher the coefficient slower the projectile.
 	var/projectile_tick_speed_ecost = 75
-	var/list/obj/item/projectile/tracked
+	var/list/obj/projectile/tracked
 	var/image/projectile_effect
 	var/field_radius = 3
 	var/active = FALSE
@@ -741,7 +741,7 @@
 /obj/item/borg/projectile_dampen/proc/process_usage(delta_time)
 	var/usage = 0
 	for(var/I in tracked)
-		var/obj/item/projectile/P = I
+		var/obj/projectile/P = I
 		if(!P.stun && P.nodamage)	//No damage
 			continue
 		usage += projectile_tick_speed_ecost * delta_time
@@ -762,7 +762,7 @@
 		host.cell.use(energy_recharge * delta_time * energy_recharge_cyborg_drain_coefficient)
 		energy += energy_recharge * delta_time
 
-/obj/item/borg/projectile_dampen/proc/dampen_projectile(obj/item/projectile/P, track_projectile = TRUE)
+/obj/item/borg/projectile_dampen/proc/dampen_projectile(obj/projectile/P, track_projectile = TRUE)
 	if(tracked[P])
 		return
 	if(track_projectile)
@@ -771,7 +771,7 @@
 	P.speed *= projectile_speed_coefficient
 	P.add_overlay(projectile_effect)
 
-/obj/item/borg/projectile_dampen/proc/restore_projectile(obj/item/projectile/P)
+/obj/item/borg/projectile_dampen/proc/restore_projectile(obj/projectile/P)
 	tracked -= P
 	P.damage *= (1/projectile_damage_coefficient)
 	P.speed *= (1/projectile_speed_coefficient)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -20,7 +20,7 @@
 	if(durability)
 		var/attackforce = 0
 		if(isprojectile(hitby))
-			var/obj/item/projectile/P = hitby
+			var/obj/projectile/P = hitby
 			if(P.damage_type != STAMINA)// disablers dont do shit to shields
 				attackforce = (P.damage / 2)
 		else if(isitem(hitby))
@@ -286,7 +286,7 @@
 /obj/item/shield/energy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(active)
 		if(isprojectile(hitby))
-			var/obj/item/projectile/P = hitby
+			var/obj/projectile/P = hitby
 			if(P.reflectable)
 				P.firer = src
 				P.setAngle(get_dir(owner, hitby))

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -59,17 +59,17 @@
 #define DECALTYPE_SCORCH 1
 #define DECALTYPE_BULLET 2
 
-/obj/item/target/clown/bullet_act(obj/item/projectile/P)
+/obj/item/target/clown/bullet_act(obj/projectile/P)
 	. = ..()
 	playsound(src.loc, 'sound/items/bikehorn.ogg', 50, 1)
 
-/obj/item/target/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/bullet/reusable)) // If it's a foam dart, don't bother with any of this other shit
+/obj/item/target/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/bullet/reusable)) // If it's a foam dart, don't bother with any of this other shit
 		return P.on_hit(src, 0)
 	var/p_x = P.p_x + pick(0,0,0,0,0,-1,1) // really ugly way of coding "sometimes offset P.p_x!"
 	var/p_y = P.p_y + pick(0,0,0,0,0,-1,1)
 	var/decaltype = DECALTYPE_SCORCH
-	if(istype(P, /obj/item/projectile/bullet))
+	if(istype(P, /obj/projectile/bullet))
 		decaltype = DECALTYPE_BULLET
 	var/icon/C = icon(icon,icon_state)
 	if(C.GetPixel(p_x, p_y) && P.original == src && overlays.len <= 35) // if the located pixel isn't blank (null)
@@ -82,7 +82,7 @@
 		bullet_hole.pixel_y = p_y - 1
 		if(decaltype == DECALTYPE_SCORCH)
 			bullet_hole.setDir(pick(NORTH,SOUTH,EAST,WEST))// random scorch design
-			if(P.damage >= 20 || istype(P, /obj/item/projectile/beam/practice))
+			if(P.damage >= 20 || istype(P, /obj/projectile/beam/practice))
 				bullet_hole.setDir(pick(NORTH,SOUTH,EAST,WEST))
 			else
 				bullet_hole.icon_state = "light_scorch"

--- a/code/game/objects/items/shrapnel.dm
+++ b/code/game/objects/items/shrapnel.dm
@@ -26,7 +26,7 @@
 	name = "\improper .38 DumDum bullet"
 	embedding = list(embed_chance=70, fall_chance=7, jostle_chance=7, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
 
-/obj/item/projectile/bullet/shrapnel
+/obj/projectile/bullet/shrapnel
 	name = "flying shrapnel shard"
 	damage = 9
 	range = 10
@@ -38,7 +38,7 @@
 	ricochet_incidence_leeway = 60
 	hit_stunned_targets = TRUE
 
-/obj/item/projectile/bullet/shrapnel/mega
+/obj/projectile/bullet/shrapnel/mega
 	name = "flying shrapnel hunk"
 	range = 25
 	dismemberment = 10
@@ -46,7 +46,7 @@
 	ricochet_chance = 90
 	ricochet_decay_chance = 0.9
 
-/obj/item/projectile/bullet/pellet/stingball
+/obj/projectile/bullet/pellet/stingball
 	name = "stingball pellet"
 	damage = 3
 	stamina = 8
@@ -59,10 +59,10 @@
 	ricochet_incidence_leeway = 0
 	shrapnel_type = /obj/item/shrapnel/stingball
 
-/obj/item/projectile/bullet/pellet/stingball/mega
+/obj/projectile/bullet/pellet/stingball/mega
 	name = "megastingball pellet"
 	ricochets_max = 6
 	ricochet_chance = 110
 
-/obj/item/projectile/bullet/pellet/stingball/on_ricochet(atom/A)
+/obj/projectile/bullet/pellet/stingball/on_ricochet(atom/A)
 	hit_stunned_targets = TRUE // ducking will save you from the first wave, but not the rebounds

--- a/code/game/objects/items/stacks/sheets/mineral/materials.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/materials.dm
@@ -101,7 +101,7 @@ Mineral Sheets
 	if(exposed_temperature > 300)
 		plasma_ignition(amount/5)
 
-/obj/item/stack/sheet/mineral/plasma/bullet_act(obj/item/projectile/Proj)
+/obj/item/stack/sheet/mineral/plasma/bullet_act(obj/projectile/Proj)
 	if(!(Proj.nodamage) && Proj.damage_type == BURN)
 		plasma_ignition(amount/5, Proj?.firer)
 	. = ..()

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -68,7 +68,7 @@
 		if(3)
 			take_damage(rand(10, 90), BRUTE, BOMB, 0)
 
-/obj/bullet_act(obj/item/projectile/P)
+/obj/bullet_act(obj/projectile/P)
 	. = ..()
 	playsound(src, P.hitsound, 50, 1)
 	if(P.suppressed != SUPPRESSED_VERY)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -419,7 +419,7 @@
 /obj/proc/on_object_saved(var/depth = 0)
 	return ""
 
-/obj/handle_ricochet(obj/item/projectile/P)
+/obj/handle_ricochet(obj/projectile/P)
 	. = ..()
 	if(. && ricochet_damage_mod)
 		take_damage(P.damage * ricochet_damage_mod, P.damage_type, P.armor_flag, 0, turn(P.dir, 180), P.armour_penetration) // pass along ricochet_damage_mod damage to the structure for the ricochet

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -275,7 +275,7 @@
 			new /obj/structure/girder/displaced(loc)
 
 
-/obj/structure/falsewall/plasma/bullet_act(obj/item/projectile/Proj)
+/obj/structure/falsewall/plasma/bullet_act(obj/projectile/Proj)
 	if(!(Proj.nodamage) && Proj.damage_type == BURN)
 		if(plasma_ignition(6, Proj?.firer))
 			new /obj/structure/girder/displaced(loc)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -285,7 +285,7 @@
 
 /obj/structure/girder/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if((mover.pass_flags & PASSGRILLE) || istype(mover, /obj/item/projectile))
+	if((mover.pass_flags & PASSGRILLE) || istype(mover, /obj/projectile))
 		return prob(girderpasschance)
 
 /obj/structure/girder/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -136,7 +136,7 @@
 
 /obj/structure/grille/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(!. && istype(mover, /obj/item/projectile))
+	if(!. && istype(mover, /obj/projectile))
 		return prob(30)
 
 /obj/structure/grille/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -126,11 +126,11 @@
 	max_integrity = 10
 	allow_walk = 0
 
-/obj/structure/holosign/barrier/cyborg/bullet_act(obj/item/projectile/P)
+/obj/structure/holosign/barrier/cyborg/bullet_act(obj/projectile/P)
 	take_damage((P.damage / 5) , BRUTE, MELEE, 1)	//Doesn't really matter what damage flag it is.
-	if(istype(P, /obj/item/projectile/energy/electrode))
+	if(istype(P, /obj/projectile/energy/electrode))
 		take_damage(10, BRUTE, MELEE, 1)	//Tasers aren't harmful.
-	if(istype(P, /obj/item/projectile/beam/disabler))
+	if(istype(P, /obj/projectile/beam/disabler))
 		take_damage(5, BRUTE, MELEE, 1)	//Disablers aren't harmful.
 	return BULLET_ACT_HIT
 
@@ -186,7 +186,7 @@
 	max_integrity = 20
 	var/shockcd = 0
 
-/obj/structure/holosign/barrier/cyborg/hacked/bullet_act(obj/item/projectile/P)
+/obj/structure/holosign/barrier/cyborg/hacked/bullet_act(obj/projectile/P)
 	take_damage(P.damage, BRUTE, MELEE, 1)	//Yeah no this doesn't get projectile resistance.
 	return BULLET_ACT_HIT
 

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -14,7 +14,7 @@
 	move_resist = MOVE_FORCE_STRONG
 	var/view_range = 2.5
 	var/cooldown = 0
-	var/projectile_type = /obj/item/projectile/bullet/manned_turret
+	var/projectile_type = /obj/projectile/bullet/manned_turret
 	var/rate_of_fire = 1
 	var/number_of_shots = 40
 	var/cooldown_duration = 90
@@ -153,7 +153,7 @@
 	var/turf/targets_from = get_turf(src)
 	if(QDELETED(target))
 		target = target_turf
-	var/obj/item/projectile/P = new projectile_type(targets_from)
+	var/obj/projectile/P = new projectile_type(targets_from)
 	P.starting = targets_from
 	P.firer = user
 	P.original = target
@@ -168,7 +168,7 @@
 /obj/machinery/manned_turret/ultimate  // Admin-only proof of concept for autoclicker automatics
 	name = "Infinity Gun"
 	view_range = 12
-	projectile_type = /obj/item/projectile/bullet/manned_turret
+	projectile_type = /obj/projectile/bullet/manned_turret
 
 /obj/machinery/manned_turret/ultimate/checkfire(atom/targeted_atom, mob/user)
 	target = targeted_atom

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -264,7 +264,7 @@
 	if(exposed_temperature > 300)
 		plasma_ignition(6)
 
-/obj/structure/mineral_door/transparent/plasma/bullet_act(obj/item/projectile/Proj)
+/obj/structure/mineral_door/transparent/plasma/bullet_act(obj/projectile/Proj)
 	if(!(Proj.nodamage) && Proj.damage_type == BURN)
 		plasma_ignition(6, Proj?.firer)
 	. = ..()

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -248,7 +248,7 @@
 
 
 //basically stolen from human_defense.dm
-/obj/structure/mirror/bullet_act(obj/item/projectile/P)
+/obj/structure/mirror/bullet_act(obj/projectile/P)
 	if(P.reflectable & REFLECT_NORMAL)
 		if(P.starting)
 			var/new_x = P.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -14,7 +14,7 @@
 	var/framebuildstackamount = 5
 	var/buildstacktype = /obj/item/stack/sheet/iron
 	var/buildstackamount = 0
-	var/list/allowed_projectile_typecache = list(/obj/item/projectile/beam)
+	var/list/allowed_projectile_typecache = list(/obj/projectile/beam)
 	var/rotation_angle = -1
 
 /obj/structure/reflector/Initialize(mapload)
@@ -62,7 +62,7 @@
 /obj/structure/reflector/proc/dir_map_to_angle(dir)
 	return 0
 
-/obj/structure/reflector/bullet_act(obj/item/projectile/P)
+/obj/structure/reflector/bullet_act(obj/projectile/P)
 	var/pdir = P.dir
 	var/pangle = P.Angle
 	var/ploc = get_turf(P)
@@ -72,7 +72,7 @@
 		return ..()
 	return BULLET_ACT_FORCE_PIERCE
 
-/obj/structure/reflector/proc/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
+/obj/structure/reflector/proc/auto_reflect(obj/projectile/P, pdir, turf/ploc, pangle)
 	P.ignore_source_check = TRUE
 	P.range = P.decayedRange
 	P.decayedRange = max(P.decayedRange--, 0)
@@ -197,7 +197,7 @@
 	admin = TRUE
 	anchored = TRUE
 
-/obj/structure/reflector/single/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
+/obj/structure/reflector/single/auto_reflect(obj/projectile/P, pdir, turf/ploc, pangle)
 	var/incidence = GET_ANGLE_OF_INCIDENCE(rotation_angle, (P.Angle + 180))
 	if(abs(incidence) > 90 && abs(incidence) < 270)
 		return FALSE
@@ -223,7 +223,7 @@
 	admin = TRUE
 	anchored = TRUE
 
-/obj/structure/reflector/double/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
+/obj/structure/reflector/double/auto_reflect(obj/projectile/P, pdir, turf/ploc, pangle)
 	var/incidence = GET_ANGLE_OF_INCIDENCE(rotation_angle, (P.Angle + 180))
 	var/new_angle = SIMPLIFY_DEGREES(rotation_angle + incidence)
 	P.setAngle(new_angle)
@@ -247,7 +247,7 @@
 	admin = TRUE
 	anchored = TRUE
 
-/obj/structure/reflector/box/auto_reflect(obj/item/projectile/P)
+/obj/structure/reflector/box/auto_reflect(obj/projectile/P)
 	P.setAngle(rotation_angle)
 	return ..()
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -110,7 +110,7 @@
 		plasma_ignition(6)
 
 
-/obj/structure/statue/plasma/bullet_act(obj/item/projectile/Proj)
+/obj/structure/statue/plasma/bullet_act(obj/projectile/Proj)
 	if(!(Proj.nodamage) && Proj.damage_type == BURN)
 		plasma_ignition(6, Proj?.firer)
 	. = ..()

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -69,7 +69,7 @@
 		pinned_target.forceMove(user.drop_location())
 		to_chat(user, "<span class='notice'>You take the target out of the stake.</span>")
 
-/obj/structure/target_stake/bullet_act(obj/item/projectile/P)
+/obj/structure/target_stake/bullet_act(obj/projectile/P)
 	if(pinned_target)
 		pinned_target.bullet_act(P)
 	else

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -141,7 +141,7 @@
 		if(plasma_ignition(6))
 			new /obj/structure/girder/displaced(loc)
 
-/turf/closed/wall/mineral/plasma/bullet_act(obj/item/projectile/Proj)
+/turf/closed/wall/mineral/plasma/bullet_act(obj/projectile/Proj)
 	if(!(Proj.nodamage) && Proj.damage_type == BURN)
 		if(plasma_ignition(6))
 			new /obj/structure/girder/displaced(loc)

--- a/code/game/turfs/open/reebe_void.dm
+++ b/code/game/turfs/open/reebe_void.dm
@@ -43,7 +43,7 @@
 	else
 		if(istype(AM, /obj/structure/window))
 			return FALSE
-		if(istype(AM, /obj/item/projectile))
+		if(istype(AM, /obj/projectile))
 			return TRUE
 		if((locate(/obj/structure/lattice) in src))
 			return TRUE

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -187,7 +187,7 @@
 		blob_attack_animation(T, controller) //if we can't, animate that we attacked
 	return null
 
-/obj/structure/blob/bullet_act(obj/item/projectile/energy/accelerated_particle/P, def_zone, piercing_hit = FALSE)
+/obj/structure/blob/bullet_act(obj/projectile/energy/accelerated_particle/P, def_zone, piercing_hit = FALSE)
 	if(istype(P))
 		playsound(src, 'sound/weapons/pierce.ogg', 50, 1) //we don't have a hitsound so lets just overwrite it here
 		visible_message("<span class='danger'>[src] is hit by \a [P]!</span>", null, null, COMBAT_MESSAGE_RANGE)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -256,7 +256,7 @@
 /obj/item/ammo_casing/magic/tentacle
 	name = "tentacle"
 	desc = "A tentacle."
-	projectile_type = /obj/item/projectile/tentacle
+	projectile_type = /obj/projectile/tentacle
 	caliber = "tentacle"
 	icon_state = "tentacle_end"
 	firing_effect_type = null
@@ -270,7 +270,7 @@
 	gun = null
 	return ..()
 
-/obj/item/projectile/tentacle
+/obj/projectile/tentacle
 	name = "tentacle"
 	icon_state = "tentacle_end"
 	pass_flags = PASSTABLE
@@ -281,20 +281,20 @@
 	var/chain
 	var/obj/item/ammo_casing/magic/tentacle/source //the item that shot it
 
-/obj/item/projectile/tentacle/Initialize(mapload)
+/obj/projectile/tentacle/Initialize(mapload)
 	source = loc
 	. = ..()
 
-/obj/item/projectile/tentacle/fire(setAngle)
+/obj/projectile/tentacle/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "tentacle", time = INFINITY, maxdistance = INFINITY, beam_sleep_time = 1)
 	..()
 
-/obj/item/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)
+/obj/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)
 	if(H.throw_mode)
 		H.throw_mode_off(THROW_MODE_TOGGLE) //Don't annoy the changeling if he doesn't catch the item
 
-/obj/item/projectile/tentacle/proc/tentacle_grab(mob/living/carbon/human/H, mob/living/carbon/C)
+/obj/projectile/tentacle/proc/tentacle_grab(mob/living/carbon/human/H, mob/living/carbon/C)
 	if(H.Adjacent(C))
 		if(H.get_active_held_item() && !H.get_inactive_held_item())
 			H.swap_hand()
@@ -303,7 +303,7 @@
 		C.grabbedby(H)
 		C.grippedby(H, instant = TRUE) //instant aggro grab
 
-/obj/item/projectile/tentacle/proc/tentacle_stab(mob/living/carbon/human/H, mob/living/carbon/C)
+/obj/projectile/tentacle/proc/tentacle_stab(mob/living/carbon/human/H, mob/living/carbon/C)
 	if(H.Adjacent(C))
 		for(var/obj/item/I in H.held_items)
 			if(I.is_sharp())
@@ -314,7 +314,7 @@
 				playsound(get_turf(H),I.hitsound,75,1)
 				return
 
-/obj/item/projectile/tentacle/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/tentacle/on_hit(atom/target, blocked = FALSE)
 	var/mob/living/carbon/human/H = firer
 	if(blocked >= 100)
 		return BULLET_ACT_BLOCK
@@ -369,7 +369,7 @@
 				L.throw_at(get_step_towards(H,L), 8, 2)
 				. = BULLET_ACT_HIT
 
-/obj/item/projectile/tentacle/Destroy()
+/obj/projectile/tentacle/Destroy()
 	qdel(chain)
 	source = null
 	return ..()

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -188,9 +188,9 @@
 	name = "energy bolt"
 	desc = "An arrow made from a strange energy."
 	icon_state = "arrow_redlight"
-	projectile_type = /obj/item/projectile/energy/clockbolt
+	projectile_type = /obj/projectile/energy/clockbolt
 
-/obj/item/projectile/energy/clockbolt
+/obj/projectile/energy/clockbolt
 	name = "energy bolt"
 	icon_state = "arrow_energy"
 	damage = 24

--- a/code/modules/antagonists/clock_cult/mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clock_cult/mobs/clockwork_marauder.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_EMPTY(clockwork_marauders)
 		return
 	. = ..()
 
-/mob/living/simple_animal/hostile/clockwork_marauder/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/clockwork_marauder/bullet_act(obj/projectile/Proj)
 	//Block Ranged Attacks
 	if(shield_health > 0)
 		damage_shield()

--- a/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 		try_warp_servant(src, T, FALSE)
 	. = ..()
 
-/mob/living/simple_animal/drone/cogscarab/force_hit_projectile(obj/item/projectile/projectile)
+/mob/living/simple_animal/drone/cogscarab/force_hit_projectile(obj/projectile/projectile)
 	if(isliving(projectile.fired_from) && is_servant_of_ratvar(projectile.fired_from))
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -125,7 +125,7 @@
 		return
 	. = ..()
 
-/mob/living/simple_animal/eminence/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/eminence/bullet_act(obj/projectile/Proj)
 	return BULLET_ACT_FORCE_PIERCE
 
 /mob/living/simple_animal/eminence/proc/run_global_event(datum/round_event_control/E)

--- a/code/modules/antagonists/clock_cult/scriptures/interdiction_lens.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/interdiction_lens.dm
@@ -107,7 +107,7 @@
 /datum/proximity_monitor/advanced/peaceborg_dampener/clockwork/setup_edge_turf(turf/T)
 	edge_turfs[T] = new /obj/effect/abstract/proximity_checker/advanced/field_edge(T, src)
 
-/datum/proximity_monitor/advanced/peaceborg_dampener/clockwork/capture_projectile(obj/item/projectile/P, track_projectile = TRUE)
+/datum/proximity_monitor/advanced/peaceborg_dampener/clockwork/capture_projectile(obj/projectile/P, track_projectile = TRUE)
 	if(P in tracked)
 		return
 	if(isliving(P.firer))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -757,17 +757,17 @@ Striking a noncultist, however, will tear their flesh."}
 	ammo_type = /obj/item/ammo_casing/magic/arcane_barrage/blood
 
 /obj/item/ammo_casing/magic/arcane_barrage/blood
-	projectile_type = /obj/item/projectile/magic/arcane_barrage/blood
+	projectile_type = /obj/projectile/magic/arcane_barrage/blood
 	firing_effect_type = /obj/effect/temp_visual/cult/sparks
 
-/obj/item/projectile/magic/arcane_barrage/blood
+/obj/projectile/magic/arcane_barrage/blood
 	name = "blood bolt"
 	icon_state = "mini_leaper"
 	nondirectional_sprite = TRUE
 	damage_type = BRUTE
 	impact_effect_type = /obj/effect/temp_visual/dir_setting/bloodsplatter
 
-/obj/item/projectile/magic/arcane_barrage/blood/Bump(atom/target)
+/obj/projectile/magic/arcane_barrage/blood/Bump(atom/target)
 	var/turf/T = get_turf(target)
 	playsound(T, 'sound/effects/splat.ogg', 50, TRUE)
 	if(iscultist(target))

--- a/code/modules/antagonists/heretic/magic/rust_wave.dm
+++ b/code/modules/antagonists/heretic/magic/rust_wave.dm
@@ -62,7 +62,7 @@
 /obj/effect/proc_holder/spell/targeted/projectile/dumbfire/rust_wave
 	name = "Patron's Reach"
 	desc = "Channels energy into your hands to release a wave of rust."
-	proj_type = /obj/item/projectile/magic/spell/rust_wave
+	proj_type = /obj/projectile/magic/spell/rust_wave
 	requires_heretic_focus = TRUE
 	charge_max = 350
 	clothes_req = FALSE
@@ -72,7 +72,7 @@
 	invocation = "SPR'D TH' WO'D"
 	invocation_type = INVOCATION_WHISPER
 
-/obj/item/projectile/magic/spell/rust_wave
+/obj/projectile/magic/spell/rust_wave
 	name = "Patron's Reach"
 	icon_state = "eldritch_projectile"
 	alpha = 180
@@ -84,7 +84,7 @@
 	range = 15
 	speed = 1
 
-/obj/item/projectile/magic/spell/rust_wave/Moved(atom/OldLoc, Dir)
+/obj/projectile/magic/spell/rust_wave/Moved(atom/OldLoc, Dir)
 	. = ..()
 	playsound(src, 'sound/items/welder.ogg', 75, TRUE)
 	var/list/turflist = list()
@@ -104,8 +104,8 @@
 
 /obj/effect/proc_holder/spell/targeted/projectile/dumbfire/rust_wave/short
 	name = "Small Patron's Reach"
-	proj_type = /obj/item/projectile/magic/spell/rust_wave/short
+	proj_type = /obj/projectile/magic/spell/rust_wave/short
 
-/obj/item/projectile/magic/spell/rust_wave/short
+/obj/projectile/magic/spell/rust_wave/short
 	range = 7
 	speed = 2

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -83,7 +83,7 @@
 	mob_size = MOB_SIZE_TINY
 	ventcrawler = VENTCRAWLER_ALWAYS
 	ranged = 1
-	projectiletype = /obj/item/projectile/beam/disabler
+	projectiletype = /obj/projectile/beam/disabler
 	ranged_cooldown_time = 20
 	projectilesound = 'sound/weapons/taser2.ogg'
 	loot = list(/obj/effect/decal/cleanable/robot_debris, /obj/item/stack/ore/bluespace_crystal)
@@ -140,7 +140,7 @@
 
 /mob/living/simple_animal/hostile/swarmer/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(istype(mover, /obj/item/projectile/beam/disabler))//Allows for swarmers to fight as a group without wasting their shots hitting each other
+	if(istype(mover, /obj/projectile/beam/disabler))//Allows for swarmers to fight as a group without wasting their shots hitting each other
 		return TRUE
 	else if(isswarmer(mover))
 		return TRUE
@@ -645,7 +645,7 @@
 
 /obj/structure/swarmer/blockade/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(isswarmer(mover) || istype(mover, /obj/item/projectile/beam/disabler))
+	if(isswarmer(mover) || istype(mover, /obj/projectile/beam/disabler))
 		return TRUE
 
 /mob/living/simple_animal/hostile/swarmer/proc/CreateSwarmer()

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -409,9 +409,9 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		turret.obj_integrity = 200
 		turret.emp_proofing = TRUE
 		turret.AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_CONTENTS | EMP_PROTECT_WIRES)
-		turret.stun_projectile = /obj/item/projectile/beam/disabler/pass_glass //// AI defenses are often built with glass, so this is big.
+		turret.stun_projectile = /obj/projectile/beam/disabler/pass_glass //// AI defenses are often built with glass, so this is big.
 		turret.stun_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
-		turret.lethal_projectile = /obj/item/projectile/beam/laser/heavylaser //Once you see it, you will know what it means to FEAR.
+		turret.lethal_projectile = /obj/projectile/beam/laser/heavylaser //Once you see it, you will know what it means to FEAR.
 		turret.lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 
 

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -411,12 +411,12 @@
 	ammo_type = /obj/item/ammo_casing/a50/ctf
 
 /obj/item/ammo_casing/a50/ctf
-	projectile_type = /obj/item/projectile/bullet/ctf
+	projectile_type = /obj/projectile/bullet/ctf
 
-/obj/item/projectile/bullet/ctf
+/obj/projectile/bullet/ctf
 	damage = 0
 
-/obj/item/projectile/bullet/ctf/prehit_pierce(atom/target)
+/obj/projectile/bullet/ctf/prehit_pierce(atom/target)
 	if(is_ctf_target(target))
 		damage = 60
 		return PROJECTILE_PIERCE_NONE	/// hey uhh don't hit anyone behind them
@@ -448,13 +448,13 @@
 		qdel(src)
 
 /obj/item/ammo_casing/caseless/laser/ctf
-	projectile_type = /obj/item/projectile/beam/ctf
+	projectile_type = /obj/projectile/beam/ctf
 
-/obj/item/projectile/beam/ctf
+/obj/projectile/beam/ctf
 	damage = 0
 	icon_state = "omnilaser"
 
-/obj/item/projectile/beam/ctf/prehit_pierce(atom/target)
+/obj/projectile/beam/ctf/prehit_pierce(atom/target)
 	if(is_ctf_target(target))
 		damage = 150
 		return PROJECTILE_PIERCE_NONE		/// hey uhhh don't hit anyone behind them
@@ -478,9 +478,9 @@
 	ammo_type = /obj/item/ammo_casing/caseless/laser/ctf/red
 
 /obj/item/ammo_casing/caseless/laser/ctf/red
-	projectile_type = /obj/item/projectile/beam/ctf/red
+	projectile_type = /obj/projectile/beam/ctf/red
 
-/obj/item/projectile/beam/ctf/red
+/obj/projectile/beam/ctf/red
 	icon_state = "laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 
@@ -493,9 +493,9 @@
 	ammo_type = /obj/item/ammo_casing/caseless/laser/ctf/blue
 
 /obj/item/ammo_casing/caseless/laser/ctf/blue
-	projectile_type = /obj/item/projectile/beam/ctf/blue
+	projectile_type = /obj/projectile/beam/ctf/blue
 
-/obj/item/projectile/beam/ctf/blue
+/obj/projectile/beam/ctf/blue
 	icon_state = "bluelaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 

--- a/code/modules/awaymissions/mission_code/TheFactory.dm
+++ b/code/modules/awaymissions/mission_code/TheFactory.dm
@@ -561,7 +561,7 @@
 	ranged = TRUE
 	rapid = 65
 	rapid_fire_delay = 0.5
-	projectiletype = /obj/item/projectile/beam
+	projectiletype = /obj/projectile/beam
 	ranged_cooldown_time = 110
 	vision_range = 9
 	speak_chance = 0

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -43,7 +43,7 @@
 	name ="retro laser"
 	icon_state = "retro"
 	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's security or military forces."
-//	projectile_type = "/obj/item/projectile/practice"
+//	projectile_type = "/obj/projectile/practice"
 	clumsy_check = 0 //No sense in having a harmless gun blow up in the clowns face
 
 //Syndicate sub-machine guns.

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -346,7 +346,7 @@
 			if (temp_pod.effectShrapnel == TRUE) //If already doing custom damage, set back to default (no shrapnel)
 				temp_pod.effectShrapnel = FALSE
 			else
-				var/shrapnelInput = input("Please enter the type of pellet cloud you'd like to create on landing (Can be any projectile!)", "Projectile Typepath",  0) in sort_list(subtypesof(/obj/item/projectile), GLOBAL_PROC_REF(cmp_typepaths_asc))
+				var/shrapnelInput = input("Please enter the type of pellet cloud you'd like to create on landing (Can be any projectile!)", "Projectile Typepath",  0) in sort_list(subtypesof(/obj/projectile), GLOBAL_PROC_REF(cmp_typepaths_asc))
 				if (isnull(shrapnelInput))
 					return
 				var/shrapnelMagnitude = input("Enter the magnitude of the pellet cloud. This is usually a value around 1-5. Please note that Ryll-Ryll has asked me to tell you that if you go too crazy with the projectiles you might crash the server. So uh, be gentle!", "Shrapnel Magnitude", 0) as null|num

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -54,7 +54,7 @@
 	var/obj/effect/supplypod_rubble/rubble
 	var/obj/effect/engineglow/glow_effect
 	var/effectShrapnel = FALSE
-	var/shrapnel_type = /obj/item/projectile/bullet/shrapnel
+	var/shrapnel_type = /obj/projectile/bullet/shrapnel
 	var/shrapnel_magnitude = 3
 	var/list/reverseOptionList = list("Mobs"=FALSE,"Objects"=FALSE,"Anchored"=FALSE,"Underfloor"=FALSE,"Wallmounted"=FALSE,"Floors"=FALSE,"Walls"=FALSE)
 	var/list/turfs_in_cargo = list()

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -119,7 +119,7 @@
 	if(!active)
 		return FALSE
 	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
+		var/obj/projectile/P = hitby
 		if(P.martial_arts_no_deflect)
 			return FALSE
 	return TRUE

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -32,15 +32,15 @@
 	ranged = 1
 	retreat_distance = 2
 	minimum_distance = 0 //Between shots they can and will close in to nash
-	projectiletype = /obj/item/projectile/magic
+	projectiletype = /obj/projectile/magic
 	projectilesound = 'sound/weapons/emitter.ogg'
 	maxHealth = 50
 	health = 50
 	random_color = FALSE
 	gold_core_spawnable = NO_SPAWN
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
+	var/allowed_projectile_types = list(/obj/projectile/magic/animate, /obj/projectile/magic/resurrection,
+	/obj/projectile/magic/death, /obj/projectile/magic/teleport, /obj/projectile/magic/door, /obj/projectile/magic/fireball,
+	/obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage)
 	discovery_points = 3000
 
 /mob/living/simple_animal/hostile/carp/ranged/Initialize(mapload)
@@ -62,12 +62,12 @@
 
 /mob/living/simple_animal/hostile/carp/ranged/xenobio
 	desc = "45% magic, 50% carp, 5% slime, 100% horrible."
-	allowed_projectile_types = list( /obj/item/projectile/magic/animate, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
+	allowed_projectile_types = list( /obj/projectile/magic/animate, /obj/projectile/magic/teleport, /obj/projectile/magic/door, /obj/projectile/magic/fireball,
+	/obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage)
 	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos/xenobio
 	desc = "95% magic, 50% carp, 5% slime, 150% horrible."
-	allowed_projectile_types = list( /obj/item/projectile/magic/animate, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
+	allowed_projectile_types = list( /obj/projectile/magic/animate, /obj/projectile/magic/teleport, /obj/projectile/magic/door, /obj/projectile/magic/fireball,
+	/obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage)
 	gold_core_spawnable = HOSTILE_SPAWN

--- a/code/modules/exploration_crew/exploration_laser_gun.dm
+++ b/code/modules/exploration_crew/exploration_laser_gun.dm
@@ -16,17 +16,17 @@
 //Anti-creature - Extra damage against simplemobs
 
 /obj/item/ammo_casing/energy/laser/anti_creature
-	projectile_type = /obj/item/projectile/beam/laser/anti_creature
+	projectile_type = /obj/projectile/beam/laser/anti_creature
 	select_name = "anti-creature"
 	e_cost = 40
 
-/obj/item/projectile/beam/laser/anti_creature
+/obj/projectile/beam/laser/anti_creature
 	damage = 15
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/laser/anti_creature/prehit_pierce(atom/target)
+/obj/projectile/beam/laser/anti_creature/prehit_pierce(atom/target)
     if(!iscarbon(target) && !issilicon(target))
         damage = 30
     return ..()
@@ -34,18 +34,18 @@
 //Cutting projectile - Damage against objects
 
 /obj/item/ammo_casing/energy/laser/cutting
-	projectile_type = /obj/item/projectile/beam/laser/cutting
+	projectile_type = /obj/projectile/beam/laser/cutting
 	select_name = "cutting laser"
 	e_cost = 30
 
-/obj/item/projectile/beam/laser/cutting
+/obj/projectile/beam/laser/cutting
 	damage = 5
 	icon_state = "heavylaser"
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 
-/obj/item/projectile/beam/laser/cutting/on_hit(atom/target, blocked)
+/obj/projectile/beam/laser/cutting/on_hit(atom/target, blocked)
 	damage = initial(damage)
 	if(isobj(target) && !istype(target, /obj/structure/blob))
 		damage = 70
@@ -57,17 +57,17 @@
 //Emagged ammo types
 
 /obj/item/ammo_casing/energy/laser/exploration_kill
-	projectile_type = /obj/item/projectile/beam/laser/exploration_kill
+	projectile_type = /obj/projectile/beam/laser/exploration_kill
 	select_name = "KILL"
 	e_cost = 80
 
-/obj/item/projectile/beam/laser/exploration_kill
+/obj/projectile/beam/laser/exploration_kill
 	damage = 30
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/laser/exploration_kill/on_hit(atom/target, blocked)
+/obj/projectile/beam/laser/exploration_kill/on_hit(atom/target, blocked)
 	damage = initial(damage)
 	if(!iscarbon(target) && !issilicon(target))
 		damage = 50
@@ -80,18 +80,18 @@
 //destroy
 
 /obj/item/ammo_casing/energy/laser/exploration_destroy
-	projectile_type = /obj/item/projectile/beam/laser/exploration_destroy
+	projectile_type = /obj/projectile/beam/laser/exploration_destroy
 	select_name = "DESTROY"
 	e_cost = 120
 
-/obj/item/projectile/beam/laser/exploration_destroy
+/obj/projectile/beam/laser/exploration_destroy
 	damage = 20
 	icon_state = "heavylaser"
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 
-/obj/item/projectile/beam/laser/exploration_destroy/on_hit(atom/target, blocked)
+/obj/projectile/beam/laser/exploration_destroy/on_hit(atom/target, blocked)
 	damage = initial(damage)
 	if(isobj(target) && !istype(target, /obj/structure/blob))
 		damage = 150

--- a/code/modules/fields/peaceborg_dampener.dm
+++ b/code/modules/fields/peaceborg_dampener.dm
@@ -17,8 +17,8 @@
 	var/static/image/southeast_corner = image('icons/effects/fields.dmi', icon_state = "projectile_dampen_southeast")
 	var/static/image/generic_edge = image('icons/effects/fields.dmi', icon_state = "projectile_dampen_generic")
 	var/obj/item/borg/projectile_dampen/projector = null
-	var/list/obj/item/projectile/tracked
-	var/list/obj/item/projectile/staging
+	var/list/obj/projectile/tracked
+	var/list/obj/projectile/staging
 	use_host_turf = TRUE
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/New()
@@ -33,9 +33,9 @@
 	if(!istype(projector))
 		qdel(src)
 	var/list/ranged = list()
-	for(var/obj/item/projectile/P in range(current_range, get_turf(host)))
+	for(var/obj/projectile/P in range(current_range, get_turf(host)))
 		ranged += P
-	for(var/obj/item/projectile/P in tracked)
+	for(var/obj/projectile/P in tracked)
 		if(!(P in ranged) || !P.loc)
 			release_projectile(P)
 	for(var/mob/living/silicon/robot/R in ohearers(current_range, get_turf(host)))
@@ -80,20 +80,20 @@
 		else
 			return generic_edge
 
-/datum/proximity_monitor/advanced/peaceborg_dampener/proc/capture_projectile(obj/item/projectile/P, track_projectile = TRUE)
+/datum/proximity_monitor/advanced/peaceborg_dampener/proc/capture_projectile(obj/projectile/P, track_projectile = TRUE)
 	if(P in tracked)
 		return
 	projector.dampen_projectile(P, track_projectile)
 	if(track_projectile)
 		tracked += P
 
-/datum/proximity_monitor/advanced/peaceborg_dampener/proc/release_projectile(obj/item/projectile/P)
+/datum/proximity_monitor/advanced/peaceborg_dampener/proc/release_projectile(obj/projectile/P)
 	projector.restore_projectile(P)
 	tracked -= P
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/field_edge_uncrossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F)
 	if(!is_turf_in_field(get_turf(AM), src))
-		if(istype(AM, /obj/item/projectile))
+		if(istype(AM, /obj/projectile))
 			if(AM in tracked)
 				release_projectile(AM)
 			else
@@ -101,13 +101,13 @@
 	return ..()
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/field_edge_crossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F)
-	if(istype(AM, /obj/item/projectile) && !(AM in tracked) && staging[AM] && !is_turf_in_field(staging[AM], src))
+	if(istype(AM, /obj/projectile) && !(AM in tracked) && staging[AM] && !is_turf_in_field(staging[AM], src))
 		capture_projectile(AM)
 	staging -= AM
 	return ..()
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/field_edge_canpass(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F, border_dir)
-	if(istype(AM, /obj/item/projectile))
+	if(istype(AM, /obj/projectile))
 		staging[AM] = get_turf(AM)
 	. = ..()
 	if(!.)

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -82,7 +82,7 @@
 	var/frozen = TRUE
 	if(isliving(A))
 		freeze_mob(A)
-	else if(istype(A, /obj/item/projectile))
+	else if(istype(A, /obj/projectile))
 		freeze_projectile(A)
 	else if(istype(A, /obj/mecha))
 		freeze_mecha(A)
@@ -114,7 +114,7 @@
 		unfreeze_throwing(A)
 	if(isliving(A))
 		unfreeze_mob(A)
-	else if(istype(A, /obj/item/projectile))
+	else if(istype(A, /obj/projectile))
 		unfreeze_projectile(A)
 	else if(istype(A, /obj/mecha))
 		unfreeze_mecha(A)
@@ -154,10 +154,10 @@
 	return ..()
 
 
-/datum/proximity_monitor/advanced/timestop/proc/freeze_projectile(obj/item/projectile/P)
+/datum/proximity_monitor/advanced/timestop/proc/freeze_projectile(obj/projectile/P)
 	P.paused = TRUE
 
-/datum/proximity_monitor/advanced/timestop/proc/unfreeze_projectile(obj/item/projectile/P)
+/datum/proximity_monitor/advanced/timestop/proc/unfreeze_projectile(obj/projectile/P)
 	P.paused = FALSE
 
 /datum/proximity_monitor/advanced/timestop/proc/freeze_mob(mob/living/L)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1317,9 +1317,9 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		qdel(src)
 		return
 	var/turf/start = pick(startlocs)
-	var/proj_type = pick(subtypesof(/obj/item/projectile/hallucination))
+	var/proj_type = pick(subtypesof(/obj/projectile/hallucination))
 	feedback_details += "Type: [proj_type]"
-	var/obj/item/projectile/hallucination/H = new proj_type(start)
+	var/obj/projectile/hallucination/H = new proj_type(start)
 	target.playsound_local(start, H.hal_fire_sound, 60, 1)
 	H.hal_target = target
 	H.preparePixelProjectile(target, start)

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -143,7 +143,7 @@
 	qdel(src)
 	target.Bumped(B)
 
-/obj/item/reagent_containers/food/drinks/bullet_act(obj/item/projectile/P)
+/obj/item/reagent_containers/food/drinks/bullet_act(obj/projectile/P)
 	. = ..()
 	if(!(P.nodamage) && P.damage_type == BRUTE && !QDELETED(src))
 		var/atom/T = get_turf(src)
@@ -496,7 +496,7 @@
 		qdel(src)
 	..()
 
-/obj/item/reagent_containers/food/drinks/soda_cans/bullet_act(obj/item/projectile/P)
+/obj/item/reagent_containers/food/drinks/soda_cans/bullet_act(obj/projectile/P)
 	. = ..()
 	if(!(P.nodamage) && P.damage_type == BRUTE && !QDELETED(src))
 		var/obj/item/trash/can/crushed_can = new /obj/item/trash/can(src.loc)

--- a/code/modules/guardian/guardian.dm
+++ b/code/modules/guardian/guardian.dm
@@ -352,7 +352,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	if( QDELETED(targeted_atom) || targeted_atom == target_from.loc || targeted_atom == target_from )
 		return
 	var/turf/startloc = get_turf(target_from)
-	var/obj/item/projectile/P = new /obj/item/projectile/guardian(startloc)
+	var/obj/projectile/P = new /obj/projectile/guardian(startloc)
 	playsound(src, projectilesound, 100, 1)
 	P.color = guardiancolor
 	P.damage = stats.damage * 1.5
@@ -728,7 +728,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 			return "A"
 	return "F"
 
-/obj/item/projectile/guardian
+/obj/projectile/guardian
 	name = "crystal spray"
 	icon_state = "guardian"
 	damage = 5

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -126,7 +126,7 @@
 		..()
 
 /obj/structure/holohoop/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if (isitem(AM) && !istype(AM,/obj/item/projectile))
+	if (isitem(AM) && !istype(AM,/obj/projectile))
 		if(prob(50))
 			AM.forceMove(get_turf(src))
 			visible_message("<span class='warning'>Swish! [AM] lands in [src].</span>")

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -91,12 +91,12 @@
 	return connected
 
 
-/obj/machinery/hydroponics/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
+/obj/machinery/hydroponics/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(!myseed)
 		return ..()
-	if(istype(Proj , /obj/item/projectile/energy/floramut))
+	if(istype(Proj , /obj/projectile/energy/floramut))
 		mutate()
-	else if(istype(Proj , /obj/item/projectile/energy/florayield))
+	else if(istype(Proj , /obj/projectile/energy/florayield))
 		return myseed.bullet_act(Proj)
 	else
 		return ..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -126,8 +126,8 @@
 
 
 
-/obj/item/seeds/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
-	if(istype(Proj, /obj/item/projectile/energy/florayield))
+/obj/item/seeds/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
+	if(istype(Proj, /obj/projectile/energy/florayield))
 		var/rating = 1
 		if(istype(loc, /obj/machinery/hydroponics))
 			var/obj/machinery/hydroponics/H = loc

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -98,7 +98,7 @@
 		plasma_ignition(0)
 
 
-/obj/item/coin/plasma/bullet_act(obj/item/projectile/Proj)
+/obj/item/coin/plasma/bullet_act(obj/projectile/Proj)
 	if(!(Proj.nodamage) && Proj.damage_type == BURN)
 		plasma_ignition(0, Proj?.firer)
 	. = ..()

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -87,7 +87,7 @@
 		var/turf/proj_turf = user.loc
 		if(!isturf(proj_turf))
 			return
-		var/obj/item/projectile/destabilizer/D = new /obj/item/projectile/destabilizer(proj_turf)
+		var/obj/projectile/destabilizer/D = new /obj/projectile/destabilizer(proj_turf)
 		for(var/t in trophies)
 			var/obj/item/crusher_trophy/T = t
 			T.on_projectile_fire(D, user)
@@ -154,7 +154,7 @@
 	item_state = "crusher[wielded]"
 
 //destablizing force
-/obj/item/projectile/destabilizer
+/obj/projectile/destabilizer
 	name = "destabilizing force"
 	icon_state = "pulse1"
 	nodamage = TRUE
@@ -165,11 +165,11 @@
 	log_override = TRUE
 	var/obj/item/kinetic_crusher/hammer_synced
 
-/obj/item/projectile/destabilizer/Destroy()
+/obj/projectile/destabilizer/Destroy()
 	hammer_synced = null
 	return ..()
 
-/obj/item/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/mob/living/L = target
 		var/had_effect = (L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)) //used as a boolean
@@ -225,7 +225,7 @@
 	return TRUE
 
 /obj/item/crusher_trophy/proc/on_melee_hit(mob/living/target, mob/living/user) //the target and the user
-/obj/item/crusher_trophy/proc/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user) //the projectile fired and the user
+/obj/item/crusher_trophy/proc/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user) //the projectile fired and the user
 /obj/item/crusher_trophy/proc/on_mark_application(mob/living/target, datum/status_effect/crusher_mark/mark, had_mark) //the target, the mark applied, and if the target had a mark before
 /obj/item/crusher_trophy/proc/on_mark_detonation(mob/living/target, mob/living/user) //the target and the user
 
@@ -280,7 +280,7 @@
 /obj/item/crusher_trophy/blaster_tubes/magma_wing/effect_desc()
 	return "mark detonation to make the next destabilizer shot deal <b>[bonus_value]</b> damage"
 
-/obj/item/crusher_trophy/blaster_tubes/magma_wing/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user)
+/obj/item/crusher_trophy/blaster_tubes/magma_wing/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user)
 	if(deadly_shot)
 		marker.name = "heated [marker.name]"
 		marker.icon_state = "lava"
@@ -397,7 +397,7 @@
 /obj/item/crusher_trophy/blaster_tubes/effect_desc()
 	return "mark detonation to make the next destabilizer shot deal <b>[bonus_value]</b> damage but move slower"
 
-/obj/item/crusher_trophy/blaster_tubes/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user)
+/obj/item/crusher_trophy/blaster_tubes/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user)
 	if(deadly_shot)
 		marker.name = "deadly [marker.name]"
 		marker.icon_state = "chronobolt"

--- a/code/modules/mining/gibtonite.dm
+++ b/code/modules/mining/gibtonite.dm
@@ -59,7 +59,7 @@
 	else
 		..()
 
-/obj/item/gibtonite/bullet_act(obj/item/projectile/P)
+/obj/item/gibtonite/bullet_act(obj/projectile/P)
 	GibtoniteReaction(P.firer)
 	. = ..()
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -410,11 +410,11 @@
 /obj/item/ammo_casing/magic/hook
 	name = "hook"
 	desc = "A hook."
-	projectile_type = /obj/item/projectile/hook
+	projectile_type = /obj/projectile/hook
 	caliber = "hook"
 	icon_state = "hook"
 
-/obj/item/projectile/hook
+/obj/projectile/hook
 	name = "hook"
 	icon_state = "hook"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
@@ -426,13 +426,13 @@
 	knockdown = 30
 	var/chain
 
-/obj/item/projectile/hook/fire(setAngle)
+/obj/projectile/hook/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "chain", time = INFINITY, maxdistance = INFINITY)
 	..()
 	//TODO: root the firer until the chain returns
 
-/obj/item/projectile/hook/on_hit(atom/target)
+/obj/projectile/hook/on_hit(atom/target)
 	. = ..()
 	if(ismovable(target))
 		var/atom/movable/A = target
@@ -443,7 +443,7 @@
 		//TODO: keep the chain beamed to A
 		//TODO: needs a callback to delete the chain
 
-/obj/item/projectile/hook/Destroy()
+/obj/projectile/hook/Destroy()
 	qdel(chain)
 	return ..()
 
@@ -456,9 +456,9 @@
 	to_chat(user, "<span class='warning'>The [src] isn't ready to fire yet!</span>")
 
 /obj/item/ammo_casing/magic/hook/bounty
-	projectile_type = /obj/item/projectile/hook/bounty
+	projectile_type = /obj/projectile/hook/bounty
 
-/obj/item/projectile/hook/bounty
+/obj/projectile/hook/bounty
 	damage = 0
 	paralyze = 20
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -319,14 +319,14 @@
 /// Minebot passthrough handling (for the PKA upgrade and crushers)
 /mob/living/simple_animal/hostile/mining_drone/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(istype(mover, /obj/item/projectile/kinetic))
-		var/obj/item/projectile/kinetic/kinetic_proj = mover
+	if(istype(mover, /obj/projectile/kinetic))
+		var/obj/projectile/kinetic/kinetic_proj = mover
 		if(kinetic_proj.kinetic_gun)
 			for(var/A as anything in kinetic_proj.kinetic_gun.get_modkits())
 				var/obj/item/borg/upgrade/modkit/modkit = A
 				if(istype(modkit, /obj/item/borg/upgrade/modkit/minebot_passthrough))
 					return TRUE
-	else if(istype(mover, /obj/item/projectile/destabilizer))
+	else if(istype(mover, /obj/projectile/destabilizer))
 		return TRUE
 
 /**********************Minebot Attack Handling**********************/

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -221,7 +221,7 @@ Doesn't work on other aliens/AI.*/
 		return FALSE
 
 	user.visible_message("<span class='danger'>[user] spits neurotoxin!", "<span class='alertalien'>You spit neurotoxin.</span>")
-	var/obj/item/projectile/bullet/neurotoxin/A = new /obj/item/projectile/bullet/neurotoxin(user.loc)
+	var/obj/projectile/bullet/neurotoxin/A = new /obj/projectile/bullet/neurotoxin(user.loc)
 	A.preparePixelProjectile(target, user, params)
 	A.firer = user
 	A.fire()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -38,7 +38,7 @@
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
 
-/mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
+/mob/living/carbon/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(affecting && affecting.dismemberable && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))
 		affecting.dismember(P.damtype)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -35,12 +35,12 @@
 	protection += physiology.armor.getRating(d_type)
 	return protection
 
-/mob/living/carbon/human/on_hit(obj/item/projectile/P)
+/mob/living/carbon/human/on_hit(obj/projectile/P)
 	if(dna?.species)
 		dna.species.on_hit(P, src)
 
 
-/mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone, piercing_hit = FALSE)
+/mob/living/carbon/human/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
 	if(dna && dna.species)
 		var/spec_return = dna.species.bullet_act(P, src)
 		if(spec_return)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1826,15 +1826,15 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage_amount)
 	return 1
 
-/datum/species/proc/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/proc/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	// called when hit by a projectile
 	switch(P.type)
-		if(/obj/item/projectile/energy/floramut) // overwritten by plants/pods
+		if(/obj/projectile/energy/floramut) // overwritten by plants/pods
 			H.show_message("<span class='notice'>The radiation beam dissipates harmlessly through your body.</span>")
-		if(/obj/item/projectile/energy/florayield)
+		if(/obj/projectile/energy/florayield)
 			H.show_message("<span class='notice'>The radiation beam dissipates harmlessly through your body.</span>")
 
-/datum/species/proc/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/proc/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	// called before a projectile hit
 	return 0
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -380,7 +380,7 @@
 		new /obj/item/stack/ore/glass(get_turf(H))
 	qdel(H)
 
-/datum/species/golem/sand/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/sand/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H))
 		if(P.armor_flag == BULLET || P.armor_flag == BOMB)
 			playsound(H, 'sound/effects/shovel_dig.ogg', 70, 1)
@@ -412,7 +412,7 @@
 		new /obj/item/shard(get_turf(H))
 	qdel(H)
 
-/datum/species/golem/glass/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/glass/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H)) //self-shots don't reflect
 		if(P.armor_flag == LASER || P.armor_flag == ENERGY)
 			H.visible_message("<span class='danger'>The [P.name] gets reflected by [H]'s glass skin!</span>", \
@@ -469,7 +469,7 @@
 	if(world.time > last_teleport + teleport_cooldown && user != H)
 		reactive_teleport(H)
 
-/datum/species/golem/bluespace/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bluespace/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	..()
 	if(world.time > last_teleport + teleport_cooldown)
 		reactive_teleport(H)
@@ -573,7 +573,7 @@
 		new/obj/item/grown/bananapeel/specialpeel(get_turf(H))
 		last_banana = world.time
 
-/datum/species/golem/bananium/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bananium/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	..()
 	if(world.time > last_banana + banana_cooldown)
 		new/obj/item/grown/bananapeel/specialpeel(get_turf(H))
@@ -878,7 +878,7 @@
 	var/last_gong_time = 0
 	var/gong_cooldown = 150
 
-/datum/species/golem/bronze/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bronze/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(world.time > last_gong_time + gong_cooldown))
 		return ..()
 	if(P.armor_flag == BULLET || P.armor_flag == BOMB)
@@ -900,7 +900,7 @@
 	if(world.time > last_gong_time + gong_cooldown)
 		gong(H)
 
-/datum/species/golem/bronze/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bronze/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	..()
 	if(world.time > last_gong_time + gong_cooldown)
 		gong(H)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -49,9 +49,9 @@
 		return TRUE
 	return ..()
 
-/datum/species/pod/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/pod/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	switch(P.type)
-		if(/obj/item/projectile/energy/floramut)
+		if(/obj/projectile/energy/floramut)
 			if(prob(15))
 				H.rad_act(rand(30,80))
 				H.Paralyze(100)
@@ -65,5 +65,5 @@
 			else
 				H.adjustFireLoss(rand(5,15))
 				H.show_message("<span class='userdanger'>The radiation beam singes you!</span>")
-		if(/obj/item/projectile/energy/florayield)
+		if(/obj/projectile/energy/florayield)
 			H.set_nutrition(min(H.nutrition+30, NUTRITION_LEVEL_FULL))

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -57,7 +57,7 @@
 
 	C.fully_replace_character_name(null, pick(GLOB.nightmare_names))
 
-/datum/species/shadow/nightmare/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/shadow/nightmare/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	var/turf/T = H.loc
 	if(istype(T))
 		var/light_amount = T.get_lumcount()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -42,10 +42,10 @@
 /mob/living/proc/is_eyes_covered(check_glasses = 1, check_head = 1, check_mask = 1)
 	return FALSE
 
-/mob/living/proc/on_hit(obj/item/projectile/P)
+/mob/living/proc/on_hit(obj/projectile/P)
 	return BULLET_ACT_HIT
 
-/mob/living/bullet_act(obj/item/projectile/P, def_zone, piercing_hit = FALSE)
+/mob/living/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, P, def_zone)
 	var/armor = run_armor_check(def_zone, P.armor_flag, "","",P.armour_penetration)
 	if(!P.nodamage)
@@ -54,7 +54,7 @@
 			check_projectile_dismemberment(P, def_zone)
 	return P.on_hit(src, armor, piercing_hit)? BULLET_ACT_HIT : BULLET_ACT_BLOCK
 
-/mob/living/proc/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
+/mob/living/proc/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	return 0
 
 /obj/item/proc/get_volume_by_throwforce_and_or_w_class()
@@ -435,5 +435,5 @@
 /mob/living/proc/ishellbound()
 	return mind?.hellbound
 
-/mob/living/proc/force_hit_projectile(obj/item/projectile/projectile)
+/mob/living/proc/force_hit_projectile(obj/projectile/projectile)
 	return FALSE

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -47,7 +47,7 @@
 
 
 
-/mob/living/silicon/ai/bullet_act(obj/item/projectile/Proj)
+/mob/living/silicon/ai/bullet_act(obj/projectile/Proj)
 	. = ..(Proj)
 	updatehealth()
 

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -46,7 +46,7 @@
 	if(user.put_in_hands(card))
 		user.visible_message("<span class='notice'>[user] promptly scoops up [user.p_their()] pAI's card.</span>")
 
-/mob/living/silicon/pai/bullet_act(obj/item/projectile/Proj)
+/mob/living/silicon/pai/bullet_act(obj/projectile/Proj)
 	if(Proj.stun)
 		fold_in(force = TRUE)
 		src.visible_message("<span class='warning'>The electrically-charged projectile disrupts [src]'s holomatrix, forcing [src] to fold in!</span>")

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -182,7 +182,7 @@
 			if (stat != DEAD)
 				adjustBruteLoss(30)
 
-/mob/living/silicon/robot/bullet_act(var/obj/item/projectile/Proj, def_zone)
+/mob/living/silicon/robot/bullet_act(var/obj/projectile/Proj, def_zone)
 	. = ..()
 	updatehealth()
 	if(prob(75) && Proj.damage > 0)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -122,7 +122,7 @@
 			M.visible_message("<span class='boldwarning'>[M] is thrown off of [src]!</span>")
 	flash_act(affect_silicon = 1)
 
-/mob/living/silicon/bullet_act(obj/item/projectile/Proj, def_zone, piercing_hit = FALSE)
+/mob/living/silicon/bullet_act(obj/projectile/Proj, def_zone, piercing_hit = FALSE)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, Proj, def_zone)
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		adjustBruteLoss(Proj.damage)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -124,7 +124,7 @@
 		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
 		return TRUE
 
-/mob/living/simple_animal/bullet_act(obj/item/projectile/Proj, def_zone, piercing_hit = FALSE)
+/mob/living/simple_animal/bullet_act(obj/projectile/Proj, def_zone, piercing_hit = FALSE)
 	apply_damage(Proj.damage, Proj.damage_type)
 	Proj.on_hit(src, 0, piercing_hit)
 	return BULLET_ACT_HIT

--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -30,7 +30,7 @@
 	. = ..()
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_CONTENTS | EMP_PROTECT_WIRES)
 
-/mob/living/simple_animal/bot/secbot/grievous/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/bot/secbot/grievous/bullet_act(obj/projectile/P)
 	visible_message("[src] deflects [P] with its energy swords!")
 	playsound(src, 'sound/weapons/blade1.ogg', 50, TRUE)
 	return BULLET_ACT_BLOCK

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -368,7 +368,7 @@
 		return
 	togglelock(user)
 
-/mob/living/simple_animal/bot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/bullet_act(obj/projectile/Proj)
 	if(Proj && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		if(prob(75) && Proj.damage > 0)
 			do_sparks(5, TRUE, src)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -40,7 +40,7 @@
 	var/weaponscheck = TRUE //If true, arrest people for weapons if they don't have access
 	var/check_records = TRUE //Does it check security records?
 	var/arrest_type = FALSE //If true, don't handcuff
-	var/projectile = /obj/item/projectile/energy/electrode //Holder for projectile type
+	var/projectile = /obj/projectile/energy/electrode //Holder for projectile type
 	var/shoot_sound = 'sound/weapons/taser2.ogg'
 	var/cell_type = /obj/item/stock_parts/cell
 	var/vest_type = /obj/item/clothing/suit/armor/vest
@@ -195,8 +195,8 @@
 		icon_state = "[lasercolor]ed209[on]"
 		set_weapon()
 
-/mob/living/simple_animal/bot/ed209/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj , /obj/item/projectile/beam/laser)||istype(Proj, /obj/item/projectile/bullet))
+/mob/living/simple_animal/bot/ed209/bullet_act(obj/projectile/Proj)
+	if(istype(Proj , /obj/projectile/beam/laser)||istype(Proj, /obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < src.health && ishuman(Proj.firer))
 				retaliate(Proj.firer)
@@ -412,17 +412,17 @@
 	shoot_sound = 'sound/weapons/laser.ogg'
 	if(emagged == 2)
 		if(lasercolor)
-			projectile = /obj/item/projectile/beam/lasertag
+			projectile = /obj/projectile/beam/lasertag
 		else
-			projectile = /obj/item/projectile/beam
+			projectile = /obj/projectile/beam
 	else
 		if(!lasercolor)
 			shoot_sound = 'sound/weapons/laser.ogg'
-			projectile = /obj/item/projectile/beam/disabler
+			projectile = /obj/projectile/beam/disabler
 		else if(lasercolor == "b")
-			projectile = /obj/item/projectile/beam/lasertag/bluetag
+			projectile = /obj/projectile/beam/lasertag/bluetag
 		else if(lasercolor == "r")
-			projectile = /obj/item/projectile/beam/lasertag/redtag
+			projectile = /obj/projectile/beam/lasertag/redtag
 
 /mob/living/simple_animal/bot/ed209/proc/shootAt(mob/target)
 	if(world.time <= lastfired + shot_delay)
@@ -438,7 +438,7 @@
 	if(!projectile)
 		return
 
-	var/obj/item/projectile/A = new projectile (loc)
+	var/obj/projectile/A = new projectile (loc)
 	playsound(src, shoot_sound, 50, TRUE)
 	A.preparePixelProjectile(target, src)
 	A.fire()
@@ -484,14 +484,14 @@
 						mode = BOT_HUNT
 
 
-/mob/living/simple_animal/bot/ed209/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/ed209/bullet_act(obj/projectile/Proj)
 	if(!disabled)
 		var/lasertag_check = 0
 		if((lasercolor == "b"))
-			if(istype(Proj, /obj/item/projectile/beam/lasertag/redtag))
+			if(istype(Proj, /obj/projectile/beam/lasertag/redtag))
 				lasertag_check++
 		else if((lasercolor == "r"))
-			if(istype(Proj, /obj/item/projectile/beam/lasertag/bluetag))
+			if(istype(Proj, /obj/projectile/beam/lasertag/bluetag))
 				lasertag_check++
 		if(lasertag_check)
 			icon_state = "[lasercolor]ed2090"

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -137,8 +137,8 @@
 		playsound(src, 'sound/machines/honkbot_evil_laugh.ogg', 75, 1, -1) // evil laughter
 		update_icon()
 
-/mob/living/simple_animal/bot/honkbot/bullet_act(obj/item/projectile/Proj)
-	if((istype(Proj,/obj/item/projectile/beam)) || (istype(Proj,/obj/item/projectile/bullet) && (Proj.damage_type == BURN))||(Proj.damage_type == BRUTE) && (!Proj.nodamage && Proj.damage < health && ishuman(Proj.firer)))
+/mob/living/simple_animal/bot/honkbot/bullet_act(obj/projectile/Proj)
+	if((istype(Proj,/obj/projectile/beam)) || (istype(Proj,/obj/projectile/bullet) && (Proj.damage_type == BURN))||(Proj.damage_type == BRUTE) && (!Proj.nodamage && Proj.damage < health && ishuman(Proj.firer)))
 		retaliate(Proj.firer)
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -216,7 +216,7 @@
 			wires.cut_random()
 
 
-/mob/living/simple_animal/bot/mulebot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/mulebot/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(. && !QDELETED(src)) //Got hit and not blown up yet.
 		if(prob(50) && !isnull(load))

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -195,8 +195,8 @@
 		declare_arrests = FALSE
 		update_icon()
 
-/mob/living/simple_animal/bot/secbot/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj , /obj/item/projectile/beam)||istype(Proj, /obj/item/projectile/bullet))
+/mob/living/simple_animal/bot/secbot/bullet_act(obj/projectile/Proj)
+	if(istype(Proj , /obj/projectile/beam)||istype(Proj, /obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < src.health && ishuman(Proj.firer))
 				retaliate(Proj.firer)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -159,8 +159,8 @@
 	AIStatus = AI_ON
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES //only token destruction, don't smash the cult wall NO STOP
 
-/mob/living/simple_animal/hostile/construct/armored/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
+/mob/living/simple_animal/hostile/construct/armored/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/energy) || istype(P, /obj/projectile/beam))
 		var/reflectchance = 40 - round(P.damage/3)
 		if(prob(reflectchance))
 			apply_damage(P.damage * 0.5, P.damage_type)

--- a/code/modules/mob/living/simple_animal/friendly/turtle.dm
+++ b/code/modules/mob/living/simple_animal/friendly/turtle.dm
@@ -62,7 +62,7 @@
 	return ..()
 
 //Bullets
-/mob/living/simple_animal/turtle/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/turtle/bullet_act(obj/projectile/Proj)
 	if(!stat && !client)
 		if(icon_state == icon_hiding)
 			turtle_hide_dur = turtle_hide_max //Reset its hiding timer

--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -1,5 +1,5 @@
 //Ranged
-/obj/item/projectile/guardian
+/obj/projectile/guardian
 	name = "crystal spray"
 	icon_state = "guardian"
 	damage = 5
@@ -11,7 +11,7 @@
 	friendly = "quietly assesses"
 	melee_damage = 10
 	damage_coeff = list(BRUTE = 0.9, BURN = 0.9, TOX = 0.9, CLONE = 0.9, STAMINA = 0, OXY = 0.9)
-	projectiletype = /obj/item/projectile/guardian
+	projectiletype = /obj/projectile/guardian
 	ranged_cooldown_time = 1 //fast!
 	projectilesound = 'sound/effects/hit_on_shattered_glass.ogg'
 	ranged = 1
@@ -52,8 +52,8 @@
 
 /mob/living/simple_animal/hostile/guardian/ranged/Shoot(atom/targeted_atom)
 	. = ..()
-	if(istype(., /obj/item/projectile))
-		var/obj/item/projectile/P = .
+	if(istype(., /obj/projectile))
+		var/obj/projectile/P = .
 		if(guardiancolor)
 			P.color = guardiancolor
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -68,7 +68,7 @@
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 
 
@@ -86,7 +86,7 @@
 	move_to_delay = 4
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 4,
 							/obj/item/stack/sheet/animalhide/xeno = 1)
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
 	unique_name = 0
@@ -139,7 +139,7 @@
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 
-/obj/item/projectile/neurotox
+/obj/projectile/neurotox
 	name = "neurotoxin"
 	damage = 30
 	icon_state = "toxin"

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -17,7 +17,7 @@
 	health = 1000
 	maxHealth = 1000
 	loot = list(/obj/effect/temp_visual/paperwiz_dying)
-	projectiletype = /obj/item/projectile/temp
+	projectiletype = /obj/projectile/temp
 	projectilesound = 'sound/weapons/emitter.ogg'
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	var/list/copies = list()

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -6,7 +6,7 @@
 	icon_living = "cat_butcher"
 	icon_dead = "syndicate_dead"
 	icon_gib = "syndicate_gib"
-	projectiletype = /obj/item/projectile/bullet/dart/tranq
+	projectiletype = /obj/projectile/bullet/dart/tranq
 	projectilesound = 'sound/items/syringeproj.ogg'
 	retreat_distance = 3
 	ranged = TRUE
@@ -104,7 +104,7 @@
 			maxHealth = (300 + (5 * (LAZYLEN(victims)-10)))
 		switch(LAZYLEN(victims))
 			if(2)
-				projectiletype = /obj/item/projectile/bullet/dart/tranq/plus
+				projectiletype = /obj/projectile/bullet/dart/tranq/plus
 			if(4)//gain space adaptation to make cheesing harder
 				atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 				icon_state = "cat_butcher_fire"
@@ -114,7 +114,7 @@
 				rapid_melee = 3
 				transform *= 1.25
 			if(8)
-				projectiletype = /obj/item/projectile/bullet/dart/tranq/plusplus
+				projectiletype = /obj/projectile/bullet/dart/tranq/plusplus
 			if(10)
 				ranged_cooldown_time = 10
 			if(15)//if he's gotten this powerful, someone has really fucked up

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -609,7 +609,7 @@
 		return FALSE
 
 	ranged_ability_user.visible_message("<span class='danger'>[ranged_ability_user] throws a web!", "<span class='notice'>You throw the web!</span>")
-	var/obj/item/projectile/bullet/spidernet/A = new /obj/item/projectile/bullet/spidernet(ranged_ability_user.loc)
+	var/obj/projectile/bullet/spidernet/A = new /obj/projectile/bullet/spidernet(ranged_ability_user.loc)
 	A.preparePixelProjectile(target, ranged_ability_user, params)
 	A.firer = ranged_ability_user
 	A.fire()

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/hivebotbullet
+/obj/projectile/hivebotbullet
 	damage = 10
 	damage_type = BRUTE
 
@@ -18,7 +18,7 @@
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	projectilesound = 'sound/weapons/gunshot.ogg'
-	projectiletype = /obj/item/projectile/hivebotbullet
+	projectiletype = /obj/projectile/hivebotbullet
 	faction = list("hivebot")
 	check_friendly_fire = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -119,7 +119,7 @@
 		FindTarget(list(user), 1)
 	return ..()
 
-/mob/living/simple_animal/hostile/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/bullet_act(obj/projectile/P)
 	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client)
 		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
 			FindTarget(list(P.firer), 1)
@@ -409,7 +409,7 @@
 		playsound(src, projectilesound, 100, 1)
 		casing.fire_casing(targeted_atom, src, null, null, null, ran_zone(), 0, 1,  src)
 	else if(projectiletype)
-		var/obj/item/projectile/P = new projectiletype(startloc)
+		var/obj/projectile/P = new projectiletype(startloc)
 		playsound(src, projectilesound, 100, 1)
 		P.starting = startloc
 		P.firer = src

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -14,7 +14,7 @@
 	maxHealth = 300
 	health = 300
 	ranged = TRUE
-	projectiletype = /obj/item/projectile/leaper
+	projectiletype = /obj/projectile/leaper
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged_cooldown_time = 30
 	pixel_x = -16
@@ -29,7 +29,7 @@
 
 	do_footstep = TRUE
 
-/obj/item/projectile/leaper
+/obj/projectile/leaper
 	name = "leaper bubble"
 	icon_state = "leaper"
 	paralyze = 50
@@ -39,7 +39,7 @@
 	nondirectional_sprite = TRUE
 	impact_effect_type = /obj/effect/temp_visual/leaper_projectile_impact
 
-/obj/item/projectile/leaper/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/leaper/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
@@ -49,7 +49,7 @@
 		var/mob/living/simple_animal/L = target
 		L.adjustHealth(25)
 
-/obj/item/projectile/leaper/on_range()
+/obj/projectile/leaper/on_range()
 	var/turf/T = get_turf(src)
 	..()
 	new /obj/structure/leaper_bubble(T)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
@@ -20,7 +20,7 @@
 	speak_emote = list("chitters")
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	ranged_cooldown_time = 60
-	projectiletype = /obj/item/projectile/mega_arachnid
+	projectiletype = /obj/projectile/mega_arachnid
 	projectilesound = 'sound/weapons/pierce.ogg'
 	alpha = 50
 	discovery_points = 5000
@@ -49,13 +49,13 @@
 	..()
 	alpha = 50
 
-/obj/item/projectile/mega_arachnid
+/obj/projectile/mega_arachnid
 	name = "flesh snare"
 	nodamage = TRUE
 	damage = 0
 	icon_state = "tentacle_end"
 
-/obj/item/projectile/mega_arachnid/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/mega_arachnid/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target) && blocked < 100)
 		var/obj/item/restraints/legcuffs/beartrap/mega_arachnid/B = new /obj/item/restraints/legcuffs/beartrap/mega_arachnid(get_turf(target))
 		B.spring_trap(null, target)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -23,7 +23,7 @@
 	aggro_vision_range = 15
 	ranged = TRUE
 	ranged_cooldown_time = 10
-	projectiletype = /obj/item/projectile/seedling
+	projectiletype = /obj/projectile/seedling
 	projectilesound = 'sound/weapons/pierce.ogg'
 	robust_searching = TRUE
 	stat_attack = UNCONSCIOUS
@@ -33,7 +33,7 @@
 	var/mob/living/beam_debuff_target
 	var/solar_beam_identifier = 0
 
-/obj/item/projectile/seedling
+/obj/projectile/seedling
 	name = "solar energy"
 	icon_state = "seedling"
 	damage = 10
@@ -45,7 +45,7 @@
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
 	nondirectional_sprite = TRUE
 
-/obj/item/projectile/seedling/Bump(atom/A)//Stops seedlings from destroying other jungle mobs through FF
+/obj/projectile/seedling/Bump(atom/A)//Stops seedlings from destroying other jungle mobs through FF
 	if(isliving(A))
 		var/mob/living/L = A
 		if("jungle" in L.faction)
@@ -179,7 +179,7 @@
 			Shoot(target)
 			return
 		var/turf/our_turf = get_turf(src)
-		var/obj/item/projectile/seedling/readied_shot = new /obj/item/projectile/seedling(our_turf)
+		var/obj/projectile/seedling/readied_shot = new /obj/projectile/seedling(our_turf)
 		readied_shot.preparePixelProjectile(target, src, null, rand(-10, 10))
 		readied_shot.fire()
 		playsound(src, projectilesound, 100, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -33,7 +33,7 @@ Difficulty: Medium
 	speak_emote = list("roars")
 	speed = 3
 	move_to_delay = 3
-	projectiletype = /obj/item/projectile/kinetic/miner
+	projectiletype = /obj/projectile/kinetic/miner
 	projectilesound = 'sound/weapons/kenetic_accel.ogg'
 	ranged = TRUE
 	ranged_cooldown_time = 16
@@ -112,7 +112,7 @@ Difficulty: Medium
 	..()
 	target.stun_absorption -= "miner"
 
-/obj/item/projectile/kinetic/miner
+/obj/projectile/kinetic/miner
 	damage = 20
 	speed = 0.9
 	icon_state = "ka_tracer"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -424,7 +424,7 @@ Difficulty: Hard
 		if(.)
 			recovery_time = world.time + 20 // can only attack melee once every 2 seconds but rapid_melee gives higher priority
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/projectile/P)
 	if(BUBBLEGUM_IS_ENRAGED)
 		visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons while enraged!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 		playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 300, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -242,7 +242,7 @@ Difficulty: Very Hard
 	if(!isnum_safe(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/P = new /obj/item/projectile/colossus(startloc)
+	var/obj/projectile/P = new /obj/projectile/colossus(startloc)
 	P.preparePixelProjectile(marker, startloc)
 	P.firer = src
 	if(target)
@@ -298,7 +298,7 @@ Difficulty: Very Hard
 	target = new_target
 	INVOKE_ASYNC(src, /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE)
 
-/mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/projectile/P)
 	if(!stat)
 		var/obj/effect/temp_visual/at_shield/AT = new /obj/effect/temp_visual/at_shield(loc, src)
 		var/random_x = rand(-32, 32)
@@ -308,7 +308,7 @@ Difficulty: Very Hard
 		AT.pixel_y += random_y
 	return ..()
 
-/obj/item/projectile/colossus
+/obj/projectile/colossus
 	name ="death bolt"
 	icon_state= "chronobolt"
 	damage = 25
@@ -318,7 +318,7 @@ Difficulty: Very Hard
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
 
-/obj/item/projectile/colossus/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/colossus/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isturf(target) || isobj(target))
 		if(isobj(target))
@@ -496,9 +496,9 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 		ActivationReaction(user, ACTIVATE_WEAPON)
 	..()
 
-/obj/machinery/anomalous_crystal/bullet_act(obj/item/projectile/P, def_zone)
+/obj/machinery/anomalous_crystal/bullet_act(obj/projectile/P, def_zone)
 	. = ..()
-	if(istype(P, /obj/item/projectile/magic))
+	if(istype(P, /obj/projectile/magic))
 		ActivationReaction(P.firer, ACTIVATE_MAGIC, P.damage_type)
 		return
 	ActivationReaction(P.firer, P.armor_flag, P.damage_type)
@@ -610,18 +610,18 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 	observer_desc = "This crystal generates a projectile when activated."
 	activation_method = ACTIVATE_TOUCH
 	cooldown_add = 50
-	var/obj/item/projectile/generated_projectile = /obj/item/projectile/beam/emitter
+	var/obj/projectile/generated_projectile = /obj/projectile/beam/emitter
 
 /obj/machinery/anomalous_crystal/emitter/Initialize(mapload)
 	. = ..()
-	generated_projectile = pick(/obj/item/projectile/colossus)
+	generated_projectile = pick(/obj/projectile/colossus)
 
 	var/proj_name = initial(generated_projectile.name)
 	observer_desc = "This crystal generates \a [proj_name] when activated."
 
 /obj/machinery/anomalous_crystal/emitter/ActivationReaction(mob/user, method)
 	if(..())
-		var/obj/item/projectile/P = new generated_projectile(get_turf(src))
+		var/obj/projectile/P = new generated_projectile(get_turf(src))
 		P.setDir(dir)
 		switch(dir)
 			if(NORTH)
@@ -760,7 +760,7 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 		/obj/item/implant,
 		/obj/item/implanter,
 		/obj/item/disk/nuclear,
-		/obj/item/projectile,
+		/obj/projectile,
 		/obj/item/spellbook,
 		/obj/item/dice/d20/fate
 	))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -241,7 +241,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/ranged_combat
 	icon_state = "swarmer_ranged"
 	icon_living = "swarmer_ranged"
-	projectiletype = /obj/item/projectile/beam/laser
+	projectiletype = /obj/projectile/beam/laser
 	projectilesound = 'sound/weapons/laser.ogg'
 	check_friendly_fire = TRUE //you're supposed to protect the resource swarmers, you poop
 	retreat_distance = 3

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -10,7 +10,7 @@
 	icon_gib = "syndicate_gib"
 	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
 	move_to_delay = 20
-	projectiletype = /obj/item/projectile/temp/basilisk
+	projectiletype = /obj/projectile/temp/basilisk
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
 	ranged_message = "stares"
@@ -34,7 +34,7 @@
 				/obj/item/stack/ore/diamond{layer = ABOVE_MOB_LAYER})
 	discovery_points = 2000
 
-/obj/item/projectile/temp/basilisk
+/obj/projectile/temp/basilisk
 	name = "freezing blast"
 	icon_state = "ice_2"
 	damage = 0
@@ -104,7 +104,7 @@
 	light_range = 3
 	light_power = 2.5
 	light_color = LIGHT_COLOR_LAVA
-	projectiletype = /obj/item/projectile/temp/basilisk/magmawing
+	projectiletype = /obj/projectile/temp/basilisk/magmawing
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/magma_wing
 	crusher_drop_mod = 60
 
@@ -117,12 +117,12 @@
 	icon_dead = "watcher_icewing_dead"
 	maxHealth = 85
 	health = 85
-	projectiletype = /obj/item/projectile/temp/basilisk/icewing
+	projectiletype = /obj/projectile/temp/basilisk/icewing
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/bone = 1) //No sinew; the wings are too fragile to be usable
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing
 	crusher_drop_mod = 30
 
-/obj/item/projectile/temp/basilisk/magmawing
+/obj/projectile/temp/basilisk/magmawing
 	name = "scorching blast"
 	icon_state = "lava"
 	damage = 5
@@ -130,7 +130,7 @@
 	nodamage = FALSE
 	temperature = 500 //Heats you up!
 
-/obj/item/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(.)
 		var/mob/living/L = target
@@ -138,12 +138,12 @@
 			L.adjust_fire_stacks(0.1)
 			L.IgniteMob()
 
-/obj/item/projectile/temp/basilisk/icewing
+/obj/projectile/temp/basilisk/icewing
 	damage = 5
 	damage_type = BURN
 	nodamage = FALSE
 
-/obj/item/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(.)
 		var/mob/living/L = target

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
@@ -93,8 +93,8 @@
 	. = ..()
 	if(mover == set_target)
 		return FALSE
-	if(istype(mover, /obj/item/projectile))
-		var/obj/item/projectile/P = mover
+	if(istype(mover, /obj/projectile))
+		var/obj/projectile/P = mover
 		if(P.firer == set_target)
 			return FALSE
 
@@ -114,7 +114,7 @@ IGNORE_PROC_IF_NOT_TARGET(attack_animal)
 
 IGNORE_PROC_IF_NOT_TARGET(attack_slime)
 
-/mob/living/simple_animal/hostile/asteroid/curseblob/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/asteroid/curseblob/bullet_act(obj/projectile/Proj)
 	if(Proj.firer != set_target)
 		return
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -122,11 +122,11 @@
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/shoot_projectile(turf/marker, set_angle, var/is_teleshot)
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/herald/H = null
+	var/obj/projectile/herald/H = null
 	if(!is_teleshot)
-		H = new /obj/item/projectile/herald(startloc)
+		H = new /obj/projectile/herald(startloc)
 	else
-		H = new /obj/item/projectile/herald/teleshot(startloc)
+		H = new /obj/projectile/herald/teleshot(startloc)
 	H.preparePixelProjectile(marker, startloc)
 	H.firer = src
 	if(target)
@@ -208,7 +208,7 @@
 		my_master.my_mirror = null
 	. = ..()
 
-/obj/item/projectile/herald
+/obj/projectile/herald
 	name ="death bolt"
 	icon_state= "chronobolt"
 	damage = 15
@@ -218,12 +218,12 @@
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
 
-/obj/item/projectile/herald/teleshot
+/obj/projectile/herald/teleshot
 	name ="golden bolt"
 	damage = 0
 	color = rgb(255,255,102)
 
-/obj/item/projectile/herald/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/herald/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
@@ -235,7 +235,7 @@
 		if(F != null && istype(F, /mob/living/simple_animal/hostile/asteroid/elite) && F.faction_check_mob(L))
 			L.heal_overall_damage(damage)
 
-/obj/item/projectile/herald/teleshot/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/herald/teleshot/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	firer.forceMove(get_turf(src))
 
@@ -256,8 +256,8 @@
 
 /obj/item/clothing/neck/cloak/herald_cloak/proc/shoot_projectile(turf/marker, set_angle, mob/living/carbon/owner)
 	var/turf/startloc = get_turf(owner)
-	var/obj/item/projectile/herald/H = null
-	H = new /obj/item/projectile/herald(startloc)
+	var/obj/projectile/herald/H = null
+	H = new /obj/projectile/herald(startloc)
 	H.preparePixelProjectile(marker, startloc)
 	H.firer = owner
 	H.fire(set_angle)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -70,7 +70,7 @@
 		visible_message("<span class='danger'>The [name] buries into the ground, vanishing from sight!</span>")
 		qdel(src)
 
-/mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/projectile/P)
 	visible_message("<span class='danger'>The [P.name] was repelled by [name]'s girth!</span>")
 	return BULLET_ACT_BLOCK
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -35,7 +35,7 @@
 		return
 	icon_state = icon_living
 
-/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
+/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
 	if(!stat)
 		Aggro()
 	if(P.damage < 30 && P.damage_type != BRUTE)

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -171,7 +171,7 @@
 		if(T.throwforce)
 			Bruise()
 
-/mob/living/simple_animal/hostile/mushroom/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/mushroom/bullet_act(obj/projectile/P)
 	. = ..()
 	if(P.nodamage)
 		Bruise()

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -76,7 +76,7 @@
 	rapid_fire_delay = 6
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/beam/laser
+	projectiletype = /obj/projectile/beam/laser
 	loot = list(/obj/effect/mob_spawn/human/corpse/pirate/ranged,
 			/obj/item/gun/energy/laser)
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -353,7 +353,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 	return
 
 //Bullets
-/mob/living/simple_animal/parrot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/parrot/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(!stat && !client)
 		if(parrot_state == PARROT_PERCH)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -261,7 +261,7 @@
 		amount = -abs(amount)
 	return ..() //Heals them
 
-/mob/living/simple_animal/slime/bullet_act(obj/item/projectile/Proj, def_zone, piercing_hit = FALSE)
+/mob/living/simple_animal/slime/bullet_act(obj/projectile/Proj, def_zone, piercing_hit = FALSE)
 	attacked += 10
 	if((Proj.damage_type == BURN))
 		adjustBruteLoss(-abs(Proj.damage)) //fire projectiles heals slimes.

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -148,6 +148,6 @@
 // "Stun" weapons can cause minor damage to components (short-circuits?)
 // "Burn" damage is equally strong against internal components and exterior casing
 // "Brute" damage mostly damages the casing.
-/obj/machinery/modular_computer/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/modular_computer/bullet_act(obj/projectile/Proj)
 	if(cpu)
 		cpu.bullet_act(Proj)

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -131,7 +131,7 @@
 	return
 
 
-/obj/machinery/power/am_control_unit/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/power/am_control_unit/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(Proj.armor_flag != BULLET)
 		stability -= Proj.force

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -101,7 +101,7 @@
 	return
 
 
-/obj/machinery/am_shielding/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/am_shielding/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(Proj.armor_flag != BULLET)
 		stability -= Proj.force/2

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -78,7 +78,7 @@
 	tesla_zap(src, 5, power_gen * 0.05)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), get_turf(src), 2, 3, 4, 8), 100) // Not a normal explosion.
 
-/obj/machinery/power/rtg/abductor/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/power/rtg/abductor/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(!going_kaboom && istype(Proj) && !Proj.nodamage && ((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE)))
 		log_bomber(Proj.firer, "triggered a", src, "explosion via projectile")

--- a/code/modules/power/singularity/anomaly.dm
+++ b/code/modules/power/singularity/anomaly.dm
@@ -11,7 +11,7 @@
 	var/dissipate_strength = 1
 	/// How long its been (in seconds) since the last dissipation
 	var/time_since_last_dissipiation = 0
-	/// How long until we start to dissipate/gain energy again after beeing hit by a /obj/item/projectile/energy/accelerated_particle/weak
+	/// How long until we start to dissipate/gain energy again after beeing hit by a /obj/projectile/energy/accelerated_particle/weak
 	var/conistant_energy_cooldown = 10 SECONDS
 	COOLDOWN_DECLARE(RESTART_DISSIPATE)
 
@@ -27,7 +27,7 @@
 
 	time_since_last_dissipiation -= dissipate_delay
 
-/obj/anomaly/bullet_act(obj/item/projectile/energy/accelerated_particle/P, def_zone, piercing_hit = FALSE)
+/obj/anomaly/bullet_act(obj/projectile/energy/accelerated_particle/P, def_zone, piercing_hit = FALSE)
 	if(istype(P))
 		if(P.stop_dissipate) //if we get hit by the weak version we won't dissipate nor gain energy
 			COOLDOWN_START(src, RESTART_DISSIPATE, conistant_energy_cooldown)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -31,7 +31,7 @@
 	var/locked = FALSE
 	var/allow_switch_interact = TRUE
 
-	var/projectile_type = /obj/item/projectile/beam/emitter
+	var/projectile_type = /obj/projectile/beam/emitter
 	var/projectile_sound = 'sound/weapons/emitter.ogg'
 	var/datum/effect_system/spark_spread/sparks
 
@@ -206,7 +206,7 @@
 		fire_beam()
 
 /obj/machinery/power/emitter/proc/fire_beam(mob/user)
-	var/obj/item/projectile/P = new projectile_type(get_turf(src))
+	var/obj/projectile/P = new projectile_type(get_turf(src))
 	playsound(get_turf(src), projectile_sound, 50, TRUE)
 	if(prob(35))
 		sparks.start()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -157,7 +157,7 @@ field_generator power level display
 	else
 		..()
 
-/obj/machinery/field/generator/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/field/generator/bullet_act(obj/projectile/Proj)
 	if(Proj.armor_flag != BULLET)
 		power = min(power + Proj.damage, field_generator_max_power)
 		check_power_level()

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -24,7 +24,7 @@
 	else
 		return ..()
 
-/obj/machinery/the_singularitygen/bullet_act(obj/item/projectile/energy/accelerated_particle/P, def_zone, piercing_hit = FALSE)
+/obj/machinery/the_singularitygen/bullet_act(obj/projectile/energy/accelerated_particle/P, def_zone, piercing_hit = FALSE)
 	if(istype(P))
 		if(energy <= 0) // we want to first add the energy then start processing so we do not immidiatly stop processing again
 			energy += P.energy

--- a/code/modules/power/singularity/particle_accelerator/particle_emitter.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_emitter.dm
@@ -27,16 +27,16 @@
 /obj/structure/particle_accelerator/particle_emitter/proc/emit_particle(strength = 0)
 	if((last_shot + fire_delay) <= world.time)
 		last_shot = world.time
-		var/obj/item/projectile/energy/accelerated_particle/P
+		var/obj/projectile/energy/accelerated_particle/P
 		switch(strength)
 			if(0)
-				P = /obj/item/projectile/energy/accelerated_particle/weak
+				P = /obj/projectile/energy/accelerated_particle/weak
 			if(1)
-				P = /obj/item/projectile/energy/accelerated_particle
+				P = /obj/projectile/energy/accelerated_particle
 			if(2)
-				P = /obj/item/projectile/energy/accelerated_particle/strong
+				P = /obj/projectile/energy/accelerated_particle/strong
 			if(3)
-				P = /obj/item/projectile/energy/accelerated_particle/powerful
+				P = /obj/projectile/energy/accelerated_particle/powerful
 		P = new P(src)
 		P.fire(dir2angle(dir))
 		return TRUE

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -516,7 +516,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	last_complete_process = world.time
 	return 1
 
-/obj/machinery/power/supermatter_crystal/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/power/supermatter_crystal/bullet_act(obj/projectile/Proj)
 	var/turf/L = loc
 	if(!istype(L))
 		return FALSE

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -11,7 +11,7 @@
 	var/fire_sound = null						//What sound should play when this ammo is fired
 	var/caliber = null							//Which kind of guns it can be loaded into
 	var/projectile_type = null					//The bullet type to create when New() is called
-	var/obj/item/projectile/BB = null 			//The loaded bullet
+	var/obj/projectile/BB = null 			//The loaded bullet
 	var/pellets = 1								//Pellets for spreadshot
 	var/variance = 0							//Variance for inaccuracy fundamental to the casing
 	var/randomspread = 0						//Randomspread for automatics

--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -5,24 +5,24 @@
 	desc = "A 7.12x82mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "mm71282"
-	projectile_type = /obj/item/projectile/bullet/mm712x82
+	projectile_type = /obj/projectile/bullet/mm712x82
 
 /obj/item/ammo_casing/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet casing"
 	desc = "A 7.12x82mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
-	projectile_type = /obj/item/projectile/bullet/mm712x82_ap
+	projectile_type = /obj/projectile/bullet/mm712x82_ap
 
 /obj/item/ammo_casing/mm712x82/hollow
 	name = "7.12x82mm hollow-point bullet casing"
 	desc = "A 7.12x82mm bullet casing designed to cause more damage to unarmored targets."
-	projectile_type = /obj/item/projectile/bullet/mm712x82_hp
+	projectile_type = /obj/projectile/bullet/mm712x82_hp
 
 /obj/item/ammo_casing/mm712x82/incen
 	name = "7.12x82mm incendiary bullet casing"
 	desc = "A 7.12x82mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames."
-	projectile_type = /obj/item/projectile/bullet/incendiary/mm712x82
+	projectile_type = /obj/projectile/bullet/incendiary/mm712x82
 
 /obj/item/ammo_casing/mm712x82/match
 	name = "7.12x82mm match bullet casing"
 	desc = "A 7.12x82mm bullet casing manufactured to unfailingly high standards, you could pull off some cool trickshots with this."
-	projectile_type = /obj/item/projectile/bullet/mm712x82_match
+	projectile_type = /obj/projectile/bullet/mm712x82_match

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -4,22 +4,22 @@
 	name = "10mm bullet casing"
 	desc = "A 10mm bullet casing."
 	caliber = "10mm"
-	projectile_type = /obj/item/projectile/bullet/c10mm
+	projectile_type = /obj/projectile/bullet/c10mm
 
 /obj/item/ammo_casing/c10mm/ap
 	name = "10mm armor-piercing bullet casing"
 	desc = "A 10mm armor-piercing bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm_ap
+	projectile_type = /obj/projectile/bullet/c10mm_ap
 
 /obj/item/ammo_casing/c10mm/hp
 	name = "10mm hollow-point bullet casing"
 	desc = "A 10mm hollow-point bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm_hp
+	projectile_type = /obj/projectile/bullet/c10mm_hp
 
 /obj/item/ammo_casing/c10mm/fire
 	name = "10mm incendiary bullet casing"
 	desc = "A 10mm incendiary bullet casing."
-	projectile_type = /obj/item/projectile/bullet/incendiary/c10mm
+	projectile_type = /obj/projectile/bullet/incendiary/c10mm
 
 // 9mm (Stechkin APS)
 
@@ -27,17 +27,17 @@
 	name = "9mm bullet casing"
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/c9mm
+	projectile_type = /obj/projectile/bullet/c9mm
 
 /obj/item/ammo_casing/c9mm/ap
 	name = "9mm armor-piercing bullet casing"
 	desc = "A 9mm armor-piercing bullet casing."
-	projectile_type =/obj/item/projectile/bullet/c9mm_ap
+	projectile_type =/obj/projectile/bullet/c9mm_ap
 
 /obj/item/ammo_casing/c9mm/inc
 	name = "9mm incendiary bullet casing"
 	desc = "A 9mm incendiary bullet casing."
-	projectile_type = /obj/item/projectile/bullet/incendiary/c9mm
+	projectile_type = /obj/projectile/bullet/incendiary/c9mm
 
 
 // .50AE (Desert Eagle)
@@ -46,5 +46,5 @@
 	name = ".50AE bullet casing"
 	desc = "A .50AE bullet casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/a50AE
+	projectile_type = /obj/projectile/bullet/a50AE
 

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -4,13 +4,13 @@
 	name = ".357 bullet casing"
 	desc = "A .357 bullet casing."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet/a357
+	projectile_type = /obj/projectile/bullet/a357
 
 /obj/item/ammo_casing/a357/match
 	name = ".357 match bullet casing"
 	desc = "A .357 bullet casing, manufactured to exceedingly high standards."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet/a357/match
+	projectile_type = /obj/projectile/bullet/a357/match
 
 // 7.62x38mmR (Nagant Revolver)
 
@@ -18,7 +18,7 @@
 	name = "7.62x38mmR bullet casing"
 	desc = "A 7.62x38mmR bullet casing."
 	caliber = "n762"
-	projectile_type = /obj/item/projectile/bullet/n762
+	projectile_type = /obj/projectile/bullet/n762
 
 // .38 (Detective's Gun)
 
@@ -26,47 +26,47 @@
 	name = ".38 bullet casing"
 	desc = "A .38 bullet casing."
 	caliber = "38"
-	projectile_type = /obj/item/projectile/bullet/c38
+	projectile_type = /obj/projectile/bullet/c38
 
 /obj/item/ammo_casing/c38/trac
 	name = ".38 TRAC bullet casing"
 	desc = "A .38 \"TRAC\" bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c38/trac
+	projectile_type = /obj/projectile/bullet/c38/trac
 
 /obj/item/ammo_casing/c38/hotshot
 	name = ".38 Hot Shot bullet casing"
 	desc = "A .38 Hot Shot bullet casing."
 	caliber = "38"
-	projectile_type = /obj/item/projectile/bullet/c38/hotshot
+	projectile_type = /obj/projectile/bullet/c38/hotshot
 
 /obj/item/ammo_casing/c38/iceblox
 	name = ".38 Iceblox bullet casing"
 	desc = "A .38 Iceblox bullet casing."
 	caliber = "38"
-	projectile_type = /obj/item/projectile/bullet/c38/iceblox
+	projectile_type = /obj/projectile/bullet/c38/iceblox
 
 /obj/item/ammo_casing/c38/match
 	name = ".38 Match bullet casing"
 	desc = "A .38 bullet casing, manufactured to exceedingly high standards."
-	projectile_type = /obj/item/projectile/bullet/c38/match
+	projectile_type = /obj/projectile/bullet/c38/match
 
 /obj/item/ammo_casing/c38/match/bouncy
 	name = ".38 Bouncy Rubber bullet casing"
 	desc = "A .38 bouncy rubber bullet casing, manufactured to exceedingly high standards."
-	projectile_type = /obj/item/projectile/bullet/c38/match/bouncy
+	projectile_type = /obj/projectile/bullet/c38/match/bouncy
 
 /obj/item/ammo_casing/c38/dumdum
 	name = ".38 DumDum bullet casing"
 	desc = "A .38 DumDum bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c38/dumdum
+	projectile_type = /obj/projectile/bullet/c38/dumdum
 
 /obj/item/ammo_casing/caseless/mime
 	name = "invisible .38 bullet casing"
 	icon_state = null
 	desc = "You shouldn't be seeing this."
 	caliber = "mime"
-	projectile_type = /obj/item/projectile/bullet/c38/mime
+	projectile_type = /obj/projectile/bullet/c38/mime
 	exists = FALSE
 
 /obj/item/ammo_casing/caseless/mime/lethal
-	projectile_type = /obj/item/projectile/bullet/c38/mime_lethal
+	projectile_type = /obj/projectile/bullet/c38/mime_lethal

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -5,10 +5,10 @@
 	desc = "A 7.62 bullet casing."
 	icon_state = "762-casing"
 	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet/a762
+	projectile_type = /obj/projectile/bullet/a762
 
 /obj/item/ammo_casing/a762/enchanted
-	projectile_type = /obj/item/projectile/bullet/a762_enchanted
+	projectile_type = /obj/projectile/bullet/a762_enchanted
 
 // 5.56mm (M-90gl Carbine)
 
@@ -16,7 +16,7 @@
 	name = "5.56mm bullet casing"
 	desc = "A 5.56mm bullet casing."
 	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/a556
+	projectile_type = /obj/projectile/bullet/a556
 
 // 40mm (Grenade Launcher)
 
@@ -25,4 +25,4 @@
 	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
 	caliber = "40mm"
 	icon_state = "40mmHE"
-	projectile_type = /obj/item/projectile/bullet/a40mm
+	projectile_type = /obj/projectile/bullet/a40mm

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -5,27 +5,27 @@
 	desc = "A 12 gauge lead slug."
 	icon_state = "blshell"
 	caliber = "shotgun"
-	projectile_type = /obj/item/projectile/bullet/shotgun_slug
+	projectile_type = /obj/projectile/bullet/shotgun_slug
 	materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_beanbag
+	projectile_type = /obj/projectile/bullet/shotgun_beanbag
 	materials = list(/datum/material/iron=250)
 
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."
 	icon_state = "ishell"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun
+	projectile_type = /obj/projectile/bullet/incendiary/shotgun
 
 /obj/item/ammo_casing/shotgun/dragonsbreath
 	name = "dragonsbreath shell"
 	desc = "A shotgun shell which fires a spread of incendiary pellets."
 	icon_state = "ishell2"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
+	projectile_type = /obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	pellets = 4
 	variance = 35
 
@@ -33,14 +33,14 @@
 	name = "taser slug"
 	desc = "A stunning taser slug."
 	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_stunslug
+	projectile_type = /obj/projectile/bullet/shotgun_stunslug
 	materials = list(/datum/material/iron=250)
 
 /obj/item/ammo_casing/shotgun/meteorslug
 	name = "meteorslug shell"
 	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
 	icon_state = "mshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_meteorslug
+	projectile_type = /obj/projectile/bullet/shotgun_meteorslug
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "pulse slug"
@@ -48,19 +48,19 @@
 	energy blast. While the heat and power drain limit it to one use, it can still allow an operator to engage targets that ballistic ammunition \
 	would have difficulty with."
 	icon_state = "pshell"
-	projectile_type = /obj/item/projectile/beam/pulse/shotgun
+	projectile_type = /obj/projectile/beam/pulse/shotgun
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "FRAG-12 slug"
 	desc = "A high explosive breaching round for a 12 gauge shotgun."
 	icon_state = "heshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun_frag12
+	projectile_type = /obj/projectile/bullet/shotgun_frag12
 
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "buckshot shell"
 	desc = "A 12 gauge buckshot shell."
 	icon_state = "gshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 6
 	variance = 10
 
@@ -68,7 +68,7 @@
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
 	variance = 20
 	materials = list(/datum/material/iron=4000)
@@ -77,7 +77,7 @@
 	name = "custom incapacitating shot"
 	desc = "A shotgun casing filled with... something. used to incapacitate targets."
 	icon_state = "bountyshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_incapacitate
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_incapacitate
 	pellets = 12//double the pellets, but half the stun power of each, which makes this best for just dumping right in someone's face.
 	variance = 20
 	materials = list(/datum/material/iron=4000)
@@ -86,7 +86,7 @@
 	name = "improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_improvised
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	materials = list(/datum/material/iron=250)
 	pellets = 10
 	variance = 25
@@ -96,7 +96,7 @@
 	desc = "An advanced shotgun shell which uses a subspace ansible crystal to produce an effect similar to a standard ion rifle. \
 	The unique properties of the crystal split the pulse into a spread of individually weaker bolts."
 	icon_state = "ionshell"
-	projectile_type = /obj/item/projectile/ion/weak
+	projectile_type = /obj/projectile/ion/weak
 	pellets = 4
 	variance = 35
 
@@ -104,7 +104,7 @@
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/item/projectile/beam/weak
+	projectile_type = /obj/projectile/beam/weak
 	pellets = 6
 	variance = 35
 
@@ -118,7 +118,7 @@
 	name = "shotgun dart"
 	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."
 	icon_state = "cshell"
-	projectile_type = /obj/item/projectile/bullet/dart
+	projectile_type = /obj/projectile/bullet/dart
 	var/reagent_amount = 30
 
 /obj/item/ammo_casing/shotgun/dart/Initialize(mapload)
@@ -153,5 +153,5 @@
 	name = "breaching slug"
 	desc = "A 12 gauge anti-material slug. Great for breaching airlocks and windows with minimal shots."
 	icon_state = "breacher"
-	projectile_type = /obj/item/projectile/bullet/shotgun_breaching
+	projectile_type = /obj/projectile/bullet/shotgun_breaching
 	materials = list(/datum/material/iron=4000)

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -4,23 +4,23 @@
 	name = "4.6x30mm bullet casing"
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/c46x30mm
+	projectile_type = /obj/projectile/bullet/c46x30mm
 
 /obj/item/ammo_casing/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet casing"
 	desc = "A 4.6x30mm armor-piercing bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c46x30mm_ap
+	projectile_type = /obj/projectile/bullet/c46x30mm_ap
 
 /obj/item/ammo_casing/c46x30mm/inc
 	name = "4.6x30mm incendiary bullet casing"
 	desc = "A 4.6x30mm incendiary bullet casing."
-	projectile_type = /obj/item/projectile/bullet/incendiary/c46x30mm
+	projectile_type = /obj/projectile/bullet/incendiary/c46x30mm
 
 /obj/item/ammo_casing/c46x30mm/rubber
 	name = "4.6x30mm bullet casing"
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/c46x30mm_rubber
+	projectile_type = /obj/projectile/bullet/c46x30mm_rubber
 
 // .45 (M1911 + C20r)
 
@@ -28,4 +28,4 @@
 	name = ".45 bullet casing"
 	desc = "A .45 bullet casing."
 	caliber = ".45"
-	projectile_type = /obj/item/projectile/bullet/c45
+	projectile_type = /obj/projectile/bullet/c45

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -4,36 +4,36 @@
 	name = ".50 bullet casing"
 	desc = "A .50 bullet casing."
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/p50
+	projectile_type = /obj/projectile/bullet/p50
 	icon_state = ".50"
 
 /obj/item/ammo_casing/p50/soporific
 	name = ".50 soporific bullet casing"
 	desc = "A .50 bullet casing, specialised in sending the target to sleep, instead of hell."
-	projectile_type = /obj/item/projectile/bullet/p50/utility/soporific
+	projectile_type = /obj/projectile/bullet/p50/utility/soporific
 	icon_state = "sleeper"
 
 /obj/item/ammo_casing/p50/penetrator
 	name = ".50 penetrator round bullet casing"
 	desc = "A .50 caliber penetrator round casing."
-	projectile_type = /obj/item/projectile/bullet/p50/penetrator
+	projectile_type = /obj/projectile/bullet/p50/penetrator
 
 /obj/item/ammo_casing/p50/emp
 	name = ".50 emp round bullet casing"
 	desc = "A .50 caliber round casing containing an iron-uranium core which will cause an electromagnetic pulse on impact."
-	projectile_type = /obj/item/projectile/bullet/p50/utility/emp
+	projectile_type = /obj/projectile/bullet/p50/utility/emp
 
 /obj/item/ammo_casing/p50/explosive
 	name = ".50 exposive round bullet casing"
 	desc = "A .50 caliber round casing with a small explosive package."
-	projectile_type = /obj/item/projectile/bullet/p50/utility/explosive
+	projectile_type = /obj/projectile/bullet/p50/utility/explosive
 
 /obj/item/ammo_casing/p50/inferno
 	name = ".50 infern round bullet casing"
 	desc = "A .50 caliber inferno round casing containing a highly volatile core which will burst into flames on impact."
-	projectile_type = /obj/item/projectile/bullet/p50/utility/inferno
+	projectile_type = /obj/projectile/bullet/p50/utility/inferno
 
 /obj/item/ammo_casing/p50/antimatter
 	name = ".50 antimatter-tipped round bullet casing"
 	desc = "A .50 caliber round casing with a contained anti-matter core. Upon impact, the energy of the antimatter will be released causing a devastating explosion. HANDLE WITH CARE."
-	projectile_type = /obj/item/projectile/bullet/p50/utility/antimatter
+	projectile_type = /obj/projectile/bullet/p50/utility/antimatter

--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/caseless/arrow
 	name = "arrow of questionable material"
 	desc = "You shouldn't be seeing this arrow"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow
+	projectile_type = /obj/projectile/bullet/reusable/arrow
 	caliber = "arrow"
 	icon_state = "arrow"
 	throwforce = 3 //good luck hitting someone with the pointy end of the arrow
@@ -15,17 +15,17 @@
 	name = "ashen arrow"
 	desc = "An arrow made from wood, hardened by fire"
 	icon_state = "ashenarrow"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/ash
+	projectile_type = /obj/projectile/bullet/reusable/arrow/ash
 
 /obj/item/ammo_casing/caseless/arrow/bone
 	name = "bone arrow"
 	desc = "An arrow made of bone and sinew. The tip is sharp enough to pierce goliath hide."
 	icon_state = "bonearrow"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/bone
+	projectile_type = /obj/projectile/bullet/reusable/arrow/bone
 
 /obj/item/ammo_casing/caseless/arrow/bronze
 	name = "bronze arrow"
 	desc = "An arrow made from wood. tipped with bronze."
 	icon_state = "bronzearrow"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/bronze
+	projectile_type = /obj/projectile/bullet/reusable/arrow/bronze
 

--- a/code/modules/projectiles/ammunition/caseless/foam.dm
+++ b/code/modules/projectiles/ammunition/caseless/foam.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/caseless/foam_dart
 	name = "foam dart"
 	desc = "It's nerf or nothing! Ages 8 and up."
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart
 	caliber = "foam_force"
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foamdart"
@@ -24,7 +24,7 @@
 
 
 /obj/item/ammo_casing/caseless/foam_dart/attackby(obj/item/A, mob/user, params)
-	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
+	var/obj/projectile/bullet/reusable/foam_dart/FD = BB
 	if (A.tool_behaviour == TOOL_SCREWDRIVER && !modified)
 		modified = TRUE
 		FD.modified = TRUE
@@ -49,7 +49,7 @@
 		return ..()
 
 /obj/item/ammo_casing/caseless/foam_dart/attack_self(mob/living/user)
-	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
+	var/obj/projectile/bullet/reusable/foam_dart/FD = BB
 	if(FD.pen)
 		FD.damage = initial(FD.damage)
 		FD.nodamage = initial(FD.nodamage)
@@ -60,6 +60,6 @@
 /obj/item/ammo_casing/caseless/foam_dart/riot
 	name = "riot foam dart"
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"
 	materials = list(/datum/material/iron = 1125)

--- a/code/modules/projectiles/ammunition/caseless/misc.dm
+++ b/code/modules/projectiles/ammunition/caseless/misc.dm
@@ -3,11 +3,11 @@
 	desc = "You shouldn't be seeing this."
 	caliber = "laser"
 	icon_state = "s-casing-live"
-	projectile_type = /obj/item/projectile/beam
+	projectile_type = /obj/projectile/beam
 	fire_sound = 'sound/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 
 /obj/item/ammo_casing/caseless/laser/gatling
-	projectile_type = /obj/item/projectile/beam/weak/penetrator
+	projectile_type = /obj/projectile/beam/weak/penetrator
 	variance = 0.8
 	click_cooldown_override = 1

--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -3,17 +3,17 @@
 	desc = "An 84mm High Explosive rocket. Fire at people and pray."
 	caliber = "84mm"
 	icon_state = "srm-8"
-	projectile_type = /obj/item/projectile/bullet/a84mm_he
+	projectile_type = /obj/projectile/bullet/a84mm_he
 
 /obj/item/ammo_casing/caseless/rocket/hedp
 	name = "\improper PM-9HEDP"
 	desc = "An 84mm High Explosive Dual Purpose rocket. Pointy end toward mechs."
 	caliber = "84mm"
 	icon_state = "84mm-hedp"
-	projectile_type = /obj/item/projectile/bullet/a84mm
+	projectile_type = /obj/projectile/bullet/a84mm
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."
 	caliber = "75"
 	icon_state = "s-casing-live"
-	projectile_type = /obj/item/projectile/bullet/gyro
+	projectile_type = /obj/projectile/bullet/gyro

--- a/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -2,7 +2,7 @@
 	name = "energy weapon lens"
 	desc = "The part of the gun that makes the laser go pew."
 	caliber = "energy"
-	projectile_type = /obj/item/projectile/energy
+	projectile_type = /obj/projectile/energy
 	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
 	var/select_name = "energy"
 	fire_sound = 'sound/weapons/laser.ogg'

--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -1,16 +1,16 @@
 /obj/item/ammo_casing/energy/bolt
-	projectile_type = /obj/item/projectile/energy/bolt
+	projectile_type = /obj/projectile/energy/bolt
 	select_name = "bolt"
 	e_cost = 500
 	fire_sound = 'sound/weapons/genhit.ogg'
 
 /obj/item/ammo_casing/energy/bolt/radbolt
-	projectile_type = /obj/item/projectile/energy/bolt/radbolt
+	projectile_type = /obj/projectile/energy/bolt/radbolt
 	select_name = "rad bolt"
 
 /obj/item/ammo_casing/energy/bolt/halloween
-	projectile_type = /obj/item/projectile/energy/bolt/halloween
+	projectile_type = /obj/projectile/energy/bolt/halloween
 
 /obj/item/ammo_casing/energy/bolt/large
-	projectile_type = /obj/item/projectile/energy/bolt/large
+	projectile_type = /obj/projectile/energy/bolt/large
 	select_name = "heavy bolt"

--- a/code/modules/projectiles/ammunition/energy/gravity.dm
+++ b/code/modules/projectiles/ammunition/energy/gravity.dm
@@ -15,15 +15,15 @@
 	. = ..()
 
 /obj/item/ammo_casing/energy/gravity/repulse
-	projectile_type = /obj/item/projectile/gravityrepulse
+	projectile_type = /obj/projectile/gravityrepulse
 	select_name = "repulse"
 
 /obj/item/ammo_casing/energy/gravity/attract
-	projectile_type = /obj/item/projectile/gravityattract
+	projectile_type = /obj/projectile/gravityattract
 	select_name = "attract"
 
 /obj/item/ammo_casing/energy/gravity/chaos
-	projectile_type = /obj/item/projectile/gravitychaos
+	projectile_type = /obj/projectile/gravitychaos
 	select_name = "chaos"
 
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,12 +1,12 @@
 /obj/item/ammo_casing/energy/laser
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/gatlinggun
 	e_cost = 1
 
 /obj/item/ammo_casing/energy/lasergun
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	e_cost = 71
 	select_name = "kill"
 
@@ -14,7 +14,7 @@
 	e_cost = 100 // Older technology is less efficient
 
 /obj/item/ammo_casing/energy/lasergun/old
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	e_cost = 200
 	select_name = "kill"
 
@@ -22,55 +22,55 @@
 	e_cost = 120
 
 /obj/item/ammo_casing/energy/laser/practice
-	projectile_type = /obj/item/projectile/beam/practice
+	projectile_type = /obj/projectile/beam/practice
 	select_name = "practice"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/scatter
-	projectile_type = /obj/item/projectile/beam/scatter
+	projectile_type = /obj/projectile/beam/scatter
 	pellets = 5
 	variance = 25
 	select_name = "scatter"
 
 /obj/item/ammo_casing/energy/laser/scatter/disabler
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	pellets = 3
 	variance = 15
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/heavy
-	projectile_type = /obj/item/projectile/beam/laser/heavylaser
+	projectile_type = /obj/projectile/beam/laser/heavylaser
 	select_name = "anti-vehicle"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pulse
-	projectile_type = /obj/item/projectile/beam/pulse
+	projectile_type = /obj/projectile/beam/pulse
 	e_cost = 200
 	select_name = "DESTROY"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
 /obj/item/ammo_casing/energy/laser/bluetag
-	projectile_type = /obj/item/projectile/beam/lasertag/bluetag
+	projectile_type = /obj/projectile/beam/lasertag/bluetag
 	select_name = "bluetag"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/bluetag/hitscan
-	projectile_type = /obj/item/projectile/beam/lasertag/bluetag/hitscan
+	projectile_type = /obj/projectile/beam/lasertag/bluetag/hitscan
 
 /obj/item/ammo_casing/energy/laser/redtag
-	projectile_type = /obj/item/projectile/beam/lasertag/redtag
+	projectile_type = /obj/projectile/beam/lasertag/redtag
 	select_name = "redtag"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/redtag/hitscan
-	projectile_type = /obj/item/projectile/beam/lasertag/redtag/hitscan
+	projectile_type = /obj/projectile/beam/lasertag/redtag/hitscan
 
 /obj/item/ammo_casing/energy/xray
-	projectile_type = /obj/item/projectile/beam/xray
+	projectile_type = /obj/projectile/beam/xray
 	e_cost = 50
 	fire_sound = 'sound/weapons/laser3.ogg'
 
 /obj/item/ammo_casing/energy/mindflayer
-	projectile_type = /obj/item/projectile/beam/mindflayer
+	projectile_type = /obj/projectile/beam/mindflayer
 	select_name = "MINDFUCK"
 	fire_sound = 'sound/weapons/laser.ogg'

--- a/code/modules/projectiles/ammunition/energy/lmg.dm
+++ b/code/modules/projectiles/ammunition/energy/lmg.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/c3dbullet
-	projectile_type = /obj/item/projectile/bullet/c3d
+	projectile_type = /obj/projectile/bullet/c3d
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	e_cost = 20

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -1,11 +1,11 @@
 /obj/item/ammo_casing/energy/plasma
-	projectile_type = /obj/item/projectile/plasma
+	projectile_type = /obj/projectile/plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	delay = 20
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/adv
-	projectile_type = /obj/item/projectile/plasma/adv
+	projectile_type = /obj/projectile/plasma/adv
 	delay = 15
 	e_cost = 10

--- a/code/modules/projectiles/ammunition/energy/portal.dm
+++ b/code/modules/projectiles/ammunition/energy/portal.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/wormhole
-	projectile_type = /obj/item/projectile/beam/wormhole
+	projectile_type = /obj/projectile/beam/wormhole
 	e_cost = 0
 	harmful = FALSE
 	fire_sound = 'sound/weapons/pulse3.ogg'
@@ -8,7 +8,7 @@
 	var/datum/weakref/gun
 
 /obj/item/ammo_casing/energy/wormhole/orange
-	projectile_type = /obj/item/projectile/beam/wormhole/orange
+	projectile_type = /obj/projectile/beam/wormhole/orange
 	select_name = "orange"
 
 /obj/item/ammo_casing/energy/wormhole/Initialize(mapload, obj/item/gun/energy/wormhole_projector/wh)
@@ -17,6 +17,6 @@
 
 /obj/item/ammo_casing/energy/wormhole/throw_proj()
 	. = ..()
-	if(istype(BB, /obj/item/projectile/beam/wormhole))
-		var/obj/item/projectile/beam/wormhole/WH = BB
+	if(istype(BB, /obj/projectile/beam/wormhole))
+		var/obj/projectile/beam/wormhole/WH = BB
 		WH.gun = gun

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -1,67 +1,67 @@
 /obj/item/ammo_casing/energy/ion
-	projectile_type = /obj/item/projectile/ion
+	projectile_type = /obj/projectile/ion
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
 /obj/item/ammo_casing/energy/declone
-	projectile_type = /obj/item/projectile/energy/declone
+	projectile_type = /obj/projectile/energy/declone
 	select_name = "declone"
 	fire_sound = 'sound/weapons/pulse3.ogg'
-	
+
 /obj/item/ammo_casing/energy/declone/weak
-	projectile_type = /obj/item/projectile/energy/declone/weak
+	projectile_type = /obj/projectile/energy/declone/weak
 
 /obj/item/ammo_casing/energy/flora
 	fire_sound = 'sound/effects/stealthoff.ogg'
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/flora/yield
-	projectile_type = /obj/item/projectile/energy/florayield
+	projectile_type = /obj/projectile/energy/florayield
 	select_name = "yield"
 
 /obj/item/ammo_casing/energy/flora/mut
-	projectile_type = /obj/item/projectile/energy/floramut
+	projectile_type = /obj/projectile/energy/floramut
 	select_name = "mutation"
 
 /obj/item/ammo_casing/energy/temp
-	projectile_type = /obj/item/projectile/temp
+	projectile_type = /obj/projectile/temp
 	select_name = "freeze"
 	e_cost = 100
 	fire_sound = 'sound/weapons/pulse3.ogg'
 
 /obj/item/ammo_casing/energy/temp/hot
-	projectile_type = /obj/item/projectile/temp/hot
+	projectile_type = /obj/projectile/temp/hot
 	select_name = "bake"
 
 /obj/item/ammo_casing/energy/meteor
-	projectile_type = /obj/item/projectile/meteor
+	projectile_type = /obj/projectile/meteor
 	select_name = "goddamn meteor"
 
 /obj/item/ammo_casing/energy/net
-	projectile_type = /obj/item/projectile/energy/net
+	projectile_type = /obj/projectile/energy/net
 	select_name = "netting"
 	pellets = 6
 	variance = 40
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/trap
-	projectile_type = /obj/item/projectile/energy/trap
+	projectile_type = /obj/projectile/energy/trap
 	select_name = "snare"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/instakill
-	projectile_type = /obj/item/projectile/beam/instakill
+	projectile_type = /obj/projectile/beam/instakill
 	e_cost = 0
 	select_name = "DESTROY"
 
 /obj/item/ammo_casing/energy/instakill/blue
-	projectile_type = /obj/item/projectile/beam/instakill/blue
+	projectile_type = /obj/projectile/beam/instakill/blue
 
 /obj/item/ammo_casing/energy/instakill/red
-	projectile_type = /obj/item/projectile/beam/instakill/red
+	projectile_type = /obj/projectile/beam/instakill/red
 
 /obj/item/ammo_casing/energy/tesla_revolver
 	fire_sound = 'sound/magic/lightningbolt.ogg'
 	e_cost = 200
 	select_name = "stun"
-	projectile_type = /obj/item/projectile/energy/tesla/revolver
+	projectile_type = /obj/projectile/energy/tesla/revolver

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/electrode
-	projectile_type = /obj/item/projectile/energy/electrode
+	projectile_type = /obj/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
 	e_cost = 200
@@ -19,7 +19,7 @@
 	e_cost = 1000
 
 /obj/item/ammo_casing/energy/disabler
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	select_name  = "disable"
 	e_cost = 40
 	fire_sound = 'sound/weapons/taser2.ogg'

--- a/code/modules/projectiles/ammunition/special/magic.dm
+++ b/code/modules/projectiles/ammunition/special/magic.dm
@@ -1,67 +1,67 @@
 /obj/item/ammo_casing/magic
 	name = "magic casing"
 	desc = "I didn't even know magic needed ammo..."
-	projectile_type = /obj/item/projectile/magic
+	projectile_type = /obj/projectile/magic
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/magic
 	heavy_metal = FALSE
 
 /obj/item/ammo_casing/magic/change
-	projectile_type = /obj/item/projectile/magic/change
+	projectile_type = /obj/projectile/magic/change
 
 /obj/item/ammo_casing/magic/animate
-	projectile_type = /obj/item/projectile/magic/animate
+	projectile_type = /obj/projectile/magic/animate
 
 /obj/item/ammo_casing/magic/heal
-	projectile_type = /obj/item/projectile/magic/resurrection
+	projectile_type = /obj/projectile/magic/resurrection
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/death
-	projectile_type = /obj/item/projectile/magic/death
+	projectile_type = /obj/projectile/magic/death
 
 /obj/item/ammo_casing/magic/teleport
-	projectile_type = /obj/item/projectile/magic/teleport
+	projectile_type = /obj/projectile/magic/teleport
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/safety
-	projectile_type = /obj/item/projectile/magic/safety
+	projectile_type = /obj/projectile/magic/safety
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/door
-	projectile_type = /obj/item/projectile/magic/door
+	projectile_type = /obj/projectile/magic/door
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/fireball
-	projectile_type = /obj/item/projectile/magic/fireball
+	projectile_type = /obj/projectile/magic/fireball
 
 /obj/item/ammo_casing/magic/chaos
-	projectile_type = /obj/item/projectile/magic
+	projectile_type = /obj/projectile/magic
 
 /obj/item/ammo_casing/magic/spellblade
-	projectile_type = /obj/item/projectile/magic/spellblade
+	projectile_type = /obj/projectile/magic/spellblade
 
 /obj/item/ammo_casing/magic/arcane_barrage
-	projectile_type = /obj/item/projectile/magic/arcane_barrage
+	projectile_type = /obj/projectile/magic/arcane_barrage
 
 /obj/item/ammo_casing/magic/honk
-	projectile_type = /obj/item/projectile/bullet/honker
+	projectile_type = /obj/projectile/bullet/honker
 
 /obj/item/ammo_casing/magic/locker
-	projectile_type = /obj/item/projectile/magic/locker
+	projectile_type = /obj/projectile/magic/locker
 
 /obj/item/ammo_casing/magic/flying
-	projectile_type = /obj/item/projectile/magic/flying
+	projectile_type = /obj/projectile/magic/flying
 
 /obj/item/ammo_casing/magic/bounty
-	projectile_type = /obj/item/projectile/magic/bounty
+	projectile_type = /obj/projectile/magic/bounty
 
 /obj/item/ammo_casing/magic/antimagic
-	projectile_type = /obj/item/projectile/magic/antimagic
+	projectile_type = /obj/projectile/magic/antimagic
 
 /obj/item/ammo_casing/magic/sapping
-	projectile_type = /obj/item/projectile/magic/sapping
+	projectile_type = /obj/projectile/magic/sapping
 
 /obj/item/ammo_casing/magic/necropotence
-	projectile_type = /obj/item/projectile/magic/necropotence
+	projectile_type = /obj/projectile/magic/necropotence
 
 /obj/item/ammo_casing/magic/wipe
-	projectile_type = /obj/item/projectile/magic/wipe
+	projectile_type = /obj/projectile/magic/wipe

--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/syringegun
 	name = "syringe gun spring"
 	desc = "A high-power spring that throws syringes."
-	projectile_type = /obj/item/projectile/bullet/dart/syringe
+	projectile_type = /obj/projectile/bullet/dart/syringe
 	firing_effect_type = null
 
 /obj/item/ammo_casing/syringegun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -14,7 +14,7 @@
 
 		var/obj/item/reagent_containers/syringe/S = SG.syringes[1]
 		BB.name = S.name
-		var/obj/item/projectile/bullet/dart/D = BB
+		var/obj/projectile/bullet/dart/D = BB
 		D.piercing = S.proj_piercing
 		SG.syringes.Remove(S)
 		S.forceMove(BB)
@@ -24,7 +24,7 @@
 /obj/item/ammo_casing/chemgun
 	name = "dart synthesiser"
 	desc = "A high-power spring, linked to an energy-based dart synthesiser."
-	projectile_type = /obj/item/projectile/bullet/dart
+	projectile_type = /obj/projectile/bullet/dart
 	firing_effect_type = null
 
 /obj/item/ammo_casing/chemgun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -42,7 +42,7 @@
 /obj/item/ammo_casing/bee
 	name = "bee synthesiser"
 	desc = "A beehive shoved into a gun."
-	projectile_type = /obj/item/projectile/bullet/dart/bee
+	projectile_type = /obj/projectile/bullet/dart/bee
 	firing_effect_type = null
 
 /obj/item/ammo_casing/bee/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -60,7 +60,7 @@
 /obj/item/ammo_casing/dnainjector
 	name = "rigged syringe gun spring"
 	desc = "A high-power spring that throws DNA injectors."
-	projectile_type = /obj/item/projectile/bullet/dnainjector
+	projectile_type = /obj/projectile/bullet/dnainjector
 	firing_effect_type = null
 
 /obj/item/ammo_casing/dnainjector/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -72,7 +72,7 @@
 			return
 
 		var/obj/item/dnainjector/S = popleft(SG.syringes)
-		var/obj/item/projectile/bullet/dnainjector/D = BB
+		var/obj/projectile/bullet/dnainjector/D = BB
 		S.forceMove(D)
 		D.injector = S
 	..()

--- a/code/modules/projectiles/ammunition/special/vortex.dm
+++ b/code/modules/projectiles/ammunition/special/vortex.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/energy/vortex
 	name = "vortex blast"
 	desc = "what the hell?"
-	projectile_type = /obj/item/projectile/energy/vortex
+	projectile_type = /obj/projectile/energy/vortex
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 	heavy_metal = FALSE
 	e_cost = 100

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -280,7 +280,7 @@
 		. = ""
 	else
 		var/obj/item/ammo_casing/energy/E = ammo_type[select]
-		var/obj/item/projectile/energy/BB = E.BB
+		var/obj/projectile/energy/BB = E.BB
 		if(!BB)
 			. = ""
 		else if(BB.nodamage || !BB.damage || BB.damage_type == STAMINA)

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -244,12 +244,12 @@
 
 /obj/item/ammo_casing/energy/duel
 	e_cost = 0
-	projectile_type = /obj/item/projectile/energy/duel
+	projectile_type = /obj/projectile/energy/duel
 	var/setting
 
 /obj/item/ammo_casing/energy/duel/ready_proj(atom/target, mob/living/user, quiet, zone_override)
 	. = ..()
-	var/obj/item/projectile/energy/duel/D = BB
+	var/obj/projectile/energy/duel/D = BB
 	D.setting = setting
 	D.update_icon()
 
@@ -261,14 +261,14 @@
 
 //Projectile
 
-/obj/item/projectile/energy/duel
+/obj/projectile/energy/duel
 	name = "dueling beam"
 	icon_state = "declone"
 	reflectable = FALSE
 	homing = TRUE
 	var/setting
 
-/obj/item/projectile/energy/duel/update_icon()
+/obj/projectile/energy/duel/update_icon()
 	. = ..()
 	switch(setting)
 		if(DUEL_SETTING_A)
@@ -278,7 +278,7 @@
 		if(DUEL_SETTING_C)
 			color = "blue"
 
-/obj/item/projectile/energy/duel/on_hit(atom/target, blocked)
+/obj/projectile/energy/duel/on_hit(atom/target, blocked)
 	. = ..()
 	var/turf/T = get_turf(target)
 	var/obj/effect/temp_visual/dueling_chaff/C = locate() in T

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -62,7 +62,7 @@
 	for(var/A in modkits)
 		. += A
 
-/obj/item/gun/energy/kinetic_accelerator/proc/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/gun/energy/kinetic_accelerator/proc/modify_projectile(obj/projectile/kinetic/K)
 	K.kinetic_gun = src //do something special on-hit, easy!
 	for(var/A in get_modkits())
 		var/obj/item/borg/upgrade/modkit/M = A
@@ -149,7 +149,7 @@
 
 //Casing
 /obj/item/ammo_casing/energy/kinetic
-	projectile_type = /obj/item/projectile/kinetic
+	projectile_type = /obj/projectile/kinetic
 	select_name = "kinetic"
 	e_cost = 500
 	fire_sound = 'sound/weapons/kenetic_accel.ogg' // fine spelling there chap
@@ -161,7 +161,7 @@
 		KA.modify_projectile(BB)
 
 //Projectiles
-/obj/item/projectile/kinetic
+/obj/projectile/kinetic
 	name = "kinetic force"
 	icon_state = null
 	damage = 20
@@ -174,11 +174,11 @@
 	var/pressure_decrease = 0.5
 	var/obj/item/gun/energy/kinetic_accelerator/kinetic_gun
 
-/obj/item/projectile/kinetic/Destroy()
+/obj/projectile/kinetic/Destroy()
 	kinetic_gun = null
 	return ..()
 
-/obj/item/projectile/kinetic/prehit_pierce(atom/target)
+/obj/projectile/kinetic/prehit_pierce(atom/target)
 	. = ..()
 	if(. == PROJECTILE_PIERCE_PHASE)
 		return
@@ -191,15 +191,15 @@
 		damage = damage * pressure_decrease
 		pressure_decrease_active = TRUE
 
-/obj/item/projectile/kinetic/on_range()
+/obj/projectile/kinetic/on_range()
 	strike_thing()
 	..()
 
-/obj/item/projectile/kinetic/on_hit(atom/target)
+/obj/projectile/kinetic/on_hit(atom/target)
 	strike_thing(target)
 	. = ..()
 
-/obj/item/projectile/kinetic/proc/strike_thing(atom/target)
+/obj/projectile/kinetic/proc/strike_thing(atom/target)
 	var/turf/target_turf = get_turf(target)
 	if(!target_turf)
 		target_turf = get_turf(src)
@@ -292,14 +292,14 @@
 
 
 
-/obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/projectile/kinetic/K)
 
 //use this one for effects you want to trigger before any damage is done at all and before damage is decreased by pressure
-/obj/item/borg/upgrade/modkit/proc/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //use this one for effects you want to trigger before mods that do damage
-/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //and this one for things that don't need to trigger before other damage-dealing mods
-/obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 
 //Range
 /obj/item/borg/upgrade/modkit/range
@@ -308,7 +308,7 @@
 	modifier = 1
 	cost = 25
 
-/obj/item/borg/upgrade/modkit/range/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/range/modify_projectile(obj/projectile/kinetic/K)
 	K.range += modifier
 
 
@@ -318,7 +318,7 @@
 	desc = "Increases the damage of kinetic accelerator when installed."
 	modifier = 10
 
-/obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/projectile/kinetic/K)
 	K.damage += modifier
 
 
@@ -374,10 +374,10 @@
 	turf_aoe = initial(turf_aoe)
 	stats_stolen = FALSE
 
-/obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/projectile/kinetic/K)
 	K.name = "kinetic explosion"
 
-/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(stats_stolen)
 		return
 	new /obj/effect/temp_visual/explosion/fast(target_turf)
@@ -421,7 +421,7 @@
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
-/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	var/valid_repeat = FALSE
 	if(isliving(target))
 		var/mob/living/L = target
@@ -441,7 +441,7 @@
 	cost = 10
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
 
-/obj/item/borg/upgrade/modkit/lifesteal/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/lifesteal/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target) && isliving(K.firer))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
@@ -456,7 +456,7 @@
 	cost = 30
 	modifier = 0.25 //A bonus 15 damage if you burst the field on a target, 60 if you lure them into it.
 
-/obj/item/borg/upgrade/modkit/resonator_blasts/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/resonator_blasts/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(target_turf && !ismineralturf(target_turf)) //Don't make fields on mineral turfs.
 		var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in target_turf
 		if(R)
@@ -474,7 +474,7 @@
 	var/maximum_bounty = 25
 	var/list/bounties_reaped = list()
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/bounty/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		var/list/existing_marks = L.has_status_effect_list(STATUS_EFFECT_SYPHONMARK)
@@ -485,7 +485,7 @@
 				qdel(SM)
 		L.apply_status_effect(STATUS_EFFECT_SYPHONMARK, src)
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(bounties_reaped[L.type])
@@ -513,7 +513,7 @@
 	maximum_of_type = 1
 	cost = 35
 
-/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/projectile/kinetic/K)
 	K.pressure_decrease *= modifier
 
 
@@ -568,7 +568,7 @@
 	denied_type = /obj/item/borg/upgrade/modkit/tracer
 	var/bolt_color = "#FFFFFF"
 
-/obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/projectile/kinetic/K)
 	K.icon_state = "ka_tracer"
 	K.color = bolt_color
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -90,17 +90,17 @@
 	ammo_x_offset = 3
 
 /obj/item/ammo_casing/energy/laser/accelerator
-	projectile_type = /obj/item/projectile/beam/laser/accelerator
+	projectile_type = /obj/projectile/beam/laser/accelerator
 	select_name = "accelerator"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
-/obj/item/projectile/beam/laser/accelerator
+/obj/projectile/beam/laser/accelerator
 	name = "accelerator laser"
 	icon_state = "scatterlaser"
 	range = 255
 	damage = 6
 
-/obj/item/projectile/beam/laser/accelerator/Range()
+/obj/projectile/beam/laser/accelerator/Range()
 	..()
 	damage += 7
 	transform *= 1 + ((damage/7) * 0.2)//20% larger per tile

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -264,7 +264,7 @@
 		var/obj/item/ammo_casing/energy/wormhole/W = ammo_type[i]
 		if(istype(W))
 			W.gun = WEAKREF(src)
-			var/obj/item/projectile/beam/wormhole/WH = W.BB
+			var/obj/projectile/beam/wormhole/WH = W.BB
 			if(istype(WH))
 				WH.gun = WEAKREF(src)
 
@@ -300,9 +300,9 @@
 	p_orange.link_portal(p_blue)
 	p_blue.link_portal(p_orange)
 
-/obj/item/gun/energy/wormhole_projector/proc/create_portal(obj/item/projectile/beam/wormhole/W, turf/target)
+/obj/item/gun/energy/wormhole_projector/proc/create_portal(obj/projectile/beam/wormhole/W, turf/target)
 	var/obj/effect/portal/P = new /obj/effect/portal(target, src, 300, null, FALSE, null, atmos_link)
-	if(istype(W, /obj/item/projectile/beam/wormhole/orange))
+	if(istype(W, /obj/projectile/beam/wormhole/orange))
 		qdel(p_orange)
 		p_orange = P
 		P.icon_state = "portal1"

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -45,11 +45,11 @@
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage, /obj/item/projectile/magic/locker, /obj/item/projectile/magic/flying,
-	/obj/item/projectile/magic/bounty, /obj/item/projectile/magic/antimagic, /obj/item/projectile/magic/fetch, /obj/item/projectile/magic/sapping,
-	/obj/item/projectile/magic/necropotence, /obj/item/projectile/magic, /obj/item/projectile/temp/chill, /obj/item/projectile/magic/wipe)
+	var/allowed_projectile_types = list(/obj/projectile/magic/change, /obj/projectile/magic/animate, /obj/projectile/magic/resurrection,
+	/obj/projectile/magic/death, /obj/projectile/magic/teleport, /obj/projectile/magic/door, /obj/projectile/magic/fireball,
+	/obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage, /obj/projectile/magic/locker, /obj/projectile/magic/flying,
+	/obj/projectile/magic/bounty, /obj/projectile/magic/antimagic, /obj/projectile/magic/fetch, /obj/projectile/magic/sapping,
+	/obj/projectile/magic/necropotence, /obj/projectile/magic, /obj/projectile/temp/chill, /obj/projectile/magic/wipe)
 
 /obj/item/gun/magic/staff/chaos/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	chambered.projectile_type = pick(allowed_projectile_types)

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -181,7 +181,7 @@
 	if(diff < AIMING_BEAM_ANGLE_CHANGE_THRESHOLD && !force_update)
 		return
 	aiming_lastangle = lastangle
-	var/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
+	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
 	P.gun = src
 	P.wall_pierce_amount = wall_pierce_amount
 	P.structure_pierce_amount = structure_piercing
@@ -361,7 +361,7 @@
 
 /obj/item/ammo_casing/energy/beam_rifle/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
 	. = ..()
-	var/obj/item/projectile/beam/beam_rifle/hitscan/HS_BB = BB
+	var/obj/projectile/beam/beam_rifle/hitscan/HS_BB = BB
 	if(!istype(HS_BB))
 		return
 	HS_BB.impact_direct_damage = projectile_damage
@@ -400,12 +400,12 @@
 	return TRUE
 
 /obj/item/ammo_casing/energy/beam_rifle/hitscan
-	projectile_type = /obj/item/projectile/beam/beam_rifle/hitscan
+	projectile_type = /obj/projectile/beam/beam_rifle/hitscan
 	select_name = "beam"
 	e_cost = 10000
 	fire_sound = 'sound/weapons/beam_sniper.ogg'
 
-/obj/item/projectile/beam/beam_rifle
+/obj/projectile/beam/beam_rifle
 	name = "particle beam"
 	icon = null
 	hitsound = 'sound/effects/explosion3.ogg'
@@ -432,7 +432,7 @@
 	var/impact_direct_damage = 0
 	var/list/pierced = list()
 
-/obj/item/projectile/beam/beam_rifle/proc/AOE(turf/epicenter)
+/obj/projectile/beam/beam_rifle/proc/AOE(turf/epicenter)
 	if(!epicenter)
 		return
 	new /obj/effect/temp_visual/explosion/fast(epicenter)
@@ -446,7 +446,7 @@
 		if(!isitem(O))
 			O.take_damage(aoe_structure_damage * get_damage_coeff(O), BURN, LASER, FALSE)
 
-/obj/item/projectile/beam/beam_rifle/prehit_pierce(atom/A)
+/obj/projectile/beam/beam_rifle/prehit_pierce(atom/A)
 	if(isclosedturf(A) && (wall_pierce < wall_pierce_amount))
 		if(prob(wall_devastate))
 			if(iswallturf(A))
@@ -463,14 +463,14 @@
 		return PROJECTILE_PIERCE_PHASE			// ditto and this could be refactored to on_hit honestly
 	return ..()
 
-/obj/item/projectile/beam/beam_rifle/proc/get_damage_coeff(atom/target)
+/obj/projectile/beam/beam_rifle/proc/get_damage_coeff(atom/target)
 	if(istype(target, /obj/machinery/door))
 		return 0.4
 	if(istype(target, /obj/structure/window))
 		return 0.5
 	return 1
 
-/obj/item/projectile/beam/beam_rifle/proc/handle_impact(atom/target)
+/obj/projectile/beam/beam_rifle/proc/handle_impact(atom/target)
 	if(isobj(target))
 		var/obj/O = target
 		O.take_damage(impact_structure_damage * get_damage_coeff(target), BURN, LASER, FALSE)
@@ -479,7 +479,7 @@
 		L.adjustFireLoss(impact_direct_damage)
 		L.emote("scream")
 
-/obj/item/projectile/beam/beam_rifle/proc/handle_hit(atom/target, piercing_hit = FALSE)
+/obj/projectile/beam/beam_rifle/proc/handle_hit(atom/target, piercing_hit = FALSE)
 	set waitfor = FALSE
 	if(nodamage)
 		return FALSE
@@ -489,17 +489,17 @@
 	if(!QDELETED(target))
 		handle_impact(target)
 
-/obj/item/projectile/beam/beam_rifle/on_hit(atom/target, blocked = FALSE, piercing_hit = FALSE)
+/obj/projectile/beam/beam_rifle/on_hit(atom/target, blocked = FALSE, piercing_hit = FALSE)
 	handle_hit(target, piercing_hit)
 	return ..()
 
-/obj/item/projectile/beam/beam_rifle/hitscan
+/obj/projectile/beam/beam_rifle/hitscan
 	icon_state = ""
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/tracer/beam_rifle
 	var/constant_tracer = FALSE
 
-/obj/item/projectile/beam/beam_rifle/hitscan/generate_hitscan_tracers(cleanup = TRUE, duration = 5, impacting = TRUE, highlander)
+/obj/projectile/beam/beam_rifle/hitscan/generate_hitscan_tracers(cleanup = TRUE, duration = 5, impacting = TRUE, highlander)
 	set waitfor = FALSE
 	if(isnull(highlander))
 		highlander = constant_tracer
@@ -515,7 +515,7 @@
 		beam_segments = null
 		QDEL_NULL(beam_index)
 
-/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam
+/obj/projectile/beam/beam_rifle/hitscan/aiming_beam
 	tracer_type = /obj/effect/projectile/tracer/tracer/aiming
 	name = "aiming beam"
 	hitsound = null
@@ -528,9 +528,9 @@
 	hitscan_light_color_override = "#99ff99"
 	reflectable = REFLECT_FAKEPROJECTILE
 
-/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/prehit_pierce(atom/target)
+/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/prehit_pierce(atom/target)
 	return PROJECTILE_DELETE_WITHOUT_HITTING
 
-/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/on_hit()
+/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/on_hit()
 	qdel(src)
 	return BULLET_ACT_BLOCK

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -104,12 +104,12 @@
 	var/turf/targturf = get_turf(target)
 	message_admins("Blast wave fired from [ADMIN_VERBOSEJMP(starting)] at [ADMIN_VERBOSEJMP(targturf)] ([target.name]) by [ADMIN_LOOKUPFLW(user)] with power [heavy]/[medium]/[light].")
 	log_game("Blast wave fired from [AREACOORD(starting)] at [AREACOORD(targturf)] ([target.name]) by [key_name(user)] with power [heavy]/[medium]/[light].")
-	var/obj/item/projectile/blastwave/BW = new(loc, heavy, medium, light)
+	var/obj/projectile/blastwave/BW = new(loc, heavy, medium, light)
 	BW.hugbox = hugbox
 	BW.preparePixelProjectile(target, get_turf(src), params, 0)
 	BW.fire()
 
-/obj/item/projectile/blastwave
+/obj/projectile/blastwave
 	name = "blast wave"
 	icon_state = "blastwave"
 	damage = 0
@@ -122,13 +122,13 @@
 	var/hugbox = TRUE
 	range = 150
 
-/obj/item/projectile/blastwave/Initialize(mapload, _h, _m, _l)
+/obj/projectile/blastwave/Initialize(mapload, _h, _m, _l)
 	heavyr = _h
 	mediumr = _m
 	lightr = _l
 	return ..()
 
-/obj/item/projectile/blastwave/Range()
+/obj/projectile/blastwave/Range()
 	..()
 	var/amount_destruction = EXPLODE_NONE
 	var/wallbreak_chance = 0
@@ -157,5 +157,5 @@
 	mediumr = max(mediumr - 1, 0)
 	lightr = max(lightr - 1, 0)
 
-/obj/item/projectile/blastwave/ex_act()
+/obj/projectile/blastwave/ex_act()
 	return

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/beam
+/obj/projectile/beam
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSTRANSPARENT | PASSGRILLE
@@ -18,12 +18,12 @@
 	ricochet_chance = 80
 	reflectable = REFLECT_NORMAL
 
-/obj/item/projectile/beam/laser
+/obj/projectile/beam/laser
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/laser/heavylaser
+/obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage = 40
@@ -31,7 +31,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 
-/obj/item/projectile/beam/laser/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/laser/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
@@ -39,25 +39,25 @@
 	else if(isturf(target))
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
-/obj/item/projectile/beam/weak
+/obj/projectile/beam/weak
 	damage = 12
 
-/obj/item/projectile/beam/weak/penetrator //laser gatling and centcom shuttle turret
+/obj/projectile/beam/weak/penetrator //laser gatling and centcom shuttle turret
 	damage = 15
 	armour_penetration = 50
 
-/obj/item/projectile/beam/practice
+/obj/projectile/beam/practice
 	name = "practice laser"
 	damage = 0
 	nodamage = TRUE
 	martial_arts_no_deflect = TRUE
 
-/obj/item/projectile/beam/scatter
+/obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
 	damage = 5
 
-/obj/item/projectile/beam/xray
+/obj/projectile/beam/xray
 	name = "\improper X-ray beam"
 	icon_state = "xray"
 	damage = 15
@@ -72,7 +72,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/xray
 	impact_type = /obj/effect/projectile/impact/xray
 
-/obj/item/projectile/beam/disabler
+/obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
 	damage = 28
@@ -86,13 +86,13 @@
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
 
-/obj/item/projectile/beam/disabler/pass_glass ///this is for the malf ai turret upgrade xdxdxd
+/obj/projectile/beam/disabler/pass_glass ///this is for the malf ai turret upgrade xdxdxd
 	name = "beam-disabler"
 	damage = 50
 	damage_type = STAMINA
 	pass_flags = PASSTABLE | PASSGRILLE | PASSTRANSPARENT
 
-/obj/item/projectile/beam/pulse
+/obj/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
@@ -102,7 +102,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	impact_type = /obj/effect/projectile/impact/pulse
 
-/obj/item/projectile/beam/pulse/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/pulse/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if (!QDELETED(target) && (isturf(target) || istype(target, /obj/structure/)))
 		if(isobj(target))
@@ -110,31 +110,31 @@
 		else
 			SSexplosions.medturf += target
 
-/obj/item/projectile/beam/pulse/shotgun
+/obj/projectile/beam/pulse/shotgun
 	damage = 40
 
-/obj/item/projectile/beam/pulse/heavy
+/obj/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"
 	icon_state = "pulse1_bl"
 	var/life = 20
 
-/obj/item/projectile/beam/pulse/heavy/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/pulse/heavy/on_hit(atom/target, blocked = FALSE)
 	life -= 10
 	if(life > 0)
 		. = BULLET_ACT_FORCE_PIERCE
 	..()
 
-/obj/item/projectile/beam/emitter
+/obj/projectile/beam/emitter
 	name = "emitter beam"
 	icon_state = "emitter"
 	damage = 30
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
-/obj/item/projectile/beam/emitter/singularity_pull()
+/obj/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss
 
-/obj/item/projectile/beam/lasertag
+/obj/projectile/beam/lasertag
 	name = "laser tag beam"
 	icon_state = "omnilaser"
 	hitsound = null
@@ -146,7 +146,7 @@
 	light_color = LIGHT_COLOR_BLUE
 	martial_arts_no_deflect = TRUE
 
-/obj/item/projectile/beam/lasertag/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/lasertag/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
@@ -154,7 +154,7 @@
 			if(M.wear_suit.type in suit_types)
 				M.adjustStaminaLoss(34)
 
-/obj/item/projectile/beam/lasertag/redtag
+/obj/projectile/beam/lasertag/redtag
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
@@ -163,20 +163,20 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/lasertag/redtag/hitscan
+/obj/projectile/beam/lasertag/redtag/hitscan
 	hitscan = TRUE
 
-/obj/item/projectile/beam/lasertag/bluetag
+/obj/projectile/beam/lasertag/bluetag
 	icon_state = "bluelaser"
 	suit_types = list(/obj/item/clothing/suit/redtag)
 	tracer_type = /obj/effect/projectile/tracer/laser/blue
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
 	impact_type = /obj/effect/projectile/impact/laser/blue
 
-/obj/item/projectile/beam/lasertag/bluetag/hitscan
+/obj/projectile/beam/lasertag/bluetag/hitscan
 	hitscan = TRUE
 
-/obj/item/projectile/beam/instakill
+/obj/projectile/beam/instakill
 	name = "instagib laser"
 	icon_state = "purple_laser"
 	damage = 200
@@ -184,17 +184,17 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	light_color = LIGHT_COLOR_PURPLE
 
-/obj/item/projectile/beam/instakill/blue
+/obj/projectile/beam/instakill/blue
 	icon_state = "blue_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
-/obj/item/projectile/beam/instakill/red
+/obj/projectile/beam/instakill/red
 	icon_state = "red_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
 
-/obj/item/projectile/beam/instakill/on_hit(atom/target)
+/obj/projectile/beam/instakill/on_hit(atom/target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet
+/obj/projectile/bullet
 	name = "bullet"
 	icon_state = "bullet"
 	damage = 60

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -1,15 +1,15 @@
-/obj/item/projectile/bullet/incendiary
+/obj/projectile/bullet/incendiary
 	damage = 20
 	var/fire_stacks = 4
 
-/obj/item/projectile/bullet/incendiary/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/incendiary/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.adjust_fire_stacks(fire_stacks)
 		M.IgniteMob()
 
-/obj/item/projectile/bullet/incendiary/Move()
+/obj/projectile/bullet/incendiary/Move()
 	. = ..()
 	var/turf/location = get_turf(src)
 	if(location)

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -1,15 +1,15 @@
-/obj/item/projectile/bullet/dart
+/obj/projectile/bullet/dart
 	name = "dart"
 	icon_state = "cbbolt"
 	damage = 6
 	var/piercing = FALSE
 	var/obj/item/reagent_containers/syringe/syringe = null
 
-/obj/item/projectile/bullet/dart/Initialize(mapload)
+/obj/projectile/bullet/dart/Initialize(mapload)
 	. = ..()
 	create_reagents(50, NO_REACT)
 
-/obj/item/projectile/bullet/dart/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/dart/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
@@ -34,25 +34,25 @@
 	reagents.handle_reactions()
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/dart/metalfoam/Initialize(mapload)
+/obj/projectile/bullet/dart/metalfoam/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent(/datum/reagent/aluminium, 15)
 	reagents.add_reagent(/datum/reagent/foaming_agent, 5)
 	reagents.add_reagent(/datum/reagent/toxin/acid/fluacid, 5)
 
 
-/obj/item/projectile/bullet/dart/syringe
+/obj/projectile/bullet/dart/syringe
 	name = "syringe"
 	icon_state = "syringeproj"
 
-/obj/item/projectile/bullet/dart/bee
+/obj/projectile/bullet/dart/bee
 	name = "bee"
 	icon_state = "bee"
 	damage = 1
 	armor_flag = MELEE
 	piercing = TRUE
 
-/obj/item/projectile/bullet/dart/bee/on_hit(atom/target, blocked)
+/obj/projectile/bullet/dart/bee/on_hit(atom/target, blocked)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
@@ -87,21 +87,21 @@
 
 	return ..()
 
-/obj/item/projectile/bullet/dart/tranq
+/obj/projectile/bullet/dart/tranq
 	name = "tranquilizer dart"
 
-/obj/item/projectile/bullet/dart/tranq/Initialize(mapload)
+/obj/projectile/bullet/dart/tranq/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 4) //these'll get the victim wallslamming and then sleep em, but it will take awhile before it puts the victim to sleep
 
-/obj/item/projectile/bullet/dart/tranq/plus
+/obj/projectile/bullet/dart/tranq/plus
 
-/obj/item/projectile/bullet/dart/tranq/plus/Initialize(mapload)
+/obj/projectile/bullet/dart/tranq/plus/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent(/datum/reagent/pax, 1)
 
-/obj/item/projectile/bullet/dart/tranq/plusplus
+/obj/projectile/bullet/dart/tranq/plusplus
 
-/obj/item/projectile/bullet/dart/tranq/plusplus/Initialize(mapload)
+/obj/projectile/bullet/dart/tranq/plusplus/Initialize(mapload)
 	. = ..()
 	reagents.add_reagent(/datum/reagent/pax, 3)

--- a/code/modules/projectiles/projectile/bullets/dnainjector.dm
+++ b/code/modules/projectiles/projectile/bullets/dnainjector.dm
@@ -1,11 +1,11 @@
-/obj/item/projectile/bullet/dnainjector
+/obj/projectile/bullet/dnainjector
 	name = "\improper DNA injector"
 	icon_state = "syringeproj"
 	var/obj/item/dnainjector/injector
 	damage = 5
 	hitsound_wall = "shatter"
 
-/obj/item/projectile/bullet/dnainjector/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/dnainjector/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100)
@@ -19,6 +19,6 @@
 									   "<span class='userdanger'>You were protected against \the [src]!</span>")
 	return ..()
 
-/obj/item/projectile/bullet/dnainjector/Destroy()
+/obj/projectile/bullet/dnainjector/Destroy()
 	QDEL_NULL(injector)
 	return ..()

--- a/code/modules/projectiles/projectile/bullets/grenade.dm
+++ b/code/modules/projectiles/projectile/bullets/grenade.dm
@@ -1,12 +1,12 @@
 // 40mm (Grenade Launcher
 
-/obj/item/projectile/bullet/a40mm
+/obj/projectile/bullet/a40mm
 	name ="40mm grenade"
 	desc = "USE A WEEL GUN"
 	icon_state= "bolter"
 	damage = 60
 
-/obj/item/projectile/bullet/a40mm/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/a40mm/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 2, 1, 0, flame_range = 3)
 	return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -1,49 +1,49 @@
 // C3D (Borgs)
 
-/obj/item/projectile/bullet/c3d
+/obj/projectile/bullet/c3d
 	damage = 20
 
 // Mech LMG
 
-/obj/item/projectile/bullet/lmg
+/obj/projectile/bullet/lmg
 	damage = 20
 
 // Mech FNX-99
 
-/obj/item/projectile/bullet/incendiary/fnx99
+/obj/projectile/bullet/incendiary/fnx99
 	damage = 20
 
 // Turrets
 
-/obj/item/projectile/bullet/manned_turret
+/obj/projectile/bullet/manned_turret
 	damage = 20
 
-/obj/item/projectile/bullet/syndicate_turret
+/obj/projectile/bullet/syndicate_turret
 	damage = 20
 
 // 7.12x82mm (SAW)
 
-/obj/item/projectile/bullet/mm712x82
+/obj/projectile/bullet/mm712x82
 	name = "7.12x82mm bullet"
 	damage = 45
 	armour_penetration = 5
 
-/obj/item/projectile/bullet/mm712x82_ap
+/obj/projectile/bullet/mm712x82_ap
 	name = "7.12x82mm armor-piercing bullet"
 	damage = 40
 	armour_penetration = 75
 
-/obj/item/projectile/bullet/mm712x82_hp
+/obj/projectile/bullet/mm712x82_hp
 	name = "7.12x82mm hollow-point bullet"
 	damage = 60
 	armour_penetration = -60
 
-/obj/item/projectile/bullet/incendiary/mm712x82
+/obj/projectile/bullet/incendiary/mm712x82
 	name = "7.12x82mm incendiary bullet"
 	damage = 20
 	fire_stacks = 3
 
-/obj/item/projectile/bullet/mm712x82_match
+/obj/projectile/bullet/mm712x82_match
 	name = "7.12x82mm match bullet"
 	damage = 40
 	ricochets_max = 2

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -1,36 +1,36 @@
 // 9mm (Stechkin APS)
 
-/obj/item/projectile/bullet/c9mm
+/obj/projectile/bullet/c9mm
 	name = "9mm bullet"
 	damage = 20
 
-/obj/item/projectile/bullet/c9mm_ap
+/obj/projectile/bullet/c9mm_ap
 	name = "9mm armor-piercing bullet"
 	damage = 15
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/incendiary/c9mm
+/obj/projectile/bullet/incendiary/c9mm
 	name = "9mm incendiary bullet"
 	damage = 10
 	fire_stacks = 1
 
 // 10mm (Stechkin)
 
-/obj/item/projectile/bullet/c10mm
+/obj/projectile/bullet/c10mm
 	name = "10mm bullet"
 	damage = 30
 
-/obj/item/projectile/bullet/c10mm_ap
+/obj/projectile/bullet/c10mm_ap
 	name = "10mm armor-piercing bullet"
 	damage = 27
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/c10mm_hp
+/obj/projectile/bullet/c10mm_hp
 	name = "10mm hollow-point bullet"
 	damage = 40
 	armour_penetration = -50
 
-/obj/item/projectile/bullet/incendiary/c10mm
+/obj/projectile/bullet/incendiary/c10mm
 	name = "10mm incendiary bullet"
 	damage = 15
 	fire_stacks = 2

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -1,18 +1,18 @@
 // 7.62x38mmR (Nagant Revolver)
 
-/obj/item/projectile/bullet/n762
+/obj/projectile/bullet/n762
 	name = "7.62x38mmR bullet"
 	damage = 60
 
 // .50AE (Desert Eagle)
 
-/obj/item/projectile/bullet/a50AE
+/obj/projectile/bullet/a50AE
 	name = ".50AE bullet"
 	damage = 60
 
 // .38 (Detective's Gun)
 
-/obj/item/projectile/bullet/c38
+/obj/projectile/bullet/c38
 	name = ".38 bullet"
 	damage = 25
 	ricochets_max = 2
@@ -20,7 +20,7 @@
 	ricochet_auto_aim_angle = 10
 	ricochet_auto_aim_range = 3
 
-/obj/item/projectile/bullet/c38/match
+/obj/projectile/bullet/c38/match
 	name = ".38 Match bullet"
 	ricochets_max = 4
 	ricochet_chance = 100
@@ -30,7 +30,7 @@
 	ricochet_decay_chance = 1
 	ricochet_decay_damage = 1
 
-/obj/item/projectile/bullet/c38/match/bouncy
+/obj/projectile/bullet/c38/match/bouncy
 	name = ".38 Bouncy Rubber bullet"
 	damage = 10
 	stamina = 30
@@ -41,19 +41,19 @@
 	ricochet_decay_damage = 0.8
 	shrapnel_type = NONE
 
-/obj/item/projectile/bullet/c38/dumdum
+/obj/projectile/bullet/c38/dumdum
 	name = ".38 DumDum bullet"
 	damage = 15
 	armour_penetration = -30
 	ricochets_max = 0
 	shrapnel_type = /obj/item/shrapnel/bullet/c38/dumdum
 
-/obj/item/projectile/bullet/c38/trac
+/obj/projectile/bullet/c38/trac
 	name = ".38 TRAC bullet"
 	damage = 10
 	ricochets_max = 0
 
-/obj/item/projectile/bullet/c38/trac/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/c38/trac/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	var/mob/living/M = target
 	if(!istype(M))
@@ -64,38 +64,38 @@
 	var/obj/item/implant/tracking/c38/imp = new (M)
 	imp.implant(M)
 
-/obj/item/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
+/obj/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
 	name = ".38 Hot Shot bullet"
 	damage = 20
 	ricochets_max = 0
 
-/obj/item/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.adjust_fire_stacks(6)
 		M.IgniteMob()
 
-/obj/item/projectile/bullet/c38/iceblox //see /obj/item/projectile/temp for the original code
+/obj/projectile/bullet/c38/iceblox //see /obj/projectile/temp for the original code
 	name = ".38 Iceblox bullet"
 	damage = 20
 	var/temperature = 100
 	ricochets_max = 0
 
-/obj/item/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/M = target
 		M.adjust_bodytemperature(((100-blocked)/100)*(temperature - M.bodytemperature))
 
-/obj/item/projectile/bullet/c38/mime
+/obj/projectile/bullet/c38/mime
 	name = "invisible .38 bullet"
 	icon_state = null
 	damage = 0
 	nodamage = TRUE
 	martial_arts_no_deflect = TRUE
 
-/obj/item/projectile/bullet/c38/mime/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/c38/mime/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/mob/living/carbon/human/M = target
 		if(M.job == JOB_NAME_MIME)
@@ -106,24 +106,24 @@
 		else
 			to_chat(M, "<span class='userdanger'>You get shot with the finger gun!</span>")
 
-/obj/item/projectile/bullet/c38/mime_lethal
+/obj/projectile/bullet/c38/mime_lethal
 	name = "invisible .38 bullet"
 	icon_state = null
 	damage = 20
 
-/obj/item/projectile/bullet/c38/mime_lethal/on_hit(atom/target, blocked)
+/obj/projectile/bullet/c38/mime_lethal/on_hit(atom/target, blocked)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.silent = max(M.silent, 10)
 // .357 (Syndie Revolver)
 
-/obj/item/projectile/bullet/a357
+/obj/projectile/bullet/a357
 	name = ".357 bullet"
 	damage = 60
 
 // admin only really, for ocelot memes
-/obj/item/projectile/bullet/a357/match
+/obj/projectile/bullet/a357/match
 	name = ".357 match bullet"
 	ricochets_max = 5
 	ricochet_chance = 140

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -1,16 +1,16 @@
 // 5.56mm (M-90gl Carbine)
 
-/obj/item/projectile/bullet/a556
+/obj/projectile/bullet/a556
 	name = "5.56mm bullet"
 	damage = 35
 
 // 7.62 (Nagant Rifle)
 
-/obj/item/projectile/bullet/a762
+/obj/projectile/bullet/a762
 	name = "7.62 bullet"
 	damage = 60
 
-/obj/item/projectile/bullet/a762_enchanted
+/obj/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62 bullet"
 	damage = 20
 	stamina = 80

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,22 +1,22 @@
-/obj/item/projectile/bullet/shotgun_slug
+/obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 60
 	armour_penetration = -20
 
-/obj/item/projectile/bullet/shotgun_beanbag
+/obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 5
 	stamina = 55
 
-/obj/item/projectile/bullet/incendiary/shotgun
+/obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
 	damage = 20
 
-/obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
+/obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
 	damage = 5
 
-/obj/item/projectile/bullet/shotgun_stunslug
+/obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
 	damage = 5
 	paralyze = 100
@@ -26,7 +26,7 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 
-/obj/item/projectile/bullet/shotgun_meteorslug
+/obj/projectile/bullet/shotgun_meteorslug
 	name = "meteorslug"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
@@ -34,50 +34,50 @@
 	paralyze = 20
 	hitsound = 'sound/effects/meteorimpact.ogg'
 
-/obj/item/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(ismovable(target))
 		var/atom/movable/M = target
 		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 		M.safe_throw_at(throw_target, 3, 2)
 
-/obj/item/projectile/bullet/shotgun_meteorslug/Initialize(mapload)
+/obj/projectile/bullet/shotgun_meteorslug/Initialize(mapload)
 	. = ..()
 	SpinAnimation()
 
-/obj/item/projectile/bullet/shotgun_frag12
+/obj/projectile/bullet/shotgun_frag12
 	name ="frag12 slug"
 	damage = 25
 	paralyze = 10
 
-/obj/item/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 1)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/pellet
+/obj/projectile/bullet/pellet
 	var/tile_dropoff = 0.75
 	var/tile_dropoff_s = 0.5
 	ricochets_max = 1
 	ricochet_chance = 50
 	ricochet_decay_chance = 0.9
 
-/obj/item/projectile/bullet/pellet/shotgun_buckshot
+/obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
 	damage = 9
 	tile_dropoff = 0.5
 
-/obj/item/projectile/bullet/pellet/shotgun_rubbershot
+/obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
 	stamina = 9
 
-/obj/item/projectile/bullet/pellet/shotgun_incapacitate
+/obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
 	damage = 1
 	stamina = 5
 
-/obj/item/projectile/bullet/pellet/Range()
+/obj/projectile/bullet/pellet/Range()
 	..()
 	if(damage > 0)
 		damage -= tile_dropoff
@@ -86,32 +86,32 @@
 	if(damage < 0 && stamina < 0)
 		qdel(src)
 
-/obj/item/projectile/bullet/pellet/shotgun_improvised
+/obj/projectile/bullet/pellet/shotgun_improvised
 	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.
 	damage = 6
 
-/obj/item/projectile/bullet/pellet/shotgun_improvised/Initialize(mapload)
+/obj/projectile/bullet/pellet/shotgun_improvised/Initialize(mapload)
 	. = ..()
 	range = rand(1, 8)
 
-/obj/item/projectile/bullet/pellet/shotgun_improvised/on_range()
+/obj/projectile/bullet/pellet/shotgun_improvised/on_range()
 	do_sparks(1, TRUE, src)
 	..()
 
 // Mech Scattershot
 
-/obj/item/projectile/bullet/scattershot
+/obj/projectile/bullet/scattershot
 	damage = 18
 
 //Breaching Ammo
 
-/obj/item/projectile/bullet/shotgun_breaching
+/obj/projectile/bullet/shotgun_breaching
 	name = "12g breaching round"
 	desc = "A breaching round designed to destroy airlocks and windows with only a few shots, but is ineffective against other targets."
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	damage = 10 //does shit damage to everything except doors and windows
 
-/obj/item/projectile/bullet/shotgun_breaching/on_hit(atom/target)
+/obj/projectile/bullet/shotgun_breaching/on_hit(atom/target)
 	if(istype(target, /obj/structure/window) || istype(target, /obj/structure/grille) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
 		damage = 500 //one shot to break a window or grille, or 3 shots to breach an airlock door
 	..()

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -1,27 +1,27 @@
 // .45 (M1911 & C20r)
 
-/obj/item/projectile/bullet/c45
+/obj/projectile/bullet/c45
 	name = ".45 bullet"
 	damage = 30
 
 // 4.6x30mm (Autorifles)
 
-/obj/item/projectile/bullet/c46x30mm
+/obj/projectile/bullet/c46x30mm
 	name = "4.6x30mm bullet"
 	damage = 20
 
-/obj/item/projectile/bullet/c46x30mm_ap
+/obj/projectile/bullet/c46x30mm_ap
 	name = "4.6x30mm armor-piercing bullet"
 	damage = 15
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/incendiary/c46x30mm
+/obj/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
 	damage = 10
 	fire_stacks = 1
 
 //Slightly worse disabler, but fully automatic
-/obj/item/projectile/bullet/c46x30mm_rubber
+/obj/projectile/bullet/c46x30mm_rubber
 	name = "4.6x30mm rubber bullet"
 	damage_type = STAMINA
 	armor_flag = STAMINA

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -1,6 +1,6 @@
 // .50 (Sniper)
 
-/obj/item/projectile/bullet/p50
+/obj/projectile/bullet/p50
 	name =".50 bullet"
 	speed = 0.2
 	damage = 70
@@ -11,13 +11,13 @@
 	projectile_piercing = PASSMOB | PASSMACHINE | PASSTRANSPARENT | PASSGRILLE | PASSDOORS | PASSFLAPS | PASSSTRUCTURE
 	var/breakthings = TRUE
 
-/obj/item/projectile/bullet/p50/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/p50/on_hit(atom/target, blocked = 0)
 	if(isobj(target) && (blocked != 100) && breakthings)
 		var/obj/O = target
 		O.take_damage(80, BRUTE, BULLET, FALSE)
 	return ..()
 
-/obj/item/projectile/bullet/p50/penetrator
+/obj/projectile/bullet/p50/penetrator
 	name =".50 penetrator bullet"
 	icon_state = "gauss"
 	damage = 60
@@ -28,13 +28,13 @@
 	paralyze = 0
 	breakthings = FALSE
 
-/obj/item/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety
+/obj/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety
 	icon_state = "gaussstrong"
 	damage = 25
 	speed = 0.3
 	range = 16
 
-/obj/item/projectile/bullet/p50/utility
+/obj/projectile/bullet/p50/utility
 	armour_penetration = 0
 	damage = 20
 	dismemberment = 0
@@ -43,42 +43,42 @@
 	// Cannot pass through things like normal rounds
 	projectile_piercing = NONE
 
-/obj/item/projectile/bullet/p50/utility/soporific
+/obj/projectile/bullet/p50/utility/soporific
 	name =".50 soporific bullet"
 
-/obj/item/projectile/bullet/p50/utility/soporific/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/p50/utility/soporific/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && isliving(target))
 		var/mob/living/L = target
 		L.Sleeping(400)
 	return ..()
 
-/obj/item/projectile/bullet/p50/utility/emp
+/obj/projectile/bullet/p50/utility/emp
 	name = ".50 emp bullet"
 
-/obj/item/projectile/bullet/p50/utility/emp/on_hit(atom/target, blocked)
+/obj/projectile/bullet/p50/utility/emp/on_hit(atom/target, blocked)
 	empulse(target, 3, 4)
 	return ..()
 
-/obj/item/projectile/bullet/p50/utility/explosive
+/obj/projectile/bullet/p50/utility/explosive
 	name = ".50 explosive bullet"
 
-/obj/item/projectile/bullet/p50/utility/explosive/on_hit(atom/target, blocked)
+/obj/projectile/bullet/p50/utility/explosive/on_hit(atom/target, blocked)
 	if (ismob(target))
 		explosion(target, 0, 1, 3)
 	else
 		explosion(target, 1, 1, 3)
 	return ..()
 
-/obj/item/projectile/bullet/p50/utility/inferno
+/obj/projectile/bullet/p50/utility/inferno
 	name = ".50 inferno bullet"
 
-/obj/item/projectile/bullet/p50/utility/inferno/on_hit(atom/target, blocked)
+/obj/projectile/bullet/p50/utility/inferno/on_hit(atom/target, blocked)
 	explosion(target, 0, 0, 0, flame_range = 5)
 	return ..()
 
-/obj/item/projectile/bullet/p50/utility/antimatter
+/obj/projectile/bullet/p50/utility/antimatter
 	name = ".50 antimatter-tipped bullet"
 
-/obj/item/projectile/bullet/p50/utility/antimatter/on_hit(atom/target, blocked)
+/obj/projectile/bullet/p50/utility/antimatter/on_hit(atom/target, blocked)
 	explosion(target, 5, 8, 8)
 	return ..()

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -1,6 +1,6 @@
 // Honker
 
-/obj/item/projectile/bullet/honker
+/obj/projectile/bullet/honker
 	name = "banana"
 	damage = 0
 	paralyze = 60
@@ -12,16 +12,16 @@
 	icon_state = "banana"
 	range = 200
 
-/obj/item/projectile/bullet/honker/Initialize(mapload)
+/obj/projectile/bullet/honker/Initialize(mapload)
 	. = ..()
 	SpinAnimation()
 
 // Mime
 
-/obj/item/projectile/bullet/mime
+/obj/projectile/bullet/mime
 	damage = 20
 
-/obj/item/projectile/bullet/mime/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/mime/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target

--- a/code/modules/projectiles/projectile/energy/_energy.dm
+++ b/code/modules/projectiles/projectile/energy/_energy.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy
+/obj/projectile/energy
 	name = "energy"
 	icon_state = "spark"
 	damage = 0

--- a/code/modules/projectiles/projectile/energy/accelerator_particle.dm
+++ b/code/modules/projectiles/projectile/energy/accelerator_particle.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/accelerated_particle
+/obj/projectile/energy/accelerated_particle
 	name = "Accelerated Particles"
 	icon = 'icons/obj/machines/particle_accelerator.dmi'
 	icon_state = "particle"
@@ -12,20 +12,20 @@
 	var/energy = 10
 	var/stop_dissipate = FALSE
 
-/obj/item/projectile/energy/accelerated_particle/singularity_pull()
+/obj/projectile/energy/accelerated_particle/singularity_pull()
 	return
 
-/obj/item/projectile/energy/accelerated_particle/weak
+/obj/projectile/energy/accelerated_particle/weak
 	range = 8
 	energy = 5
 	irradiate = 30
 	stop_dissipate = TRUE //because its supposed to keep the singu/tesla stable at the same size
 
-/obj/item/projectile/energy/accelerated_particle/strong
+/obj/projectile/energy/accelerated_particle/strong
 	range = 15
 	energy = 15
 	irradiate = 90
-/obj/item/projectile/energy/accelerated_particle/powerful
+/obj/projectile/energy/accelerated_particle/powerful
 	range = 20
 	energy = 50
 	irradiate = 300

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,5 +1,5 @@
 
-/obj/item/projectile/energy/bolt //ebow bolts
+/obj/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
 	damage = 15
@@ -10,7 +10,7 @@
 	knockdown = 10
 	slur = 5
 
-/obj/item/projectile/energy/bolt/radbolt
+/obj/projectile/energy/bolt/radbolt
 	name = "bolt"
 	icon_state = "cbbolt"
 	damage = 15
@@ -22,7 +22,7 @@
 	knockdown = 0
 	irradiate = 400
 
-/obj/item/projectile/energy/bolt/radbolt/Initialize(mapload)
+/obj/projectile/energy/bolt/radbolt/Initialize(mapload)
 	. = ..()
 	create_reagents(30, NO_REACT)
 	reagents.add_reagent(/datum/reagent/toxin/polonium, 10)
@@ -30,7 +30,7 @@
 	reagents.add_reagent(/datum/reagent/toxin, 5)
 	reagents.add_reagent(/datum/reagent/uranium/radium, 10)
 
-/obj/item/projectile/energy/bolt/radbolt/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/bolt/radbolt/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
@@ -51,9 +51,9 @@
 	reagents.handle_reactions()
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/energy/bolt/halloween
+/obj/projectile/energy/bolt/halloween
 	name = "candy corn"
 	icon_state = "candy_corn"
 
-/obj/item/projectile/energy/bolt/large
+/obj/projectile/energy/bolt/large
 	damage = 20

--- a/code/modules/projectiles/projectile/energy/misc.dm
+++ b/code/modules/projectiles/projectile/energy/misc.dm
@@ -1,16 +1,16 @@
-/obj/item/projectile/energy/declone
+/obj/projectile/energy/declone
 	name = "radiation beam"
 	icon_state = "declone"
 	damage = 20
 	damage_type = CLONE
 	irradiate = 100
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
-	
-/obj/item/projectile/energy/declone/weak
+
+/obj/projectile/energy/declone/weak
 	damage = 9
 	irradiate = 30
-	
-/obj/item/projectile/energy/dart //ninja throwing dart
+
+/obj/projectile/energy/dart //ninja throwing dart
 	name = "dart"
 	icon_state = "toxin"
 	damage = 5

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/net
+/obj/projectile/energy/net
 	name = "energy netting"
 	icon_state = "e_netting"
 	damage = 10
@@ -7,18 +7,18 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
 
-/obj/item/projectile/energy/net/Initialize(mapload)
+/obj/projectile/energy/net/Initialize(mapload)
 	. = ..()
 	SpinAnimation()
 
-/obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			new /obj/effect/nettingportal(Tloc)
 	..()
 
-/obj/item/projectile/energy/net/on_range()
+/obj/projectile/energy/net/on_range()
 	do_sparks(1, TRUE, src)
 	..()
 
@@ -71,14 +71,14 @@
 /obj/effect/nettingportal/singularity_pull()
 	return
 
-/obj/item/projectile/energy/trap
+/obj/projectile/energy/trap
 	name = "energy snare"
 	icon_state = "e_snare"
 	nodamage = TRUE
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 4
 
-/obj/item/projectile/energy/trap/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/trap/on_hit(atom/target, blocked = FALSE)
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - drop a trap
 		new/obj/item/restraints/legcuffs/beartrap/energy(get_turf(loc))
 	else if(iscarbon(target))
@@ -86,11 +86,11 @@
 		B.spring_trap(null, target)
 	. = ..()
 
-/obj/item/projectile/energy/trap/on_range()
+/obj/projectile/energy/trap/on_range()
 	new /obj/item/restraints/legcuffs/beartrap/energy(loc)
 	..()
 
-/obj/item/projectile/energy/trap/cyborg
+/obj/projectile/energy/trap/cyborg
 	name = "Energy Bola"
 	icon_state = "e_snare"
 	nodamage = TRUE
@@ -98,7 +98,7 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
 
-/obj/item/projectile/energy/trap/cyborg/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/trap/cyborg/on_hit(atom/target, blocked = FALSE)
 	if(!ismob(target) || blocked >= 100)
 		do_sparks(1, TRUE, src)
 		qdel(src)
@@ -108,10 +108,10 @@
 	QDEL_IN(src, 10)
 	. = ..()
 
-/obj/item/projectile/energy/trap/cyborg/on_range()
+/obj/projectile/energy/trap/cyborg/on_range()
 	do_sparks(1, TRUE, src)
 	qdel(src)
 
-/obj/item/projectile/energy/trap/cyborg/emp_act(severity)
+/obj/projectile/energy/trap/cyborg/emp_act(severity)
 	do_sparks(1, TRUE, src)
 	qdel(src)

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -1,5 +1,5 @@
 //Nuclear particle projectile - a deadly side effect of fusion
-/obj/item/projectile/energy/nuclear_particle
+/obj/projectile/energy/nuclear_particle
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSTRANSPARENT | PASSGRILLE
@@ -18,13 +18,13 @@
 		"purple" = "#FF00FF"
 	)
 
-/obj/item/projectile/energy/nuclear_particle/proc/random_color_time()
+/obj/projectile/energy/nuclear_particle/proc/random_color_time()
 	//Random color time!
 	var/our_color = pick(particle_colors)
 	add_atom_colour(particle_colors[our_color], FIXED_COLOUR_PRIORITY)
 	set_light(4, 3, particle_colors[our_color]) //Range of 4, brightness of 3 - Same range as a flashlight
 
-/obj/item/projectile/energy/nuclear_particle/proc/customize(custompower)
+/obj/projectile/energy/nuclear_particle/proc/customize(custompower)
 	irradiate = max(3000 * 3 ** (log(10,custompower)-FUSION_RAD_MIDPOINT),10)
 	var/custom_color = HSVtoRGB(hsv(clamp(log(10,custompower)-12,0,5)*256,rand(191,255),rand(191,255),255))
 	add_atom_colour(custom_color, FIXED_COLOUR_PRIORITY)
@@ -53,7 +53,7 @@
 			damage = 30
 
 /atom/proc/fire_nuclear_particle(angle = rand(0,360), customize = FALSE, custompower = 1e12) //used by fusion to fire random nuclear particles. Fires one particle in a random direction.
-	var/obj/item/projectile/energy/nuclear_particle/P = new /obj/item/projectile/energy/nuclear_particle(src)
+	var/obj/projectile/energy/nuclear_particle/P = new /obj/projectile/energy/nuclear_particle(src)
 	if(customize)
 		P.customize(custompower)
 	else

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/electrode
+/obj/projectile/energy/electrode
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
@@ -15,7 +15,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun
 
-/obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, TRUE, src)
@@ -30,6 +30,6 @@
 		else if((C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE))
 			addtimer(CALLBACK(C, TYPE_PROC_REF(/mob/living/carbon, do_jitter_animation), jitter), 5)
 
-/obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
+/obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, TRUE, src)
 	..()

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/tesla
+/obj/projectile/energy/tesla
 	name = "tesla bolt"
 	icon_state = "tesla_projectile"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -7,23 +7,23 @@
 	var/zap_range = 3
 	var/power = 10000
 
-/obj/item/projectile/energy/tesla/fire(setAngle)
+/obj/projectile/energy/tesla/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
 	..()
 
-/obj/item/projectile/energy/tesla/on_hit(atom/target)
+/obj/projectile/energy/tesla/on_hit(atom/target)
 	. = ..()
 	tesla_zap(target, zap_range, power, tesla_flags)
 	qdel(src)
 
-/obj/item/projectile/energy/tesla/Destroy()
+/obj/projectile/energy/tesla/Destroy()
 	qdel(chain)
 	return ..()
 
-/obj/item/projectile/energy/tesla/revolver
+/obj/projectile/energy/tesla/revolver
 	name = "energy orb"
 
-/obj/item/projectile/energy/tesla/cannon
+/obj/projectile/energy/tesla/cannon
 	name = "tesla orb"
 	power = 20000

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/magic
+/obj/projectile/magic
 	name = "bolt of nothing"
 	icon_state = "energy"
 	damage = 0
@@ -8,12 +8,12 @@
 	armor_flag = MAGIC
 	martial_arts_no_deflect = TRUE
 
-/obj/item/projectile/magic/death
+/obj/projectile/magic/death
 	name = "bolt of death"
 	icon_state = "pulse1_bl"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/death/on_hit(target)
+/obj/projectile/magic/death/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
@@ -22,7 +22,7 @@
 			return BULLET_ACT_BLOCK
 		M.death(0)
 
-/obj/item/projectile/magic/resurrection
+/obj/projectile/magic/resurrection
 	name = "bolt of resurrection"
 	icon_state = "ion"
 	damage = 0
@@ -30,7 +30,7 @@
 	nodamage = TRUE
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/resurrection/on_hit(mob/living/carbon/target)
+/obj/projectile/magic/resurrection/on_hit(mob/living/carbon/target)
 	. = ..()
 	if(isliving(target))
 		if(target.ishellbound())
@@ -48,7 +48,7 @@
 		else if(target.stat != DEAD)
 			to_chat(target, "<span class='notice'>You feel great!</span>")
 
-/obj/item/projectile/magic/teleport
+/obj/projectile/magic/teleport
 	name = "bolt of teleportation"
 	icon_state = "bluespace"
 	damage = 0
@@ -58,7 +58,7 @@
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
-/obj/item/projectile/magic/teleport/on_hit(mob/target)
+/obj/projectile/magic/teleport/on_hit(mob/target)
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
@@ -77,7 +77,7 @@
 				smoke.set_up(max(round(4 - teleammount),0), stuff.loc) //Smoke drops off if a lot of stuff is moved for the sake of sanity
 				smoke.start()
 
-/obj/item/projectile/magic/safety
+/obj/projectile/magic/safety
 	name = "bolt of safety"
 	icon_state = "bluespace"
 	damage = 0
@@ -85,7 +85,7 @@
 	nodamage = TRUE
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/safety/on_hit(atom/target)
+/obj/projectile/magic/safety/on_hit(atom/target)
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
@@ -104,7 +104,7 @@
 			smoke.set_up(0, t)
 			smoke.start()
 
-/obj/item/projectile/magic/door
+/obj/projectile/magic/door
 	name = "bolt of door creation"
 	icon_state = "energy"
 	damage = 0
@@ -112,7 +112,7 @@
 	nodamage = TRUE
 	var/list/door_types = list(/obj/structure/mineral_door/wood, /obj/structure/mineral_door/iron, /obj/structure/mineral_door/copper, /obj/structure/mineral_door/silver, /obj/structure/mineral_door/gold, /obj/structure/mineral_door/uranium, /obj/structure/mineral_door/sandstone, /obj/structure/mineral_door/transparent/plasma, /obj/structure/mineral_door/transparent/diamond)
 
-/obj/item/projectile/magic/door/on_hit(atom/target)
+/obj/projectile/magic/door/on_hit(atom/target)
 	. = ..()
 	if(istype(target, /obj/machinery/door))
 		OpenDoor(target)
@@ -121,19 +121,19 @@
 		if(isclosedturf(T) && !isindestructiblewall(T))
 			CreateDoor(T)
 
-/obj/item/projectile/magic/door/proc/CreateDoor(turf/T)
+/obj/projectile/magic/door/proc/CreateDoor(turf/T)
 	var/door_type = pick(door_types)
 	var/obj/structure/mineral_door/D = new door_type(T)
 	T.ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 	D.Open()
 
-/obj/item/projectile/magic/door/proc/OpenDoor(var/obj/machinery/door/D)
+/obj/projectile/magic/door/proc/OpenDoor(var/obj/machinery/door/D)
 	if(istype(D, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/A = D
 		A.locked = FALSE
 	D.open()
 
-/obj/item/projectile/magic/change
+/obj/projectile/magic/change
 	name = "bolt of change"
 	icon_state = "ice_1"
 	damage = 0
@@ -141,7 +141,7 @@
 	nodamage = TRUE
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/change/on_hit(atom/change)
+/obj/projectile/magic/change/on_hit(atom/change)
 	. = ..()
 	if(ismob(change))
 		var/mob/M = change
@@ -296,14 +296,14 @@
 	qdel(M)
 	return new_mob
 
-/obj/item/projectile/magic/animate
+/obj/projectile/magic/animate
 	name = "bolt of animation"
 	icon_state = "red_1"
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
 
-/obj/item/projectile/magic/animate/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/magic/animate/on_hit(atom/target, blocked = FALSE)
 	target.animate_atom_living(firer)
 	..()
 
@@ -341,7 +341,7 @@
 		if(owner)
 			C.ChangeOwner(owner)
 
-/obj/item/projectile/magic/spellblade
+/obj/projectile/magic/spellblade
 	name = "blade energy"
 	icon_state = "lavastaff"
 	damage = 15
@@ -351,7 +351,7 @@
 	nodamage = FALSE
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/spellblade/on_hit(target)
+/obj/projectile/magic/spellblade/on_hit(target)
 	if(ismob(target))
 		var/mob/M = target
 		if(M.anti_magic_check())
@@ -360,7 +360,7 @@
 			return BULLET_ACT_BLOCK
 	. = ..()
 
-/obj/item/projectile/magic/arcane_barrage
+/obj/projectile/magic/arcane_barrage
 	name = "arcane bolt"
 	icon_state = "arcane_barrage"
 	damage = 20
@@ -371,7 +371,7 @@
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/arcane_barrage/on_hit(target)
+/obj/projectile/magic/arcane_barrage/on_hit(target)
 	if(ismob(target))
 		var/mob/M = target
 		if(M.anti_magic_check())
@@ -381,7 +381,7 @@
 	. = ..()
 
 
-/obj/item/projectile/magic/locker
+/obj/projectile/magic/locker
 	name = "locker bolt"
 	icon_state = "locker"
 	nodamage = TRUE
@@ -392,7 +392,7 @@
 	var/locker_suck = TRUE
 
 
-/obj/item/projectile/magic/locker/prehit_pierce(atom/A)
+/obj/projectile/magic/locker/prehit_pierce(atom/A)
 	. = ..()
 	if(isliving(A) && locker_suck)
 		var/mob/living/M = A
@@ -404,7 +404,7 @@
 		M.forceMove(src)
 		return PROJECTILE_PIERCE_PHASE
 
-/obj/item/projectile/magic/locker/on_hit(target)
+/obj/projectile/magic/locker/on_hit(target)
 	if(created)
 		return ..()
 	var/obj/structure/closet/decay/C = new(get_turf(src))
@@ -416,7 +416,7 @@
 	created = TRUE
 	return ..()
 
-/obj/item/projectile/magic/locker/Destroy()
+/obj/projectile/magic/locker/Destroy()
 	locker_suck = FALSE
 	for(var/atom/movable/AM in contents)
 		AM.forceMove(get_turf(src))
@@ -462,12 +462,12 @@
 	update_icon()
 	addtimer(CALLBACK(src, PROC_REF(decay)), 15 SECONDS)
 
-/obj/item/projectile/magic/flying
+/obj/projectile/magic/flying
 	name = "bolt of flying"
 	icon_state = "flight"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/flying/on_hit(target)
+/obj/projectile/magic/flying/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -477,12 +477,12 @@
 		var/atom/throw_target = get_edge_target_turf(L, angle2dir(Angle))
 		L.throw_at(throw_target, 200, 4)
 
-/obj/item/projectile/magic/bounty
+/obj/projectile/magic/bounty
 	name = "bolt of bounty"
 	icon_state = "bounty"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/bounty/on_hit(target)
+/obj/projectile/magic/bounty/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -491,12 +491,12 @@
 			return BULLET_ACT_BLOCK
 		L.apply_status_effect(STATUS_EFFECT_BOUNTY, firer)
 
-/obj/item/projectile/magic/antimagic
+/obj/projectile/magic/antimagic
 	name = "bolt of antimagic"
 	icon_state = "antimagic"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/antimagic/on_hit(target)
+/obj/projectile/magic/antimagic/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -505,12 +505,12 @@
 			return BULLET_ACT_BLOCK
 		L.apply_status_effect(STATUS_EFFECT_ANTIMAGIC)
 
-/obj/item/projectile/magic/fetch
+/obj/projectile/magic/fetch
 	name = "bolt of fetching"
 	icon_state = "fetch"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/fetch/on_hit(target)
+/obj/projectile/magic/fetch/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -520,12 +520,12 @@
 		var/atom/throw_target = get_edge_target_turf(L, get_dir(L, firer))
 		L.throw_at(throw_target, 200, 4)
 
-/obj/item/projectile/magic/sapping
+/obj/projectile/magic/sapping
 	name = "bolt of sapping"
 	icon_state = "sapping"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/sapping/on_hit(target)
+/obj/projectile/magic/sapping/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
@@ -534,12 +534,12 @@
 			return BULLET_ACT_BLOCK
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, src, /datum/mood_event/sapped)
 
-/obj/item/projectile/magic/necropotence
+/obj/projectile/magic/necropotence
 	name = "bolt of necropotence"
 	icon_state = "necropotence"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/necropotence/on_hit(target)
+/obj/projectile/magic/necropotence/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -557,12 +557,12 @@
 			spell.recharging = FALSE
 			spell.update_icon()
 
-/obj/item/projectile/magic/wipe
+/obj/projectile/magic/wipe
 	name = "bolt of possession"
 	icon_state = "wipe"
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/wipe/on_hit(target)
+/obj/projectile/magic/wipe/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
@@ -577,7 +577,7 @@
 		possession_test(M)
 		return BULLET_ACT_HIT
 
-/obj/item/projectile/magic/wipe/proc/possession_test(var/mob/living/carbon/M)
+/obj/projectile/magic/wipe/proc/possession_test(var/mob/living/carbon/M)
 	var/datum/brain_trauma/special/imaginary_friend/trapped_owner/trauma = M.gain_trauma(/datum/brain_trauma/special/imaginary_friend/trapped_owner)
 	var/poll_message = "Do you want to play as [M.real_name]?"
 	if(M.mind?.assigned_role)
@@ -605,14 +605,14 @@
 		to_chat(M, "<span class='notice'>Your mind has managed to go unnoticed in the spirit world.</span>")
 		qdel(trauma)
 
-/obj/item/projectile/magic/aoe
+/obj/projectile/magic/aoe
 	name = "Area Bolt"
 	desc = "What the fuck does this do?!"
 	damage = 0
 	var/proxdet = TRUE
 	martial_arts_no_deflect = FALSE
 
-/obj/item/projectile/magic/aoe/Range()
+/obj/projectile/magic/aoe/Range()
 	if(proxdet)
 		for(var/mob/living/L in range(1, get_turf(src)))
 			if(L.stat != DEAD && L != firer && !L.anti_magic_check())
@@ -620,7 +620,7 @@
 	..()
 
 
-/obj/item/projectile/magic/aoe/lightning
+/obj/projectile/magic/aoe/lightning
 	name = "lightning bolt"
 	icon_state = "tesla_projectile"	//Better sprites are REALLY needed and appreciated!~
 	damage = 15
@@ -635,17 +635,17 @@
 	var/chain
 	var/mob/living/caster
 
-/obj/item/projectile/magic/aoe/lightning/New(loc, spell_level)
+/obj/projectile/magic/aoe/lightning/New(loc, spell_level)
 	. = ..()
 	tesla_power += 5000 * spell_level
 	tesla_range += 2 * spell_level
 
-/obj/item/projectile/magic/aoe/lightning/fire(setAngle)
+/obj/projectile/magic/aoe/lightning/fire(setAngle)
 	if(caster)
 		chain = caster.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
 	..()
 
-/obj/item/projectile/magic/aoe/lightning/on_hit(target)
+/obj/projectile/magic/aoe/lightning/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
@@ -656,11 +656,11 @@
 	tesla_zap(src, tesla_range, tesla_power, tesla_flags)
 	qdel(src)
 
-/obj/item/projectile/magic/aoe/lightning/Destroy()
+/obj/projectile/magic/aoe/lightning/Destroy()
 	qdel(chain)
 	. = ..()
 
-/obj/item/projectile/magic/fireball
+/obj/projectile/magic/fireball
 	name = "bolt of fireball"
 	icon_state = "fireball"
 	damage = 10
@@ -675,14 +675,14 @@
 	var/magic = TRUE
 	var/holy = FALSE
 
-/obj/item/projectile/magic/fireball/New(loc, spell_level)
+/obj/projectile/magic/fireball/New(loc, spell_level)
 	. = ..()
 	exp_fire += spell_level
 	exp_flash += spell_level
 	exp_light += spell_level
 	exp_heavy = max(spell_level - 2, 0)
 
-/obj/item/projectile/magic/fireball/on_hit(target)
+/obj/projectile/magic/fireball/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
@@ -693,7 +693,7 @@
 	var/turf/T = get_turf(target)
 	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, magic = magic, holy = holy)
 
-/obj/item/projectile/magic/fireball/infernal
+/obj/projectile/magic/fireball/infernal
 	name = "infernal fireball"
 	exp_heavy = -1
 	exp_light = -1
@@ -702,7 +702,7 @@
 	magic = FALSE
 	holy = TRUE
 
-/obj/item/projectile/magic/fireball/infernal/on_hit(target)
+/obj/projectile/magic/fireball/infernal/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
@@ -714,7 +714,7 @@
 
 //still magic related, but a different path
 
-/obj/item/projectile/temp/chill
+/obj/projectile/temp/chill
 	name = "bolt of chills"
 	icon_state = "ice_2"
 	damage = 0

--- a/code/modules/projectiles/projectile/magic/spellcard.dm
+++ b/code/modules/projectiles/projectile/magic/spellcard.dm
@@ -1,10 +1,10 @@
-/obj/item/projectile/spellcard
+/obj/projectile/spellcard
 	name = "enchanted card"
 	desc = "A piece of paper enchanted to give it extreme durability and stiffness, along with edges sharp enough to slice anyone unfortunate enough to get hit by a charged one."
 	icon_state = "spellcard"
 	damage_type = BRUTE
 	damage = 2
 
-/obj/item/projectile/spellcard/New(loc, spell_level)
+/obj/projectile/spellcard/New(loc, spell_level)
 	. = ..()
 	damage += spell_level

--- a/code/modules/projectiles/projectile/reusable/_reusable.dm
+++ b/code/modules/projectiles/projectile/reusable/_reusable.dm
@@ -1,19 +1,19 @@
-/obj/item/projectile/bullet/reusable
+/obj/projectile/bullet/reusable
 	name = "reusable bullet"
 	desc = "How do you even reuse a bullet?"
 	var/ammo_type = /obj/item/ammo_casing/caseless
 	var/dropped = FALSE
 	impact_effect_type = null
 
-/obj/item/projectile/bullet/reusable/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	handle_drop()
 
-/obj/item/projectile/bullet/reusable/on_range()
+/obj/projectile/bullet/reusable/on_range()
 	handle_drop()
 	..()
 
-/obj/item/projectile/bullet/reusable/proc/handle_drop()
+/obj/projectile/bullet/reusable/proc/handle_drop()
 	if(!dropped)
 		var/turf/T = get_turf(src)
 		new ammo_type(T)

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -1,24 +1,24 @@
-/obj/item/projectile/bullet/reusable/arrow
+/obj/projectile/bullet/reusable/arrow
 	name = "Wooden arrow"
 	desc = "Woosh!"
 	damage = 15
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood
 
-/obj/item/projectile/bullet/reusable/arrow/ash
+/obj/projectile/bullet/reusable/arrow/ash
 	name = "Ashen arrow"
 	desc = "Fire Hardened arrow."
 	damage = 25
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/ash
 
-/obj/item/projectile/bullet/reusable/arrow/bone //AP for ashwalkers
+/obj/projectile/bullet/reusable/arrow/bone //AP for ashwalkers
 	name = "Bone arrow"
 	desc = "An arrow made from bone and sinew."
 	damage = 25
 	armour_penetration = 40
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
 
-/obj/item/projectile/bullet/reusable/arrow/bronze
+/obj/projectile/bullet/reusable/arrow/bronze
 	name = "Bronze arrow"
 	desc = "Bronze tipped arrow"
 	damage = 20

--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet/reusable/foam_dart
+/obj/projectile/bullet/reusable/foam_dart
 	name = "foam dart"
 	desc = "I hope you're wearing eye protection."
 	damage = 0 // It's a damn toy.
@@ -12,14 +12,14 @@
 	var/modified = FALSE
 	var/obj/item/pen/pen = null
 
-/obj/item/projectile/bullet/reusable/foam_dart/handle_drop()
+/obj/projectile/bullet/reusable/foam_dart/handle_drop()
 	if(dropped)
 		return
 	var/turf/T = get_turf(src)
 	dropped = 1
 	var/obj/item/ammo_casing/caseless/foam_dart/newcasing = new ammo_type(T)
 	newcasing.modified = modified
-	var/obj/item/projectile/bullet/reusable/foam_dart/newdart = newcasing.BB
+	var/obj/projectile/bullet/reusable/foam_dart/newdart = newcasing.BB
 	newdart.modified = modified
 	if(modified)
 		newdart.damage = 5
@@ -32,11 +32,11 @@
 	newdart.update_icon()
 
 
-/obj/item/projectile/bullet/reusable/foam_dart/Destroy()
+/obj/projectile/bullet/reusable/foam_dart/Destroy()
 	pen = null
 	return ..()
 
-/obj/item/projectile/bullet/reusable/foam_dart/riot
+/obj/projectile/bullet/reusable/foam_dart/riot
 	name = "riot foam dart"
 	icon_state = "foamdart_riot_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -5,7 +5,7 @@
 /obj/projectile/curse_hand
 	name = "curse hand"
 	icon_state = "cursehand0"
-	item_state = "cursehand"
+	base_icon_state = "cursehand"
 	hitsound = 'sound/effects/curse4.ogg'
 	layer = LARGE_MOB_LAYER
 	damage_type = BURN
@@ -19,14 +19,14 @@
 /obj/projectile/curse_hand/Initialize(mapload)
 	. = ..()
 	handedness = prob(50)
-	icon_state = "[item_state][handedness]"
+	icon_state = "[base_icon_state][handedness]"
 
 /obj/projectile/curse_hand/Destroy()
 	QDEL_NULL(arm)
 	return ..()
 
 /obj/projectile/curse_hand/update_icon_state()
-	icon_state = "[item_state]0[handedness]"
+	icon_state = "[base_icon_state]0[handedness]"
 	return ..()
 
 /obj/projectile/curse_hand/fire(setAngle)

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -2,7 +2,7 @@
 	name = "curse arm"
 	layer = LARGE_MOB_LAYER
 
-/obj/item/projectile/curse_hand
+/obj/projectile/curse_hand
 	name = "curse hand"
 	icon_state = "cursehand0"
 	item_state = "cursehand"
@@ -16,31 +16,31 @@
 	var/datum/beam/arm
 	var/handedness = 0
 
-/obj/item/projectile/curse_hand/Initialize(mapload)
+/obj/projectile/curse_hand/Initialize(mapload)
 	. = ..()
 	handedness = prob(50)
 	icon_state = "[item_state][handedness]"
 
-/obj/item/projectile/curse_hand/Destroy()
+/obj/projectile/curse_hand/Destroy()
 	QDEL_NULL(arm)
 	return ..()
 
-/obj/item/projectile/curse_hand/update_icon_state()
+/obj/projectile/curse_hand/update_icon_state()
 	icon_state = "[item_state]0[handedness]"
 	return ..()
 
-/obj/item/projectile/curse_hand/fire(setAngle)
+/obj/projectile/curse_hand/fire(setAngle)
 	if(QDELETED(src)) //I'm going to try returning nothing because if it's being deleted, surely we don't want anything to happen?
 		return
 	if(starting)
 		arm = starting.Beam(src, icon_state = "curse[handedness]", beam_type=/obj/effect/ebeam/curse_arm)
 	..()
 
-/obj/item/projectile/curse_hand/prehit_pierce(atom/target)
+/obj/projectile/curse_hand/prehit_pierce(atom/target)
 	return (target == original)? PROJECTILE_PIERCE_NONE : PROJECTILE_PIERCE_PHASE
 
 /// The visual effect for the hand disappearing
-/obj/item/projectile/curse_hand/proc/finale()
+/obj/projectile/curse_hand/proc/finale()
 	if(arm)
 		QDEL_NULL(arm)
 	if((movement_type & PHASING))
@@ -58,16 +58,16 @@
 		var/obj/effect/ebeam/B = b
 		animate(B, alpha = 0, time = 32)
 
-/obj/item/projectile/curse_hand/on_range()
+/obj/projectile/curse_hand/on_range()
 	finale()
 	return ..()
 
-/obj/item/projectile/curse_hand/on_hit(atom/target, blocked, pierce_hit)
+/obj/projectile/curse_hand/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()
 	if (. == BULLET_ACT_HIT)
 		finale()
 
-/obj/item/projectile/curse_hand/hel //Used in helbital's impure reagent
+/obj/projectile/curse_hand/hel //Used in helbital's impure reagent
 	name = "Hel's grasp"
 	damage = 5
 	paralyze = 0 //Lets not stun people!

--- a/code/modules/projectiles/projectile/special/floral.dm
+++ b/code/modules/projectiles/projectile/special/floral.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/floramut
+/obj/projectile/energy/floramut
 	name = "alpha somatoray"
 	icon_state = "energy"
 	damage = 0
@@ -7,7 +7,7 @@
 	armor_flag = ENERGY
 	martial_arts_no_deflect = TRUE
 
-/obj/item/projectile/energy/florayield
+/obj/projectile/energy/florayield
 	name = "beta somatoray"
 	icon_state = "energy2"
 	damage = 0

--- a/code/modules/projectiles/projectile/special/gravity.dm
+++ b/code/modules/projectiles/projectile/special/gravity.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/gravityrepulse
+/obj/projectile/gravityrepulse
 	name = "repulsion bolt"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
@@ -11,13 +11,13 @@
 	var/power = 4
 	var/list/thrown_items = list()
 
-/obj/item/projectile/gravityrepulse/Initialize(mapload)
+/obj/projectile/gravityrepulse/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/gravity/repulse/C = loc
 	if(istype(C)) //Hard-coded maximum power so servers can't be crashed by trying to throw the entire Z level's items
 		power = min(C?.gun?.power, 15)
 
-/obj/item/projectile/gravityrepulse/on_hit()
+/obj/projectile/gravityrepulse/on_hit()
 	. = ..()
 	T = get_turf(src)
 	for(var/atom/movable/A in range(power, T))
@@ -33,7 +33,7 @@
 	for(var/turf/F as() in RANGE_TURFS(power, T))
 		new /obj/effect/temp_visual/gravpush(F)
 
-/obj/item/projectile/gravityattract
+/obj/projectile/gravityattract
 	name = "attraction bolt"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
@@ -46,13 +46,13 @@
 	var/power = 4
 	var/list/thrown_items = list()
 
-/obj/item/projectile/gravityattract/Initialize(mapload)
+/obj/projectile/gravityattract/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/gravity/attract/C = loc
 	if(istype(C)) //Hard-coded maximum power so servers can't be crashed by trying to throw the entire Z level's items
 		power = min(C?.gun?.power, 15)
 
-/obj/item/projectile/gravityattract/on_hit()
+/obj/projectile/gravityattract/on_hit()
 	. = ..()
 	T = get_turf(src)
 	for(var/atom/movable/A in range(power, T))
@@ -67,7 +67,7 @@
 	for(var/turf/F as() in RANGE_TURFS(power, T))
 		new /obj/effect/temp_visual/gravpush(F)
 
-/obj/item/projectile/gravitychaos
+/obj/projectile/gravitychaos
 	name = "gravitational blast"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
@@ -80,13 +80,13 @@
 	var/power = 4
 	var/list/thrown_items = list()
 
-/obj/item/projectile/gravitychaos/Initialize(mapload)
+/obj/projectile/gravitychaos/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/gravity/chaos/C = loc
 	if(istype(C)) //Hard-coded maximum power so servers can't be crashed by trying to throw the entire Z level's items
 		power = min(C?.gun?.power, 15)
 
-/obj/item/projectile/gravitychaos/on_hit()
+/obj/projectile/gravitychaos/on_hit()
 	. = ..()
 	T = get_turf(src)
 	for(var/atom/movable/A as mob|obj in range(power, T))

--- a/code/modules/projectiles/projectile/special/hallucination.dm
+++ b/code/modules/projectiles/projectile/special/hallucination.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/hallucination
+/obj/projectile/hallucination
 	name = "bullet"
 	icon = null
 	icon_state = null
@@ -8,7 +8,7 @@
 	ricochet_chance = 0
 	damage = 0
 	nodamage = TRUE
-	projectile_type = /obj/item/projectile/hallucination
+	projectile_type = /obj/projectile/hallucination
 	log_override = TRUE
 	var/hal_icon_state
 	var/image/fake_icon
@@ -21,19 +21,19 @@
 	var/hit_duration
 	var/hit_duration_wall
 
-/obj/item/projectile/hallucination/fire()
+/obj/projectile/hallucination/fire()
 	..()
 	fake_icon = image('icons/obj/projectiles.dmi', src, hal_icon_state, ABOVE_MOB_LAYER)
 	if(hal_target.client)
 		hal_target.client.images += fake_icon
 
-/obj/item/projectile/hallucination/Destroy()
+/obj/projectile/hallucination/Destroy()
 	if(hal_target?.client)
 		hal_target.client.images -= fake_icon
 	QDEL_NULL(fake_icon)
 	return ..()
 
-/obj/item/projectile/hallucination/Bump(atom/A)
+/obj/projectile/hallucination/Bump(atom/A)
 	if(!ismob(A))
 		if(hal_hitsound_wall)
 			hal_target.playsound_local(loc, hal_hitsound_wall, 40, 1)
@@ -46,7 +46,7 @@
 	qdel(src)
 	return TRUE
 
-/obj/item/projectile/hallucination/proc/target_on_hit(mob/M)
+/obj/projectile/hallucination/proc/target_on_hit(mob/M)
 	if(M == hal_target)
 		to_chat(hal_target, "<span class='userdanger'>[M] is hit by \a [src] in the chest!</span>")
 		hal_apply_effect()
@@ -60,7 +60,7 @@
 	else if(hal_impact_effect)
 		spawn_hit(M, FALSE)
 
-/obj/item/projectile/hallucination/proc/spawn_blood(mob/M, set_dir)
+/obj/projectile/hallucination/proc/spawn_blood(mob/M, set_dir)
 	set waitfor = 0
 	if(!hal_target.client)
 		return
@@ -102,11 +102,11 @@
 	animate(blood, pixel_x = target_pixel_x, pixel_y = target_pixel_y, alpha = 0, time = 5)
 	addtimer(CALLBACK(src, PROC_REF(cleanup_blood)), 5)
 
-/obj/item/projectile/hallucination/proc/cleanup_blood(image/blood)
+/obj/projectile/hallucination/proc/cleanup_blood(image/blood)
 	hal_target.client.images -= blood
 	qdel(blood)
 
-/obj/item/projectile/hallucination/proc/spawn_hit(atom/A, is_wall)
+/obj/projectile/hallucination/proc/spawn_hit(atom/A, is_wall)
 	set waitfor = 0
 	if(!hal_target.client)
 		return
@@ -120,10 +120,10 @@
 	qdel(hit_effect)
 
 
-/obj/item/projectile/hallucination/proc/hal_apply_effect()
+/obj/projectile/hallucination/proc/hal_apply_effect()
 	return
 
-/obj/item/projectile/hallucination/bullet
+/obj/projectile/hallucination/bullet
 	name = "bullet"
 	hal_icon_state = "bullet"
 	hal_fire_sound = "gunshot"
@@ -134,10 +134,10 @@
 	hit_duration = 5
 	hit_duration_wall = 5
 
-/obj/item/projectile/hallucination/bullet/hal_apply_effect()
+/obj/projectile/hallucination/bullet/hal_apply_effect()
 	hal_target.adjustStaminaLoss(60)
 
-/obj/item/projectile/hallucination/laser
+/obj/projectile/hallucination/laser
 	name = "laser"
 	damage_type = BURN
 	hal_icon_state = "laser"
@@ -150,11 +150,11 @@
 	hit_duration_wall = 10
 	pass_flags = PASSTABLE | PASSTRANSPARENT | PASSGRILLE
 
-/obj/item/projectile/hallucination/laser/hal_apply_effect()
+/obj/projectile/hallucination/laser/hal_apply_effect()
 	hal_target.adjustStaminaLoss(20)
 	hal_target.blur_eyes(2)
 
-/obj/item/projectile/hallucination/taser
+/obj/projectile/hallucination/taser
 	name = "electrode"
 	damage_type = BURN
 	hal_icon_state = "spark"
@@ -165,7 +165,7 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/taser/hal_apply_effect()
+/obj/projectile/hallucination/taser/hal_apply_effect()
 	hal_target.Paralyze(100)
 	hal_target.stuttering += 20
 	if(hal_target.has_dna() && hal_target.dna.check_mutation(HULK))
@@ -173,7 +173,7 @@
 	else if((hal_target.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(hal_target, TRAIT_STUNIMMUNE))
 		addtimer(CALLBACK(hal_target, TYPE_PROC_REF(/mob/living/carbon, do_jitter_animation), 20), 5)
 
-/obj/item/projectile/hallucination/disabler
+/obj/projectile/hallucination/disabler
 	name = "disabler beam"
 	damage_type = STAMINA
 	armor_flag = STAMINA
@@ -186,10 +186,10 @@
 	hit_duration = 4
 	pass_flags = PASSTABLE | PASSTRANSPARENT | PASSGRILLE
 
-/obj/item/projectile/hallucination/disabler/hal_apply_effect()
+/obj/projectile/hallucination/disabler/hal_apply_effect()
 	hal_target.adjustStaminaLoss(25)
 
-/obj/item/projectile/hallucination/ebow
+/obj/projectile/hallucination/ebow
 	name = "bolt"
 	damage_type = TOX
 	hal_icon_state = "cbbolt"
@@ -199,12 +199,12 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/ebow/hal_apply_effect()
+/obj/projectile/hallucination/ebow/hal_apply_effect()
 	hal_target.Paralyze(100)
 	hal_target.stuttering += 5
 	hal_target.adjustStaminaLoss(8)
 
-/obj/item/projectile/hallucination/change
+/obj/projectile/hallucination/change
 	name = "bolt of change"
 	damage_type = BURN
 	hal_icon_state = "ice_1"
@@ -214,10 +214,10 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/change/hal_apply_effect()
+/obj/projectile/hallucination/change/hal_apply_effect()
 	new /datum/hallucination/self_delusion(hal_target, TRUE, wabbajack = FALSE)
 
-/obj/item/projectile/hallucination/death
+/obj/projectile/hallucination/death
 	name = "bolt of death"
 	damage_type = BURN
 	hal_icon_state = "pulse1_bl"
@@ -227,5 +227,5 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/death/hal_apply_effect()
+/obj/projectile/hallucination/death/hal_apply_effect()
 	new /datum/hallucination/death(hal_target, TRUE)

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/ion
+/obj/projectile/ion
 	name = "ion bolt"
 	icon_state = "ion"
 	damage = 0
@@ -7,14 +7,14 @@
 	armor_flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 
-/obj/item/projectile/ion/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/ion/on_hit(atom/target, blocked = FALSE)
 	..()
 	empulse(target, 1, 1)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/ion/weak
+/obj/projectile/ion/weak
 
-/obj/item/projectile/ion/weak/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/ion/weak/on_hit(atom/target, blocked = FALSE)
 	..()
 	empulse(target, 0, 0)
 	return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/meteor
+/obj/projectile/meteor
 	name = "meteor"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "small1"
@@ -7,7 +7,7 @@
 	nodamage = TRUE
 	armor_flag = BULLET
 
-/obj/item/projectile/meteor/Bump(atom/A)
+/obj/projectile/meteor/Bump(atom/A)
 	if(A == firer)
 		forceMove(A.loc)
 		return

--- a/code/modules/projectiles/projectile/special/mindflayer.dm
+++ b/code/modules/projectiles/projectile/special/mindflayer.dm
@@ -1,7 +1,7 @@
-/obj/item/projectile/beam/mindflayer
+/obj/projectile/beam/mindflayer
 	name = "flayer ray"
 
-/obj/item/projectile/beam/mindflayer/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/mindflayer/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -1,10 +1,10 @@
-/obj/item/projectile/bullet/neurotoxin
+/obj/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
 
-/obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
 		paralyze = 0
 		nodamage = TRUE

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/plasma
+/obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
@@ -11,7 +11,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/plasma_cutter
 	impact_type = /obj/effect/projectile/impact/plasma_cutter
 
-/obj/item/projectile/plasma/on_hit(atom/target)
+/obj/projectile/plasma/on_hit(atom/target)
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
@@ -22,17 +22,17 @@
 		if(range > 0)
 			return BULLET_ACT_FORCE_PIERCE
 
-/obj/item/projectile/plasma/adv
+/obj/projectile/plasma/adv
 	damage = 14
 	range = 5
 	mine_range = 5
 
-/obj/item/projectile/plasma/adv/mech
+/obj/projectile/plasma/adv/mech
 	damage = 20
 	range = 9
 	mine_range = 3
 
-/obj/item/projectile/plasma/turret
+/obj/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass
 	name = "plasma beam"
 	damage = 24

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -1,14 +1,14 @@
-/obj/item/projectile/bullet/gyro
+/obj/projectile/bullet/gyro
 	name ="explosive bolt"
 	icon_state= "bolter"
 	damage = 50
 
-/obj/item/projectile/bullet/gyro/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/gyro/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 2)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/a84mm
+/obj/projectile/bullet/a84mm
 	name ="\improper HEDP rocket"
 	desc = "USE A WEEL GUN"
 	icon_state= "84mm-hedp"
@@ -17,7 +17,7 @@
 	armour_penetration = 100
 	dismemberment = 100
 
-/obj/item/projectile/bullet/a84mm/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/a84mm/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 1, 3, 1, 0, flame_range = 4)
 
@@ -29,14 +29,14 @@
 		S.take_overall_damage(anti_armour_damage*0.75, anti_armour_damage*0.25)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/a84mm_he
+/obj/projectile/bullet/a84mm_he
 	name ="\improper HE rocket"
 	desc = "Boom."
 	icon_state = "missile"
 	damage = 30
 	ricochets_max = 0 //it's a MISSILE
 
-/obj/item/projectile/bullet/a84mm_he/on_hit(atom/target, blocked=0)
+/obj/projectile/bullet/a84mm_he/on_hit(atom/target, blocked=0)
 	..()
 	if(!isliving(target)) //if the target isn't alive, so is a wall or something
 		explosion(target, 0, 1, 2, 4)

--- a/code/modules/projectiles/projectile/special/spidernet.dm
+++ b/code/modules/projectiles/projectile/special/spidernet.dm
@@ -1,9 +1,9 @@
-/obj/item/projectile/bullet/spidernet
+/obj/projectile/bullet/spidernet
 	name = "sticky webbing"
 	icon_state = "spidernet"
 	damage = 0
 
-/obj/item/projectile/bullet/spidernet/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/spidernet/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		C.Knockdown(4 SECONDS)
@@ -12,18 +12,18 @@
 		L.Immobilize(4 SECONDS)
 	return ..()
 
-/obj/item/projectile/bullet/spidernet/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/spidernet/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isliving(target))
 		var/turf/T = get_turf(target)
 		web_tile(T)
 	else
 		web_tile()
-/obj/item/projectile/bullet/spidernet/on_range()
+/obj/projectile/bullet/spidernet/on_range()
 	web_tile()
 	..()
 
-/obj/item/projectile/bullet/spidernet/proc/web_tile(var/turf/T)
+/obj/projectile/bullet/spidernet/proc/web_tile(var/turf/T)
 	if(!T)
 		T = get_turf(src)
 	var/webs = 0
@@ -34,7 +34,7 @@
 	else
 		new /obj/structure/spider/stickyweb(T)
 
-/obj/item/projectile/bullet/spidernet/prehit_pierce(atom/A)
+/obj/projectile/bullet/spidernet/prehit_pierce(atom/A)
 	if(istype(A, /mob/living/simple_animal/hostile/poison/giant_spider) || istype(A, /obj/structure/spider/stickyweb))
 		return PROJECTILE_PIERCE_PHASE
 	return ..()

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/temp
+/obj/projectile/temp
 	name = "freeze beam"
 	icon_state = "ice_2"
 	damage = 0
@@ -7,22 +7,22 @@
 	armor_flag = ENERGY
 	var/temperature = 100
 
-/obj/item/projectile/temp/on_hit(atom/target, blocked = 0)
+/obj/projectile/temp/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
 		L.adjust_bodytemperature(((100-blocked)/100)*(temperature - L.bodytemperature)) // the new body temperature is adjusted by 100-blocked % of the delta between body temperature and the bullet's effect temperature
 
-/obj/item/projectile/temp/hot
+/obj/projectile/temp/hot
 	name = "heat beam"
 	temperature = 400
 
-/obj/item/projectile/temp/cryo
+/obj/projectile/temp/cryo
 	name = "cryo beam"
 	range = 3
 	temperature = -240
 
-/obj/item/projectile/temp/cryo/on_range()
+/obj/projectile/temp/cryo/on_range()
 	var/turf/T = get_turf(src)
 	if(isopenturf(T))
 		var/turf/open/O = T

--- a/code/modules/projectiles/projectile/special/vortex.dm
+++ b/code/modules/projectiles/projectile/special/vortex.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/vortex
+/obj/projectile/energy/vortex
 	name = "vortex beam"
 	alpha = 0
 	damage = 0
@@ -10,6 +10,6 @@
 	projectile_phasing = ALL
 	projectile_piercing = NONE
 
-/obj/item/projectile/energy/vortex/Range()
+/obj/projectile/energy/vortex/Range()
 	new /obj/effect/temp_visual/hierophant/blast/vortex(get_turf(src), firer, FALSE)
 	return ..()

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/beam/wormhole
+/obj/projectile/beam/wormhole
 	name = "bluespace beam"
 	icon_state = "spark"
 	hitsound = "sparks"
@@ -14,17 +14,17 @@
 	hitscan = TRUE
 	martial_arts_no_deflect = TRUE
 
-/obj/item/projectile/beam/wormhole/orange
+/obj/projectile/beam/wormhole/orange
 	name = "orange bluespace beam"
 	color = "#FF6600"
 
-/obj/item/projectile/beam/wormhole/Initialize(mapload, obj/item/ammo_casing/energy/wormhole/casing)
+/obj/projectile/beam/wormhole/Initialize(mapload, obj/item/ammo_casing/energy/wormhole/casing)
 	. = ..()
 	if(casing)
 		gun = casing.gun
 
 
-/obj/item/projectile/beam/wormhole/on_hit(atom/target)
+/obj/projectile/beam/wormhole/on_hit(atom/target)
 	var/obj/item/gun/energy/wormhole_projector/projector = gun.resolve()
 	if(!projector)
 		qdel(src)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2474,9 +2474,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	desc = "You can feel heat rising from your stomach"
 	range = 20
 	charge_max = 300
-	projectile_type = /obj/item/projectile/magic/fireball/firebreath/weak
+	projectile_type = /obj/projectile/magic/fireball/firebreath/weak
 
-/obj/item/projectile/magic/fireball/firebreath/weak
+/obj/projectile/magic/fireball/firebreath/weak
 	exp_fire = 1
 
 /datum/reagent/consumable/ethanol/beesknees

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2171,7 +2171,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		return
 	new/obj/effect/temp_visual/dir_setting/curse/grasp_portal(spawn_turf, owner.dir)
 	playsound(spawn_turf, 'sound/effects/curse2.ogg', 80, TRUE, -1)
-	var/obj/item/projectile/curse_hand/hel/hand = new (spawn_turf)
+	var/obj/projectile/curse_hand/hel/hand = new (spawn_turf)
 	hand.preparePixelProjectile(owner, spawn_turf)
 	if(QDELETED(hand)) //safety check if above fails - above has a stack trace if it does fail
 		return

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -84,7 +84,7 @@
 	..() //extend the zap
 	boom()
 
-/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/item/projectile/P)
+/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/projectile/P)
 	. = ..()
 	if(!QDELETED(src)) //wasn't deleted by the projectile's effects.
 		if(!P.nodamage && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -477,7 +477,7 @@
 /atom/movable/proc/CanEnterDisposals()
 	return TRUE
 
-/obj/item/projectile/CanEnterDisposals()
+/obj/projectile/CanEnterDisposals()
 	return
 
 /obj/effect/CanEnterDisposals()

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -360,7 +360,7 @@
 			if(MT)
 				visible_message("<span class='danger'>[src] dangerously overheats, launching a flaming fuel orb!</span>")
 				investigate_log("Experimentor has launched a <font color='red'>fireball</font> at [M]!", INVESTIGATE_EXPERIMENTOR)
-				var/obj/item/projectile/magic/fireball/FB = new /obj/item/projectile/magic/fireball(start)
+				var/obj/projectile/magic/fireball/FB = new /obj/projectile/magic/fireball(start)
 				FB.preparePixelProjectile(MT, start)
 				FB.fire()
 		else if(prob(EFFECT_PROB_LOW-badThingCoeff))

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -114,9 +114,9 @@ Slimecrossing Weapons
 	return 1
 
 /obj/item/ammo_casing/magic/bloodchill
-	projectile_type = /obj/item/projectile/magic/bloodchill
+	projectile_type = /obj/projectile/magic/bloodchill
 
-/obj/item/projectile/magic/bloodchill
+/obj/projectile/magic/bloodchill
 	name = "blood ball"
 	icon_state = "pulse0_bl"
 	damage = 0
@@ -124,7 +124,7 @@ Slimecrossing Weapons
 	nodamage = TRUE
 	hitsound = 'sound/effects/splat.ogg'
 
-/obj/item/projectile/magic/bloodchill/on_hit(mob/living/target)
+/obj/projectile/magic/bloodchill/on_hit(mob/living/target)
 	. = ..()
 	if(isliving(target))
 		target.apply_status_effect(/datum/status_effect/bloodchill)

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -8,7 +8,7 @@
 /obj/machinery/power/emitter/energycannon/magical
 	name = "wabbajack statue"
 	desc = "Who am I? What is my purpose in life? What do I mean by who am I?"
-	projectile_type = /obj/item/projectile/magic/change
+	projectile_type = /obj/projectile/magic/change
 	icon = 'icons/obj/machines/magic_emitter.dmi'
 	icon_state = "wabbajack_statue"
 	icon_state_on = "wabbajack_statue_on"

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -183,8 +183,8 @@
 	return ..()
 
 /datum/artifact_effect/projreflect/proc/HasProximity(atom/movable/AM)
-	if(istype(AM, /obj/item/projectile))
-		var/obj/item/projectile/P = AM
+	if(istype(AM, /obj/projectile))
+		var/obj/projectile/P = AM
 		P.setAngle(rand(0, 360))
 		P.ignore_source_check = TRUE //Allow the projectile to hit the shooter after it gets reflected
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/warp_cube,
 		/obj/machinery/rnd/production, //print tracking beacons, send shuttle
 		/obj/machinery/modular_fabricator/autolathe, //same
-		/obj/item/projectile/beam/wormhole,
+		/obj/projectile/beam/wormhole,
 		/obj/effect/portal,
 		/obj/item/shared_storage,
 		/obj/structure/extraction_point,

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -1,7 +1,7 @@
 
 /obj/effect/proc_holder/spell/aimed
 	name = "aimed projectile spell"
-	var/projectile_type = /obj/item/projectile/magic/teleport
+	var/projectile_type = /obj/projectile/magic/teleport
 	var/deactive_msg = "You discharge your projectile..."
 	var/active_msg = "You charge your projectile!"
 	base_icon_state = "projectile"
@@ -77,7 +77,7 @@
 	if(!projectile_type)
 		return
 	for(var/i in 1 to projectiles_per_fire)
-		var/obj/item/projectile/P = new projectile_type(user.loc, spell_level)
+		var/obj/projectile/P = new projectile_type(user.loc, spell_level)
 		P.firer = user
 		P.preparePixelProjectile(target, user)
 		for(var/V in projectile_var_overrides)
@@ -87,7 +87,7 @@
 		P.fire()
 	return TRUE
 
-/obj/effect/proc_holder/spell/aimed/proc/ready_projectile(obj/item/projectile/P, atom/target, mob/user, iteration)
+/obj/effect/proc_holder/spell/aimed/proc/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)
 	return
 
 /obj/effect/proc_holder/spell/aimed/lightningbolt
@@ -106,7 +106,7 @@
 	projectile_var_overrides = list("tesla_range" = 15, "tesla_power" = 20000, "tesla_flags" = TESLA_MOB_DAMAGE)
 	active_msg = "You energize your hand with arcane lightning!"
 	deactive_msg = "You let the energy flow out of your hands back into yourself..."
-	projectile_type = /obj/item/projectile/magic/aoe/lightning
+	projectile_type = /obj/projectile/magic/aoe/lightning
 
 /obj/effect/proc_holder/spell/aimed/fireball
 	name = "Fireball"
@@ -118,7 +118,7 @@
 	invocation_type = INVOCATION_SHOUT
 	range = 20
 	cooldown_min = 40 //10 deciseconds reduction per rank
-	projectile_type = /obj/item/projectile/magic/fireball
+	projectile_type = /obj/projectile/magic/fireball
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
 	sound = 'sound/magic/fireball.ogg'
@@ -138,7 +138,7 @@
 	cooldown_min = 30
 	projectile_amount = 5
 	projectiles_per_fire = 7
-	projectile_type = /obj/item/projectile/spellcard
+	projectile_type = /obj/projectile/spellcard
 	base_icon_state = "spellcard"
 	action_icon_state = "spellcard0"
 	var/datum/weakref/current_target_weakref
@@ -166,7 +166,7 @@
 /obj/effect/proc_holder/spell/aimed/spell_cards/on_deactivation(mob/M)
 	QDEL_NULL(lockon_component)
 
-/obj/effect/proc_holder/spell/aimed/spell_cards/ready_projectile(obj/item/projectile/P, atom/target, mob/user, iteration)
+/obj/effect/proc_holder/spell/aimed/spell_cards/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)
 	if(current_target_weakref)
 		var/atom/A = current_target_weakref.resolve()
 		if(A && get_dist(A, user) < 7)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -57,7 +57,7 @@
 	summon_type = list(/mob/living/simple_animal/bot/ed209)
 	summon_amt = 10
 	range = 3
-	newVars = list("emagged" = 2, "remote_disabled" = 1,"shoot_sound" = 'sound/weapons/laser.ogg',"projectile" = /obj/item/projectile/beam/laser, "declare_arrests" = 0,"name" = "Wizard's Justicebot")
+	newVars = list("emagged" = 2, "remote_disabled" = 1,"shoot_sound" = 'sound/weapons/laser.ogg',"projectile" = /obj/projectile/beam/laser, "declare_arrests" = 0,"name" = "Wizard's Justicebot")
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/linkWorlds
 	name = "Link Worlds"

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -168,13 +168,13 @@
 	max_targets = 6
 	action_icon_state = "magicm"
 	action_background_icon_state = "bg_demon"
-	proj_type = /obj/item/projectile/magic/spell/magic_missile/lesser
+	proj_type = /obj/projectile/magic/spell/magic_missile/lesser
 
-/obj/item/projectile/magic/spell/magic_missile/lesser
+/obj/projectile/magic/spell/magic_missile/lesser
 	color = "red" //Looks more culty this way
 	range = 10
 
-/obj/item/projectile/magic/spell/magic_missile/lesser/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
+/obj/projectile/magic/spell/magic_missile/lesser/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
 	if(ismob(target) && iscultist(target))
 		return FALSE
 	return ..()
@@ -310,7 +310,7 @@
 /obj/effect/proc_holder/spell/targeted/projectile/dumbfire/juggernaut
 	name = "Gauntlet Echo"
 	desc = "Channels energy into your gauntlet - firing its essence forward in a slow moving, yet devastating, attack."
-	proj_type = /obj/item/projectile/magic/spell/juggernaut
+	proj_type = /obj/projectile/magic/spell/juggernaut
 	charge_max = 350
 	clothes_req = FALSE
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
@@ -318,7 +318,7 @@
 	action_background_icon_state = "bg_demon"
 	sound = 'sound/weapons/resonator_blast.ogg'
 
-/obj/item/projectile/magic/spell/juggernaut
+/obj/projectile/magic/spell/juggernaut
 	name = "Gauntlet Echo"
 	icon_state = "cultfist"
 	alpha = 180
@@ -332,7 +332,7 @@
 	range = 15
 	speed = 7
 
-/obj/item/projectile/magic/spell/juggernaut/on_hit(atom/target, blocked)
+/obj/projectile/magic/spell/juggernaut/on_hit(atom/target, blocked)
 	. = ..()
 	var/turf/T = get_turf(src)
 	playsound(T, 'sound/weapons/resonator_blast.ogg', 100, FALSE)

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -84,7 +84,7 @@
 	invocation_type = INVOCATION_SHOUT
 	range = 2
 
-	projectile_type = /obj/item/projectile/magic/fireball/infernal
+	projectile_type = /obj/projectile/magic/fireball/infernal
 
 	action_background_icon_state = "bg_demon"
 

--- a/code/modules/spells/spell_types/projectile.dm
+++ b/code/modules/spells/spell_types/projectile.dm
@@ -1,6 +1,6 @@
 
 
-/obj/item/projectile/magic/spell
+/obj/projectile/magic/spell
 	name = "custom spell projectile"
 	var/list/ignored_factions //Do not hit these
 	var/check_holy = FALSE
@@ -14,19 +14,19 @@
 	var/trail_icon_state = "trail"
 
 //todo unify this and magic/aoe under common path
-/obj/item/projectile/magic/spell/Range()
+/obj/projectile/magic/spell/Range()
 	if(trigger_range > 1)
 		for(var/mob/living/L in range(trigger_range, get_turf(src)))
 			if(can_hit_target(L, ignore_loc = TRUE))
 				return Bump(L)
 	. = ..()
 
-/obj/item/projectile/magic/spell/Moved(atom/OldLoc, Dir)
+/obj/projectile/magic/spell/Moved(atom/OldLoc, Dir)
 	. = ..()
 	if(trail)
 		create_trail()
 
-/obj/item/projectile/magic/spell/proc/create_trail()
+/obj/projectile/magic/spell/proc/create_trail()
 	if(!trajectory)
 		return
 	var/datum/point/vector/previous = trajectory.return_vector_after_increments(1,-1)
@@ -40,7 +40,7 @@
 	trail.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	QDEL_IN(trail, trail_lifespan)
 
-/obj/item/projectile/magic/spell/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
+/obj/projectile/magic/spell/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
 	. = ..()
 	if(linger && target != original)
 		return FALSE
@@ -60,7 +60,7 @@
 
 
 
-	var/proj_type =  /obj/item/projectile/magic/spell //IMPORTANT use only subtypes of this
+	var/proj_type =  /obj/projectile/magic/spell //IMPORTANT use only subtypes of this
 
 
 	var/update_projectile = FALSE //So you want to admin abuse magic bullets ? This is for you
@@ -83,7 +83,7 @@
 	var/check_holy = FALSE
 
 /obj/effect/proc_holder/spell/targeted/projectile/proc/fire_projectile(atom/target, mob/user)
-	var/obj/item/projectile/magic/spell/projectile = new proj_type(null, spell_level)
+	var/obj/projectile/magic/spell/projectile = new proj_type(null, spell_level)
 
 	if(update_projectile)
 		//Generally these should already be set on the projectile, this is mostly here for varedited spells.

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -10,11 +10,11 @@
 	range = 7
 	cooldown_min = 60 //35 deciseconds reduction per rank
 	max_targets = 0
-	proj_type = /obj/item/projectile/magic/spell/magic_missile
+	proj_type = /obj/projectile/magic/spell/magic_missile
 	action_icon_state = "magicm"
 	sound = 'sound/magic/magic_missile.ogg'
 
-/obj/item/projectile/magic/spell/magic_missile
+/obj/projectile/magic/spell/magic_missile
 	name = "a magic missile"
 	icon_state = "magicm"
 	range = 20
@@ -28,7 +28,7 @@
 	trail_lifespan = 5
 	trail_icon_state = "magicmd"
 
-/obj/item/projectile/magic/spell/magic_missile/New(loc, spell_level)
+/obj/projectile/magic/spell/magic_missile/New(loc, spell_level)
 	. = ..()
 	paralyze += spell_level * 10
 

--- a/code/modules/unit_tests/projectiles.dm
+++ b/code/modules/unit_tests/projectiles.dm
@@ -1,5 +1,5 @@
 /datum/unit_test/projectile_movetypes/Run()
-	for(var/path in typesof(/obj/item/projectile))
-		var/obj/item/projectile/projectile = path
+	for(var/path in typesof(/obj/projectile))
+		var/obj/projectile/projectile = path
 		if(initial(projectile.movement_type) & PHASING)
 			Fail("[path] has default movement type PHASING. Piercing projectiles should be done using the projectile piercing system, not movement_types!")

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -88,7 +88,7 @@
 	smoke.set_up(0, src)
 	smoke.start()
 
-/obj/vehicle/ridden/atv/bullet_act(obj/item/projectile/P)
+/obj/vehicle/ridden/atv/bullet_act(obj/projectile/P)
 	if(prob(50) && buckled_mobs)
 		for(var/mob/M in buckled_mobs)
 			M.bullet_act(P)

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -46,7 +46,7 @@
 	STOP_PROCESSING(SSobj,src)
 	return ..()
 
-/obj/vehicle/ridden/secway/bullet_act(obj/item/projectile/P)
+/obj/vehicle/ridden/secway/bullet_act(obj/projectile/P)
 	if(prob(60) && buckled_mobs)
 		for(var/mob/M in buckled_mobs)
 			M.bullet_act(P)

--- a/code/modules/xenoarchaeology/traits/xenoartifact_majors.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_majors.dm
@@ -98,14 +98,14 @@
 		victim.IgniteMob()
 		return
 	//otherwise shoot laser
-	var/obj/item/projectile/A
+	var/obj/projectile/A
 	switch(X.charge)
 		if(0 to 24)
-			A = new /obj/item/projectile/beam/disabler
+			A = new /obj/projectile/beam/disabler
 		if(25 to 79)
-			A = new /obj/item/projectile/beam/laser
+			A = new /obj/projectile/beam/laser
 		if(80 to 200)
-			A = new /obj/item/projectile/beam/laser/heavylaser
+			A = new /obj/projectile/beam/laser/heavylaser
 	//If target is our own turf, aka someone probably threw us, target a random direction to avoid always shooting east
 	if(istype(target, /turf) && X.loc == target)
 		target = get_edge_target_turf(pick(NORTH, EAST, SOUTH, WEST))


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/46692

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Projectiles share literally 2 vars with /item/, (armour_penetration and hitsound).

I just moved added those vars to projectile.dm, and it works fine from my testing.

Ive tested it with armor, penetration, through glass, all seems to work. 

It was a really trivial change, but a testmerge for a round couldn't hurt.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its literally free overhead 😎 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/de4ec4a9-8784-4f26-8393-b34fe45e0f66

</details>

## Changelog
:cl: RKz
code: Kills obj/item/projectile in favour of obj/projectile. No ingame effect, just free overhead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
