### PR TITLE
Developer prefs QoL

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -122,10 +122,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	active_character.randomise()		//let's create a random character then - rather than a fat, bald and naked man.
 	active_character.real_name = active_character.pref_species.random_name(active_character.gender, TRUE)
 	if(!loaded_preferences_successfully)
-		if(Debugger?.enabled)
-			toggles &= ~PREFTOGGLE_SOUND_AMBIENCE
-			toggles &= ~PREFTOGGLE_SOUND_SHIP_AMBIENCE
-			toggles &= ~PREFTOGGLE_SOUND_LOBBY
 		save_preferences()
 	active_character.save(C)		//let's save this new random character so it doesn't keep generating new ones.
 	return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -122,6 +122,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	active_character.randomise()		//let's create a random character then - rather than a fat, bald and naked man.
 	active_character.real_name = active_character.pref_species.random_name(active_character.gender, TRUE)
 	if(!loaded_preferences_successfully)
+		if(Debugger?.enabled)
+			toggles &= ~PREFTOGGLE_SOUND_AMBIENCE
+			toggles &= ~PREFTOGGLE_SOUND_SHIP_AMBIENCE
+			toggles &= ~PREFTOGGLE_SOUND_LOBBY
 		save_preferences()
 	active_character.save(C)		//let's save this new random character so it doesn't keep generating new ones.
 	return

--- a/code/modules/client/preferences2/preferences2.dm
+++ b/code/modules/client/preferences2/preferences2.dm
@@ -37,7 +37,10 @@
 		// TODO - Loading of sane defaults
 		if (!length(key_bindings))
 			key_bindings = deep_copy_list(GLOB.keybinding_list_by_key)
-
+		if(Debugger?.enabled)
+			toggles &= ~PREFTOGGLE_SOUND_AMBIENCE
+			toggles &= ~PREFTOGGLE_SOUND_SHIP_AMBIENCE
+			toggles &= ~PREFTOGGLE_SOUND_LOBBY
 		return
 
 	var/datum/DBQuery/read_player_data = SSdbcore.NewQuery(

--- a/code/modules/client/preferences2/preferences2.dm
+++ b/code/modules/client/preferences2/preferences2.dm
@@ -38,9 +38,7 @@
 		if (!length(key_bindings))
 			key_bindings = deep_copy_list(GLOB.keybinding_list_by_key)
 		if(Debugger?.enabled)
-			toggles &= ~PREFTOGGLE_SOUND_AMBIENCE
-			toggles &= ~PREFTOGGLE_SOUND_SHIP_AMBIENCE
-			toggles &= ~PREFTOGGLE_SOUND_LOBBY
+			toggles &= ~(PREFTOGGLE_SOUND_AMBIENCE | PREFTOGGLE_SOUND_SHIP_AMBIENCE | PREFTOGGLE_SOUND_LOBBY)
 		return
 
 	var/datum/DBQuery/read_player_data = SSdbcore.NewQuery(


### PR DESCRIPTION
## About The Pull Request

If a database is not connected and the debugger is enabled, their sound toggles will be automatically set to disable ambience and lobby music.

This should not affect any production systems as they do not have the debugger enabled and thus won't cause this problem. They would also have a database attached.

## Why It's Good For The Game

Ambiance and lobby music are extremely irritating in a testing environment and serve as more buttons to click when starting the game. This disables them by default.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Booting the game via VSCode with no DB triggers the toggles

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/474699b8-1c52-4fae-988c-0db3f2df7865)

Booting via DD with no DB does not:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/7e1c3235-8cff-493d-aeb7-bbcbcd94aa2b)


</details>

## Changelog
:cl:
tweak: Local instances of the game ran with a debugger attached will now automatically disable lobby music and ambiance if no database is connected. This does not affect the main server at all, and only affects developers.
/:cl: