### PR TITLE
Fix TGUI Input timeout display not updating

### DIFF
--- a/code/modules/tgui_input/alert.dm
+++ b/code/modules/tgui_input/alert.dm
@@ -120,6 +120,7 @@
 	if(!ui)
 		ui = new(user, src, "AlertModal")
 		ui.open()
+		ui.set_autoupdate(timeout > 0)
 
 /datum/tgui_modal/ui_close(mob/user)
 	. = ..()

--- a/code/modules/tgui_input/list.dm
+++ b/code/modules/tgui_input/list.dm
@@ -133,6 +133,7 @@
 	if(!ui)
 		ui = new(user, src, "ListInputModal")
 		ui.open()
+		ui.set_autoupdate(timeout > 0)
 
 /datum/tgui_list_input/ui_close(mob/user)
 	. = ..()

--- a/code/modules/tgui_input/number.dm
+++ b/code/modules/tgui_input/number.dm
@@ -135,6 +135,7 @@
 	if(!ui)
 		ui = new(user, src, "NumberInputModal")
 		ui.open()
+		ui.set_autoupdate(timeout > 0)
 
 /datum/tgui_input_number/ui_close(mob/user)
 	. = ..()

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -139,6 +139,7 @@
 	if(!ui)
 		ui = new(user, src, "TextInputModal")
 		ui.open()
+		ui.set_autoupdate(timeout > 0)
 
 /datum/tgui_input_text/ui_close(mob/user)
 	. = ..()

--- a/tgui/packages/tgui/styles/interfaces/AlertModal.scss
+++ b/tgui/packages/tgui/styles/interfaces/AlertModal.scss
@@ -5,6 +5,8 @@
 
 @use '../colors.scss';
 
+$bar-color: colors.bg(colors.$primary) !default;
+
 .AlertModal__Message {
   text-align: center;
   justify-content: center;
@@ -23,6 +25,6 @@
 .AlertModal__LoaderProgress {
   position: absolute;
   transition: background-color 500ms ease-out, width 500ms ease-out;
-  background-color: colors.bg(colors.$primary);
+  background-color: $bar-color;
   height: 100%;
 }

--- a/tgui/packages/tgui/styles/themes/generic.scss
+++ b/tgui/packages/tgui/styles/themes/generic.scss
@@ -28,6 +28,9 @@ $accent: #4f56a5;
 
   @include meta.load-css('../components/Input.scss', $with: ('border-color': #7b86ff));
 
+  // Other
+  @include meta.load-css('../interfaces/AlertModal.scss', $with: ('bar-color': $accent));
+
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');
   @include meta.load-css('../layouts/Window.scss');


### PR DESCRIPTION
## About The Pull Request

Sets the UI to autoupdate if the timeout is set, fixing the display bar. Also changes the bar color to fit the generic theme.

## Why It's Good For The Game

Fixes a bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/efebb324-4763-4c60-9a94-da0fac0761e2)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/ab7c1b11-75c8-4f9d-9620-8fe8629d0602)

</details>

## Changelog
:cl:
fix: TGUI Inputs with timeouts now properly update the timeout bar.
tweak: The TGUI Input timeout bar now matches the generic color theme.
/:cl: