### PR TITLE
Fixes 6 yr old broken keybind

### DIFF
--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -29,7 +29,7 @@
 	. = ..()
 	if(.)
 		return
-	winset(user, null, "command=.screenshot [!user.keys_held["shift"] ? "auto" : ""]")
+	winset(user, null, "command=.auto")
 	return TRUE
 
 


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/63293

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

F2 and Shift+F2 are supposed to do different things. F2 should do a quick screenshot, whilst Shift+F2 should do a "Save As..." screenshot

This makes quick screenshot keybind(F2) work again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
feeex

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

This file explorer appears when using F2+Shift

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/b0c5153a-1c3c-433e-af7f-469b1b4a3d2c)


</details>

## Changelog
:cl: RKz, SuperNovaa41
fix: after 6 years, F2 the quickscreenshot keybind works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
