### PR TITLE
Revert "Prevent dynamic midrounds from rolling if the shuttle is called or docked"

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -13,7 +13,6 @@
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
-#define EMERGENCY_CALLED (SSshuttle.emergency && (SSshuttle.emergency.mode == SHUTTLE_CALL))
 
 // Shuttle return values
 #define SHUTTLE_CAN_DOCK "can_dock"

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -23,10 +23,6 @@
 	if (GLOB.dynamic_forced_extended)
 		return
 
-	if(!forced_injection && (EMERGENCY_AT_LEAST_DOCKED || EMERGENCY_CALLED))
-		dynamic_log("Not rolling a midround because the shuttle is called or already here.")
-		return
-
 	if (EMERGENCY_ESCAPED_OR_ENDGAMED)
 		return
 


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#9253

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/0ad5afa0-e37e-4851-bbb7-1a7f148009d6)


:cl:
code: reverts "Prevent dynamic midrounds from rolling if the shuttle is called or docked" PR
/:cl: