### PR TITLE
Moves organ signals to the right place

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -211,6 +211,7 @@
 #include "code\__DEFINES\dcs\signals\signals_obj\signals_item\signals_grenade.dm"
 #include "code\__DEFINES\dcs\signals\signals_obj\signals_item\signals_implant.dm"
 #include "code\__DEFINES\dcs\signals\signals_obj\signals_item\signals_item.dm"
+#include "code\__DEFINES\dcs\signals\signals_obj\signals_item\signals_organs.dm"
 #include "code\__DEFINES\dcs\signals\signals_obj\signals_machine\signals_airlock.dm"
 #include "code\__DEFINES\dcs\signals\signals_obj\signals_machine\signals_aquarium.dm"
 #include "code\__DEFINES\dcs\signals\signals_obj\signals_machine\signals_elevator.dm"

--- a/code/__DEFINES/dcs/signals/signals_datum/signals_datum.dm
+++ b/code/__DEFINES/dcs/signals/signals_datum/signals_datum.dm
@@ -111,10 +111,3 @@
 
 ///Called to all children when a parent moves, as long as it has the moved relay component.
 #define COMSIG_PARENT_MOVED_RELAY "parent_moved_relay"
-
-// Organ signals
-/// Called on the organ when it is implanted into someone (mob/living/carbon/receiver)
-#define COMSIG_ORGAN_IMPLANTED "comsig_organ_implanted"
-
-/// Called on the organ when it is removed from someone (mob/living/carbon/old_owner)
-#define COMSIG_ORGAN_REMOVED "comsig_organ_removed"

--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
@@ -63,9 +63,4 @@
 // /obj/item/pen signals
 #define COMSIG_PEN_ROTATED "pen_rotated"						//! called after rotation in /obj/item/pen/attack_self(): (rotation, mob/living/carbon/user)
 
-// Organ signals
-/// Called on the organ when it is implanted into someone (mob/living/carbon/receiver)
-#define COMSIG_ORGAN_IMPLANTED "comsig_organ_implanted"
 
-/// Called on the organ when it is removed from someone (mob/living/carbon/old_owner)
-#define COMSIG_ORGAN_REMOVED "comsig_organ_removed"

--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
@@ -63,3 +63,9 @@
 // /obj/item/pen signals
 #define COMSIG_PEN_ROTATED "pen_rotated"						//! called after rotation in /obj/item/pen/attack_self(): (rotation, mob/living/carbon/user)
 
+// Organ signals
+/// Called on the organ when it is implanted into someone (mob/living/carbon/receiver)
+#define COMSIG_ORGAN_IMPLANTED "comsig_organ_implanted"
+
+/// Called on the organ when it is removed from someone (mob/living/carbon/old_owner)
+#define COMSIG_ORGAN_REMOVED "comsig_organ_removed"

--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
@@ -63,4 +63,3 @@
 // /obj/item/pen signals
 #define COMSIG_PEN_ROTATED "pen_rotated"						//! called after rotation in /obj/item/pen/attack_self(): (rotation, mob/living/carbon/user)
 
-

--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_organs.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_organs.dm
@@ -1,0 +1,6 @@
+// Organ signals
+/// Called on the organ when it is implanted into someone (mob/living/carbon/receiver)
+#define COMSIG_ORGAN_IMPLANTED "comsig_organ_implanted"
+
+/// Called on the organ when it is removed from someone (mob/living/carbon/old_owner)
+#define COMSIG_ORGAN_REMOVED "comsig_organ_removed"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the organ signals added by a wiremode PR into the correct file, they are not signals sent to all datums so they should not be in datum signals.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/df53fee6-96e7-4737-bb48-147f1def1e06)

Compilation successful, no code changes.

## Changelog
:cl:
code: Moves organ signals to the correct place
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
