### PR TITLE
SM gascomp stabilization + parse_gas_string optimization

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -64,12 +64,7 @@
 		T.__update_auxtools_turf_adjacency_info(isspaceturf(T.get_z_base_turf()), -1)
 	UNSETEMPTY(atmos_adjacent_turfs)
 	src.atmos_adjacent_turfs = atmos_adjacent_turfs
-	for(var/t in atmos_adjacent_turfs)
-		var/turf/open/T = t
-		for(var/obj/machinery/door/firedoor/FD in T)
-			FD.UpdateAdjacencyFlags()
-	for(var/obj/machinery/door/firedoor/FD in src)
-		FD.UpdateAdjacencyFlags()
+	set_sleeping(isclosedturf(src))
 	__update_auxtools_turf_adjacency_info(isspaceturf(get_z_base_turf()))
 
 /turf/proc/ImmediateDisableAdjacency(disable_adjacent = TRUE)
@@ -86,12 +81,6 @@
 			UNSETEMPTY(T.atmos_adjacent_turfs)
 			T.__update_auxtools_turf_adjacency_info(isspaceturf(T.get_z_base_turf()), -1)
 	LAZYCLEARLIST(atmos_adjacent_turfs)
-	for(var/t in atmos_adjacent_turfs)
-		var/turf/open/T = t
-		for(var/obj/machinery/door/firedoor/FD in T)
-			FD.UpdateAdjacencyFlags()
-	for(var/obj/machinery/door/firedoor/FD in src)
-		FD.UpdateAdjacencyFlags()
 	__update_auxtools_turf_adjacency_info(isspaceturf(get_z_base_turf()))
 
 /turf/proc/set_sleeping(should_sleep)

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -64,7 +64,12 @@
 		T.__update_auxtools_turf_adjacency_info(isspaceturf(T.get_z_base_turf()), -1)
 	UNSETEMPTY(atmos_adjacent_turfs)
 	src.atmos_adjacent_turfs = atmos_adjacent_turfs
-	set_sleeping(isclosedturf(src))
+	for(var/t in atmos_adjacent_turfs)
+		var/turf/open/T = t
+		for(var/obj/machinery/door/firedoor/FD in T)
+			FD.UpdateAdjacencyFlags()
+	for(var/obj/machinery/door/firedoor/FD in src)
+		FD.UpdateAdjacencyFlags()
 	__update_auxtools_turf_adjacency_info(isspaceturf(get_z_base_turf()))
 
 /turf/proc/ImmediateDisableAdjacency(disable_adjacent = TRUE)
@@ -81,6 +86,12 @@
 			UNSETEMPTY(T.atmos_adjacent_turfs)
 			T.__update_auxtools_turf_adjacency_info(isspaceturf(T.get_z_base_turf()), -1)
 	LAZYCLEARLIST(atmos_adjacent_turfs)
+	for(var/t in atmos_adjacent_turfs)
+		var/turf/open/T = t
+		for(var/obj/machinery/door/firedoor/FD in T)
+			FD.UpdateAdjacencyFlags()
+	for(var/obj/machinery/door/firedoor/FD in src)
+		FD.UpdateAdjacencyFlags()
 	__update_auxtools_turf_adjacency_info(isspaceturf(get_z_base_turf()))
 
 /turf/proc/set_sleeping(should_sleep)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -261,16 +261,6 @@ we use a hook instead
 /datum/gas_mixture/proc/__auxtools_parse_gas_string(gas_string)
 
 /datum/gas_mixture/parse_gas_string(gas_string)
-	var/list/gas = params2list(gas_string)
-	if(gas["TEMP"])
-		var/temp = text2num(gas["TEMP"])
-		gas -= "TEMP"
-		if(!isnum(temp) || temp < 2.7)
-			temp = 2.7
-		set_temperature(temp)
-	clear()
-	for(var/id in gas)
-		set_moles(id, text2num(gas[id]))
 	return __auxtools_parse_gas_string(gas_string)
 
 /datum/gas_mixture/proc/set_analyzer_results(instability)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -44,6 +44,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/lastwarning = 0				// Time in 1/10th of seconds since the last sent warning
 	var/power = 0
 
+	/// Determines the maximum rate of positive change in gas comp values
+	var/gas_change_rate = 0.05
+
 	var/n2comp = 0					// raw composition of each gas in the chamber, ranges from 0 to 1
 
 	var/plasmacomp = 0
@@ -371,15 +374,21 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		//calculating gas related values
 		combined_gas = max(removed.total_moles(), 0)
 
-		plasmacomp = max(removed.get_moles(GAS_PLASMA)/combined_gas, 0)
-		o2comp = max(removed.get_moles(GAS_O2)/combined_gas, 0)
-		co2comp = max(removed.get_moles(GAS_CO2)/combined_gas, 0)
-		pluoxiumcomp = max(removed.get_moles(GAS_PLUOXIUM)/combined_gas, 0)
-		tritiumcomp = max(removed.get_moles(GAS_TRITIUM)/combined_gas, 0)
-		bzcomp = max(removed.get_moles(GAS_BZ)/combined_gas, 0)
+		//This is more error prevention, according to all known laws of atmos, gas_mix.remove() should never make negative mol values.
+		//But this is tg
+		//Lets get the proportions of the gasses in the mix and then slowly move our comp to that value
+		//Can cause an overestimation of mol count, should stabalize things though.
+		//Prevents huge bursts of gas/heat when a large amount of something is introduced
+		//They range between 0 and 1
+		plasmacomp += clamp(max(removed.get_moles(GAS_PLASMA)/combined_gas, 0) - plasmacomp, -1, gas_change_rate)
+		o2comp += clamp(max(removed.get_moles(GAS_O2)/combined_gas, 0) - o2comp, -1, gas_change_rate)
+		co2comp += clamp(max(removed.get_moles(GAS_CO2)/combined_gas, 0) - co2comp, -1, gas_change_rate)
+		pluoxiumcomp += clamp(max(removed.get_moles(GAS_PLUOXIUM)/combined_gas, 0) - pluoxiumcomp, -1, gas_change_rate)
+		tritiumcomp += clamp(max(removed.get_moles(GAS_TRITIUM)/combined_gas, 0) - tritiumcomp, -1, gas_change_rate)
+		bzcomp += clamp(max(removed.get_moles(GAS_BZ)/combined_gas, 0) - bzcomp, -1, gas_change_rate)
 
-		n2ocomp = max(removed.get_moles(GAS_NITROUS)/combined_gas, 0)
-		n2comp = max(removed.get_moles(GAS_N2)/combined_gas, 0)
+		n2ocomp += clamp(max(removed.get_moles(GAS_NITROUS)/combined_gas, 0) - n2ocomp, -1, gas_change_rate)
+		n2comp += clamp(max(removed.get_moles(GAS_N2)/combined_gas, 0) - n2comp, -1, gas_change_rate)
 
 		gasmix_power_ratio = min(max(plasmacomp + o2comp + co2comp + tritiumcomp + bzcomp - pluoxiumcomp - n2comp, 0), 1)
 
@@ -452,7 +461,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.
 	//Use of the second function improves the power gain imparted by using co2
-	power =  max(power - min(((power/500)**3) * powerloss_inhibitor, power * 0.83 * powerloss_inhibitor),1)
+	if(is_power_processing())
+		power =  max(power - min(((power/500)**3) * powerloss_inhibitor, power * 0.83 * powerloss_inhibitor),0)
 
 	if(power > POWER_PENALTY_THRESHOLD || damage > damage_penalty_point)
 


### PR DESCRIPTION
## About The Pull Request

Ports a TG feature setting a maximum to positive gas composition accumulation, which should stabilize the SM.

Removes unnecessary calculations in parse_gas_string, improving init performance.

## Why It's Good For The Game

~~The SM randomly delamming is super annoying, this might fix it.~~
Optimization + minor stabilization

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Unfortunately the SM bug is super random. However, I made this absolute jankfest of an SM setup that runs 95% CO2 with supercooling.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/3f31a15d-0295-4873-90bb-3bbe1a87aa6b)

It did actually recover from this.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/7131da37-c9d7-4218-987c-cda005e394ed)

To me, this implies it is somewhat stable since it didn't just delam anyway like it often could. However, the bug is incredibly inconsistent so I very well could be unaffected by this. What instead this testing evidence proves is that atmos still works, which is good.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/3f52176e-b9b7-488d-b8e6-ae8ec1857e29)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/037b6a45-a7cd-4458-b406-30f8acc7a3a8)

</details>

## Changelog
:cl:
tweak: The SM now has a max positive gas composition accumulation of 5% per tick. This should reduce SM instability, but from testing it does not appear to fix the notorious "SM delam bug".
fix: The SM's power will not update when it is not supposed to.
fix: Fixed double parsing of gas strings.
/:cl:
