### PR TITLE
Optimize turf init slightly

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -29,16 +29,26 @@
 	list_clear_nulls(.)
 
 /proc/get_open_turf_in_dir(atom/center, dir)
-	var/turf/open/T = get_ranged_target_turf(center, dir, 1)
+	var/turf/open/T = get_step(center, dir)
 	if(istype(T))
 		return T
 
 /proc/get_adjacent_open_turfs(atom/center)
-	. = list(get_open_turf_in_dir(center, NORTH),
-			get_open_turf_in_dir(center, SOUTH),
-			get_open_turf_in_dir(center, EAST),
-			get_open_turf_in_dir(center, WEST))
-	list_clear_nulls(.)
+	var/list/hand_back = list()
+	// Inlined get_open_turf_in_dir, just to be fast
+	var/turf/open/new_turf = get_step(center, NORTH)
+	if(istype(new_turf))
+		hand_back += new_turf
+	new_turf = get_step(center, SOUTH)
+	if(istype(new_turf))
+		hand_back += new_turf
+	new_turf = get_step(center, EAST)
+	if(istype(new_turf))
+		hand_back += new_turf
+	new_turf = get_step(center, WEST)
+	if(istype(new_turf))
+		hand_back += new_turf
+	return hand_back
 
 /proc/get_adjacent_open_areas(atom/center)
 	. = list()

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -85,6 +85,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/old_lighting_corner_SW = lighting_corner_SW
 	var/old_lighting_corner_NW = lighting_corner_NW
 	var/old_directional_opacity = directional_opacity
+	var/old_opacity = opacity
 
 	// Z-Mimic: copy above
 	var/old_above = above
@@ -150,6 +151,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 		for(var/turf/open/space/S in RANGE_TURFS(1, src)) //RANGE_TURFS is in code\__HELPERS\game.dm
 			S.update_starlight()
+
+	if(old_opacity != opacity && SSticker)
+		GLOB.cameranet.bareMajorChunkChange(src)
 
 	return new_turf
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -74,16 +74,13 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 
 	levelupdate()
 	if(length(smoothing_groups))
-		sortTim(smoothing_groups) //In case it's not properly ordered, let's avoid duplicate entries with the same values.
 		SET_BITFLAG_LIST(smoothing_groups)
 	if(length(canSmoothWith))
-		sortTim(canSmoothWith)
-		if(canSmoothWith[length(canSmoothWith)] > MAX_S_TURF) //If the last element is higher than the maximum turf-only value, then it must scan turf contents for smoothing targets.
+		if(max(canSmoothWith) > MAX_S_TURF) //If the last element is higher than the maximum turf-only value, then it must scan turf contents for smoothing targets.
 			smoothing_flags |= SMOOTH_OBJ
 		SET_BITFLAG_LIST(canSmoothWith)
 	if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 		QUEUE_SMOOTH(src)
-	visibilityChanged()
 
 	for(var/atom/movable/content as anything in src)
 		Entered(content, null)
@@ -142,7 +139,6 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		for(var/I in B.vars)
 			B.vars[I] = null
 		return
-	visibilityChanged()
 	QDEL_LIST(blueprint_data)
 	flags_1 &= ~INITIALIZED_1
 	requires_activation = FALSE

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -31,6 +31,18 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 	y &= ~(CHUNK_SIZE - 1)
 	return chunks["[x],[y],[z]"]
 
+/// A faster, turf only version of [/datum/cameranet/proc/majorChunkChange]
+/// For use in sensitive code, be careful with it
+/datum/cameranet/proc/bareMajorChunkChange(turf/changed)
+	var/x1 = max(1, changed.x - (CHUNK_SIZE / 2))
+	var/y1 = max(1, changed.y - (CHUNK_SIZE / 2))
+	var/x2 = min(world.maxx, changed.x + (CHUNK_SIZE / 2))
+	var/y2 = min(world.maxy, changed.y + (CHUNK_SIZE / 2))
+	for(var/x = x1; x <= x2; x += CHUNK_SIZE)
+		for(var/y = y1; y <= y2; y += CHUNK_SIZE)
+			var/datum/camerachunk/chunk = chunkGenerated(x, y, changed.z)
+			chunk?.hasChanged()
+
 // Returns the chunk in the x, y, z.
 // If there is no chunk, it creates a new chunk and returns that.
 /datum/cameranet/proc/getCameraChunk(x, y, z, a)


### PR DESCRIPTION
## About The Pull Request

Uses part of https://github.com/tgstation/tgstation/pull/73261

Saves 2s init

## Why It's Good For The Game

Faster init

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Carpet smoothing
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/db805182-cc3e-4226-b284-e261528d9af0)

Catwalks/lattices
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/39ccb04d-f3d3-4a12-941d-9eba4bcd2aec)

yayy smoothing
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/5c663dbd-66ea-47ac-8ed6-7b879500b3ca)

Cameranet working
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/7e6d1302-fb6a-4bcf-8ede-28e70e0e2bf5)

Adding a wall blocks things off.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/27571c14-99c8-4336-bb03-dfe2b0cc96a7)

</details>

## Changelog
:cl:
code: Slightly optimized turf init
/:cl:
