### PR TITLE
Avoid updating air on turf init when SSair is not started

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -123,12 +123,16 @@
 	return adjacent_turfs
 
 /atom/proc/air_update_turf(command = 0)
+	if(!SSair.initialized) // I'm sorry for polutting user code, I'll do 10 hail giacom's
+		return
 	if(!isturf(loc) && command)
 		return
 	var/turf/T = get_turf(loc)
 	T.air_update_turf(command)
 
 /turf/air_update_turf(command = 0)
+	if(!SSair.initialized) // I'm sorry for polutting user code, I'll do 10 hail giacom's
+		return
 	if(command)
 		ImmediateCalculateAdjacentTurfs()
 


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/76108

## Why It's Good For The Game

Faster init, I think this cuts more time for us since our turf adjacency is especially expensive. I got maybe 2-4 seconds off?

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Atmos working
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/c93c2a81-cfc3-4308-bf6d-004b2d609be1)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/923e528e-73bb-487a-bc2a-3a4ed1b03f37)


</details>

## Changelog
:cl:
code: Slightly optimized turf atmos init.
/:cl:
