### PR TITLE
Adds RCD Logging + minor fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1483,11 +1483,11 @@
 	return FALSE
 
 /obj/machinery/door/airlock/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_DECONSTRUCT)
-			to_chat(user, "<span class='notice'>You deconstruct the airlock.</span>")
-			qdel(src)
-			return TRUE
+	if(RCD_DECONSTRUCT == passed_mode)
+		to_chat(user, "<span class='notice'>You deconstruct the airlock.</span>")
+		log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		qdel(src)
+		return TRUE
 	return FALSE
 
 /obj/machinery/door/airlock/proc/note_type() //Returns a string representing the type of note pinned to this airlock

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1485,7 +1485,7 @@
 /obj/machinery/door/airlock/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(RCD_DECONSTRUCT == passed_mode)
 		to_chat(user, "<span class='notice'>You deconstruct the airlock.</span>")
-		log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has deconstructed [src] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		qdel(src)
 		return TRUE
 	return FALSE

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -350,7 +350,7 @@
 	switch(passed_mode)
 		if(RCD_DECONSTRUCT)
 			to_chat(user, "<span class='notice'>You deconstruct [src].</span>")
-			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			qdel(src)
 			return TRUE
 	return FALSE

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -350,6 +350,7 @@
 	switch(passed_mode)
 		if(RCD_DECONSTRUCT)
 			to_chat(user, "<span class='notice'>You deconstruct [src].</span>")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			qdel(src)
 			return TRUE
 	return FALSE

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -389,6 +389,9 @@
 		if(RCD_FLOORWALL)
 			balloon_alert(user, "You finish the wall.")
 			log_attack("[key_name(user)] has constructed a wall at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			var/overlapping_lattice = locate(/obj/structure/lattice) in get_turf(src)
+			if(overlapping_lattice)
+				qdel(overlapping_lattice) // Don't need lattice burried under the wall, or in the case of catwalk - on top of it.
 			T.PlaceOnTop(/turf/closed/wall)
 			qdel(src)
 			return TRUE

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -388,11 +388,13 @@
 	switch(passed_mode)
 		if(RCD_FLOORWALL)
 			balloon_alert(user, "You finish the wall.")
+			log_attack("[key_name(user)] has constructed a wall at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			T.PlaceOnTop(/turf/closed/wall)
 			qdel(src)
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			balloon_alert(user, "You deconstruct [src].")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			qdel(src)
 			return TRUE
 	return FALSE

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -388,7 +388,7 @@
 	switch(passed_mode)
 		if(RCD_FLOORWALL)
 			balloon_alert(user, "You finish the wall.")
-			log_attack("[key_name(user)] has constructed a wall at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has constructed a wall at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			var/overlapping_lattice = locate(/obj/structure/lattice) in get_turf(src)
 			if(overlapping_lattice)
 				qdel(overlapping_lattice) // Don't need lattice burried under the wall, or in the case of catwalk - on top of it.

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -397,7 +397,7 @@
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			balloon_alert(user, "You deconstruct [src].")
-			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			qdel(src)
 			return TRUE
 	return FALSE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -63,7 +63,7 @@
 	switch(passed_mode)
 		if(RCD_DECONSTRUCT)
 			to_chat(user, "<span class='notice'>You deconstruct the grille.</span>")
-			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			qdel(src)
 			return TRUE
 		if(RCD_WINDOWGRILLE)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -63,6 +63,7 @@
 	switch(passed_mode)
 		if(RCD_DECONSTRUCT)
 			to_chat(user, "<span class='notice'>You deconstruct the grille.</span>")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			qdel(src)
 			return TRUE
 		if(RCD_WINDOWGRILLE)
@@ -77,6 +78,7 @@
 				to_chat(user, "<span class='notice'>Already a window in this direction!.</span>")
 				return FALSE
 			to_chat(user, "<span class='notice'>You construct the window.</span>")
+			log_attack("[key_name(user)] has constructed a window at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			var/obj/structure/window/WD = new the_rcd.window_type(T, user.dir)
 			WD.setAnchored(TRUE)
 			return TRUE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -78,7 +78,7 @@
 				to_chat(user, "<span class='notice'>Already a window in this direction!.</span>")
 				return FALSE
 			to_chat(user, "<span class='notice'>You construct the window.</span>")
-			log_attack("[key_name(user)] has constructed a window at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has constructed a window at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			var/obj/structure/window/WD = new the_rcd.window_type(T, user.dir)
 			WD.setAnchored(TRUE)
 			return TRUE

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -150,10 +150,9 @@
 	return FALSE
 
 /obj/structure/ladder/unbreakable/rcd_act(mob/user, var/obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_DECONSTRUCT)
-			to_chat(user, "<span class='warning'>[src] seems to resist all attempts to deconstruct it!</span>")
-			return FALSE
+	if(RCD_DECONSTRUCT == passed_mode)
+		to_chat(user, "<span class='warning'>[src] seems to resist all attempts to deconstruct it!</span>")
+		return FALSE
 
 /obj/structure/ladder/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -138,17 +138,16 @@
 	return use(user)
 
 /obj/structure/ladder/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	switch(the_rcd.mode)
-		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 30, "cost" = 15)
+	if(the_rcd.mode == RCD_DECONSTRUCT)
+		return list("mode" = RCD_DECONSTRUCT, "delay" = 30, "cost" = 15)
 	return FALSE
 
 /obj/structure/ladder/rcd_act(mob/user, var/obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_DECONSTRUCT)
-			to_chat(user, "<span class='notice'>You deconstruct the ladder.</span>")
-			qdel(src)
-			return TRUE
+	if(passed_mode == RCD_DECONSTRUCT)
+		to_chat(user, "<span class='notice'>You deconstruct the ladder.</span>")
+		qdel(src)
+		return TRUE
+	return FALSE
 
 /obj/structure/ladder/unbreakable/rcd_act(mob/user, var/obj/item/construction/rcd/the_rcd, passed_mode)
 	switch(passed_mode)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -54,14 +54,15 @@
 /obj/structure/lattice/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_FLOORWALL)
 		return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
+	return FALSE
 
 /obj/structure/lattice/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	if(passed_mode == RCD_FLOORWALL)
+	if(passed_mode == RCD_FLOORWALL && isspaceturf(src.loc)) // Don't want it trying to place a tile over in-station catwalks.
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
+		log_attack("[key_name(user)] has constructed a floor over space at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 		var/turf/T = src.loc
-		if(isspaceturf(T))
-			T.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			return TRUE
+		T.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+		return TRUE
 	return FALSE
 
 /obj/structure/lattice/singularity_pull(S, current_size)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -59,7 +59,7 @@
 /obj/structure/lattice/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL && isspaceturf(src.loc)) // Don't want it trying to place a tile over in-station catwalks.
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
-		log_attack("[key_name(user)] has constructed a floor over space at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has constructed a floor over space at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		var/turf/T = src.loc
 		T.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -86,7 +86,7 @@
 /obj/structure/window/rcd_act(mob/user, var/obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_DECONSTRUCT)
 		to_chat(user, "<span class='notice'>You deconstruct the window.</span>")
-		log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has deconstructed [src] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		qdel(src)
 		return TRUE
 	return FALSE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -79,17 +79,16 @@
 	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, PROC_REF(can_be_rotated)),CALLBACK(src, PROC_REF(after_rotation)))
 
 /obj/structure/window/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	switch(the_rcd.mode)
-		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 5)
+	if(the_rcd.mode == RCD_DECONSTRUCT)
+		return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 5)
 	return FALSE
 
-/obj/structure/window/rcd_act(mob/user, var/obj/item/construction/rcd/the_rcd)
-	switch(the_rcd.mode)
-		if(RCD_DECONSTRUCT)
-			to_chat(user, "<span class='notice'>You deconstruct the window.</span>")
-			qdel(src)
-			return TRUE
+/obj/structure/window/rcd_act(mob/user, var/obj/item/construction/rcd/the_rcd, passed_mode)
+	if(passed_mode == RCD_DECONSTRUCT)
+		to_chat(user, "<span class='notice'>You deconstruct the window.</span>")
+		log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		qdel(src)
+		return TRUE
 	return FALSE
 
 /obj/structure/window/narsie_act()

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -291,7 +291,7 @@
 /turf/closed/wall/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_DECONSTRUCT)
 		to_chat(user, "<span class='notice'>You deconstruct the wall.</span>")
-		log_attack("[key_name(user)] has deconstructed [get_turf(src)] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has deconstructed [get_turf(src)] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		ScrapeAway()
 		return TRUE
 	return FALSE

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -284,17 +284,16 @@
 	dismantle_wall(1)
 
 /turf/closed/wall/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	switch(the_rcd.mode)
-		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 40, "cost" = 26)
+	if(the_rcd.mode == RCD_DECONSTRUCT)
+		return list("mode" = RCD_DECONSTRUCT, "delay" = 40, "cost" = 26)
 	return FALSE
 
 /turf/closed/wall/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_DECONSTRUCT)
-			to_chat(user, "<span class='notice'>You deconstruct the wall.</span>")
-			ScrapeAway()
-			return TRUE
+	if(passed_mode == RCD_DECONSTRUCT)
+		to_chat(user, "<span class='notice'>You deconstruct the wall.</span>")
+		log_attack("[key_name(user)] has deconstructed [get_turf(src)] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		ScrapeAway()
+		return TRUE
 	return FALSE
 
 /turf/closed/wall/proc/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8))

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -41,7 +41,7 @@
 /turf/open/chasm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
-		log_attack("[key_name(user)] has constructed a floor over a chasm at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has constructed a floor over a chasm at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -34,17 +34,16 @@
 	return FALSE
 
 /turf/open/chasm/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	switch(the_rcd.mode)
-		if(RCD_FLOORWALL)
-			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
+	if(the_rcd.mode == RCD_FLOORWALL)
+		return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
 	return FALSE
 
 /turf/open/chasm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_FLOORWALL)
-			to_chat(user, "<span class='notice'>You build a floor.</span>")
-			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			return TRUE
+	if(passed_mode == RCD_FLOORWALL)
+		to_chat(user, "<span class='notice'>You build a floor.</span>")
+		log_attack("[key_name(user)] has constructed a floor over a chasm at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+		return TRUE
 	return FALSE
 
 /turf/open/chasm/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -239,6 +239,9 @@
 		if(RCD_FLOORWALL)
 			to_chat(user, "<span class='notice'>You build a wall.</span>")
 			log_attack("[key_name(user)] has constructed a wall at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			var/overlapping_lattice = locate(/obj/structure/lattice) in get_turf(src)
+			if(overlapping_lattice)
+				qdel(overlapping_lattice) // Don't need lattice burried under the wall, or in the case of catwalk - on top of it.
 			PlaceOnTop(/turf/closed/wall)
 			return TRUE
 		if(RCD_LADDER)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -253,7 +253,7 @@
 			if(locate(/obj/machinery/door/airlock) in src)
 				return FALSE
 			to_chat(user, "<span class='notice'>You build an airlock.</span>")
-			log_attack("[key_name(user)] has constructed an airlock at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has constructed an airlock at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			var/obj/machinery/door/airlock/A = new the_rcd.airlock_type(src)
 			A.electronics = new /obj/item/electronics/airlock(A)
 			if(the_rcd.airlock_electronics)
@@ -271,14 +271,14 @@
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			to_chat(user, "<span class='notice'>You deconstruct [src].</span>")
-			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 			return TRUE
 		if(RCD_WINDOWGRILLE)
 			if(locate(/obj/structure/grille) in src)
 				return FALSE
 			to_chat(user, "<span class='notice'>You construct the grille.</span>")
-			log_attack("[key_name(user)] has constructed a grille at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has constructed a grille at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			var/obj/structure/grille/G = new(src)
 			G.anchored = TRUE
 			return TRUE

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -238,7 +238,7 @@
 	switch(passed_mode)
 		if(RCD_FLOORWALL)
 			to_chat(user, "<span class='notice'>You build a wall.</span>")
-			log_attack("[key_name(user)] has constructed a wall at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			log_attack("[key_name(user)] has constructed a wall at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			var/overlapping_lattice = locate(/obj/structure/lattice) in get_turf(src)
 			if(overlapping_lattice)
 				qdel(overlapping_lattice) // Don't need lattice burried under the wall, or in the case of catwalk - on top of it.

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -238,6 +238,7 @@
 	switch(passed_mode)
 		if(RCD_FLOORWALL)
 			to_chat(user, "<span class='notice'>You build a wall.</span>")
+			log_attack("[key_name(user)] has constructed a wall at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			PlaceOnTop(/turf/closed/wall)
 			return TRUE
 		if(RCD_LADDER)
@@ -249,6 +250,7 @@
 			if(locate(/obj/machinery/door/airlock) in src)
 				return FALSE
 			to_chat(user, "<span class='notice'>You build an airlock.</span>")
+			log_attack("[key_name(user)] has constructed an airlock at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			var/obj/machinery/door/airlock/A = new the_rcd.airlock_type(src)
 			A.electronics = new /obj/item/electronics/airlock(A)
 			if(the_rcd.airlock_electronics)
@@ -265,14 +267,15 @@
 			A.update_icon()
 			return TRUE
 		if(RCD_DECONSTRUCT)
-			if(ScrapeAway(flags = CHANGETURF_INHERIT_AIR) == src)
-				return FALSE
 			to_chat(user, "<span class='notice'>You deconstruct [src].</span>")
+			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+			ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 			return TRUE
 		if(RCD_WINDOWGRILLE)
 			if(locate(/obj/structure/grille) in src)
 				return FALSE
 			to_chat(user, "<span class='notice'>You construct the grille.</span>")
+			log_attack("[key_name(user)] has constructed a grille at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 			var/obj/structure/grille/G = new(src)
 			G.anchored = TRUE
 			return TRUE

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -270,9 +270,11 @@
 			A.update_icon()
 			return TRUE
 		if(RCD_DECONSTRUCT)
-			to_chat(user, "<span class='notice'>You deconstruct [src].</span>")
-			log_attack("[key_name(user)] has deconstructed [src] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
-			ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
+			var/previous_turf = initial(name)
+			if(!ScrapeAway(flags = CHANGETURF_INHERIT_AIR))
+				return FALSE
+			to_chat(user, "<span class='notice'>You deconstruct [previous_turf].</span>")
+			log_attack("[key_name(user)] has deconstructed [previous_turf] at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 			return TRUE
 		if(RCD_WINDOWGRILLE)
 			if(locate(/obj/structure/grille) in src)

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -156,7 +156,7 @@
 /turf/open/floor/plating/foam/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
-		log_attack("[key_name(user)] has constructed a floor over metalfoam plating at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has constructed a floor over metalfoam plating at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -156,6 +156,7 @@
 /turf/open/floor/plating/foam/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
+		log_attack("[key_name(user)] has constructed a floor over metalfoam plating at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
 		ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -57,17 +57,16 @@
 		STOP_PROCESSING(SSobj, src)
 
 /turf/open/lava/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	switch(the_rcd.mode)
-		if(RCD_FLOORWALL)
-			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
+	if(the_rcd.mode == RCD_FLOORWALL)
+		return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
 	return FALSE
 
 /turf/open/lava/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_FLOORWALL)
-			to_chat(user, "<span class='notice'>You build a floor.</span>")
-			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			return TRUE
+	if(passed_mode == RCD_FLOORWALL)
+		to_chat(user, "<span class='notice'>You build a floor.</span>")
+		log_attack("[key_name(user)] has constructed a floor over lava at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+		return TRUE
 	return FALSE
 
 /turf/open/lava/rust_heretic_act()

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -64,7 +64,7 @@
 /turf/open/lava/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
-		log_attack("[key_name(user)] has constructed a floor over lava at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has constructed a floor over lava at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -130,11 +130,11 @@
 	return FALSE
 
 /turf/open/openspace/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_FLOORWALL)
-			to_chat(user, "<span class='notice'>You build a floor.</span>")
-			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			return TRUE
+	if(passed_mode == RCD_FLOORWALL)
+		to_chat(user, "<span class='notice'>You build a floor.</span>")
+		log_attack("[key_name(user)] has constructed a floor over open space at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+		return TRUE
 	return FALSE
 
 /turf/open/openspace/rust_heretic_act()

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -132,7 +132,7 @@
 /turf/open/openspace/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
-		log_attack("[key_name(user)] has constructed a floor over open space at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has constructed a floor over open space at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -237,7 +237,7 @@
 /turf/open/space/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, "<span class='notice'>You build a floor.</span>")
-		log_attack("[key_name(user)] has constructed a floor over space at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		log_attack("[key_name(user)] has constructed a floor over space at [loc_name(src)] using [format_text(initial(the_rcd.name))]")
 		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		return TRUE
 	return FALSE

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -226,21 +226,20 @@
 	if(!CanBuildHere())
 		return FALSE
 
-	switch(the_rcd.mode)
-		if(RCD_FLOORWALL)
-			var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-			if(L)
-				return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
-			else
-				return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
+	if(the_rcd.mode == RCD_FLOORWALL)
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+		if(L)
+			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
+		else
+			return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
 	return FALSE
 
 /turf/open/space/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
-	switch(passed_mode)
-		if(RCD_FLOORWALL)
-			to_chat(user, "<span class='notice'>You build a floor.</span>")
-			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			return TRUE
+	if(passed_mode == RCD_FLOORWALL)
+		to_chat(user, "<span class='notice'>You build a floor.</span>")
+		log_attack("[key_name(user)] has constructed a floor over space at [loc_name(get_turf(src))] using [format_text(initial(the_rcd.name))]")
+		PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+		return TRUE
 	return FALSE
 
 /turf/open/space/rust_heretic_act()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds logging to the majority of the RCD's functions, *the important ones at least*.

Building a wall ontop of a lattice will now destroy the lattice, no more overlayer catwalks on top of walls. ~~At least via an RCD, it's probably still doable with normal building - but that's an issue for another day.~~

Slightly changes the code to be a bit less inconsistent in how it's written; this shouldn't effect how it functions, and I noticed no obvious changes when testing.


- [x] Initial PR
- [x] Fix the ability to place walls ontop of overtile catwalks using an RCD. (This results in the catwalk being *over* the wall when it's done.)
- [x] Double check I didn't break literally everything to do with RCDs.
- [x] Finish PR description and gather testing evidence.

~~Cry because my code is probably bad and I'll need to fix it.~~

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Useful information for admins. RCDs are semi-frequently used for tiding and other potentially rulebreaking purposes. This mostly applies to deconstruction specifically. However, if we're going to log deconstruction, we need to log construction too. We'd need to be able to tell if someone is replacing things they're deconstructing after all.

Stacking lattices on top of walls is not good.

I believe the code is now a little easier to read - also removed a check that seems to have done nothing other than cause one of the to_chat messages to always fail.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Here's a clip of me verifying that all of the RCD functions still work as they should:
https://streamable.com/z5pz3m

And here's an example of the logging:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/13b2e655-490f-4cbf-ab5f-64e4bf19edbb)


</details>

## Changelog
:cl:
admin: Adds logging to the vast majority of the RCD's functions.
fix: You can no longer place walls overlapping with lattices using an RCD. Attempting to do so will now destroy the lattice.
fix: The to_chat message given by an RCD when deconstructing a floor turf will now actually be hit instead of returning early.
fix: Fixes RCDs not consuming matter when deconstructing floor turfs.
code: Makes RCD code a tiny bit less weird.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
