### PR TITLE
[Bugfix] No more Temp-orary combat problems

### DIFF
--- a/code/game/objects/effects/icons.dm
+++ b/code/game/objects/effects/icons.dm
@@ -1,3 +1,9 @@
+//This particular effect should never be visible in a context menu
+// or clickable, unlike other effects
+/obj/effect/icon
+	name = ""
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
 /obj/effect/icon/Initialize(mapload, icon/render_source)
 	. = ..()
 	overlays = list(render_source)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #9363 

Ever think you're going crazy while clicking something and you see something called "temp"?

Welcome to the fix for that; this was partly in due to an optimization to attack effects (part of #9265), which converted it to an atom based on `/obj/effect`.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unexpected side effect of an optimization PR, and one that is not welcome at all. Suppressing that side effect is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Despite all the code comments in the main file defining `/obj/effect`, effects are in fact clickable for the most part. It's a type that is derived by **hundreds** of things, whether they should be or not. 

The sheer amount of things derived means the fix is easier to just apply to the specific subtype at the moment, so I added this code to the definition of `/obj/effect/icon` (what the combat animations use now)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/eb2c109a-7bc8-49db-a7c2-1183778a1af5)


__Note: The biggest and most reliable indicator of temps is the bottom left corner of the client, as apparent in these videos.__

### ISSUE PRIOR TO FIX:

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/4ee3aeb9-4f58-4fd5-b150-0c9c4a699c60


### NOW WITH FIX:

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/1d80c61b-4755-4fc2-9a2a-4f21f04cb78f

</details>

## Changelog
:cl:
fix: Attack effect objects (the infamous temp) are no longer attackable and will not block clicks anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
