### PR TITLE
Makes the scientist crew objective no longer pick roundstart researched designs

### DIFF
--- a/code/modules/crew_objectives/science_objectives.dm
+++ b/code/modules/crew_objectives/science_objectives.dm
@@ -27,6 +27,7 @@
 
 /datum/objective/crew/research //inspired by old hippie's research level objective.
 	var/datum/design/target_design
+	var/static/list/possible_target_designs_list
 	explanation_text = "Make sure the research for (something broke, yell on GitHub) is available on the R&D server by the end of the shift."
 	jobs = list(
 		JOB_NAME_RESEARCHDIRECTOR,
@@ -35,8 +36,19 @@
 
 /datum/objective/crew/research/New()
 	. = ..()
-	target_design = pick(subtypesof(/datum/design))
+	if(!possible_target_designs_list)
+		fill_out_target_list()
+	target_design = pick(possible_target_designs_list)
 	update_explanation_text()
+
+/datum/objective/crew/research/proc/fill_out_target_list()
+	possible_target_designs_list = list()
+	var/list/temp_list = subtypesof(/datum/design)
+	for(var/found_design in temp_list)
+		var/datum/design/temp_design = new found_design
+		var/list/category_list = temp_design.category
+		if(!("initial" in category_list))
+			possible_target_designs_list.Add(found_design)
 
 /datum/objective/crew/research/update_explanation_text()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the crew objective for scientists, which requires you to have x design researched by the end of the shift, only pick designs that aren't automatically researched at roundstart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The scientist crew objective is no longer nonsensical.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Screenshot from testing, it disregards the design that has "initial" in its categories

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/1c13cdde-90a2-4ffa-915e-cade94bcd16f)

Normal objective get

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/c6b09962-705f-41ed-8b71-cedf9561e201)

</details>

## Changelog
:cl:
fix: Fixed the Scientist crew objective targeting roundstart researched designs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
