### PR TITLE
Puts the maximum metabolization volume to liver

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -255,9 +255,9 @@
 /datum/symptom/heal/metabolism/Heal(mob/living/carbon/C, datum/disease/advance/A, actual_power)
 	if(!istype(C))
 		return
-	C.reagents.metabolize(C, can_overdose=TRUE, metabolization_maximum=max(5, A.resistance*2)) //this works even without a liver; it's intentional since the virus is metabolizing by itself
+	C.reagents.metabolize(C, can_overdose=TRUE, metabolization_maximum=max(5, A.resistance*2), hurts_liver=FALSE) //this works even without a liver; it's intentional since the virus is metabolizing by itself
 	if(triple_metabolism)
-		C.reagents.metabolize(C, can_overdose=TRUE, metabolization_maximum=max(5, A.resistance*2))
+		C.reagents.metabolize(C, can_overdose=TRUE, metabolization_maximum=max(5, A.resistance*2), hurts_liver=FALSE)
 	C.overeatduration = max(C.overeatduration - 2, 0)
 	var/lost_nutrition = 9 - (reduced_hunger * 5)
 	C.adjust_nutrition(-lost_nutrition * HUNGER_FACTOR) //Hunger depletes at 10x the normal speed

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -240,7 +240,8 @@
 	var/reduced_hunger = FALSE
 	desc = "The virus causes the host's metabolism to accelerate rapidly, making them process chemicals twice as fast,\
 	 but also causing increased hunger."
-	threshold_desc = "<b>Stealth 3:</b> Reduces hunger rate.<br>\
+	threshold_desc = "<b>Resistance N*2:</b> Determines the maximum volume of chemicals within its host the symptom can metabolize. (Minimum 5u).<br>\
+					  <b>Stealth 3:</b> Reduces hunger rate.<br>\
 					  <b>Stage Speed 10:</b> Chemical metabolization is tripled instead of doubled."
 
 /datum/symptom/heal/metabolism/Start(datum/disease/advance/A)
@@ -254,9 +255,9 @@
 /datum/symptom/heal/metabolism/Heal(mob/living/carbon/C, datum/disease/advance/A, actual_power)
 	if(!istype(C))
 		return
-	C.reagents.metabolize(C, can_overdose=TRUE) //this works even without a liver; it's intentional since the virus is metabolizing by itself
+	C.reagents.metabolize(C, can_overdose=TRUE, metabolization_maximum=max(5, A.resistance*2)) //this works even without a liver; it's intentional since the virus is metabolizing by itself
 	if(triple_metabolism)
-		C.reagents.metabolize(C, can_overdose=TRUE)
+		C.reagents.metabolize(C, can_overdose=TRUE, metabolization_maximum=max(5, A.resistance*2))
 	C.overeatduration = max(C.overeatduration - 2, 0)
 	var/lost_nutrition = 9 - (reduced_hunger * 5)
 	C.adjust_nutrition(-lost_nutrition * HUNGER_FACTOR) //Hunger depletes at 10x the normal speed

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -322,7 +322,7 @@
 				if(liverless && !R.self_consuming) //need to be metabolized
 					continue
 				// TODO: We need a check "can_metabolize()", but that'll be done in the future chem refactor...
-				if(liver_dependent_chem)
+				if(liver_dependent_chem && !istype(R, /datum/reagent/blood)) // blood is 5u. meh
 					metabolization_maximum -= R.metabolization_rate // we can't micro-manage 10u-15u thing, but negative metabolization_maximum will penaltise people
 				if(!R.metabolizing)
 					R.metabolizing = TRUE

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -296,7 +296,7 @@
 	R.handle_reactions()
 	return amount
 
-/datum/reagents/proc/metabolize(mob/living/carbon/C, can_overdose = FALSE, liverless = FALSE, metabolization_maximum=5)
+/datum/reagents/proc/metabolize(mob/living/carbon/C, can_overdose = FALSE, liverless = FALSE, metabolization_maximum = 5, hurts_liver = TRUE)
 	if(C?.dna?.species && (NOREAGENTS in C.dna.species.species_traits))
 		return 0
 	var/list/cached_reagents = reagent_list
@@ -368,7 +368,7 @@
 						else
 							SEND_SIGNAL(C, COMSIG_CLEAR_MOOD_EVENT, "[R.type]_overdose")
 		addiction_tick++
-	if(metabolization_maximum < 0) // your liver overprocessed.
+	if(hurts_liver && metabolization_maximum < 0) // your liver overprocessed.
 		var/liver_punishment = clamp(metabolization_maximum*-0.1, 0.1, 10)
 		C.adjustOrganLoss(ORGAN_SLOT_LIVER, liver_punishment)
 	if(C && need_mob_update) //some of the metabolized reagents had effects on the mob that requires some updates.

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -19,6 +19,7 @@
 	var/toxTolerance = LIVER_DEFAULT_TOX_TOLERANCE//maximum amount of toxins the liver can just shrug off
 	var/toxLethality = LIVER_DEFAULT_TOX_LETHALITY//affects how much damage toxins do to the liver
 	var/filterToxins = TRUE //whether to filter toxins
+	var/liver_metabolization_maximum = 5
 
 #define HAS_SILENT_TOXIN 0 //don't provide a feedback message if this is the only toxin present
 #define HAS_NO_TOXIN 1
@@ -46,7 +47,7 @@
 							provide_pain_message = T.silent_toxin ? HAS_SILENT_TOXIN : HAS_PAINFUL_TOXIN
 
 			//metabolize reagents
-			C.reagents.metabolize(C, can_overdose=TRUE)
+			C.reagents.metabolize(C, can_overdose=TRUE, metabolization_maximum=liver_metabolization_maximum)
 
 			if(provide_pain_message && damage > 10 && prob(damage/3))//the higher the damage the higher the probability
 				to_chat(C, "<span class='warning'>You feel a dull pain in your abdomen.</span>")

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -19,6 +19,8 @@
 	var/toxTolerance = LIVER_DEFAULT_TOX_TOLERANCE//maximum amount of toxins the liver can just shrug off
 	var/toxLethality = LIVER_DEFAULT_TOX_LETHALITY//affects how much damage toxins do to the liver
 	var/filterToxins = TRUE //whether to filter toxins
+
+	/// this determines the maximum units of multiple chemicals a liver can handle.
 	var/liver_metabolization_maximum = 5
 
 #define HAS_SILENT_TOXIN 0 //don't provide a feedback message if this is the only toxin present
@@ -104,6 +106,7 @@
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	toxTolerance = 15 //can shrug off up to 15u of toxins
 	toxLethality = 0.008 //20% less damage than a normal liver
+	liver_metabolization_maximum = 10
 
 /obj/item/organ/liver/cybernetic/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Puts the maximum metabolization volume to liver

You need 250 ticks to metabolize 100u of Water.
But you only need 1 tick to metabolize 0.1u of 1000 different chemicals.
This is surely weird thing. a liver can't handle those things that much.

* all livers now have 5u metabolization maximum
* If your body system metabolized more than 5u...
  * your liver will ignore next chemical to metabolize at 80% chance - this means your liver will work anyway at 20% chance
  * your liver will take damage based on the overprocessed amount (if your liver metabolized 10u, 5u is the overprocess. 0.5 will be the liver damage)
* Chemicals will be randomly metabolized.
* Metabolic Boost symptom is somehow related. its Resistance stat will contribute the chemical metabolisation volume. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mixing chems is a nice thing, but we should put a limitation on it.
like I said, you shouldn't metabolize 1000 chemicals in a single tick.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/74eeb61f-8c9b-4e04-bb2b-6e5c210d3ceb)

after the red line, it means liver hard-worked.


![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d5ecf715-7f6a-42e1-89fd-5f4d54af0642)

* "By 3.24" means its leftover. It could have metabolize 3.24u more.
* The medical scanner says the first chem as Salbutamol, but consuming order is shuffled. If you scan yourself again, the order is the same.
* (they didn't take liver damage. it's debug message error)

## Changelog
:cl:
balance: Chemical metabolization is now randomized. Health scanner will still tell which one was given first, but the metabolization order is shuffled.
balance: All livers now have 5u of Metabolization Maximum. If your liver metabolizes too many multiple chems in a tick (i.e. 100 chems = 40u metabolization unit), your liver will ignore other chemicals at 80% chance. This is why the metabolization order is now shuffled. If your liver overprocessed chemicals, it takes minor liver damage.
tweak: virus symptom Metabolic Boost - Resistance stat will contribute to the chemical metabolisation volume. 
add: Advanced cyber liver has 10u of metabolization maximum
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
