### PR TITLE
Limit icon_states checks in spritesheet creation to UNIT_TESTS (saves 3s init time)

### DIFF
--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -359,6 +359,9 @@
 			var/greyscale_colors = initial(item.greyscale_colors)
 			if (greyscale_config && greyscale_colors)
 				icon_file = SSgreyscale.GetColoredIconByType(greyscale_config, greyscale_colors)
+			else if(ispath(item, /obj/item/bodypart)) // mmm snowflake limbcode as usual
+				var/obj/item/bodypart/body_part = item
+				icon_file = initial(body_part.static_icon)
 			else
 				icon_file = initial(item.icon)
 

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -330,9 +330,11 @@
 		if(initial(D.research_icon) && initial(D.research_icon_state)) //If the design has an icon replacement skip the rest
 			icon_file = initial(D.research_icon)
 			icon_state = initial(D.research_icon_state)
+			#ifdef UNIT_TESTS
 			if(!(icon_state in icon_states(icon_file)))
-				warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
+				stack_trace("design [D] with icon '[icon_file]' missing state '[icon_state]'")
 				continue
+			#endif
 			I = icon(icon_file, icon_state, SOUTH)
 
 		else
@@ -361,10 +363,11 @@
 				icon_file = initial(item.icon)
 
 			icon_state = initial(item.icon_state)
-
+			#ifdef UNIT_TESTS
 			if(!(icon_state in icon_states(icon_file)))
-				warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
+				stack_trace("design [D] with icon '[icon_file]' missing state '[icon_state]'")
 				continue
+			#endif
 			I = icon(icon_file, icon_state, SOUTH)
 
 			// computers (and snowflakes) get their screen and keyboard sprites
@@ -412,23 +415,25 @@
 		else
 			icon_file = initial(item.icon)
 		var/icon_state = initial(item.icon_state)
-		var/icon/I
 
+		#ifdef UNIT_TESTS
 		var/icon_states_list = icon_states(icon_file)
-		if(icon_state in icon_states_list)
-			I = icon(icon_file, icon_state, SOUTH)
-			var/c = initial(item.color)
-			if (!isnull(c) && c != "#FFFFFF")
-				I.Blend(c, ICON_MULTIPLY)
-		else
+		if (!(icon_state in icon_states_list))
 			var/icon_states_string
 			for (var/an_icon_state in icon_states_list)
 				if (!icon_states_string)
 					icon_states_string = "[json_encode(an_icon_state)](\ref[an_icon_state])"
 				else
 					icon_states_string += ", [json_encode(an_icon_state)](\ref[an_icon_state])"
+
 			stack_trace("[item] does not have a valid icon state, icon=[icon_file], icon_state=[json_encode(icon_state)](\ref[icon_state]), icon_states=[icon_states_string]")
-			I = icon('icons/turf/floors.dmi', "", SOUTH)
+			continue
+		#endif
+
+		var/icon/I = icon(icon_file, icon_state, SOUTH)
+		var/c = initial(item.color)
+		if (!isnull(c) && c != "#FFFFFF")
+			I.Blend(c, ICON_MULTIPLY)
 
 		var/imgid = replacetext(replacetext("[item]", "/obj/item/", ""), "/", "-")
 
@@ -453,15 +458,10 @@
 
 		var/icon_file = initial(A.icon)
 		var/icon_state = initial(A.icon_state_preview) || initial(A.icon_state)
-		var/icon/I
 
+		#ifdef UNIT_TESTS
 		var/icon_states_list = icon_states(icon_file)
-		if(icon_state in icon_states_list)
-			I = icon(icon_file, icon_state, SOUTH, 1)
-			var/c = initial(A.color)
-			if (!isnull(c) && c != "#FFFFFF") // there're colourful burgers...
-				I.Blend(c, ICON_MULTIPLY)
-		else // Failed to find an icon: build an error message
+		if (!(icon_state in icon_states_list))
 			var/icon_states_string
 			for (var/an_icon_state in icon_states_list)
 				if (!icon_states_string)
@@ -469,7 +469,13 @@
 				else
 					icon_states_string += ", [json_encode(an_icon_state)](\ref[an_icon_state])"
 			stack_trace("[A] does not have a valid icon state, icon=[icon_file], icon_state=[json_encode(icon_state)](\ref[icon_state]), icon_states=[icon_states_string]")
-			I = icon('icons/turf/floors.dmi', "", SOUTH)
+			continue
+		#endif
+
+		var/icon/I = icon(icon_file, icon_state, SOUTH)
+		var/c = initial(A.color)
+		if (!isnull(c) && c != "#FFFFFF")
+			I.Blend(c, ICON_MULTIPLY)
 		var/imgid = replacetext(copytext("[A]", 2), "/", "-")
 
 		if(I)

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -16,8 +16,8 @@
 	limb_id = "robotic"
 	attack_verb = list("slapped", "punched")
 	item_state = "buildpipe"
-	static_icon =  'icons/mob/augmentation/augments.dmi'
-	icon = null
+	static_icon = 'icons/mob/augmentation/augments.dmi'
+	icon = 'icons/mob/augmentation/augments.dmi'
 	flags_1 = CONDUCT_1
 	icon_state = "borg_l_arm"
 	is_dimorphic = FALSE
@@ -41,8 +41,8 @@
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	attack_verb = list("slapped", "punched")
 	item_state = "buildpipe"
-	static_icon =  'icons/mob/augmentation/augments.dmi'
-	icon = null
+	static_icon = 'icons/mob/augmentation/augments.dmi'
+	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
 	flags_1 = CONDUCT_1
 	icon_state = "borg_r_arm"
@@ -67,8 +67,8 @@
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	attack_verb = list("kicked", "stomped")
 	item_state = "buildpipe"
-	static_icon =  'icons/mob/augmentation/augments.dmi'
-	icon = null
+	static_icon = 'icons/mob/augmentation/augments.dmi'
+	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
 	flags_1 = CONDUCT_1
 	icon_state = "borg_l_leg"
@@ -93,8 +93,8 @@
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	attack_verb = list("kicked", "stomped")
 	item_state = "buildpipe"
-	static_icon =  'icons/mob/augmentation/augments.dmi'
-	icon = null
+	static_icon = 'icons/mob/augmentation/augments.dmi'
+	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
 	flags_1 = CONDUCT_1
 	icon_state = "borg_r_leg"
@@ -118,8 +118,8 @@
 	name = "cyborg torso"
 	desc = "A heavily reinforced case containing cyborg logic boards, with space for a standard power cell."
 	item_state = "buildpipe"
-	static_icon =  'icons/mob/augmentation/augments.dmi'
-	icon = null
+	static_icon = 'icons/mob/augmentation/augments.dmi'
+	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
 	flags_1 = CONDUCT_1
 	icon_state = "borg_chest"


### PR DESCRIPTION
## About The Pull Request

Ports
- https://github.com/tgstation/tgstation/pull/69635

Upgrades the warnings() there to stack_trace.

## Why It's Good For The Game

Lower init time

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Fixed cyborg parts
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/92b256d6-3dcb-4e66-87f9-cdfcb58beab0)


![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/a7bb38de-03e3-4a9c-a7fc-437573e1bdae)

</details>

## Changelog
:cl:
code: Optimized asset initialization, saving ~3sec init.
fix: Fixed cyborg parts and human limbs not generating icons in the R&D console properly.
/:cl: