### PR TITLE
Micro-optimize turf and atom init

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -281,7 +281,9 @@
 
 	orbiters = null // The component is attached to us normaly and will be deleted elsewhere
 
-	LAZYCLEARLIST(overlays)
+	// Checking length(overlays) before cutting has significant speed benefits
+	if (length(overlays))
+		overlays.Cut()
 	LAZYNULL(managed_overlays)
 
 	QDEL_NULL(light)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -69,8 +69,8 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 
 	// by default, vis_contents is inherited from the turf that was here before.
 	// Checking length(vis_contents) in a proc this hot has huge wins for performance.
-	if (length(vis_contents))
-		vis_contents.Cut()
+	//if (length(vis_contents)) - this doesn't seem to help performance on Bee
+	vis_contents.Cut()
 
 	assemble_baseturfs()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -67,8 +67,10 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	flags_1 |= INITIALIZED_1
 
-	// by default, vis_contents is inherited from the turf that was here before
-	vis_contents.Cut()
+	// by default, vis_contents is inherited from the turf that was here before.
+	// Checking length(vis_contents) in a proc this hot has huge wins for performance.
+	if (length(vis_contents))
+		vis_contents.Cut()
 
 	assemble_baseturfs()
 
@@ -144,7 +146,8 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 	requires_activation = FALSE
 	..()
 
-	vis_contents.Cut()
+	if (length(vis_contents))
+		vis_contents.Cut()
 
 /// WARNING WARNING
 /// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS


### PR DESCRIPTION
## About The Pull Request

I excluded the turf initialize optimization since it actually lost us time and marked it as such in code.

Ports
- https://github.com/tgstation/tgstation/pull/71046

But not the windoor thing because I already made a fix for that

## Why It's Good For The Game

Init times

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/4b52b145-3f12-48d6-940a-2b32ea30d6c1)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/4946b4ee-117d-45ce-aef2-57afc2622961)

</details>

## Changelog
:cl:
code: Saves between ~18ms init time by optimizing turf destroy and atom destroy.
/:cl:

