### PR TITLE
Microop RegisterSignal

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -95,28 +95,26 @@
 	var/list/procs = signal_procs
 	if(!procs)
 		signal_procs = procs = list()
-	if(!procs[target])
-		procs[target] = list()
+	var/list/target_procs = procs[target] || (procs[target] = list())
 	var/list/lookup = target.comp_lookup
 	if(!lookup)
 		target.comp_lookup = lookup = list()
 
-	var/list/sig_types = islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)
-	for(var/sig_type in sig_types)
-		if(!override && procs[target][sig_type])
+	for(var/sig_type in (islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)))
+		if(!override && target_procs[sig_type])
 			stack_trace("[sig_type] overridden on [target.type]. Use override = TRUE to suppress this warning")
 
-		procs[target][sig_type] = proctype
+		target_procs[sig_type] = proctype
+		var/list/looked_up = lookup[sig_type]
 
-		if(!lookup[sig_type]) // Nothing has registered here yet
+		if(!looked_up) // Nothing has registered here yet
 			lookup[sig_type] = src
-		else if(lookup[sig_type] == src) // We already registered here
+		else if(looked_up == src) // We already registered here
 			continue
-		else if(!length(lookup[sig_type])) // One other thing registered here
-			lookup[sig_type] = list(lookup[sig_type]=TRUE)
-			lookup[sig_type][src] = TRUE
+		else if(!length(looked_up)) // One other thing registered here
+			lookup[sig_type] = list((looked_up) = TRUE, (src) = TRUE)
 		else // Many other things have registered here
-			lookup[sig_type][src] = TRUE
+			looked_up[src] = TRUE
 
 /datum/proc/UnregisterSignal(datum/target, sig_type_or_types)
 	var/list/lookup = target.comp_lookup


### PR DESCRIPTION
## About The Pull Request

Ports
- https://github.com/tgstation/tgstation/pull/69638

Saves 60ms init. Not sure how TG managed to save 300ms. They probably just have more signals registered.

## Why It's Good For The Game

Init times

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/7755cccb-0388-437b-a4da-5ac6113aef71)

</details>

## Changelog
:cl:
code: Micro-optimized signal registration, saving 60ms init.
/:cl: