### PR TITLE
Adds proper logging to emagged recycler crushing

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -13,6 +13,7 @@
 	var/safety_mode = FALSE // Temporarily stops machine if it detects a mob
 	var/icon_name = "grinder-o"
 	var/blood = 0
+	var/emagged_by = null // Used for logging
 	var/eat_dir = WEST
 	var/amount_produced = 50
 	var/crush_damage = 1000
@@ -74,6 +75,8 @@
 		update_appearance()
 	playsound(src, "sparks", 75, 1, -1)
 	to_chat(user, "<span class='notice'>You use the cryptographic sequencer on [src].</span>")
+	if(user)
+		emagged_by = key_name(user) // key_name is collected here instead of when it's logged so that it gets their current mob name, not whatever future mob they may have
 
 /obj/machinery/recycler/update_icon()
 	..()
@@ -190,6 +193,7 @@
 	// Instantly lie down, also go unconscious from the pain, before you die.
 	L.Unconscious(100)
 	L.adjustBruteLoss(crush_damage)
+	L.log_message("has been crushed by a recycler that was emagged by [(emagged_by ? emagged_by : "nobody")]", LOG_ATTACK, color="red")
 	if(L.stat == DEAD && (L.butcher_results || L.guaranteed_butcher_results))
 		var/datum/component/butchering/butchering = GetComponent(/datum/component/butchering)
 		butchering.Butcher(src,L)

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -193,7 +193,7 @@
 	// Instantly lie down, also go unconscious from the pain, before you die.
 	L.Unconscious(100)
 	L.adjustBruteLoss(crush_damage)
-	L.log_message("has been crushed by a recycler that was emagged by [(emagged_by ? emagged_by : "nobody")]", LOG_ATTACK, color="red")
+	L.log_message("has been crushed by a recycler that was emagged by [(emagged_by || "nobody")]", LOG_ATTACK, color="red")
 	if(L.stat == DEAD && (L.butcher_results || L.guaranteed_butcher_results))
 		var/datum/component/butchering/butchering = GetComponent(/datum/component/butchering)
 		butchering.Butcher(src,L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds proper logging to someone being crushed by a recycler. Previously this was only really doable by checking for forced say logs triggered by a recycler crushing someone, which isn't ideal.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ooooooh you want proper logging in your atmospheric simulator.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
The "by nobody" line is due to admin proc calls and shouldn't happen under normal circumstances.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/a32f9f10-0ff4-4d23-8ecd-c3716cd6067c)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/42cb3606-7eef-41ba-9c4e-48973ba32487)

</details>

## Changelog
:cl:
admin: Adds logging for when people are crushed by an emagged recycler
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
