### PR TITLE
Cryoed antags now display as so on the roundend report

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -619,7 +619,9 @@
 	var/jobtext_custom = get_custom_title_from_id(ply) // support the custom job title to the roundend report
 
 	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext][jobtext_custom] and"
-	if(ply.current)
+	if(ply.cryoed)
+		text += " <span class='bluetext'>cryoed</span>"
+	else if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " <span class='redtext'>died</span>"
 		else

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -620,7 +620,7 @@
 
 	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext][jobtext_custom] and"
 	if(ply.cryoed)
-		text += " <span class='bluetext'>cryoed</span>"
+		text += " <span class='bluetext'>entered cryosleep</span>"
 	else if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " <span class='redtext'>died</span>"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -77,6 +77,8 @@
 	/// your bank account id in your mind
 	var/account_id
 
+	var/cryoed = FALSE
+
 /datum/mind/New(var/key)
 	src.key = key
 	soulOwner = src

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -338,6 +338,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		else
 			mob_occupant.ghostize(TRUE,SENTIENCE_ERASE)
 	if(mob_occupant.mind)
+		mob_occupant.mind.cryoed = TRUE
 		SEND_SIGNAL(mob_occupant.mind, COMSIG_MIND_CRYOED)
 	QDEL_NULL(occupant)
 	open_machine()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so, if someone on the roundend screen cryoes, it'll say so instead of "had their body destroyed"

## Why It's Good For The Game

useful info

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-07-27-1690491797](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/4a2a430f-f2e3-4112-921c-3bf7c6e51213)

</details>

## Changelog
:cl:
tweak:? Cryoed antags now display as so on the roundend report, rather than as "having their body destrpyed"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
