### PR TITLE
Add tracy support and early world init hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ Temporary Items
 
 # Common build tooling, C B T
 !/tools/build
+
+# byond-tracy
+prof.dll

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ Temporary Items
 
 # byond-tracy
 prof.dll
+libprof.so

--- a/beestation.dme
+++ b/beestation.dme
@@ -3938,6 +3938,7 @@
 #include "code\modules\xenoarchaeology\traits\xenoartifact_traits.dm"
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
+#include "code\ze_genesis_call\genesis_call.dm"
 #include "interface\interface.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -31,6 +31,11 @@
 //#define VISUALIZE_ACTIVE_TURFS	//Highlights atmos active turfs in green
 #endif //ifdef TESTING
 
+/// Enables BYOND TRACY, which allows profiling using Tracy.
+/// The prof.dll/libprof.so must be built and placed in the repo folder.
+/// https://github.com/mafemergency/byond-tracy
+//#define USE_BYOND_TRACY
+
 /////////////////////// ZMIMIC
 
 ///Enables Multi-Z lighting

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -2,6 +2,45 @@
 
 GLOBAL_VAR(restart_counter)
 
+/**
+ * WORLD INITIALIZATION
+ * THIS IS THE INIT ORDER:
+ *
+ * BYOND =>
+ * - (secret init native) =>
+ *   - world.Genesis() =>
+ *     - world.init_byond_tracy()
+ *   - (/static variable inits, reverse declaration order)
+ * - Master/New()
+ * - (all pre-mapped atoms) /atom/New()
+ * - world.New()
+ *
+ * Now listen up because I want to make something clear:
+ * If something is not in this list it should almost definitely be handled by a subsystem Initialize()ing
+ * If whatever it is that needs doing doesn't fit in a subsystem you probably aren't trying hard enough tbhfam
+ *
+ * GOT IT MEMORIZED?
+ * - Dominion/Cyberboss
+ */
+
+/**
+ * THIS !!!SINGLE!!! PROC IS WHERE ANY FORM OF INIITIALIZATION THAT CAN'T BE PERFORMED IN MASTER/NEW() IS DONE
+ * NOWHERE THE FUCK ELSE
+ * I DON'T CARE HOW MANY LAYERS OF DEBUG/PROFILE/TRACE WE HAVE, YOU JUST HAVE TO DEAL WITH THIS PROC EXISTING
+ * I'M NOT EVEN GOING TO TELL YOU WHERE IT'S CALLED FROM BECAUSE I'M DECLARING THAT FORBIDDEN KNOWLEDGE
+ * SO HELP ME GOD IF I FIND ABSTRACTION LAYERS OVER THIS!
+ */
+/world/proc/Genesis(tracy_initialized = FALSE)
+	#ifdef USE_BYOND_TRACY
+	#warn USE_BYOND_TRACY is enabled
+	if(!tracy_initialized)
+		init_byond_tracy()
+		Genesis(tracy_initialized = TRUE)
+		return
+	#endif
+	// Anything else that needs to happen before /world/New() goes here.
+	// On TG this includes debugger init and intializing Master, but for now we'll leave that as a BYOND global.
+
 //This happens after the Master subsystem new(s) (it's a global datum)
 //So subsystems globals exist, but are not initialised
 /world/New()
@@ -375,3 +414,18 @@ GLOBAL_VAR(restart_counter)
 	world.refresh_atmos_grid()
 
 /world/proc/refresh_atmos_grid()
+
+/world/proc/init_byond_tracy()
+	var/library
+
+	switch (system_type)
+		if (MS_WINDOWS)
+			library = "prof.dll"
+		if (UNIX)
+			library = "libprof.so"
+		else
+			CRASH("Unsupported platform: [system_type]")
+
+	var/init_result = LIBCALL(library, "init")("block")
+	if (init_result != "0")
+		CRASH("Error initializing byond-tracy: [init_result]")

--- a/code/ze_genesis_call/genesis_call.dm
+++ b/code/ze_genesis_call/genesis_call.dm
@@ -1,0 +1,42 @@
+/*
+	You look around.
+	There is nothing but naught about you.
+	You've come to the end of the world.
+	You get a feeling that you really shouldn't be here.
+	Ever.
+	But with all ends come beginnings.
+	As you turn to leave, you spot it out of the corner of your eye.
+	Your eye widen in wonder as you look upon the the legendary treasure.
+	After all these years of pouring through shitcode
+	your endevours have brought you to...
+*/
+
+/**
+ * THE GENESIS CALL
+ *
+ * THE VERY FIRST LINE OF DM CODE TO EXECUTE
+ * Ong this must be done after !!!EVERYTHING!!! else
+ * NO IFS ANDS OR BUTS
+ * it's a hack, not an example of any sort, and DEFINITELY should NOT be emulated
+ * IT JUST HAS TO BE LAST!!!!!!
+ * If you want to do something in the initialization pipeline
+ * FIRST RTFM IN /code/game/world.dm
+ * AND THEN NEVER RETURN TO THIS PLACE
+ *
+ *
+ *
+ * If you're still here, here's an explanation:
+ * BYOND loves to tell you about its loving spouse /global
+ * But it's actually having a sexy an affair with /static
+ * Specifically statics in procs
+ * Priority is given to these lines of code in REVERSE order of declaration in the .dme
+ * Which is why this file has a funky name
+ * So this is what we use to call world.Genesis()
+ * It's a nameless, no-op function, because it does absolutely nothing
+ * It exists to hold a static var which is initialized to null
+ * It's on /world to hide it from reflection
+ * Painful right? Good, now you share my suffering
+ * Please lock the door on your way out
+ */
+/world/proc/_()
+	var/static/_ = world.Genesis()


### PR DESCRIPTION
## About The Pull Request

Adds tracy DEFINE and adds it to gitignore so you can actually keep it in the repo folder without constantly having to avoid adding it.

The "Genisis()" thing is thoroughly explained in comments, it basically allows us to profile /world/New() and any global BYOND var init, which isn't possible if you just placed the tracy proc in /world/New().

Borrowed the genesis code from:
-  https://github.com/tgstation/tgstation/pull/74808

I was not looking to port the full refactor but we could still do that as noted in the comment I added.

## Why It's Good For The Game

Allows devs to more easily profile init times.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/894ba314-5f86-4e1f-8683-0f6e663cdc17)

</details>

## Changelog
:cl:
code: Added byondtracy support to the repository.
/:cl:
