### PR TITLE
Load circuit components from USB ports on demand

### DIFF
--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -24,7 +24,7 @@
 
 	circuit_components = list()
 
-	set_circuit_components(circuit_component_types)
+	src.circuit_component_types = circuit_component_types
 
 /datum/component/usb_port/proc/set_circuit_components(list/components)
 	var/should_register = FALSE
@@ -135,6 +135,9 @@
 
 /datum/component/usb_port/proc/on_atom_usb_cable_try_attach(datum/source, obj/item/usb_cable/connecting_cable, mob/user)
 	SIGNAL_HANDLER
+
+	if (!length(circuit_components))
+		set_circuit_components(circuit_component_types)
 
 	var/atom/atom_parent = parent
 


### PR DESCRIPTION
## About The Pull Request

Ports
- https://github.com/tgstation/tgstation/pull/69664

Saves ~120ms init.

## Why It's Good For The Game

Init times

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

0 calls on new branch, so just look at the master times:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/b9575436-21d7-4193-947a-3f31d49ce866)

</details>

## Changelog
:cl:
code: Lazy-initialized circuit USB components, saving 120ms init.
/:cl:
