### PR TITLE
Speed up camera/autoname/LateInitialize

### DIFF
--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -55,17 +55,15 @@
 
 /obj/machinery/camera/autoname/LateInitialize()
 	. = ..()
-	number = 1
-	var/area/A = get_area(src)
-	if(A)
-		for(var/obj/machinery/camera/autoname/C in GLOB.machines)
-			if(C == src)
-				continue
-			var/area/CA = get_area(C)
-			if(CA.type == A.type)
-				if(C.number)
-					number = max(number, C.number+1)
-		c_tag = "[A.name] #[number]"
+
+	var/static/list/autonames_in_areas = list()
+
+	var/area/camera_area = get_area(src)
+
+	number = autonames_in_areas[camera_area] + 1
+	autonames_in_areas[camera_area] = number
+
+	c_tag = "[format_text(camera_area.name)] #[number]"
 
 
 // UPGRADE PROCS


### PR DESCRIPTION
## About The Pull Request

Ports
- https://github.com/tgstation/tgstation/pull/70969

Saves 88ms on meta but will vary by map

## Why It's Good For The Game

Init times

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/e7ab6883-7ce6-4d21-aa9c-39f59a808468)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/b497212b-7b9f-4034-a50d-5c93141688b7)

</details>

## Changelog
:cl:
code: Optimized autoname camera init, saving 88ms init on MetaStation.
/:cl: