### PR TITLE
Require access to wires to emag

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1338,7 +1338,7 @@
 	if(!hasPower())
 		to_chat(user, "<span class='warning'>The cryptographic sequencer connects to \the [src]'s ID scanner, but nothing happens.</span>")
 		return FALSE
-	if(!panel_open)
+	if(AIRLOCK_SECURITY_NONE)
 		to_chat(user, "<span class='warning'>The wires must be exposed to hack!</span>")
 		return FALSE
 	// Don't allow emag if the door is currently open or moving

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1339,7 +1339,7 @@
 		to_chat(user, "<span class='warning'>The cryptographic sequencer connects to \the [src]'s ID scanner, but nothing happens.</span>")
 		return FALSE
 	if(!panel_open || security_level != AIRLOCK_SECURITY_NONE)
-		to_chat(user, "<span class='warning'>The wires must be exposed to hack!</span>")
+		user.balloon_alert(user, "The wires are not exposed!")
 		return FALSE
 	// Don't allow emag if the door is currently open or moving
 	return !operating && density

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1338,6 +1338,9 @@
 	if(!hasPower())
 		to_chat(user, "<span class='warning'>The cryptographic sequencer connects to \the [src]'s ID scanner, but nothing happens.</span>")
 		return FALSE
+	if(!panel_open)
+		to_chat(user, "<span class='warning'>The wires must be exposed to hack!</span>")
+		return FALSE
 	// Don't allow emag if the door is currently open or moving
 	return !operating && density
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1338,7 +1338,7 @@
 	if(!hasPower())
 		to_chat(user, "<span class='warning'>The cryptographic sequencer connects to \the [src]'s ID scanner, but nothing happens.</span>")
 		return FALSE
-	if(AIRLOCK_SECURITY_NONE)
+	if(!panel_open || security_level != AIRLOCK_SECURITY_NONE)
 		to_chat(user, "<span class='warning'>The wires must be exposed to hack!</span>")
 		return FALSE
 	// Don't allow emag if the door is currently open or moving


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Requires the wires to be exposed in order to emag doors. This means simply unscrewing the airlock or unscrewing and welding off the plasteel off the hatch.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Emagman will be no more for Command or those who upgrade their maintenance hatches. 
- You can no longer walk into Command 20 seconds into a shift.
- Engineering won't have 20+ doors to spend half a shift fixing when there is a very happy traitor.
- Could be used to make armoury harder to get into during low-pop. Again, can't walk in there within 20 seconds into a shift.
- Overall it won't take 5 seconds to emag through several doors but you have to spend a tiny amount of time to get through them and a bit more time if you wish to go through high security areas such as Bridge.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
I don't have access to my own Windows computer so I can not test it. If someone is willing, please do test it.
<summary>Screenshots&Videos</summary>

</details>

## Changelog
:cl:
balance: airlock.dm to require exposed wires in order to be emagged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
