### PR TITLE
Roundstart lighting fixes + tweaks

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -56,22 +56,6 @@
 	for(var/I in adjacent_turfs)
 		. |= get_area(I)
 
-/proc/get_department_areas(atom/AM)
-	var/department_type
-	var/area/our_area = get_area(AM)
-	var/all_master_types = direct_subtypesof(/area)
-	for(var/checkable in all_master_types)
-		if(istype(our_area,checkable))
-			department_type = checkable
-			break
-	if(!department_type)
-		department_type = our_area.type
-	var/list/department_areas = list()
-	for(var/area/A in GLOB.sortedAreas)
-		if(istype(A,department_type))
-			department_areas += A
-	return department_areas
-
 /**
  * Get a bounding box of a list of atoms.
  *

--- a/code/__HELPERS/type_processing.dm
+++ b/code/__HELPERS/type_processing.dm
@@ -58,10 +58,3 @@
 		if(findtext("[key]", filter) || findtext("[value]", filter))
 			matches[key] = value
 	return matches
-
-//Finds types that are subtypes of a type, but only 1 level down.
-/proc/direct_subtypesof(path)
-	var/list/out = subtypesof(path)
-	for(var/type in out)
-		out -= subtypesof(type) //remove any subtypes of our current entry from the list
-	return out

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -360,21 +360,36 @@ SUBSYSTEM_DEF(ticker)
 	PostSetup()
 	SSstat.clear_global_alert()
 
-//Toggle lightswitches on in occupied departments
-	var/discrete_areas = list()
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		var/area/A = get_area(H)
-		if(!(A in discrete_areas)) //We've already added their department
-			discrete_areas += get_department_areas(H)
-	for(var/area/area in discrete_areas)
+	// Toggle lightswitches on in occupied departments
+	var/list/lightup_area_typecache = list()
+	var/minimal_access = CONFIG_GET(flag/jobs_have_minimal_access)
+	for(var/mob/living/carbon/human/player in GLOB.player_list)
+		var/role = player.mind?.assigned_role
+		if(!role)
+			continue
+		var/datum/job/job = SSjob.GetJob(role)
+		if(!job)
+			continue
+		if(role in GLOB.command_positions)
+			lightup_area_typecache |= GLOB.command_areas
+		if(role in GLOB.engineering_positions)
+			lightup_area_typecache |= GLOB.engineering_areas
+		if(role in GLOB.medical_positions)
+			lightup_area_typecache |= GLOB.medical_areas
+		if(role in GLOB.science_positions)
+			lightup_area_typecache |= GLOB.science_positions
+		if(role in GLOB.supply_positions)
+			lightup_area_typecache |= GLOB.supply_areas
+		lightup_area_typecache |= job.minimal_lightup_areas
+		if(!minimal_access)
+			lightup_area_typecache |= job.lightup_areas
+	for(var/area/area as() in typecache_filter_list(GLOB.sortedAreas, lightup_area_typecache))
 		if(area.lights_always_start_on)
 			continue
 		area.lightswitch = TRUE
 		area.update_appearance()
-
-		for(var/obj/machinery/light_switch/L in area)
-			L.update_appearance()
-
+		for(var/obj/machinery/light_switch/lswitch in area)
+			lswitch.update_appearance()
 		area.power_change()
 
 	return TRUE

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -370,21 +370,7 @@ SUBSYSTEM_DEF(ticker)
 		var/datum/job/job = SSjob.GetJob(role)
 		if(!job)
 			continue
-		if(role in GLOB.command_positions)
-			lightup_area_typecache |= GLOB.command_lightup_areas
-		if(role in GLOB.engineering_positions)
-			lightup_area_typecache |= GLOB.engineering_lightup_areas
-		if(role in GLOB.medical_positions)
-			lightup_area_typecache |= GLOB.medical_lightup_areas
-		if(role in GLOB.science_positions)
-			lightup_area_typecache |= GLOB.science_lightup_areas
-		if(role in GLOB.supply_positions)
-			lightup_area_typecache |= GLOB.supply_lightup_areas
-		if(role in GLOB.security_positions)
-			lightup_area_typecache |= GLOB.security_lightup_areas
-		lightup_area_typecache |= job.minimal_lightup_areas
-		if(!minimal_access)
-			lightup_area_typecache |= job.lightup_areas
+		lightup_area_typecache |= job.areas_to_light_up(minimal_access)
 	for(var/area/area as() in typecache_filter_list(GLOB.sortedAreas, lightup_area_typecache))
 		if(area.lights_always_start_on)
 			continue

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -371,15 +371,17 @@ SUBSYSTEM_DEF(ticker)
 		if(!job)
 			continue
 		if(role in GLOB.command_positions)
-			lightup_area_typecache |= GLOB.command_areas
+			lightup_area_typecache |= GLOB.command_lightup_areas
 		if(role in GLOB.engineering_positions)
-			lightup_area_typecache |= GLOB.engineering_areas
+			lightup_area_typecache |= GLOB.engineering_lightup_areas
 		if(role in GLOB.medical_positions)
-			lightup_area_typecache |= GLOB.medical_areas
+			lightup_area_typecache |= GLOB.medical_lightup_areas
 		if(role in GLOB.science_positions)
 			lightup_area_typecache |= GLOB.science_positions
 		if(role in GLOB.supply_positions)
-			lightup_area_typecache |= GLOB.supply_areas
+			lightup_area_typecache |= GLOB.supply_lightup_areas
+		if(role in GLOB.security_positions)
+			lightup_area_typecache |= GLOB.security_lightup_areas
 		lightup_area_typecache |= job.minimal_lightup_areas
 		if(!minimal_access)
 			lightup_area_typecache |= job.lightup_areas

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -377,7 +377,7 @@ SUBSYSTEM_DEF(ticker)
 		if(role in GLOB.medical_positions)
 			lightup_area_typecache |= GLOB.medical_lightup_areas
 		if(role in GLOB.science_positions)
-			lightup_area_typecache |= GLOB.science_positions
+			lightup_area_typecache |= GLOB.science_lightup_areas
 		if(role in GLOB.supply_positions)
 			lightup_area_typecache |= GLOB.supply_lightup_areas
 		if(role in GLOB.security_positions)

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -646,7 +646,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "fitness"
 
 /area/crew_quarters/park
-	name = "Recrational Park"
+	name = "Recreational Park"
 	icon_state = "fitness"
 	lighting_colour_bulb = "#80aae9"
 	lighting_colour_tube = "#80aae9"
@@ -655,7 +655,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/crew_quarters/cafeteria
 	name = "Cafeteria"
 	icon_state = "cafeteria"
-	lights_always_start_on = FALSE
 
 /area/crew_quarters/kitchen
 	name = "Kitchen"
@@ -678,7 +677,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_bulb = "#ffebc1"
 	sound_environment = SOUND_AREA_WOODFLOOR
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
-	lights_always_start_on = FALSE
 
 /area/crew_quarters/bar/mood_check(mob/living/carbon/subject)
 	if(istype(subject) && HAS_TRAIT(subject, TRAIT_LIGHT_DRINKER))
@@ -686,13 +684,16 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	return ..()
 
 /area/crew_quarters/bar/lounge
-	name = "Bar lounge"
+	name = "Bar Lounge"
 	icon_state = "lounge"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 
 /area/crew_quarters/bar/Initialize(mapload)
 	. = ..()
 	GLOB.bar_areas += src
+
+/area/service/bar
+	lights_always_start_on = TRUE
 
 /area/service/bar/Initialize(mapload)
 	. = ..()
@@ -718,16 +719,17 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Theatre"
 	icon_state = "theatre"
 	sound_environment = SOUND_AREA_WOODFLOOR
-	lights_always_start_on = FALSE
 
 /area/crew_quarters/theatre/backstage
 	name = "Backstage"
 	icon_state = "theatre_back"
 	sound_environment = SOUND_AREA_WOODFLOOR
+	lights_always_start_on = FALSE
 
 /area/crew_quarters/theatre/abandoned
 	name = "Abandoned Theatre"
 	icon_state = "theatre"
+	lights_always_start_on = FALSE
 
 /area/library
 	name = "Library"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -265,17 +265,17 @@
 	. = minimal_lightup_areas.Copy()
 	if(!minimal_access)
 		. |= lightup_areas
-	if(title in GLOB.command_positions)
+	if(CHECK_BITFIELD(departments, DEPT_BITFLAG_COM))
 		. |= GLOB.command_lightup_areas
-	if(title in GLOB.engineering_positions)
+	if(CHECK_BITFIELD(departments, DEPT_BITFLAG_ENG))
 		. |= GLOB.engineering_lightup_areas
-	if(title in GLOB.medical_positions)
+	if(CHECK_BITFIELD(departments, DEPT_BITFLAG_MED))
 		. |= GLOB.medical_lightup_areas
-	if(title in GLOB.science_positions)
+	if(CHECK_BITFIELD(departments, DEPT_BITFLAG_SCI))
 		. |= GLOB.science_lightup_areas
-	if(title in GLOB.supply_positions)
+	if(CHECK_BITFIELD(departments, DEPT_BITFLAG_CAR))
 		. |= GLOB.supply_lightup_areas
-	if(title in GLOB.security_positions)
+	if(CHECK_BITFIELD(departments, DEPT_BITFLAG_SEC))
 		. |= GLOB.security_lightup_areas
 
 /datum/job/proc/available_in_days(client/C)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -90,9 +90,23 @@
 	///RPG job names, for the memes
 	var/rpg_title
 
+	/**
+	 * A list of job-specific areas to enable lights for if this job is present at roundstart, whenever minimal access is not in effect.
+	 * This will be combined with minimal_lightup_areas, so no need to duplicate entries.
+	 * Areas within their department will have their lights turned on automatically, so you should really only use this for areas outside of their department.
+	 */
+	var/list/lightup_areas = list()
+	/**
+	 * A list of job-specific areas to enable lights for if this job is present at roundstart.
+	 * Areas within their department will have their lights turned on automatically, so you should really only use this for areas outside of their department.
+	 */
+	var/list/minimal_lightup_areas = list()
+
 
 /datum/job/New()
 	. = ..()
+	lightup_areas = typecacheof(lightup_areas)
+	minimal_lightup_areas = typecacheof(minimal_lightup_areas)
 
 //Only override this proc, unless altering loadout code. Loadouts act on H but get info from M
 //H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -261,6 +261,22 @@
 		return TRUE	//Available in 0 days = available right now = player is old enough to play.
 	return FALSE
 
+/datum/job/proc/areas_to_light_up(minimal_access = TRUE)
+	. = minimal_lightup_areas.Copy()
+	if(!minimal_access)
+		. |= lightup_areas
+	if(title in GLOB.command_positions)
+		. |= GLOB.command_lightup_areas
+	if(title in GLOB.engineering_positions)
+		. |= GLOB.engineering_lightup_areas
+	if(title in GLOB.medical_positions)
+		. |= GLOB.medical_lightup_areas
+	if(title in GLOB.science_positions)
+		. |= GLOB.science_lightup_areas
+	if(title in GLOB.supply_positions)
+		. |= GLOB.supply_lightup_areas
+	if(title in GLOB.security_positions)
+		. |= GLOB.security_lightup_areas
 
 /datum/job/proc/available_in_days(client/C)
 	if(!C)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -27,6 +27,7 @@ Assistant
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman
 	)
+
 /datum/job/assistant/get_access()
 	if(CONFIG_GET(flag/assistants_have_maint_access) || !CONFIG_GET(flag/jobs_have_minimal_access)) //Config has assistant maint access set
 		. = ..()

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -28,6 +28,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/atmospherics
 	)
 
+	minimal_lightup_areas = list(/area/engine/atmos)
+
 /datum/outfit/job/atmospheric_technician
 	name = JOB_NAME_ATMOSPHERICTECHNICIAN
 	jobtype = /datum/job/atmospheric_technician

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -25,6 +25,13 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/bartender
 	)
+
+	lightup_areas = list(
+		/area/hydroponics,
+		/area/medical/morgue,
+		/area/crew_quarters/kitchen
+	)
+
 /datum/outfit/job/bartender
 	name = JOB_NAME_BARTENDER
 	jobtype = /datum/job/bartender

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -25,6 +25,9 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/botany
 	)
 
+	lightup_areas = list(/area/crew_quarters/bar, /area/service/bar)
+	minimal_lightup_areas = list(/area/hydroponics, /area/medical/morgue)
+
 /datum/outfit/job/botanist
 	name = JOB_NAME_BOTANIST
 	jobtype = /datum/job/botanist

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -25,7 +25,6 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/botany
 	)
 
-	lightup_areas = list(/area/crew_quarters/bar, /area/service/bar)
 	minimal_lightup_areas = list(/area/hydroponics, /area/medical/morgue)
 
 /datum/outfit/job/botanist

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -29,7 +29,11 @@
 	)
 	biohazard = 25 //still deals with the sick and injured, just less than a medical doctor
 
-	minimal_lightup_areas = list(/area/security/brig, /area/security/courtroom)
+	minimal_lightup_areas = list(
+		/area/medical/morgue,
+		/area/security/brig,
+		/area/security/courtroom
+	)
 
 /datum/outfit/job/brig_physician
 	name = JOB_NAME_BRIGPHYSICIAN

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -29,11 +29,7 @@
 	)
 	biohazard = 25 //still deals with the sick and injured, just less than a medical doctor
 
-	minimal_lightup_areas = list(
-		/area/medical/morgue,
-		/area/security/brig,
-		/area/security/courtroom
-	)
+	minimal_lightup_areas = list(/area/medical/morgue)
 
 /datum/outfit/job/brig_physician
 	name = JOB_NAME_BRIGPHYSICIAN

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -29,6 +29,8 @@
 	)
 	biohazard = 25 //still deals with the sick and injured, just less than a medical doctor
 
+	minimal_lightup_areas = list(/area/security/brig, /area/security/courtroom)
+
 /datum/outfit/job/brig_physician
 	name = JOB_NAME_BRIGPHYSICIAN
 	jobtype = /datum/job/brig_physician

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -33,6 +33,13 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/command
 	)
+
+	minimal_lightup_areas = list(
+		/area/security,
+		/area/crew_quarters/heads/hop,
+		/area/crew_quarters/heads/captain
+	)
+
 /datum/job/captain/get_access()
 	return get_all_accesses()
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -35,9 +35,9 @@
 	)
 
 	minimal_lightup_areas = list(
-		/area/security,
+		/area/crew_quarters/heads/captain,
 		/area/crew_quarters/heads/hop,
-		/area/crew_quarters/heads/captain
+		/area/security
 	)
 
 /datum/job/captain/get_access()

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -27,6 +27,8 @@
 	)
 	biohazard = 25
 
+	lightup_areas = list(/area/quartermaster/qm, /area/quartermaster/qm_bedroom)
+
 /datum/outfit/job/cargo_technician
 	name = JOB_NAME_CARGOTECHNICIAN
 	jobtype = /datum/job/cargo_technician

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -26,6 +26,12 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/chaplain
 	)
 
+	minimal_lightup_areas = list(
+		/area/chapel,
+		/area/medical/morgue,
+		/area/crew_quarters/theatre
+	)
+
 /datum/job/chaplain/after_spawn(mob/living/H, mob/M)
 	. = ..()
 

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -28,6 +28,17 @@
 	)
 	biohazard = 25
 
+	lightup_areas = list(
+		/area/medical/surgery,
+		/area/medical/virology,
+		/area/medical/genetics
+	)
+	minimal_lightup_areas = list(
+		/area/medical/morgue,
+		/area/medical/chemistry,
+		/area/medical/apothecary
+	)
+
 /datum/outfit/job/chemist
 	name = JOB_NAME_CHEMIST
 	jobtype = /datum/job/chemist

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -41,7 +41,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/chief_engineer
 	)
 
-	minimal_lightup_areas = list(/area/crew_quarters/heads/chief)
+	minimal_lightup_areas = list(/area/crew_quarters/heads/chief, /area/engine/atmos)
 
 /datum/outfit/job/chief_engineer
 	name = JOB_NAME_CHIEFENGINEER

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -41,7 +41,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/chief_engineer
 	)
 
-	minimal_lightup_areas = list(/area/security/brig, /area/crew_quarters/heads/chief)
+	minimal_lightup_areas = list(/area/crew_quarters/heads/chief)
 
 /datum/outfit/job/chief_engineer
 	name = JOB_NAME_CHIEFENGINEER

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -41,6 +41,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/chief_engineer
 	)
 
+	minimal_lightup_areas = list(/area/security/brig, /area/crew_quarters/heads/chief)
+
 /datum/outfit/job/chief_engineer
 	name = JOB_NAME_CHIEFENGINEER
 	jobtype = /datum/job/chief_engineer

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -40,7 +40,15 @@
 	)
 	biohazard = 45
 
-	minimal_lightup_areas = list(/area/storage/eva, /area/crew_quarters/heads/cmo)
+	minimal_lightup_areas = list(
+		/area/storage/eva,
+		/area/medical/morgue,
+		/area/medical/surgery,
+		/area/medical/chemistry,
+		/area/medical/apothecary,
+		/area/medical/genetics/cloning,
+		/area/crew_quarters/heads/cmo
+	)
 
 /datum/outfit/job/chief_medical_officer
 	name = JOB_NAME_CHIEFMEDICALOFFICER

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -40,6 +40,12 @@
 	)
 	biohazard = 45
 
+	minimal_lightup_areas = list(
+		/area/storage/eva,
+		/area/security/brig,
+		/area/crew_quarters/heads/cmo
+	)
+
 /datum/outfit/job/chief_medical_officer
 	name = JOB_NAME_CHIEFMEDICALOFFICER
 	jobtype = /datum/job/chief_medical_officer

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -40,11 +40,7 @@
 	)
 	biohazard = 45
 
-	minimal_lightup_areas = list(
-		/area/storage/eva,
-		/area/security/brig,
-		/area/crew_quarters/heads/cmo
-	)
+	minimal_lightup_areas = list(/area/storage/eva, /area/crew_quarters/heads/cmo)
 
 /datum/outfit/job/chief_medical_officer
 	name = JOB_NAME_CHIEFMEDICALOFFICER

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -42,12 +42,12 @@
 
 	minimal_lightup_areas = list(
 		/area/crew_quarters/heads/cmo,
-		/area/storage/eva,
+		/area/medical/apothecary,
+		/area/medical/chemistry,
+		/area/medical/genetics,
 		/area/medical/morgue,
 		/area/medical/surgery,
-		/area/medical/chemistry,
-		/area/medical/apothecary,
-		/area/medical/genetics/cloning
+		/area/storage/eva
 	)
 
 /datum/outfit/job/chief_medical_officer

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -41,13 +41,13 @@
 	biohazard = 45
 
 	minimal_lightup_areas = list(
+		/area/crew_quarters/heads/cmo,
 		/area/storage/eva,
 		/area/medical/morgue,
 		/area/medical/surgery,
 		/area/medical/chemistry,
 		/area/medical/apothecary,
-		/area/medical/genetics/cloning,
-		/area/crew_quarters/heads/cmo
+		/area/medical/genetics/cloning
 	)
 
 /datum/outfit/job/chief_medical_officer

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -26,6 +26,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/honk
 	)
 
+	minimal_lightup_areas = list(/area/crew_quarters/theatre)
+
 /datum/job/clown/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	H.apply_pref_name("clown", M.client)

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -27,6 +27,9 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/chef
 	)
 
+	minimal_lightup_areas = list(/area/crew_quarters/kitchen, /area/medical/morgue)
+	lightup_areas = list(/area/crew_quarters/bar, /area/hydroponics)
+
 /datum/outfit/job/cook
 	name = JOB_NAME_COOK
 	jobtype = /datum/job/cook

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -28,7 +28,7 @@
 	)
 
 	minimal_lightup_areas = list(/area/crew_quarters/kitchen, /area/medical/morgue)
-	lightup_areas = list(/area/crew_quarters/bar, /area/hydroponics)
+	lightup_areas = list(/area/hydroponics)
 
 /datum/outfit/job/cook
 	name = JOB_NAME_COOK

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -27,6 +27,11 @@
 	//they doesnt get out that much
 	biohazard = 10
 
+	minimal_lightup_areas = list(
+		/area/library,
+		/area/construction/mining/aux_base
+	)
+
 /datum/outfit/job/curator
 	name = JOB_NAME_CURATOR
 	jobtype = /datum/job/curator

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -31,6 +31,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/detective
 	)
 
+	minimal_lightup_areas = list(/area/medical/morgue)
+
 /datum/outfit/job/detective
 	name = JOB_NAME_DETECTIVE
 	jobtype = /datum/job/detective

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -31,7 +31,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/detective
 	)
 
-	minimal_lightup_areas = list(/area/medical/morgue)
+	minimal_lightup_areas = list(/area/medical/morgue, /area/security/detectives_office)
 
 /datum/outfit/job/detective
 	name = JOB_NAME_DETECTIVE

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -29,6 +29,13 @@
 	)
 	biohazard = 40//who knows what you'll find out there that could have nasties on it...
 
+	lightup_areas = list(
+		/area/science/mixing,
+		/area/science/storage,
+		/area/science/xenobiology
+	)
+	minimal_lightup_areas =  = list(/area/quartermaster/exploration_dock, /area/quartermaster/exploration_prep)
+
 /datum/job/exploration_crew/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source)
 	if(outfit_override)
 		return ..()

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -34,7 +34,7 @@
 		/area/science/storage,
 		/area/science/xenobiology
 	)
-	minimal_lightup_areas =  = list(/area/quartermaster/exploration_dock, /area/quartermaster/exploration_prep)
+	minimal_lightup_areas = list(/area/quartermaster/exploration_dock, /area/quartermaster/exploration_prep)
 
 /datum/job/exploration_crew/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source)
 	if(outfit_override)

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -30,6 +30,14 @@
 	)
 	biohazard = 25
 
+	lightup_areas = list(
+		/area/medical/surgery,
+		/area/medical/virology,
+		/area/medical/chemistry,
+		/area/medical/apothecary
+	)
+	minimal_lightup_areas = list(/area/medical/morgue, /area/medical/genetics)
+
 /datum/outfit/job/geneticist
 	name = JOB_NAME_GENETICIST
 	jobtype = /datum/job/geneticist

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -23,6 +23,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman
 	)
+
 /datum/outfit/job/gimmick
 	can_be_admin_equipped = FALSE // we want just the parent outfit to be unequippable since this leads to problems
 
@@ -44,6 +45,9 @@
 	payment_per_department = list(ACCOUNT_SRV_ID = PAYCHECK_ASSISTANT)
 
 	rpg_title = "Scissorhands"
+
+	minimal_lightup_areas = list(/area/medical/morgue)
+
 /datum/outfit/job/gimmick/barber
 	name = JOB_NAME_BARBER
 	jobtype = /datum/job/gimmick/barber
@@ -77,6 +81,9 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/magic
 	)
+
+	minimal_lightup_areas = list(/area/crew_quarters/theatre)
+
 /datum/outfit/job/gimmick/stage_magician
 	name = JOB_NAME_STAGEMAGICIAN
 	jobtype = /datum/job/gimmick/stage_magician
@@ -111,6 +118,7 @@
 	mind_traits = list(TRAIT_MADNESS_IMMUNE, TRAIT_MEDICAL_METABOLISM)
 
 	rpg_title = "Enchanter"
+
 /datum/outfit/job/gimmick/psychiatrist //psychiatrist doesnt get much shit, but he has more access and a cushier paycheck
 	name = JOB_NAME_PSYCHIATRIST
 	jobtype = /datum/job/gimmick/psychiatrist
@@ -141,6 +149,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/vip
 	)
+
 /datum/outfit/job/gimmick/vip
 	name = JOB_NAME_VIP
 	jobtype = /datum/job/gimmick/vip

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -48,6 +48,10 @@
 
 	minimal_lightup_areas = list(/area/crew_quarters/heads/hop)
 
+// Special handling to avoid lighting up the entirety of supply whenever there's a HoP.
+/datum/job/head_of_personnel/areas_to_light_up(minimal_access = TRUE)
+	return minimal_lightup_areas | GLOB.command_lightup_areas
+
 /datum/outfit/job/head_of_personnel
 	name = JOB_NAME_HEADOFPERSONNEL
 	jobtype = /datum/job/head_of_personnel

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -46,7 +46,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/head_of_personnel
 	)
 
-	minimal_lightup_areas = list(/area/crew_quarters/heads/hop)
+	minimal_lightup_areas = list(/area/security/brig, /area/crew_quarters/heads/hop)
 
 /datum/outfit/job/head_of_personnel
 	name = JOB_NAME_HEADOFPERSONNEL

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -46,7 +46,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/head_of_personnel
 	)
 
-	minimal_lightup_areas = list(/area/crew_quarters/heads/hop)
+	minimal_lightup_areas = list(/area/crew_quarters/heads/hop, /area/security/nuke_storage)
 
 // Special handling to avoid lighting up the entirety of supply whenever there's a HoP.
 /datum/job/head_of_personnel/areas_to_light_up(minimal_access = TRUE)

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -46,6 +46,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/head_of_personnel
 	)
 
+	minimal_lightup_areas = list(/area/crew_quarters/heads/hop)
+
 /datum/outfit/job/head_of_personnel
 	name = JOB_NAME_HEADOFPERSONNEL
 	jobtype = /datum/job/head_of_personnel

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -46,7 +46,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/head_of_personnel
 	)
 
-	minimal_lightup_areas = list(/area/security/brig, /area/crew_quarters/heads/hop)
+	minimal_lightup_areas = list(/area/crew_quarters/heads/hop)
 
 /datum/outfit/job/head_of_personnel
 	name = JOB_NAME_HEADOFPERSONNEL

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -39,7 +39,11 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/head_of_security
 	)
 
-	minimal_lightup_areas = list(/area/crew_quarters/heads/hos)
+	minimal_lightup_areas = list(
+		/area/crew_quarters/heads/hos,
+		/area/security/detectives_office,
+		/area/security/warden
+	)
 
 /datum/outfit/job/head_of_security
 	name = JOB_NAME_HEADOFSECURITY

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -39,6 +39,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/head_of_security
 	)
 
+	minimal_lightup_areas = list(/area/crew_quarters/heads/hos)
+
 /datum/outfit/job/head_of_security
 	name = JOB_NAME_HEADOFSECURITY
 	jobtype = /datum/job/head_of_security

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -26,6 +26,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/janitor
 	)
 
+	minimal_lightup_areas = list(/area/janitor)
+
 /datum/outfit/job/janitor
 	name = JOB_NAME_JANITOR
 	jobtype = /datum/job/janitor

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -27,6 +27,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/lawyer
 	)
 
+	minimal_lightup_areas = list(/area/lawoffice)
+
 /datum/outfit/job/lawyer
 	name = JOB_NAME_LAWYER
 	jobtype = /datum/job/lawyer

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -28,6 +28,18 @@
 	)
 	biohazard = 40
 
+	lightup_areas = list(
+		/area/medical/genetics,
+		/area/medical/virology,
+		/area/medical/chemistry,
+		/area/medical/apothecary
+	)
+	minimal_lightup_areas = list(
+		/area/medical/morgue,
+		/area/medical/surgery,
+		/area/medical/genetics/cloning
+	)
+
 /datum/outfit/job/medical_doctor
 	name = JOB_NAME_MEDICALDOCTOR
 	jobtype = /datum/job/medical_doctor

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -25,6 +25,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/mime
 	)
 
+	minimal_lightup_areas = list(/area/crew_quarters/theatre)
+
 /datum/job/mime/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	H.apply_pref_name("mime", M.client)

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -29,6 +29,8 @@
 	)
 	biohazard = 50//deal with sick like MDS, but also muck around in maint and get into the thick of it
 
+	minimal_lightup_areas = list(/area/storage/eva)
+
 /datum/outfit/job/paramedic
 	name = JOB_NAME_PARAMEDIC
 	jobtype = /datum/job/paramedic

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -29,7 +29,12 @@
 	)
 	biohazard = 50//deal with sick like MDS, but also muck around in maint and get into the thick of it
 
-	minimal_lightup_areas = list(/area/storage/eva)
+	lightup_areas = list(/area/medical/surgery)
+	minimal_lightup_areas = list(
+		/area/storage/eva,
+		/area/medical/morgue,
+		/area/medical/genetics/cloning
+	)
 
 /datum/outfit/job/paramedic
 	name = JOB_NAME_PARAMEDIC

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -28,6 +28,13 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/cargo_technician
 	)
 
+	minimal_lightup_areas = list(
+		/area/quartermaster/qm,
+		/area/quartermaster/qm_bedroom,
+		/area/quartermaster/exploration_prep,
+		/area/quartermaster/exploration_dock
+	)
+
 /datum/outfit/job/quartermaster
 	name = JOB_NAME_QUARTERMASTER
 	jobtype = /datum/job/quartermaster

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -43,7 +43,7 @@
 	)
 	biohazard = 40
 
-	minimal_lightup_areas = list(/area/security/brig, /area/crew_quarters/heads/hor)
+	minimal_lightup_areas = list(/area/crew_quarters/heads/hor)
 
 /datum/outfit/job/research_director
 	name = JOB_NAME_RESEARCHDIRECTOR

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -43,7 +43,17 @@
 	)
 	biohazard = 40
 
-	minimal_lightup_areas = list(/area/crew_quarters/heads/hor)
+	minimal_lightup_areas = list(
+		/area/crew_quarters/heads/hor,
+		/area/science/explab,
+		/area/science/misc_lab,
+		/area/science/mixing,
+		/area/science/nanite,
+		/area/science/robotics,
+		/area/science/server,
+		/area/science/storage,
+		/area/science/xenobiology
+	)
 
 /datum/outfit/job/research_director
 	name = JOB_NAME_RESEARCHDIRECTOR

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -43,6 +43,8 @@
 	)
 	biohazard = 40
 
+	minimal_lightup_areas = list(/area/crew_quarters/heads/hor)
+
 /datum/outfit/job/research_director
 	name = JOB_NAME_RESEARCHDIRECTOR
 	jobtype = /datum/job/research_director

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -43,7 +43,7 @@
 	)
 	biohazard = 40
 
-	minimal_lightup_areas = list(/area/crew_quarters/heads/hor)
+	minimal_lightup_areas = list(/area/security/brig, /area/crew_quarters/heads/hor)
 
 /datum/outfit/job/research_director
 	name = JOB_NAME_RESEARCHDIRECTOR

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -29,6 +29,12 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/robotics
 	)
 
+	minimal_lightup_areas = list(
+		/area/storage/tech,
+		/area/medical/morgue,
+		/area/construction/mining/aux_base
+	)
+
 /datum/outfit/job/roboticist
 	name = JOB_NAME_ROBOTICIST
 	jobtype = /datum/job/roboticist

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -29,7 +29,11 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/robotics
 	)
 
-	minimal_lightup_areas = list(/area/storage/tech, /area/medical/morgue)
+	minimal_lightup_areas = list(
+		/area/medical/morgue,
+		/area/science/robotics,
+		/area/storage/tech
+	)
 
 /datum/outfit/job/roboticist
 	name = JOB_NAME_ROBOTICIST

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -29,6 +29,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/robotics
 	)
 
+	lightup_areas = list(/area/science/mixing, /area/science/storage)
 	minimal_lightup_areas = list(
 		/area/medical/morgue,
 		/area/science/robotics,

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -29,11 +29,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/robotics
 	)
 
-	minimal_lightup_areas = list(
-		/area/storage/tech,
-		/area/medical/morgue,
-		/area/construction/mining/aux_base
-	)
+	minimal_lightup_areas = list(/area/storage/tech, /area/medical/morgue)
 
 /datum/outfit/job/roboticist
 	name = JOB_NAME_ROBOTICIST

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -30,10 +30,7 @@
 	)
 	biohazard = 35
 
-	minimal_access = list(
-		/area/storage/tech,
-		/area/construction/mining/aux_base
-	)
+	lightup_areas = list(/area/storage/tech)
 
 /datum/outfit/job/scientist
 	name = JOB_NAME_SCIENTIST

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -30,7 +30,14 @@
 	)
 	biohazard = 35
 
-	lightup_areas = list(/area/storage/tech)
+	lightup_areas = list(/area/storage/tech, /area/science/robotics)
+	minimal_lightup_areas = list(
+		/area/science/explab,
+		/area/science/misc_lab,
+		/area/science/nanite,
+		/area/science/storage,
+		/area/science/xenobiology
+	)
 
 /datum/outfit/job/scientist
 	name = JOB_NAME_SCIENTIST

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -34,6 +34,7 @@
 	minimal_lightup_areas = list(
 		/area/science/explab,
 		/area/science/misc_lab,
+		/area/science/mixing,
 		/area/science/nanite,
 		/area/science/storage,
 		/area/science/xenobiology

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -30,6 +30,11 @@
 	)
 	biohazard = 35
 
+	minimal_access = list(
+		/area/storage/tech,
+		/area/construction/mining/aux_base
+	)
+
 /datum/outfit/job/scientist
 	name = JOB_NAME_SCIENTIST
 	jobtype = /datum/job/scientist

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -34,6 +34,8 @@
 	)
 	biohazard = 25 //clean your baton, man
 
+	minimal_lightup_areas = list(/area/construction/mining/aux_base)
+
 /datum/job/security_officer/get_access()
 	var/list/L = list()
 	L |= ..() | check_config_for_sec_maint()
@@ -65,24 +67,28 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 			destination = /area/security/checkpoint/supply
 			spawn_point = locate(/obj/effect/landmark/start/depsec/supply) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/cargo
+			minimal_lightup_areas |= GLOB.supply_areas
 		if(SEC_DEPT_ENGINEERING)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/engi
 			dep_access = list(ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE)
 			destination = /area/security/checkpoint/engineering
 			spawn_point = locate(/obj/effect/landmark/start/depsec/engineering) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/engine
+			minimal_lightup_areas |= GLOB.engineering_areas
 		if(SEC_DEPT_MEDICAL)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/med
 			dep_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_CLONING)
 			destination = /area/security/checkpoint/medical
 			spawn_point = locate(/obj/effect/landmark/start/depsec/medical) in GLOB.department_security_spawns
 			accessory =  /obj/item/clothing/accessory/armband/medblue
+			minimal_lightup_areas |= GLOB.medical_areas
 		if(SEC_DEPT_SCIENCE)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/sci
 			dep_access = list(ACCESS_RESEARCH, ACCESS_TOX, ACCESS_AUX_BASE)
 			destination = /area/security/checkpoint/science
 			spawn_point = locate(/obj/effect/landmark/start/depsec/science) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/science
+			minimal_lightup_areas |= GLOB.science_areas
 
 	if(accessory)
 		var/obj/item/clothing/under/U = H.w_uniform

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -67,28 +67,28 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 			destination = /area/security/checkpoint/supply
 			spawn_point = locate(/obj/effect/landmark/start/depsec/supply) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/cargo
-			minimal_lightup_areas |= GLOB.supply_areas
+			minimal_lightup_areas |= GLOB.supply_lightup_areas
 		if(SEC_DEPT_ENGINEERING)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/engi
 			dep_access = list(ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE)
 			destination = /area/security/checkpoint/engineering
 			spawn_point = locate(/obj/effect/landmark/start/depsec/engineering) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/engine
-			minimal_lightup_areas |= GLOB.engineering_areas
+			minimal_lightup_areas |= GLOB.engineering_lightup_areas
 		if(SEC_DEPT_MEDICAL)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/med
 			dep_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_CLONING)
 			destination = /area/security/checkpoint/medical
 			spawn_point = locate(/obj/effect/landmark/start/depsec/medical) in GLOB.department_security_spawns
 			accessory =  /obj/item/clothing/accessory/armband/medblue
-			minimal_lightup_areas |= GLOB.medical_areas
+			minimal_lightup_areas |= GLOB.medical_lightup_areas
 		if(SEC_DEPT_SCIENCE)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/sci
 			dep_access = list(ACCESS_RESEARCH, ACCESS_TOX, ACCESS_AUX_BASE)
 			destination = /area/security/checkpoint/science
 			spawn_point = locate(/obj/effect/landmark/start/depsec/science) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/science
-			minimal_lightup_areas |= GLOB.science_areas
+			minimal_lightup_areas |= GLOB.science_lightup_areas
 
 	if(accessory)
 		var/obj/item/clothing/under/U = H.w_uniform

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -27,6 +27,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/shaft_miner
 	)
 
+	minimal_lightup_areas = list(/area/construction/mining/aux_base)
+
 /datum/outfit/job/miner
 	name = JOB_NAME_SHAFTMINER
 	jobtype = /datum/job/shaft_miner

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -30,6 +30,8 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/engineering
 	)
 
+	lightup_areas = list(/area/engine/atmos)
+
 /datum/outfit/job/engineer
 	name = JOB_NAME_STATIONENGINEER
 	jobtype = /datum/job/station_engineer

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -29,6 +29,15 @@
 	)
 	biohazard = 75 //duh
 
+	lightup_areas = list(
+		/area/medical/morgue,
+		/area/medical/surgery,
+		/area/medical/genetics,
+		/area/medical/chemistry,
+		/area/medical/apothecary
+	)
+	minimal_lightup_areas = list(/area/medical/virology)
+
 /datum/outfit/job/virologist
 	name = JOB_NAME_VIROLOGIST
 	jobtype = /datum/job/virologist

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -31,6 +31,9 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/warden
 	)
 
+	lightup_areas = list(/area/security/detectives_office)
+	minimal_lightup_areas = list(/area/security/warden)
+
 /datum/job/warden/get_access()
 	var/list/L = list()
 	L = ..() | check_config_for_sec_maint()

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -55,7 +55,6 @@ GLOBAL_LIST_INIT(science_positions, list(
 ))
 
 GLOBAL_LIST_INIT(science_lightup_areas, typecacheof(list(
-	/area/medical,
 	/area/science,
 	/area/security/checkpoint/science,
 	/area/construction/mining/aux_base,

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -4,13 +4,30 @@ GLOBAL_LIST_INIT(command_positions, list(
 	JOB_NAME_HEADOFSECURITY,
 	JOB_NAME_CHIEFENGINEER,
 	JOB_NAME_RESEARCHDIRECTOR,
-	JOB_NAME_CHIEFMEDICALOFFICER))
+	JOB_NAME_CHIEFMEDICALOFFICER
+))
+
+GLOBAL_LIST_INIT(command_areas, typecacheof(list(
+	/area/bridge,
+	/area/gateway,
+	/area/teleporter
+)))
 
 
 GLOBAL_LIST_INIT(engineering_positions, list(
 	JOB_NAME_CHIEFENGINEER,
 	JOB_NAME_STATIONENGINEER,
-	JOB_NAME_ATMOSPHERICTECHNICIAN))
+	JOB_NAME_ATMOSPHERICTECHNICIAN
+))
+
+GLOBAL_LIST_INIT(engineering_areas, typecacheof(list(
+	/area/solar,
+	/area/engine,
+	/area/tcommsat,
+	/area/vacant_room,
+	/area/construction,
+	/area/security/checkpoint/engineering
+)))
 
 
 GLOBAL_LIST_INIT(medical_positions, list(
@@ -20,21 +37,50 @@ GLOBAL_LIST_INIT(medical_positions, list(
 	JOB_NAME_VIROLOGIST,
 	JOB_NAME_PARAMEDIC,
 	JOB_NAME_CHEMIST,
-	JOB_NAME_BRIGPHYSICIAN))
+	JOB_NAME_BRIGPHYSICIAN
+))
+
+GLOBAL_LIST_INIT(medical_areas, typecacheof(list(
+	/area/medical,
+	/area/security/checkpoint/medical
+)))
 
 
 GLOBAL_LIST_INIT(science_positions, list(
 	JOB_NAME_RESEARCHDIRECTOR,
 	JOB_NAME_SCIENTIST,
 	JOB_NAME_EXPLORATIONCREW,
-	JOB_NAME_ROBOTICIST))
+	JOB_NAME_ROBOTICIST
+))
+
+GLOBAL_LIST_INIT(science_areas, typecacheof(list(
+	/area/medical,
+	/area/science,
+	/area/security/checkpoint/science,
+	/area/quartermaster/exploration_prep,
+	/area/quartermaster/exploration_dock
+)))
 
 
 GLOBAL_LIST_INIT(supply_positions, list(
 	JOB_NAME_HEADOFPERSONNEL,
 	JOB_NAME_QUARTERMASTER,
 	JOB_NAME_CARGOTECHNICIAN,
-	JOB_NAME_SHAFTMINER))
+	JOB_NAME_SHAFTMINER
+))
+
+GLOBAL_LIST_INIT(supply_areas,					\
+	typecacheof(list(							\
+		/area/cargo,							\
+		/area/quartermaster,					\
+		/area/security/checkpoint/supply		\
+	)) - typecacheof(list(						\
+		/area/quartermaster/qm,					\
+		/area/quartermaster/qm_bedroom,			\
+		/area/quartermaster/exploration_prep,	\
+		/area/quartermaster/exploration_dock	\
+	))											\
+)
 
 
 GLOBAL_LIST_INIT(civilian_positions, list(
@@ -48,27 +94,35 @@ GLOBAL_LIST_INIT(civilian_positions, list(
 	JOB_NAME_CHAPLAIN,
 	JOB_NAME_MIME,
 	JOB_NAME_CLOWN,
-	JOB_NAME_ASSISTANT))
+	JOB_NAME_ASSISTANT
+))
 
 GLOBAL_LIST_INIT(gimmick_positions, list(
 	JOB_NAME_GIMMICK,
 	JOB_NAME_BARBER,
 	JOB_NAME_STAGEMAGICIAN,
 	JOB_NAME_PSYCHIATRIST,
-	JOB_NAME_VIP))
+	JOB_NAME_VIP
+))
 
 GLOBAL_LIST_INIT(security_positions, list(
 	JOB_NAME_HEADOFSECURITY,
 	JOB_NAME_WARDEN,
 	JOB_NAME_DETECTIVE,
 	JOB_NAME_SECURITYOFFICER,
-	JOB_NAME_DEPUTY))
+	JOB_NAME_DEPUTY
+))
+
+GLOBAL_LIST_INIT(security_areas, typecacheof(list(
+	/area/security
+)))
 
 
 GLOBAL_LIST_INIT(nonhuman_positions, list(
 	JOB_NAME_AI,
 	JOB_NAME_CYBORG,
-	ROLE_PAI))
+	ROLE_PAI
+))
 
 
 // they are for hud_icon-based crew manifest

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_INIT(command_positions, list(
 	JOB_NAME_CHIEFMEDICALOFFICER
 ))
 
-GLOBAL_LIST_INIT(command_areas, typecacheof(list(
+GLOBAL_LIST_INIT(command_lightup_areas, typecacheof(list(
 	/area/bridge,
 	/area/gateway,
 	/area/teleporter,
@@ -21,7 +21,7 @@ GLOBAL_LIST_INIT(engineering_positions, list(
 	JOB_NAME_ATMOSPHERICTECHNICIAN
 ))
 
-GLOBAL_LIST_INIT(engineering_areas, typecacheof(list(
+GLOBAL_LIST_INIT(engineering_lightup_areas, typecacheof(list(
 	/area/solar,
 	/area/engine,
 	/area/tcommsat,
@@ -41,7 +41,7 @@ GLOBAL_LIST_INIT(medical_positions, list(
 	JOB_NAME_BRIGPHYSICIAN
 ))
 
-GLOBAL_LIST_INIT(medical_areas, typecacheof(list(
+GLOBAL_LIST_INIT(medical_lightup_areas, typecacheof(list(
 	/area/medical,
 	/area/security/checkpoint/medical
 )))
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(science_positions, list(
 	JOB_NAME_ROBOTICIST
 ))
 
-GLOBAL_LIST_INIT(science_areas, typecacheof(list(
+GLOBAL_LIST_INIT(science_lightup_areas, typecacheof(list(
 	/area/medical,
 	/area/science,
 	/area/security/checkpoint/science,
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(supply_positions, list(
 	JOB_NAME_SHAFTMINER
 ))
 
-GLOBAL_LIST_INIT(supply_areas,					\
+GLOBAL_LIST_INIT(supply_lightup_areas,					\
 	typecacheof(list(							\
 		/area/cargo,							\
 		/area/quartermaster,					\
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(security_positions, list(
 	JOB_NAME_DEPUTY
 ))
 
-GLOBAL_LIST_INIT(security_areas, typecacheof(list(
+GLOBAL_LIST_INIT(security_lightup_areas, typecacheof(list(
 	/area/security
 )))
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -10,8 +10,8 @@ GLOBAL_LIST_INIT(command_positions, list(
 GLOBAL_LIST_INIT(command_lightup_areas, typecacheof(list(
 	/area/bridge,
 	/area/gateway,
-	/area/teleporter,
-	/area/security/brig
+	/area/security/brig,
+	/area/teleporter
 )))
 
 
@@ -21,14 +21,19 @@ GLOBAL_LIST_INIT(engineering_positions, list(
 	JOB_NAME_ATMOSPHERICTECHNICIAN
 ))
 
-GLOBAL_LIST_INIT(engineering_lightup_areas, typecacheof(list(
-	/area/solar,
-	/area/engine,
-	/area/tcommsat,
-	/area/vacant_room,
-	/area/construction,
-	/area/security/checkpoint/engineering
-)))
+GLOBAL_LIST_INIT(engineering_lightup_areas,		\
+	typecacheof(list(							\
+		/area/construction,						\
+		/area/engine,							\
+		/area/security/checkpoint/engineering,	\
+		/area/solar,							\
+		/area/tcommsat,							\
+		/area/vacant_room						\
+	)) - typecacheof(list(						\
+		/area/engine/atmos,						\
+		/area/engine/gravity_generator			\
+	))											\
+)
 
 
 GLOBAL_LIST_INIT(medical_positions, list(
@@ -41,10 +46,20 @@ GLOBAL_LIST_INIT(medical_positions, list(
 	JOB_NAME_BRIGPHYSICIAN
 ))
 
-GLOBAL_LIST_INIT(medical_lightup_areas, typecacheof(list(
-	/area/medical,
-	/area/security/checkpoint/medical
-)))
+GLOBAL_LIST_INIT(medical_lightup_areas, 	\
+	typecacheof(list(						\
+		/area/medical,						\
+		/area/security/checkpoint/medical	\
+	)) - typecacheof(list(					\
+		/area/medical/abandoned,			\
+		/area/medical/apothecary,			\
+		/area/medical/chemistry,			\
+		/area/medical/genetics,				\
+		/area/medical/morgue,				\
+		/area/medical/surgery,				\
+		/area/medical/virology				\
+	))										\
+)
 
 
 GLOBAL_LIST_INIT(science_positions, list(
@@ -54,13 +69,21 @@ GLOBAL_LIST_INIT(science_positions, list(
 	JOB_NAME_ROBOTICIST
 ))
 
-GLOBAL_LIST_INIT(science_lightup_areas, typecacheof(list(
-	/area/science,
-	/area/security/checkpoint/science,
-	/area/construction/mining/aux_base,
-	/area/quartermaster/exploration_prep,
-	/area/quartermaster/exploration_dock
-)))
+GLOBAL_LIST_INIT(science_lightup_areas, 		\
+	typecacheof(list(							\
+		/area/science,							\
+		/area/security/checkpoint/science		\
+	)) - typecacheof(list(						\
+		/area/science/explab,					\
+		/area/science/misc_lab,					\
+		/area/science/mixing,					\
+		/area/science/nanite,					\
+		/area/science/robotics,					\
+		/area/science/server,					\
+		/area/science/storage,					\
+		/area/science/xenobiology				\
+	))											\
+)
 
 
 GLOBAL_LIST_INIT(supply_positions, list(
@@ -70,16 +93,16 @@ GLOBAL_LIST_INIT(supply_positions, list(
 	JOB_NAME_SHAFTMINER
 ))
 
-GLOBAL_LIST_INIT(supply_lightup_areas,					\
+GLOBAL_LIST_INIT(supply_lightup_areas,			\
 	typecacheof(list(							\
 		/area/cargo,							\
 		/area/quartermaster,					\
 		/area/security/checkpoint/supply		\
 	)) - typecacheof(list(						\
-		/area/quartermaster/qm,					\
-		/area/quartermaster/qm_bedroom,			\
+		/area/quartermaster/exploration_dock,	\
 		/area/quartermaster/exploration_prep,	\
-		/area/quartermaster/exploration_dock	\
+		/area/quartermaster/qm,					\
+		/area/quartermaster/qm_bedroom			\
 	))											\
 )
 
@@ -114,9 +137,15 @@ GLOBAL_LIST_INIT(security_positions, list(
 	JOB_NAME_DEPUTY
 ))
 
-GLOBAL_LIST_INIT(security_lightup_areas, typecacheof(list(
-	/area/security
-)))
+GLOBAL_LIST_INIT(security_lightup_areas,	\
+	typecacheof(list(						\
+		/area/security						\
+	)) - typecacheof(list(					\
+		/area/security/detectives_office,	\
+		/area/security/nuke_storage,		\
+		/area/security/warden				\
+	))										\
+)
 
 
 GLOBAL_LIST_INIT(nonhuman_positions, list(

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -10,7 +10,8 @@ GLOBAL_LIST_INIT(command_positions, list(
 GLOBAL_LIST_INIT(command_areas, typecacheof(list(
 	/area/bridge,
 	/area/gateway,
-	/area/teleporter
+	/area/teleporter,
+	/area/security/brig
 )))
 
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -57,6 +57,7 @@ GLOBAL_LIST_INIT(science_areas, typecacheof(list(
 	/area/medical,
 	/area/science,
 	/area/security/checkpoint/science,
+	/area/construction/mining/aux_base,
 	/area/quartermaster/exploration_prep,
 	/area/quartermaster/exploration_dock
 )))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes several changes/fixes to roundstart lighting:
- Now, departments will _properly_ have all their lights turned on, based on a typecache of areas associated with a department, rather than hacky typepath filtering
- Areas that roundstart crewmembers can access will also have their lights turned on at roundstart.
- Set the bar and cafeteria to always have lights on at roundstart, as these can often serve as public crew gathering areas, even if there's no bartender/chef tending to it.
- Also, fixed a few typos in a couple of area names while I was at it.

## Why It's Good For The Game

Fixes some weirdness and makes things more consistent.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-07-28-1690591253-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/7c4df833-2a4b-4759-8e65-1efea4b9ad9c)
![23-07-28-1690591263-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/76a71dfd-910c-4c90-94b0-6c50de7bc6c8)
![23-07-28-1690591287-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/063f6f34-70a7-45f9-80ad-96507266721f)
![23-07-28-1690591294-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ccbb330c-1a2f-4604-a62d-264bfb204495)

</details>

## Changelog
:cl:
fix: Staffed department lighting will now properly be completely switched on at roundstart.
tweak: Lighting of ALL areas accessible by roundstart crewmembers (taking into account minimal or skeleton crew access) will be switched on at roundstart.
tweak: The bar and cafeteria now have their lights always switched on at roundstart, due to the fact they often serve as public crew gathering places, even if there is no bartender/chef tending to them.
spellcheck: Fixed a couple of typos in some area names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
