### PR TITLE
Photocopiers no longer exclusively print gray documents

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -287,7 +287,7 @@
 /obj/machinery/photocopier/proc/make_paper_copy()
 	if(!paper_copy || !toner_cartridge)
 		return
-	var/copy_colour = toner_cartridge.charges > 10 ? COLOR_FULL_TONER_BLACK : COLOR_GRAY;
+	var/copy_colour = toner_cartridge.charges > 1 ? COLOR_FULL_TONER_BLACK : COLOR_GRAY;
 
 	var/obj/item/paper/copied_paper = paper_copy.copy(/obj/item/paper, loc, FALSE, copy_colour)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug in which all printed documents from default photocopiers would have light gray text. The photocopier is supposed to print documents in light gray text when it has less than 10 charges left to simulate ink running out, but the default toner cartridges in photocopiers start with 5 charges and use 0.125 per document. This changes the charge cutoff to 1, meaning the last 8 documents will be faded gray instead of all documents printed by default photocopiers.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots</summary>

![ink](https://github.com/BeeStation/BeeStation-Hornet/assets/35978630/13e92ddc-d330-4411-8d7e-036d8e6412b5)

![ink2](https://github.com/BeeStation/BeeStation-Hornet/assets/35978630/ef682af1-fad0-4231-9374-d9f05d16b831)

</details>

## Changelog
:cl:
fix: Photocopiers no longer print exclusively gray text with default toner cartridges.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
