### PR TITLE
Fix coder OOC being sorted improperly

### DIFF
--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -85,7 +85,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_OOC,
     name: 'OOC',
     description: 'OOC and LOOC messages',
-    selector: '.ooc, .looc, .adminooc',
+    selector: '.ooc, .looc, .adminooc, .adminobserverooc',
   },
   {
     type: MESSAGE_TYPE_ADMINPM,


### PR DESCRIPTION
## About The Pull Request

Sorts adminobserverooc into the OOC category. Otherwise it will hide any non R_ADMIN ooc chats.

## Why It's Good For The Game

People seeing things they want to see is good

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

This is a PITA to test, the code is self explanatory.

</details>

## Changelog
:cl:
fix: Coder OOC will now sort into the correct chat filters.
/:cl:
