### PR TITLE
Double bugfix - Package Wrap and Bluespace capsules

### DIFF
--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -43,16 +43,18 @@
 		return SHAME
 
 /obj/item/proc/can_be_package_wrapped() //can the item be wrapped with package wrapper into a delivery package
-	return 1
+	if(w_class >= WEIGHT_CLASS_GIGANTIC)
+		return FALSE
+	return TRUE
 
 /obj/item/storage/can_be_package_wrapped()
-	return 0
+	return FALSE
 
 /obj/item/storage/box/can_be_package_wrapped()
-	return 1
+	return TRUE
 
 /obj/item/small_delivery/can_be_package_wrapped()
-	return 0
+	return FALSE
 
 /obj/item/stack/package_wrap/afterattack(obj/target, mob/user, proximity)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -334,11 +334,10 @@
 	return FALSE
 
 /obj/structure/closet/crate/capsule/insertion_allowed(atom/movable/AM)
-	if(isitem(AM))
-		var/obj/item/I = AM
-		if(I.w_class >= WEIGHT_CLASS_BULKY) //capsule pod can't hold bulky or larger objects
-			return FALSE
-	if(ismob(AM)) //capsule pod can't hold mobs
+	if(!isitem(AM))
+		return FALSE //Capsule pod can only hold items, not mobs, structures or otherwise
+	var/obj/item/I = AM
+	if(I.w_class >= WEIGHT_CLASS_BULKY) //capsule pod can't hold bulky or larger objects
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1) Package Wrap no longer works on objects of WEIGHT_CLASS_GIGANTIC, because these items should not be of a size that can be picked up. 
2) Adjusts the logic on bluespace capsules to fix an exploit - they will only accept `obj/item` now, instead of potentially picking up structures and otherwise. 

## Why It's Good For The Game

These changes address exploits brought to light in a [forum thread](https://forums.beestation13.com/t/fun-tricks-with-wrapping-paper/23480?u=ruko)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_92ZBtdDptg](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/0f1f416d-f63d-4a04-9cf5-5af768c4dfce)

## Changelog
:cl:
tweak: Package Wrap (and by extension gift wrap) no longer works on gigantic objects
fix: fixed an exploit that enabled bluespace capsules to carry things it was not intended to carry. They are intended to carry items that can be placed within a normal backpack. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
