### PR TITLE
Random Turf init optimizations

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -176,6 +176,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			. = ..()
 		else
 			. = ..()
+			if(flags & CHANGETURF_SKIP) // don't init air before the air subsystem runs
+				return
 			if(!istype(air,/datum/gas_mixture))
 				Initalize_Atmos(0)
 

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -106,7 +106,7 @@
 
 /turf/open/space/transit/Initialize(mapload)
 	. = ..()
-	update_icon()
+	transform = turn(matrix(), get_transit_angle(src))
 	for(var/atom/movable/AM in src)
 		throw_atom(AM, src)
 


### PR DESCRIPTION
## About The Pull Request

Fixes two unnecessary calls during init, saving ~275ms.

## Why It's Good For The Game

Init times

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Lava atmos working (river gen calls Changeturf with the skip flag, lava is an open turf)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/c3f180a5-fc69-4b77-918b-c28c5a8f0a6a)

Transit turfs working
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/9571dfdd-1965-45bd-a2f1-b6dbff445d28)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/e66c3044-ca9c-4101-b5f9-8c8ccf769aa0)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/8b858e03-f76e-49c3-a08b-61095d564aec)

</details>

## Changelog
:cl:
code: Removed unnecessary atmos init during terrain generation, saving 250ms init.
code: Removed unnecessary icon update during transit turf creation, saving 25ms init.
/:cl:
