### PR TITLE
Fixes crafting menu showing incorrect result item icons

### DIFF
--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -433,7 +433,7 @@
 			continue
 		#endif
 
-		var/icon/I = icon(icon_file, icon_state, SOUTH)
+		var/icon/I = icon(icon_file, icon_state, SOUTH, 1)
 		var/c = initial(item.color)
 		if (!isnull(c) && c != "#FFFFFF")
 			I.Blend(c, ICON_MULTIPLY)
@@ -475,7 +475,7 @@
 			continue
 		#endif
 
-		var/icon/I = icon(icon_file, icon_state, SOUTH)
+		var/icon/I = icon(icon_file, icon_state, SOUTH, 1)
 		var/c = initial(A.color)
 		if (!isnull(c) && c != "#FFFFFF")
 			I.Blend(c, ICON_MULTIPLY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes crafting menu showing incorrect result item icons
also, made a change to vendor asset where it can have the same issue

the bug was caused by because of missing frame parameter in icon proc
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/71a385c4-26c7-4e38-88da-fa5f0b8a4220)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/aca8f55e-e68b-4e48-b048-e047f800e842)


## Changelog
:cl:
fix: Fixed crafting menu showing incorrect result item icons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
