### PR TITLE
Deadmins will be visible to admins / deadmins can use advanced staffwho

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -68,21 +68,30 @@
 
 /client/proc/staff_who(via)
 	var/msg
+	var/list/full_admin_list = GLOB.admin_datums+GLOB.deadmins
 
 	// when you are admin
-	if(holder)
+	if(holder || GLOB.deadmins[ckey])
 		msg = "<b>Current Admins:</b>\n"
-		for(var/client/C in GLOB.admins)
-			var/rank = "\improper [C.holder.rank]"
+		for(var/datum/admins/a_datum as() in full_admin_list)
+			a_datum = full_admin_list[a_datum]
+			if(!a_datum)
+				continue
+			var/client/C = a_datum.owner || GLOB.directory[a_datum.target]
+			if(!C)
+				continue
+			var/rank = "\improper [a_datum.rank]"
 			msg += "\t[C] is \a [rank]"
 
-			if(C.holder.fakekey)
-				msg += " <i>(as [C.holder.fakekey])</i>"
+			if(a_datum.fakekey)
+				msg += " <i>(as [a_datum.fakekey])</i>"
 
 			if(isobserver(C.mob))
 				msg += " - Observing"
 			else if(isnewplayer(C.mob))
 				msg += " - Lobby"
+			else if(C.mob.stat == DEAD)
+				msg += " - Observing (in a corpse)"
 			else
 				msg += " - Playing"
 

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -86,7 +86,7 @@
 			if(a_datum.fakekey)
 				msg += " <i>(as [a_datum.fakekey])</i>"
 			if(a_datum.deadmined)
-				msg += " <b>(as Deadmin)</b>"
+				msg += " <b>(Deadmined)</b>"
 
 			if(isobserver(C.mob))
 				msg += " - Observing"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -68,10 +68,10 @@
 
 /client/proc/staff_who(via)
 	var/msg
-	var/list/full_admin_list = GLOB.admin_datums+GLOB.deadmins
 
 	// when you are admin
 	if(holder || GLOB.deadmins[ckey])
+		var/list/full_admin_list = GLOB.admin_datums+GLOB.deadmins
 		msg = "<b>Current Admins:</b>\n"
 		for(var/datum/admins/a_datum as() in full_admin_list)
 			a_datum = full_admin_list[a_datum]
@@ -85,6 +85,8 @@
 
 			if(a_datum.fakekey)
 				msg += " <i>(as [a_datum.fakekey])</i>"
+			if(a_datum.deadmined)
+				msg += " <b>(as Deadmin)</b>"
 
 			if(isobserver(C.mob))
 				msg += " - Observing"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* somea supports to deadmin features
  * Deadmins will be visible to admins
  * Deadmins can use advanced staffwho
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
For deadmins:
* They can see if any staff is online (especially stealthmins) without becoming admin

For admins:
* They can check if there're any deadmin whom they should care in case
For example, a moderator would want to have an admin to handle issues, but if they know if there's an (dead)admin in active, a mod can ask them for an approval.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/669c2acf-8fbe-482b-b037-d4608db9a686)

## Changelog
:cl:
admin: Deadmins can use admin version of staffwho without becoming admin
admin: Deadmins will be visible to staffwho (as being marked as deadmin)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
