### PR TITLE
Revenants can no longer cheese people with electric grilles

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -42,7 +42,7 @@
 	movement_type = FLYING
 	move_resist = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_TINY
-	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
+	pass_flags = PASSTABLE | PASSMOB
 	speed = 1
 	unique_name = TRUE
 	hud_possible = list(ANTAG_HUD)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -249,6 +249,8 @@
 	if(!isrevenant(user))
 		return FALSE
 	var/mob/living/simple_animal/revenant/revenant = user
+	if(!revenant.castcheck(0))
+		return FALSE
 	// if they're trapped in consecrated tiles, they can get out with this. but they can't hide back on these tiles.
 	if(revenant.incorporeal_move != INCORPOREAL_MOVE_JAUNT)
 		var/turf/open/floor/stepTurf = get_turf(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Revenants can no longer pass through grilles when corporeal
* Fixes a critical oversight I made all the way back in #7293 that didn't seem particularly consequential until now - There was no check for valid turf when casting phase shift. 
* Closes #9560

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Revenants have begun to drag stunned players repeatedly into electrified grilles, which is a guaranteed stunlock until soul absorption.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/6f521a61-288b-4493-9cee-8e5b608e32e9)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/e4f9fb44-b57e-42f6-b3e3-d7734700e249)

## Changelog
:cl:
fix: Revenants can no longer phase shift inside of dense objects! There was a missing check which made this possible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
