### PR TITLE
Introduces a cooldown for dragging mobs into turfs with dense objects

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -184,7 +184,7 @@
 			var/mob/living/L = ex_pulled
 			L.update_mobility()// mob gets up if it was lyng down in a chokehold
 
-/atom/movable/proc/Move_Pulled(atom/A)
+/atom/movable/proc/Move_Pulled(atom/A, longercooldown = FALSE)
 	if(!pulling)
 		return
 	if(pulling.anchored || pulling.move_resist > move_force || !pulling.Adjacent(src, src, pulling))
@@ -202,8 +202,12 @@
 	step(pulling, get_dir(pulling.loc, A))
 	return TRUE
 
-/mob/living/Move_Pulled(atom/A)
+/mob/living/Move_Pulled(atom/A, longercooldown = FALSE)
 	. = ..()
+	if(longercooldown)
+		changeNext_move(CLICK_CD_MELEE)
+	else
+		changeNext_move(CLICK_CD_RAPID)
 	if(!. || !isliving(A))
 		return
 	var/mob/living/L = A

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -184,7 +184,7 @@
 			var/mob/living/L = ex_pulled
 			L.update_mobility()// mob gets up if it was lyng down in a chokehold
 
-/atom/movable/proc/Move_Pulled(atom/A, longercooldown = FALSE)
+/atom/movable/proc/Move_Pulled(atom/A)
 	if(!pulling)
 		return
 	if(pulling.anchored || pulling.move_resist > move_force || !pulling.Adjacent(src, src, pulling))
@@ -199,15 +199,10 @@
 		return
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
-	step(pulling, get_dir(pulling.loc, A))
-	return TRUE
+	return step(pulling, get_dir(pulling.loc, A))
 
-/mob/living/Move_Pulled(atom/A, longercooldown = FALSE)
+/mob/living/Move_Pulled(atom/A)
 	. = ..()
-	if(longercooldown)
-		changeNext_move(CLICK_CD_MELEE)
-	else
-		changeNext_move(CLICK_CD_RAPID)
 	if(!. || !isliving(A))
 		return
 	var/mob/living/L = A

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -175,12 +175,10 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		. = TRUE
 	if(.)
 		return
-	var/longercooldown = FALSE
-	for(var/atom/A in contents)
-		if(A.density)//Can't drag mobs into turfs with dense objects on them (i.e tables or grilles)
-			longercooldown = TRUE
-			break
-	user.Move_Pulled(src, longercooldown)
+	if(user.Move_Pulled(src))
+		user.changeNext_move(CLICK_CD_RAPID)
+	else
+		user.changeNext_move(CLICK_CD_MELEE)
 
 /turf/eminence_act(mob/living/simple_animal/eminence/eminence)
 	if(get_turf(eminence) == src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -175,6 +175,9 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		. = TRUE
 	if(.)
 		return
+	for(var/atom/A in contents)
+		if(A.density)//Can't drag mobs into turfs with dense objects on them (i.e tables or grilles)
+			return
 	user.Move_Pulled(src)
 
 /turf/eminence_act(mob/living/simple_animal/eminence/eminence)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -175,10 +175,12 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		. = TRUE
 	if(.)
 		return
+	var/longercooldown = FALSE
 	for(var/atom/A in contents)
 		if(A.density)//Can't drag mobs into turfs with dense objects on them (i.e tables or grilles)
-			return
-	user.Move_Pulled(src)
+			longercooldown = TRUE
+			break
+	user.Move_Pulled(src, longercooldown)
 
 /turf/eminence_act(mob/living/simple_animal/eminence/eminence)
 	if(get_turf(eminence) == src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Introduces a cooldown for dragging mobs into turfs with dense objects with the alt-click menu
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops things like this from happening
<details>
<summary>Abuse showcase</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/b465ae04-db19-4900-90f1-60e0736a7832

</details>

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/4374c25c-b8ad-4aa1-9a16-4b503733a121

</details>

## Changelog
:cl:
balance: Added a cooldown for dragging mobs into turfs with dense objects through the alt-click menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
