### PR TITLE
Adds a cooldown macro to prevent excessive grille shocking

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -700,6 +700,7 @@ so as to remain in compliance with the most up-to-date laws."
 
 /mob
 	var/list/alerts = list() // contains /atom/movable/screen/alert only // On /mob so clientless mobs will throw alerts properly
+	COOLDOWN_DECLARE(grilleshock_immunity)
 
 /atom/movable/screen/alert/Click(location, control, params)
 	if(!usr || !usr.client)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -244,7 +244,9 @@
 // returns 1 if shocked, 0 otherwise
 
 /obj/structure/grille/proc/shock(mob/user, prb)
-	if(!anchored || broken)		// anchored/broken grilles are never connected
+	if(!COOLDOWN_FINISHED(user, grilleshock_immunity))
+		return FALSE
+	if(!anchored || broken) // anchored/broken grilles are never connected
 		return FALSE
 	if(!prob(prb))
 		return FALSE
@@ -254,6 +256,7 @@
 	var/obj/structure/cable/C = T.get_cable_node()
 	if(C)
 		if(electrocute_mob(user, C, src, 1, TRUE))
+			COOLDOWN_START(user, grilleshock_immunity, 1 SECONDS)
 			var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 			s.set_up(3, 1, src)
 			s.start()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
alternative to #9564, because its an interesting dilemma

Simply put, adds a cooldown check to `/obj/structure/grille/proc/shock`.

When a mob is shocked and fulfills all the correct criteria to feel the effects of that shock, a cooldown is started on that mob. 

During that 1-second window, a cooldown check makes other calls from that mob to `/obj/structure/grille/proc/shock` return FALSE.

This check prevents grille shocks to that mob during this period.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops drag abuse from occurring that can be used to wipe players out in less than a second, through many calls to the shock proc.

Forcing calls to obey a 1 second interval makes them much less egregious, and will only effect grilles, no other part of dragging or movement.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/b1584a63-2a99-4b74-994b-3e08a8266916



</details>

## Changelog
:cl:
balance: Added a cooldown for applying shock from grilles to people, reduces egregious dragging abuse from instantly killing players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
