### PR TITLE
Fix runtime when using reagent spawner

### DIFF
--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -63,11 +63,11 @@
 /datum/admins/proc/beaker_panel()
 	set category = "Debug"
 	set name = "Spawn reagent container"
-	if(!check_rights())
+	if(!check_rights(R_DEBUG))
 		return
 
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/namespaced/common)
-	asset_datum.send()
+	asset_datum.send(usr.client)
 	//Could somebody tell me why this isn't using the browser datum, given that it copypastes all of browser datum's html
 	var/dat = {"
 		<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">

--- a/code/modules/asset_cache/transports/asset_transport.dm
+++ b/code/modules/asset_cache/transports/asset_transport.dm
@@ -91,7 +91,7 @@
 			else //no stacktrace because this will mainly happen because the client went away
 				return
 		else
-			CRASH("Invalid argument: client: `[client]`")
+			CRASH("Invalid client passed to send_assets: [client] ([REF(client)])")
 	if (!islist(asset_list))
 		asset_list = list(asset_list)
 	var/list/unreceived = list()


### PR DESCRIPTION
## About The Pull Request

Fixes #9457 (usr.client can't be null due to check_rights)
Adds a better error message as well.
Adds R_DEBUG check to the verb (which it already has, but just in case of a proccall this will protect it more)

## Why It's Good For The Game

Fixes a runtime and fixes the asset sent

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/70016b72-db2d-4ee2-865c-031976390ff8)

</details>

## Changelog
:cl:
fix: Fixed a runtime when using the spawn reagent containers verb.
/:cl:
