### PR TITLE
Adds some admin tools relating to chemical grenades

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1630,6 +1630,7 @@
 #include "code\modules\admin\smites\pacifism.dm"
 #include "code\modules\admin\smites\puzzle.dm"
 #include "code\modules\admin\smites\rod.dm"
+#include "code\modules\admin\smites\sabotage_grenade.dm"
 #include "code\modules\admin\smites\sleep.dm"
 #include "code\modules\admin\smites\stalker.dm"
 #include "code\modules\admin\smites\stub_toe.dm"

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -44,6 +44,8 @@
 		message_admins("\An [assembly] has pulsed [grenade] ([grenade.type]), which was installed by [fingerprint].")
 	log_game("\An [assembly] has pulsed [grenade] ([grenade.type]), which was installed by [fingerprint].")
 	var/mob/M = get_mob_by_ckey(fingerprint)
+	if(!grenade.sabotage)
+		grenade.sabotage = get_grenade_sabotage(M, grenade)
 	var/turf/T = get_turf(M)
 	grenade.log_grenade(M, T)
 	grenade.prime()

--- a/code/modules/admin/smites/sabotage_grenade.dm
+++ b/code/modules/admin/smites/sabotage_grenade.dm
@@ -1,0 +1,159 @@
+GLOBAL_LIST_EMPTY(grenade_sabotages_by_ckey)
+
+/// Sabotages any grenades this player attempts to use or rig.
+/datum/smite/sabotage_grenade
+	name = "Sabotage Grenade"
+	/// A list of premade sabotages.
+	var/static/list/sabotages = list(
+		// Just foam that makes everything funny colors
+		"Colorful Reagent (Rainbow) Foam" = list(
+			list(
+				/datum/reagent/colorful_reagent = 0.6,
+				/datum/reagent/fluorosurfactant = 0.4
+			),
+			list(
+				/datum/reagent/colorful_reagent = 0.6,
+				/datum/reagent/water = 0.4
+			),
+		),
+		"Carpet Foam" = list(
+			list(
+				/datum/reagent/carpet = 0.6,
+				/datum/reagent/fluorosurfactant = 0.4
+			),
+			list(
+				/datum/reagent/carpet = 0.6,
+				/datum/reagent/water = 0.4
+			),
+		),
+		// hardcoded, just makes the grenade do nothing
+		"Nothing" = TRUE,
+		// hardcoded, just makes the grenade do nothing except honk
+		"Nothing (but it honks)" = TRUE,
+		// hardcoded, pulls reagents from admin's marked grenade
+		"Marked Grenade" = TRUE,
+		// hardcoded, just cluwnes the person we smited
+		"Cluwneify" = TRUE,
+		// hardcoded, just nuggets the person we smited
+		"Nugget" = TRUE
+	)
+
+/datum/smite/sabotage_grenade/effect(client/user, mob/living/target)
+	. = ..()
+	var/target_ckey = target.ckey || (target.mind && ckey(target.mind.key))
+	var/effect = tgui_input_list(user, "Which grenade effect would you like to use to sabotage?", "Griffman Pranking Tool", assoc_list_strip_value(sabotages), default = "Nothing (but it honks)")
+	if(!effect || !user.holder || !sabotages[effect])
+		return
+	var/datum/callback/sabotage
+	switch(effect)
+		if("Nothing")
+			sabotage = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(sabotage_effect_nothing), FALSE)
+		if("Nothing (but it honks)")
+			sabotage = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(sabotage_effect_nothing), TRUE)
+		if("Marked Grenade")
+			var/datum/admins/admin_holder = user.holder
+			var/obj/item/grenade/chem_grenade/marked_grenade = admin_holder.marked_datum
+			if(!istype(marked_grenade) || marked_grenade.stage != GRENADE_READY || !length(marked_grenade.beakers))
+				to_chat(user, "<span class='warning'>You must have a finished chemical grenade marked through VV in order to use the Marked Grenade sabotage!</span>")
+				return
+			var/list/datum/reagents/reagents = list()
+			for(var/obj/item/reagent_containers/beaker in marked_grenade.beakers)
+				if(!beaker.reagents)
+					continue
+				var/datum/reagents/new_reagents = new(beaker.reagents.maximum_volume, beaker.reagents.flags)
+				beaker.reagents.copy_to(new_reagents, beaker.reagents.maximum_volume)
+				reagents += new_reagents
+			sabotage = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(sabotage_effect_marked), reagents)
+		if("Cluwneify")
+			sabotage = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(sabotage_effect_cluwne), target_ckey)
+		if("Nugget")
+			sabotage = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(sabotage_effect_nugget), target_ckey)
+		else
+			var/list/sabotage_reagents = sabotages[effect]
+			if(!length(sabotage_reagents))
+				return
+			sabotage = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(sabotage_effect_premade), sabotage_reagents.Copy())
+	if(!sabotage)
+		return
+	var/list/grenades_sabotaged = list()
+	for(var/obj/item/grenade/chem_grenade/grenade in target.GetAllContents())
+		grenade.sabotage = sabotage
+		grenades_sabotaged |= grenade
+	for(var/obj/item/grenade/chem_grenade/grenade as() in GLOB.chem_grenades)
+		var/datum/wires/explosive/chem_grenade/wiring = grenade.wires
+		if(!istype(wiring))
+			continue
+		if(wiring.fingerprint == target_ckey)
+			grenade.sabotage = sabotage
+			grenades_sabotaged |= grenade
+	if(target_ckey)
+		GLOB.grenade_sabotages_by_ckey[target_ckey] = sabotage
+	log_admin("[key_name_admin(usr)] sabotaged all grenades belonging to [key_name_admin(target)] with the effect '[effect]', affecting [length(grenades_sabotaged)] grenades")
+	message_admins("[key_name_admin(usr)] sabotaged all grenades belonging to [ADMIN_LOOKUPFLW(target)] with the effect '[effect]', affecting [length(grenades_sabotaged)] grenades")
+
+/proc/sabotage_effect_nothing(honk = TRUE, obj/item/grenade/chem_grenade/grenade)
+	for(var/obj/item/reagent_containers/beaker in grenade.beakers)
+		beaker.reagents?.clear_reagents()
+	if(honk)
+		playsound(get_turf(grenade), 'sound/items/bikehorn.ogg', vol = 100, vary = TRUE)
+	return FALSE
+
+/proc/sabotage_effect_premade(list/reagents, obj/item/grenade/chem_grenade/grenade)
+	var/reagents_len = length(reagents)
+	if(!reagents_len)
+		return FALSE
+	for(var/i = 1 to length(grenade.beakers))
+		var/obj/item/reagent_containers/beaker = grenade.beakers[i]
+		if(!istype(beaker) || !beaker.reagents)
+			continue
+		beaker.reagents.clear_reagents()
+		if(i <= reagents_len)
+			var/list/new_contents = reagents[i]
+			for(var/reagent_type in new_contents)
+				beaker.reagents.add_reagent(reagent_type, beaker.reagents.maximum_volume * new_contents[reagent_type])
+	return TRUE
+
+/proc/sabotage_effect_marked(list/datum/reagents/reagents, obj/item/grenade/chem_grenade/grenade)
+	var/reagents_len = length(reagents)
+	if(!reagents_len)
+		return FALSE
+	for(var/i = 1 to length(grenade.beakers))
+		var/obj/item/reagent_containers/beaker = grenade.beakers[i]
+		if(!istype(beaker) || !beaker.reagents)
+			continue
+		beaker.reagents.clear_reagents()
+		if(i <= reagents_len)
+			var/datum/reagents/new_reagents = reagents[i]
+			beaker.reagents.maximum_volume = new_reagents.maximum_volume
+			beaker.reagents.flags = new_reagents.flags
+			new_reagents.copy_to(beaker.reagents, new_reagents.maximum_volume)
+	return TRUE
+
+/proc/sabotage_effect_cluwne(ckey, obj/item/grenade/chem_grenade/grenade)
+	var/mob/living/target = get_mob_by_ckey(ckey)
+	if(istype(target))
+		target.cluwne()
+	return FALSE
+
+/proc/sabotage_effect_nugget(ckey, obj/item/grenade/chem_grenade/grenade)
+	var/mob/living/target = get_mob_by_ckey(ckey)
+	if(istype(target))
+		if(iscarbon(target))
+			var/mob/living/carbon/nugget = target
+			for (var/obj/item/bodypart/limb in nugget.bodyparts)
+				if(limb.body_part == HEAD || limb.body_part == CHEST)
+					continue
+				INVOKE_ASYNC(limb, TYPE_PROC_REF(/obj/item/bodypart, dismember))
+				INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), nugget, 'sound/effects/cartoon_pop.ogg', 75, TRUE)
+		else
+			target.gib(TRUE, TRUE, TRUE)
+	return FALSE
+
+/proc/get_grenade_sabotage(mob/user, obj/item/grenade/chem_grenade/grenade)
+	if(grenade.sabotage)
+		return grenade.sabotage
+	if(!istype(user))
+		return
+	var/target_ckey = user.ckey || (user.mind && ckey(user.mind.key))
+	if(target_ckey && GLOB.grenade_sabotages_by_ckey[target_ckey])
+		return GLOB.grenade_sabotages_by_ckey[target_ckey]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds some admin tools (read: a smite) relating to chemical grenades, allowing admins to permanently change what happens whenever a certain player uses a chemical grenade.
These changes are _undetectable_ until they actually try to set off a grenade, as the changes only occur during the actual grenade activation process.

In addition, these changes are 'sticky', and will apply to any grenades with the following criteria:
- Any grenades armed by the target user.
- Any grenades within the target user's contents at the time of smite.
- Any grenades that have been 'finished' by the target user.

The following grenade effects are available:
- **Nothing**: just makes the grenade do nothing and disappear whenever it's set off
- **Nothing (but it honks)**: same as Nothing... but it also does a clown honk whenever it disappears.
- **Marked Grenade**: the grenade copies the beakers from whatever grenade the admin had set as their marked datum (wiping out all other reagents in the grenade)
- **Cluwneify**: the target gets turned into a cluwne whenever the grenade gets set off (and the grenade does nothing anyways)
- **Nugget**: the target gets nuggeted (or just gibbed if they're not a carbon) whenever the grenade gets set off (and the grenade does nothing anyways)
- **Colorful Reagent (Rainbow) Foam**: The contents of the grenade are replaced with colorful reagent foam, which has no effect other than randomly changing the colors of anything caught in said foam
- **Carpet Foam**: The contents of the grenade are replaced with carpet foam, which just makes the floor in the foam's area into nice-looking carpet.

## Why It's Good For The Game

hehe funny prank to waste griffman's time

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ad00a6ba-3055-400c-9e74-7c6ba1d298ee

</details>

## Changelog
:cl:
admin: Adds some admin tools relating to chemical grenades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
