### PR TITLE
Minor changes to supermatter distortion

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -125,7 +125,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /atom/movable/distortion_effect
 	name = ""
 	plane = GRAVITY_PULSE_PLANE
-	appearance_flags = PIXEL_SCALE
+	// Changing the colour of this based on the parent will cause issues with the displacement effect
+	// so we need to ensure that it always has the default colour (clear).
+	appearance_flags = PIXEL_SCALE | RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM | NO_CLIENT_COLOR
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "SM_base"
@@ -144,7 +146,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	radio.listening = 0
 	radio.recalculateChannels()
 	distort = new(src)
-	add_overlay(distort)
 	add_emitter(/obj/emitter/sparkle, "supermatter_sparkle")
 	investigate_log("has been created.", INVESTIGATE_ENGINES)
 	if(is_main_engine)
@@ -277,10 +278,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	. = ..()
 	if(final_countdown)
 		. += "casuality_field"
+	. += get_displacement_icon()
 
 // Switches the overlay based on the supermatter's current state; only called when the status has changed
-/obj/machinery/power/supermatter_crystal/proc/update_displacement()
-	cut_overlay(distort)
+/obj/machinery/power/supermatter_crystal/proc/get_displacement_icon()
 	switch(last_status)
 		if(SUPERMATTER_INACTIVE)
 			distort.icon = 'icons/effects/96x96.dmi'
@@ -307,7 +308,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			distort.icon_state = "SM_delam_3"
 			distort.pixel_x = -128
 			distort.pixel_y = -128
-	add_overlay(distort)
+	return distort
 
 /obj/machinery/power/supermatter_crystal/proc/countdown()
 	set waitfor = FALSE
@@ -510,7 +511,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/current_status = get_status()
 	if(current_status != last_status)
 		last_status = current_status
-		update_displacement()
+		update_icon(UPDATE_OVERLAYS)
 
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.
 	//Use of the second function improves the power gain imparted by using co2

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -276,9 +276,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 /obj/machinery/power/supermatter_crystal/update_overlays()
 	. = ..()
-	if(final_countdown)
-		. += "casuality_field"
 	. += get_displacement_icon()
+	if(final_countdown)
+		. += "causality_field"
 
 // Switches the overlay based on the supermatter's current state; only called when the status has changed
 /obj/machinery/power/supermatter_crystal/proc/get_displacement_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Makes the displacement effect be applied by using update_overlays
- Makes the displacement map unable to be recoloured.

## Why It's Good For The Game

Managed overlays should use the system for managed overlays (update_overlays).
Displacement maps being coloured causes them to break.

## Testing Photographs and Procedure


https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2d8182d0-8798-4c37-af4b-cf3d7cd38b3d


This thing persists after death
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/0ecc6179-1137-4e7d-9a4d-41cf53e571ff)

## Changelog
:cl:
fix: Fixes some minor issues with the supermatter distortion effect.
fix: Fixes the causality field not appearing due to being mispelt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
