### PR TITLE
Smooth aurora & Cheap starlight lighting

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2622,6 +2622,7 @@
 #include "code\modules\lighting\lighting_setup.dm"
 #include "code\modules\lighting\lighting_source.dm"
 #include "code\modules\lighting\lighting_turf.dm"
+#include "code\modules\lighting\starlight.dm"
 #include "code\modules\mapexporting\mapexporter.dm"
 #include "code\modules\mapping\map_template.dm"
 #include "code\modules\mapping\mapping_helpers.dm"

--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -33,3 +33,5 @@
 #define COMSIG_GLOB_NEW_RESEARCH "!remote_research_changed"
 /// Called after the round has fully setup and all jobs have been spawned
 #define COMSIG_GLOB_POST_START "!post_start"
+/// Called when the parallax background changes colour. (new_colour, transition_time, force_colour)
+#define COMSIG_GLOB_PARALLAX_COLOUR_CHANGE "!parallax_colour_change"

--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -33,5 +33,5 @@
 #define COMSIG_GLOB_NEW_RESEARCH "!remote_research_changed"
 /// Called after the round has fully setup and all jobs have been spawned
 #define COMSIG_GLOB_POST_START "!post_start"
-/// Called when the parallax background changes colour. (new_colour, transition_time, force_colour)
-#define COMSIG_GLOB_PARALLAX_COLOUR_CHANGE "!parallax_colour_change"
+/// Called when the parallax background changes colour. (new_colour, transition_time)
+#define COMSIG_GLOB_STARLIGHT_COLOUR_CHANGE "!starlight_colour_change"

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -108,6 +108,10 @@
 ///Normal 1 per turf dynamic lighting objects
 #define LIGHTING_PLANE 100
 
+/// The plane for managing the global starlight effect
+#define STARLIGHT_PLANE 105
+#define STARLIGHT_RENDER_TARGET "*STARLIGHT_PLANE"
+
 ///Lighting objects that are "free floating"
 #define O_LIGHTING_VISUAL_PLANE 110
 #define O_LIGHTING_VISUAL_RENDER_TARGET "O_LIGHT_VISUAL_PLANE"

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -110,7 +110,6 @@
 
 /// The plane for managing the global starlight effect
 #define STARLIGHT_PLANE 105
-#define STARLIGHT_RENDER_TARGET "*STARLIGHT_PLANE"
 
 ///Lighting objects that are "free floating"
 #define O_LIGHTING_VISUAL_PLANE 110

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -84,6 +84,10 @@
 #define DYNAMIC_LIGHTING_IFSTARLIGHT 3 //! dynamic lighting enabled only if starlight is.
 #define IS_DYNAMIC_LIGHTING(A) A.dynamic_lighting
 
+// Fullbright lighting defines
+#define FULLBRIGHT_NONE 0		//! Do not use fullbright (Only applies to turfs)
+#define FULLBRIGHT_DEFAULT 1	//! Use the default fullbright overlay of just 100% lighting
+#define FULLBRIGHT_STARLIGHT 2	//! Use the starlight brightness overlay
 
 //code assumes higher numbers override lower numbers.
 #define LIGHTING_NO_UPDATE 0
@@ -143,4 +147,11 @@ GLOBAL_DATUM_INIT(fullbright_overlay, /image, create_fullbright_overlay())
 /proc/create_fullbright_overlay()
 	var/image/lighting_effect = new()
 	lighting_effect.appearance = /obj/effect/fullbright
+	return lighting_effect
+
+GLOBAL_DATUM_INIT(starlight_overlay, /image, create_starlight_overlay())
+
+/proc/create_starlight_overlay()
+	var/image/lighting_effect = new()
+	lighting_effect.appearance = /obj/effect/fullbright/starlight
 	return lighting_effect

--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -44,4 +44,22 @@
 	C.color = flash_color
 	animate(C, color = animate_color, time = flash_time)
 
+/// Ensures that the lightness value of a colour must be greater than the provided
+/// minimum.
+/proc/color_min_lightness(colour, min_lightness)
+	var/list/rgb = rgb2num(colour)
+	var/list/hsl = rgb2hsl(rgb[1], rgb[2], rgb[3])
+	// Ensure high lightness (Minimum of 90%)
+	hsl[3] = max(hsl[3], min_lightness)
+	return hsv(hsl[1], hsl[2], hsl[3])
+
+/// Ensures that the lightness value of a colour must be less than the provided
+/// maximum.
+/proc/color_max_lightness(colour, max_lightness)
+	var/list/rgb = rgb2num(colour)
+	var/list/hsl = rgb2hsl(rgb[1], rgb[2], rgb[3])
+	// Ensure high lightness (Minimum of 90%)
+	hsl[3] = min(hsl[3], max_lightness)
+	return hsv(hsl[1], hsl[2], hsl[3])
+
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))

--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -46,7 +46,7 @@
 
 /// Ensures that the lightness value of a colour must be greater than the provided
 /// minimum.
-/proc/color_min_lightness(colour, min_lightness)
+/proc/color_lightness_max(colour, min_lightness)
 	var/list/rgb = rgb2num(colour)
 	var/list/hsl = rgb2hsl(rgb[1], rgb[2], rgb[3])
 	// Ensure high lightness (Minimum of 90%)
@@ -55,7 +55,7 @@
 
 /// Ensures that the lightness value of a colour must be less than the provided
 /// maximum.
-/proc/color_max_lightness(colour, max_lightness)
+/proc/color_lightness_min(colour, max_lightness)
 	var/list/rgb = rgb2num(colour)
 	var/list/hsl = rgb2hsl(rgb[1], rgb[2], rgb[3])
 	// Ensure high lightness (Minimum of 90%)

--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -51,7 +51,8 @@
 	var/list/hsl = rgb2hsl(rgb[1], rgb[2], rgb[3])
 	// Ensure high lightness (Minimum of 90%)
 	hsl[3] = max(hsl[3], min_lightness)
-	return hsv(hsl[1], hsl[2], hsl[3])
+	var/list/transformed_rgb = hsl2rgb(hsl[1], hsl[2], hsl[3])
+	return rgb(transformed_rgb[1], transformed_rgb[2], transformed_rgb[3])
 
 /// Ensures that the lightness value of a colour must be less than the provided
 /// maximum.
@@ -60,6 +61,7 @@
 	var/list/hsl = rgb2hsl(rgb[1], rgb[2], rgb[3])
 	// Ensure high lightness (Minimum of 90%)
 	hsl[3] = min(hsl[3], max_lightness)
-	return hsv(hsl[1], hsl[2], hsl[3])
+	var/list/transformed_rgb = hsl2rgb(hsl[1], hsl[2], hsl[3])
+	return rgb(transformed_rgb[1], transformed_rgb[2], transformed_rgb[3])
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -485,6 +485,36 @@ Takes a string and a datum. The string is well, obviously the string being check
 	var/B = hex2num(copytext(A, 6, 8))
 	return R+G+B
 
+/proc/color_red(colour)
+	if (copytext(colour, 1, 2) == "#")
+		colour = copytext(colour, 2)
+	if (length(colour) == 3)
+		return hex2num(copytext(colour, 1, 2)) * 16
+	else if(length(colour) == 6)
+		return hex2num(copytext(colour, 1, 3))
+	else
+		return 0
+
+/proc/color_green(colour)
+	if (copytext(colour, 1, 2) == "#")
+		colour = copytext(colour, 2)
+	if (length(colour) == 3)
+		return hex2num(copytext(colour, 2, 3)) * 16
+	else if(length(colour) == 6)
+		return hex2num(copytext(colour, 3, 5))
+	else
+		return 0
+
+/proc/color_blue(colour)
+	if (copytext(colour, 1, 2) == "#")
+		colour = copytext(colour, 2)
+	if (length(colour) == 3)
+		return hex2num(copytext(colour, 3, 4)) * 16
+	else if(length(colour) == 6)
+		return hex2num(copytext(colour, 5, 7))
+	else
+		return 0
+
 //word of warning: using a matrix like this as a color value will simplify it back to a string after being set
 /proc/color_hex2color_matrix(string)
 	var/length = length(string)

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -485,36 +485,6 @@ Takes a string and a datum. The string is well, obviously the string being check
 	var/B = hex2num(copytext(A, 6, 8))
 	return R+G+B
 
-/proc/color_red(colour)
-	if (copytext(colour, 1, 2) == "#")
-		colour = copytext(colour, 2)
-	if (length(colour) == 3)
-		return hex2num(copytext(colour, 1, 2)) * 16
-	else if(length(colour) == 6)
-		return hex2num(copytext(colour, 1, 3))
-	else
-		return 0
-
-/proc/color_green(colour)
-	if (copytext(colour, 1, 2) == "#")
-		colour = copytext(colour, 2)
-	if (length(colour) == 3)
-		return hex2num(copytext(colour, 2, 3)) * 16
-	else if(length(colour) == 6)
-		return hex2num(copytext(colour, 3, 5))
-	else
-		return 0
-
-/proc/color_blue(colour)
-	if (copytext(colour, 1, 2) == "#")
-		colour = copytext(colour, 2)
-	if (length(colour) == 3)
-		return hex2num(copytext(colour, 3, 4)) * 16
-	else if(length(colour) == 6)
-		return hex2num(copytext(colour, 5, 7))
-	else
-		return 0
-
 //word of warning: using a matrix like this as a color value will simplify it back to a string after being set
 /proc/color_hex2color_matrix(string)
 	var/length = length(string)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -178,6 +178,27 @@
 	layer = BACKGROUND_LAYER+20
 	show_when_dead = TRUE
 
+/// Provides a black background to the starlight layer
+/atom/movable/screen/fullscreen/lighting_backdrop/starlight
+	layer = BACKGROUND_LAYER+21
+	plane = STARLIGHT_PLANE
+	show_when_dead = TRUE
+	color = "#000"
+
+/atom/movable/screen/fullscreen/starlight_overlay
+	render_source = STARLIGHT_RENDER_TARGET
+	plane = LIGHTING_PLANE
+	// Overlay seems to work better due to being able to transition lighting
+	// without over-exposure in the transition period
+	blend_mode = BLEND_OVERLAY
+	appearance_flags = NO_CLIENT_COLOR
+	show_when_dead = TRUE
+	screen_loc = "CENTER,CENTER"
+
+/atom/movable/screen/fullscreen/starlight_overlay/update_for_view(client_view)
+	// We automatically scale to the view due to being rendered from a plane.
+	return
+
 /atom/movable/screen/fullscreen/see_through_darkness
 	icon_state = "nightvision"
 	plane = LIGHTING_PLANE

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -178,20 +178,6 @@
 	layer = BACKGROUND_LAYER+20
 	show_when_dead = TRUE
 
-/atom/movable/screen/fullscreen/starlight_overlay
-	render_source = STARLIGHT_RENDER_TARGET
-	plane = LIGHTING_PLANE
-	// Overlay seems to work better due to being able to transition lighting
-	// without over-exposure in the transition period
-	blend_mode = BLEND_OVERLAY
-	appearance_flags = NO_CLIENT_COLOR
-	show_when_dead = TRUE
-	screen_loc = "CENTER,CENTER"
-
-/atom/movable/screen/fullscreen/starlight_overlay/update_for_view(client_view)
-	// We automatically scale to the view due to being rendered from a plane.
-	return
-
 /atom/movable/screen/fullscreen/see_through_darkness
 	icon_state = "nightvision"
 	plane = LIGHTING_PLANE

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -178,13 +178,6 @@
 	layer = BACKGROUND_LAYER+20
 	show_when_dead = TRUE
 
-/// Provides a black background to the starlight layer
-/atom/movable/screen/fullscreen/lighting_backdrop/starlight
-	layer = BACKGROUND_LAYER+21
-	plane = STARLIGHT_PLANE
-	show_when_dead = TRUE
-	color = "#000"
-
 /atom/movable/screen/fullscreen/starlight_overlay
 	render_source = STARLIGHT_RENDER_TARGET
 	plane = LIGHTING_PLANE

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -314,7 +314,7 @@
 	icon_state = "random_layer1"
 
 /atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, view)
-	src.add_atom_colour(SSparallax.random_parallax_color, ADMIN_COLOUR_PRIORITY)
+	src.add_atom_colour(SSparallax.assign_random_parallax_colour(), ADMIN_COLOUR_PRIORITY)
 
 /atom/movable/screen/parallax_layer/random/asteroids
 	icon_state = "random_layer2"

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -139,14 +139,8 @@
 	if (force_colour)
 		animate(src, time = transition_time, color = new_colour)
 		return
-	var/red = color_red(new_colour)
-	var/green = color_green(new_colour)
-	var/blue = color_blue(new_colour)
-	var/list/hsl = rgb2hsl(red, green, blue)
-	hsl[2] = max(hsl[2], 0.71)
-	hsl[3] = max(hsl[3], 0.9)
-	var/lighting_colour = hsl2rgb(hsl[1], hsl[2], hsl[3])
-	// Ensure high lightness and low saturation
+	// Ensure that the lightness of the colour is quite high to give us good looking lighting colours
+	var/lighting_colour = color_min_lightness(new_colour, 0.85)
 	animate(src, time = transition_time, color = lighting_colour)
 
 /**

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -108,7 +108,6 @@
 	. = ..()
 	mymob.overlay_fullscreen("lighting_backdrop_lit", /atom/movable/screen/fullscreen/lighting_backdrop/lit)
 	mymob.overlay_fullscreen("lighting_backdrop_unlit", /atom/movable/screen/fullscreen/lighting_backdrop/unlit)
-	mymob.overlay_fullscreen("starlight_overlay", /atom/movable/screen/fullscreen/starlight_overlay)
 
 /atom/movable/screen/plane_master/lighting/Initialize(mapload)
 	. = ..()
@@ -123,8 +122,8 @@
 	name = "starlight plane master"
 	plane = STARLIGHT_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	render_target = STARLIGHT_RENDER_TARGET
-	render_relay_plane = null
+	render_relay_plane = LIGHTING_PLANE
+	blend_mode_override = BLEND_OVERLAY
 	color = "#bcdaf7"
 
 /atom/movable/screen/plane_master/starlight/Initialize(mapload)

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -130,7 +130,7 @@
 	. = ..()
 	add_filter("guassian_blur", 1, gauss_blur_filter(6))
 	// Default the colour to whatever the parallax is currently
-	transition_colour(src, SSparallax.random_parallax_color, 0, FALSE)
+	transition_colour(src, GLOB.starlight_colour, 0, FALSE)
 	// Transition the colour to whatever the global tells us to go to
 	RegisterSignal(SSdcs, COMSIG_GLOB_STARLIGHT_COLOUR_CHANGE, PROC_REF(transition_colour))
 

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -140,7 +140,7 @@
 		animate(src, time = transition_time, color = new_colour)
 		return
 	// Ensure that the lightness of the colour is quite high to give us good looking lighting colours
-	var/lighting_colour = color_min_lightness(new_colour, 0.85)
+	var/lighting_colour = color_min_lightness(new_colour, 0.9)
 	animate(src, time = transition_time, color = lighting_colour)
 
 /**

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -135,10 +135,6 @@
 	// Transition the colour to whatever the global tells us to go to
 	RegisterSignal(SSdcs, COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, PROC_REF(transition_colour))
 
-/atom/movable/screen/plane_master/starlight/backdrop(mob/mymob)
-	. = ..()
-	mymob.overlay_fullscreen("starlight_backdrop", /atom/movable/screen/fullscreen/lighting_backdrop/starlight)
-
 /atom/movable/screen/plane_master/starlight/proc/transition_colour(datum/source, new_colour, transition_time = 5 SECONDS, force_colour = FALSE)
 	SIGNAL_HANDLER
 	if (force_colour)

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -132,16 +132,11 @@
 	// Default the colour to whatever the parallax is currently
 	transition_colour(src, SSparallax.random_parallax_color, 0, FALSE)
 	// Transition the colour to whatever the global tells us to go to
-	RegisterSignal(SSdcs, COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, PROC_REF(transition_colour))
+	RegisterSignal(SSdcs, COMSIG_GLOB_STARLIGHT_COLOUR_CHANGE, PROC_REF(transition_colour))
 
-/atom/movable/screen/plane_master/starlight/proc/transition_colour(datum/source, new_colour, transition_time = 5 SECONDS, force_colour = FALSE)
+/atom/movable/screen/plane_master/starlight/proc/transition_colour(datum/source, new_colour, transition_time = 5 SECONDS)
 	SIGNAL_HANDLER
-	if (force_colour)
-		animate(src, time = transition_time, color = new_colour)
-		return
-	// Ensure that the lightness of the colour is quite high to give us good looking lighting colours
-	var/lighting_colour = color_min_lightness(new_colour, 0.9)
-	animate(src, time = transition_time, color = lighting_colour)
+	animate(src, time = transition_time, color = new_colour)
 
 /**
   * Things placed on this mask the lighting plane. Doesn't render directly.

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -111,5 +111,5 @@ SUBSYSTEM_DEF(parallax)
 	if (!random_colour_assigned)
 		random_parallax_color = pick(COLOR_TEAL, COLOR_GREEN, COLOR_SILVER, COLOR_YELLOW, COLOR_CYAN, COLOR_ORANGE, COLOR_PURPLE)//Special color for random_layer1. Has to be done here so everyone sees the same color.
 		random_colour_assigned = TRUE
-		set_starlight_colour(color_lightness_max(random_parallax_color, 0.9), 0)
+		set_starlight_colour(color_lightness_max(random_parallax_color, 0.75), 0)
 	return random_parallax_color

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -111,5 +111,5 @@ SUBSYSTEM_DEF(parallax)
 	if (!random_colour_assigned)
 		random_parallax_color = pick(COLOR_TEAL, COLOR_GREEN, COLOR_SILVER, COLOR_YELLOW, COLOR_CYAN, COLOR_ORANGE, COLOR_PURPLE)//Special color for random_layer1. Has to be done here so everyone sees the same color.
 		random_colour_assigned = TRUE
-		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, random_parallax_color, 5 SECONDS, FALSE)
+		set_starlight_colour(color_lightness_max(random_parallax_color, 0.9), 0)
 	return random_parallax_color

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -10,7 +10,9 @@ SUBSYSTEM_DEF(parallax)
 	var/planet_x_offset = 128
 	var/planet_y_offset = 128
 	var/random_layer
-	var/random_parallax_color
+	var/random_colour_assigned = FALSE
+	/// The random colour of the parallax, a nice blue that works for all space by default
+	var/random_parallax_color = "#d2e5f7"
 	//Amount of ticks between the parallax being allowed to freely fire without going into the queue
 	var/parallax_free_fire_delay_ticks = 10
 
@@ -25,7 +27,6 @@ SUBSYSTEM_DEF(parallax)
 	. = ..()
 	if(prob(70))	//70% chance to pick a special extra layer
 		random_layer = pick(/atom/movable/screen/parallax_layer/random/space_gas, /atom/movable/screen/parallax_layer/random/asteroids)
-		random_parallax_color = pick(COLOR_TEAL, COLOR_GREEN, COLOR_SILVER, COLOR_YELLOW, COLOR_CYAN, COLOR_ORANGE, COLOR_PURPLE)//Special color for random_layer1. Has to be done here so everyone sees the same color.
 	planet_y_offset = rand(100, 160)
 	planet_x_offset = rand(100, 160)
 
@@ -105,3 +106,10 @@ SUBSYSTEM_DEF(parallax)
 	//Mark it as being queued
 	updater?.parallax_update_queued = TRUE
 	queued += updater
+
+/datum/controller/subsystem/parallax/proc/assign_random_parallax_colour()
+	if (!random_colour_assigned)
+		random_parallax_color = pick(COLOR_TEAL, COLOR_GREEN, COLOR_SILVER, COLOR_YELLOW, COLOR_CYAN, COLOR_ORANGE, COLOR_PURPLE)//Special color for random_layer1. Has to be done here so everyone sees the same color.
+		random_colour_assigned = TRUE
+		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, random_parallax_color, 5 SECONDS, FALSE)
+	return random_parallax_color

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -35,6 +35,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	ambient_music_index = AMBIENCE_SPACE
 	ambient_buzz = null //Space is deafeningly quiet
 	sound_environment = SOUND_AREA_SPACE
+	fullbright_type = FULLBRIGHT_STARLIGHT
 
 /area/space/nearstation
 	icon_state = "space_near"
@@ -64,6 +65,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	ambience_index = AMBIENCE_MINING
 	sound_environment = SOUND_AREA_ASTEROID
 	area_flags = UNIQUE_AREA
+	fullbright_type = FULLBRIGHT_STARLIGHT
 
 /area/asteroid/nearstation
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -214,7 +214,10 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	if(!IS_DYNAMIC_LIGHTING(src))
 		blend_mode = BLEND_MULTIPLY // Putting this in the constructor so that it stops the icons being screwed up in the map editor.
-		add_overlay(GLOB.fullbright_overlay)
+		if (fullbright_type == FULLBRIGHT_STARLIGHT)
+			add_overlay(GLOB.starlight_overlay)
+		else
+			add_overlay(GLOB.fullbright_overlay)
 	else if(lighting_overlay_opacity && lighting_overlay_colour)
 		generate_lighting_overlay()
 	reg_in_areas_in_z()

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -136,6 +136,7 @@
 	name = "Hyperspace"
 	desc = "Weeeeee"
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+	fullbright_type = FULLBRIGHT_STARLIGHT
 
 /area/shuttle/custom
 	name = "Custom player shuttle"

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -61,6 +61,10 @@
 	plane = LIGHTING_PLANE
 	blend_mode = BLEND_ADD
 
+/obj/effect/fullbright/starlight
+	plane = STARLIGHT_PLANE
+	transform = matrix(2, 0, 0, 0, 2, 0)
+
 /obj/effect/abstract/marker
 	name = "marker"
 	icon = 'icons/effects/effects.dmi'

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(flags & CHANGETURF_SKIP)
 		return new path(src)
 
-	var/old_dynamic_lighting = dynamic_lighting
+	var/old_fullbright_type = fullbright_type
 	var/old_lighting_object = lighting_object
 	var/old_lighting_corner_NE = lighting_corner_NE
 	var/old_lighting_corner_SE = lighting_corner_SE
@@ -143,14 +143,11 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		directional_opacity = old_directional_opacity
 		recalculate_directional_opacity()
 
-		if(dynamic_lighting != old_dynamic_lighting)
-			if (IS_DYNAMIC_LIGHTING(src))
+		if(fullbright_type != old_fullbright_type)
+			if (!fullbright_type)
 				lighting_build_overlay()
 			else
 				lighting_clear_overlay()
-
-		for(var/turf/open/space/S in RANGE_TURFS(1, src)) //RANGE_TURFS is in code\__HELPERS\game.dm
-			S.update_starlight()
 
 	if(old_opacity != opacity && SSticker)
 		GLOB.cameranet.bareMajorChunkChange(src)

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -413,6 +413,7 @@
 	broken_states = list("damaged")
 	plane = PLANE_SPACE
 	tiled_dirt = FALSE
+	fullbright_type = FULLBRIGHT_STARLIGHT
 
 /turf/open/floor/fakespace/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -414,6 +414,7 @@
 	plane = PLANE_SPACE
 	tiled_dirt = FALSE
 	fullbright_type = FULLBRIGHT_STARLIGHT
+	luminosity = 2
 
 /turf/open/floor/fakespace/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -14,6 +14,10 @@
 	thermal_conductivity = 0
 	heat_capacity = 700000
 
+	// Since we have a lighting layer that extends further than the turf, make this turf
+	// create luminosity to nearby turfs.
+	luminosity = 2
+
 	var/destination_z
 	var/destination_x
 	var/destination_y
@@ -24,7 +28,7 @@
 	plane = PLANE_SPACE
 	layer = SPACE_LAYER
 	light_power = 0.25
-	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
+	fullbright_type = FULLBRIGHT_STARLIGHT
 	bullet_bounce_sound = null
 
 	z_eventually_space = TRUE
@@ -59,8 +63,8 @@
 	flags_1 |= INITIALIZED_1
 
 	var/area/A = loc
-	if(!IS_DYNAMIC_LIGHTING(src) && IS_DYNAMIC_LIGHTING(A))
-		overlays += GLOB.fullbright_overlay
+	if(IS_DYNAMIC_LIGHTING(A))
+		overlays += GLOB.starlight_overlay
 
 	return INITIALIZE_HINT_NORMAL
 
@@ -96,16 +100,6 @@
 
 /turf/open/space/remove_air_ratio(amount)
 	return null
-
-/turf/open/space/proc/update_starlight()
-	if(CONFIG_GET(flag/starlight))
-		for(var/t in RANGE_TURFS(1,src)) //RANGE_TURFS is in code\__HELPERS\game.dm
-			if(isspaceturf(t))
-				//let's NOT update this that much pls
-				continue
-			set_light(2)
-			return
-		set_light(0)
 
 /turf/open/space/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -98,8 +98,11 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		Entered(content, null)
 
 	var/area/A = loc
-	if(!IS_DYNAMIC_LIGHTING(src) && IS_DYNAMIC_LIGHTING(A))
-		add_overlay(GLOB.fullbright_overlay)
+	if(fullbright_type && IS_DYNAMIC_LIGHTING(A))
+		if (fullbright_type == FULLBRIGHT_STARLIGHT)
+			add_overlay(GLOB.starlight_overlay)
+		else
+			add_overlay(GLOB.fullbright_overlay)
 
 	if(requires_activation)
 		CALCULATE_ADJACENT_TURFS(src)

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -14,7 +14,7 @@
 	announceWhen = 1
 	startWhen = 9
 	endWhen = 50
-	var/list/aurora_colors = list("#A2FF80", "#A2FF8B", "#A2FF96", "#A2FFA5", "#A2FFB6", "#A2FFC7", "#A2FFDE", "#A2FFEE")
+	var/list/aurora_colors = list("#A2FF80", "#8bff99", "#A2FF96", "#a2ffe3", "#a2efff", "#a2d8ff", "#a2b1ff", "#b190ff")
 	var/aurora_progress = 0 //this cycles from 1 to 8, slowly changing colors from gentle green to gentle blue
 
 /datum/round_event/aurora_caelus/announce()
@@ -27,33 +27,16 @@
 			M.playsound_local(M, 'sound/ambience/aurora_caelus.ogg', 20, FALSE, pressure_affected = FALSE)
 
 /datum/round_event/aurora_caelus/start()
-	for(var/area/affected_area as anything in GLOB.areas)
-		if(initial(affected_area.dynamic_lighting) == DYNAMIC_LIGHTING_IFSTARLIGHT)
-			for(var/turf/open/space/S in affected_area.get_contained_turfs())
-				S.set_light(S.light_range * 3, S.light_power * 0.5)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, aurora_colors[1], 5 SECONDS, TRUE)
 
 /datum/round_event/aurora_caelus/tick()
 	if(activeFor % 5 == 0)
 		aurora_progress++
 		var/aurora_color = aurora_colors[aurora_progress]
-		for(var/area/affected_area as anything in GLOB.areas)
-			if(initial(affected_area.dynamic_lighting) == DYNAMIC_LIGHTING_IFSTARLIGHT)
-				for(var/turf/open/space/S in affected_area.get_contained_turfs())
-					S.set_light(l_color = aurora_color)
+		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, aurora_color, 5 SECONDS, TRUE)
 
 /datum/round_event/aurora_caelus/end()
-	for(var/area/affected_area as anything in GLOB.areas)
-		if(initial(affected_area.dynamic_lighting) == DYNAMIC_LIGHTING_IFSTARLIGHT)
-			for(var/turf/open/space/S in affected_area.get_contained_turfs())
-				fade_to_black(S)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, SSparallax.random_parallax_color, 30 SECONDS, FALSE)
 	priority_announce("The aurora caelus event is now ending. Starlight conditions will slowly return to normal. When this has concluded, please return to your workplace and continue work as normal. Have a pleasant shift, [station_name()], and thank you for watching with us.",
 	sound = 'sound/misc/notice2.ogg',
 	sender_override = "Nanotrasen Meteorology Division")
-
-/datum/round_event/aurora_caelus/proc/fade_to_black(turf/open/space/S)
-	set waitfor = FALSE
-	var/new_light = initial(S.light_range)
-	while(S.light_range > new_light)
-		S.set_light(S.light_range - 0.2)
-		sleep(30)
-	S.set_light(new_light, initial(S.light_power), initial(S.light_color))

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -36,7 +36,7 @@
 		set_starlight_colour(aurora_color, 5 SECONDS)
 
 /datum/round_event/aurora_caelus/end()
-	set_starlight_colour(color_lightness_max(SSparallax.random_parallax_color, 0.9), 30 SECONDS)
+	set_starlight_colour(color_lightness_max(SSparallax.random_parallax_color, 0.75), 30 SECONDS)
 	priority_announce("The aurora caelus event is now ending. Starlight conditions will slowly return to normal. When this has concluded, please return to your workplace and continue work as normal. Have a pleasant shift, [station_name()], and thank you for watching with us.",
 	sound = 'sound/misc/notice2.ogg',
 	sender_override = "Nanotrasen Meteorology Division")

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -27,16 +27,16 @@
 			M.playsound_local(M, 'sound/ambience/aurora_caelus.ogg', 20, FALSE, pressure_affected = FALSE)
 
 /datum/round_event/aurora_caelus/start()
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, aurora_colors[1], 5 SECONDS, TRUE)
+	set_starlight_colour(aurora_colors[1], 5 SECONDS)
 
 /datum/round_event/aurora_caelus/tick()
 	if(activeFor % 5 == 0)
 		aurora_progress++
 		var/aurora_color = aurora_colors[aurora_progress]
-		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, aurora_color, 5 SECONDS, TRUE)
+		set_starlight_colour(aurora_color, 5 SECONDS)
 
 /datum/round_event/aurora_caelus/end()
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_PARALLAX_COLOUR_CHANGE, SSparallax.random_parallax_color, 30 SECONDS, FALSE)
+	set_starlight_colour(color_lightness_max(SSparallax.random_parallax_color, 0.9), 30 SECONDS)
 	priority_announce("The aurora caelus event is now ending. Starlight conditions will slowly return to normal. When this has concluded, please return to your workplace and continue work as normal. Have a pleasant shift, [station_name()], and thank you for watching with us.",
 	sound = 'sound/misc/notice2.ogg',
 	sender_override = "Nanotrasen Meteorology Division")

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -104,6 +104,7 @@
 	name = "\proper space"
 	icon = 'icons/turf/space.dmi'
 	icon_state = "0"
+	fullbright_type = FULLBRIGHT_STARLIGHT
 
 /turf/open/floor/holofloor/space/Initialize(mapload)
 	icon_state = SPACE_ICON_STATE // so realistic
@@ -115,6 +116,7 @@
 	icon_state = "speedspace_ns_1"
 	bullet_bounce_sound = null
 	tiled_dirt = FALSE
+	fullbright_type = FULLBRIGHT_STARLIGHT
 
 /turf/open/floor/holofloor/hyperspace/nograv/check_gravity()
     return FALSE

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -105,6 +105,7 @@
 	icon = 'icons/turf/space.dmi'
 	icon_state = "0"
 	fullbright_type = FULLBRIGHT_STARLIGHT
+	luminosity = 2
 
 /turf/open/floor/holofloor/space/Initialize(mapload)
 	icon_state = SPACE_ICON_STATE // so realistic
@@ -117,6 +118,7 @@
 	bullet_bounce_sound = null
 	tiled_dirt = FALSE
 	fullbright_type = FULLBRIGHT_STARLIGHT
+	luminosity = 2
 
 /turf/open/floor/holofloor/hyperspace/nograv/check_gravity()
     return FALSE

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -1,6 +1,7 @@
 /area
 	luminosity           = TRUE
 	var/dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
+	var/fullbright_type = FULLBRIGHT_DEFAULT
 
 /area/proc/set_dynamic_lighting(var/new_dynamic_lighting = DYNAMIC_LIGHTING_ENABLED)
 	if (new_dynamic_lighting == dynamic_lighting)
@@ -10,6 +11,7 @@
 
 	if (IS_DYNAMIC_LIGHTING(src))
 		cut_overlay(GLOB.fullbright_overlay)
+		cut_overlay(GLOB.starlight_overlay)
 		blend_mode = BLEND_DEFAULT
 		if(lighting_overlay)
 			cut_overlay(lighting_overlay)
@@ -17,14 +19,17 @@
 			update_lighting_overlay()
 			add_overlay(lighting_overlay)
 		for(var/turf/T as anything in get_contained_turfs())
-			if (IS_DYNAMIC_LIGHTING(T))
+			if (!T.fullbright_type)
 				T.lighting_build_overlay()
 			T.update_above()
 
 	else
 		if(lighting_overlay)
 			cut_overlay(lighting_overlay)
-		add_overlay(GLOB.fullbright_overlay)
+		if (fullbright_type == FULLBRIGHT_STARLIGHT)
+			add_overlay(GLOB.starlight_overlay)
+		else
+			add_overlay(GLOB.fullbright_overlay)
 		blend_mode = BLEND_DEFAULT
 		for(var/turf/T as anything in get_contained_turfs())
 			if (T.lighting_object)

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -24,9 +24,6 @@
 	myturf.lighting_object = src
 	myturf.luminosity = 0
 
-	for(var/turf/open/space/S in RANGE_TURFS(1, src)) //RANGE_TURFS is in code\__HELPERS\game.dm
-		S.update_starlight()
-
 	needs_update = TRUE
 	SSlighting.objects_queue += src
 

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -36,7 +36,7 @@
 			stack_trace("A lighting object was qdeleted with a different loc then it is suppose to have ([COORD(oldturf)] -> [COORD(newturf)])")
 		if (isturf(myturf))
 			myturf.lighting_object = null
-			myturf.luminosity = 1
+			myturf.luminosity = initial(myturf.luminosity)
 		myturf = null
 
 		return ..()

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -4,7 +4,7 @@
 			continue
 
 		for(var/turf/T as anything in A.get_contained_turfs())
-			if(!IS_DYNAMIC_LIGHTING(T))
+			if(T.fullbright_type)
 				continue
 
 			new/atom/movable/lighting_object(T)

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -1,5 +1,5 @@
 /turf
-	var/dynamic_lighting = TRUE
+	var/fullbright_type = FULLBRIGHT_NONE
 	luminosity = 1
 
 	var/tmp/lighting_corners_initialised = FALSE

--- a/code/modules/lighting/starlight.dm
+++ b/code/modules/lighting/starlight.dm
@@ -1,0 +1,6 @@
+
+GLOBAL_VAR_INIT(starlight_colour, "#d2e5f7")
+
+/proc/set_starlight_colour(new_colour, transition_time)
+	GLOB.starlight_colour = new_colour
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_STARLIGHT_COLOUR_CHANGE, new_colour, transition_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a new system for starlight lighting which in theory is very cheap. This does not go through the lighting system at all, instead it utilises a plane which is drawn as an overlay to the lighting plane. This should have incredibly small processing cost and only a relatively minor maptick cost for drawing, the difference should be minimal as we are taking 1 overlay and replacing it with a different overlay instead (-1, +1).

- It draws to a plane which can be recoloured. This means that in order to change the colour of starlight, all we have to do is change the colour of the plane for all clients, as oppossed to iterating over all turfs and changing the colour of the overlay.
- Since we are using overlays and planes, colour transitions can be animated.
- Aurora event does not make a single set_light call.
- Colours of the lighting has an appropriate saturation and lightness value, so will always look nice and not overwhelming.
- Starlight can be set to be applied to any turf/area, meaning you can make turfs like the space carpet have starlight or make asteroids have starlight instead of being fullbright or expensively lit.

How it works:
- Fullbright overlay replaced with a starlight overlay, which is a variant of the fullbright overlay that renders to its own plane and is 2x the size.
- The fullbright plane renders to a render_target.
- This render target renders to a fullscreen overlay which draws itself to the lighting plane.

We use a fullscreen overlay because the layering filter has bugs which make the corners of the screen fullbright.

The colour of the global starlight overlay can be changed by sending a global starlight recolour signal.

This PR was inspired by https://github.com/tgstation/tgstation/pull/77020 but takes no actual code from that PR.

Alters the colours of the aurora event to be more pretty.

This system could also be expanded to provide per-z level lighting effects as the starlight colour is per-client. This means that we could adjust it to implement a simple system for planetary lighting including a day and night cycle.

This makes it so that turfs on the side of the station aren't fully black by setting the luminosity of space tiles to 2. I believe this only affects client-side rendering so having a large number of tiles with luminosity 2 should not have a heavy impact on the server, though this might affect view. I don't think any changes will be big at all, at least not compared to using set_light for starlight which is insanely heavy.

## Why It's Good For The Game

This makes starlight lighting incredibly pretty while being a lot cheaper than the previous implementation.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/7198951a-35f6-420a-85d8-a69018b280f3

<details>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5f0e5989-592f-4207-b5b1-e53e22ca50b7)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/7fbd4e40-f3ed-49f5-be6f-34b5bb1b153a)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/35ab9226-7ffb-419a-a504-48eee07a207e)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/778057ca-e6ed-457d-85c7-e571c835e466)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/73a1f8ab-3290-456a-9156-faa2b3edcb1a)

</details>

## Changelog
:cl:
refactor: Refactors starlight lighting to be a lot cheaper and more dynamic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
