### PR TITLE
Monkey Sentience Helmet Fixes

### DIFF
--- a/code/modules/clothing/head/mind_monkey_helmet.dm
+++ b/code/modules/clothing/head/mind_monkey_helmet.dm
@@ -10,6 +10,13 @@
 	COOLDOWN_DECLARE(message_cooldown) //It'll get annoying quick when someone tries to remove their own helmet 20 times a second
 	var/datum/mind/magnification = null ///A reference to the mind we govern
 
+/obj/item/clothing/head/monkey_sentience_helmet/update_icon()
+	. = ..()
+	compile_monkey_icon()
+	if(ismob(loc))
+		var/mob/mob = loc
+		mob.update_inv_head()
+
 /obj/item/clothing/head/monkey_sentience_helmet/update_icon_state()
 	. = ..()
 	icon_state = "[base_icon_state][magnification ? "_active" : ""]"
@@ -60,8 +67,6 @@
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 
 	update_icon()
-	compile_monkey_icon() //Have to do this in order to make it appear active
-	user.update_inv_head()
 	to_chat(user, "<span class='notice'>You're a mind magnified monkey! Protect your helmet with your life; if you lose it, your sentience goes with it! Your helmet also strongly compels you to assist Nanotrasen and you should always act with the best interests of the station in mind.</span>")
 
 
@@ -90,10 +95,10 @@
 		new /obj/effect/decal/cleanable/ash/crematorium(drop_location()) //just in case they're in a locker or other containers it needs to use crematorium ash, see the path itself for an explanation
 		qdel(src)
 		return
-	playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
-	update_icon()
-	compile_monkey_icon() //Have to do this in order to make it appear inactive
-	current.visible_message("<span class='warning'>[src] powers down!</span>")
+	else
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
+		update_icon()
+		current.visible_message("<span class='warning'>[src] powers down!</span>")
 
 /obj/item/clothing/head/monkey_sentience_helmet/attack_paw(mob/user)
 	//Typecasting to monkey just to see if we're on the user's head


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a few problems that slipped through during the addition of the monkey sentience helmet; ones which I thought I had fixed.

The problems in question are the fact that you can cheese the helmet altogether and turn the monkey into crew, death leaving the monkey revivable, disconnected players not being obvious to detect because the AI automatically assumes control, and lastly the helmet not visibly turning off when kicking a player out of the monkey.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People exploiting the helmet to add more a lot of crew is a *bad* thing. Keeping people from doing that is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Video Evidence:</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/b32b85f9-6a62-42f0-870f-cc65adabf1e0

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/fffca6b9-cbb3-41fb-829f-52d8743738b3

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/66d8a6ad-055b-4062-91a6-2da3be3f7abc

</details>

## Changelog
:cl:
fix: Monkey Sentience Helmets now properly ghost players when subjected to: mind transfers, death, and disconnection/ghosting. Note that if you do lose connection you immediately lose control of the monkey.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
