### PR TITLE
Fixes dynamic config, simulations and threat curve mathematics

### DIFF
--- a/code/datums/mocking/client.dm
+++ b/code/datums/mocking/client.dm
@@ -5,3 +5,6 @@
 
 	/// The view of the client, similar to /client/var/view
 	var/view = "17x15"
+
+/datum/client_interface/proc/should_include_for_role(banning_key = BAN_ROLE_ALL_ANTAGONISTS, role_preference_key = null, poll_ignore_key = null, req_hours = 0, feedback = FALSE)
+	return TRUE

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -506,7 +506,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (initial(ruleset_type.weight) == 0)
 			continue
 
-		var/ruleset = new ruleset_type
+		var/ruleset = new ruleset_type(src)
 		configure_ruleset(ruleset)
 		rulesets += ruleset
 
@@ -832,21 +832,21 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (-INFINITY to -20)
 			return rand(0, 10)
 		if (-20 to -10)
-			return RULE_OF_THREE(-40, -20, x) + 50
+			return RULE_OF_THREE(1, 1, x) + 30
 		if (-10 to -5)
-			return RULE_OF_THREE(-30, -10, x) + 50
+			return RULE_OF_THREE(2, 1, x) + 40
 		if (-5 to -2.5)
-			return RULE_OF_THREE(-20, -5, x) + 50
+			return RULE_OF_THREE(3, 1, x) + 45
 		if (-2.5 to -0)
-			return RULE_OF_THREE(-10, -2.5, x) + 50
+			return RULE_OF_THREE(5, 1, x) + 50
 		if (0 to 2.5)
-			return RULE_OF_THREE(10, 2.5, x) + 50
+			return RULE_OF_THREE(5, 1, x) + 50
 		if (2.5 to 5)
-			return RULE_OF_THREE(20, 5, x) + 50
+			return RULE_OF_THREE(3, 1, x) + 45
 		if (5 to 10)
-			return RULE_OF_THREE(30, 10, x) + 50
+			return RULE_OF_THREE(2, 1, x) + 40
 		if (10 to 20)
-			return RULE_OF_THREE(40, 20, x) + 50
+			return RULE_OF_THREE(1, 1, x) + 30
 		if (20 to INFINITY)
 			return rand(90, 100)
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -633,7 +633,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 /datum/game_mode/dynamic/proc/picking_specific_rule(ruletype, forced = FALSE, ignore_cost = FALSE)
 	var/datum/dynamic_ruleset/midround/new_rule
 	if(ispath(ruletype))
-		new_rule = new ruletype() // You should only use it to call midround rules though.
+		new_rule = new ruletype(src) // You should only use it to call midround rules though.
 		configure_ruleset(new_rule)
 	else if(istype(ruletype, /datum/dynamic_ruleset))
 		new_rule = ruletype

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -84,13 +84,13 @@
 	var/logged_repeated_mode_adjust = FALSE
 
 
-/datum/dynamic_ruleset/New()
+/datum/dynamic_ruleset/New(datum/game_mode/dynamic/dynamic_mode)
 	// Rulesets can be instantiated more than once, such as when an admin clicks
 	// "Execute Midround Ruleset". Thus, it would be wrong to perform any
 	// side effects here. Dynamic rulesets should be stateless anyway.
 	SHOULD_NOT_OVERRIDE(TRUE)
 
-	mode = SSticker.mode
+	mode = dynamic_mode
 	..()
 
 /datum/dynamic_ruleset/roundstart // One or more of those drafted at roundstart

--- a/code/game/gamemodes/dynamic/dynamic_simulations.dm
+++ b/code/game/gamemodes/dynamic/dynamic_simulations.dm
@@ -6,7 +6,6 @@
 
 /datum/dynamic_simulation/proc/initialize_gamemode(forced_threat, roundstart_players)
 	gamemode = new
-	gamemode.roundstart_pop_ready = roundstart_players
 
 	if (forced_threat)
 		gamemode.create_threat(forced_threat)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -227,7 +227,7 @@
 			return alert(usr, "The game mode has to be dynamic mode.", null, null, null, null)
 		var/roundstart_rules = list()
 		for (var/rule in subtypesof(/datum/dynamic_ruleset/roundstart))
-			var/datum/dynamic_ruleset/roundstart/newrule = new rule()
+			var/datum/dynamic_ruleset/roundstart/newrule = new rule(SSticker.mode)
 			roundstart_rules[newrule.name] = newrule
 		var/added_rule = input(usr,"What ruleset do you want to force? This will bypass threat level and population restrictions.", "Rigging Roundstart", null) as null|anything in roundstart_rules
 		if (added_rule)
@@ -263,7 +263,7 @@
 		var/latejoin_rules = list()
 		var/datum/game_mode/dynamic/mode = SSticker.mode
 		for (var/rule in subtypesof(/datum/dynamic_ruleset/latejoin))
-			var/datum/dynamic_ruleset/latejoin/newrule = new rule()
+			var/datum/dynamic_ruleset/latejoin/newrule = new rule(SSticker.mode)
 			mode.configure_ruleset(newrule)
 			latejoin_rules[newrule.name] = newrule
 		var/added_rule = input(usr,"What ruleset do you want to force upon the next latejoiner? This will bypass threat level and population restrictions.", "Rigging Latejoin", null) as null|anything in latejoin_rules
@@ -293,7 +293,7 @@
 		var/midround_rules = list()
 		var/datum/game_mode/dynamic/mode = SSticker.mode
 		for (var/rule in subtypesof(/datum/dynamic_ruleset/midround))
-			var/datum/dynamic_ruleset/midround/newrule = new rule()
+			var/datum/dynamic_ruleset/midround/newrule = new rule(SSticker.mode)
 			mode.configure_ruleset(newrule)
 			midround_rules[newrule.name] = rule
 		var/added_rule = input(usr,"What ruleset do you want to force right now? This will bypass threat level and population restrictions.", "Execute Ruleset", null) as null|anything in midround_rules

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -6,7 +6,6 @@
 			"scaling_cost": 9,
 			"weight": 5,
 			"required_candidates": 1,
-			"minimum_required_age": 0,
 			"requirements": [8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
 			"antag_cap": {
 				"denominator": 38


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes dynamic simulation not functioning correctly.
- Fixes default dynamic config containing invalid values.
- Fixes the lorentz_to_amount being a relation instead of a function

## Why It's Good For The Game

A large number of bug fixes and mathematical fixes

## Testing Photographs and Procedure

Previously the threat graph looked like this:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/962f70f5-6eb0-439f-8fd8-827ddf14fa3e)

After updating it, it now looks like this:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/6348f688-dacc-41bc-807a-43d2be62c5d8)

Now that this is a function and not a relation, we can take the inverse of it to give us a probability function allowing us to reason about dynamic a bit easier.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2af82094-1fa8-4491-9e96-1f518f79fe3e)

The desmos functions for this are:
```
l=\left\{x<-20:10,x<-10:r\left(1,1,x\right)+30,x<-5:r\left(2,1,x\right)+40,x<-2.5:r\left(3,1,x\right)+45,x<0:r\left(5,1,x\right)+50,x<2.5:r\left(5,1,x\right)+50,x<5:r\left(3,1,x\right)+55,x<10:r\left(2,1,x\right)+60,x<20:r\left(1,1,x\right)+70,90\right\}

h\left(x\right)=1-\frac{\arctan\left(\frac{\left(x-c\right)}{-w}\right)+90}{180}
c=1.8
w=1
r\left(a,b,x\right)=\frac{ax}{b}
p\left(x\right)=\left\{x<10:-20,x<20:x-30,x<30:r\left(1,2,x-40\right),x<37.5:r\left(1,3,x-45\right),x<50:r\left(1,5,x-50\right),x<62.5:r\left(1,5,x-50\right),x<70:r\left(1,3,x-55\right),x<80:r\left(1,2,x-60\right),x<90:x-70,20\right\}
t\left(x\right)=h\left(p\left(x\right)\right)
```

This is the probability function where the x axis represents the threat and the y axis represents the probability of the threat being less than the value along the x axis.

Prior to scaling and distribution threat to both midrounds and roundstart antags:
The mean round will have a threat value of 59.
The 75% percentile is 63.4
The 25% percentile is 54

Here are the results of running the dynamic simulation 40 times prior to applying the changes to the threat function:

<details>
```
[{"roundstart_players":50,"threat_level":41.2,"snapshot":{"antag_percent":0.04,"remaining_threat":25.2,"rulesets":["Changelings"]}},{"roundstart_players":50,"threat_level":39.5,"snapshot":{"antag_percent":0.02,"remaining_threat":19.5,"rulesets":["Wizard"]}},{"roundstart_players":50,"threat_level":10,"snapshot":{"antag_percent":0,"remaining_threat":10,"rulesets":[]}},{"roundstart_players":50,"threat_level":39.8,"snapshot":{"antag_percent":0.02,"remaining_threat":19.8,"rulesets":["Wizard"]}},{"roundstart_players":50,"threat_level":51.7,"snapshot":{"antag_percent":0.08,"remaining_threat":31.7,"rulesets":["Nuclear Emergency"]}},{"roundstart_players":50,"threat_level":34.4,"snapshot":{"antag_percent":0.04,"remaining_threat":22.4,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":31.5,"snapshot":{"antag_percent":0,"remaining_threat":31.5,"rulesets":[]}},{"roundstart_players":50,"threat_level":39,"snapshot":{"antag_percent":0.02,"remaining_threat":19,"rulesets":["Wizard"]}},{"roundstart_players":50,"threat_level":34.5,"snapshot":{"antag_percent":0.02,"remaining_threat":14.5,"rulesets":["Wizard"]}},{"roundstart_players":50,"threat_level":42.9,"snapshot":{"antag_percent":0.08,"remaining_threat":22.9,"rulesets":["Nuclear Emergency"]}},{"roundstart_players":50,"threat_level":32.5,"snapshot":{"antag_percent":0.04,"remaining_threat":16.5,"rulesets":["Changelings"]}},{"roundstart_players":50,"threat_level":33.2,"snapshot":{"antag_percent":0.08,"remaining_threat":13.2,"rulesets":["Blood Cult"]}},{"roundstart_players":50,"threat_level":68.2,"snapshot":{"antag_percent":0.12,"remaining_threat":33.2,"rulesets":["Clockwork Cult"]}},{"roundstart_players":50,"threat_level":4,"snapshot":{"antag_percent":0,"remaining_threat":4,"rulesets":[]}},{"roundstart_players":50,"threat_level":42.2,"snapshot":{"antag_percent":0.1,"remaining_threat":19.2,"rulesets":["Heretics","Traitors"]}},{"roundstart_players":50,"threat_level":38.5,"snapshot":{"antag_percent":0.06,"remaining_threat":23.5,"rulesets":["Heretics"]}},{"roundstart_players":50,"threat_level":39.5,"snapshot":{"antag_percent":0.04,"remaining_threat":31.5,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":48.2,"snapshot":{"antag_percent":0.02,"remaining_threat":28.2,"rulesets":["Wizard"]}},{"roundstart_players":50,"threat_level":90,"snapshot":{"antag_percent":0.08,"remaining_threat":70,"rulesets":["Nuclear Emergency"]}},{"roundstart_players":50,"threat_level":32.4,"snapshot":{"antag_percent":0,"remaining_threat":32.4,"rulesets":[]}},{"roundstart_players":50,"threat_level":28.8,"snapshot":{"antag_percent":0.04,"remaining_threat":16.8,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":68.8,"snapshot":{"antag_percent":0.08,"remaining_threat":48.8,"rulesets":["Blood Cult"]}},{"roundstart_players":50,"threat_level":36.7,"snapshot":{"antag_percent":0.08,"remaining_threat":19.7,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":44.2,"snapshot":{"antag_percent":0.08,"remaining_threat":20.2,"rulesets":["Changelings","Traitors"]}},{"roundstart_players":50,"threat_level":34.9,"snapshot":{"antag_percent":0.04,"remaining_threat":22.9,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":42.1,"snapshot":{"antag_percent":0.04,"remaining_threat":26.1,"rulesets":["Changelings"]}},{"roundstart_players":50,"threat_level":35.9,"snapshot":{"antag_percent":0.02,"remaining_threat":15.9,"rulesets":["Wizard"]}},{"roundstart_players":50,"threat_level":42.8,"snapshot":{"antag_percent":0.08,"remaining_threat":22.8,"rulesets":["Traitors","Blood Brothers"]}},{"roundstart_players":50,"threat_level":33.2,"snapshot":{"antag_percent":0.04,"remaining_threat":25.2,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":2,"snapshot":{"antag_percent":0,"remaining_threat":2,"rulesets":[]}},{"roundstart_players":50,"threat_level":35.7,"snapshot":{"antag_percent":0.08,"remaining_threat":15.7,"rulesets":["Traitors","Blood Brothers"]}},{"roundstart_players":50,"threat_level":32.9,"snapshot":{"antag_percent":0.06,"remaining_threat":17.9,"rulesets":["Heretics"]}},{"roundstart_players":50,"threat_level":41,"snapshot":{"antag_percent":0.04,"remaining_threat":33,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":36.3,"snapshot":{"antag_percent":0.04,"remaining_threat":20.3,"rulesets":["Changelings"]}},{"roundstart_players":50,"threat_level":42.5,"snapshot":{"antag_percent":0.08,"remaining_threat":25.5,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":44.8,"snapshot":{"antag_percent":0,"remaining_threat":44.8,"rulesets":[]}},{"roundstart_players":50,"threat_level":72.4,"snapshot":{"antag_percent":0.12,"remaining_threat":37.4,"rulesets":["Incursion","Heretics"]}},{"roundstart_players":50,"threat_level":36,"snapshot":{"antag_percent":0.06,"remaining_threat":21,"rulesets":["Heretics"]}},{"roundstart_players":50,"threat_level":39.4,"snapshot":{"antag_percent":0.04,"remaining_threat":27.4,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":1,"snapshot":{"antag_percent":0,"remaining_threat":1,"rulesets":[]}}]
```
</details>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/250ab328-a0ec-4ed9-b0d2-9c490045139d)


Here are the results of running the dynamic simulation 40 times after applying the changes to the threat function:

<details>
```
[{"roundstart_players":50,"threat_level":34.8,"snapshot":{"antag_percent":0.04,"remaining_threat":18.8,"rulesets":["Changelings"]}},{"roundstart_players":50,"threat_level":42.7,"snapshot":{"antag_percent":0.04,"remaining_threat":34.7,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":11.6,"snapshot":{"antag_percent":0,"remaining_threat":11.6,"rulesets":[]}},{"roundstart_players":50,"threat_level":7,"snapshot":{"antag_percent":0,"remaining_threat":7,"rulesets":[]}},{"roundstart_players":50,"threat_level":29,"snapshot":{"antag_percent":0,"remaining_threat":29,"rulesets":[]}},{"roundstart_players":50,"threat_level":35.5,"snapshot":{"antag_percent":0.04,"remaining_threat":27.5,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":37.2,"snapshot":{"antag_percent":0.08,"remaining_threat":20.2,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":8,"snapshot":{"antag_percent":0,"remaining_threat":8,"rulesets":[]}},{"roundstart_players":50,"threat_level":45.2,"snapshot":{"antag_percent":0.08,"remaining_threat":25.2,"rulesets":["Blood Brothers","Traitors"]}},{"roundstart_players":50,"threat_level":36.3,"snapshot":{"antag_percent":0.04,"remaining_threat":20.3,"rulesets":["Changelings"]}},{"roundstart_players":50,"threat_level":38.6,"snapshot":{"antag_percent":0.1,"remaining_threat":15.6,"rulesets":["Heretics","Traitors"]}},{"roundstart_players":50,"threat_level":35.8,"snapshot":{"antag_percent":0.04,"remaining_threat":27.8,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":32.8,"snapshot":{"antag_percent":0,"remaining_threat":32.8,"rulesets":[]}},{"roundstart_players":50,"threat_level":42,"snapshot":{"antag_percent":0.1,"remaining_threat":19,"rulesets":["Traitors","Heretics"]}},{"roundstart_players":50,"threat_level":36.3,"snapshot":{"antag_percent":0.06,"remaining_threat":21.3,"rulesets":["Heretics"]}},{"roundstart_players":50,"threat_level":2,"snapshot":{"antag_percent":0,"remaining_threat":2,"rulesets":[]}},{"roundstart_players":50,"threat_level":42.4,"snapshot":{"antag_percent":0.08,"remaining_threat":22.4,"rulesets":["Blood Cult"]}},{"roundstart_players":50,"threat_level":39.4,"snapshot":{"antag_percent":0.08,"remaining_threat":19.4,"rulesets":["Nuclear Emergency"]}},{"roundstart_players":50,"threat_level":34.7,"snapshot":{"antag_percent":0,"remaining_threat":34.7,"rulesets":[]}},{"roundstart_players":50,"threat_level":40.6,"snapshot":{"antag_percent":0.06,"remaining_threat":25.6,"rulesets":["Heretics"]}},{"roundstart_players":50,"threat_level":22.1,"snapshot":{"antag_percent":0.04,"remaining_threat":10.1,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":53.8,"snapshot":{"antag_percent":0.1,"remaining_threat":25.8,"rulesets":["Incursion","Traitors"]}},{"roundstart_players":50,"threat_level":53.9,"snapshot":{"antag_percent":0.1,"remaining_threat":30.9,"rulesets":["Heretics","Traitors"]}},{"roundstart_players":50,"threat_level":35.9,"snapshot":{"antag_percent":0.04,"remaining_threat":27.9,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":43.3,"snapshot":{"antag_percent":0.04,"remaining_threat":31.3,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":56,"snapshot":{"antag_percent":0.1,"remaining_threat":28,"rulesets":["Incursion","Traitors"]}},{"roundstart_players":50,"threat_level":34.5,"snapshot":{"antag_percent":0.04,"remaining_threat":22.5,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":43.9,"snapshot":{"antag_percent":0.08,"remaining_threat":26.9,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":37.9,"snapshot":{"antag_percent":0.08,"remaining_threat":17.9,"rulesets":["Blood Cult"]}},{"roundstart_players":50,"threat_level":29.6,"snapshot":{"antag_percent":0.04,"remaining_threat":21.6,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":27.9,"snapshot":{"antag_percent":0.04,"remaining_threat":19.9,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":51.5,"snapshot":{"antag_percent":0.1,"remaining_threat":31.5,"rulesets":["Traitors","Blood Brothers"]}},{"roundstart_players":50,"threat_level":53.9,"snapshot":{"antag_percent":0.08,"remaining_threat":25.9,"rulesets":["Blood Brothers","Changelings"]}},{"roundstart_players":50,"threat_level":1,"snapshot":{"antag_percent":0,"remaining_threat":1,"rulesets":[]}},{"roundstart_players":50,"threat_level":29.3,"snapshot":{"antag_percent":0.06,"remaining_threat":14.3,"rulesets":["Heretics"]}},{"roundstart_players":50,"threat_level":22.3,"snapshot":{"antag_percent":0,"remaining_threat":22.3,"rulesets":[]}},{"roundstart_players":50,"threat_level":29.8,"snapshot":{"antag_percent":0.04,"remaining_threat":21.8,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":35.9,"snapshot":{"antag_percent":0.08,"remaining_threat":18.9,"rulesets":["Traitors"]}},{"roundstart_players":50,"threat_level":32.4,"snapshot":{"antag_percent":0.04,"remaining_threat":20.4,"rulesets":["Blood Brothers"]}},{"roundstart_players":50,"threat_level":55.5,"snapshot":{"antag_percent":0.08,"remaining_threat":35.5,"rulesets":["Nuclear Emergency"]}}]
```
</details>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f079184f-4968-4a52-904f-8f00fb724895)

The average went from 38 to 34, however that might be just due to the low count.

## Changelog
:cl:
fix: Fixes some internal dynamic calculations, fixes dynamic simulations, fixes default dynamic server config.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
