### PR TITLE
(Rotatable Stasis Beds) Woke up on the wrong side of the bed?

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -523,10 +523,14 @@ Class Procs:
 		return 1
 	return 0
 
-/obj/machinery/proc/default_change_direction_wrench(mob/user, obj/item/I)
+/**
+ * * turns: The amount of times to turn -90 degrees. Pointless to set this to anything above 4
+ */
+/obj/machinery/proc/default_change_direction_wrench(mob/user, obj/item/I, turns = 1)
+	turns *= -90
 	if(panel_open && I.tool_behaviour == TOOL_WRENCH)
 		I.play_tool_sound(src, 50)
-		setDir(turn(dir,-90))
+		setDir(turn(dir,turns))
 		to_chat(user, "<span class='notice'>You rotate [src].</span>")
 		return 1
 	return 0

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -20,12 +20,7 @@
 
 // dir check for buckle_lying state
 /obj/machinery/stasis/Initialize()
-	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
-	switch(dir)
-		if(WEST, NORTH)
-			buckle_lying = 270
-		if(EAST, SOUTH)
-			buckle_lying = 90
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed)) //This gets called later during initialization
 	return ..()
 
 /obj/machinery/stasis/Initialize(mapload)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -20,6 +20,7 @@
 
 // dir check for buckle_lying state
 /obj/machinery/stasis/Initialize()
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
 	switch(dir)
 		if(WEST, NORTH)
 			buckle_lying = 270
@@ -36,6 +37,7 @@
 	initial_link()
 
 /obj/machinery/stasis/Destroy()
+	UnregisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
 	. = ..()
 	if(op_computer?.sbed == src)
 		op_computer.sbed = null
@@ -180,6 +182,20 @@
 	multitool.buffer = src
 	to_chat(user, "<span class='notice'>You store the linking data of \the [src] in \the [multitool]'s buffer. Use it on an operating computer to complete linking.</span>")
 	balloon_alert(user, "saved in buffer")
+
+/obj/machinery/stasis/wrench_act(mob/living/user, obj/item/I) //We want to rotate, but we need to do it in 180 degree rotations.
+	if(panel_open && has_buckled_mobs())
+		to_chat(user, "<span class='notice'>\The [src] is too heavy to rotate while someone is buckled to it!</span>")
+		return TRUE
+	. = default_change_direction_wrench(user, I, 2)
+
+/obj/machinery/stasis/proc/dir_changed(datum/source, old_dir, new_dir)
+	SIGNAL_HANDLER
+	switch(new_dir)
+		if(WEST, NORTH)
+			buckle_lying = 270
+		if(EAST, SOUTH)
+			buckle_lying = 90
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -23,6 +23,15 @@
 	var/buildstackamount = 2
 	var/bolts = TRUE
 
+// dir check for buckle_lying state
+/obj/structure/bed/Initialize()
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed)) //This gets called later during initialization
+	. = ..()
+
+/obj/structure/bed/Destroy()
+	UnregisterSignal(src, COMSIG_ATOM_DIR_CHANGE)
+	return ..()
+
 /obj/structure/bed/examine(mob/user)
 	. = ..()
 	if(bolts)
@@ -43,6 +52,14 @@
 		deconstruct(TRUE)
 	else
 		return ..()
+
+/obj/structure/bed/proc/dir_changed(datum/source, old_dir, new_dir)
+	SIGNAL_HANDLER
+	switch(new_dir)
+		if(WEST, SOUTH)
+			buckle_lying = 90
+		if(EAST, NORTH)
+			buckle_lying = 270
 
 /*
  * Roller beds


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does three things:
- Makes it so that stasis beds can be rotated to face left or right with a wrench.
- Normal Beds now acknowledge their direction in regards to their buckle_lying variable
- Adds an extra parameter to `/obj/machinery/proc/default_change_direction_wrench` called `turns`; this is a number that is multiplied by `-90` to offset how much a machine is rotated in direction.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rotating stasis beds is a nice QoL that makes 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Stasis Beds</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/b431ef68-7bb7-405c-a591-eb2d968c0d0d

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/57e96147-2d1c-4155-908d-c1ffd6db32f1

</details>

<details>

<summary>Normal Beds</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/b4c069a3-8bea-45c7-a569-3fc970c37403)

</details>

## Changelog
:cl:
tweak: Stasis Beds can now be rotated by using a wrench while no-one is buckled to it and the maintenance panel is open.
fix: Beds now properly rotate the mob buckled to them. No more waking up on the wrong side of the bed.
code: /obj/machinery/default_change_direction_wrench() now accepts a new parameter that controls how much rotation occurs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
