### PR TITLE
Potential fix for roundstart lightup failures?

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -367,7 +367,7 @@ SUBSYSTEM_DEF(ticker)
 		var/role = player.mind?.assigned_role
 		if(!role)
 			continue
-		var/datum/job/job = SSjob.GetJob(role)
+		var/datum/job/job = SSjob.name_occupations[role]
 		if(!job)
 			continue
 		lightup_area_typecache |= job.areas_to_light_up(minimal_access)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i've noticed some areas failing to light up at roundstart despite being occupied and their areas obviously being correctly in the typecache. no clue why, but this may be related, so i decided i'd try this out - this code does the same thing, minus the possibility to runtime.

## Why It's Good For The Game

hopefully this fixes things?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I can't reproduce this issue locally, so uh, no clue if this changes anything or not.

</details>

## Changelog
:cl:
fix: Did a potential fix for some areas failing to lightup at roundstart despite being occupied?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
