### PR TITLE
Fixes the Radstation AI Sat for the forseeable future

### DIFF
--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -1173,9 +1173,6 @@
 "atm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fans/tiny,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/engine/o2,
 /area/ai_monitored/turret_protected/ai)
 "atq" = (
@@ -1427,13 +1424,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/engine/engine_room)
-"axq" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/engine/o2,
-/area/ai_monitored/turret_protected/ai)
 "axK" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -2940,7 +2930,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
@@ -4967,9 +4957,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted{
-	alpha = 180
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -4979,13 +4966,13 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bFo" = (
 /obj/machinery/door/airlock/security/glass{
@@ -15357,7 +15344,7 @@
 /obj/machinery/power/apc/auto_name/east{
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/floor/engine/o2,
@@ -18788,7 +18775,7 @@
 	name = "MiniSat Teleporter";
 	req_one_access_txt = "17;65"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fKs" = (
 /obj/machinery/door/airlock/grunge{
@@ -19189,7 +19176,7 @@
 /area/maintenance/department/medical)
 "fQn" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/engine/o2,
@@ -24479,12 +24466,6 @@
 	pixel_y = -8
 	},
 /obj/structure/fans/tiny,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/item/toy/plush/opa{
 	pixel_x = -6;
 	pixel_y = -8
@@ -27113,7 +27094,7 @@
 "inF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/upload/ai,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/circuit,
@@ -28305,7 +28286,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -29122,13 +29103,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"iYS" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/engine/o2,
-/area/ai_monitored/turret_protected/ai)
 "iZa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40205,7 +40179,7 @@
 /obj/structure/cable/cyan{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mCd" = (
@@ -43237,7 +43211,7 @@
 /area/security/nuke_storage)
 "nwh" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine/o2,
@@ -44937,7 +44911,7 @@
 "nUR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine/o2,
@@ -46552,6 +46526,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"oxk" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/floor/engine/o2,
+/area/ai_monitored/turret_protected/ai)
 "oxm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/blue,
@@ -46559,9 +46538,6 @@
 /area/maintenance/department/medical/morgue)
 "oxq" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
@@ -52344,18 +52320,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/power/smes,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
 	},
 /obj/machinery/camera/motion{
 	network = list("minisat");
 	c_tag = "MiniSat Core Hallway 1";
 	dir = 9
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qol" = (
@@ -54625,15 +54601,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor{
 	id = "AIwindows";
 	name = "AI View Blast door"
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "qXx" = (
@@ -56350,13 +56326,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"rBP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/engine/o2,
-/area/ai_monitored/turret_protected/ai)
 "rBQ" = (
 /obj/effect/decal/cleanable/insectguts,
 /obj/effect/landmark/xeno_spawn,
@@ -61757,6 +61726,10 @@
 	c_tag = "MiniSat Upload Chamber";
 	dir = 10
 	},
+/obj/structure/cable,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "tqK" = (
@@ -64448,6 +64421,15 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/quartermaster/storage)
+"uil" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "uin" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66778,11 +66760,8 @@
 "uVN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fans/tiny,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/engine/o2,
 /area/ai_monitored/turret_protected/ai)
@@ -68324,9 +68303,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/structure/cable/yellow,
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Core";
@@ -69778,7 +69754,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine/o2,
@@ -72505,10 +72481,14 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/terminal,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -75726,17 +75706,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"xNY" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/fans/tiny,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/engine/o2,
-/area/ai_monitored/turret_protected/ai)
 "xOg" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/item/radio/intercom{
@@ -108482,7 +108451,7 @@ ucq
 wsM
 ilX
 fES
-fme
+uil
 qok
 fme
 fme
@@ -109510,9 +109479,9 @@ uGh
 bwl
 kDi
 qcK
-axq
+deN
 atm
-rBP
+deN
 qcK
 pRk
 bwl
@@ -109765,7 +109734,7 @@ gVH
 gac
 kWV
 vuZ
-nUR
+oxk
 oxq
 huP
 kBB
@@ -110024,8 +109993,8 @@ uGh
 iXg
 fBU
 uZd
-iYS
-xNY
+deN
+uVN
 fQn
 uZd
 ste


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the AI their own SMES for their APC. Additionally sets both of their SMES's to 5e+006 charge, a mapping standard among Delta and Meta. Also makes the disconnected line more obvious.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

AIs start off with 30 minutes of charge, and if they don't do anything they will die in silence. This is not acceptable, and other maps that have the AI not connected to the power grid don't have this issue.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/14d519b4-51ab-4844-a596-5406ce7d2b8e)

</details>

## Changelog
:cl:
fix: Radstation AI Satellite no longer depowers 30 minutes into a shift.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
