### PR TITLE
Safer hacking

### DIFF
--- a/code/__DEFINES/airlock.dm
+++ b/code/__DEFINES/airlock.dm
@@ -8,7 +8,7 @@
 
 #define AIRLOCK_WIRE_SECURITY_NONE 0	// Airlocks that are super easy to hack and have mostly labelled wires. No risk.
 #define AIRLOCK_WIRE_SECURITY_SIMPLE 1	// Airlock with less labelled wires, takes longer to hack but not shock risk.
-#define AIRLOCK_WIRE_SECURITY_PROTECTED 2	// Airlock has no labelled wires and has a single shock wire
+#define AIRLOCK_WIRE_SECURITY_PROTECTED 2	// Airlock has no labelled wires and has a single shock wire that is labelled
 #define AIRLOCK_WIRE_SECURITY_ADVANCED 3	// Airlock has 2 duds and 1 shock wire
 #define AIRLOCK_WIRE_SECURITY_ELITE 4	// Airlock has 2 duds and 2 shock wires
 #define AIRLOCK_WIRE_SECURITY_MAXIMUM 5	// Airlock has 2 duds, 2 shock wires and only a single power cable.

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -39,7 +39,8 @@
 		//At security level 1, there are duds and the open, bolt and shock wires are not revealed.
 		labelled_wires[WIRE_SAFETY] = TRUE
 		labelled_wires[WIRE_TIMING] = TRUE
-
+	if (security_level == AIRLOCK_WIRE_SECURITY_PROTECTED)
+		labelled_wires[WIRE_ZAP1] = TRUE
 	..()
 
 /datum/wires/airlock/interactable(mob/user)

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -45,8 +45,6 @@
 
 /datum/wires/airlock/interactable(mob/user)
 	var/obj/machinery/door/airlock/A = holder
-	if(!issilicon(user) && A.isElectrified() && A.shock(user, 100))
-		return FALSE
 	if(A.panel_open)
 		return TRUE
 
@@ -54,7 +52,7 @@
 	var/obj/machinery/door/airlock/A = holder
 	var/list/status = list()
 	status += "The door bolts [A.locked ? "have fallen!" : "look up."]"
-	status += "The test light is [A.hasPower() ? "on" : "off"]."
+	status += "The test light is [A.hasPower() ? (A.isElectrified() ? "bright and flicking" : "on") : "off"]."
 	status += "The AI connection light is [A.aiControlDisabled || (A.obj_flags & EMAGGED) ? "off" : "on"]."
 	status += "The check wiring light is [A.safe ? "off" : "on"]."
 	status += "The timer is powered [A.autoclose ? "on" : "off"]."
@@ -66,6 +64,10 @@
 /datum/wires/airlock/on_pulse(wire)
 	set waitfor = FALSE
 	var/obj/machinery/door/airlock/A = holder
+	// Pulsing a wire while it is shocked will shock you
+	if(isliving(usr) && A.hasPower() && A.isElectrified())
+		if (A.shock(usr, 100))
+			return
 	if(A.hasPower()) //Multitool has no effect at all if the door has lost power
 		switch(wire)
 			if(WIRE_POWER1, WIRE_POWER2) // Pulse to loose power.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Airlock security level protected will now have the shock wire labelled. This means that the following airlocks will have labelled shock wires making them safe, but time consuming, to hack into:
- Chapel
- Law office
- Virology
- Morgue
- Chemistry
- Genetics
- Cargo bay
- Tech storage

Makes it so electrified doors will not shock while the UI is open, unless you pulse another wire. This means you won't get stuck in a shock look because of pulsing the electricution wire and also makes airlocks that shouldn't have shock wires, have no shocking wires.

## Why It's Good For The Game

Hacking should be time consuming but not so difficult that its impossible to get into fairly easy to access departments. This allows nefarious people to enter these departments without insulated gloves, however they will still have to spend some time hacking the airlock.

Hacking is significantly harder than intended in many easy to access areas because there is always the electricute cable on doors which shocks the user repeatedly as a side effect. Only the dedicated shock wires should shock the user.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/04a0045e-0d96-477d-bd11-dda63bd1df0b)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/c8ff60ca-9ce4-4b04-90c6-581b7ace6957)

The door only shocks me when I touch it, or try to multitool it without the UI being opened already.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8f3bc055-6976-494f-bb14-b5cf5f59c7bb)


## Changelog
:cl:
balance: Chapel, Law office, virology, morgue, chemistry, genetics, cargo bay and tech storage will now have their airlock shock wires labelled.
balance: Electricuted airlocks will no longer shock people with the UI open, only when performing a pulse action or using a multitool on the door for the first time. This means that low tier airlocks are now safe to hack.
balance: Airlocks now have an indication when they are shocked (Test light is bright and flickering).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
