### PR TITLE
Adds support for roundstart night shift APCs

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -147,6 +147,17 @@
 					break_light_tube(1)
 		spawn(1)
 			update(FALSE, TRUE, maploaded)
+	if(mapload)
+		return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/light/LateInitialize()
+	. = ..()
+	var/area/A = get_area(src)
+	if(A.apc)
+		var/obj/machinery/power/apc/temp_apc = A.apc
+		nightshift_enabled = temp_apc?.nightshift_lights
+		if(nightshift_enabled)
+			update(FALSE, TRUE, TRUE)
 
 /obj/machinery/light/Destroy()
 	var/area/A = get_area(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds support for lights updating to have night shift lighting if the APC in the are has night shift lighting enabled right away
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It can be used in mapping to create a more cozy atmosphere in certain areas.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/f949ed34-cf85-4c95-86ba-615d2bddbc2a

</details>

## Changelog
:cl:
add: Added lights updating to have nightshift lighting if their APC has nightshift lighting enabled at roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
