### PR TITLE
Makes air alarms passively trigger the blue lighting overlay

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -461,13 +461,13 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	for(var/obj/machinery/light/L in src)
 		L.update(TRUE, TRUE, TRUE)
 
-/area/proc/set_vacuum_alarm_effect() //Just like fire alarm but blue
+/area/proc/set_pressure_alarm_effect() //Just like fire alarm but blue
 	vacuum = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/obj/machinery/light/L in src)
 		L.update(TRUE, TRUE, TRUE)
 
-/area/proc/unset_vacuum_alarm_effect()
+/area/proc/unset_pressure_alarm_effect()
 	vacuum = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/obj/machinery/light/L in src)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -693,12 +693,13 @@
 	var/area/A = get_area(src)
 	if(alert_level==2)
 		alert_signal.data["alert"] = "severe"
-		A.set_vacuum_alarm_effect()
+		A.set_pressure_alarm_effect()
 	else if (alert_level==1)
 		alert_signal.data["alert"] = "minor"
+		A.set_pressure_alarm_effect()
 	else if (alert_level==0)
 		alert_signal.data["alert"] = "clear"
-		A.unset_vacuum_alarm_effect()
+		A.unset_pressure_alarm_effect()
 
 	frequency.post_signal(src, alert_signal, range = -1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes air alarms trigger the blue lighting overlay whenever they send out an alarm, rather than only when manually toggled.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The blue overlay for lights is very, very nice for indicating areas with anomalous pressure. Unfortunately, it can only happen when the air alarm is manually toggled, which means an atmos tech is on the scene and has probably already locked the area down with resin and holofans.
This PR makes the air alarm trigger the blue lighting whenever it sends out an alarm, thus serving as a nice visual warning to everyone that something isn't right up ahead.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/8f650f4b-eee4-42ba-af41-669f1a0de264

</details>

## Changelog
:cl:
tweak: Made the air alarm set the lights to vacuum emergency blue mode whenever they send out an alarm, rather than when only manually triggered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
