### PR TITLE
Fix 'false' Observe targets that would blank your screen or crash you

### DIFF
--- a/code/game/points_of_interest.dm
+++ b/code/game/points_of_interest.dm
@@ -30,9 +30,8 @@
 
 /// Orders mobs by type then by name
 /proc/sortmobs()
-	var/static/list/forbidden_mobs = typecacheof(list(/mob/living/carbon/human/dummy))
 	var/list/moblist = list()
-	var/list/sortmob = sort_names(typecache_filter_list_reverse(GLOB.mob_list, forbidden_mobs))
+	var/list/sortmob = sort_names(GLOB.mob_list)
 	for(var/mob/living/silicon/ai/M in sortmob)
 		moblist.Add(M)
 	for(var/mob/camera/M in sortmob)

--- a/code/game/points_of_interest.dm
+++ b/code/game/points_of_interest.dm
@@ -30,8 +30,9 @@
 
 /// Orders mobs by type then by name
 /proc/sortmobs()
+	var/static/list/forbidden_mobs = typecacheof(list(/mob/living/carbon/human/dummy))
 	var/list/moblist = list()
-	var/list/sortmob = sort_names(GLOB.mob_list)
+	var/list/sortmob = sort_names(typecache_filter_list_reverse(GLOB.mob_list, forbidden_mobs))
 	for(var/mob/living/silicon/ai/M in sortmob)
 		moblist.Add(M)
 	for(var/mob/camera/M in sortmob)

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -47,3 +47,15 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	if(istype(D))
 		D.wipe_state()
 		D.in_use = FALSE
+
+/mob/living/carbon/human/dummy/add_to_mob_list()
+	return
+
+/mob/living/carbon/human/dummy/remove_from_mob_list()
+	return
+
+/mob/living/carbon/human/dummy/add_to_alive_mob_list()
+	return
+
+/mob/living/carbon/human/dummy/remove_from_alive_mob_list()
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out, _preference dummies_ were being included in `sortmobs` and therefore `getpois`.

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/8549

Thank you so much Tamumus for helping me figure this out!

## Why It's Good For The Game

bugfix good, client crash bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-08-05-1691258583-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/701f6df4-4932-4419-acfc-927906926c9a)


</details>

## Changelog
:cl: Absolucy & Tamumus
fix: Fix 'false' Observe targets that would blank your screen or crash you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
