### PR TITLE
Fixes bomb cores not detonated when installed

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -37,6 +37,7 @@
 	wires = new /datum/wires/syndicatebomb(src)
 	if(payload)
 		payload = new payload(src)
+		payload.installed = TRUE
 	update_icon()
 	countdown = new(src)
 	end_processing()
@@ -150,6 +151,7 @@
 			if(payload)
 				to_chat(user, "<span class='notice'>You carefully pry out [payload].</span>")
 				payload.forceMove(drop_location())
+				payload.installed = FALSE
 				payload = null
 			else
 				to_chat(user, "<span class='warning'>There isn't anything in here to remove!</span>")
@@ -162,6 +164,7 @@
 			if(!user.transferItemToLoc(I, src))
 				return
 			payload = I
+			payload.installed = TRUE
 			to_chat(user, "<span class='notice'>You place [payload] into [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>[payload] is already loaded into [src]! You'll have to remove it first.</span>")
@@ -283,6 +286,8 @@
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE //Burnable (but the casing isn't)
+	/// Indicates if the bombcore is inside a valid bomb and is ready to explode. Set this to true to allow for activation.
+	var/installed = FALSE
 	var/adminlog = null
 	var/range_heavy = 3
 	var/range_medium = 9
@@ -299,7 +304,7 @@
 /obj/item/bombcore/proc/detonate()
 	if(!loc)
 		return
-	if(!istype(loc, /obj/machinery/syndicatebomb))
+	if(!installed)
 		qdel(src)
 		return
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -37,7 +37,9 @@
 	wires = new /datum/wires/syndicatebomb(src)
 	if(payload)
 		payload = new payload(src)
-		payload.installed = TRUE
+		if (istype(payload, /obj/item/bombcore))
+			var/obj/item/bombcore/installed_bomb = payload
+			installed_bomb.installed = TRUE
 	update_icon()
 	countdown = new(src)
 	end_processing()
@@ -151,7 +153,9 @@
 			if(payload)
 				to_chat(user, "<span class='notice'>You carefully pry out [payload].</span>")
 				payload.forceMove(drop_location())
-				payload.installed = FALSE
+				var/obj/item/bombcore/bomb_payload = payload
+				if (istype(bomb_payload))
+					bomb_payload.installed = FALSE
 				payload = null
 			else
 				to_chat(user, "<span class='warning'>There isn't anything in here to remove!</span>")
@@ -164,7 +168,9 @@
 			if(!user.transferItemToLoc(I, src))
 				return
 			payload = I
-			payload.installed = TRUE
+			var/obj/item/bombcore/bomb_payload = payload
+			if (istype(bomb_payload))
+				bomb_payload.installed = TRUE
 			to_chat(user, "<span class='notice'>You place [payload] into [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>[payload] is already loaded into [src]! You'll have to remove it first.</span>")

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -332,6 +332,7 @@
 
 /turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
 	var/obj/item/bombcore/large/bombcore = new(get_turf(src))
+	bombcore.installed = TRUE
 	bombcore.detonate()
 	..()
 

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -123,6 +123,7 @@
 			if(wires.is_all_cut() && bomb_defused)
 				user.put_in_hands(bomb)
 				to_chat(user, "<span class='notice'>You carefully remove the [bomb] from [src].</span>")
+				bomb.installed = FALSE
 				bomb = null
 				update_icon()
 				return
@@ -191,6 +192,7 @@
 				return
 			wires = new /datum/wires/explosive/pizza(src)
 			bomb = I
+			bomb.installed = TRUE
 			to_chat(user, "<span class='notice'>You put [I] in [src]. Sneeki breeki...</span>")
 			update_icon()
 			return
@@ -271,6 +273,7 @@
 	var/randompizza = pick(subtypesof(/obj/item/reagent_containers/food/snacks/pizza))
 	pizza = new randompizza(src)
 	bomb = new(src)
+	bomb.installed = TRUE
 	wires = new /datum/wires/explosive/pizza(src)
 
 /obj/item/pizzabox/margherita/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bomb cores will now determine if they are allowed to explode based on some installed variable.

## Why It's Good For The Game

This will fix pizza bombs and bomb turfs not exploding.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2495a215-e104-4ef1-851d-789eb64875a1)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2f1a65dc-f1a5-4b55-84d2-5c4fb291d5bf)


## Changelog
:cl:
fix: Pizza bombs and the syndicate lavaland base will now properly explode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
