### PR TITLE
Makes blood brother chat color list shuffled

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -81,8 +81,7 @@
 #define COLOR_ASSEMBLY_BLUE    "#38559E"
 #define COLOR_ASSEMBLY_PURPLE  "#6F6192"
 
-//Colours used by blood brothers
-#define COLOR_LIST_BLOOD_BROTHERS list(\
+GLOBAL_LIST_INIT(color_list_blood_brothers, shuffle(list(
 	"#FF5050",\
 	"#D977FD",\
 	"#422ED8",\
@@ -91,9 +90,7 @@
 	"#0EF5CE",\
 	"#0DF447",\
 	"#D6B20C",\
-	"#FF902A",\
-)
-#define COLOR_BLOOD_BROTHERS_DEFAULT "#FF5050" // because your color isn't red, noticing there are another BB team is bad (metaknowledge)
+	"#FF902A")))
 
 // Color Filters
 /// Icon filter that creates ambient occlusion

--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -93,6 +93,7 @@
 	"#D6B20C",\
 	"#FF902A",\
 )
+#define COLOR_BLOOD_BROTHERS_DEFAULT "#FF5050" // because your color isn't red, noticing there are another BB team is bad (metaknowledge)
 
 // Color Filters
 /// Icon filter that creates ambient occlusion

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -24,6 +24,8 @@
 
 		var/my_message = "<font color=\"[implant_colour]\"><b><i>[imp_in.mind.name]:</i></b></font> [input]" //add sender, color source with syndie color
 		var/ghost_message = "<font color=\"[implant_colour]\"><b><i>[imp_in.mind.name] -> Blood Brothers:</i></b></font> [input]"
+		// Reminder: putting a font color directly is bad because color has different readability by your chat theme white/dark
+		// This should be eventually changed to a form of `<span class="red">`, so that a color has a good readability for a chat theme.
 
 		to_chat(imp_in, my_message) // Sends message to the user
 		for(var/obj/item/implant/bloodbrother/i in linked_implants) // Sends message to all linked implnats

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -22,7 +22,7 @@
 			return
 		input = imp_in.treat_message_min(input)
 
-		var/my_message = "<font color=\"[implant_colour]\"><b><i>[imp_in.mind.name]:</i></b></font> [input]" //add sender, color source with syndie color
+		var/my_message = "<font color=\"[COLOR_BLOOD_BROTHERS_DEFAULT]\"><b><i>[imp_in.mind.name]:</i></b></font> [input]" //add sender, color source with syndie color
 		var/ghost_message = "<font color=\"[implant_colour]\"><b><i>[imp_in.mind.name] -> Blood Brothers:</i></b></font> [input]"
 
 		to_chat(imp_in, my_message) // Sends message to the user

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -22,7 +22,7 @@
 			return
 		input = imp_in.treat_message_min(input)
 
-		var/my_message = "<font color=\"[COLOR_BLOOD_BROTHERS_DEFAULT]\"><b><i>[imp_in.mind.name]:</i></b></font> [input]" //add sender, color source with syndie color
+		var/my_message = "<font color=\"[implant_colour]\"><b><i>[imp_in.mind.name]:</i></b></font> [input]" //add sender, color source with syndie color
 		var/ghost_message = "<font color=\"[implant_colour]\"><b><i>[imp_in.mind.name] -> Blood Brothers:</i></b></font> [input]"
 
 		to_chat(imp_in, my_message) // Sends message to the user

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -74,8 +74,8 @@
 /datum/antagonist/brother/proc/finalize_brother()
 	var/obj/item/implant/bloodbrother/I = new /obj/item/implant/bloodbrother()
 	I.implant(owner.current, null, TRUE, TRUE)
-	if(team.team_id <= 9)
-		I.implant_colour = COLOR_LIST_BLOOD_BROTHERS[team.team_id]
+	if(team.team_id <= length(GLOB.color_list_blood_brothers))
+		I.implant_colour = GLOB.color_list_blood_brothers[team.team_id]
 	else
 		I.implant_colour = "#ff0000"
 		stack_trace("Blood brother teams exist more than 9 teams, and colour preset is ran out")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes blood brother chat color list shuffled
If your chat colour isn't red, you can simply notice there are more than BB team.
* Purple: you know one more team exists
* Blue: you know two more teams exists
* ...yellow: you know 8 more BB teams exist

This PR makes the BB chat colour list as global list, and be shuffled when it's initialized. every round will show a different BB color to every team regardless of their team number

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Metainformation bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/9d2dffac-3721-468d-8ae3-b8b68f9549b7)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/37ecef1f-5631-4899-8d4e-69211cef0bb2)


## Changelog
:cl:
tweak: BB implant chat colour will be randomly chosen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
