### PR TITLE
Dense objects no longer can be hidden under the floor (Sensible densible)

### DIFF
--- a/code/datums/elements/undertile.dm
+++ b/code/datums/elements/undertile.dm
@@ -23,6 +23,11 @@
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
 
+	var/atom/movable/target_as_atom
+
+	if(target_as_atom.density)
+		return ELEMENT_INCOMPATIBLE
+
 	RegisterSignal(target, COMSIG_OBJ_HIDE, PROC_REF(hide))
 
 	src.invisibility_trait = invisibility_trait

--- a/code/datums/elements/undertile.dm
+++ b/code/datums/elements/undertile.dm
@@ -39,6 +39,9 @@
 ///called when a tile has been covered or uncovered
 /datum/element/undertile/proc/hide(atom/movable/source, covered)
 
+	if(source.density)
+		stack_trace("([src]): Atom [source] was given an undertile element, but has become dense! This can lead to invisible walls!")
+		return //Returning to actually prevent this from happening
 
 	source.invisibility = covered ? invisibility_level : 0
 

--- a/code/datums/elements/undertile.dm
+++ b/code/datums/elements/undertile.dm
@@ -23,7 +23,7 @@
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
 
-	var/atom/movable/target_as_atom
+	var/atom/movable/target_as_atom = target
 
 	if(target_as_atom.density)
 		return ELEMENT_INCOMPATIBLE

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -36,7 +36,7 @@
 
 	update_icon()
 
-	if(!pipe_type.density) //This prevents dense disposals machinery from being hidable under floor tiles
+	if(!initial(pipe_type.density)) //This prevents dense disposals machinery from being hidable under floor tiles
 		AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
 
 /obj/structure/disposalconstruct/Move()

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -36,7 +36,8 @@
 
 	update_icon()
 
-	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
+	if(!pipe_type.density) //This prevents dense disposals machinery from being hidable under floor tiles
+		AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
 
 /obj/structure/disposalconstruct/Move()
 	var/old_dir = dir


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently dense objects could be hidden under floor tiling and turf, which was not intended at all. This PR prevents that from happening by doing two things: 
- Firstly, addressing the object (`/obj/structure/disposalconstruct`) that it could be created with.
- Secondly, prevents the element (`/datum/element/undertile`) from attaching to objects with density, which should runtime and give warning that this is happening when it shouldn't be.

## Why It's Good For The Game

Fixes a potential exploit where you can make invisible walls of things.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/b6d6a0c8-0f4a-4372-bdc0-16d362dc76cf)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/4abe4274-dfec-41ce-9b04-e83284821b0b)

------

An error for whenever a dense object tries to hide. (Object is also prevented from hiding.)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/c9e11efa-beb6-4c92-92e9-4a2d0b138474)

</details>

## Changelog
:cl:
fix: Dense objects can no longer be hidden under the floor, and will now produce a runtime when attempted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
