### PR TITLE
Only 1 person can follow wakes and it takes 10s

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -275,3 +275,16 @@
 		for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 			diag_hud.remove_from_hud(src)
 	return ..()
+
+/obj/effect/temp_visual/portal_opening
+	name = "Portal Opening"
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "portal"
+	alpha = 0
+	duration = 11 SECONDS
+
+/obj/effect/temp_visual/portal_opening/Initialize(mapload)
+	. = ..()
+	transform = matrix() * 0
+	animate(src, time = 10 SECONDS, transform = matrix(), alpha = 255)
+	animate(time = 0.5 SECONDS, transform = matrix() * 0, alpha = 0)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -164,7 +164,7 @@
 			continue
 		var/distance = get_dist(wake, user)
 		var/range = distance <= 3 ? "Strong" : "Weak"
-		L["Slipspace Wake [++i] ([range])"] = get_teleport_turf(wake.destination, 2 + distance)
+		L["Slipspace Wake [++i] ([range])"] = wake
 	// Add on a random turf nearby
 	var/list/turfs = list()
 	for(var/turf/T as() in (RANGE_TURFS(10, user) - get_turf(user)))
@@ -184,8 +184,23 @@
 	if(active_portal_pairs.len >= max_portal_pairs)
 		user.show_message("<span class='notice'>\The [src] is recharging!</span>")
 		return
-	var/atom/T = L[t1]
-	var/area/A = get_area(T)
+	var/teleport_target = L[t1]
+	// Non-turfs (Wakes) are handled differently
+	if (istype(teleport_target, /obj/effect/temp_visual/teleportation_wake))
+		var/obj/effect/temp_visual/teleportation_wake/wake = teleport_target
+		to_chat(user, "<span class='notice'>You begin teleporting to the target.</span>")
+		var/obj/effect/temp_visual/portal_opening/target_effect = new(get_turf(wake.destination))
+		var/obj/effect/temp_visual/portal_opening/source_effect = new(get_turf(user))
+		if (do_after(user, 10 SECONDS, user))
+			var/distance = get_dist(wake.destination, user)
+			var/turf/target_turf = get_teleport_turf(wake.destination, 2 + distance)
+			do_teleport(user, target_turf)
+		else
+			animate(user, flags = ANIMATION_END_NOW)
+			qdel(target_effect)
+			qdel(source_effect)
+		return
+	var/area/A = get_area(teleport_target)
 	if(A.teleport_restriction)
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
 		return
@@ -194,7 +209,7 @@
 	if(!current_location || current_area.teleport_restriction || is_away_level(current_location.z) || is_centcom_level(current_location.z) || !isturf(user.loc))//If turf was not found or they're on z level 2 or >7 which does not currently exist. or if user is not located on a turf
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
 		return
-	var/list/obj/effect/portal/created = create_portal_pair(current_location, get_teleport_turf(get_turf(T)), src, 300, 1, null, atmos_link_override)
+	var/list/obj/effect/portal/created = create_portal_pair(current_location, get_teleport_turf(get_turf(teleport_target)), src, 300, 1, null, atmos_link_override)
 	if(!(LAZYLEN(created) == 2))
 		return
 

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -187,13 +187,13 @@
 	var/teleport_target = L[t1]
 	// Non-turfs (Wakes) are handled differently
 	if (istype(teleport_target, /obj/effect/temp_visual/teleportation_wake))
+		var/distance = get_dist(teleport_target, user)
 		var/obj/effect/temp_visual/teleportation_wake/wake = teleport_target
+		var/turf/target_turf = get_teleport_turf(wake.destination, 2 + distance)
 		to_chat(user, "<span class='notice'>You begin teleporting to the target.</span>")
-		var/obj/effect/temp_visual/portal_opening/target_effect = new(get_turf(wake.destination))
+		var/obj/effect/temp_visual/portal_opening/target_effect = new(target_turf)
 		var/obj/effect/temp_visual/portal_opening/source_effect = new(get_turf(user))
 		if (do_after(user, 10 SECONDS, user))
-			var/distance = get_dist(wake.destination, user)
-			var/turf/target_turf = get_teleport_turf(wake.destination, 2 + distance)
 			do_teleport(user, target_turf)
 		else
 			animate(user, flags = ANIMATION_END_NOW)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modifys the ability to follow teleportation wakes so that:
- It takes 10 seconds to complete.
- The other side can see the portal slowly opening.
- It now directly teleports the user rather than opening a portal, meaning the person teleporting cannot bring other people with them.

## Why It's Good For The Game

Makes it harder and risky to use the hand teleporter to follow wakes but still allows for sec to follow people using teleportations.

## Testing Photographs and Procedure


https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/79922392-1dda-4e56-aae6-14ad820486be



## Changelog
:cl:
balance: Following wakes with the hand teleporter takes 10 seconds, is visible on the other side and only teleports the holder of the hand teleporter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
