### PR TITLE
You can now examine organs/implants to see where in the body they go

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -364,6 +364,27 @@
 		if(ITEM_SLOT_LEGCUFFED)
 			return pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 
+/proc/zone2text(zone)
+	switch(zone)
+		if(BODY_ZONE_L_ARM)
+			return "left arm"
+		if(BODY_ZONE_R_ARM)
+			return "right arm"
+		if(BODY_ZONE_L_LEG)
+			return "left leg"
+		if(BODY_ZONE_R_LEG)
+			return "right leg"
+		if(BODY_ZONE_PRECISE_L_HAND)
+			return "left hand"
+		if(BODY_ZONE_PRECISE_R_HAND)
+			return "right hand"
+		if(BODY_ZONE_PRECISE_L_FOOT)
+			return "left foot"
+		if(BODY_ZONE_PRECISE_R_FOOT)
+			return "right foot"
+		else
+			return zone
+
 /// adapted from http://www.tannerhelland.com/4435/convert-temperature-rgb-algorithm-code/
 /proc/heat2colour(temp)
 	return rgb(heat2colour_r(temp), heat2colour_g(temp), heat2colour_b(temp))

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -364,27 +364,6 @@
 		if(ITEM_SLOT_LEGCUFFED)
 			return pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 
-/proc/zone2text(zone)
-	switch(zone)
-		if(BODY_ZONE_L_ARM)
-			return "left arm"
-		if(BODY_ZONE_R_ARM)
-			return "right arm"
-		if(BODY_ZONE_L_LEG)
-			return "left leg"
-		if(BODY_ZONE_R_LEG)
-			return "right leg"
-		if(BODY_ZONE_PRECISE_L_HAND)
-			return "left hand"
-		if(BODY_ZONE_PRECISE_R_HAND)
-			return "right hand"
-		if(BODY_ZONE_PRECISE_L_FOOT)
-			return "left foot"
-		if(BODY_ZONE_PRECISE_R_FOOT)
-			return "right foot"
-		else
-			return zone
-
 /// adapted from http://www.tannerhelland.com/4435/convert-temperature-rgb-algorithm-code/
 /proc/heat2colour(temp)
 	return rgb(heat2colour_r(temp), heat2colour_g(temp), heat2colour_b(temp))

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -110,7 +110,7 @@
 		return
 	if(damage > high_threshold)
 		. += "<span class='warning'>[src] is starting to look discolored.</span>"
-	. += "<span class='info'>[src] fits in the <b>[zone2text(zone)]</b>.</span>"
+	. += "<span class='info'>[src] fit[name[length(name)] == "s" ? "" : "s"] in the <b>[zone2text(zone)]</b>.</span>"
 
 /obj/item/organ/Initialize(mapload)
 	. = ..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -110,6 +110,7 @@
 		return
 	if(damage > high_threshold)
 		. += "<span class='warning'>[src] is starting to look discolored.</span>"
+	. += "<span class='info'>[src] fits in the <b>[zone2text(zone)]</b>.</span>"
 
 /obj/item/organ/Initialize(mapload)
 	. = ..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -110,7 +110,7 @@
 		return
 	if(damage > high_threshold)
 		. += "<span class='warning'>[src] is starting to look discolored.</span>"
-	. += "<span class='info'>[src] fit[name[length(name)] == "s" ? "" : "s"] in the <b>[zone2text(zone)]</b>.</span>"
+	. += "<span class='info'>[src] fit[name[length(name)] == "s" ? "" : "s"] in the <b>[parse_zone(zone)]</b>.</span>"
 
 /obj/item/organ/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This adds an examine message to organs/implants that says which body zone they go in.

## Why It's Good For The Game

Reduces confusion - having information available easily in-game is always a good thing

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/024820a2-e4ec-4444-9bb7-3d1184877893)


</details>

## Changelog
:cl:
add: You can now examine organs and implants to see which part of the body it fits in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
