### PR TITLE
Fix Build Mode map generator not working or hiding undertiles

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -355,7 +355,7 @@
 	var/y_skip_above = min(world.maxy - y_relative_to_absolute, y_upper, relative_y)
 	// How many lines to skip because they'd be above the y cuttoff line
 	var/y_starting_skip = relative_y - y_skip_above
-	highest_y += y_starting_skip
+	highest_y -= y_starting_skip
 
 
 	// Y is the LOWEST it will ever be here, so we can easily set a threshold for how low to go

--- a/code/modules/procedural_mapping/mapGenerators/repair.dm
+++ b/code/modules/procedural_mapping/mapGenerators/repair.dm
@@ -32,19 +32,17 @@
 
 	var/list/obj/machinery/atmospherics/atmos_machines = list()
 	var/list/obj/structure/cable/cables = list()
+	var/list/obj/undertiles = list()
 	var/list/atom/atoms = list()
 
 	require_area_resort()
 
-	for(var/turf/updated_turf as anything in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], SSmapping.station_start),
-						locate(bounds[MAP_MAXX], bounds[MAP_MAXY], z_offset - 1)))
-		set waitfor = FALSE
+	for(var/turf/updated_turf as anything in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], SSmapping.station_start), locate(bounds[MAP_MAXX], bounds[MAP_MAXY], z_offset - 1)))
 		atoms += updated_turf
 		for(var/atom/contained_atom as anything in updated_turf)
 			atoms += contained_atom
-			// Re-implement levelupdate()
-			if(!istype(updated_turf, /turf/open/space) && isobj(contained_atom))
-				SEND_SIGNAL(contained_atom, COMSIG_OBJ_HIDE, updated_turf.intact)
+			if(isobj(contained_atom) )
+				undertiles += contained_atom
 			if(istype(contained_atom, /obj/structure/cable))
 				cables += contained_atom
 				continue
@@ -54,6 +52,12 @@
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
+	// We can't just add stuff in a list, as some atoms create other undertiles (APC terminals, for example) so let's just loop again.
+	// This is a manual verb so performance is not a priority.
+	for(var/turf/updated_turf as anything in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], SSmapping.station_start), locate(bounds[MAP_MAXX], bounds[MAP_MAXY], z_offset - 1)))
+		for(var/atom/contained_atom as anything in updated_turf)
+			if(isobj(contained_atom) && !istype(updated_turf, /turf/open/space) && updated_turf.intact)
+				SEND_SIGNAL(contained_atom, COMSIG_OBJ_HIDE, TRUE)
 	GLOB.reloading_map = FALSE
 
 /datum/mapGenerator/repair

--- a/code/modules/procedural_mapping/mapGenerators/repair.dm
+++ b/code/modules/procedural_mapping/mapGenerators/repair.dm
@@ -36,18 +36,20 @@
 
 	require_area_resort()
 
-	for(var/L in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], SSmapping.station_start),
+	for(var/turf/updated_turf as anything in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], SSmapping.station_start),
 						locate(bounds[MAP_MAXX], bounds[MAP_MAXY], z_offset - 1)))
 		set waitfor = FALSE
-		var/turf/B = L
-		atoms += B
-		for(var/A in B)
-			atoms += A
-			if(istype(A,/obj/structure/cable))
-				cables += A
+		atoms += updated_turf
+		for(var/atom/contained_atom as anything in updated_turf)
+			atoms += contained_atom
+			// Re-implement levelupdate()
+			if(!istype(updated_turf, /turf/open/space) && isobj(contained_atom))
+				SEND_SIGNAL(contained_atom, COMSIG_OBJ_HIDE, updated_turf.intact)
+			if(istype(contained_atom, /obj/structure/cable))
+				cables += contained_atom
 				continue
-			if(istype(A,/obj/machinery/atmospherics))
-				atmos_machines += A
+			if(istype(contained_atom, /obj/machinery/atmospherics))
+				atmos_machines += contained_atom
 
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)


### PR DESCRIPTION
## About The Pull Request

Fixes #9588 

Nothing else uses "partial" template loading so not even TG encountered this issue, but it was starting from wayy above the max index causing crds to be null and thus nothing to generate.

Also calls COMSIG_OBJ_HIDE to cause undertiles to properly update.

## Why It's Good For The Game

Fixes a bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/68ca7a97-4d82-4110-9ca5-fdbb309b3eb2)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/5c1f8bd8-7d13-41de-9d2d-38274b0bbe66)


</details>

## Changelog
:cl:
fix: Fixed build mode's map regenerator not working.
fix: Fixed build mode's map regenerator not properly hiding undertile elements.
/:cl: