### PR TITLE
fixes usbs not working

### DIFF
--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -37,6 +37,8 @@
 		var/obj/item/circuit_component/component = circuit_component
 		if(ispath(circuit_component))
 			component = new circuit_component(null)
+		if(!should_register)
+			component.register_usb_parent(parent)
 		RegisterSignal(component, COMSIG_CIRCUIT_COMPONENT_SAVE, PROC_REF(save_component))
 		circuit_components += component
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Likely introduced in https://github.com/BeeStation/BeeStation-Hornet/pull/9536
Fixed by this PR https://github.com/tgstation/tgstation/pull/69920
Fixes #9579 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not working features bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
1.Print USB compatible shell, integrated circuit and USB cable
2. Insert a battery into integrated circuit and setup the shell by screwdriving it (if needed)
3. insert integrated circuit into the shell
4. connect USB from shell to BS launchpad console
5. set X and Y of the BS launchpad component to some value (for example -2, 1)
6. click on retrieve node 
7. launchpad gets the command and executes it

<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: fixed wiremod USBs not working
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
