### PR TITLE
Players cannot view the contents of trash bags

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -376,6 +376,7 @@
 
 /datum/component/storage/proc/show_to(mob/M)
 	if(!can_be_opened)
+		to_chat(M, "<span class='warning'>You shouldn't rummage through garbage!</span>")
 		return FALSE
 	if(!M.client)
 		return FALSE

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -32,6 +32,7 @@
 	var/allow_quick_empty = FALSE					//allow empty verb which allows dumping on the floor of everything inside quickly.
 	var/allow_quick_gather = FALSE					//allow toggle mob verb which toggles collecting all items from a tile.
 	var/insert_while_closed = TRUE					//the user can insert items while the storage is closed, if not the user will have to click/alt click to open it before they can insert items
+	var/can_be_opened = TRUE						//if FALSE, the container cannot be opened to look inside
 
 	var/collection_mode = COLLECT_EVERYTHING
 
@@ -374,6 +375,8 @@
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
 
 /datum/component/storage/proc/show_to(mob/M)
+	if(!can_be_opened)
+		return FALSE
 	if(!M.client)
 		return FALSE
 	var/atom/real_location = real_location()

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -50,6 +50,7 @@
 	STR.max_combined_w_class = 30
 	STR.max_items = 30
 	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear))
+	STR.can_be_opened = FALSE //Have to dump a trash bag out to look at its contents
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts [src] over [user.p_their()] head and starts chomping at the insides! Disgusting!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the ability to "open" a trash bag
Trash bags must be emptied onto the floor to access its contents

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Minor nerf that encourages more immersive use of trash bags, instead of being used as a second backpack that fits on the belt. 
This does nothing to affect their intended use of gathering trash for the sake of cleaning up.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

**Not really possible to show that I can't open the bag, so here's proof that it compiles.**
![dreamseeker_7fAAag2hI1](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/49cd3fb5-671c-4595-a628-cace2aab5907)


## Changelog
:cl:
tweak: Trash bags can no longer be opened to view contents, the bag must be dumped out onto the floor instead. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
