### PR TITLE
Dynamic visual (overlay addition) code

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2380,6 +2380,7 @@
 #include "code\modules\detectivework\evidence.dm"
 #include "code\modules\detectivework\footprints_and_rag.dm"
 #include "code\modules\detectivework\scanner.dm"
+#include "code\modules\dynamic_visual\dynamic_visual.dm"
 #include "code\modules\economy\_economy.dm"
 #include "code\modules\economy\account.dm"
 #include "code\modules\economy\pay_stand.dm"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -452,6 +452,8 @@
 	QDEL_NULL(em_block)
 	if(bound_overlay)
 		QDEL_NULL(bound_overlay)
+	if(dynamic_vis_contents)
+		cut_dynavis()
 
 	unbuckle_all_mobs(force = TRUE)
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -219,7 +219,7 @@ effective or pretty fucking useless.
 	if(!user)
 		return
 	to_chat(user, "<span class='notice'>You activate [src].</span>")
-	user.add_dynavis("inviscloak")
+	user.add_self_dynavis("inviscloak")
 	src.user = user
 	START_PROCESSING(SSobj, src)
 	old_alpha = user.alpha

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -219,6 +219,7 @@ effective or pretty fucking useless.
 	if(!user)
 		return
 	to_chat(user, "<span class='notice'>You activate [src].</span>")
+	user.add_dynavis("inviscloak")
 	src.user = user
 	START_PROCESSING(SSobj, src)
 	old_alpha = user.alpha
@@ -229,6 +230,7 @@ effective or pretty fucking useless.
 	STOP_PROCESSING(SSobj, src)
 	if(user)
 		user.alpha = old_alpha
+	user.remove_dynavis("inviscloak")
 	on = FALSE
 	user = null
 

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -22,10 +22,12 @@
 /obj/structure/closet/cardboard/agent/Initialize(mapload)
 	. = ..()
 	go_invisible()
+	add_dynavis("agent_box")
 
 
 /obj/structure/closet/cardboard/agent/open()
 	. = ..()
+	remove_dynavis("agent_box")
 	qdel(src)
 
 /obj/structure/closet/cardboard/agent/process()

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -22,7 +22,7 @@
 /obj/structure/closet/cardboard/agent/Initialize(mapload)
 	. = ..()
 	go_invisible()
-	add_dynavis("agent_box")
+	add_self_dynavis("agent_box")
 
 
 /obj/structure/closet/cardboard/agent/open()

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -44,6 +44,7 @@
 			Snake = L
 			break
 		if(Snake)
+			transfer_observers_to(Snake)
 			alerted = viewers(7,src)
 	..()
 	if(LAZYLEN(alerted))

--- a/code/modules/dynamic_visual/dynamic_visual.dm
+++ b/code/modules/dynamic_visual/dynamic_visual.dm
@@ -6,7 +6,7 @@
 	appearance_flags = RESET_ALPHA | KEEP_APART | TILE_BOUND | PIXEL_SCALE
 	vis_flags = VIS_INHERIT_PLANE | VIS_INHERIT_ID | VIS_INHERIT_DIR | VIS_UNDERLAY
 
-/atom/movable/proc/add_dynavis(key, invisibility_level=INVISIBILITY_OBSERVER)
+/atom/movable/proc/add_self_dynavis(key, invisibility_level=INVISIBILITY_OBSERVER)
 	var/atom/movable/dynamic_visual/dyvis = new()
 	var/current_alpha = alpha
 	var/alpha_check = appearance_flags & RESET_ALPHA

--- a/code/modules/dynamic_visual/dynamic_visual.dm
+++ b/code/modules/dynamic_visual/dynamic_visual.dm
@@ -7,21 +7,21 @@
 	vis_flags = VIS_INHERIT_PLANE | VIS_INHERIT_ID | VIS_INHERIT_DIR | VIS_UNDERLAY
 
 /atom/movable/proc/add_self_dynavis(key, invisibility_level=INVISIBILITY_OBSERVER)
-	var/atom/movable/dynamic_visual/dyvis = new()
+	var/atom/movable/dynamic_visual/dynavis = new()
 	var/current_alpha = alpha
 	var/alpha_check = appearance_flags & RESET_ALPHA
 	if(!alpha_check)
 		appearance_flags |= RESET_ALPHA
 	alpha = 120
-	dyvis.add_overlay(src)
+	dynavis.add_overlay(src)
 	alpha = current_alpha
 	if(!alpha_check)
 		appearance_flags &= ~RESET_ALPHA
-	dyvis.invisibility = invisibility_level
-	vis_contents += dyvis
+	dynavis.invisibility = invisibility_level
+	vis_contents += dynavis
 
 	LAZYINITLIST(dynamic_vis_contents)
-	dynamic_vis_contents[key] = dyvis
+	dynamic_vis_contents[key] = dynavis
 
 /atom/movable/proc/remove_dynavis(key)
 	var/dynavis = dynamic_vis_contents[key]

--- a/code/modules/dynamic_visual/dynamic_visual.dm
+++ b/code/modules/dynamic_visual/dynamic_visual.dm
@@ -1,0 +1,38 @@
+/atom/movable/var/list/dynamic_vis_contents
+/atom/movable/dynamic_visual
+	//parent_type = /atom/movable // I hate long typepath
+	name = "dynamic visual atom"
+	desc = "You shouldn't see this."
+	appearance_flags = RESET_ALPHA | KEEP_APART | TILE_BOUND | PIXEL_SCALE
+	vis_flags = VIS_INHERIT_PLANE | VIS_INHERIT_ID | VIS_INHERIT_DIR | VIS_UNDERLAY
+
+/atom/movable/proc/add_dynavis(key, invisibility_level=INVISIBILITY_OBSERVER)
+	var/atom/movable/dynamic_visual/dyvis = new()
+	var/current_alpha = alpha
+	var/alpha_check = appearance_flags & RESET_ALPHA
+	if(!alpha_check)
+		appearance_flags |= RESET_ALPHA
+	alpha = 120
+	dyvis.add_overlay(src)
+	alpha = current_alpha
+	if(!alpha_check)
+		appearance_flags &= ~RESET_ALPHA
+	dyvis.invisibility = invisibility_level
+	vis_contents += dyvis
+
+	LAZYINITLIST(dynamic_vis_contents)
+	dynamic_vis_contents[key] = dyvis
+
+/atom/movable/proc/remove_dynavis(key)
+	var/dynavis = dynamic_vis_contents[key]
+	LAZYREMOVE(dynamic_vis_contents, key)
+	vis_contents -= dynavis
+	qdel(dynavis)
+
+/atom/movable/proc/cut_dynavis()
+	for(var/each_key in dynamic_vis_contents)
+		var/dynavis = dynamic_vis_contents[each_key]
+		dynamic_vis_contents -= each_key
+		vis_contents -= dynavis
+		qdel(dynavis)
+	dynamic_vis_contents = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 - **This is basically introducing a concept rather than requesting a pull.**


Adds Dynamic visual code
It's basically `vis_contents` thing, but it allows you to see different sprites based on your visibility level
This may be possible to used in alternative hud, but I am not sure yet, so I just posted this anyway.


### why not using `SSvis_overlays.add_vis_overlay()`?
because it needs icon, iconstate, blabla to add it into vis_contents, but this one is specifically made for adding yourself as add_overlay then to apply it to yourself again, but also different appearance based on your visibility level.

I mean, providing `(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)` is not possible, but also you need 


meanwhile, I am not sure about the performance cost.
Maybe it should be a subsystem that works different from vis_overlay subsystem...


### Additional case to add

we can add "aura" thing to stuff.
for example, something is very looks normal, but somewhere between 25(mob default)~60(spirit), we can let them to see some aura from an item as long as their visibility qualifies.

 * i.e.)
Chaplain sword looks very normal sword.
but once it accepts a spirit, it starts to emit aura (at 50 visibility level)
and people with 50 see_visible level can see if the sword has a mind by seeing the aura.

 * i.e.2)
Put Halo to chaplains
Only specific people can see their halo

 * i.e.3)
an anomaly aura from an item that you can see when you wear glasses

maybe it can be great if it's compatible well with alternative hud.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
better overlay management

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/743dcc35-ca6e-41fe-b5ab-b4dd1cd0a56d)

basically, it's invisible to everyone when you're invisible
you need to use vis_contents to let overlay is only visible to observers

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/a698b5cd-2c87-4b3b-a845-85c4a1b5e1e0)

It's what I see myself when I aghost


## Changelog
:cl:
add: dynamic visual atom for overlay thing
tweak: Now you can see stealth-agent-box, and invisible cloaked person as observer
tweak: you'll be automatically orbit-transferred to the pop-up man in a box when the box is opened
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
