### PR TITLE
Minor Antag Preference fixes

### DIFF
--- a/code/modules/antagonists/role_preference/role_midrounds.dm
+++ b/code/modules/antagonists/role_preference/role_midrounds.dm
@@ -208,15 +208,6 @@
 
 	return finish_preview_icon(final_icon)
 
-/datum/role_preference/midround_ghost/slaughter_demon
-	name = "Slaughter Demon"
-	description = "Use your blood jaunt to terrorize the crew, and drag them all to hell."
-	antag_datum = /datum/antagonist/slaughter
-	category = ROLE_PREFERENCE_CATEGORY_LEGACY
-
-/datum/role_preference/midround_ghost/slaughter_demon/get_preview_icon()
-	return finish_preview_icon(icon('icons/mob/mob.dmi', "daemon"))
-
 /datum/role_preference/midround_ghost/devil
 	name = "Devil (Midround)"
 	description = "Sign deals with crewmembers, turn them to the side of the Devil."
@@ -243,6 +234,15 @@
 	back = /obj/item/tank/jetpack/carbondioxide
 	// No katana because it has trouble GCing
 	//belt = /obj/item/energy_katana
+
+/datum/role_preference/midround_ghost/slaughter_demon
+	name = "Slaughter Demon"
+	description = "Use your blood jaunt to terrorize the crew, and drag them all to hell."
+	antag_datum = /datum/antagonist/slaughter
+	category = ROLE_PREFERENCE_CATEGORY_MIDROUND_GHOST
+
+/datum/role_preference/midround_ghost/slaughter_demon/get_preview_icon()
+	return finish_preview_icon(icon('icons/mob/mob.dmi', "daemon"))
 
 /datum/role_preference/midround_living/malfunctioning_ai
 	name = "Malfunctioning AI"

--- a/code/modules/antagonists/role_preference/role_midrounds.dm
+++ b/code/modules/antagonists/role_preference/role_midrounds.dm
@@ -163,6 +163,7 @@
 	across for the following invasion force. \n\
 	Consume machines, structures, walls, anything to get materials. Replicate \
 	as many swarmers as you can to repeat the process."
+	antag_datum = /datum/antagonist/swarmer
 
 /datum/role_preference/midround_ghost/swarmer/get_preview_icon()
 	var/icon/swarmer_icon = icon('icons/mob/swarmer.dmi', "swarmer")

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
@@ -1,3 +1,4 @@
+import { round } from 'common/math';
 import { classes } from 'common/react';
 import { useBackend, useLocalState } from '../../backend';
 import { Box, Button, Flex, Section, Stack, Tooltip, Divider, Input, Icon } from '../../components';
@@ -104,12 +105,13 @@ const AntagSelection = (
               data.antag_living_playtime_hours_left[antagonist.path]) ||
             0;
 
+          let displayHours = round(hoursLeft, 2);
           let full_description = `${
             isBanned ? `You are banned from ${antagonist.name}.${antagonist.description || hoursLeft > 0 ? '\n' : ''}` : ''
           }${
             hoursLeft > 0
-              ? `You require ${hoursLeft} more hour${
-                hoursLeft !== 1 ? 's' : ''
+              ? `You require ${displayHours} more hour${
+                displayHours !== 1 ? 's' : ''
               } of living playtime in order to play this role.${antagonist.description ? '\n' : ''}`
               : ''
           }${antagonist.description}`;
@@ -201,7 +203,7 @@ const AntagSelection = (
 
                       {hoursLeft > 0 && (
                         <Box className="antagonist-overlay-text">
-                          <span className="antagonist-overlay-text-hours">{hoursLeft}</span>
+                          <span className="antagonist-overlay-text-hours">{Math.ceil(hoursLeft)}</span>
                           <br />
                           hours left
                         </Box>


### PR DESCRIPTION
## About The Pull Request

Fixes
- Swarmer pref not having an antag datum and not displaying bans
- Moves Slaughter Demon out of legacy since it exists it's just very rare.
- Fixes hour requirements not rounding

## Why It's Good For The Game

Fixes some visual bugs/inconsistencies

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/d0643278-1091-4269-a9fe-93c6e5237865)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/88712f12-9f37-4684-8cbe-752946500596)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/cbe022bf-4016-48ac-9fd7-f85506ec70fd)


</details>

## Changelog
:cl:
fix: Being banned from Swarmer will now properly display in the preferences menu.
tweak: Antag preference playtime requirement displays will now properly round.
tweak: Moved Slaughter Demon out of Legacy Roles since it exists, but is very rare.
/:cl: