### PR TITLE
Stat panel general cleanup + Improvements (Partial Bounty)

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1785,4 +1785,3 @@
 			qdel(src)
 		return TRUE
 	return FALSE
-

--- a/code/modules/admin/verbs/_help.dm
+++ b/code/modules/admin/verbs/_help.dm
@@ -233,10 +233,19 @@
 		for(var/datum/help_ticket/AH in l)
 			if(AH.initiator)
 				tab_data["#[AH.id]. [AH.initiator_key_name]"] = list(
-					text = AH.name,
+					text = AH.stat_text,
 					type = STAT_BUTTON,
 					action = "open_ticket",
 					params = list("id" = AH.id),
+					multirow = TRUE,
+					buttons = list(
+						list(
+							"title" = AH.claimee_key_name ? "Claimed by [AH.claimee_key_name]" : "Claim",
+							"color" = AH.claimee_key_name ? "red" : "green",
+							"action_id" = "claim_ticket",
+							"params" = list("id" = AH.id)
+						)
+					)
 				)
 			else
 				++num_disconnected
@@ -311,6 +320,7 @@
 /datum/help_ticket
 	var/id
 	var/name
+	var/stat_text
 	var/state = TICKET_UNCLAIMED
 	/// The first (sanitized) message for this ticket
 	var/initial_msg
@@ -359,6 +369,7 @@
 	opened_at = world.time
 
 	name = copytext_char(msg, 1, 100)
+	stat_text = copytext_char(msg, 1, 500)
 
 	var/datum/help_tickets/data_glob = get_data_glob()
 	if(!istype(data_glob))

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -168,7 +168,7 @@
 			var/image/override_image = image_overrides[first_atom]
 			atom_name = override_image.name
 		tab_data[REF(first_atom)] = list(
-			text = "[atom_name][length(atom_items) > 1 ? " (x[length(atom_items)])" : ""]",
+			text = "[atom_name][item_count > 1 ? " (x[item_count])" : ""]",
 			tag = STAT_PANEL_TAG(first_atom),
 			type = STAT_ATOM
 		)

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -118,6 +118,7 @@
 	var/max_item_sanity = MAX_ITEMS_TO_READ
 	var/icon_count_sanity = MAX_ICONS_PER_TILE
 	var/list/atom_count = list()
+	var/list/image_overrides = list()
 	// Find items and group them by both name and count
 	for (var/atom/A as() in src)
 		// Too many items read
@@ -134,6 +135,7 @@
 		if(overrides.len && overrides[A])
 			var/image/override_image = overrides[A]
 			atom_name = override_image.name
+			image_overrides[A] = override_image
 		var/list/item_group = atom_count["[atom_type][atom_name]"]
 		if (item_group)
 			item_group += A
@@ -151,8 +153,12 @@
 			item_count = 0
 			for (var/obj/item/stack/stack_item as() in atom_items)
 				item_count += stack_item.amount
+		var/atom_name = first_atom.name
+		if (image_overrides[first_atom])
+			var/image/override_image = image_overrides[first_atom]
+			atom_name = override_image.name
 		tab_data[REF(first_atom)] = list(
-			text = "[initial(first_atom.name)][length(atom_items) > 1 ? " (x[length(atom_items)])" : ""]",
+			text = "[atom_name][length(atom_items) > 1 ? " (x[length(atom_items)])" : ""]",
 			tag = STAT_PANEL_TAG(first_atom),
 			type = STAT_ATOM
 		)

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -254,18 +254,33 @@
 		return
 	switch(button_pressed)
 		if("browsetickets")
+			if (!client.holder)
+				return
 			GLOB.ahelp_tickets.BrowseTickets(src)
 		if("browseinterviews")
+			if (!check_rights(R_ADMIN))
+				return
 			GLOB.interviews.BrowseInterviews(src)
 		if("open_interview")
+			if (!check_rights(R_ADMIN))
+				return
 			var/datum/interview/I = GLOB.interviews.interview_by_id(text2num(params["id"]))
 			if (I && client.holder)
 				I.ui_interact(src)
 		if("open_ticket")
+			if (!client.holder)
+				return
 			var/ticket_id = text2num(params["id"])
 			var/datum/help_ticket/AH = GLOB.ahelp_tickets.TicketByID(ticket_id)
 			if(AH && client.holder)
 				AH.ui_interact(src)
+		if ("claim_ticket")
+			if (!check_rights(R_ADMIN))
+				return
+			var/ticket_id = text2num(params["id"])
+			var/datum/help_ticket/AH = GLOB.ahelp_tickets.TicketByID(ticket_id)
+			if(AH && client.holder)
+				AH.Claim()
 		if("atomClick")
 			var/atomRef = params["ref"]
 			var/atom/atom_actual = locate(atomRef)
@@ -305,13 +320,19 @@
 			var/verb_name = params["verb"]
 			winset(client, null, "command=[replacetext(verb_name, " ", "-")]")
 		if("sdql2debug")
+			if (!check_rights(R_DEBUG))
+				return
 			client.debug_variables(GLOB.sdql2_queries)
 		if("sdql2delete")
+			if (!check_rights(R_DEBUG))
+				return
 			var/query_id = params["qid"]
 			var/datum/SDQL2_query/query = sdqlQueryByID(text2num(query_id))
 			if(query)
 				query.delete_click()
 		if("sdql2toggle")
+			if (!check_rights(R_DEBUG))
+				return
 			var/query_id = params["qid"]
 			var/datum/SDQL2_query/query = sdqlQueryByID(text2num(query_id))
 			if(query)

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -20,28 +20,30 @@ export const StatText = (props, context) => {
     <div className="StatBorder">
       <Box>
         {statPanelData
-          ? Object.keys(statPanelData).sort((a, b) => {
+          ? Object.keys(statPanelData)
+            .sort((a, b) => {
               return StatTagToPriority(statPanelData[b].tag) - StatTagToPriority(statPanelData[a].tag);
-            }).map(
-            (key) =>
-              !!statPanelData[key] &&
-              ((statPanelData[key].type === STAT_TEXT && <StatTextText title={key} text={statPanelData[key].text} />) ||
-                (statPanelData[key].type === STAT_BUTTON && (
-                  <StatTextButton
-                    title={key}
-                    text={statPanelData[key].text}
-                    action_id={statPanelData[key].action}
-                    params={statPanelData[key].params}
-                    multirow={statPanelData[key].multirow}
-                    buttons={statPanelData[key].buttons}
-                  />
-                )) ||
-                (statPanelData[key].type === STAT_ATOM && (
-                  <StatTextAtom atom_ref={key} atom_name={statPanelData[key].text} atom_tag={statPanelData[key].tag} />
-                )) ||
-                (statPanelData[key].type === STAT_DIVIDER && <StatTextDivider />) ||
-                (statPanelData[key].type === STAT_BLANK && <br />))
-          )
+            })
+            .map(
+              (key) =>
+                !!statPanelData[key] &&
+                ((statPanelData[key].type === STAT_TEXT && <StatTextText title={key} text={statPanelData[key].text} />) ||
+                  (statPanelData[key].type === STAT_BUTTON && (
+                    <StatTextButton
+                      title={key}
+                      text={statPanelData[key].text}
+                      action_id={statPanelData[key].action}
+                      params={statPanelData[key].params}
+                      multirow={statPanelData[key].multirow}
+                      buttons={statPanelData[key].buttons}
+                    />
+                  )) ||
+                  (statPanelData[key].type === STAT_ATOM && (
+                    <StatTextAtom atom_ref={key} atom_name={statPanelData[key].text} atom_tag={statPanelData[key].tag} />
+                  )) ||
+                  (statPanelData[key].type === STAT_DIVIDER && <StatTextDivider />) ||
+                  (statPanelData[key].type === STAT_BLANK && <br />))
+            )
           : 'No data'}
         {Object.keys(verbs).map((verb) => (
           <StatTextVerb key={verb} title={verb} action_id={verbs[verb].action} params={verbs[verb].params} />
@@ -53,17 +55,17 @@ export const StatText = (props, context) => {
 
 const StatTagToPriority = (text) => {
   switch (text) {
-    case "Human":
+    case 'Human':
       return 10;
-    case "Mob":
+    case 'Mob':
       return 9;
-    case "Structure":
+    case 'Structure':
       return 8;
-    case "Machinery":
+    case 'Machinery':
       return 7;
-    case "Item":
+    case 'Item':
       return 6;
-    case "Turf":
+    case 'Turf':
       return 4;
   }
   return 5;
@@ -71,20 +73,20 @@ const StatTagToPriority = (text) => {
 
 const StatTagToClassName = (text) => {
   switch (text) {
-    case "Turf":
-    return "StatAtomTag Turf";
-    case "Human":
-    return "StatAtomTag Human";
-    case "Mob":
-    return "StatAtomTag Mob";
-    case "Structure":
-    return "StatAtomTag Structure";
-    case "Machinery":
-    return "StatAtomTag Machinery";
-    case "Item":
-    return "StatAtomTag Item";
+    case 'Turf':
+      return 'StatAtomTag Turf';
+    case 'Human':
+      return 'StatAtomTag Human';
+    case 'Mob':
+      return 'StatAtomTag Mob';
+    case 'Structure':
+      return 'StatAtomTag Structure';
+    case 'Machinery':
+      return 'StatAtomTag Machinery';
+    case 'Item':
+      return 'StatAtomTag Item';
   }
-  return "StatAtomTag Other";
+  return 'StatAtomTag Other';
 };
 
 /*
@@ -170,11 +172,7 @@ const storeAtomRef = (value) => {
 const retrieveAtomRef = () => janky_storage;
 
 export const StatTextAtom = (props, context) => {
-  const {
-    atom_name,
-    atom_ref,
-    atom_tag,
-  } = props;
+  const { atom_name, atom_ref, atom_tag } = props;
 
   storeAtomRef(null);
 
@@ -231,9 +229,7 @@ export const StatTextAtom = (props, context) => {
         <div className="StatAtomElement">
           <Flex direction="row" wrap="wrap">
             <Flex.Item basis={6} mr={2}>
-              <div className={StatTagToClassName(atom_tag)}>
-                {atom_tag}
-              </div>
+              <div className={StatTagToClassName(atom_tag)}>{atom_tag}</div>
             </Flex.Item>
             <Flex.Item grow={1}>{capitalize(atom_name)}</Flex.Item>
           </Flex>

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -55,6 +55,8 @@ export const StatText = (props, context) => {
 
 const StatTagToPriority = (text) => {
   switch (text) {
+    case "You":
+      return 11;
     case 'Human':
       return 10;
     case 'Mob':
@@ -73,6 +75,8 @@ const StatTagToPriority = (text) => {
 
 const StatTagToClassName = (text) => {
   switch (text) {
+    case "You":
+      return "StatAtomTag Self";
     case 'Turf':
       return 'StatAtomTag Turf';
     case 'Human':
@@ -118,20 +122,29 @@ export const StatTextButton = (props, context) => {
         }
         color="transparent">
         {!multirow ? (
-          <>
-            <Box bold inline mr="5px" verticalAlign="top">
-              {title}
-            </Box>
-            <Box
-              width="100%"
-              pr="80px"
-              inline
-              style={{
+          <Flex direction="row">
+            <Flex.Item bold>{title}</Flex.Item>
+            {buttons.map((buttonInfo) => (
+              <Flex.Item shrink={1} key={buttonInfo}>
+                <Button
+                  color={buttonInfo['color']}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    Byond.sendMessage('stat/pressed', {
+                      action_id: buttonInfo['action_id'],
+                      params: buttonInfo['params'],
+                    });
+                  }}>
+                  {buttonInfo['title']}
+                </Button>
+              </Flex.Item>
+            ))}
+            <Flex.Item grow={1} ml={1.5} style={{
                 'white-space': 'normal',
-              }}>
+            }}>
               {text}
-            </Box>
-          </>
+            </Flex.Item>
+          </Flex>
         ) : (
           <>
             <Flex bold direction="row">

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -63,14 +63,7 @@ export const StatTextText = (props, context) => {
 };
 
 export const StatTextButton = (props, context) => {
-  const {
-    title,
-    text,
-    action_id,
-    params = [],
-    multirow = false,
-    buttons = [],
-  } = props;
+  const { title, text, action_id, params = [], multirow = false, buttons = [] } = props;
   return (
     <Flex.Item mt={1}>
       <Button
@@ -82,13 +75,19 @@ export const StatTextButton = (props, context) => {
             params: params,
           })
         }
-        color="transparent" >
+        color="transparent">
         {!multirow ? (
           <>
-            <Box bold inline mr="5px" verticalAlign="top">{title}</Box>
-            <Box width="100%" pr="80px" inline style={{
-              'white-space': 'normal',
-            }}>
+            <Box bold inline mr="5px" verticalAlign="top">
+              {title}
+            </Box>
+            <Box
+              width="100%"
+              pr="80px"
+              inline
+              style={{
+                'white-space': 'normal',
+              }}>
               {text}
             </Box>
           </>
@@ -96,28 +95,30 @@ export const StatTextButton = (props, context) => {
           <>
             <Flex bold direction="row">
               <Flex.Item grow={1}>{title}</Flex.Item>
-              {buttons.map(buttonInfo => (
+              {buttons.map((buttonInfo) => (
                 <Flex.Item shrink={1} key={buttonInfo}>
-                  <Button color={buttonInfo["color"]} onClick={(e) => {
-                    e.stopPropagation();
-                    Byond.sendMessage('stat/pressed', {
-                      action_id: buttonInfo["action_id"],
-                      params: buttonInfo["params"],
-                    });
-                  }}>
-                    {buttonInfo["title"]}
+                  <Button
+                    color={buttonInfo['color']}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      Byond.sendMessage('stat/pressed', {
+                        action_id: buttonInfo['action_id'],
+                        params: buttonInfo['params'],
+                      });
+                    }}>
+                    {buttonInfo['title']}
                   </Button>
                 </Flex.Item>
               ))}
             </Flex>
-            <Box style={{
-              'white-space': 'normal',
-            }}>
+            <Box
+              style={{
+                'white-space': 'normal',
+              }}>
               {text}
             </Box>
           </>
         )}
-
       </Button>
     </Flex.Item>
   );

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -4,6 +4,7 @@ import { useSettings } from '../settings';
 import { selectStatPanel } from './selectors';
 import { Divider, Table } from '../../tgui/components';
 import { STAT_TEXT, STAT_BUTTON, STAT_ATOM, STAT_DIVIDER, STAT_BLANK } from './constants';
+import { capitalize } from 'common/string';
 
 export const StatText = (props, context) => {
   const stat = useSelector(context, selectStatPanel);
@@ -19,7 +20,9 @@ export const StatText = (props, context) => {
     <div className="StatBorder">
       <Box>
         {statPanelData
-          ? Object.keys(statPanelData).map(
+          ? Object.keys(statPanelData).sort((a, b) => {
+              return StatTagToPriority(statPanelData[b].tag) - StatTagToPriority(statPanelData[a].tag);
+            }).map(
             (key) =>
               !!statPanelData[key] &&
               ((statPanelData[key].type === STAT_TEXT && <StatTextText title={key} text={statPanelData[key].text} />) ||
@@ -34,7 +37,7 @@ export const StatText = (props, context) => {
                   />
                 )) ||
                 (statPanelData[key].type === STAT_ATOM && (
-                  <StatTextAtom atom_ref={key} atom_name={statPanelData[key].text} />
+                  <StatTextAtom atom_ref={key} atom_name={statPanelData[key].text} atom_tag={statPanelData[key].tag} />
                 )) ||
                 (statPanelData[key].type === STAT_DIVIDER && <StatTextDivider />) ||
                 (statPanelData[key].type === STAT_BLANK && <br />))
@@ -46,6 +49,42 @@ export const StatText = (props, context) => {
       </Box>
     </div>
   );
+};
+
+const StatTagToPriority = (text) => {
+  switch (text) {
+    case "Human":
+      return 10;
+    case "Mob":
+      return 9;
+    case "Structure":
+      return 8;
+    case "Machinery":
+      return 7;
+    case "Item":
+      return 6;
+    case "Turf":
+      return 4;
+  }
+  return 5;
+};
+
+const StatTagToClassName = (text) => {
+  switch (text) {
+    case "Turf":
+    return "StatAtomTag Turf";
+    case "Human":
+    return "StatAtomTag Human";
+    case "Mob":
+    return "StatAtomTag Mob";
+    case "Structure":
+    return "StatAtomTag Structure";
+    case "Machinery":
+    return "StatAtomTag Machinery";
+    case "Item":
+    return "StatAtomTag Item";
+  }
+  return "StatAtomTag Other";
 };
 
 /*
@@ -131,13 +170,20 @@ const storeAtomRef = (value) => {
 const retrieveAtomRef = () => janky_storage;
 
 export const StatTextAtom = (props, context) => {
-  const { atom_name, atom_ref } = props;
+  const {
+    atom_name,
+    atom_ref,
+    atom_tag,
+  } = props;
 
   storeAtomRef(null);
 
   return (
-    <Flex.Item mt={1}>
+    <Flex.Item mt={0.5}>
       <Button
+        pl={0}
+        width="100%"
+        overflowX="hidden"
         draggable
         onDragStart={(e) => {
           // e.dataTransfer.setData("text", atom_ref);
@@ -182,7 +228,16 @@ export const StatTextAtom = (props, context) => {
           })
         }
         color="transparent">
-        {atom_name}
+        <div className="StatAtomElement">
+          <Flex direction="row" wrap="wrap">
+            <Flex.Item basis={6} mr={2}>
+              <div className={StatTagToClassName(atom_tag)}>
+                {atom_tag}
+              </div>
+            </Flex.Item>
+            <Flex.Item grow={1}>{capitalize(atom_name)}</Flex.Item>
+          </Flex>
+        </div>
       </Button>
     </Flex.Item>
   );

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -55,7 +55,7 @@ export const StatText = (props, context) => {
 
 const StatTagToPriority = (text) => {
   switch (text) {
-    case "You":
+    case 'You':
       return 11;
     case 'Human':
       return 10;
@@ -75,8 +75,8 @@ const StatTagToPriority = (text) => {
 
 const StatTagToClassName = (text) => {
   switch (text) {
-    case "You":
-      return "StatAtomTag Self";
+    case 'You':
+      return 'StatAtomTag Self';
     case 'Turf':
       return 'StatAtomTag Turf';
     case 'Human':
@@ -139,9 +139,12 @@ export const StatTextButton = (props, context) => {
                 </Button>
               </Flex.Item>
             ))}
-            <Flex.Item grow={1} ml={1.5} style={{
+            <Flex.Item
+              grow={1}
+              ml={1.5}
+              style={{
                 'white-space': 'normal',
-            }}>
+              }}>
               {text}
             </Flex.Item>
           </Flex>

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -29,6 +29,8 @@ export const StatText = (props, context) => {
                     text={statPanelData[key].text}
                     action_id={statPanelData[key].action}
                     params={statPanelData[key].params}
+                    multirow={statPanelData[key].multirow}
+                    buttons={statPanelData[key].buttons}
                   />
                 )) ||
                 (statPanelData[key].type === STAT_ATOM && (
@@ -61,19 +63,61 @@ export const StatTextText = (props, context) => {
 };
 
 export const StatTextButton = (props, context) => {
-  const { title, text, action_id, params = [] } = props;
+  const {
+    title,
+    text,
+    action_id,
+    params = [],
+    multirow = false,
+    buttons = [],
+  } = props;
   return (
     <Flex.Item mt={1}>
       <Button
+        width="100%"
+        overflowX="hidden"
         onClick={() =>
           Byond.sendMessage('stat/pressed', {
             action_id: action_id,
             params: params,
           })
         }
-        color="transparent">
-        <b>{title}: </b>
-        {text}
+        color="transparent" >
+        {!multirow ? (
+          <>
+            <Box bold inline mr="5px" verticalAlign="top">{title}</Box>
+            <Box width="100%" pr="80px" inline style={{
+              'white-space': 'normal',
+            }}>
+              {text}
+            </Box>
+          </>
+        ) : (
+          <>
+            <Flex bold direction="row">
+              <Flex.Item grow={1}>{title}</Flex.Item>
+              {buttons.map(buttonInfo => (
+                <Flex.Item shrink={1} key={buttonInfo}>
+                  <Button color={buttonInfo["color"]} onClick={(e) => {
+                    e.stopPropagation();
+                    Byond.sendMessage('stat/pressed', {
+                      action_id: buttonInfo["action_id"],
+                      params: buttonInfo["params"],
+                    });
+                  }}>
+                    {buttonInfo["title"]}
+                  </Button>
+                </Flex.Item>
+              ))}
+            </Flex>
+            <Box style={{
+              'white-space': 'normal',
+            }}>
+              {text}
+            </Box>
+          </>
+        )}
+
       </Button>
     </Flex.Item>
   );

--- a/tgui/packages/tgui-panel/styles/components/Stat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Stat.scss
@@ -96,5 +96,4 @@ $border-color: color.scale(colors.fg(colors.$primary), $lightness: 75%) !default
   &.Other {
     background-color: #adadad;
   }
-
 }

--- a/tgui/packages/tgui-panel/styles/components/Stat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Stat.scss
@@ -77,6 +77,10 @@ $border-color: color.scale(colors.fg(colors.$primary), $lightness: 75%) !default
     background-color: #f1eaaa;
   }
 
+  &.Self {
+    background-color: #fafafa;
+  }
+
   &.Human {
     background-color: #aff1aa;
   }

--- a/tgui/packages/tgui-panel/styles/components/Stat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Stat.scss
@@ -57,3 +57,44 @@ $border-color: color.scale(colors.fg(colors.$primary), $lightness: 75%) !default
 .StatTabBackground {
   border-bottom: math.div(1em, 6) solid #666666;
 }
+
+.StatAtomElement {
+  cursor: pointer;
+  color: lighten($color: $background-color, $amount: 65%);
+}
+
+.StatAtomTag {
+  background-color: #ff94f1;
+  color: #2b2b2b;
+  border-radius: 5px;
+  text-align: center;
+
+  &.Structure {
+    background-color: #b2aaf1;
+  }
+
+  &.Turf {
+    background-color: #f1eaaa;
+  }
+
+  &.Human {
+    background-color: #aff1aa;
+  }
+
+  &.Mob {
+    background-color: #aaf1d3;
+  }
+
+  &.Machinery {
+    background-color: #f5b59c;
+  }
+
+  &.Item {
+    background-color: #f59cbb;
+  }
+
+  &.Other {
+    background-color: #adadad;
+  }
+
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Was offered a £30 bounty by Floria in order to alter the listed turf stat panel to:
- Be sorted so that structures/machinery will be on top
- Concatenate similar items into 1 by putting (x30) instead.

I have done some additional improvements and changes to make it a bit nicer overall which were not part of this.

## About The Pull Request

Cleans up some of the elements of the stat panel which in the past have been a bit broken, now that I actually know react.

Firstly, prevents buttons from over-running the tab:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/60bd5de4-1c13-4876-85c5-b12f3580bb0a)

Makes the buttons extend the entire width of the screen:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/80cd9afc-f278-404e-96d4-f318e241c16c)

Implements the ability to have multi-row buttons which support sub-buttons:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/b70965e6-a795-49d7-9b9f-f073ccd9f564)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/0915734a-d036-4937-a491-c7afe954f391)

This also fixes an exploit where non-admins could delete SDQL queries that they know the ID of, as well as admins that don't have the correct permissions being able to delete SDQL queries.

Stat panel atoms will now extend the full width of the stat tab, have a tag showing what the thing is (which is coloured for better readability) and is sorted by tag.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8ad64083-cc11-4b48-978b-ed265b755e54)

The mouse cursor will now change when hovering over atoms in that menu to indicate that they can be dragged.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/db5b9a43-24ce-4ac1-8e88-1e354cf4bc3f)


## Why It's Good For The Game

When I made the ticket panel, I thought that admins could have it open on their second screens however it is a mostly redundant panel due to the stat panel displaying the information better. Unfortunately, the claiming system is entirely dependant on that panel and not the stat panel, making it so its hard to see at a glance who has claimed a ticket. This fixes that.

Also cleans up some long outstanding issues with the stat panel/

## Testing Photographs and Procedure

See above.

## Changelog
:cl:
fix: Fixes stat panel buttons overrunning the screen on the MC tab.
fix: Enforces permission requirement on stat button presses.
add: Adds support for multi-row stat buttons which have sub-buttons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
