### PR TITLE
Correct preference SQL migration oversights

### DIFF
--- a/SQL/prefs_migration_2023-07-26.sql
+++ b/SQL/prefs_migration_2023-07-26.sql
@@ -271,12 +271,14 @@ INSERT IGNORE INTO `SS13_preferences` (`ckey`, `preference_tag`, `preference_val
 INSERT IGNORE INTO `SS13_preferences` (`ckey`, `preference_tag`, `preference_value`) (
     SELECT `ckey`,'sound_announcements',IF(`preference_value` & (1<<11) > 0, 1, 0) AS `preference_value` FROM `SS13_preferences` WHERE `preference_tag` = '1'
 );
+/* These two are inverted, as they were switched from 'disable' to 'enable' */
 INSERT IGNORE INTO `SS13_preferences` (`ckey`, `preference_tag`, `preference_value`) (
-    SELECT `ckey`,'death_rattle',IF(`preference_value` & (1<<12) > 0, 1, 0) AS `preference_value` FROM `SS13_preferences` WHERE `preference_tag` = '1'
+    SELECT `ckey`,'death_rattle',IF(`preference_value` & (1<<12) > 0, 0, 1) AS `preference_value` FROM `SS13_preferences` WHERE `preference_tag` = '1'
 );
 INSERT IGNORE INTO `SS13_preferences` (`ckey`, `preference_tag`, `preference_value`) (
-    SELECT `ckey`,'arrivals_rattle',IF(`preference_value` & (1<<13) > 0, 1, 0) AS `preference_value` FROM `SS13_preferences` WHERE `preference_tag` = '1'
+    SELECT `ckey`,'arrivals_rattle',IF(`preference_value` & (1<<13) > 0, 0, 1) AS `preference_value` FROM `SS13_preferences` WHERE `preference_tag` = '1'
 );
+/* Back to normal now */
 INSERT IGNORE INTO `SS13_preferences` (`ckey`, `preference_tag`, `preference_value`) (
     SELECT `ckey`,'combohud_lighting',IF(`preference_value` & (1<<14) > 0, 1, 0) AS `preference_value` FROM `SS13_preferences` WHERE `preference_tag` = '1'
 );

--- a/SQL/prefs_migration_2023-07-26.sql
+++ b/SQL/prefs_migration_2023-07-26.sql
@@ -174,6 +174,8 @@ ALTER TABLE `SS13_preferences` MODIFY COLUMN `preference_tag` VARCHAR(255) NOT N
 
 UPDATE `SS13_preferences`
     SET `preference_tag` = CASE
+    WHEN `preference_tag` = '3' THEN 'asaycolor'
+    WHEN `preference_tag` = '4' THEN 'ooccolor'
     WHEN `preference_tag` = '5' THEN 'last_changelog'
     WHEN `preference_tag` = '6' THEN 'ui_style'
     WHEN `preference_tag` = '7' THEN 'outline_color'


### PR DESCRIPTION
## About The Pull Request

I made a mistake in #8776, causing the wrong toggle value to be migrated. This corrects it in the changelog, we will be manually fixing the values in the database. This is for downstreams mainly, I will be linking this PR in the original PR.

I also somehow missed asay and ooc colors. Not sure how that happened.

## Why It's Good For The Game

For downstreams, repo change

## Testing Photographs and Procedure

N/A