### PR TITLE
Fixes null clients being passed to prefs during /client/New()

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -245,6 +245,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	get_metabalance_db()
 	// Retrieve cached antag token count
 	get_antag_token_count_db()
+	if(!src) // Yes this is possible, because the procs above sleep.
+		return
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]
 	if(prefs)

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -102,6 +102,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	return ..()
 
 /datum/preferences/New(client/parent)
+	if(!istype(parent))
+		QDEL_IN(src, 0)
+		return
 	src.parent = parent
 
 	for (var/middleware_type in subtypesof(/datum/preference_middleware))

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /datum/preferences/New(client/parent)
 	if(!istype(parent))
-		QDEL_IN(src, 0)
+		qdel(src)
 		return
 	src.parent = parent
 


### PR DESCRIPTION
## About The Pull Request

Because yes this is possible. I am so tired of null clients.

## Why It's Good For The Game

Fix runtime

## Testing Photographs and Procedure

Can't really test but it works from a code perspective

## Changelog
:cl:
fix: Fixed a runtime from prefs if a player disconnected during their client initialization.
/:cl:
