### PR TITLE
Runtime pass on stack merges and fingerprints

### DIFF
--- a/code/game/objects/items/bedsheets.dm
+++ b/code/game/objects/items/bedsheets.dm
@@ -46,9 +46,13 @@
 
 /obj/item/bedsheet/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_WIRECUTTER || I.is_sharp())
-		var/obj/item/stack/sheet/cotton/cloth/C = new (get_turf(src), 3)
-		transfer_fingerprints_to(C)
-		C.add_fingerprint(user)
+		var/turf/T = get_turf(src)
+		var/obj/item/stack/sheet/cotton/cloth/C = new (T, 3)
+		if(QDELETED(C))
+			C = locate(/obj/item/stack/sheet/cotton/cloth) in T
+		if(C)
+			transfer_fingerprints_to(C)
+			C.add_fingerprint(user)
 		qdel(src)
 		to_chat(user, "<span class='notice'>You tear [src] up.</span>")
 	else

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -338,14 +338,22 @@
 		balloon_alert(user, "You start slicing apart [src]...")
 		if(W.use_tool(src, user, 40, volume=50))
 			balloon_alert(user, "You slice [src] apart.")
-			var/obj/item/stack/sheet/runed_metal/R = new(drop_location(), 1)
-			transfer_fingerprints_to(R)
+			var/drop_loc = drop_location()
+			var/obj/item/stack/sheet/runed_metal/R = new(drop_loc, 1)
+			if(QDELETED(R))
+				R = locate(/obj/item/stack/sheet/runed_metal) in drop_loc
+			if(R)
+				transfer_fingerprints_to(R)
 			qdel(src)
 
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
 		to_chat(user, "<span class='notice'>Your jackhammer smashes through [src]!</span>")
-		var/obj/item/stack/sheet/runed_metal/R = new(drop_location(), 2)
-		transfer_fingerprints_to(R)
+		var/drop_loc = drop_location()
+		var/obj/item/stack/sheet/runed_metal/R = new(drop_loc, 2)
+		if(QDELETED(R))
+			R = locate(/obj/item/stack/sheet/runed_metal) in drop_loc
+		if(R)
+			transfer_fingerprints_to(R)
 		W.play_tool_sound(src)
 		qdel(src)
 
@@ -412,14 +420,22 @@
 		balloon_alert(user, "You start slicing apart [src]...")
 		if(W.use_tool(src, user, 40, volume=50))
 			balloon_alert(user, "You slice apart [src].")
-			var/obj/item/stack/sheet/bronze/B = new(drop_location(), 2)
-			transfer_fingerprints_to(B)
+			var/drop_loc = drop_location()
+			var/obj/item/stack/sheet/bronze/B = new(drop_loc, 2)
+			if(QDELETED(B))
+				B = locate(/obj/item/stack/sheet/bronze) in drop_loc
+			if(B)
+				transfer_fingerprints_to(B)
 			qdel(src)
 
 	else if(istype(W, /obj/item/pickaxe/drill/jackhammer))
 		to_chat(user, "<span class='notice'>Your jackhammer smashes through [src]!</span>")
-		var/obj/item/stack/sheet/bronze/B = new(drop_location(), 2)
-		transfer_fingerprints_to(B)
+		var/drop_loc = drop_location()
+		var/obj/item/stack/sheet/bronze/B = new(drop_loc, 2)
+		if(QDELETED(B))
+			B = locate(/obj/item/stack/sheet/bronze) in drop_loc
+		if(B)
+			transfer_fingerprints_to(B)
 		W.play_tool_sound(src)
 		qdel(src)
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -227,16 +227,24 @@
 	if(!loc) //if already qdel'd somehow, we do nothing
 		return
 	if(!(flags_1&NODECONSTRUCT_1))
-		var/obj/R = new rods_type(drop_location(), rods_amount)
-		transfer_fingerprints_to(R)
+		var/drop_loc = drop_location()
+		var/obj/R = new rods_type(drop_loc, rods_amount)
+		if(QDELETED(R)) // the rods merged with something on the tile
+			R = locate(rods_type) in drop_loc
+		if(R)
+			transfer_fingerprints_to(R)
 		qdel(src)
 	..()
 
 /obj/structure/grille/obj_break()
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
 		new broken_type(src.loc)
-		var/obj/R = new rods_type(drop_location(), rods_broken)
-		transfer_fingerprints_to(R)
+		var/drop_loc = drop_location()
+		var/obj/R = new rods_type(drop_loc, rods_broken)
+		if(QDELETED(R)) // the rods merged with something on the tile
+			R = locate(rods_type) in drop_loc
+		if(R)
+			transfer_fingerprints_to(R)
 		qdel(src)
 
 

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -169,8 +169,12 @@
 				user.visible_message("<span class='notice'>[user] cuts [src].</span>", \
 									 "<span class='notice'>You cut [src].</span>")
 				I.play_tool_sound(src, 100)
-				var/obj/R = new /obj/item/stack/rods(drop_location(), 10)
-				transfer_fingerprints_to(R)
+				var/drop_loc = drop_location()
+				var/obj/R = new /obj/item/stack/rods(drop_loc, 10)
+				if(QDELETED(R)) // the rods merged with something on the tile
+					R = locate(/obj/item/stack/rods) in drop_loc
+				if(R)
+					transfer_fingerprints_to(R)
 				qdel(src)
 				return TRUE
 	else

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -62,8 +62,12 @@
 
 /obj/structure/railing/deconstruct(disassembled)
 	if(!(flags_1 & NODECONSTRUCT_1))
-		var/obj/item/stack/rods/rod = new /obj/item/stack/rods(drop_location(), 3)
-		transfer_fingerprints_to(rod)
+		var/drop_loc = drop_location()
+		var/obj/R = new /obj/item/stack/rods(drop_loc, 3)
+		if(QDELETED(R)) // the rods merged with something on the tile
+			R = locate(/obj/item/stack/rods) in drop_loc
+		if(R)
+			transfer_fingerprints_to(R)
 	return ..()
 
 ///Implements behaviour that makes it possible to unanchor the railing.

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -109,6 +109,10 @@ GLOBAL_LIST_INIT(marker_beacon_colors, sort_list(list(
 	to_chat(user, "<span class='notice'>You start picking [src] up...</span>")
 	if(do_after(user, remove_speed, target = src))
 		var/obj/item/stack/marker_beacon/M = new(loc)
+		if(QDELETED(M))
+			M = locate(/obj/item/stack/marker_beacon) in loc
+		if(!M)
+			return
 		M.picked_color = picked_color
 		M.update_icon()
 		transfer_fingerprints_to(M)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -112,8 +112,11 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(!(flags_1 & NODECONSTRUCT_1))
 		var/turf/T = get_turf(loc)
 		if(T)
-			var/obj/item/stack/cable_coil/temp_item = new /obj/item/stack/cable_coil(T, d1 ? 2 : 1, cable_color)
-			transfer_fingerprints_to(temp_item)
+			var/obj/R = new /obj/item/stack/cable_coil(T, d1 ? 2 : 1, cable_color)
+			if(QDELETED(R)) // the coil merged with something on the tile
+				R = locate(/obj/item/stack/cable_coil) in T
+			if(R)
+				transfer_fingerprints_to(R)
 		var/turf/T_below = T.below()
 		if((d1 == DOWN || d2 == DOWN) && T_below)
 			for(var/obj/structure/cable/C in T_below)

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -227,7 +227,9 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			set_operating(FALSE)
 			if(!(machine_stat & BROKEN))
 				var/obj/item/stack/conveyor/C = new /obj/item/stack/conveyor(loc, 1, TRUE, null, id)
-				if(!QDELETED(C)) //God I hate stacks
+				if(QDELETED(C))
+					C = locate(/obj/item/stack/conveyor) in loc
+				if(C)
 					transfer_fingerprints_to(C)
 			to_chat(user, "<span class='notice'>You remove the conveyor belt.</span>")
 


### PR DESCRIPTION
## About The Pull Request

A common pattern is creating a stack of something (rods etc) and then adding a fingerprint to it.

Unfortunately stacks like to qdel themselves on init, so we need to check for this and then find the new (merged) stack.

## Why It's Good For The Game

Fixes runtimes

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/fd95e354-5079-4407-aa66-575d351fda98)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/7e880ed9-0d73-4169-8fc3-ce39d7a45c8d)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/6e528f99-3071-4882-a07d-b6a1d49dc0cf)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/2484d303-5307-4f74-9d98-293abbde7101)


</details>

## Changelog
:cl:
fix: Fixed runtimes and fingerprints not getting properly applied when a stack merges with something during deconstruction.
/:cl: