### PR TITLE
Fixes killer tomatos attacking podpeople in frenzy

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -33,7 +33,8 @@
 	var/tomatosseen = 0
 	for(var/mob/living/simple_animal/hostile/killertomato/T in oview(7, src))
 		tomatosseen += 1
-	if(tomatosseen >= frenzythreshold)
+	if(tomatosseen >= frenzythreshold && istype(the_target, /mob/living/simple_animal/hostile/killertomato))
 		attack_same = TRUE
 	. = ..()
-
+	// Reset the attack same flag
+	attack_same = initial(attack_same)

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -31,7 +31,7 @@
 
 /mob/living/simple_animal/hostile/killertomato/CanAttack(atom/the_target)
 	var/tomatosseen = 0
-	for(var/mob/living/simple_animal/hostile/killertomato/T in oview(7, src))
+	for(var/mob/living/simple_animal/hostile/killertomato/T in orange(5, src))
 		tomatosseen += 1
 	if(tomatosseen >= frenzythreshold && istype(the_target, /mob/living/simple_animal/hostile/killertomato))
 		attack_same = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -28,12 +28,17 @@
 	maxbodytemp = 500
 	gold_core_spawnable = HOSTILE_SPAWN
 	var/frenzythreshold = 5 //how many tomatoes can this tomato see on screen before going berserk
+	var/is_frenzy = FALSE
+	var/last_frenzy_check = 0
 
 /mob/living/simple_animal/hostile/killertomato/CanAttack(atom/the_target)
-	var/tomatosseen = 0
-	for(var/mob/living/simple_animal/hostile/killertomato/T in orange(5, src))
-		tomatosseen += 1
-	if(tomatosseen >= frenzythreshold && istype(the_target, /mob/living/simple_animal/hostile/killertomato))
+	if (last_frenzy_check + 5 SECONDS < world.time)
+		var/tomatosseen = 0
+		for(var/mob/living/simple_animal/hostile/killertomato/T in orange(5, src))
+			tomatosseen += 1
+		is_frenzy = (tomatosseen >= frenzythreshold)
+		last_frenzy_check = world.time
+	if(is_frenzy && istype(the_target, /mob/living/simple_animal/hostile/killertomato))
 		attack_same = TRUE
 	. = ..()
 	// Reset the attack same flag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #9635

Killer tomatos would friendly fire when in frenzy mode, which was intended to make them attack other tomatos however this also causes them to friendly fire against pod-people and wood golems which I don't think was intended.
This PR makes it so that frenzy mode will only make them friendly fire against killer tomatos, and will cause them to de-activate frenzy mode after searching for the target.
Also replaces the view with a range and decreases the radius since this code is pretty awful and adds in a 5 second time limit between frenzy checks.

## Why It's Good For The Game

Pod-people and wood golems can now use killer tomatos without getting attacked by them.
Optimises killer tomato lag code.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2f23c292-497b-429b-848b-b57169a6e730)


## Changelog
:cl:
balance: Killer tomatos will no longer attack pod people and wood golems when in frenzy mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
