### PR TITLE
Removes necrotic metabolism's ability to have diseases act inside dead bodies.

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -32,6 +32,7 @@
 	var/list/strain_data = list() //dna_spread special bullshit
 	var/list/infectable_biotypes = list(MOB_ORGANIC) //if the disease can spread on organics, synthetics, or undead
 	var/process_dead = FALSE //if this ticks while the host is dead
+	var/spread_dead = FALSE
 	var/copy_type = null //if this is null, copies will use the type of the instance being copied
 	var/initial = TRUE //used in advance diseases to check if a virus has already infected a mob- the first infection never mutates
 
@@ -106,6 +107,9 @@
 		return
 
 	if(!(spread_flags & DISEASE_SPREAD_AIRBORNE) && !force_spread)
+		return
+
+	if (affected_mob.stat == DEAD && !spread_dead && !force_spread)
 		return
 
 	if(affected_mob.reagents.has_reagent(/datum/reagent/medicine/spaceacillin) || (affected_mob.satiety > 0 && prob(affected_mob.satiety/10)))

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -601,7 +601,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	. = ..()
 	if(A.transmission >= 4)
 		severity -= 1
-	if((A.stealth >= 2) && (A.transmission >= 6) && A.process_dead)
+	if((A.stealth >= 2) && (A.transmission >= 6) && (MOB_UNDEAD in A.infectable_biotypes))
 		severity -= 1
 		bodies = list("Vampir", "Blood")
 
@@ -615,7 +615,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 		maxbloodpoints += 50
 	if(A.stage_rate >= 7)
 		power += 1
-	if((A.stealth >= 2) && (A.transmission >= 6) && A.process_dead) //this is low transmission for 2 reasons: transmission is hard to raise, especially with stealth, and i dont want this to be obligated to be transmittable
+	if((A.stealth >= 2) && (A.transmission >= 6) && (MOB_UNDEAD in A.infectable_biotypes)) //this is low transmission for 2 reasons: transmission is hard to raise, especially with stealth, and i dont want this to be obligated to be transmittable
 		vampire = TRUE
 		maxbloodpoints += 50
 		power += 1

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -10,12 +10,12 @@
 	prefixes = list("Zombie ")
 
 /datum/symptom/undead_adaptation/OnAdd(datum/disease/advance/A)
-	A.process_dead = TRUE
 	A.infectable_biotypes |= MOB_UNDEAD
+	A.spread_dead = TRUE
 
 /datum/symptom/undead_adaptation/OnRemove(datum/disease/advance/A)
-	A.process_dead = FALSE
 	A.infectable_biotypes -= MOB_UNDEAD
+	A.spread_dead = FALSE
 
 /datum/symptom/inorganic_adaptation
 	name = "Inorganic Biology"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #9606

- Removes Necrotic Metabolism being able to have the virus stage_act inside dead hosts, as almost all symptoms are fundamentally incompatible with this concept.
- Viruses will no longer spready from dead bodies via airbourne transmission. (Instead it will spread via contact with infected bodies.)
- Necrotic Metabolism will allow for viruses to spread airbourne with the origin being dead bodies.

## Why It's Good For The Game

This symptom causes a lot of issues, I was going to remove it from specific symptoms but then I found myself removing it from the majority of symptoms as processing disease symtpoms while dead is incompatible with the majority of symptoms. Instead, this makes it so viruses won't spread airbourne from dead bodies and instead gives this symptom the ability to allow for dead mobs to spread the disease.

Also this is a virus nerf which is immediately good for the game due.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/c3a7548a-ea1e-4071-a63b-8950e1c0a8a2)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/208a9eac-a454-45f7-a2d9-a306a3c6096b)
No dchat talking

## Changelog
:cl:
balance: Necrotic Metabolism will no longer allow symtpoms to process in dead hosts, instead it will allow dead bodies to spread the disease via airbourne transmission which no longer happens by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
