### PR TITLE
Mechs are now affected by the runspeed slowdown

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -149,6 +149,7 @@
 	diag_hud_set_mechcell()
 	diag_hud_set_mechstat()
 	become_hearing_sensitive(trait_source = ROUNDSTART_TRAIT)
+	update_step_speed()
 
 /obj/mecha/update_icon()
 	if (silicon_pilot && silicon_icon_state)
@@ -524,6 +525,14 @@
 //////////////////////////////////
 ////////  Movement procs  ////////
 //////////////////////////////////
+
+/obj/mecha/proc/update_step_speed()
+	var/original_speed = initial(step_in)
+	// Calculate the speed delta
+	// Calculate the move multiplier speed, to be proportional to mob speed
+	// 1.5 was the previous value, so calculate hte multiplier in proportion to that
+	var/vehicle_move_multiplier = CONFIG_GET(number/movedelay/run_delay) / 1.5
+	step_in = original_speed * vehicle_move_multiplier
 
 /obj/mecha/Move(atom/newloc, direct)
 	. = ..()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -17,6 +17,7 @@
 	var/can_move = 0 //time of next allowed movement
 	var/mob/living/carbon/occupant = null
 	var/step_in = 10 //make a step in step_in/10 sec.
+	var/step_multiplier = 1
 	var/step_restricted = 0 //applied on_entered() by things which slow or restrict mech movement. Resets to zero at the end of every movement
 	var/dir_in = 2//What direction will the mech face when entered/powered on? Defaults to South.
 	var/normal_step_energy_drain = 10 //How much energy the mech will consume each time it moves. This variable is a backup for when leg actuators affect the energy drain.
@@ -527,12 +528,10 @@
 //////////////////////////////////
 
 /obj/mecha/proc/update_step_speed()
-	var/original_speed = initial(step_in)
 	// Calculate the speed delta
 	// Calculate the move multiplier speed, to be proportional to mob speed
 	// 1.5 was the previous value, so calculate hte multiplier in proportion to that
-	var/vehicle_move_multiplier = CONFIG_GET(number/movedelay/run_delay) / 1.5
-	step_in = original_speed * vehicle_move_multiplier
+	step_multiplier = CONFIG_GET(number/movedelay/run_delay) / 1.5
 
 /obj/mecha/Move(atom/newloc, direct)
 	. = ..()
@@ -621,7 +620,7 @@
 		move_result = mechstep(direction)
 	if(move_result || loc != oldloc)// halfway done diagonal move still returns false
 		use_power(step_energy_drain)
-		can_move = world.time + step_in + step_restricted
+		can_move = world.time + (step_in * step_multiplier) + step_restricted
 		step_restricted = 0
 		return TRUE
 	return FALSE
@@ -661,13 +660,13 @@
 				var/turf/target = get_step(src, dir)
 				if(target.flags_1 & NOJAUNT_1)
 					occupant_message("Phasing anomaly detected, emergency deactivation initiated.")
-					sleep(step_in*3)
+					sleep(step_in*3*step_multiplier)
 					can_move = 1
 					phasing = FALSE
 					return
 				if(do_teleport(src, get_step(src, dir), no_effects = TRUE))
 					use_power(phasing_energy_drain)
-				sleep(step_in*3)
+				sleep(step_in*3*step_multiplier)
 				can_move = 1
 	else
 		if(..()) //mech was thrown

--- a/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
@@ -289,6 +289,6 @@
 
 /mob/living/simple_animal/hostile/syndicate/mecha_pilot/Goto(target, delay, minimum_distance)
 	if(mecha)
-		SSmove_manager.move_to(mecha, target, minimum_distance, mecha.step_in)
+		SSmove_manager.move_to(mecha, target, minimum_distance, mecha.step_in * mecha.step_multiplier)
 	else
 		..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ever since #7744 the mech movement speed has been significantly higher than regular walking speed due to not being proportional to the movespeed modifier.
This brings mechs back to the correct speed proportional to normal players on the ground.
This means that the movement delay of mechs is now 33% higher.

## Why It's Good For The Game

At the moment mechs are about the same speed as normal players which leads them to being really annoying to fight as they can just back away at the same speed as you, while shooting you with their infinite ammo weapons. Considering their only weakness is someone getting up behind them, them being almost as fast as players, especially when the player gets damaged, is really bad.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5298efe8-cd29-4118-bda3-a25aa33bf2c7

## Changelog
:cl:
balance: Mech movement speed is now proportional to player movement speed, increasing their movement delay by 33%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
