### PR TITLE
Slightly better holocall QoL for AI

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -49,11 +49,13 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		create_chat_message(src, message_language, show_overhead_message_to, message, spans, message_mods)
 
 /// this creates runechat, so that they can communicate better
-/atom/movable/proc/create_private_chat_message(message, datum/language/message_language=/datum/language/metalanguage, list/hearers)
+/atom/movable/proc/create_private_chat_message(message, datum/language/message_language=/datum/language/metalanguage, list/hearers, includes_ghosts=TRUE)
 	if(!hearers || !islist(hearers))
 		return
+	if(includes_ghosts)
+		hearers += GLOB.dead_mob_list.Copy()
 	var/list/runechat_readers = list()
-	for(var/mob/each_mob in hearers+GLOB.dead_mob_list)
+	for(var/mob/each_mob in hearers)
 		if(!each_mob.should_show_chat_message(src, message_language))
 			continue
 		runechat_readers += each_mob

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -921,6 +921,11 @@
 
 	var/rendered = "<span class='holocall'><b>\[Holocall\] [language_icon]<span class='name'>[hrefpart][namepart] ([jobpart])</a></span></b>[treated_message]</span>"
 	show_message(rendered, 2)
+	speaker.create_private_chat_message(
+		message = message,
+		message_language = message_language,
+		hearers = list(src),
+		includes_ghosts = FALSE) // ghosts already see this except for you...
 
 	// renders message for ghosts
 	rendered = "<span class='holocall'><b>\[Holocall\] [language_icon]<span class='name'>[speaker.GetVoice()]</span></b>[treated_message]</span>"

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -38,7 +38,11 @@
 	if(!QDELETED(ai_hologram))
 		ai_hologram.say(message, language = language, source=current_holopad)
 		src.log_talk(message, LOG_SAY, tag="Hologram in [AREACOORD(ai_hologram)]")
-		message = "<span class='robot'>[say_emphasis(lang_treat(src, language, message))]</span>"
+		ai_hologram.create_private_chat_message(
+			message = message,
+			message_language = language,
+			hearers = list(src),
+			includes_ghosts = FALSE) // ghosts already see this except for you...
 
 		// duplication part from `game/say.dm` to make a language icon
 		var/language_icon = ""
@@ -46,6 +50,7 @@
 		if(istype(D) && D.display_icon(src))
 			language_icon = "[D.get_icon()] "
 
+		message = "<span class='robot'>[say_emphasis(lang_treat(src, language, message))]</span>"
 		message = "<span class='holocall'><b>\[Holocall\] [language_icon]<span class='name'>[real_name]</span></b> [message]</span>"
 		to_chat(src, message)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slightly better holocall QoL for AI
AI will see runechat for their own. The current code only shows it to who can actually hear it
Now it mimics Holopad being AI core that can hear chats.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Reading runechat is good for RP improvement
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/fcf7b3bf-ea94-4963-86df-78afc476b182)


## Changelog
:cl:
add: Holocall chat shows runechat to AI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
