### PR TITLE
Adds a minimum pop to brainwashing surgery disk

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1599,6 +1599,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
+	player_minimum = 25
 	cost = 5
 
 /datum/uplink_item/device_tools/briefcase_launchpad


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a minimum pop count of 25 (same as de-sword and guardians) to purchase the brainwashing surgery disk.

## Why It's Good For The Game

Brainwashing is simply not very fun on lower population rounds as there isn't much you can do about it, and there is little risk of getting spotted while converting people.

## Testing Photographs and Procedure

We know this system works already, but here is it not showing up in the uplink at 1 pop:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/0ebd8a71-7f18-41b0-b7bc-e41057ba1338)


## Changelog
:cl:
balance: Brainwashing surgery can no longer be purchased below 25 pop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
