### PR TITLE
Fixes infrared emitters looking weird when on the ground

### DIFF
--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -4,7 +4,7 @@
 	icon_state = "infrared"
 	custom_materials = list(/datum/material/iron=1000, /datum/material/glass=500)
 	is_position_sensitive = TRUE
-
+	item_flags = NO_PIXEL_RANDOM_DROP
 
 	var/on = FALSE
 	var/visible = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the infrared emitter the NO_RANDOM_PIXEL_DROP flag, which makes it be perfectly positioned at the center of the tile when dropped.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Visual consistency is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Before the fix : 

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/a75aad3b-1cf5-47ff-be26-2e18cf71cd87)

After : 

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/42bfb065-5bc2-442f-b3e8-72fe9a2fda75)

</details>

## Changelog
:cl:
fix: Fixed Infrared emitters not being alligned with their "lazers"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
