### PR TITLE
Fixes a runtime in supermatter.dm

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -510,7 +510,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			air_update_turf()
 
 	for(var/mob/living/carbon/human/l in viewers(HALLUCINATION_RANGE(power), src)) // If they can see it without mesons on.  Bad on them.
-		if(HAS_TRAIT(l, TRAIT_MADNESS_IMMUNE) || l.mind && HAS_TRAIT(l.mind, TRAIT_MADNESS_IMMUNE))
+		if(HAS_TRAIT(l, TRAIT_MADNESS_IMMUNE) || (l.mind && HAS_TRAIT(l.mind, TRAIT_MADNESS_IMMUNE)))
 			continue
 		var/D = sqrt(1 / max(1, get_dist(l, src)))
 		l.hallucination += power * config_hallucination_power * D

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -510,7 +510,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			air_update_turf()
 
 	for(var/mob/living/carbon/human/l in viewers(HALLUCINATION_RANGE(power), src)) // If they can see it without mesons on.  Bad on them.
-		if(HAS_TRAIT(l, TRAIT_MADNESS_IMMUNE) || HAS_TRAIT(l.mind, TRAIT_MADNESS_IMMUNE))
+		if(HAS_TRAIT(l, TRAIT_MADNESS_IMMUNE) || l.mind && HAS_TRAIT(l.mind, TRAIT_MADNESS_IMMUNE))
 			continue
 		var/D = sqrt(1 / max(1, get_dist(l, src)))
 		l.hallucination += power * config_hallucination_power * D


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #9453
Was missing a check for mindless carbons.
No more runtimes if a mindless carbon sits next to an active supermatter.
```
runtime error: Cannot read null.status_traits
 - proc name: process atmos (/obj/machinery/power/supermatter_crystal/process_atmos)
 -   source file: supermatter.dm,513
 ```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/7d07a675-62a5-4b9a-8dad-28bc258e1b83)
Hallucinations triggering, no runtime.

</details>

## Changelog
:cl:
fix: Fixed a runtime in supermatter.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
