### PR TITLE
Stasis beds and beds now initialize their lying angle once again

### DIFF
--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -22,11 +22,7 @@
 // dir check for buckle_lying state
 /obj/machinery/stasis/Initialize()
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
-	switch(dir)
-		if(WEST, NORTH)
-			buckle_lying = 270
-		if(EAST, SOUTH)
-			buckle_lying = 90
+	dir_changed()
 	return ..()
 
 /obj/machinery/stasis/Initialize(mapload)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -20,7 +20,12 @@
 
 // dir check for buckle_lying state
 /obj/machinery/stasis/Initialize()
-	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed)) //This gets called later during initialization
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
+	switch(dir)
+		if(WEST, NORTH)
+			buckle_lying = 270
+		if(EAST, SOUTH)
+			buckle_lying = 90
 	return ..()
 
 /obj/machinery/stasis/Initialize(mapload)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -22,7 +22,7 @@
 // dir check for buckle_lying state
 /obj/machinery/stasis/Initialize()
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
-	dir_changed()
+	dir_changed(new_dir = dir)
 	return ..()
 
 /obj/machinery/stasis/Initialize(mapload)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -6,6 +6,7 @@
 	icon_state = "stasis"
 	density = FALSE
 	can_buckle = TRUE
+	buckle_lying = 90
 	circuit = /obj/item/circuitboard/machine/stasis
 	idle_power_usage = 50
 	active_power_usage = 500

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -25,7 +25,12 @@
 
 // dir check for buckle_lying state
 /obj/structure/bed/Initialize()
-	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed)) //This gets called later during initialization
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
+	switch(dir)
+		if(WEST, NORTH)
+			buckle_lying = 270
+		if(EAST, SOUTH)
+			buckle_lying = 90
 	. = ..()
 
 /obj/structure/bed/Destroy()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -26,7 +26,7 @@
 // dir check for buckle_lying state
 /obj/structure/bed/Initialize()
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
-	dir_changed()
+	dir_changed(new_dir = dir)
 	. = ..()
 
 /obj/structure/bed/Destroy()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -27,10 +27,10 @@
 /obj/structure/bed/Initialize()
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
 	switch(dir)
-		if(WEST, NORTH)
-			buckle_lying = 270
-		if(EAST, SOUTH)
+		if(WEST, SOUTH)
 			buckle_lying = 90
+		if(EAST, NORTH)
+			buckle_lying = 270
 	. = ..()
 
 /obj/structure/bed/Destroy()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -26,11 +26,7 @@
 // dir check for buckle_lying state
 /obj/structure/bed/Initialize()
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
-	switch(dir)
-		if(WEST, SOUTH)
-			buckle_lying = 90
-		if(EAST, NORTH)
-			buckle_lying = 270
+	dir_changed()
 	. = ..()
 
 /obj/structure/bed/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Do you ever make presumptions based on what you're seeing without actually taking a good 15 to 30 minutes to understand exactly what's actually happening? 

This PR is the result of that. (Fixing a mistake I made in #9582)

## About The Pull Request
Re-adds some code that I removed thinking that it was being executed twice while debugging. This code was what allowed for stasis beds to correctly initialize their lying_angle on mapload.

My misconception was that while debugging I saw it executed twice. What I didn't take into account was it being caused by stasis beds loading in on the emergency shuttle at round start. (In hindsight, it makes more sense that set_dir wasn't actually being called during initialization because why would it be.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was the intended behaviour in the first place.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>The Sanity Check</summary>

The code compiles, is functionally identical to what it was originally, and while stepping through it actually sets the angle during initialize.

I even stepped through it to make sure it works

![Debugging Beds](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/806e45b6-0be8-4a26-9c9e-3549385677f7)

![Debugging Stasis Beds](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/74d775a7-5277-4448-b69e-a0eca06be9b2)


![Buckling the mobs](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/399dad0f-a469-4360-8f06-d68cbdbef6a3)

Buckled to a bed and stasis bed on MetaStation's medbay, which has two rotated instances of the beds

</details>

## Changelog
:cl:
fix: Beds now actually properly initialize their lying angle on map load
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
