### PR TITLE
Signal jammer movement

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -603,6 +603,7 @@
 #include "code\datums\components\heirloom.dm"
 #include "code\datums\components\honkspam.dm"
 #include "code\datums\components\infective.dm"
+#include "code\datums\components\jam_receiver.dm"
 #include "code\datums\components\jousting.dm"
 #include "code\datums\components\knockoff.dm"
 #include "code\datums\components\larryknife.dm"

--- a/code/__DEFINES/dcs/signals/signals_atom.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom.dm
@@ -171,3 +171,10 @@
 #define COMSIG_ATOM_SHOULD_EMAG "atom_should_emag"
 /// Do the emag action (if CHECK is FALSE)
 #define COMSIG_ATOM_ON_EMAG "atom_on_emag"
+
+/////////////////
+/// Radio jamming signals
+/////////////////
+
+#define COMSIG_ATOM_JAMMED "become_jammed"						//! Relayed to atoms when they become jammed if they have the jam_receiver components.
+#define COMSIG_ATOM_UNJAMMED "become_unjammed"					//! Relayed to atoms when they become unjammed if they have the jam_receiver components.

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -30,6 +30,7 @@ GLOBAL_LIST_EMPTY(pinpointer_list)			//list of all pinpointers. Used to change s
 GLOBAL_LIST_EMPTY(zombie_infection_list) 		// A list of all zombie_infection organs, for any mass "animation"
 GLOBAL_LIST_EMPTY(meteor_list)				// List of all meteors.
 GLOBAL_LIST_EMPTY(active_jammers)             // List of active radio jammers
+GLOBAL_LIST_EMPTY(jam_receivers_by_z)		// List of jam receivers by Z
 GLOBAL_LIST_EMPTY(ladders)
 GLOBAL_LIST_EMPTY(bot_elevator)
 GLOBAL_LIST_EMPTY(janitor_devices)

--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -1,0 +1,55 @@
+/datum/component/jam_receiver
+	/// Will not be blocked by intensities lower than this
+	var/intensity_resist
+	/// Are we currently jammed?
+	var/jammed = FALSE
+	/// Moved relay
+	var/datum/component/moved_relay/associated_relay
+
+/datum/component/jam_receiver/Initialize(_intensity_resist = JAMMER_PROTECTION_RADIO_BASIC)
+	. = ..()
+
+	if (!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	var/atom/parent_atom = parent
+	// Register this receiver. Clump them together by Z since there will be more of them then jammers.
+	while (length(GLOB.jam_receivers_by_z) < parent_atom.z)
+		GLOB.jam_receivers_by_z += list(list())
+
+	GLOB.jam_receivers_by_z[parent_atom.z] += src
+
+	// We need to know when our parent atoms move
+	associated_relay = parent.AddComponent(/datum/component/moved_relay)
+
+	// Register a signal when we move to see if we enter the range of a jammer
+	RegisterSignal(parent, COMSIG_PARENT_MOVED_RELAY, PROC_REF(on_move))
+	// See if we are starting off jammed
+	check_jammed()
+
+/datum/component/jam_receiver/Destroy(force, silent)
+	. = ..()
+	// Cleanup the moved relay if we need to
+	var/datum/component/moved_relay/move_relay = associated_relay
+	move_relay.depth --
+	if (move_relay.depth == 0)
+		move_relay.RemoveComponent()
+		associated_relay = null
+
+/datum/component/jam_receiver/proc/on_move(...)
+	SIGNAL_HANDLER
+	check_jammed()
+
+/datum/component/jam_receiver/proc/check_jammed()
+	var/atom/atom_parent = parent
+	var/new_state = atom_parent.is_jammed(intensity_resist)
+	set_jammed(new_state)
+
+/datum/component/jam_receiver/proc/set_jammed(new_state)
+	if (new_state == jammed)
+		return
+	jammed = new_state
+	if (jammed)
+		SEND_SIGNAL(parent, COMSIG_ATOM_JAMMED)
+	else
+		SEND_SIGNAL(parent, COMSIG_ATOM_UNJAMMED)

--- a/code/datums/components/moved_relay.dm
+++ b/code/datums/components/moved_relay.dm
@@ -5,11 +5,18 @@
  * still know when that other object moves.
  */
 /datum/component/moved_relay
+	dupe_mode = COMPONENT_DUPE_SELECTIVE
+	/// How many move relays were added to this object?
+	var/depth = 1
 	//List of ordered parents
 	//Index 1: parent
 	//Index 2: Parent's parent
 	//etc.
 	var/list/atom/ordered_parents = list()
+
+/datum/component/moved_relay/CheckDupeComponent(datum/component/C, ...)
+	depth ++
+	return TRUE
 
 /datum/component/moved_relay/Initialize(...)
 	var/atom/A = parent

--- a/code/datums/components/radio_jamming.dm
+++ b/code/datums/components/radio_jamming.dm
@@ -21,6 +21,7 @@
 	// We need to know when our parent atoms move
 	parent.AddComponent(/datum/component/moved_relay)
 	RegisterSignal(parent, COMSIG_PARENT_MOVED_RELAY, PROC_REF(check_move_jams))
+	check_move_jams()
 
 /datum/component/radio_jamming/Destroy(force, silent)
 	disable()

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -14,6 +14,7 @@
 			var/datum/callback/CB = foo
 			CB.Invoke()
 
-	qdel(GetComponent(/datum/component/moved_relay))
+	for (var/datum/component/comp in GetComponents(/datum/component/moved_relay))
+		comp.RemoveComponent()
 
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in some new signals which can be used to implement entities which need to be jammed actively rather than passively. This is used for cameras to make them switch off when a jammer comes close by, rather than when they randomly decide to update and a jammer is near.

Cameras will also visably disable when a jammer is nearby.

## Why It's Good For The Game

Improves the speed at which jammers will jam cameras and the consistency of that. Allows other people to implement things that receive jams but don't constantly want to check is_jammed.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/18fb7443-6a8c-4961-a8c8-9892b68556d8

## Changelog
:cl:
code: Implements a new system for determining when a jammer moves into range of an object.
balance: Cameras will now visibly turn off when a singal jammer is nearby.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
