### PR TITLE
Adds the ability to "lock" chameleon gear with a multitool

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -458,6 +458,8 @@ update_label("John Doe", "Clowny")
 				to_chat(usr, "<span class='notice'>The card's microscanners activate as you pass it over the ID, copying its access.</span>")
 
 /obj/item/card/id/syndicate/attack_self(mob/user)
+	if(chameleon_action.hidden)
+		return ..()
 	if(isliving(user) && user.mind)
 		var/first_use = registered_name ? FALSE : TRUE
 		if(!(user.mind.special_role || anyone)) //Unless anyone is allowed, only syndies can use the card, to stop metagaming.
@@ -529,6 +531,20 @@ update_label("John Doe", "Clowny")
 	if(. & EMP_PROTECT_SELF)
 		return
 	chameleon_action.emp_randomise()
+
+/obj/item/card/id/syndicate/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
 
 // broken chameleon agent card
 /obj/item/card/id/syndicate/broken

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -545,6 +545,7 @@ update_label("John Doe", "Clowny")
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the agent ID ([name]) with [W]")
+			return
 	. = ..()
 
 // broken chameleon agent card

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -538,12 +538,13 @@ update_label("John Doe", "Clowny")
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the agent ID ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the agent ID ([name]) with [W]")
 	. = ..()
 
 // broken chameleon agent card

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -415,12 +415,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon jumpsuit ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon jumpsuit ([name]) with [W]")
 	. = ..()
 
 /obj/item/clothing/suit/chameleon
@@ -458,12 +459,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon suit ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon suit ([name]) with [W]")
 	. = ..()
 
 /obj/item/clothing/glasses/chameleon
@@ -500,12 +502,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon glasses ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon glasses ([name]) with [W]")
 	. = ..()
 
 /obj/item/clothing/glasses/chameleon/flashproof
@@ -551,12 +554,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon gloves ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon gloves ([name]) with [W]")
 	. = ..()
 
 /obj/item/clothing/gloves/chameleon/combat
@@ -609,12 +613,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon hat ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon hat ([name]) with [W]")
 	. = ..()
 
 /obj/item/clothing/head/chameleon/envirohelm
@@ -754,12 +759,13 @@
 			chameleon_action.Grant(user)
 			actions += tongue_action
 			tongue_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon mask ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			actions -= tongue_action
+			log_game("[key_name(user)] has locked the disguise of the chameleon mask ([name]) with [W]")
 			tongue_action.Remove(user)
 			return
 	. = ..()
@@ -816,11 +822,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon shoes ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
+			log_game("[key_name(user)] has locked the disguise of the chameleon shoes ([name]) with [W]")
 			return
 	. = ..()
 
@@ -859,12 +867,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon backpack ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon backpack ([name]) with [W]")
 	. = ..()
 
 /obj/item/storage/belt/chameleon
@@ -901,12 +910,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon belt ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon belt ([name]) with [W]")
 	. = ..()
 
 /obj/item/radio/headset/chameleon
@@ -936,12 +946,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon headset ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon headset ([name]) with [W]")
 	. = ..()
 
 /obj/item/radio/headset/chameleon/bowman
@@ -978,12 +989,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon PDA ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon PDA ([name]) with [W]")
 	. = ..()
 
 /obj/item/stamp/chameleon
@@ -1006,12 +1018,13 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon stamp ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon stamp ([name]) with [W]")
 	. = ..()
 
 /obj/item/clothing/neck/chameleon
@@ -1043,10 +1056,11 @@
 			chameleon_action.hidden = FALSE
 			actions += chameleon_action
 			chameleon_action.Grant(user)
+			log_game("[key_name(user)] has removed the disguise lock on the chameleon necktie ([name]) with [W]")
 			return
 		else
 			chameleon_action.hidden = TRUE
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
-			return
+			log_game("[key_name(user)] has locked the disguise of the chameleon necktie ([name]) with [W]")
 	. = ..()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -422,6 +422,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon jumpsuit ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/clothing/suit/chameleon
@@ -466,6 +467,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon suit ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/clothing/glasses/chameleon
@@ -509,6 +511,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon glasses ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/clothing/glasses/chameleon/flashproof
@@ -561,6 +564,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon gloves ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/clothing/gloves/chameleon/combat
@@ -620,6 +624,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon hat ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/clothing/head/chameleon/envirohelm
@@ -874,6 +879,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon backpack ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/storage/belt/chameleon
@@ -917,6 +923,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon belt ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/radio/headset/chameleon
@@ -953,6 +960,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon headset ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/radio/headset/chameleon/bowman
@@ -996,6 +1004,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon PDA ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/stamp/chameleon
@@ -1025,6 +1034,7 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon stamp ([name]) with [W]")
+			return
 	. = ..()
 
 /obj/item/clothing/neck/chameleon
@@ -1063,4 +1073,5 @@
 			actions -= chameleon_action
 			chameleon_action.Remove(user)
 			log_game("[key_name(user)] has locked the disguise of the chameleon necktie ([name]) with [W]")
+			return
 	. = ..()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -163,7 +163,12 @@
 
 	var/emp_timer
 
+	var/hidden = FALSE
+
 /datum/action/item_action/chameleon/change/Grant(mob/M)
+	if(hidden)
+		Remove(M)
+		return
 	if(M && (owner != M))
 		if(!M.chameleon_item_actions)
 			M.chameleon_item_actions = list(src)
@@ -355,6 +360,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
+
 /obj/item/clothing/under/chameleon/envirosuit
 	name = "plasma envirosuit"
 	desc = "A special containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy. It has a small dial on the wrist."
@@ -403,6 +409,20 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/clothing/under/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
+
 /obj/item/clothing/suit/chameleon
 	name = "armor"
 	desc = "A slim armored vest that protects against most types of damage."
@@ -432,6 +452,20 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/clothing/suit/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
+
 /obj/item/clothing/glasses/chameleon
 	name = "Optical Meson Scanner"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
@@ -459,6 +493,20 @@
 /obj/item/clothing/glasses/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/clothing/glasses/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
 
 /obj/item/clothing/glasses/chameleon/flashproof
 	name = "welding goggles"
@@ -496,6 +544,20 @@
 /obj/item/clothing/gloves/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/clothing/gloves/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
 
 /obj/item/clothing/gloves/chameleon/combat
 	name = "combat gloves"
@@ -540,6 +602,20 @@
 /obj/item/clothing/head/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/clothing/head/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
 
 /obj/item/clothing/head/chameleon/envirohelm
 	name = "plasma envirosuit helmet"
@@ -656,8 +732,11 @@
 	chameleon_action.emp_randomise(INFINITY)
 
 /obj/item/clothing/mask/chameleon/attack_self(mob/user)
-	voice_change = !voice_change
-	to_chat(user, "<span class='notice'>The voice changer is now [voice_change ? "on" : "off"]!</span>")
+	if(!chameleon_action.hidden)
+		voice_change = !voice_change
+		to_chat(user, "<span class='notice'>The voice changer is now [voice_change ? "on" : "off"]!</span>")
+	else
+		return ..()
 
 /obj/item/clothing/mask/chameleon/get_name(mob/user, default_name)
 	var/mob/living/carbon/human/H = user
@@ -666,6 +745,24 @@
 		if(istype(idcard) && idcard.electric)
 			return idcard.registered_name
 	return default_name
+
+/obj/item/clothing/mask/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			actions += tongue_action
+			tongue_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			actions -= tongue_action
+			tongue_action.Remove(user)
+			return
+	. = ..()
 
 /obj/item/clothing/mask/chameleon/drone
 	//Same as the drone chameleon hat, undroppable and no protection
@@ -713,6 +810,20 @@
 		return
 	chameleon_action.emp_randomise()
 
+/obj/item/clothing/shoes/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
+
 /obj/item/clothing/shoes/chameleon/noslip
 	clothing_flags = NOSLIP
 	can_be_bloody = FALSE
@@ -742,6 +853,20 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/storage/backpack/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
+
 /obj/item/storage/belt/chameleon
 	name = "toolbelt"
 	desc = "Holds tools."
@@ -770,6 +895,20 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/storage/belt/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
+
 /obj/item/radio/headset/chameleon
 	name = "radio headset"
 	var/datum/action/item_action/chameleon/change/chameleon_action
@@ -790,6 +929,20 @@
 /obj/item/radio/headset/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/radio/headset/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
 
 /obj/item/radio/headset/chameleon/bowman
 	name = "bowman headset"
@@ -819,6 +972,20 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/modular_computer/tablet/pda/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
+
 /obj/item/stamp/chameleon
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -832,6 +999,20 @@
 /obj/item/stamp/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/stamp/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()
 
 /obj/item/clothing/neck/chameleon
 	name = "black tie"
@@ -855,3 +1036,17 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	chameleon_action.emp_randomise()
+
+/obj/item/clothing/neck/chameleon/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(chameleon_action.hidden)
+			chameleon_action.hidden = FALSE
+			actions += chameleon_action
+			chameleon_action.Grant(user)
+			return
+		else
+			chameleon_action.hidden = TRUE
+			actions -= chameleon_action
+			chameleon_action.Remove(user)
+			return
+	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the ability to hide/show any chameleon abilities of chameleon gear by hitting it with a multitool. This includes the disguise button, individual shape change buttons, tongue disguise button for the gas mask, alt-clicking the mask to turn it on or off, forging the agent ID.
Note that all of them are still vulnerable to EMPs in that state.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chameleon gear is great for sneaking around, framing other people and plethora of other uses. But it has a dead giveaway - anyone who picks up any piece of such gear can immediately recognize it due to the UI buttons.
Imposing metaprotection and metaknowledge rules for this would honestly be quite silly, so here comes an alternative solution - hiding those buttons! Just be sure not to forget what's a real piece of clothing and what's chameleon.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/f24fd7f8-ffe5-4a73-ba79-f72fe6cfef82

</details>

## Changelog
:cl:
add: The Syndicate has upgraded its chameleon gear with the ability to completely hide any and all chameleon functionality with a multitool. Be sure not to confuse your own gear for a plain old piece of clothing, agent!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
