### PR TITLE
Hoods no Longer Stored in Coats' Internal Storage

### DIFF
--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -22,8 +22,7 @@
 		var/obj/item/clothing/head/hooded/W = new hoodtype(src)
 		W.suit = src
 		hood = W
-		W.moveToNullspace() //Moves hood to nullspace upon init; jackets on map at round start do not start with hood in inventory.
-
+		W.moveToNullspace() //Moves hood to nullspace upon init; jackets on map at round otherwise start with hood in inventory.
 
 /obj/item/clothing/suit/hooded/ui_action_click()
 	ToggleHood()

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -22,6 +22,8 @@
 		var/obj/item/clothing/head/hooded/W = new hoodtype(src)
 		W.suit = src
 		hood = W
+		W.moveToNullspace() //Moves hood to nullspace upon init; jackets on map at round start do not start with hood in inventory.
+
 
 /obj/item/clothing/suit/hooded/ui_action_click()
 	ToggleHood()
@@ -45,7 +47,7 @@
 			H.update_inv_wear_suit()
 		else
 			if(!qdel_hood)
-				hood.forceMove(src)
+				hood.moveToNullspace() //Hides hood in nullspace instead of within the pocket of whatever it's on
 		if(qdel_hood)
 			QDEL_NULL(hood)
 	for(var/X in actions)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies the code for toggling the hood on jackets/suits to be stored in nullspace rather than the suit's internal inventory, freeing up the second inventory slot that is taken up by it. This only affects suits that do not use the qdel flag for the hood, and does not affect hardsuits as they use a separate function for deploying and retracting the helmet.

This allows hoods to keep their different changes (spraypaint, wigs, goliath plates, etc.) while not consuming an inventory slot (and not requiring the cheese of deploying the hood, putting an item in, and then having 3 items in a 2 slot inventory).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Storing the hood of a jacket within its own pocket doesn't make sense, and it eats up an inventory slot on every winter coat in the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Thank you [CydiaLamiales](https://github.com/CydiaLamiales) for informing me of nullspace in the first place!

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/71556ff9-c584-481e-88a4-dfc6395d83c6

</details>

## Changelog
:cl:Impish_Delights
tweak: Hoods for winter coats/hoodies/explorer suits are now stored in nullspace instead of the suit's inventory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
