### PR TITLE
Adds a specific preference for AI VOX announcements

### DIFF
--- a/code/modules/client/preferences/entries/player/sound.dm
+++ b/code/modules/client/preferences/entries/player/sound.dm
@@ -86,3 +86,12 @@
 		client.mob?.play_current_soundtrack()
 	else
 		client.mob?.stop_sound_channel(CHANNEL_SOUNDTRACK)
+
+/datum/preference/toggle/sound_vox
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	db_key = "sound_vox"
+	preference_type = PREFERENCE_PLAYER
+
+/datum/preference/toggle/sound_vox/apply_to_client(client/client, value)
+	if (!value)
+		client.mob?.stop_sound_channel(CHANNEL_VOX)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -154,7 +154,7 @@
 		if(!only_listener)
 			// Play voice for all mobs in the z level
 			for(var/mob/M in GLOB.player_list)
-				if(M.client && M.can_hear() && M.client.prefs.read_player_preference(/datum/preference/toggle/sound_announcements))
+				if(M.client && M.can_hear() && M.client.prefs.read_player_preference(/datum/preference/toggle/sound_vox))
 					var/turf/T = get_turf(M)
 					if(T.get_virtual_z_level() == z_level)
 						SEND_SOUND(M, voice)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sound.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sound.tsx
@@ -77,3 +77,11 @@ export const sound_soundtrack: FeatureToggle = {
     'When enabled, hear automatic soundtrack music triggered during situations like nuclear countdowns or xenomorph invasions.',
   component: CheckboxInput,
 };
+
+export const sound_vox: FeatureToggle = {
+  name: 'Enable AI VOX announcements',
+  category: 'SOUND',
+  subcategory: 'IC',
+  description: 'When enabled, hear AI VOX (text-to-speech) announcements.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a specific preference for AI VOX announcements, allowing you to still hear normal announcement sounds, while ignoring AI TTS, or vice versa.

## Why It's Good For The Game

Because almost nothing of value is ever said over AI VOX, and I _don't want to hear it._

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/78476811-8f69-4478-b3f5-b700aa08493d)


</details>

## Changelog
:cl:
add: Adds a specific preference to enable/disable AI VOX (text-to-speech) announcements.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
