### PR TITLE
Fixes two runtimes + RPED inhand emptying function

### DIFF
--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -94,6 +94,6 @@
 	to_chat(M, "<span class='notice'>You start dumping out Tier/Cell rating [lowest_rating] parts from [parent].</span>")
 	var/turf/T = get_turf(A)
 	var/datum/progressbar/progress = new(M, length(things), T)
-	while (do_after(M, 10, TRUE, T, FALSE, CALLBACK(src, PROC_REF(mass_remove_from_storage), T, things, progress)))
+	while (do_after(M, 3 SECONDS, T, NONE, FALSE, CALLBACK(src, PROC_REF(mass_remove_from_storage), T, things, progress)))
 		stoplag(1)
 	qdel(progress)

--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -44,7 +44,7 @@
 	to_chat(M, "<span class='notice'>You start dumping out Tier/Cell rating [lowest_rating] parts from [parent].</span>")
 	var/turf/T = get_turf(A)
 	var/datum/progressbar/progress = new(M, length(things), T)
-	while (do_after(M, 10, TRUE, T, FALSE, CALLBACK(src, PROC_REF(mass_remove_from_storage), T, things, progress)))
+	while (do_after(M, 3 SECONDS, T, NONE, FALSE, CALLBACK(src, PROC_REF(mass_remove_from_storage), T, things, progress)))
 		stoplag(1)
 	qdel(progress)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -412,7 +412,7 @@
 		return FALSE
 	if(!override_blindness_check && is_blind())
 		return FALSE
-	if(client.prefs.read_player_preference(/datum/preference/toggle/darkened_flash))
+	if(client?.prefs.read_player_preference(/datum/preference/toggle/darkened_flash))
 		type = /atom/movable/screen/fullscreen/flash/black
 	overlay_fullscreen("flash", type)
 	addtimer(CALLBACK(src, PROC_REF(clear_fullscreen), "flash", 2.5 SECONDS), 2.5 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the following runtimes:
```
runtime error: Cannot read 1.targeted_by
 - proc name: do after (/proc/do_after)
 -   source file: mobs.dm,265
 -   usr: Central Command (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (168,129,2) (/turf/open/floor/plasteel)
 -   call stack:
 - do after(Central Command (/mob/living/carbon/human), 10, 1, the floor (168,129,2) (/turf/open/floor/plasteel), 0, /datum/callback (/datum/callback))
 - /datum/component/storage/concr... (/datum/component/storage/concrete/bluespace/rped): quick empty(Central Command (/mob/living/carbon/human))
 ```
For some reason a `TRUE` value was put where the Target should be, so it was trying to call `do_after()` with a Target of `1` - which obviously doesn't work.
This only effected RPED's and not other storage items, as the RPED has it's own niche version of the `quick_empty()` proc (not to be confused with the normal storage component quick_empty proc, which confusingly enough can still be used on an RPED by click dragging it onto something, same as any other storage item).

Seems to have been an unintended side effect of https://github.com/BeeStation/BeeStation-Hornet/pull/8135

And

```
runtime error: Cannot read null.prefs
 - proc name: flash act (/mob/living/proc/flash_act)
 -   source file: code/modules/mob/living/living_defense.dm,415
 -   usr: Angela Woods (/mob/living/carbon/human)
 -   src: Moses Rathen (/mob/living/carbon/human)
 -   usr.loc: the floor (173,87,1) (/turf/open/floor/plasteel)
 -   src.loc: the floor (174,86,1) (/turf/open/floor/plasteel)
 -   call stack:
 - Moses Rathen (/mob/living/carbon/human): flash act(2, 1, 0, 0, /atom/movable/screen/fullscree... (/atom/movable/screen/fullscreen/flash))
 ```
Which happened if you attempted to flash a mob without a client due to a missing check.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime(s) bad. Regressing functionality bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://streamable.com/1b17o4

</details>

## Changelog
:cl:
fix: RPED's inhand empty function works once more
fix: Fixes a runtime in rped.dm
fix: Fixes a runtime in living_defense.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
