### PR TITLE
Removes unintentional "omnibelts" from maps

### DIFF
--- a/_maps/RandomRooms/5x3/sk_rdm054_metaclutter3.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm054_metaclutter3.dmm
@@ -1,10 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/rack,
-/obj/item/storage/belt{
-	desc = "Can hold quite a lot of stuff.";
-	name = "multi-belt"
-	},
 /obj/item/clothing/gloves/color/fyellow,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/sink/kitchen{
@@ -12,6 +8,7 @@
 	name = "old sink";
 	pixel_y = 28
 	},
+/obj/item/storage/belt/utility,
 /turf/open/floor/plating,
 /area/template_noop)
 "b" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -25729,7 +25729,6 @@
 /area/bridge/showroom/corporate)
 "cES" = (
 /obj/structure/table,
-/obj/item/storage/belt,
 /obj/item/radio,
 /obj/item/radio,
 /obj/item/radio,
@@ -25739,6 +25738,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/gateway)
 "cET" = (
@@ -62581,11 +62581,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "mVG" = (
-/obj/item/storage/belt,
 /obj/item/radio,
 /obj/machinery/light,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "mVL" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -22412,7 +22412,6 @@
 /area/hallway/primary/central)
 "fOU" = (
 /obj/structure/table,
-/obj/item/storage/belt,
 /obj/item/radio,
 /obj/machinery/light{
 	dir = 4
@@ -22426,6 +22425,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -2929,9 +2929,9 @@
 /area/science/shuttledock)
 "aUl" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 4;
 	node1_concentration = 0.21;
-	node2_concentration = 0.79;
-	dir = 4
+	node2_concentration = 0.79
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -27584,7 +27584,7 @@
 /obj/item/reagent_containers/glass/waterbottle/empty{
 	pixel_x = -10
 	},
-/obj/item/storage/belt,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel/sepia,
 /area/maintenance/port/central)
 "iwl" = (
@@ -31818,7 +31818,7 @@
 "jQo" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/spawner/lootdrop/maintenance/three,
-/obj/item/storage/belt,
+/obj/item/storage/belt/utility,
 /turf/open/floor/carpet/royalblack,
 /area/maintenance/port/aft)
 "jQp" = (
@@ -48281,7 +48281,7 @@
 	pixel_x = 3
 	},
 /obj/effect/decal/cleanable/glass,
-/obj/item/storage/belt,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oXv" = (
@@ -53519,7 +53519,7 @@
 	},
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/item/storage/belt,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/maintenance/department/security)
 "qDZ" = (
@@ -76708,7 +76708,7 @@
 "xZa" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
-/obj/item/storage/belt,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "xZj" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes several parent belt objects and replaces them with toolbelts
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The parent belt object is really not meant to be used, and cannot be obtained normally. Due to mapping oversights several of them were placed instead of toolbelts, and this fixes that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

They ain't there anymore

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/cf558832-da40-4fd2-8e07-5cfd8ea2f571)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/a494fff3-50ca-4be0-bafb-16caf29e005a)


</details>

## Changelog
:cl:
fix: Fixed maps having the "omnibelt" parent object instead of toolbelts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
