### PR TITLE
Fullscreen mode

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2245,6 +2245,7 @@
 #include "code\modules\client\preferences\entries\player\darkened_flash.dm"
 #include "code\modules\client\preferences\entries\player\deadmin.dm"
 #include "code\modules\client\preferences\entries\player\fps.dm"
+#include "code\modules\client\preferences\entries\player\fullscreen.dm"
 #include "code\modules\client\preferences\entries\player\ghost.dm"
 #include "code\modules\client\preferences\entries\player\glasses.dm"
 #include "code\modules\client\preferences\entries\player\hotkeys.dm"

--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -26,6 +26,7 @@
 #define COMSIG_KB_CLIENT_SCREENSHOT_DOWN "keybinding_client_screenshot_down"
 #define COMSIG_KB_CLIENT_MINIMALHUD_DOWN "keybinding_client_minimalhud_down"
 #define COMSIG_KB_CLIENT_ZOOMIN_DOWN "keybinding_client_zoomin_down"
+#define COMSIG_KB_CLIENT_FULLSCREEN "keybinding_fullscreen"
 
 #define COMSIG_KB_CLIENT_SAY_DOWN "keybinding_client_say_down"
 #define COMSIG_KB_CLIENT_RADIO_DOWN "keybinding_client_radio_down"

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -41,6 +41,8 @@
 #define PROC_REF(X) (.proc/##X)
 /// Call by name proc reference, checks if the proc exists on given type or as a global proc
 #define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
+/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) (##TYPE.verb/##X)
 /// Call by name proc reference, checks if the proc is existing global proc
 #define GLOBAL_PROC_REF(X) (/proc/##X)
 #else
@@ -48,6 +50,8 @@
 #define PROC_REF(X) (nameof(.proc/##X))
 /// Call by name proc reference, checks if the proc exists on given type or as a global proc
 #define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
+/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) (nameof(##TYPE.verb/##X))
 /// Call by name proc reference, checks if the proc is existing global proc
 #define GLOBAL_PROC_REF(X) (/proc/##X)
 #endif

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -63,3 +63,17 @@
 
 /datum/keybinding/client/zoomin/up(client/user)
 	winset(user, "mapwindow.map", "zoom=[user.prefs.read_player_preference(/datum/preference/numeric/pixel_size)]")
+
+/datum/keybinding/client/fullscreen
+	keys = list("F11")
+	name = "fullscreen"
+	full_name = "Toggle Fullscreen"
+	description = "Switch between windowed and fullscreen mode."
+	keybind_signal = COMSIG_KB_CLIENT_FULLSCREEN
+
+/datum/keybinding/client/fullscreen/down(client/user)
+	. = ..()
+	if (.)
+		return
+	var/previous_result = user.prefs?.read_player_preference(/datum/preference/toggle/fullscreen)
+	user.prefs?.update_preference(/datum/preference/toggle/fullscreen, !previous_result)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -359,6 +359,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	connection_realtime = world.realtime
 	connection_timeofday = world.timeofday
 	winset(src, null, "command=\".configure graphics-hwmode on\"")
+
 	var/breaking_version = CONFIG_GET(number/client_error_version)
 	var/breaking_build = CONFIG_GET(number/client_error_build)
 	var/warn_version = CONFIG_GET(number/client_warn_version)

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -1,5 +1,6 @@
 /datum/preference/toggle/fullscreen
 	db_key = "fullscreen"
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	preference_type = PREFERENCE_PLAYER
 	default_value = FALSE
 

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -1,0 +1,18 @@
+/datum/preference/toggle/fullscreen
+	db_key = "fullscreen"
+	preference_type = PREFERENCE_PLAYER
+	default_value = TRUE
+
+/datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
+	if (isobserver(client?.mob))
+		client?.mob.hud_used?.show_hud()
+	if (value)
+		winset(client,"mainwindow","Titlebar=false")
+		winset(client,"mainwindow","can-resize=false")
+		// Set it to minimized first because otherwise it doesn't enter fullscreen properly
+		// This line is important, and the game won't properly enter fullscreen mode otherwise
+		winset(client,"mainwindow","is-minimized=true")
+		winset(client,"mainwindow","is-maximized=true")
+	else
+		winset(client,"mainwindow","Titlebar=true")
+		winset(client,"mainwindow","can-resize=true")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -5,8 +5,6 @@
 	default_value = FALSE
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
-	if (isobserver(client?.mob))
-		client?.mob.hud_used?.show_hud()
 	if (value)
 		// Delete the menu
 		winset(client, "mainwindow", "menu=\"\"")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -1,18 +1,45 @@
 /datum/preference/toggle/fullscreen
 	db_key = "fullscreen"
 	preference_type = PREFERENCE_PLAYER
-	default_value = TRUE
+	default_value = FALSE
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
 	if (isobserver(client?.mob))
 		client?.mob.hud_used?.show_hud()
 	if (value)
-		winset(client,"mainwindow","Titlebar=false")
-		winset(client,"mainwindow","can-resize=false")
+		// Delete the menu
+		winset(client, "mainwindow", "menu=\"\"")
+		// Switch to the cool status bar
+		winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
+		winset(client, "status_bar_wide", "is-visible=false")
+		// Switch to fullscreen mode
+		winset(client, "mainwindow","titlebar=false")
+		winset(client, "mainwindow","can-resize=false")
 		// Set it to minimized first because otherwise it doesn't enter fullscreen properly
 		// This line is important, and the game won't properly enter fullscreen mode otherwise
-		winset(client,"mainwindow","is-minimized=true")
-		winset(client,"mainwindow","is-maximized=true")
+		winset(client, "mainwindow","is-minimized=true")
+		winset(client, "mainwindow","is-maximized=true")
+		// Set the main window's size
+		winset(client, null, "split.size=mainwindow.size")
+		// Fit the viewport
+		INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
 	else
-		winset(client,"mainwindow","Titlebar=true")
-		winset(client,"mainwindow","can-resize=true")
+		// Restore the menu
+		winset(client, "mainwindow", "menu=\"menu\"")
+		// Switch to the lame status bar
+		winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
+		winset(client, "status_bar", "is-visible=false")
+		winset(client, "status_bar_wide", "is-visible=true")
+		// Exit fullscreen mode
+		winset(client, "mainwindow","titlebar=true")
+		winset(client, "mainwindow","can-resize=true")
+		// Fix the mapsize, turning off statusbar doesn't update scaling
+		INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
+
+/datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
+	var/windowsize = winget(client, "split", "size")
+	if (!client || !windowsize)
+		return
+	var/split = findtext(windowsize, "x")
+	winset(client, "split", "size=[copytext(windowsize, 1, split)]x[text2num(copytext(windowsize, split + 1)) - 16]")
+	client.fit_viewport()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -73,23 +73,36 @@ window "mainwindow"
 		type = MAIN
 		pos = 372,0
 		size = 640x440
-		anchor1 = none
-		anchor2 = none
+		anchor1 = 0,0
+		anchor2 = 100,100
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
 		icon = 'icons\\ss13_64.png'
 		macro = "default"
 		menu = "menu"
+		statusbar = false
+		on-status = ".winset \"status_bar_wide.text = [[*]]\""
 	elem "split"
 		type = CHILD
-		pos = 3,0
-		size = 634x440
+		pos = 0,0
+		size = 640x424
 		anchor1 = 0,0
 		anchor2 = 100,100
 		saved-params = "splitter"
 		left = "mapwindow"
 		right = "infowindow"
 		is-vert = true
+	elem "status_bar_wide"
+		type = LABEL
+		pos = 0,424
+		size=640x16
+		anchor1 = 0,100
+		anchor2 = 100,100
+		text = ""
+		align = left
+		background-color = #ffffff
+		text-color = #222222
+		border = sunken
 	elem "asset_cache_browser"
 		type = BROWSER
 		pos = 0,0
@@ -112,8 +125,8 @@ window "mapwindow"
 		type = MAIN
 		pos = 0,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = 0,0
+		anchor2 = 100,100
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
 	elem "map"
@@ -128,6 +141,17 @@ window "mapwindow"
 		is-default = true
 		saved-params = "zoom;letterbox;zoom-mode"
 		style=".center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clowntext { color: #FF69Bf !important; font-size: 9px;  font-weight: bold; } .megaphone { font-size: 9px; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; } .emote { font-size: 6px; }"
+	elem "status_bar"
+		type = LABEL
+		pos = 0,464
+		size = 280x16
+		anchor1 = 0,100
+		is-visible = false
+		text = ""
+		align = left
+		background-color = #222222
+		text-color = #ffffff
+		border = line
 
 window "infowindow"
 	elem "infowindow"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/fullscreen.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/fullscreen.tsx
@@ -1,0 +1,9 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const fullscreen: FeatureToggle = {
+  name: 'Fullscreen Mode',
+  category: 'GRAPHICS',
+  subcategory: 'Quality',
+  description: 'Enabling this will cause the game window to take up the entire screen space, hiding the taskbar.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a fullscreen mode.
Sources used to create this PR:
- http://www.byond.com/forum/post/2185681
- https://github.com/BeeStation/BeeStation-Hornet/pull/5973

The statusbar may have slightly changed in non-fullscreen mode since I had to workaround byond not updating the control sizes when you disable the status bar.

The preference is disabled by default.
There is a hotkey of F11 to toggle fullscreen mode on and off.

## Why It's Good For The Game

This is a nice QOL update and allows the game to be played in a relatively modern feeling mode. Anyone with a small screen can enter fullscreen mode to gain like 40-50 pixels more height and width on the map screen.
I kept a statusbar that looks close to the old one and used a floating one for fullscreen mode.

The custom statusbar is entirely clientside and doesn't use MouseEntered at all, so is both instant and doesn't add a load of communication overhead to the server.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5368fefc-ce95-4ef6-ab98-21c71d88e2c3)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/6aa0595f-1860-406e-9465-aa06f786b8fa)

Note that toggling this mode makes the icon go weird. I have checked other servers and they don't seem to have any code fixing this, so it may be a byond issue with Windows 11.

I also just absolutely spammed F11 and in the end it was in a valid state.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5bd5ad14-68ff-48da-8975-6a7064dde7ee)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/3bd3be79-3f0a-451b-beb2-ccdbe6637d99)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2577cde5-57c1-4e7f-8835-516171e202d5)


## Changelog
:cl: PowerfulBacon, KubeRoot, Victor239, stylemistake
add: Adds fullscreen mode, toggleable with F11 or via game preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
