### PR TITLE
Makes machines and lockers no longer block diagonal clicks

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -92,6 +92,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASSFLAPS 		(1<<9)
 #define PASSDOORS 		(1<<10)
 #define PASSANOMALY		(1<<11)
+/// Do not intercept click attempts during Adjacent() checks. See [turf/proc/ClickCross]. **ONLY MEANINGFUL ON pass_flags_self!**
+#define LETPASSCLICKS	(1<<12)
 
 //! ## Movement Types
 #define GROUND			(1<<0)

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -94,12 +94,16 @@
 	for(var/obj/O in src)
 		if((mover && O.CanPass(mover, target_dir)) || (!mover && !O.density))
 			continue
-		if(O == target || O == mover || (O.pass_flags_self & LETPASSTHROW)) //check if there's a dense object present on the turf
+
+		//If there's a dense object on the turf, only allow the click to pass if you can throw items over it or it has a special flag.
+		if(O == target || O == mover || (O.pass_flags_self & LETPASSTHROW|LETPASSCLICKS))
 			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)
 
 		if( O.flags_1&ON_BORDER_1) // windows are on border, check them first
 			if( O.dir & target_dir || O.dir & (O.dir-1) ) // full tile windows are just diagonals mechanically
 				return FALSE //O.dir&(O.dir-1) is false for any cardinal direction, but true for diagonal ones
+
 		else if( !border_only ) // dense, not on border, cannot pass over
 			return FALSE
+
 	return TRUE

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -87,7 +87,7 @@ Class Procs:
 	verb_say = "beeps"
 	verb_yell = "blares"
 	pressure_resistance = 15
-	pass_flags_self = PASSMACHINE
+	pass_flags_self = PASSMACHINE | LETPASSCLICKS
 	max_integrity = 200
 	layer = BELOW_OBJ_LAYER //keeps shit coming out of the machine from ending up underneath it.
 	flags_ricochet = RICOCHET_HARD

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -8,6 +8,7 @@
 	max_integrity = 200
 	integrity_failure = 50
 	armor = list(MELEE = 20,  BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 70, ACID = 60, STAMINA = 0)
+	pass_flags_self = LETPASSCLICKS
 	var/contents_initialised = FALSE
 	var/icon_door = null
 	var/icon_door_override = FALSE //override to have open overlay use icon different to its base's


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/DaedalusDock/daedalusdock/pull/106
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for mappers to make better use of cramped rooms.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/b1da8825-8c15-4ae9-a355-9e9a3a96152d

</details>

## Changelog
:cl:Kapu1178,CydiaLamiales
add: Lockers, crates, and machines no longer block click attempts in adjacency checks. Basically, you can reach tables cornered between lockers/machines.
code: Adds a new pass_flags_self flag called LETPASSCLICKS that lets you mark an atom to not block ClickCross() attempts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
