### PR TITLE
Makes the atmos analyzer also show the contents of a gas tank inserted into a pump/scrubber/canister

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -39,6 +39,10 @@
 
 	return ..()
 
+/obj/machinery/portable_atmospherics/analyzer_act(mob/living/user, obj/item/I)
+	if(..() && holding)
+		return atmosanalyzer_scan(user, holding, TRUE)
+
 /obj/machinery/portable_atmospherics/process_atmos()
 	if(!connected_port && air_contents != null && src != null) // Pipe network handles reactions if connected.
 		air_contents.react(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the atmos analyzer also show the contents of a gas tank inserted into a pump/scrubber/canister
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for easier and faster gas manipulations where you don't need to pull out the gas tank out of the device to check what's inside.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/fe8d3f73-bd64-4080-8f8f-1592b9159866

</details>

## Changelog
:cl:
add: Made the gas analyzers show the contents of a gas tank inside of a portable pump/scrubber/canister
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
