### PR TITLE
Remove xeno spawn landmarks in atmos tanks

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13833,10 +13833,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"bXY" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "bYe" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/tile/blue{
@@ -18297,10 +18293,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cBP" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/air,
-/area/engine/atmos)
 "cBQ" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -97381,7 +97373,7 @@ upK
 ckV
 clb
 cla
-cBP
+cmW
 cmW
 bLK
 aaa
@@ -99421,7 +99413,7 @@ bTW
 bUW
 bTW
 bLK
-bXY
+bXW
 bYW
 bXW
 bLK

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -51718,10 +51718,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/dark/side,
 /area/engine/atmos)
-"nwz" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/air/light,
-/area/engine/atmos)
 "nwC" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/safe/caps_spare{
@@ -70697,7 +70693,6 @@
 "sgB" = (
 /obj/machinery/atmospherics/miner/plasma,
 /obj/machinery/light/floor,
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/plasma/light,
 /area/engine/atmos)
 "sgY" = (
@@ -143111,7 +143106,7 @@ wNp
 lVB
 fVd
 vEb
-nwz
+wVT
 wVT
 cKm
 ufF

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19312,10 +19312,6 @@
 "bPy" = (
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"bPz" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "bPD" = (
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating{
@@ -22623,10 +22619,6 @@
 	dir = 8
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos)
-"cji" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/air,
 /area/engine/atmos)
 "cjj" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -122669,7 +122661,7 @@ cei
 cfy
 cgB
 chT
-cji
+ckI
 ckI
 bAR
 aaf
@@ -125224,7 +125216,7 @@ bJd
 bKJ
 bMn
 bAR
-bPz
+bPy
 bQZ
 bSl
 bAR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Atmos tanks work perfectly fine for xeno spawns, due to the vents, but uh... several non-xeno things use these landmarks, like nightmares, which are not known for their ventcrawling ability.

## Why It's Good For The Game

![6e71d25f3f63f10e8bb763c4b1709472804a7302](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/1eeccc00-8f08-4b08-a0d7-72f60b59a67d)


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Hard to test, this is just landmark removals from maps.

</details>

## Changelog
:cl:
del: Xenos, morphs, and nightmares can no longer spawn in the atmos gas tanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
