### PR TITLE
Surgery tool indicators

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_carbon.dm
@@ -24,3 +24,7 @@
 /// Called from bodypart being removed /obj/item/bodypart/proc/drop_limb(mob/living/carbon/old_owner, dismembered)
 #define COMSIG_BODYPART_REMOVED "bodypart_removed"
 #define COMSIG_CARBON_TRANSFORMED	"carbon_transformed"			//! Called whenever a carbon is transformed into another carbon, i.e monkeyize/humanize (mob/living/carbon/new_body)
+/// Called from a mouse moving over a carbon (mob/user, location, control, params)
+#define COMSIG_CARBON_MOUSE_ENTERED "carbon_mouse_entered"
+/// Called from a mouse moving off a carbon (mob/user, location, control, params)
+#define COMSIG_CARBON_MOUSE_EXITED "carbon_mouse_exited"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -67,6 +67,7 @@
 		if(!(mobility_flags & MOBILITY_STAND) || !S.lying_required)
 			if((S.self_operable || user != src) && (user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM))
 				if(S.next_step(user,user.a_intent))
+					S.refresh_outlines()
 					return TRUE
 	return ..()
 
@@ -1070,3 +1071,13 @@
 	if(update_icon)
 		update_body()
 		update_body_parts(TRUE)
+
+/mob/living/carbon/MouseEntered(location, control, params)
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
+	SEND_SIGNAL(src, COMSIG_CARBON_MOUSE_ENTERED, usr, location, control, params)
+
+/mob/living/carbon/MouseExited(location, control, params)
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
+	SEND_SIGNAL(src, COMSIG_CARBON_MOUSE_EXITED, usr, location, control, params)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -135,6 +135,7 @@
 		if(!(mobility_flags & MOBILITY_STAND) || !S.lying_required)
 			if(user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM)
 				if(S.next_step(user, user.a_intent))
+					S.refresh_outlines()
 					return 1
 	return 0
 

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -348,7 +348,6 @@
 			if(M.a_intent == INTENT_HELP || M.a_intent == INTENT_DISARM)
 				for(var/datum/surgery/S in surgeries)
 					if(S.next_step(M,M.a_intent))
-						S.refresh_outlines()
 						return 1
 		if(..()) //successful attack
 			attacked += 10
@@ -364,7 +363,6 @@
 		if(user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM)
 			for(var/datum/surgery/S in surgeries)
 				if(S.next_step(user,user.a_intent))
-					S.refresh_outlines()
 					return 1
 	if(istype(W, /obj/item/stack/sheet/mineral/plasma) && !stat) //Let's you feed slimes plasma.
 		add_friendship(user, 1)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -348,6 +348,7 @@
 			if(M.a_intent == INTENT_HELP || M.a_intent == INTENT_DISARM)
 				for(var/datum/surgery/S in surgeries)
 					if(S.next_step(M,M.a_intent))
+						S.refresh_outlines()
 						return 1
 		if(..()) //successful attack
 			attacked += 10
@@ -363,6 +364,7 @@
 		if(user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM)
 			for(var/datum/surgery/S in surgeries)
 				if(S.next_step(user,user.a_intent))
+					S.refresh_outlines()
 					return 1
 	if(istype(W, /obj/item/stack/sheet/mineral/plasma) && !stat) //Let's you feed slimes plasma.
 		add_friendship(user, 1)

--- a/code/modules/surgery/advanced/bioware/experimental_dissection.dm
+++ b/code/modules/surgery/advanced/bioware/experimental_dissection.dm
@@ -21,7 +21,7 @@
 		return FALSE
 
 /datum/surgery_step/dissection
-	name = "dissection"
+	name = "dissection (scalpel)"
 	implements = list(TOOL_SCALPEL = 60, /obj/item/kitchen/knife = 30, /obj/item/shard = 15)
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/ligament_hook.dm
+++ b/code/modules/surgery/advanced/bioware/ligament_hook.dm
@@ -13,7 +13,7 @@
 	bioware_target = BIOWARE_LIGAMENTS
 
 /datum/surgery_step/reshape_ligaments
-	name = "reshape ligaments"
+	name = "reshape ligaments (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/ligament_reinforcement.dm
+++ b/code/modules/surgery/advanced/bioware/ligament_reinforcement.dm
@@ -13,7 +13,7 @@
 	bioware_target = BIOWARE_LIGAMENTS
 
 /datum/surgery_step/reinforce_ligaments
-	name = "reinforce ligaments"
+	name = "reinforce ligaments (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/muscled_veins.dm
+++ b/code/modules/surgery/advanced/bioware/muscled_veins.dm
@@ -12,7 +12,7 @@
 	bioware_target = BIOWARE_CIRCULATION
 
 /datum/surgery_step/muscled_veins
-	name = "shape vein muscles"
+	name = "shape vein muscles (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/bioware/nerve_grounding.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_grounding.dm
@@ -12,7 +12,7 @@
 	bioware_target = BIOWARE_NERVES
 
 /datum/surgery_step/ground_nerves
-	name = "ground nerves"
+	name = "ground nerves (hand)"
 	accept_hand = TRUE
 	time = 155
 

--- a/code/modules/surgery/advanced/bioware/nerve_splicing.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_splicing.dm
@@ -12,7 +12,7 @@
 	bioware_target = BIOWARE_NERVES
 
 /datum/surgery_step/splice_nerves
-	name = "splice nerves"
+	name = "splice nerves (hand)"
 	accept_hand = TRUE
 	time = 155
 

--- a/code/modules/surgery/advanced/bioware/vein_threading.dm
+++ b/code/modules/surgery/advanced/bioware/vein_threading.dm
@@ -13,7 +13,7 @@
 	self_operable = TRUE
 
 /datum/surgery_step/thread_veins
-	name = "thread veins"
+	name = "thread veins (hand)"
 	accept_hand = TRUE
 	time = 125
 

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -26,7 +26,7 @@
 	return TRUE
 
 /datum/surgery_step/brainwash
-	name = "brainwash"
+	name = "brainwash (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_WIRECUTTER = 50, /obj/item/stack/package_wrap = 35, /obj/item/stack/cable_coil = 15)
 	time = 200
 	preop_sound = 'sound/surgery/hemostat1.ogg'

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -22,7 +22,7 @@
 	return TRUE
 
 /datum/surgery_step/lobotomize
-	name = "perform lobotomy"
+	name = "perform lobotomy (scalpel)"
 	implements = list(TOOL_SCALPEL = 85, /obj/item/melee/transforming/energy/sword = 55, /obj/item/kitchen/knife = 35,
 		/obj/item/shard = 25, /obj/item = 20)
 	time = 100

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -18,7 +18,7 @@
 		return FALSE
 
 /datum/surgery_step/bionecrosis
-	name = "start bionecrosis"
+	name = "start bionecrosis (syringe)"
 	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
 	time = 50
 	chems_needed = list(/datum/reagent/toxin/zombiepowder, /datum/reagent/medicine/rezadone)

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -19,7 +19,7 @@
 		return FALSE
 
 /datum/surgery_step/pacify
-	name = "rewire brain"
+	name = "rewire brain (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
 	time = 40
 	preop_sound = 'sound/surgery/hemostat1.ogg'

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -26,7 +26,7 @@
 	return TRUE
 
 /datum/surgery_step/revive
-	name = "shock body"
+	name = "shock brain (defibrillator)"
 	implements = list(/obj/item/shockpaddles = 100, /obj/item/melee/baton = 75, /obj/item/gun/energy = 60)
 	repeatable = TRUE
 	time = 120

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -20,7 +20,7 @@
 	return TRUE
 
 /datum/surgery_step/viral_bond
-	name = "viral bond"
+	name = "viral bond (cautery)"
 	implements = list(TOOL_CAUTERY = 100, TOOL_WELDER = 50, /obj/item = 30) // 30% success with any hot item.
 	time = 100
 	chems_needed = list(/datum/reagent/medicine/spaceacillin,/datum/reagent/consumable/virus_food,/datum/reagent/toxin/formaldehyde)

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -9,7 +9,7 @@
 
 
 /datum/surgery_step/sever_limb
-	name = "sever limb"
+	name = "sever limb (circular saw)"
 	implements = list(TOOL_SCALPEL = 100, TOOL_SAW = 100, /obj/item/melee/arm_blade = 80, /obj/item/fireaxe = 50, /obj/item/hatchet = 40, /obj/item/kitchen/knife/butcher = 25)
 	time = 64
 	preop_sound = 'sound/surgery/scalpel1.ogg'

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -34,7 +34,7 @@
 	return ..()
 
 /datum/surgery_step/filter_blood
-	name = "Filter blood"
+	name = "filter blood (blood filter)"
 	implements = list(/obj/item/blood_filter = 95)
 	repeatable = TRUE
 	time = 2.5 SECONDS

--- a/code/modules/surgery/brain_recalibration.dm
+++ b/code/modules/surgery/brain_recalibration.dm
@@ -13,7 +13,7 @@
 	requires_bodypart_type = 0
 
 /datum/surgery_step/fix_brain
-	name = "fix brain"
+	name = "fix brain (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	time = 120 //long and complicated
 	repeatable = TRUE

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -13,7 +13,7 @@
 
 //extract brain
 /datum/surgery_step/extract_core
-	name = "extract core"
+	name = "extract core (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 100)
 	time = 16
 

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -14,7 +14,7 @@
 
 //an incision but with greater bleed, and a 90% base success chance
 /datum/surgery_step/incise_heart
-	name = "incise heart"
+	name = "incise heart (scalpel)"
 	implements = list(TOOL_SCALPEL = 90, /obj/item/melee/transforming/energy/sword = 45, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 25)
 	time = 16
@@ -50,7 +50,7 @@
 
 //grafts a coronary bypass onto the individual's heart, success chance is 90% base again
 /datum/surgery_step/coronary_bypass
-	name = "graft coronary bypass"
+	name = "graft coronary bypass (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 90, TOOL_WIRECUTTER = 35, /obj/item/stack/package_wrap = 15, /obj/item/stack/cable_coil = 5)
 	time = 90
 

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -7,7 +7,7 @@
 
 //fix eyes
 /datum/surgery_step/fix_eyes
-	name = "fix eyes"
+	name = "fix eyes (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 45, /obj/item/pen = 25)
 	time = 64
 

--- a/code/modules/surgery/gastrectomy.dm
+++ b/code/modules/surgery/gastrectomy.dm
@@ -21,7 +21,7 @@
 ////Gastrectomy, because we truly needed a way to repair stomachs.
 //95% chance of success to be consistent with most organ-repairing surgeries.
 /datum/surgery_step/gastrectomy
-	name = "remove lower duodenum"
+	name = "remove lower duodenum (scalpel)"
 	implements = list(TOOL_SCALPEL = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 35)
 	time = 52

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -22,7 +22,7 @@
 					/datum/surgery_step/close)
 
 /datum/surgery_step/heal
-	name = "repair body"
+	name = "repair body (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
 	repeatable = TRUE
 	time = 25

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -20,7 +20,7 @@
 ////hepatectomy, removes damaged parts of the liver so that the liver may regenerate properly
 //95% chance of success, not 100 because organs are delicate
 /datum/surgery_step/hepatectomy
-	name = "remove damaged liver section"
+	name = "remove damaged liver section (scalpel)"
 	implements = list(TOOL_SCALPEL = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 35)
 	time = 52

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -6,7 +6,7 @@
 
 //extract implant
 /datum/surgery_step/extract_implant
-	name = "extract implant"
+	name = "extract implant (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 65)
 	time = 64
 	var/obj/item/implant/I = null

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -11,7 +11,7 @@
 
 //cut fat
 /datum/surgery_step/cut_fat
-	name = "cut excess fat"
+	name = "cut excess fat (saw)"
 	implements = list(TOOL_SAW = 100, /obj/item/hatchet = 35, /obj/item/kitchen/knife/butcher = 25)
 	time = 64
 
@@ -29,7 +29,7 @@
 
 //remove fat
 /datum/surgery_step/remove_fat
-	name = "remove loose fat"
+	name = "remove loose fat (retractor)"
 	implements = list(TOOL_RETRACTOR = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
 	time = 32
 

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -14,7 +14,7 @@
 
 //lobectomy, removes the most damaged lung lobe with a 95% base success chance
 /datum/surgery_step/lobectomy
-	name = "excise damaged lung node"
+	name = "excise damaged lung node (scalpel)"
 	implements = list(TOOL_SCALPEL = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 35)
 	time = 42

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -1,6 +1,6 @@
 //open shell
 /datum/surgery_step/mechanic_open
-	name = "unscrew shell"
+	name = "unscrew shell (screwdriver)"
 	implements = list(
 		TOOL_SCREWDRIVER		= 100,
 		TOOL_SCALPEL 			= 75, // med borgs could try to unskrew shell with scalpel
@@ -25,7 +25,7 @@
 
 //close shell
 /datum/surgery_step/mechanic_close
-	name = "screw shell"
+	name = "screw shell (screwdriver)"
 	implements = list(
 		TOOL_SCREWDRIVER		= 100,
 		TOOL_SCALPEL 			= 75,
@@ -50,7 +50,7 @@
 
 //prepare electronics
 /datum/surgery_step/prepare_electronics
-	name = "prepare electronics"
+	name = "prepare electronics (multitool)"
 	implements = list(
 		TOOL_MULTITOOL = 100,
 		TOOL_HEMOSTAT = 10) // try to reboot internal controllers via short circuit with some conductor
@@ -65,7 +65,7 @@
 
 //unwrench
 /datum/surgery_step/mechanic_unwrench
-	name = "unwrench bolts"
+	name = "unwrench bolts (wrench)"
 	implements = list(
 		TOOL_WRENCH = 100,
 		TOOL_RETRACTOR = 10)
@@ -79,7 +79,7 @@
 
 //wrench
 /datum/surgery_step/mechanic_wrench
-	name = "wrench bolts"
+	name = "wrench bolts (wrench)"
 	implements = list(
 		TOOL_WRENCH = 100,
 		TOOL_RETRACTOR = 10)
@@ -93,7 +93,7 @@
 
 //open hatch
 /datum/surgery_step/open_hatch
-	name = "open the hatch"
+	name = "open the hatch (hand)"
 	accept_hand = 1
 	time = 10
 	preop_sound = 'sound/items/ratchet.ogg'

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -1,7 +1,7 @@
 
 //make incision
 /datum/surgery_step/incise
-	name = "make incision"
+	name = "make incision (scalpel)"
 	implements = list(TOOL_SCALPEL = 100, /obj/item/melee/transforming/energy/sword = 75, /obj/item/kitchen/knife = 65,
 		/obj/item/shard = 45, /obj/item = 30) // 30% success with any sharp item.
 	time = 16
@@ -41,7 +41,7 @@
 
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders
-	name = "clamp bleeders"
+	name = "clamp bleeders (hemostat)"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_WIRECUTTER = 60, /obj/item/stack/package_wrap = 35, /obj/item/stack/cable_coil = 15)
 	time = 24
 	preop_sound = 'sound/surgery/hemostat1.ogg'
@@ -59,7 +59,7 @@
 
 //retract skin
 /datum/surgery_step/retract_skin
-	name = "retract skin"
+	name = "retract skin (retractor)"
 	implements = list(TOOL_RETRACTOR = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
 	time = 24
 	preop_sound = 'sound/surgery/retractor1.ogg'
@@ -74,7 +74,7 @@
 
 //close incision
 /datum/surgery_step/close
-	name = "mend incision"
+	name = "mend incision (cautery)"
 	implements = list(TOOL_CAUTERY = 100, /obj/item/gun/energy/laser = 90, TOOL_WELDER = 70,
 		/obj/item = 30) // 30% success with any hot item.
 	time = 24
@@ -101,7 +101,7 @@
 
 //saw bone
 /datum/surgery_step/saw
-	name = "saw bone"
+	name = "saw bone (circular saw)"
 	implements = list(TOOL_SAW = 100,/obj/item/melee/arm_blade = 75,
 	/obj/item/fireaxe = 50, /obj/item/hatchet = 35, /obj/item/kitchen/knife/butcher = 25)
 	time = 54
@@ -129,7 +129,7 @@
 
 //drill bone
 /datum/surgery_step/drill
-	name = "drill bone"
+	name = "drill bone (surgical drill)"
 	implements = list(TOOL_DRILL = 100, /obj/item/powertool/hand_drill = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 20)
 	time = 30
 

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -5,7 +5,7 @@
 
 //reshape_face
 /datum/surgery_step/reshape_face
-	name = "reshape face"
+	name = "reshape face (scalpel)"
 	implements = list(TOOL_SCALPEL = 100, /obj/item/kitchen/knife = 50, TOOL_WIRECUTTER = 35)
 	time = 64
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -149,7 +149,7 @@
 
 /datum/surgery/proc/on_mouse_entered(datum/_source, mob/living/user)
 	SIGNAL_HANDLER
-	if(!istype(user) || user.zone_selected != location || (user in hovering_users))
+	if(!istype(user) || user.zone_selected != location || !HAS_TRAIT(user, TRAIT_MEDICAL_HUD) || (user in hovering_users))
 		return
 	add_outlines(user)
 	hovering_users += user

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -149,7 +149,7 @@
 
 /datum/surgery/proc/on_mouse_entered(datum/_source, mob/living/user)
 	SIGNAL_HANDLER
-	if(!istype(user) || user.zone_selected != location || !HAS_TRAIT(user, TRAIT_MEDICAL_HUD) || (user in hovering_users))
+	if(!istype(user) || user.zone_selected != location || !(HAS_TRAIT(user, TRAIT_MEDICAL_HUD) || HAS_TRAIT(user, TRAIT_SURGEON) || HAS_TRAIT(user, TRAIT_ABDUCTOR_SURGEON)) || (user in hovering_users))
 		return
 	add_outlines(user)
 	hovering_users += user

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -149,7 +149,9 @@
 
 /datum/surgery/proc/on_mouse_entered(datum/_source, mob/living/user)
 	SIGNAL_HANDLER
-	if(!istype(user) || user.zone_selected != location || !(HAS_TRAIT(user, TRAIT_MEDICAL_HUD) || HAS_TRAIT(user, TRAIT_SURGEON) || HAS_TRAIT(user, TRAIT_ABDUCTOR_SURGEON)) || (user in hovering_users))
+	if(!istype(user) || user.zone_selected != location || (user in hovering_users))
+		return
+	if(!HAS_TRAIT(user, TRAIT_MEDICAL_HUD) && !HAS_TRAIT(user, TRAIT_SURGEON) && !HAS_TRAIT(user, TRAIT_ABDUCTOR_SURGEON) && !(user.mind && (HAS_TRAIT(user.mind, TRAIT_SURGEON) || HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_SURGEON))))
 		return
 	add_outlines(user)
 	hovering_users += user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This renames most surgery steps to tell which tool is needed, and also adds a feature where, whenever you have your mouse hovered over someone undergoing surgery, the tools that will work for the current step in your inventory will be highlighted.

The outlines will only render if you have a medhud or are a perfect/abductor surgeon.

## Why It's Good For The Game

Helps players who don't quite have surgery memorized figure out which tools to use.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/fa7d1c8e-a47c-40ab-9a41-10511ce71eaa

</details>

## Changelog
:cl:
tweak: Surgery steps on the operating computer now say which tool to use.
add: Added surgery tool helper outlines — whenever you have a medical HUD equipped, and you hover your mouse over someone undergoing surgery, all the tools in your inventory that can be used for the current surgery step will be highlighted with an outline, with the color of the outline representing the success rate of the tool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
