### PR TITLE
You can now craft IV drips and anesthetic holders

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1159,3 +1159,23 @@
 	reqs = list(/obj/item/stack/sheet/mineral/silver = 1, /obj/item/stack/sheet/glass = 2)
 	tools = list(TOOL_WRENCH)
 	category = CAT_STRUCTURE
+
+/datum/crafting_recipe/anesthetic_machine
+	name = "Anesthetic Tank Holder"
+	result = /obj/machinery/anesthetic_machine
+	time = 10 SECONDS
+	reqs = list(/obj/item/stack/sheet/iron = 10,
+				/obj/item/stack/rods = 5,
+				/obj/item/clothing/mask/breath = 1)
+	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
+	category = CAT_STRUCTURE
+
+/datum/crafting_recipe/iv_drip
+	name = "IV Drip"
+	result = /obj/machinery/iv_drip
+	time = 10 SECONDS
+	reqs = list(/obj/item/stack/sheet/iron = 10,
+				/obj/item/stack/rods = 5,
+				/obj/item/reagent_containers/syringe = 1)
+	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
+	category = CAT_STRUCTURE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This allows you to craft IV drips and anesthetic holders in the crafting menu, with 10 iron sheets, 5 rods, and either a syringe (for the iv) or a breath mask (for the tank holder)

## Why It's Good For The Game

I've lost IV drips too many times to count, and getting more anesthetic tank holders relies entirely on maint room rng...

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/782faf28-4f89-4ca1-b6e7-278d64d3b889



</details>

## Changelog
:cl:
add: You can now craft IV drips and anesthetic holders in the crafting menu, with 10 iron sheets, 5 rods, and either a syringe (for the iv) or a breath mask (for the tank holder)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
