### PR TITLE
You can now attach an anesthetic tank to yourself much faster

### DIFF
--- a/code/modules/surgery/anesthetic_machine.dm
+++ b/code/modules/surgery/anesthetic_machine.dm
@@ -28,7 +28,7 @@
 /obj/machinery/anesthetic_machine/attack_hand(mob/living/user)
 	. = ..()
 	if(retract_mask())
-		visible_message("<span class='notice'>[user] retracts the mask back into the [src].</span>")
+		visible_message("<span class='notice'>[user] retracts the mask back into \the [src].</span>")
 
 /obj/machinery/anesthetic_machine/attacked_by(obj/item/I, mob/living/user)
 	if(istype(I, /obj/item/tank))
@@ -47,7 +47,7 @@
 		return
 	if(attached_tank)// If attached tank, remove it.
 		attached_tank.forceMove(loc)
-		to_chat(user, "<span class='notice'>You remove the [attached_tank].</span>")
+		to_chat(user, "<span class='notice'>You remove \the [attached_tank].</span>")
 		attached_tank = null
 		update_icon()
 		if(mask_out)
@@ -72,14 +72,14 @@
 		return
 	if(Adjacent(target) && usr.Adjacent(target))
 		if(attached_tank && !mask_out)
-			usr.visible_message("<span class='warning'>[usr] attemps to attach the [src] to [target].</span>", "<span class='notice'>You attempt to attach the [src] to [target].</span>")
-			if(!do_after(usr, 70, target))
+			usr.visible_message("<span class='warning'>[usr] attempts to attach \the [src] to [target].</span>", "<span class='notice'>You attempt to attach \the [src] to [target].</span>")
+			if(!do_after(usr, target != usr ? (7 SECONDS) : (1 SECONDS), target))
 				return
 			if(!target.equip_to_appropriate_slot(attached_mask))
-				to_chat(usr, "<span class='warning'>You are unable to attach the [src] to [target]!</span>")
+				to_chat(usr, "<span class='warning'>You are unable to attach \the [src] to [target]!</span>")
 				return
 			else
-				usr.visible_message("<span class='warning'>[usr] attaches the [src] to [target].</span>", "<span class='notice'>You attach the [src] to [target].</span>")
+				usr.visible_message("<span class='warning'>[usr] attaches \the [src] to [target].</span>", "<span class='notice'>You attach \the [src] to [target].</span>")
 				target.external = attached_tank
 				mask_out = TRUE
 				START_PROCESSING(SSmachines, src)
@@ -93,7 +93,7 @@
 		return PROCESS_KILL
 
 	if(get_dist(src, get_turf(attached_mask)) > 1) // If too far away, detach
-		to_chat(attached_mask.loc, "<span class='warning'>The [attached_mask] is ripped off of your face!</span>")
+		to_chat(attached_mask.loc, "<span class='warning'>\The [attached_mask] is ripped off of your face!</span>")
 		retract_mask()
 		return PROCESS_KILL
 
@@ -151,5 +151,5 @@
 /obj/item/clothing/mask/breath/machine/dropped(mob/user)
 	..()
 	if(loc != machine_attached) // If not already in machine, go back in when dropped (dropped is called on unequip)
-		to_chat(user, "<span class='notice'>The mask snaps back into the [machine_attached].</span>")
+		to_chat(user, "<span class='notice'>The mask snaps back into \the [machine_attached].</span>")
 		machine_attached.retract_mask()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so attaching an anesthetic tank to yourself takes 1 second, rather than 7. It's not instant so you still have a moment to nope out if you didn't mean to do it or something.

Also fixed a typo, and used `\the` instead of plain `the`s for messages.

## Why It's Good For The Game

Eh, you're attaching it to yourself, why should it take 7 seconds?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ecf8f1e8-20eb-44ab-904f-5d1a23b5ecb3

</details>

## Changelog
:cl:
tweak: Attaching an anesthetic tank to yourself is much quicker than attaching it to someone else.
spellcheck: Fixed some typos in the anesthetic tank holder chat messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
