### PR TITLE
Buffs atmosbots

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -1,7 +1,7 @@
 #define ATMOSBOT_MAX_AREA_SCAN 100
 #define ATMOSBOT_HOLOBARRIER_COOLDOWN 150
 
-#define ATMOSBOT_MAX_PRESSURE_CHANGE 5
+#define ATMOSBOT_MAX_PRESSURE_CHANGE 1
 #define ATMOSBOT_MAX_SCRUB_CHANGE 0.4
 
 #define ATMOSBOT_CHECK_BREACH 0
@@ -202,7 +202,10 @@
 
 /mob/living/simple_animal/bot/atmosbot/proc/vent_air()
 	//Just start pumping out air
+	var/turf/source_turf = get_turf(src)
 	for (var/turf/T in RANGE_TURFS(atmos_range, src))
+		if (!inLineOfSight(source_turf.x, source_turf.y, T.x, T.y, T.z))
+			continue
 		var/datum/gas_mixture/environment = T.return_air()
 		var/environment_pressure = environment.return_pressure()
 
@@ -220,6 +223,8 @@
 
 /mob/living/simple_animal/bot/atmosbot/proc/scrub_toxins()
 	for (var/turf/T in RANGE_TURFS(atmos_range, src))
+		if (!inLineOfSight(source_turf.x, source_turf.y, T.x, T.y, T.z))
+			continue
 		var/datum/gas_mixture/environment = T.return_air()
 		for(var/G in gasses)
 			if(gasses[G])

--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -1,8 +1,8 @@
 #define ATMOSBOT_MAX_AREA_SCAN 100
 #define ATMOSBOT_HOLOBARRIER_COOLDOWN 150
 
-#define ATMOSBOT_MAX_PRESSURE_CHANGE 150
-#define ATMOSBOT_MAX_SCRUB_CHANGE 15
+#define ATMOSBOT_MAX_PRESSURE_CHANGE 5
+#define ATMOSBOT_MAX_SCRUB_CHANGE 0.4
 
 #define ATMOSBOT_CHECK_BREACH 0
 #define ATMOSBOT_LOW_OXYGEN 1
@@ -63,8 +63,14 @@
 		GAS_TRITIUM = 1,
 		GAS_H2O = 0,
 	)
+	// Have we spoken our alert yet?
+	var/has_spoken = FALSE
 	//Tank type
 	var/tank_type = /obj/item/tank/internals/oxygen/empty
+	// The range that our atmos operations act on
+	var/atmos_range = 3
+	// Last time we spoke
+	var/last_speech
 
 /mob/living/simple_animal/bot/atmosbot/Initialize(mapload, new_toolbox_color)
 	. = ..()
@@ -117,20 +123,26 @@
 				else
 					target = get_vent_turf()
 					action = ATMOSBOT_VENT_AIR
+				try_speak("Low pressure detected at [get_area(src)], attempting to detect and isolate breach...")
 			if(ATMOSBOT_LOW_OXYGEN)
 				target = get_vent_turf()
 				action = ATMOSBOT_VENT_AIR
+				try_speak("Low oxygen detected at [get_area(src)].")
 			if(ATMOSBOT_HIGH_TOXINS)
 				target = get_vent_turf()
 				action = ATMOSBOT_SCRUB_TOXINS
+				try_speak("Toxic contaminants in the atmosphere have been detected at [get_area(src)].")
 			if(ATMOSBOT_BAD_TEMP)
 				target = get_vent_turf()
 				action = ATMOSBOT_TEMPERATURE_CONTROL
+				try_speak("The atmospheric temperature in [get_area(src)] exceeds allows operating limits.")
 			if(ATMOSBOT_AREA_STABLE)
 				if(emagged == 2)
 					if(prob(20))
 						target = get_vent_turf()
 						action = ATMOSBOT_VENT_AIR
+				else
+					has_spoken = FALSE
 	update_icon()
 
 	if(!target)
@@ -176,6 +188,13 @@
 			mode = BOT_IDLE
 			return
 
+/mob/living/simple_animal/bot/atmosbot/proc/try_speak(message)
+	if (has_spoken || last_speech > world.time + 3 MINUTES)
+		return
+	has_spoken = TRUE
+	last_speech = world.time
+	speak(message, radio_channel)
+
 /mob/living/simple_animal/bot/atmosbot/proc/change_temperature()
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/environment = T.return_air()
@@ -183,30 +202,29 @@
 
 /mob/living/simple_animal/bot/atmosbot/proc/vent_air()
 	//Just start pumping out air
-	var/turf/T = get_turf(src)
+	for (var/turf/T in RANGE_TURFS(atmos_range, src))
+		var/datum/gas_mixture/environment = T.return_air()
+		var/environment_pressure = environment.return_pressure()
 
-	var/datum/gas_mixture/environment = T.return_air()
-	var/environment_pressure = environment.return_pressure()
+		var/pressure_delta = min(ATMOSBOT_MAX_PRESSURE_CHANGE, (ONE_ATMOSPHERE - environment_pressure))
 
-	var/pressure_delta = min(ATMOSBOT_MAX_PRESSURE_CHANGE, (ONE_ATMOSPHERE - environment_pressure))
-
-	if(pressure_delta > 0)
-		var/transfer_moles = pressure_delta*environment.return_volume()/(T20C * R_IDEAL_GAS_EQUATION)
-		if(emagged == 2)
-			environment.adjust_moles(GAS_CO2, transfer_moles)
-		else
-			environment.adjust_moles(GAS_N2, transfer_moles * 0.7885)
-			environment.adjust_moles(GAS_O2, transfer_moles * 0.2115)
-		air_update_turf()
-		new /obj/effect/temp_visual/vent_wind(get_turf(src))
+		if(pressure_delta > 0)
+			var/transfer_moles = pressure_delta*environment.return_volume()/(T20C * R_IDEAL_GAS_EQUATION)
+			if(emagged == 2)
+				environment.adjust_moles(GAS_CO2, transfer_moles)
+			else
+				environment.adjust_moles(GAS_N2, transfer_moles * 0.7885)
+				environment.adjust_moles(GAS_O2, transfer_moles * 0.2115)
+			air_update_turf()
+	new /obj/effect/temp_visual/vent_wind(get_turf(src))
 
 /mob/living/simple_animal/bot/atmosbot/proc/scrub_toxins()
-	var/turf/T = get_turf(src)
-	var/datum/gas_mixture/environment = T.return_air()
-	for(var/G in gasses)
-		if(gasses[G])
-			var/moles_in_atmos = environment.get_moles(G)
-			environment.adjust_moles(G, -min(moles_in_atmos, ATMOSBOT_MAX_SCRUB_CHANGE))
+	for (var/turf/T in RANGE_TURFS(atmos_range, src))
+		var/datum/gas_mixture/environment = T.return_air()
+		for(var/G in gasses)
+			if(gasses[G])
+				var/moles_in_atmos = environment.get_moles(G)
+				environment.adjust_moles(G, -min(moles_in_atmos, ATMOSBOT_MAX_SCRUB_CHANGE))
 
 /mob/living/simple_animal/bot/atmosbot/proc/deploy_holobarrier()
 	if(deployed_holobarrier)
@@ -270,12 +288,21 @@
 			break
 		if(blocked || !checking_turf.CanAtmosPass(checking_turf))
 			continue
+		var/datum/gas_mixture/current_air = checking_turf.return_air()
+		if (!current_air)
+			continue
+		var/current_pressure = current_air.return_pressure()
 		//Add adjacent turfs
 		for(var/direction in list(NORTH, SOUTH, EAST, WEST))
 			var/turf/adjacent_turf = get_step(checking_turf, direction)
-			if(adjacent_turf in checked_turfs || !adjacent_turf.CanAtmosPass(adjacent_turf) || istype(adjacent_turf.loc, /area/space))
+			if(adjacent_turf in checked_turfs || !adjacent_turf.CanAtmosPass(adjacent_turf))
 				continue
-			if(isspaceturf(adjacent_turf))
+			var/datum/gas_mixture/checking_air = checking_turf.return_air()
+			if (!checking_air)
+				continue
+			var/checking_pressure = checking_air.return_pressure()
+			// If the pressure difference is high or its a space turf, place a shield wall here
+			if (abs(checking_pressure - current_pressure) > 30 || isspaceturf(adjacent_turf))
 				return checking_turf
 			to_check_turfs |= adjacent_turf
 	return null

--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -222,6 +222,7 @@
 	new /obj/effect/temp_visual/vent_wind(get_turf(src))
 
 /mob/living/simple_animal/bot/atmosbot/proc/scrub_toxins()
+	var/turf/source_turf = get_turf(src)
 	for (var/turf/T in RANGE_TURFS(atmos_range, src))
 		if (!inLineOfSight(source_turf.x, source_turf.y, T.x, T.y, T.z))
 			continue

--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -135,7 +135,7 @@
 			if(ATMOSBOT_BAD_TEMP)
 				target = get_vent_turf()
 				action = ATMOSBOT_TEMPERATURE_CONTROL
-				try_speak("The atmospheric temperature in [get_area(src)] exceeds allows operating limits.")
+				try_speak("The atmospheric temperature in [get_area(src)] exceeds allowed operating limits.")
 			if(ATMOSBOT_AREA_STABLE)
 				if(emagged == 2)
 					if(prob(20))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs atmosbots, increasing their scrubbing and venting range.
Lowers the amount of pressure they can put out and take in at any one time.

## Why It's Good For The Game

Atmosbots have a really powerful atmos correction ability right now but only affect the turf they are on, meaning that they scrub away all of the gas and then continue scrubbing as trace amounts of gasses flow into the turfs. This makes their area of affect range significantly larger but significantly lowers how fast they can pump gasses in, or pump gasses out.

This makes them really handy for fixing small amounts of gasses in the atmosphere across the entire station.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f1330779-26cb-4c55-9502-5e469352f753

## Changelog
:cl:
balance: Atmosbots have been given a larger area of effect but have had the amount of gasses they transfer in a single tick reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
