### PR TITLE
Fixes people taking the weapons from the ninja hotel.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -393,6 +393,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STICKY_NODROP "sticky-nodrop" //sticky nodrop sounds like a bad soundcloud rapper's name
 #define TRAIT_PRESERVE_UI_WITHOUT_CLIENT "preserve_ui_without_client" //this mob should never close ui even if it doesn't have a client
 #define EXPERIMENTAL_SURGERY_TRAIT "experimental_surgery"
+#define NINJA_KIDNAPPED_TRAIT "ninja_kidnapped"
 
 ///Traits given by station traits
 #define STATION_TRAIT_BANANIUM_SHIPMENTS "station_trait_bananium_shipments"

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -54,8 +54,14 @@ It is possible to destroy the net by the occupant or someone else.
 		var/mob/living/carbon/human/H = affecting
 		for(var/obj/item/W in H)
 			if(W == H.w_uniform)
+				ADD_TRAIT(W, TRAIT_NODROP, NINJA_KIDNAPPED_TRAIT)
+				for (var/obj/item/subitem in W)
+					H.dropItemToGround(subitem)
 				continue//So all they're left with are shoes and uniform.
 			if(W == H.shoes)
+				ADD_TRAIT(W, TRAIT_NODROP, NINJA_KIDNAPPED_TRAIT)
+				for (var/obj/item/subitem in W)
+					H.dropItemToGround(subitem)
 				continue
 			H.dropItemToGround(W)
 
@@ -68,6 +74,7 @@ It is possible to destroy the net by the occupant or someone else.
 	visible_message("[affecting] suddenly vanishes!")
 	affecting.forceMove(pick(GLOB.holdingfacility)) //Throw mob in to the holding facility.
 	to_chat(affecting, "<span class='danger'>You appear in a strange place!</span>")
+	to_chat(affecting, "<span class='hypnotext'>You have been captured by a ninja! The portal that brought you here will collapse in 5 minutes and return you to the station.</span>")
 
 	if(!QDELETED(master))//As long as they still exist.
 		to_chat(master, "<span class='notice'><b>SUCCESS</b>: transport procedure of [affecting] complete.</span>")
@@ -91,8 +98,15 @@ It is possible to destroy the net by the occupant or someone else.
 		var/mob/living/carbon/human/H = target
 		for(var/obj/item/W in H)
 			if(W == H.w_uniform)
+				REMOVE_TRAIT(W, TRAIT_NODROP, NINJA_KIDNAPPED_TRAIT)
+				// So no cheeky buggers can store stuff in their boots to bring it back
+				for (var/obj/item/subitem in W)
+					H.dropItemToGround(subitem)
 				continue//So all they're left with are shoes and uniform.
 			if(W == H.shoes)
+				REMOVE_TRAIT(W, TRAIT_NODROP, NINJA_KIDNAPPED_TRAIT)
+				for (var/obj/item/subitem in W)
+					H.dropItemToGround(subitem)
 				continue
 			H.dropItemToGround(W)
 		// After we remove items, at least give them what they need to live.

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -86,6 +86,18 @@ It is possible to destroy the net by the occupant or someone else.
 	// If you get gibbed or deleted, your soul will be trapped forever
 	if (QDELETED(target))
 		return
+	// Drop any items acquired from the location
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		for(var/obj/item/W in H)
+			if(W == H.w_uniform)
+				continue//So all they're left with are shoes and uniform.
+			if(W == H.shoes)
+				continue
+			H.dropItemToGround(W)
+		// After we remove items, at least give them what they need to live.
+		H.dna.species.give_important_for_life(H)
+	// Teleport
 	var/turf/safe_location = get_safe_random_station_turfs()
 	do_teleport(target, safe_location, channel = TELEPORT_CHANNEL_FREE, forced = TRUE)
 	target.Unconscious(3 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so people can no longer bring items back from the ninja hotel.
People drop all items that they didn't come with before leaving and cannot change their clothes while in the hotel.

## Why It's Good For The Game

People can bring back the null rods and other overpowered weapons that are in the hotel.

## Testing Photographs and Procedure


https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e3493533-c7c5-4b42-850d-56a3ee6ee0e6

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/463e3db9-83c6-425a-b3ea-7f059628c00f)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/c6392241-0bcd-4e79-8658-bdf568ecdd03)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/708651ff-18a0-4246-8165-1292ae747e65)

## Changelog
:cl:
fix: You can no longer bring items back from the hotel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
