### PR TITLE
Stasis beds no longer protect against changeling eggs, xeno eggs or zombie tumours

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -54,9 +54,6 @@
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/organ/body_egg/alien_embryo/egg_process()
-	var/mob/living/L = owner
-	if(IS_IN_STASIS(L))
-		return
 	if(!next_stage_time)
 		COOLDOWN_START(src, next_stage_time, 30 SECONDS)
 		return
@@ -77,8 +74,6 @@
 				AttemptGrow(FALSE)
 				return
 		AttemptGrow()
-
-
 
 /obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(kill_on_success = TRUE)
 	if(!owner || bursting)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -56,10 +56,7 @@
 	var/time
 
 /obj/item/organ/body_egg/changeling_egg/egg_process()
-	// Changeling eggs grow in dead people, but not people in stasis
-	var/mob/living/L = owner
-	if(IS_IN_STASIS(L))
-		return
+	// Changeling eggs grow in dead people
 	time++
 	if(time >= EGG_INCUBATION_TIME)
 		Pop()

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -43,8 +43,6 @@
 /obj/item/organ/zombie_infection/process(delta_time)
 	if(!owner)
 		return
-	if(IS_IN_STASIS(owner))
-		return
 	if(!(src in owner.internal_organs))
 		Remove(owner, TRUE)
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stasis beds will no longer slow down changeling egg progression, xeno egg progression or zombie tumour development.

## Why It's Good For The Game

These things can be treated as external processes which aren't part of the main mob's body.
The main reason for this is balancing, stasis beds completely remove any sense of time urgency and pressure when dealing with these threats which ruins the extremely tense moments of trying to remove a xeno egg from someone at the last moment. It also completely nullifies them, making the game no risk and incredibly boring.

## Testing Photographs and Procedure


https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/db4f6266-edae-4bd6-993c-b8a526fd1b48



## Changelog
:cl:
balance: Xeno eggs, Changeling eggs and Zombie tumours are no longer slowed by stasis beds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
