### PR TITLE
Tells players to check their notes if they have an objective that has special equipment

### DIFF
--- a/code/game/gamemodes/objectives/basic/steal.dm
+++ b/code/game/gamemodes/objectives/basic/steal.dm
@@ -38,10 +38,20 @@ GLOBAL_LIST_EMPTY(possible_items)
 		explanation_text = "Steal [targetinfo.name]"
 		if (length(targetinfo.special_equipment))
 			generate_stash(targetinfo.special_equipment)
+		update_explanation_text()
 		return steal_target
 	else
 		explanation_text = "Free objective"
 		return
+
+/datum/objective/steal/update_explanation_text()
+	if (!targetinfo)
+		explanation_text = "Free objective"
+		return
+	explanation_text = "Steal [targetinfo.name]"
+	if (length(targetinfo.special_equipment))
+		explanation_text += " Check your character's notes for the location of your special equipment."
+	return ..()
 
 /datum/objective/steal/admin_edit(mob/admin)
 	var/list/possible_items_all = GLOB.possible_items


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds on a message telling players to check their notes if they get an objective that needs special equipment.

## Why It's Good For The Game

Informs players of where to find the information about their stash.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/259b10b9-f66c-459f-9939-9952a265f2d8)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/4163d1a7-143f-453c-b616-1f9fe2736f4d)

## Changelog
:cl:
add: Adds a note onto objectives that require a stash informing players to read their notes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
