### PR TITLE
Makes crafting items put the result on a rack/table in front of the user if the user's hands are full

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -202,9 +202,7 @@
 			if(!user.put_in_hands(result))
 				var/turf/front_turf = get_step(user, user.dir)
 				if(user.TurfAdjacent(front_turf))
-					var/obj/structure/rack/found_rack = locate(/obj/structure/rack) in front_turf
-					var/obj/structure/table/found_table = locate(/obj/structure/table) in front_turf
-					if(found_rack || found_table)
+					if((locate(/obj/structure/table) in front_turf) || (locate(/obj/structure/rack) in front_turf))
 						result.forceMove(front_turf)
 						result.pixel_x = rand(-4, 4)
 						result.pixel_y = rand(-4, 4)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -201,12 +201,13 @@
 		if(ismob(user) && isitem(result)) //In case the user is actually possessing a non mob like a machine
 			if(!user.put_in_hands(result))
 				var/turf/front_turf = get_step(user, user.dir)
-				var/obj/structure/rack/found_rack = locate(/obj/structure/rack) in front_turf
-				var/obj/structure/table/found_table = locate(/obj/structure/table) in front_turf
-				if(found_rack || found_table)
-					result.forceMove(front_turf)
-					result.pixel_x = rand(-4, 4)
-					result.pixel_y = rand(-4, 4)
+				if(user.TurfAdjacent(front_turf))
+					var/obj/structure/rack/found_rack = locate(/obj/structure/rack) in front_turf
+					var/obj/structure/table/found_table = locate(/obj/structure/table) in front_turf
+					if(found_rack || found_table)
+						result.forceMove(front_turf)
+						result.pixel_x = rand(-4, 4)
+						result.pixel_y = rand(-4, 4)
 		else
 			result.forceMove(user.drop_location())
 		to_chat(user, "<span class='notice'>[TR.name] constructed.</span>")

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -199,7 +199,14 @@
 	log_crafting(user, TR.name, result, TR.dangerous_craft)
 	if(!istext(result)) //We made an item and didn't get a fail message
 		if(ismob(user) && isitem(result)) //In case the user is actually possessing a non mob like a machine
-			user.put_in_hands(result)
+			if(!user.put_in_hands(result))
+				var/turf/front_turf = get_step(user, user.dir)
+				var/obj/structure/rack/found_rack = locate(/obj/structure/rack) in front_turf
+				var/obj/structure/table/found_table = locate(/obj/structure/table) in front_turf
+				if(found_rack || found_table)
+					result.forceMove(front_turf)
+					result.pixel_x = rand(-4, 4)
+					result.pixel_y = rand(-4, 4)
 		else
 			result.forceMove(user.drop_location())
 		to_chat(user, "<span class='notice'>[TR.name] constructed.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes crafting items put the result on a rack/table in front of the user if the user's hands are full
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It would make sense that you'd put something on a table after making it instead of dropping it on the floor.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/34a23317-75e2-45f3-8dae-08af2822a74a

</details>

## Changelog
:cl:
tweak: Made crafting an item be put on a table or rack in front of the user if their hands are full
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
