### PR TITLE
PDA messages now highlight codewords.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -390,6 +390,13 @@
 		if(signal.data["automated"])
 			reply = "\[Automated Message\]"
 
+		var/datum/antagonist/traitor/receiver_traitor = L.mind?.has_antag_datum(/datum/antagonist/traitor)
+		if(receiver_traitor?.should_give_codewords)
+			var/message = signal.data["message"]
+			message = GLOB.syndicate_code_phrase_regex.Replace(message, "<span class='blue'>$1</span>")
+			message = GLOB.syndicate_code_response_regex.Replace(message, "<span class='red'>$1</span>")
+			signal.data["message"] = message
+
 		var/inbound_message = signal.format_message(include_photo = TRUE)
 		if(signal.data["emojis"] == TRUE)//so will not parse emojis as such from pdas that don't send emojis
 			inbound_message = emoji_parse(inbound_message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes PDA message notifications highlight codewords. Simple af. Sadly, the code's a bit... hardcoded, but there's no better way to do this without a refactor.

## Why It's Good For The Game

Easy to miss codewords in PDA messages

## Testing Photographs and Procedure

![23-08-23-1692830814-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/e74f99af-23de-48df-a0fc-d489edfc9254)

## Changelog
:cl:
add: As a traitor, PDA message notifications now highlight codewords.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
