### PR TITLE
Fix flaky operating computer linking test

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -14,13 +14,9 @@
 	var/datum/techweb/linked_techweb
 	light_color = LIGHT_COLOR_BLUE
 
-/obj/machinery/computer/operating/Initialize(mapload)
-	..()
-	linked_techweb = SSresearch.science_tech
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/computer/operating/LateInitialize()
+/obj/machinery/computer/operating/Initialize()
 	. = ..()
+	linked_techweb = SSresearch.science_tech
 	link_with_table()
 
 /obj/machinery/computer/operating/Destroy()

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -23,13 +23,6 @@
 /obj/machinery/stasis/Initialize()
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(dir_changed))
 	dir_changed(new_dir = dir)
-	return ..()
-
-/obj/machinery/stasis/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/machinery/stasis/LateInitialize()
 	. = ..()
 	initial_link()
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -556,11 +556,7 @@
 	var/mob/living/carbon/human/patient = null
 	var/obj/machinery/computer/operating/computer = null
 
-/obj/structure/table/optable/Initialize(mapload)
-	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/structure/table/optable/LateInitialize()
+/obj/structure/table/optable/Initialize()
 	. = ..()
 	initial_link()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This just manually calls the initial linking proc for stasis beds / operating computers / operating tables immediately during the unit test

## Why It's Good For The Game

unit tests are good when they work

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Hard to test due to inconsistency of errors; let's see if the tests here pass

## Changelog
:cl:
code: Fixed the unit test for operating computer linking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
