### PR TITLE
Fixes the obsessed greeting displaying twice

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST(admin_antag_list)
 			to_chat(owner.current, "<span class='boldnotice'>For more info, read the panel. \
 				You can always come back to it using the button in the top left.</span>")
 			info_button?.Trigger()
-	greet()
+		greet()
 	apply_innate_effects()
 	give_antag_moodies()
 	if(is_banned(owner.current) && replace_banned)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Antag datum `on_gain` always ran `greet()` regardless of the `silent` variable... This fixes that.

## Why It's Good For The Game

bugfix good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

### Before
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/3cc7dd89-848a-41ce-9e01-c1493e91cf31)

### After
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/09ed0ec9-d4a2-4080-9cf7-ed96b362b8aa)

</details>

## Changelog
:cl:
fix: Fixed the obsessed greeting text displaying twice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
