### PR TITLE
Fixes the raven emergency shuttle console

### DIFF
--- a/_maps/shuttles/emergency/emergency_raven.dmm
+++ b/_maps/shuttles/emergency/emergency_raven.dmm
@@ -19,7 +19,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "af" = (
-/obj/machinery/computer/shuttle_flight,
+/obj/machinery/computer/emergency_shuttle,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)


### PR DESCRIPTION
## About The Pull Request

Fixes #5468
Looks like the attempted fix in the supercruise PR actually just replaced it with a wrong other type of shuttle console

## Why It's Good For The Game

Being able to early launch emergency shuttles can be useful

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
You can look at mapdiffbot
</details>

## Changelog
:cl:
fix: Fixed raven emergency shuttle console not working
/:cl:
