### PR TITLE
Revert "Abductors can now make custom abductee objectives"

### DIFF
--- a/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
@@ -1,5 +1,5 @@
 /datum/objective/abductee
-	completed = TRUE
+	completed = 1
 
 /datum/objective/abductee/random
 
@@ -52,6 +52,3 @@
 /datum/objective/abductee/forbiddennumber/New()
 	var/number = rand(2,10)
 	explanation_text = "Ignore anything in a set of [number], they don't exist."
-
-/datum/objective/abductee/custom
-	explanation_text = "Custom abductee objective failed to initialize, this is a BUG!"

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -189,13 +189,6 @@
 	roundend_category = "abductees"
 	antagpanel_category = "Abductee"
 	banning_key = UNBANNABLE_ANTAGONIST
-	var/list/cured_objectives = list()
-	var/custom_objective
-
-/datum/antagonist/abductee/New(custom_objective)
-	. = ..()
-	if(custom_objective)
-		src.custom_objective = custom_objective
 
 /datum/antagonist/abductee/on_gain()
 	give_objective()
@@ -212,14 +205,10 @@
 
 /datum/antagonist/abductee/proc/give_objective()
 	var/mob/living/carbon/human/H = owner.current
-	var/datum/objective/abductee/objective
-	if(custom_objective)
-		objective = new /datum/objective/abductee/custom(custom_objective)
-	else
-		var/objective_type = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
-		objective = new objective_type
-	objectives += objective
-	log_objective(H, objective.explanation_text)
+	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
+	var/datum/objective/abductee/O = new objtype()
+	objectives += O
+	log_objective(H, O.explanation_text)
 
 /datum/antagonist/abductee/apply_innate_effects(mob/living/mob_override)
 	update_abductor_icons_added(mob_override ? mob_override.mind : owner,"abductee")
@@ -227,30 +216,6 @@
 /datum/antagonist/abductee/remove_innate_effects(mob/living/mob_override)
 	update_abductor_icons_removed(mob_override ? mob_override.mind : owner)
 
-/datum/antagonist/abductee/roundend_report()
-	var/list/report = list()
-
-	if(!owner)
-		CRASH("antagonist datum without owner")
-
-	report += printplayer(owner)
-
-	if(length(objectives))
-		report += "<b>[owner.name] was <span class='redtext'>burdened</span> with the following obsessions:</b>"
-		var/count = 1
-		for(var/datum/objective/objective as() in objectives)
-			report += "<b>Objective #[count]</b>: [objective.explanation_text]"
-			count++
-	if(length(cured_objectives))
-		report += "<b>[owner.name] was <span class='greentext'>freed</span> from the following obsessions:</b>"
-		var/count = 1
-		for(var/cured_objective in cured_objectives)
-			report += "<b>Objective #[count]</b>: [cured_objective]"
-			count++
-	if(!length(objectives))
-		report += "<span class='big greentext'>[owner.name] was freed from the obsessions imprinted upon them!</span>"
-
-	return report.Join("<br>")
 
 // LANDMARKS
 /obj/effect/landmark/abductor

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -101,7 +101,7 @@
 			var/mob/living/mob_occupant = occupant
 			if(mob_occupant.stat == DEAD)
 				return
-			flash = experiment(mob_occupant, params["experiment_type"], usr, params["objective"])
+			flash = experiment(mob_occupant, params["experiment_type"], usr)
 			return TRUE
 
 /**
@@ -112,7 +112,7 @@
  * * type The type of experiment to be performed
  * * user The mob starting the experiment
  */
-/obj/machinery/abductor/experiment/proc/experiment(mob/occupant, type, mob/user, custom_objective)
+/obj/machinery/abductor/experiment/proc/experiment(mob/occupant, type, mob/user)
 	LAZYINITLIST(history)
 	var/mob/living/carbon/human/H = occupant
 
@@ -147,16 +147,7 @@
 				to_chat(H, "<span class='warning'>You feel intensely watched.</span>")
 		sleep(5)
 		user_abductor.team.abductees += H.mind
-		if(custom_objective)
-			if(OOC_FILTER_CHECK(custom_objective))
-				message_admins("[ADMIN_LOOKUPFLW(user)] attempted to imprint [ADMIN_LOOKUPFLW(occupant)] with the custom abductee objective '[custom_objective]', however it was blocked by the OOC filter!")
-				log_admin("[key_name(user)] attempted to imprint [key_name(occupant)] with the custom abductee objective '[custom_objective]', however it was blocked by the OOC filter!")
-				custom_objective = null
-			else
-				deadchat_broadcast("<span class='deadsay'><b>[H]</b> has been imprinted with the custom abductee objective: <b>[custom_objective]</b></span>", follow_target = occupant, turf_target = get_turf(occupant), message_type = DEADCHAT_REGULAR)
-				log_game("[key_name(user)] imprinted [key_name(occupant)] with the custom abductee objective '[custom_objective]'.")
-				message_admins("[ADMIN_LOOKUPFLW(user)] imprinted [ADMIN_LOOKUPFLW(occupant)] with the custom abductee objective '[custom_objective]'.")
-		H.mind.add_antag_datum(new /datum/antagonist/abductee(custom_objective))
+		H.mind.add_antag_datum(/datum/antagonist/abductee)
 
 		for(var/obj/item/organ/heart/gland/G in H.internal_organs)
 			G.Start()

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -45,32 +45,8 @@
 			"[user] successfully lobotomizes [target]!",
 			"[user] completes the surgery on [target]'s brain.")
 	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
-	if(target.mind)
-		if(target.mind.has_antag_datum(/datum/antagonist/brainwashed))
-			unbrainwash(target)
-		// Remove abductee objectives.
-		var/datum/antagonist/abductee/abductee = target.mind.has_antag_datum(/datum/antagonist/abductee)
-		if(abductee && length(abductee.objectives))
-			if(istype(target.getorganslot(ORGAN_SLOT_HEART), /obj/item/organ/heart/gland))
-				target.visible_message("<span class='warning'>[target]'s facial expression relaxes for a second, before seeming stressed once more.</span>")
-				to_chat(target, "<span class='danger'>You feel <span class='hypnophrase'>free</span> from the objective imprinted upon your broken psyche for a second... but it takes hold of you once more.</span>")
-			else
-				message_admins("[ADMIN_LOOKUPFLW(user)] removed [ADMIN_LOOKUPFLW(target)]'s abductee objectives with a lobotomy.")
-				log_game("[key_name(user)] removed [key_name(target)]'s abductee objectives with a lobotomy.")
-				for(var/datum/objective/abductee/objective in abductee.objectives)
-					abductee.cured_objectives |= objective.explanation_text
-				QDEL_LIST(abductee.objectives)
-				to_chat(target, "<span class='userdanger'>You're <span class='hypnophrase'>FREE</span>! The obsessions imprinted upon your broken psyche no longer has any hold over you, although you cannot remember any actions you took while under the influence of them...</span>")
-				switch(target.stat)
-					if(CONSCIOUS)
-						// dramatically faint, to give them a bit of time to come to terms with being free.
-						target.Unconscious(30 SECONDS)
-						target.visible_message("<span class='warning'>[target] suddenly faints, [target.p_their()] body relaxing as if [target.p_theyve()] been freed from a deep stress!</span>")
-					if(UNCONSCIOUS)
-						target.visible_message("<span class='warning'>[target]'s facial expression relaxes, as if [target.p_theyve()] been freed from a deep stress!</span>")
-					else
-						SWITCH_EMPTY_STATEMENT // they're dead, how tf you gonna tell?
-				target.mind.announce_objectives()
+	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
+		unbrainwash(target)
 	switch(rand(0, 3))//Now let's see what hopefully-not-important part of the brain we cut off
 		if(1)
 			target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)

--- a/tgui/packages/tgui/interfaces/ProbingConsole.js
+++ b/tgui/packages/tgui/interfaces/ProbingConsole.js
@@ -1,65 +1,12 @@
-import { useBackend, useLocalState } from '../backend';
-import { Button, Dimmer, LabeledList, NoticeBox, Icon, Input, Section, Stack } from '../components';
+import { useBackend } from '../backend';
+import { Button, LabeledList, NoticeBox, Section } from '../components';
 import { Window } from '../layouts';
 
-const ProbingConsoleConfirmation = (_props, context) => {
-  const { act } = useBackend(context);
-  const [customObjective, setCustomObjective] = useLocalState(context, 'customObjective', '');
-  const [experimentPopup, setExperimentPopup] = useLocalState(context, 'experimentPopup', 0);
-  return (
-    <Dimmer>
-      <Stack align="baseline" textAlign="center" fontSize="14px" vertical>
-        <Stack.Item>
-          <Icon color="yellow" name="brain" size={5} />
-        </Stack.Item>
-        <Stack.Item>
-          Are you sure you want to imprint the <br />
-          following goal onto the subject?
-        </Stack.Item>
-        <Stack.Item>
-          <b>{customObjective}</b>
-        </Stack.Item>
-        <Stack.Item>
-          <Stack>
-            <Stack.Item grow>
-              <Button
-                color="good"
-                content="Yes!"
-                onClick={() => {
-                  act('experiment', {
-                    experiment_type: experimentPopup,
-                    objective: customObjective,
-                  });
-                  setExperimentPopup(0);
-                  setCustomObjective('');
-                }}
-              />
-            </Stack.Item>
-            <Stack.Item grow>
-              <Button
-                color="bad"
-                content="No"
-                onClick={() => {
-                  setExperimentPopup(0);
-                }}
-              />
-            </Stack.Item>
-          </Stack>
-        </Stack.Item>
-      </Stack>
-    </Dimmer>
-  );
-};
-
-export const ProbingConsole = (_props, context) => {
+export const ProbingConsole = (props, context) => {
   const { act, data } = useBackend(context);
   const { open, feedback, occupant, occupant_name, occupant_status } = data;
-  const [customObjective, setCustomObjective] = useLocalState(context, 'customObjective', '');
-  const [experimentPopup, setExperimentPopup] = useLocalState(context, 'experimentPopup', 0);
-  const trimmedCustomObjective = customObjective.trim();
   return (
-    <Window width={400} height={240} theme="abductor">
-      {experimentPopup > 0 && <ProbingConsoleConfirmation />}
+    <Window width={330} height={207} theme="abductor">
       <Window.Content>
         <Section>
           <LabeledList>
@@ -83,53 +30,33 @@ export const ProbingConsole = (_props, context) => {
                 color={occupant_status === 3 ? 'bad' : occupant_status === 2 ? 'average' : 'good'}>
                 {occupant_status === 3 ? 'Deceased' : occupant_status === 2 ? 'Unconscious' : 'Conscious'}
               </LabeledList.Item>
-              <LabeledList.Item label="Psyche Imprinter">
-                <Input
-                  value={customObjective}
-                  onInput={(_e, value) => setCustomObjective(value)}
-                  placeholder="Optional Objective"
-                  fluid
-                />
-              </LabeledList.Item>
               <LabeledList.Item label="Experiments">
                 <Button
                   icon="thermometer"
                   content="Probe"
-                  onClick={() => {
-                    if (trimmedCustomObjective.length > 0) {
-                      setExperimentPopup(1);
-                    } else {
-                      act('experiment', {
-                        experiment_type: 1,
-                      });
-                    }
-                  }}
+                  onClick={() =>
+                    act('experiment', {
+                      experiment_type: 1,
+                    })
+                  }
                 />
                 <Button
                   icon="brain"
                   content="Dissect"
-                  onClick={() => {
-                    if (trimmedCustomObjective.length > 0) {
-                      setExperimentPopup(2);
-                    } else {
-                      act('experiment', {
-                        experiment_type: 2,
-                      });
-                    }
-                  }}
+                  onClick={() =>
+                    act('experiment', {
+                      experiment_type: 2,
+                    })
+                  }
                 />
                 <Button
                   icon="search"
                   content="Analyze"
-                  onClick={() => {
-                    if (trimmedCustomObjective.length > 0) {
-                      setExperimentPopup(3);
-                    } else {
-                      act('experiment', {
-                        experiment_type: 2,
-                      });
-                    }
-                  }}
+                  onClick={() =>
+                    act('experiment', {
+                      experiment_type: 3,
+                    })
+                  }
                 />
               </LabeledList.Item>
             </LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts BeeStation/BeeStation-Hornet#8996

## Why It's Good For The Game

yeah turns out this was unbalanced and led to a shitshow

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
del: Abductors can no longer customize abductee objectives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
