### PR TITLE
Abductor mental interface devices messages are now shown to deadchat

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -346,6 +346,11 @@
 
 		to_chat(L, "<span class='italics'>You hear a voice in your head saying: </span><span class='abductor'>[message]</span>")
 		to_chat(user, "<span class='notice'>You send the message to your target.</span>")
+
+		for(var/mob/dead/observer/ghost in GLOB.dead_mob_list)
+			var/sender = FOLLOW_LINK(ghost, user)
+			var/receiver = FOLLOW_LINK(ghost, L)
+			to_chat(ghost, "<span class='deadsay'>[sender] <span class='name'>[user]</span> <span class='abductor'>Abductor Mental Telepathy</span> -> [receiver] <span class='name'>[L]</span>: <span class='bold message'>[message]</span></span>")
 		log_directed_talk(user, L, message, LOG_SAY, "abductor whisper")
 
 

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -59,7 +59,7 @@
 	to_chat(owner, "<span class='mind_control'>[command]</span>")
 	active_mind_control = TRUE
 	log_admin("[key_name(user)] sent an abductor mind control message to [key_name(owner)]: [command]")
-	deadchat_broadcast("<span class='deadsay'><span class='name'>[user]</span> send an abductor mind control message to <span class='name'>[owner]</span>: <span class='bold message'>[command]</span></span>", follow_target = owner, turf_target = get_turf(owner), message_type = DEADCHAT_REGULAR)
+	deadchat_broadcast("<span class='deadsay'><span class='name'>[user]</span> sent an abductor mind control message to <span class='name'>[owner]</span>: <span class='bold message'>[command]</span></span>", follow_target = owner, turf_target = get_turf(owner), message_type = DEADCHAT_REGULAR)
 	update_gland_hud()
 	var/atom/movable/screen/alert/mind_control/mind_alert = owner.throw_alert("mind_control", /atom/movable/screen/alert/mind_control)
 	mind_alert.command = command

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -59,6 +59,7 @@
 	to_chat(owner, "<span class='mind_control'>[command]</span>")
 	active_mind_control = TRUE
 	log_admin("[key_name(user)] sent an abductor mind control message to [key_name(owner)]: [command]")
+	deadchat_broadcast("<span class='deadsay'><span class='name'>[user]</span> send an abductor mind control message to <span class='name'>[owner]</span>: <span class='bold message'>[command]</span></span>", follow_target = owner, turf_target = get_turf(owner), message_type = DEADCHAT_REGULAR)
 	update_gland_hud()
 	var/atom/movable/screen/alert/mind_control/mind_alert = owner.throw_alert("mind_control", /atom/movable/screen/alert/mind_control)
 	mind_alert.command = command


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This ensures telepathy and mind control messages sent by abductor mental interface thingymajigs are now shown to deadchat.

## Why It's Good For The Game

No reason for it not to.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-08-29-1693354027-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/b2c912c1-171d-4c59-8af1-c6fecd0cff20)

</details>

## Changelog
:cl:
add: Abductor mental interface devices messages are now shown to deadchat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
