### PR TITLE
Fix NtOS notepad easily hitting rate limits

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNotepad.js
+++ b/tgui/packages/tgui/interfaces/NtosNotepad.js
@@ -1,3 +1,4 @@
+import { Component } from 'inferno';
 import { NtosWindow } from '../layouts';
 import { useBackend } from '../backend';
 import { Section, TextArea, Button } from '../components';
@@ -13,18 +14,58 @@ export const NtosNotepad = (props, context) => {
           buttons={!!has_paper && <Button icon="file-alt" content="Show Scanned Paper" onClick={() => act('ShowPaper')} />}
           fill
           fitted>
-          <TextArea
-            fluid
-            style={{ height: '100%' }}
-            backgroundColor="black"
-            textColor="white"
-            onInput={(_, value) => {
-              act('UpdateNote', { newnote: value });
-            }}
-            value={note}
-          />
+          <BufferedNotepad note={note} />
         </Section>
       </NtosWindow.Content>
     </NtosWindow>
   );
 };
+
+const NOTEPAD_UPDATE_INTERVAL = 4000;
+
+class BufferedNotepad extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      bufferedNotes: props.note || '',
+      notesChanged: false,
+    };
+  }
+
+  componentDidMount() {
+    this.bufferTimer = setInterval(this.pushBuffer.bind(this), NOTEPAD_UPDATE_INTERVAL);
+  }
+
+  componentWillUnmount() {
+    this.pushBuffer();
+    clearInterval(this.bufferTimer);
+  }
+
+  pushBuffer = () => {
+    const { act } = useBackend(this.context);
+    const { bufferedNotes, notesChanged } = this.state;
+    if (notesChanged) {
+      act('UpdateNote', { newnote: bufferedNotes });
+      this.setState({ notesChanged: false });
+    }
+  };
+
+  render() {
+    const { bufferedNotes } = this.state;
+    const updateBuffer = (_, value) => {
+      this.setState({ bufferedNotes: value, notesChanged: true });
+    };
+
+    return (
+      <TextArea
+        fluid
+        style={{ height: '100%' }}
+        backgroundColor="black"
+        textColor="white"
+        onInput={updateBuffer}
+        onChange={this.pushBuffer.bind(this)}
+        value={bufferedNotes}
+      />
+    );
+  }
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This reworks the PDA notepad into buffering writes, so that it doesn't send an act for Every. Single. Input, which easily hits rate limits and results in stuff you type being lost.

## Why It's Good For The Game

Because the PDA notepad should be, y'know, usable

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/38f79282-d1cc-480a-a393-2e060f66960d



</details>

## Changelog
:cl: Absolucy, Itsmeowdev
fix: The PDA/NtOS notepad is now actually usable, you won't hit rate limits just typing into it normally!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
