### PR TITLE
Makes sleepers no longer block reagents other than Epinephrene for patients in crit + small sleeper bugfix

### DIFF
--- a/code/game/machinery/sleeper.dm
+++ b/code/game/machinery/sleeper.dm
@@ -344,8 +344,7 @@
 	var/obj/item/reagent_containers/stored_vial = inserted_vials[chem]
 	for (var/datum/reagent/reagent in stored_vial.reagents.reagent_list)
 		var/amount = mob_occupant.reagents.get_reagent_amount(reagent.type) + 10 <= 16 * efficiency
-		var/occ_health = mob_occupant.health > min_health || reagent.type == /datum/reagent/medicine/epinephrine
-		if (!amount || !occ_health)
+		if(!amount)
 			return FALSE
 	return TRUE
 

--- a/code/game/machinery/sleeper.dm
+++ b/code/game/machinery/sleeper.dm
@@ -106,9 +106,9 @@
 		if (length(inserted_vials) >= max_vials)
 			to_chat(user, "<span class='warning'>[src] cannot hold any more!</span>")
 			return
+		if(!user.transferItemToLoc(I, null))
+			return
 		user.visible_message("<span class='notice'>[user] inserts \the [I] into \the [src]</span>", "<span class='notice'>You insert \the [I] into \the [src]</span>")
-		user.temporarilyRemoveItemFromInventory(I)
-		I.forceMove(null)
 		inserted_vials += I
 		ui_update()
 		return

--- a/code/game/machinery/sleeper.dm
+++ b/code/game/machinery/sleeper.dm
@@ -15,7 +15,6 @@
 	clicksound = 'sound/machines/pda_button1.ogg'
 
 	var/efficiency = 1.25
-	var/min_health = -25
 	var/list/available_chems
 	var/controls_inside = FALSE
 	/// the maximum amount of chem containers the sleeper can hold. Value can be changed by parts tier and RefreshParts()
@@ -86,7 +85,6 @@
 
 	max_vials = 5 + E
 	efficiency = initial(efficiency) * sqrt(I)
-	min_health = initial(min_health) * E
 	available_chems = list()
 
 	//Eject chems

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -122,7 +122,7 @@ export const Sleeper = (props, context) => {
                     fluid
                     content={chem.name + ' (' + chem.amount + 'u)'}
                     tooltip={chem.name + ' (' + chem.amount + 'u)'}
-                    disabled={!(occupied && chem.allowed)}
+                    disabled={!(occupied)}
                     onClick={() =>
                       act('inject', {
                         chem: chem.id,

--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -122,7 +122,7 @@ export const Sleeper = (props, context) => {
                     fluid
                     content={chem.name + ' (' + chem.amount + 'u)'}
                     tooltip={chem.name + ' (' + chem.amount + 'u)'}
-                    disabled={!(occupied)}
+                    disabled={!occupied}
                     onClick={() =>
                       act('inject', {
                         chem: chem.id,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the sleeper unit no longer block people from injecting chemicals other than Epinephrene when a patient is in critical state.
Fixes an issue where inserting an item into the sleeper and getting forcestripped through means like contractor abduction would "duplicate" the inserted items.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
https://github.com/BeeStation/BeeStation-Hornet/pull/7861 majorly overhauled sleeper beds, making them draw chemicals from inserted beakers and chemical bags. This paved way for chemists making their own custom critical stabilization mixes. Which sadly were unusable to to the sleeper blocking anything that wasn't epinephrene. This PR allows custom crit heal mixes to actually be used by sleepers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/29cb4331-a3d5-454a-b580-8c6ac1e9e374

</details>

## Changelog
:cl:
tweak: Made sleeper beds no longer block chemicals other than Epinephrine from being injected into patients in critical state.
fix: Fixed the contents of the sleeper being duplicated after the person who inserted them got forcestripped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
