### PR TITLE
Prevent rust heretic from mansus grasping floors/walls/objects when on harm intent

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -57,7 +57,7 @@
 /datum/heretic_knowledge/rust_fist
 	name = "Grasp of Rust"
 	desc = "Your Mansus Grasp will deal 500 damage to non-living matter and rust any surface it touches. \
-		Already rusted surfaces are destroyed. Surfaces and structures can only be rusted by using Disarm intent."
+		Already rusted surfaces are destroyed. Surfaces and structures can only be rusted while in Help, Disarm or Grab intent."
 	gain_text = "On the ceiling of the Mansus, rust grows as moss does on a stone."
 	next_knowledge = list(/datum/heretic_knowledge/rust_regen)
 	cost = 1

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -71,6 +71,8 @@
 
 /datum/heretic_knowledge/rust_fist/proc/on_mansus_grasp(mob/living/source, mob/living/target)
 	SIGNAL_HANDLER
+	if(source.a_intent == INTENT_HARM && !iscarbon(target))
+		return
 	return target.rust_heretic_act()
 
 


### PR DESCRIPTION
## About The Pull Request

Prevent rust heretic from mansus grasping floors/walls/objects when on harm intent.

## Why It's Good For The Game

We all know you don't want to rust that floor tile when in a fight.
The other lores don't have this issue as they don't interact with floors/walls

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/8070319/be356ba2-78f4-4809-9bd7-e545547afc95



</details>

## Changelog
:cl:
tweak: Rust heretic will no longer mansus grasping floors/walls/objects when on harm intent
/:cl:
