### PR TITLE
Makes lights turning off roundstart in unstaffed departments a config option

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -444,3 +444,5 @@
 /datum/config_entry/flag/spare_enforce_coc
 
 /datum/config_entry/flag/station_traits
+
+/datum/config_entry/flag/dark_unstaffed_departments

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -28,7 +28,8 @@
 		name = "light switch ([area.name])"
 
 	update_appearance(updates = UPDATE_ICON|UPDATE_OVERLAYS)
-	RegisterSignal(SSdcs, COMSIG_GLOB_POST_START, PROC_REF(turn_off))
+	if(CONFIG_GET(flag/dark_unstaffed_departments))
+		RegisterSignal(SSdcs, COMSIG_GLOB_POST_START, PROC_REF(turn_off))
 	return
 
 /obj/machinery/light_switch/update_overlays()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -656,3 +656,6 @@ SPARE_ENFORCE_COC
 
 ## Uncomment to disable local bans, effectively enforcing only global bans
 DISABLE_LOCAL_BANS
+
+## Comment this to disable roundstart lights being turned off in non-staffed departments
+#DARK_UNSTAFFED_DEPARTMENTS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes lights turning off roundstart in unstaffed departments a config option.
* closes https://github.com/BeeStation/BeeStation-Hornet/issues/9762
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for less stress during testing and for turning off the feature for downstreams.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/1c13506d-9273-4178-8453-c17cdd7987b0)

</details>

## Changelog
:cl:
config: Made unstaffed departments having their lights be turned off at roundstart a config option
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
