### PR TITLE
Adds automatic chat highlighting + a toggle for a sound playing when someone mentions the AI on the radio.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1153,4 +1153,4 @@
 			break
 
 	if(ai_notice_jingle && found_mention)
-		playsound_local(get_turf(src), 'sound/machines/twobeep.ogg', 50)
+		playsound_local(get_turf(src), 'sound/machines/twobeep.ogg', 25)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes any variation of "AI" plus the AI's name and name with dots removed, be automatically highlighted in the chat for AI players.
Adds a toggle for a sound playing whenever "AI" or the AI's name is mentioned for the AI player.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows AI players to more easily notice people calling for their attention.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/c3fb21c3-8846-432d-a931-dea99cb7e691

</details>

## Changelog
:cl:
add: Added automatic chat highlighting for AI players that includes "AI" and the AI player's name
add: Added a toggle for a sound playing whenever the AI player hears "AI" or their name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
