### PR TITLE
Fix incorrect custom virus names being shown

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -234,6 +234,10 @@
 		SSdisease.archive_diseases[the_id] = Copy()
 		if(new_name)
 			AssignName()
+	else
+		var/actual_name = SSdisease.get_disease_name(GetDiseaseID())
+		if(actual_name != "Unknown")
+			name = actual_name
 
 //Generate disease properties based on the effects. Returns an associated list.
 /datum/disease/advance/proc/GenerateProperties()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This properly updates advance virus names upon refresh.

## Why It's Good For The Game

It's annoying making a healing virus with a name like "Healing Virus", but scanners only show a symptom name as the disease name, and can lead to both IC and OOC confusion.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-09-03-1693785552-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/c931513b-639a-4f37-8606-56aa492900b7)
![23-09-03-1693785538-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/62152e60-4859-47a7-8787-84689cbbf5a9)

</details>

## Changelog
:cl:
fix: Fix incorrect custom virus names being shown by health analyzers and viral extrapolators.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->