### PR TITLE
Removes reinforcements from most airlocks

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -6,7 +6,6 @@
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	normal_integrity = 450
-	security_level = AIRLOCK_SECURITY_PLASTEEL_O_S
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
@@ -86,7 +85,6 @@
 	opacity = FALSE
 	glass = TRUE
 	normal_integrity = 400
-	security_level = AIRLOCK_SECURITY_PLASTEEL_O_S
 
 /obj/machinery/door/airlock/engineering/glass
 	opacity = FALSE
@@ -444,7 +442,6 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_highsecurity
 	explosion_block = 2
 	normal_integrity = 500
-	security_level = AIRLOCK_SECURITY_IRON
 	damage_deflection = 30
 
 //////////////////////////////////
@@ -476,7 +473,6 @@
 	hackProof = TRUE
 	aiControlDisabled = 1
 	normal_integrity = 700
-	security_level = AIRLOCK_SECURITY_IRON
 	allow_repaint = FALSE
 
 //////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes roundstart plasteel and iron plating from most airlocks, with exception to the vault and centcom airlocks. Airlocks may still be manually reinforced if desired. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

With wiring changes it's an unnecessary hurdle to hacking (*and repairing*) airlocks

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/c3f8c7a6-fefd-401a-840e-c19e1955f87c)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/05e1d0fa-8300-410b-9ab0-aebc87bc23f8)

## Changelog
:cl:
tweak: Removes roundstart plasteel and iron reinforcements from most airlocks, with exception to CentCom and the Vault. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
