### PR TITLE
Fix Rust heretic's mansus grasp on doors

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -71,8 +71,17 @@
 
 /datum/heretic_knowledge/rust_fist/proc/on_mansus_grasp(mob/living/source, mob/living/target)
 	SIGNAL_HANDLER
-	if(source.a_intent == INTENT_HARM && (!iscarbon(target) && !istype(target, /obj/machinery/door)))
-		return
+	var/static/list/always_hit_typecache = typecacheof(list(
+        /mob/living/carbon,
+        /mob/living/silicon,
+        /mob/living/simple_animal/bot,
+        /obj/item/storage/secure/safe/caps_spare,
+        /obj/machinery/door,
+        /obj/mecha
+    ))
+    // The reason this is not simply an isturf is because we likely don't want to hit random machinery like holopads and such!
+    if(source.a_intent == INTENT_HARM && !is_type_in_typecache(target, always_hit_typecache))
+        return
 	return target.rust_heretic_act()
 
 

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -71,7 +71,7 @@
 
 /datum/heretic_knowledge/rust_fist/proc/on_mansus_grasp(mob/living/source, mob/living/target)
 	SIGNAL_HANDLER
-	if(source.a_intent == INTENT_HARM && !iscarbon(target))
+	if(source.a_intent == INTENT_HARM && (!iscarbon(target) && !istype(target, /obj/machinery/door)))
 		return
 	return target.rust_heretic_act()
 

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -72,16 +72,16 @@
 /datum/heretic_knowledge/rust_fist/proc/on_mansus_grasp(mob/living/source, mob/living/target)
 	SIGNAL_HANDLER
 	var/static/list/always_hit_typecache = typecacheof(list(
-        /mob/living/carbon,
-        /mob/living/silicon,
-        /mob/living/simple_animal/bot,
-        /obj/item/storage/secure/safe/caps_spare,
-        /obj/machinery/door,
-        /obj/mecha
-    ))
-    // The reason this is not simply an isturf is because we likely don't want to hit random machinery like holopads and such!
-    if(source.a_intent == INTENT_HARM && !is_type_in_typecache(target, always_hit_typecache))
-        return
+		/mob/living/carbon,
+		/mob/living/silicon,
+		/mob/living/simple_animal/bot,
+		/obj/item/storage/secure/safe/caps_spare,
+		/obj/machinery/door,
+		/obj/mecha
+	))
+	// The reason this is not simply an isturf is because we likely don't want to hit random machinery like holopads and such!
+	if(source.a_intent == INTENT_HARM && !is_type_in_typecache(target, always_hit_typecache))
+		return
 	return target.rust_heretic_act()
 
 


### PR DESCRIPTION
## About The Pull Request


After testing again I found out that you can only **attack** doors when in HARM intent and any other intent would just open/close it.
Due to  #9771 ignoring everything besides carbons you could not rust-attack doors anymore

Absolucy has improved the code and added objects that you nearly always want to hit, like borgs, bots, mechs.

## Why It's Good For The Game

Breaking door/windoor with magic hand = good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/8070319/f85808a0-5a32-4781-8f1a-f962bba2c149



</details>

## Changelog
:cl: Absolucy 
fix: Rust mansus grasp now works on door, mechs, borgs, bots while in Harm intent
/:cl: