### PR TITLE
Fixes holopad hologram plays record where it shouldn't exist anylonger

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -634,6 +634,10 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/holopad/proc/replay_entry(entry_number)
 	if(!replay_mode)
 		return
+	if(!anchored || (machine_stat & NOPOWER))
+		record_stop()
+		replay_stop()
+		return
 	if (!disk.record.entries.len) // check for zero entries such as photographs and no text recordings
 		return // and pretty much just display them statically until manually stopped
 	if(disk.record.entries.len < entry_number)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Fixes: #9785

Permanently lingering hologram that says things unlimitedly is annoying

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/7dd38f68-3ce0-405e-8e53-14989da11112)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/2fb53fb6-b317-4a94-a430-2fd1b7ce6629)

after unwrenched


## Changelog
:cl:
fix: Holopad holograms are no longer projected when its originated holopad is unanchored or depowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
