### PR TITLE
No Unanchoring Holopads Anymore

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -157,9 +157,6 @@ Possible to do for anyone motivated enough:
 	if(default_pry_open(P))
 		return
 
-	if(default_unfasten_wrench(user, P))
-		return
-
 	if(default_deconstruction_crowbar(P))
 		return
 


### PR DESCRIPTION
## About The Pull Request

## Why It's Good For The Game

Bugs and Soft Griefing Bad. 

My thought process behind removing the unanchoring was that there is no real use to have an unanchored holopad, if it needs to be secured to project holograms. Plus, most machines in game have to be disassembled to move, and because this is not a dense machine, nothing is really lost by having to screwdriver + crowbar first.

Fixes #9785.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/fdb90a31-13e1-4f67-a3d0-06d56a1b5f8d)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/f7583629-4b31-4043-a92e-67230f12473f)

</details>

## Changelog
:cl:
del: Mobile Holopads are a thing of the past
/:cl: