### PR TITLE
Virology symptom culture naming bugfix, extrapolator extra scanning info, and PANDEMIC consistency tweaks

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -43,6 +43,8 @@
 	var/mutability = 1
 	var/dormant = FALSE //this prevents a disease from having any effects or spreading
 	var/keepid = FALSE
+	/// Whether to always keep the name, and never update it based on the archive
+	var/name_locked = FALSE
 	var/archivecure
 	var/static/list/advance_cures = list(
 		list(/datum/reagent/water, /datum/reagent/consumable/nutriment, /datum/reagent/ash, /datum/reagent/iron),
@@ -165,6 +167,7 @@
 	A.speed = speed
 	A.keepid = keepid
 	A.id = id
+	A.name_locked = name_locked
 	//this is a new disease starting over at stage 1, so processing is not copied
 	return A
 
@@ -234,7 +237,7 @@
 		SSdisease.archive_diseases[the_id] = Copy()
 		if(new_name)
 			AssignName()
-	else
+	else if(!name_locked)
 		var/actual_name = SSdisease.get_disease_name(GetDiseaseID())
 		if(actual_name != "Unknown")
 			name = actual_name
@@ -479,7 +482,8 @@
 
 	 // Should be only 1 entry left, but if not let's only return a single entry
 	var/datum/disease/advance/to_return = pick(diseases)
-	to_return.Refresh(1)
+	to_return.name_locked = FALSE
+	to_return.Refresh(TRUE)
 	return to_return
 
 /proc/SetViruses(datum/reagent/R, list/data)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -1163,7 +1163,14 @@ GENE SCANNER
 				var/datum/disease/advance/advance_disease = disease
 				if(advance_disease.stealth >= maximum_stealth) //the extrapolator can detect diseases of higher stealth than a normal scanner
 					continue
-				message += "<span class='info'><b>[advance_disease.name]</b>, [advance_disease.dormant ? "<i>dormant virus</i>" : "stage [advance_disease.stage]/5"]</span>"
+				var/list/properties
+				if(!advance_disease.mutable)
+					LAZYADD(properties, "immutable")
+				if(advance_disease.faltered)
+					LAZYADD(properties, "faltered")
+				if(advance_disease.carrier)
+					LAZYADD(properties, "carrier")
+				message += "<span class='info'><b>[advance_disease.name]</b>[LAZYLEN(properties) ? " ([properties.Join(", ")])" : ""], [advance_disease.dormant ? "<i>dormant virus</i>" : "stage [advance_disease.stage]/5"]</span>"
 				if(extracted_ids[advance_disease.GetDiseaseID()])
 					message += "<span class='info italics'>This virus has been extracted by \the [src] previously.</span>"
 				message += "<span class='info bold'>[advance_disease.name] has the following symptoms:</span>"
@@ -1224,6 +1231,7 @@ GENE SCANNER
 	var/datum/disease/advance/symptom_holder = new
 	symptom_holder.name = chosen.name
 	symptom_holder.symptoms += chosen
+	symptom_holder.name_locked = TRUE
 	symptom_holder.Finalize()
 	symptom_holder.Refresh()
 	if(do_after(user, extract_time, target = target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just some minor virology tweaks and bugfixes, a follow-up to my previous virology PR. See changelog for info.

## Why It's Good For The Game

bugfix good, qol good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-09-06-1694022319-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/570405c8-3072-4ecf-b51e-58820ca7e3ea)
![23-09-06-1694022366](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ee3ed670-5aba-455b-81b3-ff0790d940ed)
![23-09-06-1694022405](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/941c2f32-75bd-4cff-9d92-ca1c09ca91f7)
![23-09-06-1694022432-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/d608e236-6d0c-47f5-a927-6fe6cdfde40e)
![23-09-06-1694022470-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/7a7260c1-588e-4b43-be86-966fccacc624)
![23-09-06-1694022489-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/8dcb0250-574b-44da-bfc9-97736c34c663)

</details>

## Changelog
:cl:
fix: Virus symptom cultures extracted by the viral extrapolator will now always be properly named as the symptom.
add: The viral extrapolator will now show if a disease is immutable, faltered, and/or a carrier.
tweak: The PanD.E.M.I.C will now copy properties such as faltering and immutability to newly made cultures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
