### PR TITLE
Glue tweaks

### DIFF
--- a/code/game/objects/items/devices/glue.dm
+++ b/code/game/objects/items/devices/glue.dm
@@ -1,11 +1,12 @@
 /obj/item/syndie_glue
 	name = "bottle of super glue"
-	desc = "A black market brand of high strength adhesive, rarely sold to the public. Do not ingest."
+	desc = "A black market brand of high strength adhesive, rarely sold to the public. Sudden air movements may cause instant drying! Do not ingest."
 	icon = 'icons/obj/tools.dmi'
 	icon_state	= "glue"
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = ISWEAPON
 	var/uses = 1
+	var/drying_time = 30 SECONDS //Adminbus, woo! Set to 0 if you want the glue to work instantly
 
 /obj/item/syndie_glue/suicide_act(mob/living/M)
 	M.visible_message("<span class='suicide'>[M] is drinking the whole bottle of glue! It looks like [M.p_theyre()] trying to commit suicide!</span>")
@@ -16,19 +17,36 @@
 	if(!proximity || !target)
 		return
 	else
-		if(uses == 0)
-			to_chat(user, "<span class='warning'>The bottle of glue is empty!</span>")
+		if(uses <= 0) //Just in case it somehow goes below 0
+			to_chat(user, "<span class='warning'>\The [name] is empty!</span>")
 			return
 		if(istype(target, /obj/item))
 			var/obj/item/I = target
 			if(HAS_TRAIT_FROM(I, TRAIT_NODROP, GLUED_ITEM_TRAIT))
-				to_chat(user, "<span class='warning'>[I] is already sticky!</span>")
+				to_chat(user, "<span class='warning'>\The [I] is already sticky!</span>")
 				return
 			uses -= 1
-			ADD_TRAIT(I, TRAIT_NODROP, GLUED_ITEM_TRAIT)
-			I.desc += " It looks sticky."
-			to_chat(user, "<span class='notice'>You smear the [I] with glue, making it incredibly sticky!</span>")
-			if(uses == 0)
+			if(uses <= 0)
 				icon_state = "glue_used"
 				name = "empty bottle of super glue"
+			if(drying_time > 0)
+				addtimer(CALLBACK(I, PROC_REF(get_glued)), drying_time)
+				I.register_glue_signals()
+				to_chat(user, "<span class='notice'>You smear \the [I] with glue, which will make it incredibly sticky once the glue dries!</span>")
+			else
+				get_glued()
+				to_chat(user, "<span class='notice'>You smear \the [I] with glue, making it incredibly sticky!</span>")
 			return
+
+/obj/item/proc/register_glue_signals()
+	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, PROC_REF(get_glued))
+	RegisterSignal(src, COMSIG_ITEM_DROPPED, PROC_REF(get_glued))
+
+/obj/item/proc/get_glued()
+	SIGNAL_HANDLER
+	if(HAS_TRAIT_FROM(src, TRAIT_NODROP, GLUED_ITEM_TRAIT))
+		return
+	ADD_TRAIT(src, TRAIT_NODROP, GLUED_ITEM_TRAIT)
+	desc += "<span class='notice'> It looks sticky.</span>"
+	UnregisterSignal(src, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
+	return

--- a/code/game/objects/items/devices/glue.dm
+++ b/code/game/objects/items/devices/glue.dm
@@ -49,4 +49,3 @@
 	ADD_TRAIT(src, TRAIT_NODROP, GLUED_ITEM_TRAIT)
 	desc += "<span class='notice'> It looks sticky.</span>"
 	UnregisterSignal(src, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
-	return

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -41,12 +41,14 @@
 			to_chat(user,"<span class='notice'>[src] already has a wig attached!</span>")
 			return
 		else
+			if(!user.transferItemToLoc(W, src))
+				to_chat(user, "<span class='warning'>\The [W] is stuck to your hand and can't be attached to \the [src]!</span>")
+				return
 			attached_wig = W
 			attached_wig.hat_attached_to = src
-			W.forceMove(src)
 			add_verb(/obj/item/clothing/head/verb/unattach_wig)
 			update_icon()
-			strip_delay = 10 //The fake hair makes it really easy to swipe the hat off the head
+			strip_delay = 1 SECONDS //The fake hair makes it really easy to swipe the hat off the head
 			attached_wig.equipped(user, ITEM_SLOT_HEAD)
 
 
@@ -55,17 +57,23 @@
 	set category = "Object"
 	set src in usr
 
-	usr.put_in_hands(attached_wig)
-	if (usr.get_item_by_slot(ITEM_SLOT_HEAD) == src)
-		attached_wig.dropped(usr)
+	var/mob/user = usr
+	if(!user)
+		return
+	if(HAS_TRAIT_FROM(attached_wig, TRAIT_NODROP, GLUED_ITEM_TRAIT))
+		to_chat(user, "<span class='warning'>\The [attached_wig] is stuck to \the [src] and can't be detached!</span>")
+		return
+	user.put_in_hands(attached_wig)
+	if (user.get_item_by_slot(ITEM_SLOT_HEAD) == user)
+		attached_wig.dropped(user)
 	attached_wig.hat_attached_to = null
 	attached_wig = null
 	update_icon()
 	remove_verb(/obj/item/clothing/head/verb/unattach_wig)
 	strip_delay = initial(strip_delay)
-	if(ishuman(usr))
-		var/mob/living/carbon/human/H = usr
-		if(H.head == src)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.head == user)
 			H.update_inv_head()
 
 /obj/item/clothing/head/Destroy()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -974,7 +974,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 /mob/living/simple_animal/parrot/Poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."
-	color = "#2ba8f077"
+	color = "#FFFFFF77"
 	speak_chance = 20
 	status_flags = GODMODE
 	incorporeal_move = INCORPOREAL_MOVE_BASIC

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -974,7 +974,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 /mob/living/simple_animal/parrot/Poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."
-	color = "#FFFFFF77"
+	color = "#2ba8f077"
 	speak_chance = 20
 	status_flags = GODMODE
 	incorporeal_move = INCORPOREAL_MOVE_BASIC

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1689,8 +1689,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Glue"
 	desc = "A cheap bottle of one use syndicate brand super glue. \
 			Use on any item to make it undroppable. \
-			Takes approximately thirty seconds to dry up once used. \
-			Sudden movement may cause it to dry up instantly. \
+			When applied, will stick the item in either thirty seconds or instantly upon dropping or picking it up. \
 			Be careful not to glue an item you're already holding!"
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	item = /obj/item/syndie_glue

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1689,6 +1689,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Glue"
 	desc = "A cheap bottle of one use syndicate brand super glue. \
 			Use on any item to make it undroppable. \
+			Takes approximately thirty seconds to dry up once used. \
+			Sudden movement may cause it to dry up instantly. \
 			Be careful not to glue an item you're already holding!"
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	item = /obj/item/syndie_glue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the glue item apply the nodrop trait after you hold the item for 30 seconds or drop/equip it. Meaning you can reverse pickpocket or throw something after applying glue to it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for more gimmick opportunities for tator tots.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/53d59620-10bd-403b-a4dc-1de75cf91295

</details>

## Changelog
:cl:
tweak: Made applying glue to an item make it stuck either after 30 seconds pass or after you drop/move/equip the item
fix: Fixed being able to add/remove glued wigs to hats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
