### PR TITLE
Syndicate bombs no longer get negative timers

### DIFF
--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -62,7 +62,7 @@
 			else if(seconds_left >= MEDIUM_FUSE_THRESHOLD)
 				if(time_cut)
 					return
-				B.detonation_timer -= seconds_left * 0.5
+				B.detonation_timer -= seconds_left * 0.5 SECONDS
 				time_cut = TRUE
 			else if(seconds_left >= SHORT_FUSE_THRESHOLD) // Both to prevent negative timers and to have a little mercy.
 				B.detonation_timer = world.time + 10 SECONDS

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -13,8 +13,6 @@
 	var/fake_delayed_hesitate = FALSE
 	/// If the time's been cut in half by a bad pulse
 	var/time_cut = FALSE
-	/// If mercy's already been shown for a bad pulse
-	var/
 
 /datum/wires/syndicatebomb/New(atom/holder)
 	wires = list(

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -13,6 +13,8 @@
 	var/fake_delayed_hesitate = FALSE
 	/// If the time's been cut in half by a bad pulse
 	var/time_cut = FALSE
+	/// If mercy's already been shown for a bad pulse
+	var/
 
 /datum/wires/syndicatebomb/New(atom/holder)
 	wires = list(
@@ -56,15 +58,15 @@
 		if(WIRE_PROCEED)
 			holder.visible_message("<span class='danger'>[icon2html(B, viewers(holder))] The bomb buzzes ominously!</span>")
 			playsound(B, 'sound/machines/buzz-sigh.ogg', 30, 1)
-			var/seconds = B.seconds_remaining()
-			if(seconds >= LONG_FUSE_THRESHOLD) // Long fuse bombs can suddenly become more dangerous if you tinker with them.
+			var/seconds_left = B.seconds_remaining()
+			if(seconds_left >= LONG_FUSE_THRESHOLD) // Long fuse bombs can suddenly become more dangerous if you tinker with them.
 				B.detonation_timer = world.time + 60 SECONDS
-			else if(seconds >= MEDIUM_FUSE_THRESHOLD)
+			else if(seconds_left >= MEDIUM_FUSE_THRESHOLD)
 				if(time_cut)
 					return
-				B.detonation_timer *= 0.5
+				B.detonation_timer -= seconds_left * 0.5
 				time_cut = TRUE
-			else if(seconds >= SHORT_FUSE_THRESHOLD) // Both to prevent negative timers and to have a little mercy.
+			else if(seconds_left >= SHORT_FUSE_THRESHOLD) // Both to prevent negative timers and to have a little mercy.
 				B.detonation_timer = world.time + 10 SECONDS
 		if(WIRE_ACTIVATE)
 			if(!B.active)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a problem where syndicate bombs could get negative timers when pulsing wires.

<details>
<summary>Diagnosing the Issue</summary>

Referenced code: [/code/datums/wires/syndicatebomb.dm](https://github.com/BeeStation/BeeStation-Hornet/blob/66083df3ccde4c4e299827dee12f4885b72188b7/code/datums/wires/syndicatebomb.dm)

When pulsing wires, the Proceed wire's logic is as follows:
<details>
<summary>Proceed Wire Code</summary>

```dm
if(WIRE_PROCEED)
	holder.visible_message("<span class='danger'>[icon2html(B, viewers(holder))] The bomb buzzes ominously!</span>")
	playsound(B, 'sound/machines/buzz-sigh.ogg', 30, 1)
	var/seconds = B.seconds_remaining()		if(seconds >= LONG_FUSE_THRESHOLD) // Long fuse bombs can suddenly become more dangerous if you tinker with them.
		B.detonation_timer = world.time + 60 SECONDS
	else if(seconds >= MEDIUM_FUSE_THRESHOLD)
		if(time_cut)
			return
		B.detonation_timer *= 0.5
		time_cut = TRUE
	else if(seconds >= SHORT_FUSE_THRESHOLD) // Both to prevent negative timers and to have a little mercy.
		B.detonation_timer = world.time + 10 SECONDS
```
</details>

`B.detionation_timer` is when the bomb explodes in `world.time`, and most of it acknowledges that ***except*** for this line:
`B.detonation_timer *= 0.5`

The effect is that this sets the detonation timer to a point *before* the bomb was even activated, causing instananeous detonation. (And in effect, a *negative* timer, which isn't intended)
<details>
<summary>The effect</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/cf9e90f6-9a39-468e-9a7c-b138a13a74a5)
</details>
</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unintended behaviour is often unwanted behaviour.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Referenced code: [/code/datums/wires/syndicatebomb.dm](https://github.com/BeeStation/BeeStation-Hornet/blob/66083df3ccde4c4e299827dee12f4885b72188b7/code/datums/wires/syndicatebomb.dm)

<details>
<summary>Solving</summary>
What *should* be happening is the bomb's detonation time being set to a time directly in the middle of `world.time` `B.detonation_timer`, which halves the bomb's time as per this variable description. 

```dm
	/// If the time's been cut in half by a bad pulse
	var/time_cut = FALSE
```

`B.detonation_timer *= 0.5`
The problem is this statement gives a time between `0` and `B.detonation_timer`, and doesn't take into account `world.time`.

So, what I did was take into account that we have a time currently set (`B.detonation_timer`), and the seconds left in that time (`seconds_left`). So with that in mind, this is what I came up with:

`B.detonation_timer -= seconds_left * 0.5 SECONDS`

Which solves the problem, as shown:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/6acfe678-da9e-45aa-b9c6-0ffdb0ba77cd)
</details>

(this PR also refactors the inline variable `seconds` to be `seconds_left`)

## Changelog
:cl:
fix: Syndicate bombs no longer gain a negative timer when pulsing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
