### PR TITLE
Slight armour slowdowns.

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -22,6 +22,7 @@
 		/obj/item/gun/energy,
 		/obj/item/restraints/handcuffs
 		)
+	slowdown = 0
 	var/mode = VEST_STEALTH
 	var/stealth_active = FALSE
 	/// Cooldown in seconds

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -11,6 +11,7 @@
 	resistance_flags = NONE
 	armor = list(MELEE = 30,  BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, STAMINA = 30)
 	clothing_flags = THICKMATERIAL
+	slowdown = 0.02
 
 /obj/item/clothing/suit/armor/Initialize(mapload)
 	. = ..()
@@ -155,6 +156,7 @@
 	blood_overlay_type = "armor"
 	armor = list(MELEE = 35,  BULLET = 25, LASER = 25, ENERGY = 30, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, STAMINA = 20)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
+	slowdown = 0.04
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "bulletproof armor"
@@ -209,6 +211,7 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	armor = list(MELEE = 80,  BULLET = 80, LASER = 50, ENERGY = 60, BOMB = 100, BIO = 100, RAD = 100, FIRE = 90, ACID = 90, STAMINA = 70)
+	slowdown = 0.04
 
 /obj/item/clothing/suit/armor/heavy
 	name = "heavy armor"
@@ -222,6 +225,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor = list(MELEE = 80,  BULLET = 80, LASER = 50, ENERGY = 60, BOMB = 100, BIO = 100, RAD = 100, FIRE = 90, ACID = 90, STAMINA = 60)
 	move_sound = list('sound/effects/suitstep1.ogg', 'sound/effects/suitstep2.ogg')
+	slowdown = 0.1
 
 /obj/item/clothing/suit/armor/tdome
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -265,6 +269,7 @@
 	icon_state = "knight_green"
 	item_state = "knight_green"
 	move_sound = null
+	slowdown = 0.08
 
 /obj/item/clothing/suit/armor/riot/knight/yellow
 	icon_state = "knight_yellow"
@@ -295,6 +300,7 @@
 	icon_state = "rus_armor"
 	item_state = "rus_armor"
 	armor = list(MELEE = 25,  BULLET = 30, LASER = 0, ENERGY = 15, BOMB = 10, BIO = 0, RAD = 20, FIRE = 20, ACID = 50, STAMINA = 25)
+	slowdown = 0.01
 
 /obj/item/clothing/suit/armor/vest/russian_coat
 	name = "russian battle coat"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -11,7 +11,7 @@
 	resistance_flags = NONE
 	armor = list(MELEE = 30,  BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, STAMINA = 30)
 	clothing_flags = THICKMATERIAL
-	slowdown = 0.02
+	slowdown = 0.08
 
 /obj/item/clothing/suit/armor/Initialize(mapload)
 	. = ..()
@@ -145,7 +145,7 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
-	slowdown = 0.05
+	slowdown = 0.15
 	move_sound = list('sound/effects/suitstep1.ogg', 'sound/effects/suitstep2.ogg')
 
 /obj/item/clothing/suit/armor/bone
@@ -156,7 +156,7 @@
 	blood_overlay_type = "armor"
 	armor = list(MELEE = 35,  BULLET = 25, LASER = 25, ENERGY = 30, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, STAMINA = 20)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	slowdown = 0.04
+	slowdown = 0.1
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "bulletproof armor"
@@ -211,7 +211,7 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	armor = list(MELEE = 80,  BULLET = 80, LASER = 50, ENERGY = 60, BOMB = 100, BIO = 100, RAD = 100, FIRE = 90, ACID = 90, STAMINA = 70)
-	slowdown = 0.04
+	slowdown = 0.1
 
 /obj/item/clothing/suit/armor/heavy
 	name = "heavy armor"
@@ -225,7 +225,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor = list(MELEE = 80,  BULLET = 80, LASER = 50, ENERGY = 60, BOMB = 100, BIO = 100, RAD = 100, FIRE = 90, ACID = 90, STAMINA = 60)
 	move_sound = list('sound/effects/suitstep1.ogg', 'sound/effects/suitstep2.ogg')
-	slowdown = 0.1
+	slowdown = 0.3
 
 /obj/item/clothing/suit/armor/tdome
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -300,7 +300,7 @@
 	icon_state = "rus_armor"
 	item_state = "rus_armor"
 	armor = list(MELEE = 25,  BULLET = 30, LASER = 0, ENERGY = 15, BOMB = 10, BIO = 0, RAD = 20, FIRE = 20, ACID = 50, STAMINA = 25)
-	slowdown = 0.01
+	slowdown = 0.05
 
 /obj/item/clothing/suit/armor/vest/russian_coat
 	name = "russian battle coat"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -624,6 +624,7 @@
 	item_state = "coatsecurity"
 	armor = list(MELEE = 25,  BULLET = 15, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 0, ACID = 45, STAMINA = 20)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/security
+	slowdown = 0.01
 
 /obj/item/clothing/suit/hooded/wintercoat/security/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -624,7 +624,7 @@
 	item_state = "coatsecurity"
 	armor = list(MELEE = 25,  BULLET = 15, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 0, ACID = 45, STAMINA = 20)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/security
-	slowdown = 0.01
+	slowdown = 0.05
 
 /obj/item/clothing/suit/hooded/wintercoat/security/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -56,7 +56,12 @@
   *
   */
 /client/Move(n, direct)
-	if(world.time < move_delay) //do not move anything ahead of this check please
+	// If the movement delay is slightly less than the period from now until the next tick,
+	// let us move and take the additional delay and add it onto the next move. This means that
+	// it will slowly stack until we can lose a tick, where the ticks we lose are proportional
+	// to the slowdowns difference to the next tick step.
+	var/floored_move_delay = FLOOR(move_delay, 1 / world.fps)
+	if(world.time < floored_move_delay) //do not move anything ahead of this check please
 		return FALSE
 	else
 		next_move_dir_add = 0
@@ -132,6 +137,10 @@
 
 	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
 		add_delay *= 1.414214 // sqrt(2)
+	// Record any time that we gained due to sub-tick slowdown
+	var/move_delta = move_delay - floored_move_delay
+	add_delay += move_delta
+	// Apply the movement delay
 	move_delay += add_delay
 	if(.) // If mob is null here, we deserve the runtime
 		if(mob.throwing)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts an extremely small amount of slowdowns on armour.
This also fixes a bug I found during testing where the current riot armour slowdown doesn't actually slow you down at all.

|Armor Type|Slowdown|
|-|-|
|Standard armor suit|8ms longer between each step|
|Riot Armour|15ms longer between each step|
|Bone Armour|10ms longer between each step|
|Russain vest & Security winter coat|5ms longer between each step|
|Abductor vest|No additional increase|

(A slowdown of 1 means that each step takes 100ms longer)

Previously with a run relay of 200ms per step, this should theoretically give the following speeds
|Armor|20 meters|
|-|-|
|None|4 seconds|
|Standard|4.16 seconds|
|Riot armour|4.3 seconds|

The security winter coat is worse than the armour vest so I gave it less slowdown.

## Why It's Good For The Game

This gives an extremely minor amount of slowdown to most armours, which in turns means that when people are trying to evade security they have an extremely slight speed advantage and if are actually able to evade for long enough have a chance of getting away.
People getting away from sec provides a lot more long term engagement when compared to someone being captured and allows security to be closer to that position of hard to kill but at the same time aren't too cracked at arresting everyone on the station within seconds of their prescence being announced.

This is part of one of my goals to have more minor speed differences in players so that situations like chases, arrests and other combat things aren't fully balanced in terms of speed between a heavily armed person and someone with nothing.

Abductors get a slowdown of 0 because they need to chase people.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/1fafede6-d358-49ca-be44-297be0373ff1

## Changelog

:cl:
balance: All forms of armour will now provide minor amounts of slowdown.
fix: Fixes slowdowns not working for values smaller than 1/world.fps seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
