### PR TITLE
Lowers the volume of IPC footsteps and riot armour for the wearer

### DIFF
--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -98,7 +98,7 @@
 			//Sound of wearing shoes always plays, special movement sound
 			// IE (server motors wont play bare footed.)
 			if(H.dna.species.special_step_sounds)
-				playsound(T, pick(H.dna.species.special_step_sounds), 50, TRUE)
+				playsound(LM, pick(H.dna.species.special_step_sounds), 80, TRUE, self_volume = 40)
 
 			else if((!H.shoes && !feetCover)) //are we NOT wearing shoes
 				playsound(T, pick(GLOB.barefootstep[T.barefootstep][1]),

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -41,7 +41,7 @@ falloff_distance - Distance at which falloff begins. Sound is at peak volume (in
 
 */
 
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, self_volume = null)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -76,7 +76,7 @@ falloff_distance - Distance at which falloff begins. Sound is at peak volume (in
 			listeners += get_hearers_in_view(maxdistance, below_turf)
 	for(var/mob/listening_mob in listeners | SSmobs.dead_players_by_zlevel[source_z])//observers always hear through walls
 		if(get_dist(listening_mob, turf_source) <= maxdistance)
-			listening_mob.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb)
+			listening_mob.playsound_local(turf_source, soundin, listening_mob == source && !isnull(self_volume) ? self_volume : vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, maxdistance, falloff_distance, 1, use_reverb)
 			hearers += listening_mob
 	return hearers
 

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -46,7 +46,7 @@
 	if(!istype(H) || H.wear_suit != src)
 		return
 	if(world.time > footstep)
-		playsound(src, pick(move_sound), 65, 1)
+		playsound(H, pick(move_sound), 65, 1, self_volume = 25)
 		footstep = world.time + FOOTSTEP_COOLDOWN
 
 /obj/item/clothing/suit/equipped(mob/user, slot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Players can get annoyed by things like the riot armour movesound, so this lowers the volume for the wearer.

## Why It's Good For The Game

Things will be quiet for the wearer while still retaining the downside of being hearable by other players.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/7635a2a6-c0d1-4d1a-bfad-8d50eb35822c)
Can't record with audio, so have a screenshot to show the testing instead.

## Changelog
:cl:
tweak: Servo motor sound and worn clothing will now be quieter for the person wearing them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
