### PR TITLE
Add recharging station to Kilo

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -21992,9 +21992,6 @@
 /area/crew_quarters/toilet/restrooms)
 "bKU" = (
 /obj/effect/turf_decal/box,
-/obj/structure/toilet{
-	dir = 8
-	},
 /obj/structure/mirror{
 	pixel_x = -28
 	},
@@ -22020,6 +22017,7 @@
 	pixel_x = 24;
 	pixel_y = -8
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
 "bKX" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

added a borg charging station in the bathroom of Kilo Station, replacing a toilet. 

## Testing Photos and Procedures

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/134568049/7e39644f-2021-4cf8-8942-f7cad94eb42e)


## Why It's Good For The Game

Helps unify Kilo with other maps, and adds convenience for borg players and IPCs

</details>

## Changelog
add: added a recharging station