### PR TITLE
Remove breath-related moodlets and alerts whenever NOBREATH is added

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -106,6 +106,7 @@
 	source.failed_last_breath = FALSE
 	for(var/alert_category in thrown_alerts)
 		source.clear_alert(alert_category)
+	LAZYNULL(thrown_alerts)
 	for(var/moodlet in breath_moodlets)
 		SEND_SIGNAL(source, COMSIG_CLEAR_MOOD_EVENT, moodlet)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, there is a bug where, if self-resp (or some other source of `TRAIT_NOBREATH`, but self-resp is the most common) kicks in while you are currently suffocating, you'll be stuck suffocating forever - you'll have the alert popup and the "CAN'T... BREATHE..." moodlet forever.

This fixes that.

## Why It's Good For The Game

eternally suffocating bc self-resp kicked in while you were suffocating is bad and annoying and stupid

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/daffe083-73e1-4e9c-a59d-54017800c39c

</details>

## Changelog
:cl:
fix: You will no longer suffocate eternally if you stop needing to breathe while in the middle of suffocating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
