### PR TITLE
Projectile Shrapnel Embed Fix

### DIFF
--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -229,6 +229,8 @@
 			INVOKE_ASYNC(to_hands, TYPE_PROC_REF(/mob, put_in_hands), weapon)
 		else
 			INVOKE_ASYNC(weapon, TYPE_PROC_REF(/atom/movable, forceMove), get_turf(victim))
+		if(istype(weapon, /obj/item/shrapnel))
+			weapon.disableEmbedding()
 
 	qdel(src)
 

--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -29,7 +29,7 @@
 	var/armour_block
 	var/payload_type
 
-/datum/element/embed/Attach(datum/target, embed_chance, fall_chance, pain_chance, pain_mult, max_damage_mult, remove_pain_mult, rip_time, ignore_throwspeed_threshold, jostle_chance, jostle_pain_mult, pain_stam_pct, armour_block, projectile_payload=/obj/item/shard)
+/datum/element/embed/Attach(datum/target, embed_chance, fall_chance, pain_chance, pain_mult, max_damage_mult, remove_pain_mult, rip_time, ignore_throwspeed_threshold, jostle_chance, jostle_pain_mult, pain_stam_pct, armour_block)
 	. = ..()
 
 	if(!isitem(target) && !isprojectile(target))
@@ -56,7 +56,8 @@
 			src.armour_block = armour_block
 			initialized = TRUE
 	else
-		payload_type = projectile_payload
+		var/obj/projectile/P = target
+		payload_type = P.shrapnel_type
 		RegisterSignal(target, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(checkEmbedProjectile))
 
 
@@ -192,5 +193,6 @@
 	else if(isbodypart(target))
 		limb = target
 		C = limb.owner
+		hit_zone = limb.body_zone
 
 	return checkEmbed(I, C, hit_zone, forced=TRUE)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1211,6 +1211,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(item_flags & DROPDEL)
 		QDEL_NULL(src)
 		return TRUE
+	if(istype(src, /obj/item/shrapnel))
+		src.disableEmbedding()
 
 /**
   * tryEmbed() is for when you want to try embedding something without dealing with the damage + hit messages of calling hitby() on the item while targetting the target.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -149,7 +149,7 @@
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 	var/martial_arts_no_deflect = FALSE
 
-	///If defined, on hit we create an item of this type then call hitby() on the hit target with this, mainly used for embedding items (bullets) in targets
+	///If defined, gets passed to checkEmbedProjectile() via signalling & adds embed element to projectile
 	var/shrapnel_type
 	///If TRUE, hit mobs even if they're on the floor and not our target
 	var/hit_stunned_targets = FALSE
@@ -162,6 +162,8 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	if(shrapnel_type) //Only add embed element if the project HAS STUFF to try to embed
+		AddElement(/datum/element/embed) //Allows Embed to read signal from COMSIG_PROJECTILE_SELF_ON_HIT, actually embedding handled by shrapnel_type
 
 /obj/projectile/proc/Range()
 	range--
@@ -196,7 +198,7 @@
 		SEND_SIGNAL(fired_from, COMSIG_PROJECTILE_BEFORE_FIRE, src, original)
 	// i know that this is probably more with wands and gun mods in mind, but it's a bit silly that the projectile on_hit signal doesn't ping the projectile itself.
 	// maybe we care what the projectile thinks! See about combining these via args some time when it's not 5AM
-	SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle)
+	SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle, def_zone)
 	var/turf/target_loca = get_turf(target)
 
 	var/hitx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes projectile embedding so projectiles that actually bother to set their shrapnel_type variable don't get kicked to the curb after hitting a carbon. This adds an embed element to any projectile with said variable set, spawns a piece of shrapnel on impact, and then attempts to embed that shrapnel in the target at the limb that was hit.

Any shrapnel that failed to embed the first time, or has since fallen out of the target will lose its embed flag (so you can't throw bullets into people after pulling them out of your arm).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Stuff working properly is good; embed code is a fucking nightmare but at least this reigns it in and makes it work properly.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/f1d1390b-f58c-4099-a557-3e259c218d87

As seen below, this bullet shrapnel no long can embed after falling out (no special examine text)
![Post Embed Shrapnel](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/2b4dc2e1-7cff-48d3-b612-76ab807436f1)

</details>

## Changelog
:cl: Impish_Delights, HowToLoLu
fix: Projectile Shrapnel Generates and Embeds Properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
