### PR TITLE
AZERTY + Misc keybind fixes

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -23,7 +23,9 @@ GLOBAL_LIST_INIT(valid_keys, list(
 	"Gamepad3L1" = 1, "Gamepad3L2" = 1, "Gamepad3L3" = 1, "Gamepad3Start" = 1, "Gamepad3Select" = 1, "Gamepad4Up" = 1, "Gamepad4Down" = 1, "Gamepad4Left" = 1,
 	"Gamepad4Right" = 1, "Gamepad4DownLeft" = 1,"Gamepad4DownRight" = 1, "Gamepad4UpLeft" = 1, "Gamepad4UpRight" = 1, "Gamepad4Face1" = 1, "Gamepad4Face2" = 1,
 	"Gamepad4Face3" = 1, "Gamepad4Face4" = 1, "Gamepad4R1" = 1, "Gamepad4R2" = 1, "Gamepad4R3" = 1, "Gamepad4L1" = 1, "Gamepad4L2" = 1, "Gamepad4L3" = 1,
-	"Gamepad4Start" = 1, "Gamepad4Select" = 1, "VolumeUp" = 1, "VolumeDown" = 1, "VolumeMute" = 1, "MediaPlayPause" = 1, "MediaStop" = 1, "MediaNext" = 1,	"MediaPrev" = 1
+	"Gamepad4Start" = 1, "Gamepad4Select" = 1, "VolumeUp" = 1, "VolumeDown" = 1, "VolumeMute" = 1, "MediaPlayPause" = 1, "MediaStop" = 1, "MediaNext" = 1,	"MediaPrev" = 1,
+	// AZERTY support
+	"&" = 1, "é" = 1, "\"" = 1, "(" = 1, "è" = 1, "_" = 1, "ç" = 1, "à" = 1, ")" = 1, "*" = 1, "$" = 1, "!" = 1, ":" = 1, "²" = 1, "ù" = 1,
 ))
 
 /proc/input_sanity_check(client/C, key)
@@ -60,7 +62,11 @@ GLOBAL_LIST_INIT(valid_keys, list(
 		if("Alt", "Ctrl", "Shift")
 			full_key = "[AltMod][CtrlMod][ShiftMod]"
 		else
-			full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
+			if(AltMod || CtrlMod || ShiftMod)
+				full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
+				key_combos_held[_key] = full_key
+			else
+				full_key = _key
 
 	var/list/kbs = list()
 	for (var/kb_name in prefs.key_bindings_by_key[full_key])
@@ -89,6 +95,11 @@ GLOBAL_LIST_INIT(valid_keys, list(
 
 	if(input_sanity_check(src, _key))
 		return
+
+	var/key_combo = key_combos_held[_key]
+	if(key_combo)
+		key_combos_held -= _key
+		keyUp(key_combo)
 
 	keys_held -= _key
 	var/movement = SSinput.movement_keys[_key]

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -25,7 +25,8 @@ GLOBAL_LIST_INIT(valid_keys, list(
 	"Gamepad4Face3" = 1, "Gamepad4Face4" = 1, "Gamepad4R1" = 1, "Gamepad4R2" = 1, "Gamepad4R3" = 1, "Gamepad4L1" = 1, "Gamepad4L2" = 1, "Gamepad4L3" = 1,
 	"Gamepad4Start" = 1, "Gamepad4Select" = 1, "VolumeUp" = 1, "VolumeDown" = 1, "VolumeMute" = 1, "MediaPlayPause" = 1, "MediaStop" = 1, "MediaNext" = 1,	"MediaPrev" = 1,
 	// AZERTY support
-	"&" = 1, "é" = 1, "\"" = 1, "(" = 1, "è" = 1, "_" = 1, "ç" = 1, "à" = 1, ")" = 1, "*" = 1, "$" = 1, "!" = 1, ":" = 1, "²" = 1, "ù" = 1,
+	"&" = 1, "É" = 1, "\"" = 1, "(" = 1, "È" = 1, "_" = 1, "Ç" = 1, "À" = 1, ")" = 1, "*" = 1, "$" = 1, "!" = 1, ":" = 1, "²" = 1, "Ù" = 1,
+	"é" = 1, "è" = 1, "ç" = 1, "à" = 1, "ù" = 1,
 ))
 
 /proc/input_sanity_check(client/C, key)

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -1,6 +1,8 @@
 /client
 	/// A list of any keys held currently
 	var/list/keys_held = list()
+	/// A buffer for combinations such of modifiers + keys (ex: CtrlD, AltE, ShiftT). Format: ["key"] -> ["combo"] (ex: ["D"] -> ["CtrlD"])
+	var/list/key_combos_held = list()
 	// These next two vars are to apply movement for keypresses and releases made while move delayed.
 	// Because discarding that input makes the game less responsive.
 	var/next_move_dir_add // On next move, add this dir to the move that would otherwise be done

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -396,6 +396,8 @@ export class KeybindingsPage extends Component<{}, KeybindingsPageState> {
           <br />
           Contact a maintainer or create an issue report by pressing Report Issue in the top right of the game window.
           <br />
+          Reconnecting will also likely fix this issue.
+          <br />
           <Box textAlign="left" fontSize="12px" textColor="white" style={{ 'white-space': 'pre-wrap' }}>
             Error Details:{'\n'}
             {typeof this.state.error === 'object' && Object.keys(this.state.error).includes('stack')

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -39,6 +39,11 @@ const isStandardKey = (event: KeyboardEvent): boolean => {
   return event.key !== 'Alt' && event.key !== 'Control' && event.key !== 'Shift' && event.key !== 'Esc';
 };
 
+/**
+ * Keys that JS wants to capitalize but BYOND does not.
+ */
+const NO_CAPS_KEYS = ['é', 'è', 'ç', 'à', 'ù'];
+
 const KEY_CODE_TO_BYOND: Record<string, string> = {
   'DEL': 'Delete',
   'DOWN': 'South',
@@ -88,7 +93,10 @@ const formatKeyboardEvent = (event: KeyboardEvent): string => {
   }
 
   if (isStandardKey(event)) {
-    const key = event.key.toUpperCase();
+    let key = event.key;
+    if (!NO_CAPS_KEYS.includes(key)) {
+      key = key.toUpperCase();
+    }
     text += KEY_CODE_TO_BYOND[key] || key;
   }
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/ServerPreferencesFetcher.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/ServerPreferencesFetcher.tsx
@@ -67,6 +67,8 @@ export class ServerPreferencesFetcher extends Component<
         <br />
         Contact a maintainer or create an issue report by pressing Report Issue in the top right of the game window.
         <br />
+        Reconnecting will also likely fix this issue.
+        <br />
         <Box textAlign="left" fontSize="12px" textColor="white" style={{ 'white-space': 'pre-wrap' }}>
           Error Details:{'\n'}
           {typeof lastError === 'object' && Object.keys(lastError).includes('stack') ? lastError.stack : lastError.toString()}


### PR DESCRIPTION
## About The Pull Request

Allows more AZERTY keys to be bound directly.

Fixes #9520

Also ports this to fix stuck keys
- https://github.com/tgstation/tgstation/pull/53988

## Why It's Good For The Game

Fixes a bug and lets people play with AZERTY keybinds.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Tested with various AZERTY keys, they function as expected.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/5633dd17-8116-4dc4-bdca-6e2496c7bc19)

Spammed combinations of Alt, Shift, Ctrl and movement keys, no keys got stuck down.

</details>

## Changelog
:cl:
fix: You can now use keybinds bound to common AZERTY keys such as: & é " ( è _ ç à ) ² $ ù : * !
fix: Keys will no longer get stuck down when using key combinations like Alt, Shift, and Ctrl.
tweak: Improved the error message when preferences/keybinds fail to fetch client data, stating that reconnecting will likely fix it.
/:cl: