### PR TITLE
Fix Z-Clear not properly removing baseturfs

### DIFF
--- a/code/__HELPERS/string_lists.dm
+++ b/code/__HELPERS/string_lists.dm
@@ -18,8 +18,8 @@ GLOBAL_LIST_EMPTY(string_lists)
 	//	return values
 	if(length(values) > 10)
 		stack_trace("The baseturfs list of [baseturf_holder] at [baseturf_holder.x], [baseturf_holder.y], [baseturf_holder.z] is [length(values)]. Values: [values.Join(", ")]")
-		//baseturf_holder.ChangeTurf(/turf/closed/indestructible/baseturfs_ded, list(/turf/closed/indestructible/baseturfs_ded), flags = CHANGETURF_FORCEOP)
-		//return string_list(list(/turf/closed/indestructible/baseturfs_ded)) //I want this reported god damn it
+		baseturf_holder.ChangeTurf(/turf/closed/indestructible/baseturfs_ded, list(/turf/closed/indestructible/baseturfs_ded), flags = CHANGETURF_FORCEOP)
+		return string_list(list(/turf/closed/indestructible/baseturfs_ded)) //I want this reported god damn it
 	return string_list(values)
 
 /turf/closed/indestructible/baseturfs_ded

--- a/code/__HELPERS/string_lists.dm
+++ b/code/__HELPERS/string_lists.dm
@@ -17,9 +17,9 @@ GLOBAL_LIST_EMPTY(string_lists)
 		return values //baseturf things
 	//	return values
 	if(length(values) > 10)
-		stack_trace("The baseturfs list of [baseturf_holder] at [baseturf_holder.x], [baseturf_holder.y], [baseturf_holder.z] is [length(values)], it should never be this long, investigate. I've set baseturfs to a flashing wall as a visual queue")
-		baseturf_holder.ChangeTurf(/turf/closed/indestructible/baseturfs_ded, list(/turf/closed/indestructible/baseturfs_ded), flags = CHANGETURF_FORCEOP)
-		return string_list(list(/turf/closed/indestructible/baseturfs_ded)) //I want this reported god damn it
+		stack_trace("The baseturfs list of [baseturf_holder] at [baseturf_holder.x], [baseturf_holder.y], [baseturf_holder.z] is [length(values)]. Values: [values.Join(", ")]")
+		//baseturf_holder.ChangeTurf(/turf/closed/indestructible/baseturfs_ded, list(/turf/closed/indestructible/baseturfs_ded), flags = CHANGETURF_FORCEOP)
+		//return string_list(list(/turf/closed/indestructible/baseturfs_ded)) //I want this reported god damn it
 	return string_list(values)
 
 /turf/closed/indestructible/baseturfs_ded

--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -330,8 +330,9 @@ SUBSYSTEM_DEF(zclear)
 		var/turf/newT
 		if(istype(T, /turf/open/space))
 			newT = T
+			newT.baseturfs = /turf/baseturf_bottom
 		else
-			newT = T.ChangeTurf(/turf/open/space, flags = CHANGETURF_IGNORE_AIR | CHANGETURF_DEFER_CHANGE)
+			newT = T.ChangeTurf(/turf/open/space, /turf/baseturf_bottom, flags = CHANGETURF_IGNORE_AIR | CHANGETURF_DEFER_CHANGE)
 		var/area/old_area = newT.loc
 		if(!istype(newT.loc, /area/space))
 			var/area/newA = GLOB.areas_by_type[/area/space]


### PR DESCRIPTION
## About The Pull Request

Actually includes the baseturf list in the runtime. Why the fuck didn't it do this. Dammit TG.

Pictured useless turfs:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/4f644926-983e-4ae9-99a2-c78c46cdad3f)

With this I was able to find that Z-Clear was not removing baseturfs leading to huge baseturfs lists. I added an argument that should reset the baseturfs.

## Why It's Good For The Game

I can actually debug the shit instead of just getting a useless message and then removing the offending turf so I can't even investigate via varedit.

Fixes a bug with baseturfs being huge.

## Testing Photographs and Procedure

N/A

## Changelog
:cl:
tweak: Fixed SHIT IS FUCK turfs in explo generation, improved debugging message so the root cause can be identified.
fix: Fixed large baseturf lists from Z-Clear not clearing baseturfs.
/:cl:
