### PR TITLE
Billy Clubs (and now Fireaxes) Bash Glass (and Grills, Tables, Windoors) Harder

### DIFF
--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -41,10 +41,14 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(ISWIELDED(src)) //destroys windows and grilles in one hit
+	if(ISWIELDED(src)) //destroys windows, and grilles in one hit
 		if(istype(A, /obj/structure/window))
 			var/obj/structure/window/W = A
 			W.take_damage(200, BRUTE, MELEE, 0)
+		else if(istype(A, /obj/machinery/door/window) || istype(A, /obj/structure/windoor_assembly)\
+				|| istype(A, /obj/structure/table/glass))
+			var/obj/WD = A
+			WD.take_damage(80, BRUTE, MELEE, 0) //Destroy glass tables in one hit, windoors in two hits.
 		else if(istype(A, /obj/structure/grille))
 			var/obj/structure/grille/G = A
 			G.take_damage(40, BRUTE, MELEE, 0)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -933,12 +933,13 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(!proximity)
 		return
-	if(istype(A, /obj/structure/window)) //Bonus damage to windows and grilles
-		var/obj/structure/window/W = A
+	if(istype(A, /obj/structure/window) || istype(A, /obj/machinery/door/window)\
+		|| istype(A, /obj/structure/windoor_assembly) || istype(A, /obj/structure/table/glass)) //Bonus damage to windows, windoors, and windoor assemblies
+		var/obj/W = A
 		W.take_damage(30, BRUTE, MELEE, 0)
-	else if(istype(A, /obj/structure/grille))
+	else if(istype(A, /obj/structure/grille)) //Bonus damage to grilles
 		var/obj/structure/grille/G = A
-		G.take_damage(10, BRUTE, MELEE, 0)
+		G.take_damage(20, BRUTE, MELEE, 0)
 
 /obj/item/club/tailclub
 	name = "tail club"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -929,6 +929,17 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			H.apply_damage(stamforce, STAMINA, blocked = def_check)
 	return ..()
 
+/obj/item/club/afterattack(atom/A, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	if(istype(A, /obj/structure/window)) //Bonus damage to windows and grilles
+		var/obj/structure/window/W = A
+		W.take_damage(30, BRUTE, MELEE, 0)
+	else if(istype(A, /obj/structure/grille))
+		var/obj/structure/grille/G = A
+		G.take_damage(10, BRUTE, MELEE, 0)
+
 /obj/item/club/tailclub
 	name = "tail club"
 	desc = "For the beating to death of lizards with their own tails."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Based off of fireaxe code, and as per suggested in thinktank (with 6 upvotes!), Billy Clubs now deal additional damage to windows and grilles, similar to the increased damage against shields. With this change, grilles now take 2 hits to break, regular windows 3 hits to break, and reinforced windows 10 hits to break. This also adds additional damage for the fireaxe and billyclub to glass tables (both regular and plasma), windoors (regular and reinforced), and windoor assemblies.

This also fixes an inconsistency as noted by Dragonfiend; fire axes previously did not deal bonus damage to *glass* tables and windoors/windoor assembles, this makes them fall in line with their other window-shattering capabilities.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Makes it a more versatile tool for getting into places quickly should the need arise. Makes the tool that's good for bashing things, good for bashing other things. Windoors are just sliding glass, make them fear THE MIGHT OF THE AXE AND CLUB (and tables are cringe, less glass tableslamming and more glass tableshattering)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


Awahwahwahwahwahwah

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/afdb2f6a-0aa3-4508-8fe5-edf8c039adc1

Updated version in responses down below, with a side-by-side compared to the fireaxe!

</details>

## Changelog
:cl: Impish_Delights
add: Billy Clubs now deal minor bonus damage to windows, grilles, glass tables, and windoors/windoor assemblies.
add: Fireaxes additionally deal bonus damage to glass tables, windoors, and windoor assemblies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
