### PR TITLE
Medical labcoat standardization 

### DIFF
--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -2166,7 +2166,7 @@
 	brute_damage = 145;
 	id_job = "Geneticist";
 	oxy_damage = 55;
-	suit = /obj/item/clothing/suit/toggle/labcoat/genetics;
+	suit = /obj/item/clothing/suit/toggle/labcoat/med/genetics;
 	uniform = /obj/item/clothing/under/rank/medical/geneticist
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -3192,7 +3192,7 @@
 	brute_damage = 145;
 	id_job = "Geneticist";
 	oxy_damage = 55;
-	suit = /obj/item/clothing/suit/toggle/labcoat/genetics;
+	suit = /obj/item/clothing/suit/toggle/labcoat/med/genetics;
 	uniform = /obj/item/clothing/under/rank/medical/geneticist
 	},
 /obj/effect/decal/cleanable/blood,
@@ -4283,7 +4283,7 @@
 	brute_damage = 145;
 	id_job = "Geneticist";
 	oxy_damage = 55;
-	suit = /obj/item/clothing/suit/toggle/labcoat/genetics;
+	suit = /obj/item/clothing/suit/toggle/labcoat/med/genetics;
 	uniform = /obj/item/clothing/under/rank/medical/geneticist
 	},
 /obj/effect/decal/cleanable/blood,
@@ -4697,7 +4697,7 @@
 	brute_damage = 145;
 	id_job = "Geneticist";
 	oxy_damage = 55;
-	suit = /obj/item/clothing/suit/toggle/labcoat/genetics;
+	suit = /obj/item/clothing/suit/toggle/labcoat/med/genetics;
 	uniform = /obj/item/clothing/under/rank/medical/geneticist
 	},
 /obj/effect/decal/cleanable/blood,

--- a/code/game/objects/effects/spawners/bundle.dm
+++ b/code/game/objects/effects/spawners/bundle.dm
@@ -31,7 +31,7 @@
 	items = list(
 		/obj/item/clothing/under/rank/captain/suit,
 		/obj/item/clothing/head/flatcap,
-		/obj/item/clothing/suit/toggle/labcoat/mad)
+		/obj/item/clothing/suit/toggle/labcoat/med/mad)
 
 /obj/effect/spawner/bundle/costume/elpresidente
 	name = "el presidente costume spawner"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -167,7 +167,7 @@
 			new /obj/item/slimepotion/slime/sentience(src)
 
 		if("mad_scientist")
-			new /obj/item/clothing/suit/toggle/labcoat/mad(src) // 0 tc
+			new /obj/item/clothing/suit/toggle/labcoat/med/mad(src) // 0 tc
 			new /obj/item/clothing/shoes/jackboots(src) // 0 tc
 			new /obj/item/megaphone(src) // 0 tc (because how else are they to know you're mad?)
 			new /obj/item/grenade/clusterbuster/random(src) // 10 tc?

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -251,7 +251,7 @@
 	var/static/items_inside = list(
 		/obj/item/clothing/under/rank/medical/chemist = 2,
 		/obj/item/clothing/shoes/sneakers/white = 2,
-		/obj/item/clothing/suit/toggle/labcoat/chemist = 2,
+		/obj/item/clothing/suit/toggle/labcoat/med/chemist = 2,
 		/obj/item/storage/backpack/chemistry = 2,
 		/obj/item/storage/backpack/satchel/chem = 2,
 		/obj/item/storage/bag/chemistry = 2)
@@ -267,7 +267,7 @@
 	var/static/items_inside = list(
 		/obj/item/clothing/under/rank/medical/geneticist = 2,
 		/obj/item/clothing/shoes/sneakers/white = 2,
-		/obj/item/clothing/suit/toggle/labcoat/genetics = 2,
+		/obj/item/clothing/suit/toggle/labcoat/med/genetics = 2,
 		/obj/item/storage/backpack/genetics = 2,
 		/obj/item/storage/backpack/satchel/gen = 2)
 	generate_items_inside(items_inside,src)
@@ -282,7 +282,7 @@
 	var/static/items_inside = list(
 		/obj/item/clothing/under/rank/medical/virologist = 2,
 		/obj/item/clothing/shoes/sneakers/white = 2,
-		/obj/item/clothing/suit/toggle/labcoat/virologist = 2,
+		/obj/item/clothing/suit/toggle/labcoat/med/virologist = 2,
 		/obj/item/clothing/mask/surgical = 2,
 		/obj/item/storage/backpack/virology = 2,
 		/obj/item/storage/backpack/satchel/vir = 2,

--- a/code/modules/antagonists/gang/gang_datums.dm
+++ b/code/modules/antagonists/gang/gang_datums.dm
@@ -87,7 +87,7 @@
 	color = "#00FF00"
 	hat = /obj/item/clothing/head/soft/green
 	outfit = /obj/item/clothing/under/color/green
-	suit = /obj/item/clothing/suit/toggle/labcoat/mad
+	suit = /obj/item/clothing/suit/toggle/labcoat/med/mad
 
 /datum/team/gang/gib
 	name = "Gib"

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -32,23 +32,23 @@
 	item_state = "labcoat_sec"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0, fire = 50, acid = 50, stamina = 30)
 
-/obj/item/clothing/suit/toggle/labcoat/mad
+/obj/item/clothing/suit/toggle/labcoat/med/mad
 	name = "\proper The Mad's labcoat"
 	desc = "It makes you look capable of konking someone on the noggin and shooting them into space."
 	icon_state = "labgreen"
 	item_state = "labgreen"
 
-/obj/item/clothing/suit/toggle/labcoat/genetics
+/obj/item/clothing/suit/toggle/labcoat/med/genetics
 	name = "geneticist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a blue stripe on the shoulder."
 	icon_state = "labcoat_gen"
 
-/obj/item/clothing/suit/toggle/labcoat/chemist
+/obj/item/clothing/suit/toggle/labcoat/med/chemist
 	name = "chemist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has an orange stripe on the shoulder."
 	icon_state = "labcoat_chem"
 
-/obj/item/clothing/suit/toggle/labcoat/virologist
+/obj/item/clothing/suit/toggle/labcoat/med/virologist
 	name = "virologist labcoat"
 	desc = "A suit that protects against minor chemical spills. Offers slightly more protection against biohazards than the standard model. Has a green stripe on the shoulder."
 	icon_state = "labcoat_vir"

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -51,7 +51,7 @@
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/medical/chemist
 	shoes = /obj/item/clothing/shoes/sneakers/white
-	suit =  /obj/item/clothing/suit/toggle/labcoat/chemist
+	suit =  /obj/item/clothing/suit/toggle/labcoat/med/chemist
 	backpack = /obj/item/storage/backpack/chemistry
 	satchel = /obj/item/storage/backpack/satchel/chem
 	duffelbag = /obj/item/storage/backpack/duffelbag/med

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -49,7 +49,7 @@
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/medical/geneticist
 	shoes = /obj/item/clothing/shoes/sneakers/white
-	suit =  /obj/item/clothing/suit/toggle/labcoat/genetics
+	suit =  /obj/item/clothing/suit/toggle/labcoat/med/genetics
 	suit_store =  /obj/item/flashlight/pen
 	l_pocket = /obj/item/sequence_scanner
 

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -50,7 +50,7 @@
 	uniform = /obj/item/clothing/under/rank/medical/virologist
 	mask = /obj/item/clothing/mask/surgical
 	shoes = /obj/item/clothing/shoes/sneakers/white
-	suit =  /obj/item/clothing/suit/toggle/labcoat/virologist
+	suit =  /obj/item/clothing/suit/toggle/labcoat/med/virologist
 	suit_store =  /obj/item/flashlight/pen
 	r_pocket = /obj/item/modular_computer/tablet/pda/virologist
 

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -18,7 +18,7 @@
 					/obj/item/clothing/head/helmet/gladiator = 1,
 					/obj/item/clothing/under/rank/captain/suit = 1,
 					/obj/item/clothing/head/flatcap = 1,
-					/obj/item/clothing/suit/toggle/labcoat/mad = 1,
+					/obj/item/clothing/suit/toggle/labcoat/med/mad = 1,
 					/obj/item/clothing/shoes/jackboots = 1,
 					/obj/item/clothing/under/costume/schoolgirl = 1,
 					/obj/item/clothing/under/costume/schoolgirl/red = 1,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -456,7 +456,7 @@
 					/obj/item/clothing/under/plasmaman/chemist = 2,
 					/obj/item/clothing/head/helmet/space/plasmaman/chemist = 2,
 					/obj/item/clothing/shoes/sneakers/white = 2,
-					/obj/item/clothing/suit/toggle/labcoat/chemist = 2,
+					/obj/item/clothing/suit/toggle/labcoat/med/chemist = 2,
 					/obj/item/storage/backpack/chemistry = 2,
 					/obj/item/storage/backpack/satchel/chem = 2,
 					/obj/item/storage/bag/chemistry = 2,
@@ -477,7 +477,7 @@
 					/obj/item/clothing/under/plasmaman/genetics = 2,
 					/obj/item/clothing/head/helmet/space/plasmaman/genetics = 2,
 					/obj/item/clothing/shoes/sneakers/white = 2,
-					/obj/item/clothing/suit/toggle/labcoat/genetics = 2,
+					/obj/item/clothing/suit/toggle/labcoat/med/genetics = 2,
 					/obj/item/storage/backpack/genetics = 2,
 					/obj/item/storage/backpack/satchel/gen = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/gene_wardrobe
@@ -496,7 +496,7 @@
 					/obj/item/clothing/under/plasmaman/viro = 2,
 					/obj/item/clothing/head/helmet/space/plasmaman/viro = 2,
 					/obj/item/clothing/shoes/sneakers/white = 2,
-					/obj/item/clothing/suit/toggle/labcoat/virologist = 2,
+					/obj/item/clothing/suit/toggle/labcoat/med/virologist = 2,
 					/obj/item/clothing/mask/surgical = 2,
 					/obj/item/storage/backpack/virology = 2,
 					/obj/item/storage/backpack/satchel/vir = 2)


### PR DESCRIPTION
## About The Pull Request

All Medical department labcoats can now store medkits in suit storage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Medkits were previously made bulky and only able to be added to the suit storage of paramedic's, normal doctor's, brig physician's and CMO's Labcoat.
This PR adds that for all medical labcoats in the medical department.

It removes the need for members in medical to swap a doctors' labcoat (free to purchase in the medidrobe) just to access the feature.

## Testing Photographs and Procedure

<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/78978345/96b8d19a-00d9-4954-8989-c527618e5888

</details>

## Changelog
:cl:
balance: All medical department labcoats can now carry medkits
/:cl: