### PR TITLE
Removed the ability to spawn modular receivers in maints

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -110,7 +110,6 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/throwing_star = 1,
 	/obj/item/toy/eightball = 1,
 	/obj/item/vending_refill/cola = 1,
-	/obj/item/weaponcrafting/receiver = 2,
 	/obj/item/weldingtool = 3,
 	/obj/item/wirecutters = 1,
 	/obj/item/wrench = 4,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed the ability for modular receivers to spawn in maints. 
## Why It's Good For The Game

Having modular receivers, one of the necessary ingredients in improvised shotguns, in maints enables powergaming and self-antagging by greytiders, and due to the randomness of maints loot, it does not help antags in any meaningful way. I checked with @PowerfulBacon  and he said there shouldn't be any issue.

</details>

## Changelog
:cl:
del: deleted the line in _globalvars/lists/maintenance_loot that allowed for modular receivers to spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
