### PR TITLE
Remove reactive tableport armor from random maintenance room

### DIFF
--- a/_maps/RandomRooms/3x5/sk_rdm086_laststand.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm086_laststand.dmm
@@ -37,6 +37,7 @@
 /area/template_noop)
 "h" = (
 },
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised,
 /obj/effect/mob_spawn/human/corpse/assistant,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/decal/cleanable/blood/old,

--- a/_maps/RandomRooms/3x5/sk_rdm086_laststand.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm086_laststand.dmm
@@ -36,11 +36,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "h" = (
-/obj/item/clothing/suit/armor/reactive/table{
-	name = "reactive tableport armor";
-	tele_range = 2
-	},
-/obj/item/gun/ballistic/shotgun/doublebarrel/improvised,
+},
 /obj/effect/mob_spawn/human/corpse/assistant,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/decal/cleanable/blood/old,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After discussing with @PowerfulBacon , I have determined that it's probably OK to have the shotgun in the random maints room, if someone does something bad with it admins can take care of it. 
Instead, I am removing the Reactive Tableport Armor. It makes it extremely difficult for someone to assassinate someone who has the armor. 

## Why It's Good For The Game

Makes it more fun for antags because now there is no risk of your target finding OP armor and being hard to kill

## Testing Photographs and Procedure
I don't know how to represent the change in a photograph or video

the file changed is _maps/RandomRooms/3x5/sk_rdm086_laststand.dmm

</details>

## Changelog
del: removed Reactive Tableport armor from the above file
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
