### PR TITLE
Ports: Adds Sequential mode to SQDL2

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -244,7 +244,7 @@
 		if(usr)
 			query.show_next_to_key = usr.ckey
 		waiting_queue += query
-		if(query.options && SDQL2_OPTION_SEQUENTIAL)
+		if(query.options & SDQL2_OPTION_SEQUENTIAL)
 			sequential = TRUE
 
 	if(sequential) //Start first one

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -158,6 +158,7 @@
 	SELECT = FORCE_NULLS, (D)SKIP_NULLS
 	PRIORITY = HIGH, (D) NORMAL
 	AUTOGC = (D) AUTOGC, KEEP_ALIVE
+	SEQUENTIAL = TRUE - The queries in this batch will be executed sequentially one by one not in parallel
 
 	Example: USING PROCCALL = BLOCKING, SELECT = FORCE_NULLS, PRIORITY = HIGH SELECT /mob FROM world WHERE z == 1
 
@@ -172,13 +173,14 @@
 #define SDQL2_STATE_SWITCHING 5
 #define SDQL2_STATE_HALTING 6
 
-#define SDQL2_VALID_OPTION_TYPES list("proccall", "select", "priority", "autogc")
-#define SDQL2_VALID_OPTION_VALUES list("async", "blocking", "force_nulls", "skip_nulls", "high", "normal", "keep_alive")
+#define SDQL2_VALID_OPTION_TYPES list("proccall", "select", "priority", "autogc" , "sequential")
+#define SDQL2_VALID_OPTION_VALUES list("async", "blocking", "force_nulls", "skip_nulls", "high", "normal", "keep_alive" , "true")
 
 #define SDQL2_OPTION_SELECT_OUTPUT_SKIP_NULLS			(1<<0)
 #define SDQL2_OPTION_BLOCKING_CALLS						(1<<1)
 #define SDQL2_OPTION_HIGH_PRIORITY						(1<<2)		//High priority SDQL query, allow using almost all of the tick.
 #define SDQL2_OPTION_DO_NOT_AUTOGC						(1<<3)
+#define SDQL2_OPTION_SEQUENTIAL							(1<<4)
 
 #define SDQL2_OPTIONS_DEFAULT		(SDQL2_OPTION_SELECT_OUTPUT_SKIP_NULLS)
 
@@ -222,6 +224,7 @@
 	NOTICE(query_log)
 
 	var/start_time_total = REALTIMEOFDAY
+	var/sequential = FALSE
 
 	if(!length(query_text))
 		return
@@ -232,18 +235,35 @@
 	if(!length(querys))
 		return
 	var/list/datum/SDQL2_query/running = list()
+	var/list/datum/SDQL2_query/waiting_queue = list() //Sequential queries queue.
+	
 	for(var/list/query_tree in querys)
 		var/datum/SDQL2_query/query = new /datum/SDQL2_query(query_tree)
 		if(QDELETED(query))
 			continue
 		if(usr)
 			query.show_next_to_key = usr.ckey
+		waiting_queue += query
+		if(query.options && SDQL2_OPTION_SEQUENTIAL)
+			sequential = TRUE
+
+	if(sequential) //Start first one
+		var/datum/SDQL2_query/query = popleft(waiting_queue)
 		running += query
 		var/msg = "Starting query #[query.id] - [query.get_query_text()]."
 		if(usr)
 			to_chat(usr, "<span class='admin'>[msg]</span>")
 		log_admin(msg)
 		query.ARun()
+	else //Start all
+		for(var/datum/SDQL2_query/query in waiting_queue)
+			running += query
+			var/msg = "Starting query #[query.id] - [query.get_query_text()]."
+			if(usr)
+				to_chat(usr, "<span class='admin'>[msg]</span>")
+			log_admin(msg)
+			query.ARun()
+	
 	var/finished = FALSE
 	var/objs_all = 0
 	var/objs_eligible = 0
@@ -259,10 +279,10 @@
 				continue
 			else if(query.state != SDQL2_STATE_IDLE)
 				finished = FALSE
-			else if(query.state == SDQL2_STATE_ERROR)
-				if(usr)
-					to_chat(usr, "<span class='admin'>SDQL query [query.get_query_text()] errored. It will NOT be automatically garbage collected. Please remove manually.</span>")
-				running -= query
+				if(query.state == SDQL2_STATE_ERROR)
+					if(usr)
+						to_chat(usr, "<span class='admin'>SDQL query [query.get_query_text()] errored. It will NOT be automatically garbage collected. Please remove manually.</span>")
+					running -= query
 			else
 				if(query.finished)
 					objs_all += islist(query.obj_count_all)? length(query.obj_count_all) : query.obj_count_all
@@ -272,6 +292,15 @@
 					running -= query
 					if(!CHECK_BITFIELD(query.options, SDQL2_OPTION_DO_NOT_AUTOGC))
 						QDEL_IN(query, 50)
+					if(sequential && waiting_queue.len)
+						finished = FALSE
+						var/datum/SDQL2_query/next_query = popleft(waiting_queue)
+						running += next_query
+						var/msg = "Starting query #[next_query.id] - [next_query.get_query_text()]."
+						if(usr)
+							to_chat(usr, "<span class='admin'>[msg]</span>")
+						log_admin(msg)
+						next_query.ARun()
 				else
 					if(usr)
 						to_chat(usr, "<span class='admin'>SDQL query [query.get_query_text()] was halted. It will NOT be automatically garbage collected. Please remove manually.</span>")
@@ -468,6 +497,10 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 			switch(value)
 				if("keep_alive")
 					ENABLE_BITFIELD(options, SDQL2_OPTION_DO_NOT_AUTOGC)
+		if("sequential")
+			switch(value)
+				if("true")
+					ENABLE_BITFIELD(options,SDQL2_OPTION_SEQUENTIAL)
 
 /datum/SDQL2_query/proc/ARun()
 	INVOKE_ASYNC(src, PROC_REF(Run))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Recoup of: https://github.com/BeeStation/BeeStation-Hornet/pull/9355
Partially ports from TG: https://github.com/tgstation/tgstation/pull/44213

Also tweaks it slightly because part of TG's version of this has always been broken, and is still broken even to this day.
*This fix is admittedly a bit unhinged and an alternative solution would be appreciated.*


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

~~I need it for my evil machinations.~~

Being able to guarantee that a given query in a chain is executed at the right time can be useful, mostly for admins (hi). Sometimes having everything run side by side is not ideal.
This interests me in particular as a premade SDQL2 query can save a massive amount of time when it comes to setting up events or other bus.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
---

https://streamable.com/xxm2ac

Main queries used in testing:

Spawns bodyparts under the marked mob and then attaches them.
```
CALL global._new(/obj/item/bodypart/l_arm/robot, [marked.loc]) ON * IN marked;
CALL global._new(/obj/item/bodypart/r_arm/robot, [marked.loc]) ON * IN marked;
CALL global._new(/obj/item/bodypart/l_leg/robot, [marked.loc]) ON * IN marked; 
CALL global._new(/obj/item/bodypart/r_leg/robot, [marked.loc]) ON * IN marked;
CALL global._new(/obj/item/bodypart/chest/robot, [marked.loc]) ON * IN marked;

CALL replace_limb(marked) ON /obj/item/bodypart IN marked.loc.contents
```

Runs a select query on a large number of objects, in this case I had spawned roughly 5000 of the item (the WHERE check is to stop it from lagging me when it prints the list at the end). Then it proceeds to do the same thing as the above query. Due to the fact that `SEQUENTIAL = TRUE` is used here - it waits until the first lengthy query has been completed before continuing; this feature is the point of this PR.
```
USING SEQUENTIAL = TRUE
SELECT /obj/item/kirbyplants/photosynthetic where ricochet_damage_mod = 1;
CALL global._new(/obj/item/bodypart/l_arm/robot, [marked.loc]) ON * IN marked;
CALL global._new(/obj/item/bodypart/r_arm/robot, [marked.loc]) ON * IN marked;
CALL global._new(/obj/item/bodypart/l_leg/robot, [marked.loc]) ON * IN marked; 
CALL global._new(/obj/item/bodypart/r_leg/robot, [marked.loc]) ON * IN marked;
CALL global._new(/obj/item/bodypart/chest/robot, [marked.loc]) ON * IN marked;

CALL replace_limb(marked) ON /obj/item/bodypart IN marked.loc.contents
```
</details>

## Changelog
:cl: Tyranicranger4, AnturK, Rkz
admin: Adds "Sequential Mode" to SDQL2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
