### PR TITLE
Toy shurikens in maint

### DIFF
--- a/_maps/RandomRooms/5x3/sk_rdm089_nastytrap.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm089_nastytrap.dmm
@@ -13,7 +13,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/throwing_star,
+/obj/item/throwing_star/toy,
 /turf/open/floor/plating,
 /area/template_noop)
 "c" = (
@@ -65,7 +65,7 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/throwing_star,
+/obj/item/throwing_star/toy,
 /turf/open/floor/plating,
 /area/template_noop)
 "j" = (

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/storage/toolbox/mechanical = 1,
 	/obj/item/t_scanner = 5,
 	/obj/item/tank/internals/emergency_oxygen = 2,
-	/obj/item/throwing_star = 1,
+	/obj/item/throwing_star/toy = 1,
 	/obj/item/toy/eightball = 1,
 	/obj/item/vending_refill/cola = 1,
 	/obj/item/weaponcrafting/receiver = 2,

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -344,7 +344,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	sharpness = IS_BLUNT
 	force = 0
 	throwforce = 0
-	embedding = list("pain_mult" = 0, "jostle_pain_mult" = 0, "embed_chance" = 300, "fall_chance" = 0, "armour_block" = 70)
+	embedding = list("pain_mult" = 0, "jostle_pain_mult" = 0, "embed_chance" = 300, "fall_chance" = 75, "armour_block" = 70)
 
 /obj/item/throwing_star/magspear
 	name = "magnetic spear"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -344,7 +344,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	sharpness = IS_BLUNT
 	force = 0
 	throwforce = 0
-	embedding = list("pain_mult" = 0, "jostle_pain_mult" = 0, "embed_chance" = 300, "fall_chance" = 75, "armour_block" = 70)
+	embedding = list("pain_mult" = 0, "jostle_pain_mult" = 0, "embed_chance" = 300, "fall_chance" = 25, "armour_block" = 70)
 
 /obj/item/throwing_star/magspear
 	name = "magnetic spear"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the throwing stars in maints with toy throwing stars
Adds a chance for toy throwing stars to fall off on their own

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Throwing stars are easily one of the most powerful things available in maints. They don't kill in one hit, but they do come close with high damage, a perfect embed chance and further damage if they aren't removed immediately. In the hands of an antagonist they're fine, but they are instead very frequently collected by the first person who finds them due to how much noise their spawning location makes. 

Additionally toy throwing stars are not really available in the game and we could always use more prank objects on the station to clown on security officers without actually dunking on them. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_81NH8bjeCq](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/bfa65ebd-ac63-4218-8cfe-50fe6db314e8)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/7d268a40-bd4c-4dc6-a311-68d7be68716d)

</details>

## Changelog
:cl:
tweak: Replaced throwing stars in maints with a toy version. Get honked on. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
