### PR TITLE
Iterator Wiremod Component

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -4041,7 +4041,7 @@
 #include "code\modules\wiremod\components\string\tostring.dm"
 #include "code\modules\wiremod\components\utility\clock.dm"
 #include "code\modules\wiremod\components\utility\delay.dm"
-#include "code\modules\wiremod\components\utility\forloop.dm"
+#include "code\modules\wiremod\components\utility\iterator.dm"
 #include "code\modules\wiremod\components\utility\getter.dm"
 #include "code\modules\wiremod\components\utility\router.dm"
 #include "code\modules\wiremod\components\utility\setter.dm"

--- a/beestation.dme
+++ b/beestation.dme
@@ -4041,6 +4041,7 @@
 #include "code\modules\wiremod\components\string\tostring.dm"
 #include "code\modules\wiremod\components\utility\clock.dm"
 #include "code\modules\wiremod\components\utility\delay.dm"
+#include "code\modules\wiremod\components\utility\forloop.dm"
 #include "code\modules\wiremod\components\utility\getter.dm"
 #include "code\modules\wiremod\components\utility\router.dm"
 #include "code\modules\wiremod\components\utility\setter.dm"

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -89,6 +89,12 @@
 	build_path = /obj/item/circuit_component/compare/logic
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_LOGIC_COMPONENTS)
 
+/datum/design/component/forloop
+	name = "For Loop Component"
+	id = "comp_forloop"
+	build_path = /obj/item/circuit_component/forloop
+	category = list(WIREMOD_CIRCUITRY, WIREMOD_LOGIC_COMPONENTS)
+
 /datum/design/component/delay
 	name = "Delay Component"
 	id = "comp_delay"

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -89,10 +89,10 @@
 	build_path = /obj/item/circuit_component/compare/logic
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_LOGIC_COMPONENTS)
 
-/datum/design/component/forloop
-	name = "For Loop Component"
-	id = "comp_forloop"
-	build_path = /obj/item/circuit_component/forloop
+/datum/design/component/iterator
+	name = "Iterator Component"
+	id = "comp_iterator"
+	build_path = /obj/item/circuit_component/iterator
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_LOGIC_COMPONENTS)
 
 /datum/design/component/delay

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -181,6 +181,7 @@
 		"comp_concat",
 		"comp_delay",
 		"comp_direction",
+		"comp_forloop",
 		"comp_get_column",
 		"comp_get_name",
 		"comp_gps",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -181,7 +181,7 @@
 		"comp_concat",
 		"comp_delay",
 		"comp_direction",
-		"comp_forloop",
+		"comp_iterator",
 		"comp_get_column",
 		"comp_get_name",
 		"comp_gps",

--- a/code/modules/wiremod/components/utility/forloop.dm
+++ b/code/modules/wiremod/components/utility/forloop.dm
@@ -1,0 +1,115 @@
+/**
+ * # For Loop Component
+ *
+ * Iterates through a range of numbers when the iterate input is triggered.
+ */
+/obj/item/circuit_component/forloop
+	display_name = "For Loop"
+	desc = "Iterates through a range of numbers"
+
+	/// The Initial Value the Loop will start at
+	var/datum/port/input/initial_value
+	/// The Final Value the Loop will rollover at
+	var/datum/port/input/final_value
+	/// The Step the internal variable will take on each Iterate trigger
+	var/datum/port/input/iterate_value
+
+	/// Resets the loop to the initial value.
+	var/datum/port/input/init_input
+	/// Triggers the variable to iterate.
+	var/datum/port/input/iterate_input
+
+	/// Value Output
+	var/datum/port/output/value
+
+	/// Trigger Output
+	var/datum/port/output/on_triggered
+	/// Rollover Output
+	var/datum/port/output/on_rollover
+
+	/// Stores the Internal State of the For Loop
+	var/current_value = 0
+
+/obj/item/circuit_component/forloop/populate_ports()
+
+	initial_value = add_input_port("Initial Value", PORT_TYPE_NUMBER)
+	final_value = add_input_port("Final Value", PORT_TYPE_NUMBER)
+
+	/// No need to trigger when the iterator value changes.
+	iterate_value = add_input_port("Iterate Value", PORT_TYPE_NUMBER, trigger = null)
+
+	init_input = add_input_port("Initialize", PORT_TYPE_SIGNAL)
+	iterate_input = add_input_port("Iterate", PORT_TYPE_SIGNAL)
+
+	value = add_output_port("Value", PORT_TYPE_NUMBER)
+	on_triggered = add_output_port("Triggered", PORT_TYPE_SIGNAL)
+	on_rollover = add_output_port("Rollover", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/forloop/input_received(datum/port/input/port)
+
+	/// If we don't have any values for the iterator, or
+	/// if the initial value and final values are equivalent
+	if(initial_value.value == final_value.value || !iterate_value.value)
+		current_value = initial_value.value
+		value.set_output(current_value)
+		return
+
+	/// Depending on the bounds of the for loop, we need to either iterate in a positive direction or a negative direction.
+	/// To ensure that we iterate in the correct direction, take the abs of the iterator, and either add or subtract depending on
+	/// direction of iteration. This way silly spacemen can't screw up the sign on the iterator.
+	var/iterate_positive = abs(iterate_value.value)
+
+	/// Used to determine if we increment or decrement, and bounds
+	var/pos_iter = initial_value.value < final_value.value
+
+	/// when we update the initial and final values, we need to ensure the current value gets bounded to the new range..
+	/// If we are iterating upwards, the current value can't be less than the initial value.
+	/// If we are iterating upwards, the current value can't be greater than the final value.
+	/// If we are iterating downwards, the current value can't be greater than the initial value.
+	/// If we are iterating downwards, the current value can't be less than the final value.
+	/// Truncate it to the new bound, and silently update it without the rollover signal.
+	if(COMPONENT_TRIGGERED_BY(port, initial_value) || COMPONENT_TRIGGERED_BY(port, final_value))
+		if(pos_iter)
+			if(current_value < initial_value.value)
+				current_value = initial_value.value
+				value.set_output(current_value)
+			if(current_value > final_value.value)
+				current_value = final_value.value
+				value.set_output(current_value)
+		else
+			if(current_value > initial_value.value)
+				current_value = initial_value.value
+				value.set_output(current_value)
+			if(current_value < final_value.value)
+				current_value = final_value.value
+				value.set_output(current_value)
+		return
+
+
+	/// Reset the Internal Value if the initialization port triggers
+	if(COMPONENT_TRIGGERED_BY(port, init_input))
+		current_value = initial_value.value
+		value.set_output(current_value)
+		on_triggered.set_output(COMPONENT_SIGNAL)
+		return
+
+	/// Let's get iterating
+	if(COMPONENT_TRIGGERED_BY(port, iterate_input))
+		if(pos_iter)
+			current_value += iterate_positive
+			/// We've gone over the final value, return to the initial
+			if(current_value > final_value.value)
+				current_value = initial_value.value
+				/// and send the rollover signal
+				on_rollover.set_output(COMPONENT_SIGNAL)
+		else
+			/// Going negative, so subtract instead of negative.
+			current_value -= iterate_positive
+			if(current_value < final_value.value)
+				current_value = initial_value.value
+				/// and send the rollover signal
+				on_rollover.set_output(COMPONENT_SIGNAL)
+
+		value.set_output(current_value)
+		on_triggered.set_output(COMPONENT_SIGNAL)
+		return

--- a/code/modules/wiremod/components/utility/iterator.dm
+++ b/code/modules/wiremod/components/utility/iterator.dm
@@ -1,10 +1,10 @@
 /**
- * # For Loop Component
+ * # Iterator Component
  *
  * Iterates through a range of numbers when the iterate input is triggered.
  */
-/obj/item/circuit_component/forloop
-	display_name = "For Loop"
+/obj/item/circuit_component/iterator
+	display_name = "Iterator"
 	desc = "Iterates through a range of numbers"
 
 	/// The Initial Value the Loop will start at
@@ -27,10 +27,10 @@
 	/// Rollover Output
 	var/datum/port/output/on_rollover
 
-	/// Stores the Internal State of the For Loop
+	/// Stores the Count of the Iterator
 	var/current_value = 0
 
-/obj/item/circuit_component/forloop/populate_ports()
+/obj/item/circuit_component/iterator/populate_ports()
 
 	initial_value = add_input_port("Initial Value", PORT_TYPE_NUMBER)
 	final_value = add_input_port("Final Value", PORT_TYPE_NUMBER)
@@ -45,7 +45,7 @@
 	on_triggered = add_output_port("Triggered", PORT_TYPE_SIGNAL)
 	on_rollover = add_output_port("Rollover", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/forloop/input_received(datum/port/input/port)
+/obj/item/circuit_component/iterator/input_received(datum/port/input/port)
 
 	/// If we don't have any values for the iterator, or
 	/// if the initial value and final values are equivalent
@@ -54,7 +54,7 @@
 		value.set_output(current_value)
 		return
 
-	/// Depending on the bounds of the for loop, we need to either iterate in a positive direction or a negative direction.
+	/// Depending on the bounds of the iterator, we need to either iterate in a positive direction or a negative direction.
 	/// To ensure that we iterate in the correct direction, take the abs of the iterator, and either add or subtract depending on
 	/// direction of iteration. This way silly spacemen can't screw up the sign on the iterator.
 	var/iterate_positive = abs(iterate_value.value)

--- a/code/modules/wiremod/components/utility/iterator.dm
+++ b/code/modules/wiremod/components/utility/iterator.dm
@@ -12,12 +12,12 @@
 	/// The Final Value the Loop will rollover at
 	var/datum/port/input/final_value
 	/// The Step the internal variable will take on each Iterate trigger
-	var/datum/port/input/iterate_value
+	var/datum/port/input/step_value
 
 	/// Resets the loop to the initial value.
-	var/datum/port/input/init_input
+	var/datum/port/input/reset_input
 	/// Triggers the variable to iterate.
-	var/datum/port/input/iterate_input
+	var/datum/port/input/step_input
 
 	/// Value Output
 	var/datum/port/output/value
@@ -35,11 +35,11 @@
 	initial_value = add_input_port("Initial Value", PORT_TYPE_NUMBER)
 	final_value = add_input_port("Final Value", PORT_TYPE_NUMBER)
 
-	/// No need to trigger when the iterator value changes.
-	iterate_value = add_input_port("Iterate Value", PORT_TYPE_NUMBER, trigger = null)
+	/// No need to trigger when the step value changes.
+	step_value = add_input_port("Step Value", PORT_TYPE_NUMBER, trigger = null)
 
-	init_input = add_input_port("Initialize", PORT_TYPE_SIGNAL)
-	iterate_input = add_input_port("Iterate", PORT_TYPE_SIGNAL)
+	reset_input = add_input_port("Reset", PORT_TYPE_SIGNAL)
+	step_input = add_input_port("Step", PORT_TYPE_SIGNAL)
 
 	value = add_output_port("Value", PORT_TYPE_NUMBER)
 	on_triggered = add_output_port("Triggered", PORT_TYPE_SIGNAL)
@@ -49,7 +49,7 @@
 
 	/// If we don't have any values for the iterator, or
 	/// if the initial value and final values are equivalent
-	if(initial_value.value == final_value.value || !iterate_value.value)
+	if(initial_value.value == final_value.value || !step_value.value)
 		current_value = initial_value.value
 		value.set_output(current_value)
 		return
@@ -57,7 +57,7 @@
 	/// Depending on the bounds of the iterator, we need to either iterate in a positive direction or a negative direction.
 	/// To ensure that we iterate in the correct direction, take the abs of the iterator, and either add or subtract depending on
 	/// direction of iteration. This way silly spacemen can't screw up the sign on the iterator.
-	var/iterate_positive = abs(iterate_value.value)
+	var/iterate_positive = abs(step_value.value)
 
 	/// Used to determine if we increment or decrement, and bounds
 	var/pos_iter = initial_value.value < final_value.value
@@ -87,14 +87,14 @@
 
 
 	/// Reset the Internal Value if the initialization port triggers
-	if(COMPONENT_TRIGGERED_BY(port, init_input))
+	if(COMPONENT_TRIGGERED_BY(port, reset_input))
 		current_value = initial_value.value
 		value.set_output(current_value)
 		on_triggered.set_output(COMPONENT_SIGNAL)
 		return
 
 	/// Let's get iterating
-	if(COMPONENT_TRIGGERED_BY(port, iterate_input))
+	if(COMPONENT_TRIGGERED_BY(port, step_input))
 		if(pos_iter)
 			current_value += iterate_positive
 			/// We've gone over the final value, return to the initial


### PR DESCRIPTION
## About The Pull Request

Wiremod has lacked a For Loop component, which iterates from a lower bound up to a higher bound. To create a simple counter with a rollover was not complicated, but time consuming, requiring a bunch of components to create a basic construct present in all higher level programming applications.

This PR adds a For Loop component, which counts up or down from an Initial Value, to a Final value, and then rolls back over to the initial value.  A rollover signal is emitted when the rollover happens, and the for loop can be reset by the Initialization signal.

The range is inclusive, so the initial value will be the value that the for loop starts on, and will include the final value. Thus, a for loop set up to iterate from 5 to 10 by 1 will output 5,6,7,8,9,10, before rolling back to 5. If it is instead configured to count by 2, it will iterate, 5, 7, 9, and then roll back over to 5 as it exceeded the final value.

The iterator always iterates the value towards the final value, even if the value is opposite the direction. So, for instance, if you are iterating from 0 to 10, and enter a -2 iterator, the value will still increment rather then decrement. This is to avoid edge cases where the silly spaceman accidentally gets the ranges backwards or messes up the bounds. 

If the bounds are updated, the current value will be bounded to the new values. So, if my current count is 0, and I change the values to go from 5 to 10, the value will be bumped up to 5.

## Why It's Good For The Game

Tedium on circuitry for a basic function of most coding languages is very annoying. Adding this removes that barrier to get a basic programming structure in the game.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>
Component in Techweb:

![Tech Web](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/86f0da20-43df-4b4c-a4fd-baf332fce55e)

Basic Testing Circuit (the delay is to allow the rollover to print out first in chat, followed by the value):

![circuit1](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/473298fe-6902-42b3-8717-9d9a5d526b2d)

Chat output from First Test Circuit:
![circuit1chat](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/cfde2019-15da-4a08-90c0-3e61ae8d929f)

Iterating in a positive direction with a negative iterator count

![circuit1 negative](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/69bea720-e264-4bce-93d5-615393e8a328)

Negative Final value with a negative iterator:

![circuit1 final negative](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/24b37bee-0bdc-44c0-8e7e-75d8996f3b7b)

Negative final value with a positive iterator:

![circuit1 final negative iterate positive](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/6a2c42a8-0690-4bb4-b8e3-1c61226fc980)

Negative initial value with positive final value:

![circuit1 negative start positive end](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/2ae75cd5-baae-4704-8af6-28d193996255)

</details>

## Changelog
:cl:
add: Adds a Wiremod Iterator Component for Iterating over Ranges of Numbers
/:cl:
