### PR TITLE
Minor detective tweaks

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6654,7 +6654,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aGv" = (
-/obj/structure/filingcabinet{
+/obj/structure/filingcabinet/security{
 	pixel_x = 8
 	},
 /obj/structure/filingcabinet{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6650,11 +6650,16 @@
 /area/security/brig)
 "aGu" = (
 /obj/machinery/light/small,
-/obj/structure/filingcabinet/security,
+/obj/structure/closet,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aGv" = (
-/obj/structure/closet/secure_closet/detective,
+/obj/structure/filingcabinet{
+	pixel_x = 8
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -8
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aGw" = (

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -372,13 +372,13 @@
 
 /datum/supply_pack/security/forensics
 	name = "Forensics Crate"
-	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."
+	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, detective's camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."
 	cost = 1700
 	max_supply = 1
 	access_budget = ACCESS_MORGUE
 	contains = list(/obj/item/detective_scanner,
 					/obj/item/storage/box/evidence,
-					/obj/item/camera,
+					/obj/item/camera/detective,
 					/obj/item/taperecorder,
 					/obj/item/toy/crayon/white,
 					/obj/item/clothing/head/fedora/det_hat)

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -530,7 +530,7 @@
 					/obj/item/clothing/gloves/color/latex = 2,
 					/obj/item/reagent_containers/food/drinks/flask/det = 2,
 					/obj/item/storage/fancy/cigarettes = 5)
-	premium = list(/obj/item/clothing/head/flatcap = 1)
+	premium = list(/obj/item/clothing/head/flatcap = 1, /obj/item/clothing/suit/armor/vest/det_suit = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/det_wardrobe
 	extra_price = 350
 	dept_req_for_free = ACCOUNT_SEC_BITFLAG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a duplicate detective locker (complete with a second revolver!) from MetaStation.

Adds one Detective's green armor vest to their vendor as a premium item. Armor wise this vest is identical to a normal security vest, it's just a spare in the event the Detective loses theirs.

Replaces the normal camera in the cargo forensics crate with a Detective's camera (Detective's camera gets 20 extra charges).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Detective's shouldn't have two revolvers on MetaStation lol.
They should be able to buy a spare vest in the event theirs is destroyed. Yet again, it's just a security vest but with a different icon.
It makes sense for the forensics crate to include the slightly improved camera.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/db7bac69-db7b-4160-aa25-35950fa36bb6)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/4d016692-a7f3-4e4e-aeed-58eab27e1587)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/5b2ee3bd-0bfd-433a-b071-45a5a10dd8e7)

</details>

## Changelog
:cl:
del: Removed the duplicate Detective's locker - and thus the duplicate revolver from MetaStation
tweak: Forensics crates now include the detective's camera instead of a normal camera (20 extra charges)
add: Adds a spare detective armor vest to their vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
