### PR TITLE
Adds proper holodeck logging

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -172,6 +172,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		if("safety")
 			if((obj_flags & EMAGGED) && program)
 				emergency_shutdown()
+			log_game("[key_name(usr)] has [(obj_flags & EMAGGED ? "enabled" : "disabled" )] the holodeck safety settings at [loc_name(src)].")
 			nerf(obj_flags & EMAGGED,FALSE)
 			obj_flags ^= EMAGGED
 			say("Safeties reset. Restarting...")
@@ -227,6 +228,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 				holo_turf.baseturfs -= baseturf
 				holo_turf.baseturfs += /turf/open/floor/holofloor/plating
 
+	log_game("[key_name(usr)] has loaded the holodeck program '[program]' at [loc_name(src)].")
 	template = SSmapping.holodeck_templates[map_id]
 	var/datum/map_generator/template_placer = template.load(bottom_left) //this is what actually loads the holodeck simulation into the map
 	template_placer.on_completion(CALLBACK(src, PROC_REF(finish_spawn), template))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently the holodeck only logs what template has been loaded as part of the `/datum/map_template/proc/load()` proc. This does ***not*** include who loaded the template. Love to see it.

---

This PR doesn't touch that proc, it instead adds additional logging to the holodeck; this additional logging accounts for both loading templates and interacting with the safety settings.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hot take: Unlogged griefing tools are bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/4ee4c5de-f66d-4eb1-8e1b-491213d35c11)
</details>

## Changelog
:cl:
admin: Improved holodeck logging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
