### PR TITLE
Fixes being able to access 5000u beakers

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -484,3 +484,9 @@
 	name = "saline canister"
 	volume = 5000
 	list_reagents = list(/datum/reagent/medicine/salglu_solution = 5000)
+
+/obj/item/reagent_containers/glass/saline/Moved(atom/OldLoc, Dir)
+	if (!istype(loc, /obj/machinery/iv_drip/saline))
+		qdel(src)
+		return
+	return ..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -486,7 +486,7 @@
 	list_reagents = list(/datum/reagent/medicine/salglu_solution = 5000)
 
 /obj/item/reagent_containers/glass/saline/Moved(atom/OldLoc, Dir)
-	if (!istype(loc, /obj/machinery/iv_drip/saline))
+	if (loc && !istype(loc, /obj/machinery/iv_drip/saline))
 		qdel(src)
 		return
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Saline canister internal beakers will now be deleted when they are moved to a location other than their saline container.

## Why It's Good For The Game

These beakers hold up to 5000 units and should not be accessible.

## Testing Photographs and Procedure


https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e2101a78-026e-4eca-a262-8919d56c7b24



## Changelog
:cl:
fix: Fixes being able to access beakers which hold 5000 units of chems.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
