### PR TITLE
Fixes one (1) minor runtime in rust_lore.dm

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -163,8 +163,8 @@
 
 /datum/heretic_knowledge/rust_mark/proc/on_mansus_grasp(mob/living/source, mob/living/target)
 	SIGNAL_HANDLER
-
-	target.apply_status_effect(/datum/status_effect/heretic_mark/rust)
+	if(isliving(target))
+		target.apply_status_effect(/datum/status_effect/heretic_mark/rust)
 
 /datum/heretic_knowledge/rust_mark/proc/on_eldritch_blade(mob/living/user, mob/living/target)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
```
runtime error: undefined proc or verb /obj/item/codex_cicatrix/apply status effect().
 
 - proc name: on mansus grasp (/datum/heretic_knowledge/rust_mark/proc/on_mansus_grasp)
  -   source file: rust_lore.dm,167
  -   usr: Denys Joyce (/mob/living/carbon/human)
  -   src: Mark of Rust (/datum/heretic_knowledge/rust_mark)
  -   usr.loc: the floor (108,158,2) (/turf/open/floor/plasteel)
  -   call stack:
```
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/eb29bdef-3702-4158-bdfc-5f947899c81d)
Non-living things don't have status effects, and thus don't have this proc.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

💯 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

It's not there anymore. I can go record a video of me left clicking a random object with the mansus grasp and upload it if you really want.

</details>

## Changelog
:cl:
fix: Fixes a minor runtime in rust_lore.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
