### PR TITLE
Dynamic lategame & Midround simulations

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -17,6 +17,11 @@
 /// This ruleset will be logged in persistence, to reduce the chances of it repeatedly rolling several rounds in a row.
 #define PERSISTENT_RULESET (1 << 5)
 
+/// Can this ruleset be executed once we consider the round to be in the late game context?
+/// We generally want lategame rulesets to be chaotic and antagonists which do not require a long setup in order to get started.
+/// These are rulesets that should push the round to a close
+#define LATEGAME_RULESET (1 << 6)
+
 /// This is a "heavy" midround ruleset, and should be run later into the round
 #define MIDROUND_RULESET_STYLE_HEAVY "Heavy"
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -378,7 +378,10 @@
 				parts += "[FOURSPACES][FOURSPACES][entry]<BR>"
 		parts += "[FOURSPACES]Executed rules:"
 		for(var/datum/dynamic_ruleset/rule in mode.executed_rules)
-			parts += "[FOURSPACES][FOURSPACES][rule.ruletype] - <b>[rule.name]</b>: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat"
+			if (rule.lategame_spawned)
+				parts += "[FOURSPACES][FOURSPACES][rule.ruletype] - <b>[rule.name]</b>: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat (Lategame, threat level ignored)"
+			else
+				parts += "[FOURSPACES][FOURSPACES][rule.ruletype] - <b>[rule.name]</b>: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat"
 	return parts.Join("<br>")
 
 /client/proc/roundend_report_file()
@@ -742,7 +745,10 @@
         discordmsg += "Threat left: [mode.mid_round_budget]\n"
         discordmsg += "Executed rules:\n"
         for(var/datum/dynamic_ruleset/rule in mode.executed_rules)
-            discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat\n"
+			if (rule.lategame_spawned)
+				discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat (Lategame, threat level ignored)\n"
+            else
+				discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat\n"
     var/list/ded = SSblackbox.first_death
     if(ded)
         discordmsg += "First Death: [ded["name"]], [ded["role"]], at [ded["area"]]\n"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -729,32 +729,32 @@
 
 
 /datum/controller/subsystem/ticker/proc/sendtodiscord(var/survivors, var/escapees, var/integrity)
-    var/discordmsg = ""
-    discordmsg += "--------------ROUND END--------------\n"
-    discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
-    discordmsg += "Round Number: [GLOB.round_id]\n"
-    discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
-    discordmsg += "Players: [GLOB.player_list.len]\n"
-    discordmsg += "Survivors: [survivors]\n"
-    discordmsg += "Escapees: [escapees]\n"
-    discordmsg += "Integrity: [integrity]\n"
-    discordmsg += "Gamemode: [SSticker.mode.name]\n"
-    if(istype(SSticker.mode, /datum/game_mode/dynamic))
-        var/datum/game_mode/dynamic/mode = SSticker.mode
-        discordmsg += "Threat level: [mode.threat_level]\n"
-        discordmsg += "Threat left: [mode.mid_round_budget]\n"
-        discordmsg += "Executed rules:\n"
-        for(var/datum/dynamic_ruleset/rule in mode.executed_rules)
+	var/discordmsg = ""
+	discordmsg += "--------------ROUND END--------------\n"
+	discordmsg += "Server: [CONFIG_GET(string/servername)]\n"
+	discordmsg += "Round Number: [GLOB.round_id]\n"
+	discordmsg += "Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]\n"
+	discordmsg += "Players: [GLOB.player_list.len]\n"
+	discordmsg += "Survivors: [survivors]\n"
+	discordmsg += "Escapees: [escapees]\n"
+	discordmsg += "Integrity: [integrity]\n"
+	discordmsg += "Gamemode: [SSticker.mode.name]\n"
+	if(istype(SSticker.mode, /datum/game_mode/dynamic))
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		discordmsg += "Threat level: [mode.threat_level]\n"
+		discordmsg += "Threat left: [mode.mid_round_budget]\n"
+		discordmsg += "Executed rules:\n"
+		for(var/datum/dynamic_ruleset/rule in mode.executed_rules)
 			if (rule.lategame_spawned)
 				discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat (Lategame, threat level ignored)\n"
-            else
+			else
 				discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat\n"
-    var/list/ded = SSblackbox.first_death
-    if(ded)
-        discordmsg += "First Death: [ded["name"]], [ded["role"]], at [ded["area"]]\n"
-        var/last_words = ded["last_words"] ? "Their last words were: \"[ded["last_words"]]\"\n" : "They had no last words.\n"
-        discordmsg += "[last_words]\n"
-    else
-        discordmsg += "Nobody died!\n"
-    discordmsg += "--------------------------------------\n"
-    sendooc2ext(discordmsg)
+	var/list/ded = SSblackbox.first_death
+	if(ded)
+		discordmsg += "First Death: [ded["name"]], [ded["role"]], at [ded["area"]]\n"
+		var/last_words = ded["last_words"] ? "Their last words were: \"[ded["last_words"]]\"\n" : "They had no last words.\n"
+		discordmsg += "[last_words]\n"
+	else
+		discordmsg += "Nobody died!\n"
+	discordmsg += "--------------------------------------\n"
+	sendooc2ext(discordmsg)

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
+//#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE	//Enables the ability to cache datum vars and retrieve later for debugging which vars changed.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-//#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
+#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE	//Enables the ability to cache datum vars and retrieve later for debugging which vars changed.

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -439,7 +439,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 /datum/game_mode/dynamic/proc/set_cooldowns()
 	var/latejoin_injection_cooldown_middle = 0.5*(latejoin_delay_max + latejoin_delay_min)
-	latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + (simulated_time || world.time)
+	latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + get_time()
 
 /datum/game_mode/dynamic/pre_setup()
 	if(CONFIG_GET(flag/dynamic_config_enabled))
@@ -741,7 +741,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/game_mode/dynamic, execute_midround_latejoin_rule), forced_latejoin_rule), forced_latejoin_rule.delay)
 		forced_latejoin_rule = null
 
-	else if (latejoin_injection_cooldown < (simulated_time || world.time) && (forced_injection || prob(latejoin_roll_chance)))
+	else if (latejoin_injection_cooldown < get_time() && (forced_injection || prob(latejoin_roll_chance)))
 		forced_injection = FALSE
 
 		var/list/drafted_rules = list()
@@ -763,7 +763,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 		if (drafted_rules.len > 0 && pick_latejoin_rule(drafted_rules))
 			var/latejoin_injection_cooldown_middle = 0.5*(latejoin_delay_max + latejoin_delay_min)
-			latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + (simulated_time || world.time)
+			latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + get_time()
 
 /// Apply configurations to rule.
 /datum/game_mode/dynamic/proc/configure_ruleset(datum/dynamic_ruleset/ruleset)
@@ -864,7 +864,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			return rand(90, 100)
 
 /datum/game_mode/dynamic/proc/is_lategame()
-	return ((simulated_time || world.time) - SSticker.round_start_time) > midround_upper_bound
+	return (get_time() - SSticker.round_start_time) > midround_upper_bound
 
 /// Log to messages and to the game
 /datum/game_mode/dynamic/proc/dynamic_log(text)
@@ -872,6 +872,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		return
 	message_admins("DYNAMIC: [text]")
 	log_game("DYNAMIC: [text]")
+
+/datum/game_mode/dynamic/proc/get_time()
+	return simulated_time || world.time
 
 /// This sets the "don't roll after high impact rules die" flag
 /// if the mode is dynamic, signalling that something major has happened

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -95,7 +95,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// The upper bound for the midround roll time splits.
 	/// This number influences where to place midround rolls, making this larger
 	/// will make midround rolls less frequent, and vice versa.
-	/// A midround will never be able to roll farther than this.
+	/// Once this time has passed, only midround antags with the LATEGAME_RULESET
+	/// flag may roll, and these will roll independant of threat requirements.
 	var/midround_upper_bound = 100 MINUTES
 
 	/// The distance between the chosen midround roll point (which is deterministic),
@@ -207,6 +208,15 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 	/// Cached value of is_station_intact.
 	var/cached_station_intact = TRUE
+
+	/// If not null, use this instead of world.time
+	var/simulated_time = null
+
+	/// If we are running simulations and should treat nobody signing up as successful spawns
+	var/simulated = FALSE
+
+	/// Should we simulate there being more alive players than there actually are?
+	var/simulated_alive_players = 0
 
 	/// When the cached station intactness will expire.
 	COOLDOWN_DECLARE(intact_cache_expiry)
@@ -429,7 +439,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 /datum/game_mode/dynamic/proc/set_cooldowns()
 	var/latejoin_injection_cooldown_middle = 0.5*(latejoin_delay_max + latejoin_delay_min)
-	latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + world.time
+	latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + (simulated_time || world.time)
 
 /datum/game_mode/dynamic/pre_setup()
 	if(CONFIG_GET(flag/dynamic_config_enabled))
@@ -604,7 +614,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	ruleset.trim_candidates()
 	var/added_threat = ruleset.scale_up(roundstart_pop_ready, scaled_times)
 
-	if(ruleset.pre_execute(roundstart_pop_ready))
+	if(simulated || ruleset.pre_execute(roundstart_pop_ready))
 		threat_log += "[worldtime2text()]: Roundstart [ruleset.name] spent [ruleset.cost + added_threat]. [ruleset.scaling_cost ? "Scaled up [ruleset.scaled_times]/[scaled_times] times." : ""]"
 		if(CHECK_BITFIELD(ruleset.flags, ONLY_RULESET))
 			only_ruleset_executed = TRUE
@@ -653,6 +663,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		else if(CHECK_BITFIELD(new_rule.flags, HIGH_IMPACT_RULESET))
 			if(threat_level < GLOB.dynamic_stacking_limit && GLOB.dynamic_no_stacking && high_impact_ruleset_active())
 				return FALSE
+
+	// Stop respecting cost once we reach the late game stage
+	ignore_cost = ignore_cost || is_lategame()
 
 	var/population =  current_players[CURRENT_LIVING_PLAYERS].len
 	if((new_rule.acceptable(population, threat_level) && (ignore_cost || new_rule.cost <= mid_round_budget)) || forced)
@@ -728,7 +741,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/game_mode/dynamic, execute_midround_latejoin_rule), forced_latejoin_rule), forced_latejoin_rule.delay)
 		forced_latejoin_rule = null
 
-	else if (latejoin_injection_cooldown < world.time && (forced_injection || prob(latejoin_roll_chance)))
+	else if (latejoin_injection_cooldown < (simulated_time || world.time) && (forced_injection || prob(latejoin_roll_chance)))
 		forced_injection = FALSE
 
 		var/list/drafted_rules = list()
@@ -750,7 +763,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 		if (drafted_rules.len > 0 && pick_latejoin_rule(drafted_rules))
 			var/latejoin_injection_cooldown_middle = 0.5*(latejoin_delay_max + latejoin_delay_min)
-			latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + world.time
+			latejoin_injection_cooldown = round(clamp(EXP_DISTRIBUTION(latejoin_injection_cooldown_middle), latejoin_delay_min, latejoin_delay_max)) + (simulated_time || world.time)
 
 /// Apply configurations to rule.
 /datum/game_mode/dynamic/proc/configure_ruleset(datum/dynamic_ruleset/ruleset)
@@ -850,8 +863,13 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (20 to INFINITY)
 			return rand(90, 100)
 
+/datum/game_mode/dynamic/proc/is_lategame()
+	return ((simulated_time || world.time) - SSticker.round_start_time) > midround_upper_bound
+
 /// Log to messages and to the game
 /datum/game_mode/dynamic/proc/dynamic_log(text)
+	if (simulated)
+		return
 	message_admins("DYNAMIC: [text]")
 	log_game("DYNAMIC: [text]")
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -96,7 +96,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// This number influences where to place midround rolls, making this larger
 	/// will make midround rolls less frequent, and vice versa.
 	/// Once this time has passed, only midround antags with the LATEGAME_RULESET
-	/// flag may roll, and these will roll independant of threat requirements.
+	/// flag may roll, and these will roll independent of threat requirements.
 	var/midround_upper_bound = 100 MINUTES
 
 	/// The distance between the chosen midround roll point (which is deterministic),

--- a/code/game/gamemodes/dynamic/dynamic_hijacking.dm
+++ b/code/game/gamemodes/dynamic/dynamic_hijacking.dm
@@ -15,12 +15,12 @@
 
 	var/time_range = rand(random_event_hijack_minimum, random_event_hijack_maximum)
 
-	if (world.time - last_midround_injection_attempt < time_range)
+	if ((simulated_time || world.time) - last_midround_injection_attempt < time_range)
 		random_event_hijacked = HIJACKED_TOO_RECENT
 		dynamic_log("Random event [round_event_control.name] tried to roll, but the last midround injection \
 			was too recent. Heavy injection chance has been raised to [get_heavy_midround_injection_chance(dry_run = TRUE)]%.")
 		return CANCEL_PRE_RANDOM_EVENT
 
-	if (next_midround_injection() - world.time < time_range)
+	if (next_midround_injection() - (simulated_time || world.time) < time_range)
 		dynamic_log("Random event [round_event_control.name] tried to roll, but the next midround injection is too soon.")
 		return CANCEL_PRE_RANDOM_EVENT

--- a/code/game/gamemodes/dynamic/dynamic_hijacking.dm
+++ b/code/game/gamemodes/dynamic/dynamic_hijacking.dm
@@ -15,12 +15,12 @@
 
 	var/time_range = rand(random_event_hijack_minimum, random_event_hijack_maximum)
 
-	if ((simulated_time || world.time) - last_midround_injection_attempt < time_range)
+	if (get_time() - last_midround_injection_attempt < time_range)
 		random_event_hijacked = HIJACKED_TOO_RECENT
 		dynamic_log("Random event [round_event_control.name] tried to roll, but the last midround injection \
 			was too recent. Heavy injection chance has been raised to [get_heavy_midround_injection_chance(dry_run = TRUE)]%.")
 		return CANCEL_PRE_RANDOM_EVENT
 
-	if (next_midround_injection() - (simulated_time || world.time) < time_range)
+	if (next_midround_injection() - get_time() < time_range)
 		dynamic_log("Random event [round_event_control.name] tried to roll, but the next midround injection is too soon.")
 		return CANCEL_PRE_RANDOM_EVENT

--- a/code/game/gamemodes/dynamic/dynamic_logging.dm
+++ b/code/game/gamemodes/dynamic/dynamic_logging.dm
@@ -73,7 +73,7 @@
 	var/datum/dynamic_snapshot/new_snapshot = new
 
 	new_snapshot.remaining_threat = mid_round_budget
-	new_snapshot.time = world.time
+	new_snapshot.time = (simulated_time || world.time)
 	new_snapshot.alive_players = current_players[CURRENT_LIVING_PLAYERS].len
 	new_snapshot.dead_players = current_players[CURRENT_DEAD_PLAYERS].len
 	new_snapshot.observers = current_players[CURRENT_OBSERVERS].len

--- a/code/game/gamemodes/dynamic/dynamic_logging.dm
+++ b/code/game/gamemodes/dynamic/dynamic_logging.dm
@@ -73,7 +73,7 @@
 	var/datum/dynamic_snapshot/new_snapshot = new
 
 	new_snapshot.remaining_threat = mid_round_budget
-	new_snapshot.time = (simulated_time || world.time)
+	new_snapshot.time = get_time()
 	new_snapshot.alive_players = current_players[CURRENT_LIVING_PLAYERS].len
 	new_snapshot.dead_players = current_players[CURRENT_DEAD_PLAYERS].len
 	new_snapshot.observers = current_players[CURRENT_OBSERVERS].len

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -16,19 +16,19 @@
 
 	return last_midround_injection_attempt + distance
 
-/datum/game_mode/dynamic/proc/try_midround_roll()
-	if (!forced_injection && next_midround_injection() > world.time)
-		return
+/datum/game_mode/dynamic/proc/try_midround_roll(force = FALSE)
+	if (!forced_injection && next_midround_injection() > (simulated_time || world.time))
+		return null
 
 	if (GLOB.dynamic_forced_extended)
-		return
+		return null
 
 	if (EMERGENCY_ESCAPED_OR_ENDGAMED)
-		return
+		return null
 
 	var/spawn_heavy = prob(get_heavy_midround_injection_chance())
 
-	last_midround_injection_attempt = world.time
+	last_midround_injection_attempt = (simulated_time || world.time)
 	next_midround_injection = null
 	forced_injection = FALSE
 
@@ -44,15 +44,15 @@
 			log_game("DYNAMIC: FAIL: [ruleset] has a weight of 0")
 			continue
 
-		if (!ruleset.acceptable(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len, threat_level))
+		if (!ruleset.acceptable(simulated_alive_players || SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len, threat_level))
 			log_game("DYNAMIC: FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len], threat level: [threat_level]")
 			continue
 
-		if (mid_round_budget < ruleset.cost)
+		if (mid_round_budget < ruleset.cost && !is_lategame())
 			log_game("DYNAMIC: FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], ruleset cost: [ruleset.cost]")
 			continue
 
-		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)
+		if (ruleset.minimum_round_time > (simulated_time || world.time) - SSticker.round_start_time)
 			log_game("DYNAMIC: FAIL: [ruleset] is trying to run too early. Minimum round time: [ruleset.minimum_round_time], current round time: [world.time - SSticker.round_start_time]")
 			continue
 
@@ -62,7 +62,7 @@
 			continue
 
 		ruleset.trim_candidates()
-		if (!ruleset.ready())
+		if (!ruleset.ready(force))
 			log_game("DYNAMIC: FAIL: [ruleset] is not ready()")
 			continue
 
@@ -76,9 +76,9 @@
 
 	log_game("DYNAMIC: Rolling [spawn_heavy ? "HEAVY" : "LIGHT"]... [heavy_light_log_count]")
 
-	if (spawn_heavy && drafted_heavies.len > 0 && pick_midround_rule(drafted_heavies, "heavy rulesets"))
+	if (spawn_heavy && drafted_heavies.len > 0 && (. = pick_midround_rule(drafted_heavies, "heavy rulesets")))
 		return
-	else if (drafted_lights.len > 0 && pick_midround_rule(drafted_lights, "light rulesets"))
+	else if (drafted_lights.len > 0 && (. = pick_midround_rule(drafted_lights, "light rulesets")))
 		if (spawn_heavy)
 			dynamic_log("A heavy ruleset was intended to roll, but there weren't any available. [heavy_light_log_count]")
 	else

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -112,6 +112,9 @@
 		log_game("DYNAMIC: FAIL: [src] failed acceptable: maximum_players ([maximum_players]) < population ([population])")
 		return FALSE
 
+	if (mode.is_lategame())
+		return (flags & LATEGAME_RULESET)
+
 	pop_per_requirement = pop_per_requirement > 0 ? pop_per_requirement : mode.pop_per_requirement
 	indice_pop = min(requirements.len,round(population/pop_per_requirement)+1)
 	if (threat_level < requirements[indice_pop])
@@ -228,6 +231,9 @@
 
 /// Checks if the ruleset is "dead", where all the antags are either dead or deconverted.
 /datum/dynamic_ruleset/proc/is_dead()
+	// Don't let dead threats affect simulation results
+	if (mode.simulated)
+		return FALSE
 	for(var/datum/mind/mind in assigned)
 		var/mob/living/body = mind.current
 		// If they have no body, they're dead for realsies.
@@ -248,7 +254,7 @@
 			if(body.soul_departed() || mind.hellbound)
 				continue
 			// Are they in medbay or an operating table/stasis bed, and have been dead for less than 20 minutes? If so, they're probably being revived.
-			if(world.time <= (mind.last_death + 15 MINUTES) && (istype(get_area(body), /area/medical) || (locate(/obj/machinery/stasis) in body.loc) || (locate(/obj/structure/table/optable) in body.loc)))
+			if((mode.simulated_time || world.time) <= (mind.last_death + 15 MINUTES) && (istype(get_area(body), /area/medical) || (locate(/obj/machinery/stasis) in body.loc) || (locate(/obj/structure/table/optable) in body.loc)))
 				log_undead()
 				return FALSE
 		else

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -83,6 +83,9 @@
 	/// Whether repeated_mode_adjust weight changes have been logged already.
 	var/logged_repeated_mode_adjust = FALSE
 
+	/// Was this ruleset spawned from the lategame mode?
+	var/lategame_spawned = FALSE
+
 
 /datum/dynamic_ruleset/New(datum/game_mode/dynamic/dynamic_mode)
 	// Rulesets can be instantiated more than once, such as when an admin clicks
@@ -91,6 +94,7 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	mode = dynamic_mode
+	lategame_spawned = mode.is_lategame()
 	..()
 
 /datum/dynamic_ruleset/roundstart // One or more of those drafted at roundstart

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -189,7 +189,7 @@
 	// As a consequence, latejoin heretics start out at a massive
 	// disadvantage if the round's been going on for a while.
 	// Let's give them some influence points when they arrive.
-	new_heretic.knowledge_points += round((world.time - SSticker.round_start_time) / new_heretic.passive_gain_timer)
+	new_heretic.knowledge_points += round(((mode.simulated_time || world.time) - SSticker.round_start_time) / new_heretic.passive_gain_timer)
 	// BUT let's not give smugglers a million points on arrival.
 	// Limit it to four missed passive gain cycles (4 points).
 	new_heretic.knowledge_points = min(new_heretic.knowledge_points, 5)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -298,7 +298,7 @@
 	weight = 1
 	cost = 15
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
-	flags = HIGH_IMPACT_RULESET|PERSISTENT_RULESET
+	flags = HIGH_IMPACT_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard/ready(forced = FALSE)
 	if(!length(GLOB.wizardstart))
@@ -367,7 +367,7 @@
 	weight = 3
 	cost = 12
 	minimum_players = 25
-	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET
+	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
 	var/body = applicant.become_overmind()
@@ -391,7 +391,7 @@
 	weight = 3
 	cost = 12
 	minimum_players = 25
-	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET
+	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 	var/list/vents
 
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph/acceptable(population=0, threat=0)
@@ -492,7 +492,7 @@
 	cost = 11
 	minimum_players = 25
 	repeatable = TRUE
-	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET
+	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 	var/list/spawn_locs
 
 /datum/dynamic_ruleset/midround/from_ghosts/space_dragon/ready(forced = FALSE)
@@ -625,6 +625,7 @@
 	cost = 8
 	minimum_players = 27
 	repeatable = FALSE
+	flags = LATEGAME_RULESET
 
 /datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
 	if (!SSmapping.empty_space)
@@ -690,7 +691,7 @@
 	weight = 3
 	cost = 11
 	repeatable = TRUE
-	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET
+	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 	minimum_players = 27
 	var/fed = 1
 	var/list/vents
@@ -886,6 +887,7 @@
 	minimum_players = 20
 	repeatable = TRUE
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/nuclear, /datum/dynamic_ruleset/roundstart/clockcult)
+	flags = LATEGAME_RULESET
 	var/spawn_loc
 
 /datum/dynamic_ruleset/midround/from_ghosts/ninja/ready(forced)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -546,11 +546,11 @@
 	var/rampupdelta = 5
 
 /datum/dynamic_ruleset/roundstart/meteor/rule_process()
-	if(nometeors || meteordelay > world.time - SSticker.round_start_time)
+	if(nometeors || meteordelay > (mode.simulated_time || world.time) - SSticker.round_start_time)
 		return
 
 	var/list/wavetype = GLOB.meteors_normal
-	var/meteorminutes = (world.time - SSticker.round_start_time - meteordelay) / 10 / 60
+	var/meteorminutes = ((mode.simulated_time || world.time) - SSticker.round_start_time - meteordelay) / 10 / 60
 
 	if (prob(meteorminutes))
 		wavetype = GLOB.meteors_threatening

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -24,13 +24,13 @@
 		if (ruleset.weight == 0)
 			continue
 
-		if (ruleset.cost > max_threat_level)
+		if (ruleset.cost > max_threat_level && !is_lategame())
 			continue
 
 		if (!ruleset.acceptable(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len, threat_level))
 			continue
 
-		if (ruleset.minimum_round_time > world.time - SSticker.round_start_time)
+		if (ruleset.minimum_round_time > (simulated_time || world.time) - SSticker.round_start_time)
 			continue
 
 		if(istype(ruleset, /datum/dynamic_ruleset/midround/from_ghosts) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -30,7 +30,7 @@
 		if (!ruleset.acceptable(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len, threat_level))
 			continue
 
-		if (ruleset.minimum_round_time > (simulated_time || world.time) - SSticker.round_start_time)
+		if (ruleset.minimum_round_time > get_time() - SSticker.round_start_time)
 			continue
 
 		if(istype(ruleset, /datum/dynamic_ruleset/midround/from_ghosts) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Once the midround upper bound limit on dynamic has expired (100 minutes atm), threat checks are disabled and only rulesets with the LATEGAME flag can roll.
- Updates the simulation algorithm to disable actually executing the rulesets so that clockie spawning won't cause it to take ages. This in turn makes the execution of the simulation a lot faster.

The rulesets that are considered late-game are ones that do not require a significant amount of prep time (we need to work with the assumption that the shuttle will come any minute) and that will generally cause enough chaos to result in the shuttle call coming closer. These rulesets are:
- Wizard
- Blob
- Xenomorph Infestation
- Space Dragon
- Space Pirates
- Spiders
- Space Ninja

Note that once we reach the game end point, the time between threats will still remain the same as before so lower threat rounds will have longer gaps between lategame threats spawning, however will still ignore the cost of the ruleset.

In the future I will trial lowering this value to 75 minutes and making threat more consistent if we continue to have issues with exhausting rounds.

## Why It's Good For The Game

Dynamic has an upper-bound on when it will consume all of its threat and after 100 minutes should stop spawning antags. This behaviour works for rounds that never exceed 90 minutes, however we are more commonly having rounds that go on for a really long amount of time which often end up in really large player drops. This will disengage threat once we reach the end game (100 minute mark) so that more chaotic threats will begin spawning even after all of the threat has been consumed. For most rounds we should either see:
- Evacuation prior to dynamic lategame
- Chaos slowly increasing over the round before reaching the end-game where more round-ending threats will begin to exclusively spawn.
- Not much happening before round-ending threats begin to spawn. (Less ideal, but this is hard to control especially when we get low threat or low-pop rounds)

I have toyed around with the idea of decreasing the lategame dynamic time to 70 minutes as there will always be a delay and that will bring a wrap to the usual round in around 90-120 minutes, although I haven't changed it in this PR.

Of course not all long rounds are boring, however players still get exhausted from them and an overly long round (2.5 hours or more) can be deterimental especially at high-pop hours, as a large chunk of players leaving often results in less players joining.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/cb6886d8-59d4-421b-81a9-0f120e433d17)

Note that after 60000 seconds, only certain rulesets can run

<details>
<summary>Json</summary>

```json
[
  {
    "roundstart_players": 50,
    "threat_level": 40,
    "snapshot": {
      "antag_percent": 0.08,
      "remaining_threat": 23,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Syndicate Sleeper Agent",
        "weight": 20,
        "cost": 8,
        "execution_time": 14571.4,
        "remaining_threat": 15,
        "simulated_alive_players": 49
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 29142.9,
        "remaining_threat": 4,
        "simulated_alive_players": 48
      },
      {
        "ruleset": "Blob",
        "weight": 3,
        "cost": 12,
        "execution_time": 72857.1,
        "remaining_threat": 0,
        "simulated_alive_players": 40
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 23.3,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 15.3,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Obsessed",
        "weight": 3,
        "cost": 5,
        "execution_time": 21000,
        "remaining_threat": 10.3,
        "simulated_alive_players": 45
      },
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 42000,
        "remaining_threat": 2.3,
        "simulated_alive_players": 40
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 63000,
        "remaining_threat": 0,
        "simulated_alive_players": 38
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 30,
    "snapshot": {
      "antag_percent": 0.06,
      "remaining_threat": 15,
      "rulesets": [
        "Heretics"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Abductors",
        "weight": 4,
        "cost": 7,
        "execution_time": 16000,
        "remaining_threat": 8,
        "simulated_alive_players": 45
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 32000,
        "remaining_threat": 0,
        "simulated_alive_players": 45
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 64000,
        "remaining_threat": 0,
        "simulated_alive_players": 38
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 38.1,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 30.1,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Abductors",
        "weight": 4,
        "cost": 7,
        "execution_time": 14571.4,
        "remaining_threat": 23.1,
        "simulated_alive_players": 47
      },
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 29142.9,
        "remaining_threat": 15.1,
        "simulated_alive_players": 44
      },
      {
        "ruleset": "Blob",
        "weight": 3,
        "cost": 12,
        "execution_time": 43714.3,
        "remaining_threat": 3.1,
        "simulated_alive_players": 44
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 72857.1,
        "remaining_threat": 0,
        "simulated_alive_players": 38
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 45.9,
    "snapshot": {
      "antag_percent": 0.08,
      "remaining_threat": 28.9,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Syndicate Sleeper Agent",
        "weight": 20,
        "cost": 8,
        "execution_time": 14571.4,
        "remaining_threat": 20.9,
        "simulated_alive_players": 46
      },
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 29142.9,
        "remaining_threat": 12.9,
        "simulated_alive_players": 42
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 43714.3,
        "remaining_threat": 1.9,
        "simulated_alive_players": 39
      },
      {
        "ruleset": "Space Ninja",
        "weight": 3,
        "cost": 9,
        "execution_time": 72857.1,
        "remaining_threat": 0,
        "simulated_alive_players": 34
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 56.7,
    "snapshot": {
      "antag_percent": 0.08,
      "remaining_threat": 36.7,
      "rulesets": [
        "Nuclear Emergency"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Obsessed",
        "weight": 3,
        "cost": 5,
        "execution_time": 12666.7,
        "remaining_threat": 31.7,
        "simulated_alive_players": 47
      },
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 25333.3,
        "remaining_threat": 23.7,
        "simulated_alive_players": 42
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 38000,
        "remaining_threat": 12.7,
        "simulated_alive_players": 39
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 50666.7,
        "remaining_threat": 4.7,
        "simulated_alive_players": 36
      },
      {
        "ruleset": "Space Dragon",
        "weight": 1,
        "cost": 11,
        "execution_time": 63333.3,
        "remaining_threat": 0,
        "simulated_alive_players": 34
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 33.2,
    "snapshot": {
      "antag_percent": 0.06,
      "remaining_threat": 18.2,
      "rulesets": [
        "Heretics"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Abductors",
        "weight": 4,
        "cost": 7,
        "execution_time": 16000,
        "remaining_threat": 11.2,
        "simulated_alive_players": 46
      },
      {
        "ruleset": "Space Ninja",
        "weight": 3,
        "cost": 9,
        "execution_time": 32000,
        "remaining_threat": 2.2,
        "simulated_alive_players": 42
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 64000,
        "remaining_threat": 0,
        "simulated_alive_players": 40
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 14.2,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 6.2,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Obsessed",
        "weight": 3,
        "cost": 5,
        "execution_time": 26000,
        "remaining_threat": 1.2,
        "simulated_alive_players": 50
      },
      {
        "ruleset": "Space Ninja",
        "weight": 3,
        "cost": 9,
        "execution_time": 78000,
        "remaining_threat": 0,
        "simulated_alive_players": 46
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 29.6,
    "snapshot": {
      "antag_percent": 0.06,
      "remaining_threat": 14.6,
      "rulesets": [
        "Heretics"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Syndicate Sleeper Agent",
        "weight": 20,
        "cost": 8,
        "execution_time": 16000,
        "remaining_threat": 6.6,
        "simulated_alive_players": 45
      },
      {
        "ruleset": "Obsessed",
        "weight": 3,
        "cost": 5,
        "execution_time": 32000,
        "remaining_threat": 1.6,
        "simulated_alive_players": 41
      },
      {
        "ruleset": "Blob",
        "weight": 3,
        "cost": 12,
        "execution_time": 64000,
        "remaining_threat": 0,
        "simulated_alive_players": 35
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 35.6,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 27.6,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 16000,
        "remaining_threat": 16.6,
        "simulated_alive_players": 49
      },
      {
        "ruleset": "Malfunctioning AI",
        "weight": 2,
        "cost": 13,
        "execution_time": 32000,
        "remaining_threat": 3.6,
        "simulated_alive_players": 49
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 64000,
        "remaining_threat": 0,
        "simulated_alive_players": 47
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 36.5,
    "snapshot": {
      "antag_percent": 0.08,
      "remaining_threat": 19.5,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Syndicate Sleeper Agent",
        "weight": 20,
        "cost": 8,
        "execution_time": 14571.4,
        "remaining_threat": 11.5,
        "simulated_alive_players": 48
      },
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 29142.9,
        "remaining_threat": 3.5,
        "simulated_alive_players": 43
      },
      {
        "ruleset": "Wizard",
        "weight": 1,
        "cost": 15,
        "execution_time": 72857.1,
        "remaining_threat": 0,
        "simulated_alive_players": 39
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 32.8,
    "snapshot": {
      "antag_percent": 0.06,
      "remaining_threat": 20.8,
      "rulesets": [
        "Blood Brothers"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 16000,
        "remaining_threat": 12.8,
        "simulated_alive_players": 47
      },
      {
        "ruleset": "Blob",
        "weight": 3,
        "cost": 12,
        "execution_time": 32000,
        "remaining_threat": 0.799999,
        "simulated_alive_players": 43
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 64000,
        "remaining_threat": 0,
        "simulated_alive_players": 41
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 19.2,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 11.2,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Syndicate Sleeper Agent",
        "weight": 20,
        "cost": 8,
        "execution_time": 21000,
        "remaining_threat": 3.2,
        "simulated_alive_players": 50
      },
      {
        "ruleset": "Space Ninja",
        "weight": 3,
        "cost": 9,
        "execution_time": 63000,
        "remaining_threat": 0,
        "simulated_alive_players": 42
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 42.2,
    "snapshot": {
      "antag_percent": 0.08,
      "remaining_threat": 25.2,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Syndicate Sleeper Agent",
        "weight": 20,
        "cost": 8,
        "execution_time": 14571.4,
        "remaining_threat": 17.2,
        "simulated_alive_players": 48
      },
      {
        "ruleset": "Malfunctioning AI",
        "weight": 2,
        "cost": 13,
        "execution_time": 29142.9,
        "remaining_threat": 4.2,
        "simulated_alive_players": 45
      },
      {
        "ruleset": "Space Ninja",
        "weight": 3,
        "cost": 9,
        "execution_time": 72857.1,
        "remaining_threat": 0,
        "simulated_alive_players": 42
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 49.1,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 33.1,
      "rulesets": [
        "Changelings"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Syndicate Sleeper Agent",
        "weight": 20,
        "cost": 8,
        "execution_time": 13500,
        "remaining_threat": 25.1,
        "simulated_alive_players": 47
      },
      {
        "ruleset": "Blob",
        "weight": 3,
        "cost": 12,
        "execution_time": 27000,
        "remaining_threat": 13.1,
        "simulated_alive_players": 42
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 40500,
        "remaining_threat": 2.1,
        "simulated_alive_players": 40
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 67500,
        "remaining_threat": 0,
        "simulated_alive_players": 35
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 44.3,
    "snapshot": {
      "antag_percent": 0.02,
      "remaining_threat": 24.3,
      "rulesets": [
        "Wizard"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Obsessed",
        "weight": 3,
        "cost": 5,
        "execution_time": 14571.4,
        "remaining_threat": 19.3,
        "simulated_alive_players": 48
      },
      {
        "ruleset": "Space Ninja",
        "weight": 3,
        "cost": 9,
        "execution_time": 29142.9,
        "remaining_threat": 10.3,
        "simulated_alive_players": 47
      },
      {
        "ruleset": "Space Ninja",
        "weight": 1,
        "cost": 9,
        "execution_time": 43714.3,
        "remaining_threat": 1.3,
        "simulated_alive_players": 47
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 72857.1,
        "remaining_threat": 0,
        "simulated_alive_players": 43
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 38.2,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 30.2,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 16000,
        "remaining_threat": 22.2,
        "simulated_alive_players": 45
      },
      {
        "ruleset": "Blob",
        "weight": 3,
        "cost": 12,
        "execution_time": 32000,
        "remaining_threat": 10.2,
        "simulated_alive_players": 40
      },
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 48000,
        "remaining_threat": 2.2,
        "simulated_alive_players": 36
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 64000,
        "remaining_threat": 0,
        "simulated_alive_players": 33
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 3,
    "snapshot": {
      "antag_percent": 0,
      "remaining_threat": 3,
      "rulesets": [
        
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 72000,
        "remaining_threat": 0,
        "simulated_alive_players": 50
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 32,
    "snapshot": {
      "antag_percent": 0,
      "remaining_threat": 32,
      "rulesets": [
        
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Abductors",
        "weight": 4,
        "cost": 7,
        "execution_time": 18000,
        "remaining_threat": 25,
        "simulated_alive_players": 46
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 36000,
        "remaining_threat": 17,
        "simulated_alive_players": 43
      },
      {
        "ruleset": "Space Ninja",
        "weight": 3,
        "cost": 9,
        "execution_time": 54000,
        "remaining_threat": 8,
        "simulated_alive_players": 42
      },
      {
        "ruleset": "Space Dragon",
        "weight": 4,
        "cost": 11,
        "execution_time": 72000,
        "remaining_threat": 0,
        "simulated_alive_players": 38
      }
    ]
  },
  {
    "roundstart_players": 50,
    "threat_level": 26.7,
    "snapshot": {
      "antag_percent": 0.04,
      "remaining_threat": 18.7,
      "rulesets": [
        "Traitors"
      ]
    },
    "midround_rules": [
      {
        "ruleset": "Morph",
        "weight": 3,
        "cost": 8,
        "execution_time": 18000,
        "remaining_threat": 10.7,
        "simulated_alive_players": 48
      },
      {
        "ruleset": "Space Pirates",
        "weight": 4,
        "cost": 8,
        "execution_time": 36000,
        "remaining_threat": 2.7,
        "simulated_alive_players": 45
      },
      {
        "ruleset": "Blob",
        "weight": 3,
        "cost": 12,
        "execution_time": 72000,
        "remaining_threat": 0,
        "simulated_alive_players": 39
      }
    ]
  }
]
```

<details>

## Changelog
:cl:
tweak: Tweaks dynamic's endgame, making only specific threats capable of spawning after the midround spawn time limit has passed (100 minute mark) and making dynamic ignore the cost of threats after that point has passed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
