### PR TITLE
Ports a couple of minor logging/admin related PRs from TG

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -107,6 +107,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/eng
 		FD.CalculateAffectingAreas()
 
 	to_chat(creator, "<span class='notice'>You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered.</span>")
+	log_game("created a new area: [AREACOORD(creator)] (previously \"[oldA.name]\")", LOG_GAME)
 	return TRUE
 
 #undef BP_MAX_ROOM_SIZE

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/eng
 		FD.CalculateAffectingAreas()
 
 	to_chat(creator, "<span class='notice'>You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered.</span>")
-	log_game("created a new area: [AREACOORD(creator)] (previously \"[oldA.name]\")", LOG_GAME)
+	log_game("[key_name(creator)] created a new area: [AREACOORD(creator)] (previously \"[oldA.name]\")", LOG_GAME)
 	return TRUE
 
 #undef BP_MAX_ROOM_SIZE

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/eng
 		FD.CalculateAffectingAreas()
 
 	to_chat(creator, "<span class='notice'>You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered.</span>")
-	log_game("[key_name(creator)] created a new area: [AREACOORD(creator)] (previously \"[oldA.name]\")", LOG_GAME)
+	log_game("[key_name(creator)] created a new area: [AREACOORD(creator)] (previously \"[oldA.name]\")")
 	return TRUE
 
 #undef BP_MAX_ROOM_SIZE

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -7,6 +7,9 @@
 /obj/machinery/computer/upload/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/gps, "Encrypted Upload")
+	if(!mapload)
+		log_game("A [name] was created at [loc_name(src)].")
+		message_admins("A [name] was created at [ADMIN_VERBOSEJMP(src)].")
 	GLOB.uploads_list += src
 
 /obj/machinery/computer/upload/Destroy()

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -8,8 +8,8 @@
 	. = ..()
 	AddComponent(/datum/component/gps, "Encrypted Upload")
 	if(!mapload)
-		log_game("A [name] was created at [loc_name(src)].")
-		message_admins("A [name] was created at [ADMIN_VERBOSEJMP(src)].")
+		log_game("\A [name] was created at [loc_name(src)].")
+		message_admins("\A [name] was created at [ADMIN_VERBOSEJMP(src)].")
 	GLOB.uploads_list += src
 
 /obj/machinery/computer/upload/Destroy()

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -8,8 +8,8 @@
 	. = ..()
 	AddComponent(/datum/component/gps, "Encrypted Upload")
 	if(!mapload)
-		log_game("\A [name] was created at [loc_name(src)].")
-		message_admins("\A [name] was created at [ADMIN_VERBOSEJMP(src)].")
+		log_game("A [name] was created at [loc_name(src)].")
+		message_admins("A [name] was created at [ADMIN_VERBOSEJMP(src)].")
 	GLOB.uploads_list += src
 
 /obj/machinery/computer/upload/Destroy()

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -8,7 +8,7 @@
 	. = ..()
 	AddComponent(/datum/component/gps, "Encrypted Upload")
 	if(!mapload)
-		log_game("A [name] was created at [loc_name(src)].")
+		log_game("A [name] was created at [AREACOORD(src)].")
 		message_admins("A [name] was created at [ADMIN_VERBOSEJMP(src)].")
 	GLOB.uploads_list += src
 

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -164,7 +164,7 @@
 		dat += "Living crew limit: <a href='?_src_=holder;[HrefToken()];alter_midround_life_limit=1'>[CONFIG_GET(number/midround_antag_life_check) * 100]% of crew alive</a><BR>"
 		dat += "If limits past: <a href='?_src_=holder;[HrefToken()];toggle_noncontinuous_behavior=1'>[SSticker.mode.round_ends_with_antag_death ? "End The Round" : "Continue As Extended"]</a><BR>"
 	dat += "<a href='?_src_=holder;[HrefToken()];end_round=[REF(usr)]'>End Round Now</a><br>"
-	dat += "<a href='?_src_=holder;[HrefToken()];delay_round_end=1'>[SSticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
+	dat += "<a href='?_src_=holder;[HrefToken()];delay_round_end=1'>[SSticker.delay_end ? "Undelay Round End" : "Delay Round End"]</a><br>"
 	dat += "<a href='?_src_=holder;[HrefToken()];check_teams=1'>Check Teams</a>"
 	var/connected_players = GLOB.clients.len
 	var/lobby_players = 0

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -388,7 +388,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(isliving(mind?.current))
 		mind.current.med_hud_set_status()
 	to_chat(src, "You can no longer be brought back into your body.")
-	log_game("[key_name(usr)] has opted to do-not-resuscitate / DNR from their body [current_mob]")
+	src.log_message("[key_name(src)] has opted to do-not-resuscitate / DNR from their body [mind?.current]", LOG_GAME)
 	return TRUE
 
 /mob/dead/observer/proc/notify_cloning(var/message, var/sound, var/atom/source, flashwindow = TRUE)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -388,6 +388,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(isliving(mind?.current))
 		mind.current.med_hud_set_status()
 	to_chat(src, "You can no longer be brought back into your body.")
+	log_game("[key_name(usr)] has opted to do-not-resuscitate / DNR from their body [current_mob]")
 	return TRUE
 
 /mob/dead/observer/proc/notify_cloning(var/message, var/sound, var/atom/source, flashwindow = TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -177,6 +177,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.key = elitemind.key
 		mychild.sentience_act()
 		notify_ghosts("\A [mychild] has been awakened in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite awakened")
+	mychild.log_message("has been awakened by [key_name(activator)]!", LOG_GAME, color="#960000")
 	icon_state = "tumor_popped"
 	INVOKE_ASYNC(src, PROC_REF(arena_checks))
 
@@ -189,6 +190,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.maxHealth = mychild.maxHealth * 2
 		mychild.health = mychild.maxHealth
 		notify_ghosts("\A [mychild] has been challenged in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite challenged")
+	mychild.log_message("has been challenged by [key_name(activator)]!", LOG_GAME, color="#960000")
 
 /obj/structure/elite_tumor/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -178,6 +178,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.sentience_act()
 		notify_ghosts("\A [mychild] has been awakened in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite awakened")
 	mychild.log_message("has been awakened by [key_name(activator)]!", LOG_GAME, color="#960000")
+	activator.log_message("has awakened [key_name(mychild)]!", LOG_GAME, color="#960000")
 	icon_state = "tumor_popped"
 	INVOKE_ASYNC(src, PROC_REF(arena_checks))
 

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -306,6 +306,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/bsa/middle)
 		options += GLOB.teleportlocs
 	var/V = input(user,"Select target", "Select target",null) in options|null
 	target = options[V]
+	log_game("[key_name(user)] has aimed the artillery strike at [target].")
 
 
 /obj/machinery/computer/bsa_control/proc/get_target_name()

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -304,9 +304,14 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/bsa/middle)
 	var/list/options = gps_locators
 	if(area_aim)
 		options += GLOB.teleportlocs
-	var/V = input(user,"Select target", "Select target",null) in options|null
-	target = options[V]
-	log_game("[key_name(user)] has aimed the artillery strike at [target].")
+	var/victim = tgui_input_list(user, "Select target", "Artillery Targeting", options)
+	if(isnull(victim))
+		return
+	if(isnull(options[victim]))
+		return
+	target = options[victim]
+	var/datum/component/gps/log_target = target
+	log_game("[key_name(user)] has aimed the artillery strike at [get_area_name(log_target.parent)].")
 
 
 /obj/machinery/computer/bsa_control/proc/get_target_name()

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -311,7 +311,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/bsa/middle)
 		return
 	target = options[victim]
 	var/datum/component/gps/log_target = target
-	log_game("[key_name(user)] has aimed the artillery strike at [get_area_name(log_target.parent)].")
+	log_game("[key_name(user)] has aimed the bluespace artillery strike (BSA) at [get_area_name(log_target.parent)].")
 
 
 /obj/machinery/computer/bsa_control/proc/get_target_name()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports/partially ports multiple minor logging PRs from TG, in addition to another minor admin related PR. Some of these are taken one to one - others are modified slightly; either for better readability (in my opinion) or to account for code differences.



Relevant PRs: 
https://github.com/tgstation/tgstation/pull/70096 Logging
https://github.com/tgstation/tgstation/pull/69206 Logging
https://github.com/tgstation/tgstation/pull/68819 Logging
https://github.com/tgstation/tgstation/pull/71399 Logging
https://github.com/tgstation/tgstation/pull/64867 Logging and also also swaps out the input list when aiming the BSA to a tgui input list (this change didn't originate from this PR, but that's where I'm taking it from)
https://github.com/tgstation/tgstation/pull/71681 This one isn't logging related, but was minor enough that I still threw it in. All it does is rename "End Round Normally" to "Undelay Round End" in the check-antagonists panel.




<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Logs are good. 
No reason not to have the BSA artillery input list be a tgui input list.
"Undelay Round End" is a much better way of wording the Undelay button.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/336d8501-1e35-4132-a491-6664dead9673)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/442a7a6a-3edf-47f5-b384-c6a7219cbd17)

</details>

## Changelog
:cl: Tyranicranger4, San7890, Dragomagol, Melbert, Mothblocks
admin: Adds logging to Lavaland elite creation
admin: Adds logging to BSA aiming (seperate from firing)
admin: Adds logging to going DNR
admin: Adds logging to creating areas using blueprints (seperate from modifying them)
admin: Adds logging plus an admin notification for when non-roundstart upload consoles are created
admin: Renames the undelay round end button from "End Round Normally" to "Undelay Round End"
tweak: BSArtillery aiming now uses a tgui input list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
