### PR TITLE
Created holoparasites no longer have their stats linked to their injector

### DIFF
--- a/code/modules/holoparasite/holoparasite_builder.dm
+++ b/code/modules/holoparasite/holoparasite_builder.dm
@@ -380,6 +380,7 @@
 	var/mob/dead/observer/candidate = pick(candidates)
 	var/mob/living/simple_animal/hostile/holoparasite/holoparasite = new(user, candidate.key, holopara_name, theme, accent_color, notes, user.mind, saved_stats)
 	var/datum/antagonist/holoparasite/holopara_antag = holoparasite.mind.add_antag_datum(new /datum/antagonist/holoparasite(user.mind.holoparasite_holder(), saved_stats, theme))
+	saved_stats = new
 	holopara_antag.ui_interact(holoparasite) // Show them the info popup
 	user.log_message("summoned [key_name(holoparasite)], a holoparasite ([theme.name]), with the following stats: [tldr_stats]", LOG_GAME)
 	message_admins("[ADMIN_LOOKUPFLW(user)] has summoned [ADMIN_LOOKUPFLW(holoparasite)], a holoparasite ([theme.name]), with the following stats: [tldr_stats]")

--- a/code/modules/holoparasite/holoparasite_stats.dm
+++ b/code/modules/holoparasite/holoparasite_stats.dm
@@ -15,6 +15,9 @@
 	var/mob/living/simple_animal/hostile/holoparasite/last_holopara
 
 /datum/holoparasite_stats/Destroy()
+	if(!QDELETED(last_holopara))
+		message_admins("Holoparasite stats belonging to [ADMIN_LOOKUPFLW(last_holopara)] tried to be deleted while still attached to a holoparasite! This is very likely a bug!!")
+		CRASH("Holoparasite stats belonging to [key_name(last_holopara)] tried to be deleted while still attached to a holoparasite!")
 	remove()
 	if(ability)
 		QDEL_NULL(ability)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can no longer qdel a holoparasite's stats by destroying the injector that created them.

## Why It's Good For The Game

bug bad, bugfix good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/461bb339-8bad-4969-b13f-cbe93ce0b95f

</details>

## Changelog
:cl:
fix: Created holoparasites no longer have their stats linked to their injector.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
