### PR TITLE
Adds linting for and attach() element, and equipped() proc

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -79,13 +79,14 @@
 	START_PROCESSING(SSfastprocess, src)
 
 /obj/item/tk_grab/Destroy()
-	focus = null
 	STOP_PROCESSING(SSfastprocess, src)
+	focus = null
+	tk_user = null
 	return ..()
 
 /obj/item/tk_grab/process()
 	if(check_if_focusable(focus)) //if somebody grabs your thing, no waiting for them to put it down and hitting them again.
-		update_icon()
+		update_appearance()
 
 /obj/item/tk_grab/dropped(mob/user)
 	..()
@@ -95,10 +96,10 @@
 
 //stops TK grabs being equipped anywhere but into hands
 /obj/item/tk_grab/equipped(mob/user, slot)
+	. = ..()
 	if(slot == ITEM_SLOT_HANDS)
 		return
 	qdel(src)
-	return
 
 /obj/item/tk_grab/examine(user)
 	if (focus)

--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -22,7 +22,7 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 
 /datum/controller/global_vars/Destroy(force)
 	// This is done to prevent an exploit where admins can get around protected vars
-	SHOULD_CALL_PARENT(0)
+	SHOULD_CALL_PARENT(FALSE)
 	return QDEL_HINT_IWILLGC
 
 /datum/controller/global_vars/stat_entry()

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -396,5 +396,6 @@
 	var/wielded = FALSE
 
 /obj/item/offhand/equipped(mob/user, slot)
+	. = ..()
 	if(wielded && !user.is_holding(src))
 		qdel(src)

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -8,6 +8,7 @@
 	var/id_arg_index = INFINITY
 
 /datum/element/proc/Attach(datum/target)
+	SHOULD_CALL_PARENT(TRUE)
 	if(type == /datum/element)
 		return ELEMENT_INCOMPATIBLE
 	SEND_SIGNAL(target, COMSIG_ELEMENT_ATTACH, src)

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -46,12 +46,13 @@
 			log_combat(A, D, "knocked out (boxing) ")
 		else if(!(D.mobility_flags & MOBILITY_STAND))
 			D.force_say(A)
-	return 1
+	return TRUE
 
 /obj/item/clothing/gloves/boxing
 	var/datum/martial_art/boxing/style = new
 
 /obj/item/clothing/gloves/boxing/equipped(mob/user, slot)
+	..()
 	if(!ishuman(user))
 		return
 	if(slot == ITEM_SLOT_GLOVES)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -191,6 +191,7 @@
 	var/datum/martial_art/krav_maga/style = new
 
 /obj/item/clothing/gloves/krav_maga/equipped(mob/user, slot)
+	. = ..()
 	if(!ishuman(user))
 		return
 	if(slot == ITEM_SLOT_GLOVES)
@@ -198,7 +199,7 @@
 		style.teach(H,1)
 
 /obj/item/clothing/gloves/krav_maga/dropped(mob/user)
-	..()
+	. = ..()
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -455,6 +455,7 @@
 	var/datum/martial_art/wrestling/style = new
 
 /obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot)
+	. = ..()
 	if(!ishuman(user))
 		return
 	if(slot == ITEM_SLOT_BELT)
@@ -463,7 +464,7 @@
 	return
 
 /obj/item/storage/belt/champion/wrestling/dropped(mob/user)
-	..()
+	. = ..()
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -713,6 +713,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 // for items that can be placed in multiple slots
 // note this isn't called during the initial dressing of a player
 /obj/item/proc/equipped(mob/user, slot, initial = FALSE)
+	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	SEND_SIGNAL(user, COMSIG_MOB_EQUIPPED_ITEM, src, slot)
 	for(var/X in actions)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -915,6 +915,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.clear_reagents()
 
 /obj/item/clothing/mask/vape/equipped(mob/user, slot)
+	. = ..()
 	if(slot == ITEM_SLOT_MASK)
 		if(!screw)
 			to_chat(user, "<span class='notice'>You start puffing on the vape.</span>")
@@ -924,7 +925,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			to_chat(user, "<span class='warning'>You need to close the cap first!</span>")
 
 /obj/item/clothing/mask/vape/dropped(mob/user)
-	..()
+	. = ..()
 	if(user.get_item_by_slot(ITEM_SLOT_MASK) == src)
 		ENABLE_BITFIELD(reagents.flags, NO_REACT)
 		STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/pitchfork.dm
+++ b/code/game/objects/items/pitchfork.dm
@@ -60,7 +60,7 @@
 	return (BRUTELOSS)
 
 /obj/item/pitchfork/demonic/pickup(mob/living/user)
-	..()
+	. = ..()
 	if(isliving(user) && user.mind && user.owns_soul() && !is_devil(user))
 		var/mob/living/U = user
 		U.visible_message("<span class='warning'>As [U] picks [src] up, [U]'s arms briefly catch fire.</span>", \

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -450,10 +450,11 @@
 	emaggedhitdamage = 0
 
 /obj/item/borg/lollipop/equipped()
+	. = ..()
 	check_amount()
 
 /obj/item/borg/lollipop/dropped()
-	..()
+	. = ..()
 	check_amount()
 
 /obj/item/borg/lollipop/proc/check_amount()	//Doesn't even use processing ticks.

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -97,7 +97,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/claymore/highlander //ALL COMMENTS MADE REGARDING THIS SWORD MUST BE MADE IN ALL CAPS
 	desc = "<b><i>THERE CAN BE ONLY ONE, AND IT WILL BE YOU!!!</i></b>\nActivate it in your hand to point to the nearest victim."
 	flags_1 = CONDUCT_1
-	item_flags = DROPDEL | ISWEAPON
+	item_flags = DROPDEL | ISWEAPON //dropdel occurs because you lost an arm
 	slot_flags = null
 	light_range = 3
 	attack_verb = list("brutalized", "eviscerated", "disemboweled", "hacked", "carved", "cleaved") //ONLY THE MOST VISCERAL ATTACK VERBS
@@ -128,16 +128,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 
 /obj/item/claymore/highlander/pickup(mob/living/user)
-	..()
+	. = ..()
 	to_chat(user, "<span class='notice'>The power of Scotland protects you! You are shielded from all stuns and knockdowns.</span>")
 	user.add_stun_absorption("highlander", INFINITY, 1, " is protected by the power of Scotland!", "The power of Scotland absorbs the stun!", " is protected by the power of Scotland!")
 	user.ignore_slowdown(HIGHLANDER)
 
 /obj/item/claymore/highlander/dropped(mob/living/user)
-	..()
+	. = ..()
 	user.unignore_slowdown(HIGHLANDER)
-	if(!QDELETED(src))
-		qdel(src) //If this ever happens, it's because you lost an arm
 
 /obj/item/claymore/highlander/examine(mob/user)
 	. = ..()

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -211,6 +211,7 @@
 		addtimer(CALLBACK(src, PROC_REF(effect), user, .), 1 SECONDS)
 
 /obj/item/dice/d20/fate/equipped(mob/user, slot)
+	. = ..()
 	if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
 		to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans! You should leave it alone.</span>")
 		user.dropItemToGround(src)

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -122,6 +122,7 @@
 	var/datum/language/piratespeak/L = new
 
 /obj/item/clothing/head/pirate/equipped(mob/user, slot)
+	. = ..()
 	if(!ishuman(user))
 		return
 	if(slot == ITEM_SLOT_HEAD)
@@ -129,7 +130,7 @@
 		to_chat(user, "You suddenly know how to speak like a pirate!")
 
 /obj/item/clothing/head/pirate/dropped(mob/user)
-	..()
+	. = ..()
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -26,6 +26,7 @@
 		user.update_inv_head()	//so our mob-overlays update
 
 /obj/item/clothing/head/soft/equipped(mob/user, slot)
+	. = ..()
 	if(slot == ITEM_SLOT_HEAD)
 		if(HAS_TRAIT(user, TRAIT_PROSKATER))
 			if(!flipped)

--- a/code/modules/clothing/masks/cluwne.dm
+++ b/code/modules/clothing/masks/cluwne.dm
@@ -51,12 +51,13 @@
     return SPEECH_MESSAGE
 
 /obj/item/clothing/mask/cluwne/equipped(mob/user, slot)
-    if(!user.has_dna())
-        return
-    if(slot == ITEM_SLOT_MASK)
-        var/mob/living/carbon/C = user
-        C.dna.add_mutation(CLUWNEMUT)
-    return
+	. = ..()
+	if(!user.has_dna())
+		return
+	if(slot == ITEM_SLOT_MASK)
+		var/mob/living/carbon/C = user
+		C.dna.add_mutation(CLUWNEMUT)
+	return
 
 /obj/item/clothing/mask/cluwne/happy_cluwne
     name = "Happy Cluwne Mask"
@@ -83,22 +84,23 @@
         play_laugh1()
 
 /obj/item/clothing/mask/cluwne/happy_cluwne/equipped(mob/user, slot)
-    if(!ishuman(user))
-        return
-    var/mob/living/carbon/human/H = user
-    if(slot == ITEM_SLOT_MASK)
-        if(is_cursed && can_cluwne) //logic predetermined
-            log_admin("[key_name(H)] was made into a cluwne by [src]")
-            message_admins("[key_name(H)] got cluwned by [src]")
-            to_chat(H, "<span class='userdanger'>The masks straps suddenly tighten to your face and your thoughts are erased by a horrible green light!</span>")
-            H.dropItemToGround(src)
-            H.cluwneify()
-            qdel(src)
-        else if(is_very_cursed && can_cluwne)
-            var/turf/T = get_turf(src)
-            var/mob/living/simple_animal/hostile/floor_cluwne/S = new(T)
-            S.Acquire_Victim(user)
-            log_admin("[key_name(user)] summoned a floor cluwne using the [src]")
-            message_admins("[key_name(user)] summoned a floor cluwne using the [src]")
-            to_chat(H, "<span class='warning'>The mask suddenly slips off your face and... slides under the floor?</span>")
-    to_chat(H, "<i>...dneirf uoy ot gnoleb ton seod tahT</i>")
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(slot == ITEM_SLOT_MASK)
+		if(is_cursed && can_cluwne) //logic predetermined
+			log_admin("[key_name(H)] was made into a cluwne by [src]")
+			message_admins("[key_name(H)] got cluwned by [src]")
+			to_chat(H, "<span class='userdanger'>The masks straps suddenly tighten to your face and your thoughts are erased by a horrible green light!</span>")
+			H.dropItemToGround(src)
+			H.cluwneify()
+			qdel(src)
+		else if(is_very_cursed && can_cluwne)
+			var/turf/T = get_turf(src)
+			var/mob/living/simple_animal/hostile/floor_cluwne/S = new(T)
+			S.Acquire_Victim(user)
+			log_admin("[key_name(user)] summoned a floor cluwne using the [src]")
+			message_admins("[key_name(user)] summoned a floor cluwne using the [src]")
+			to_chat(H, "<span class='warning'>The mask suddenly slips off your face and... slides under the floor?</span>")
+	to_chat(H, "<i>...dneirf uoy ot gnoleb ton seod tahT</i>")

--- a/code/modules/clothing/shoes/cluwne.dm
+++ b/code/modules/clothing/shoes/cluwne.dm
@@ -21,6 +21,7 @@
 		footstep++
 
 /obj/item/clothing/shoes/cluwne/equipped(mob/user, slot)
+	. = ..()
 	if(!user.has_dna())
 		return
 	if(slot == ITEM_SLOT_FEET)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -98,6 +98,7 @@
 		Die()
 
 /obj/item/clothing/mask/facehugger/equipped(mob/M)
+	. = ..()
 	Attach(M)
 	compile_monkey_icon()
 

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -75,7 +75,7 @@
 	icon_state = "flatgun"
 
 /obj/item/gun/ballistic/automatic/pistol/stickman/pickup(mob/living/user)
-	..()
+	SHOULD_CALL_PARENT(FALSE)
 	to_chat(user, "<span class='notice'>As you try to pick up [src], it slips out of your grip..</span>")
 	if(prob(50))
 		to_chat(user, "<span class='notice'>..and vanishes from your vision! Where the hell did it go?</span>")

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -74,9 +74,9 @@
 	desc = "A 2 dimensional gun.. what?"
 	icon_state = "flatgun"
 
-/obj/item/gun/ballistic/automatic/pistol/stickman/pickup(mob/living/user)
-	SHOULD_CALL_PARENT(FALSE)
-	to_chat(user, "<span class='notice'>As you try to pick up [src], it slips out of your grip..</span>")
+/obj/item/gun/ballistic/automatic/pistol/stickman/equipped(mob/user, slot)
+	..()
+	to_chat(user, "<span class='notice'>As you try to manipulate [src], it slips out of your possession..</span>")
 	if(prob(50))
 		to_chat(user, "<span class='notice'>..and vanishes from your vision! Where the hell did it go?</span>")
 		qdel(src)


### PR DESCRIPTION
- https://github.com/tgstation/tgstation/pull/46614
- https://github.com/tgstation/tgstation/pull/61453

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds linting for equipped()

Also fixes thing with tk_grab by nulling tk_user when its destroyed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
code improvement

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Nice hat, no runtime
![hat](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/fd708670-4d59-468e-9b42-35a321f723ab)


</details>

## Changelog
:cl: RKz, necromanceranne, Spookydonut
code: adds linting for equipped()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
