### PR TITLE
Changes power_change() to respect parent calls, modernizes and makes it suck less

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_obj/signals_machine/signals_machinery.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_machine/signals_machinery.dm
@@ -10,6 +10,10 @@
 #define COMSIG_MACHINE_CLOSE "machine_close"
 //from /obj/machinery/obj_break(damage_flag): (damage_flag)
 #define COMSIG_MACHINERY_BROKEN "machinery_broken"
+///from base power_change() when power is lost
+#define COMSIG_MACHINERY_POWER_LOST "machinery_power_lost"
+///from base power_change() when power is restored
+#define COMSIG_MACHINERY_POWER_RESTORED "machinery_power_restored"
 ///from /obj/machinery/set_occupant(atom/movable/O): (new_occupant)
 #define COMSIG_MACHINERY_SET_OCCUPANT "machinery_set_occupant"
 

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -238,11 +238,6 @@
 		storedid = null
 		update_icon()
 
-/obj/machinery/pdapainter/power_change()
-	..()
-	update_icon()
-
-
 /proc/get_card_style_list(emagged)
 	var/static/valid_jobs = list(
 		"----Command----", "Command (Custom)",JOB_NAME_CAPTAIN,"Acting Captain",

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -159,14 +159,13 @@ Class Procs:
 	if(processing_flags & START_PROCESSING_ON_INIT)
 		begin_processing()
 
-	power_change()
-	RegisterSignal(src, COMSIG_MOVABLE_ENTERED_AREA, PROC_REF(power_change))
-
 	if(occupant_typecache)
 		occupant_typecache = typecacheof(occupant_typecache)
 
 	if(!seller_department)
 		seller_department = dept_req_for_free
+
+	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/proc/set_occupant(atom/movable/new_occupant)
 	SHOULD_CALL_PARENT(TRUE)
@@ -183,6 +182,11 @@ Class Procs:
 /obj/machinery/proc/end_processing()
 	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
 	STOP_PROCESSING(subsystem, src)
+
+/obj/machinery/LateInitialize()
+	. = ..()
+	power_change()
+	RegisterSignal(src, COMSIG_MOVABLE_ENTERED_AREA, PROC_REF(power_change))
 
 /obj/machinery/Destroy()
 	GLOB.machines.Remove(src)

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -17,18 +17,13 @@
 	. = ..()
 	. += "<span class='notice'>It has <b>[uses]</b> uses of foam remaining.</span>"
 
-/obj/machinery/ai_slipper/power_change()
+/obj/machinery/ai_slipper/update_icon()
 	if(machine_stat & BROKEN)
 		return
+	if((machine_stat & NOPOWER) || cooldown_time > world.time || !uses)
+		icon_state = "ai-slipper0"
 	else
-		if(powered())
-			set_machine_stat(machine_stat & ~NOPOWER)
-		else
-			set_machine_stat(machine_stat | NOPOWER)
-		if((machine_stat & (NOPOWER|BROKEN)) || cooldown_time > world.time || !uses)
-			icon_state = "ai-slipper0"
-		else
-			icon_state = "ai-slipper1"
+		icon_state = "ai-slipper1"
 
 /obj/machinery/ai_slipper/interact(mob/user)
 	if(!allowed(user))

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -54,10 +54,6 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	GLOB.announcement_systems -= src //"OH GOD WHY ARE THERE 100,000 LISTED ANNOUNCEMENT SYSTEMS?!!"
 	return ..()
 
-/obj/machinery/announcement_system/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/announcement_system/attackby(obj/item/P, mob/user, params)
 	if(P.tool_behaviour == TOOL_SCREWDRIVER)
 		P.play_tool_sound(src)

--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -127,7 +127,3 @@
 		return
 	else
 		eject_part(user)
-
-/obj/machinery/aug_manipulator/power_change()
-	..()
-	update_icon()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -177,10 +177,6 @@
 
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), 15)
 
-/obj/machinery/button/power_change()
-	..()
-	update_icon()
-
 
 /obj/machinery/button/door
 	name = "door button"

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -79,13 +79,13 @@
 	. += emissive_appearance(icon, icon_screen)
 
 /obj/machinery/computer/power_change()
-	..()
+	. = ..()
+	if(!.)
+		return // reduce unneeded light changes
 	if(machine_stat & NOPOWER)
 		set_light(FALSE)
 	else
 		set_light(TRUE)
-	update_appearance()
-	return
 
 /obj/machinery/computer/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -64,10 +64,6 @@
 	//running
 	icon_state = initial(icon_state)+ (state_open ? "_open" : "")
 
-/obj/machinery/dna_scannernew/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/dna_scannernew/proc/toggle_open(mob/user)
 	if(locked)
 		to_chat(user, "<span class='notice'>The bolts are locked down, securing the door [state_open ? "open" : "shut"].</span>")

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -82,11 +82,6 @@
 			timer_end() // open doors, reset timer, clear status screen
 		update_icon()
 
-// has the door power sitatuation changed, if so update icon.
-/obj/machinery/door_timer/power_change()
-	..()
-	update_icon()
-
 // open/closedoor checks if door_timer has power, if so it checks if the
 // linked door is open/closed (by density) then opens it/closes it.
 /obj/machinery/door_timer/proc/timer_start()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -83,10 +83,6 @@
 	else
 		layer = initial(layer)
 
-/obj/machinery/door/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/door/Destroy()
 	update_freelook_sight()
 	GLOB.airlocks -= src

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -88,11 +88,8 @@
 
 
 /obj/machinery/door/firedoor/power_change()
-	if(powered(power_channel))
-		set_machine_stat(machine_stat & ~NOPOWER)
-		INVOKE_ASYNC(src, PROC_REF(latetoggle))
-	else
-		set_machine_stat(machine_stat | NOPOWER)
+	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(latetoggle))
 
 /obj/machinery/door/firedoor/attack_hand(mob/user)
 	. = ..()

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -190,16 +190,18 @@
 
 	return TRUE
 
-/obj/machinery/doppler_array/power_change()
+/obj/machinery/doppler_array/powered()
+	if(!anchored)
+		return FALSE
+	return ..()
+
+/obj/machinery/doppler_array/update_icon()
 	if(machine_stat & BROKEN)
 		icon_state = "[initial(icon_state)]-broken"
+	else if(powered())
+		icon_state = initial(icon_state)
 	else
-		if(powered() && anchored)
-			icon_state = initial(icon_state)
-			set_machine_stat(machine_stat & ~NOPOWER)
-		else
-			icon_state = "[initial(icon_state)]-off"
-			set_machine_stat(machine_stat | NOPOWER)
+		icon_state = "[initial(icon_state)]-off"
 
 //Portable version, built into EOD equipment. It simply provides an explosion's three damage levels.
 /obj/machinery/doppler_array/integrated

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -133,10 +133,6 @@
 	if((mode == DRONE_RECHARGING) && !machine_stat && recharging_text)
 		. += "<span class='warning'>[recharging_text]</span>"
 
-/obj/machinery/droneDispenser/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/droneDispenser/process()
 	if((machine_stat & (NOPOWER|BROKEN)) || !anchored)
 		return

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -89,10 +89,6 @@
 		else
 			icon_state = "access_button_standby"
 
-/obj/machinery/doorButtons/access_button/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/doorButtons/access_button/removeMe(obj/O)
 	if(O == door)
 		door = null
@@ -229,13 +225,12 @@
 		cycleOpen(interiorAirlock)
 
 /obj/machinery/doorButtons/airlock_controller/power_change()
-	..()
+	. = ..()
 	if(machine_stat & NOPOWER)
 		lostPower = TRUE
 	else
 		if(!busy)
 			lostPower = FALSE
-	update_icon()
 
 /obj/machinery/doorButtons/airlock_controller/findObjsByTag()
 	for(var/obj/machinery/door/airlock/A in GLOB.machines)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -77,10 +77,6 @@
 	LAZYREMOVE(myarea.firealarms, src)
 	return ..()
 
-/obj/machinery/firealarm/power_change()
-	..()
-	update_appearance()
-
 /obj/machinery/firealarm/update_overlays()
 	. = ..()
 	var/area/A = src.loc

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -42,15 +42,18 @@
 	QDEL_NULL(bulb)
 	return ..()
 
-/obj/machinery/flasher/power_change()
-	if (powered() && anchored && bulb)
-		set_machine_stat(machine_stat & ~NOPOWER)
+/obj/machinery/flasher/powered()
+	if(!anchored || !bulb)
+		return FALSE
+	return ..()
+
+/obj/machinery/flasher/update_icon()
+	if (powered())
 		if(bulb.burnt_out)
 			icon_state = "[base_state]1-p"
 		else
 			icon_state = "[base_state]1"
 	else
-		set_machine_stat(machine_stat | NOPOWER)
 		icon_state = "[base_state]1-p"
 
 //Don't want to render prison breaks impossible

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -40,10 +40,6 @@ The console is located at computer/gulag_teleporter.dm
 		linked_reclaimer.linked_teleporter = null
 	return ..()
 
-/obj/machinery/gulag_teleporter/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/gulag_teleporter/interact(mob/user)
 	. = ..()
 	if(locked)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -123,10 +123,8 @@ Possible to do for anyone motivated enough:
 	return ..()
 
 /obj/machinery/holopad/power_change()
-	if (powered())
-		set_machine_stat(machine_stat & ~NOPOWER)
-	else
-		set_machine_stat(machine_stat | NOPOWER)
+	. = ..()
+	if (!powered())
 		if(replay_mode)
 			replay_stop()
 		if(record_mode)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -94,13 +94,9 @@
 		return
 
 /obj/machinery/light_switch/power_change()
+	SHOULD_CALL_PARENT(FALSE)
 	if(area == get_area(src))
-		if(powered(AREA_USAGE_LIGHT))
-			set_machine_stat(machine_stat & ~NOPOWER)
-		else
-			set_machine_stat(machine_stat | NOPOWER)
-
-		update_appearance(updates = UPDATE_ICON|UPDATE_OVERLAYS)
+		return ..()
 
 /obj/machinery/light_switch/emp_act(severity)
 	. = ..()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -1003,10 +1003,6 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/turretid)
 		aTurret.setState(enabled, lethal, shoot_cyborgs)
 	update_icon()
 
-/obj/machinery/turretid/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/turretid/update_icon()
 	..()
 	if(machine_stat & NOPOWER)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -145,10 +145,6 @@
 	else
 		return PROCESS_KILL
 
-/obj/machinery/recharger/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/recharger/emp_act(severity)
 	. = ..()
 	if (. & EMP_PROTECT_CONTENTS)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -96,10 +96,6 @@
 	else
 		icon_state = (state_open ? "borgcharger-u0" : "borgcharger-u1")
 
-/obj/machinery/recharge_station/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/recharge_station/proc/process_occupant(delta_time)
 	if(!occupant)
 		return

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -49,10 +49,6 @@
 	"The safety-mode light is [safety_mode ? "on" : "off"].\n"+\
 	"The safety-sensors status light is [obj_flags & EMAGGED ? "off" : "on"]."
 
-/obj/machinery/recycler/power_change()
-	..()
-	update_icon()
-
 
 /obj/machinery/recycler/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "grinder-oOpen", "grinder-o0", I))

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -74,10 +74,6 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 	light_color = LIGHT_COLOR_GREEN
 	light_power = 1.5
 
-/obj/machinery/requests_console/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/requests_console/update_icon()
 	if(machine_stat & NOPOWER)
 		set_light(0)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -78,10 +78,6 @@
 	else
 		icon_state = "slots1"
 
-/obj/machinery/computer/slot_machine/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/computer/slot_machine/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/coin))
 		var/obj/item/coin/C = I

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -116,7 +116,6 @@
 /obj/machinery/stasis/power_change()
 	. = ..()
 	play_power_sound()
-	update_icon()
 
 /obj/machinery/stasis/proc/chill_out(mob/living/target)
 	if(target != occupant)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -98,10 +98,6 @@
 	else
 		icon_state = "tele0"
 
-/obj/machinery/teleport/hub/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/teleport/hub/proc/is_ready()
 	. = !panel_open && !(machine_stat & (BROKEN|NOPOWER)) && power_station && power_station.engaged && !(power_station.machine_stat & (BROKEN|NOPOWER))
 
@@ -225,8 +221,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/teleport/station)
 	add_fingerprint(user)
 
 /obj/machinery/teleport/station/power_change()
-	..()
-	update_icon()
+	. = ..()
 	if(teleporter_hub)
 		teleporter_hub.update_icon()
 

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -34,10 +34,6 @@
 	QDEL_NULL(countdown)
 	. = ..()
 
-/obj/machinery/transformer/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/transformer/update_icon()
 	..()
 	if(machine_stat & (BROKEN|NOPOWER) || cooldown == 1)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -838,10 +838,6 @@
 			to_chat(user, "<span class='danger'>Access denied.</span>")
 	return
 
-/obj/machinery/airalarm/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/airalarm/on_emag(mob/user)
 	..()
 	visible_message("<span class='warning'>Sparks fly out of [src]!</span>", "<span class='notice'>You emag [src], disabling its safeties.</span>")

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -156,10 +156,6 @@ Passive gate is similar to the regular pump except:
 	update_icon()
 	ui_update()
 
-/obj/machinery/atmospherics/components/binary/passive_gate/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/atmospherics/components/binary/passive_gate/can_unwrench(mob/user)
 	. = ..()
 	if(. && on)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -171,10 +171,6 @@
 	update_icon()
 	ui_update()
 
-/obj/machinery/atmospherics/components/binary/pump/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/atmospherics/components/binary/pump/can_unwrench(mob/user)
 	. = ..()
 	if(. && on && is_operational)

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -179,10 +179,6 @@
 	update_icon()
 	ui_update()
 
-/obj/machinery/atmospherics/components/binary/volume_pump/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/atmospherics/components/binary/volume_pump/can_unwrench(mob/user)
 	. = ..()
 	if(. && on && is_operational)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -61,11 +61,6 @@
 	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational
 	icon_state = "filter_[on_state ? "on" : "off"]-[set_overlay_offset(piping_layer)][flipped ? "_f" : ""]"
 
-/obj/machinery/atmospherics/components/trinary/filter/power_change()
-	var/old_stat = machine_stat
-	..()
-	if(machine_stat != old_stat)
-		update_icon()
 
 /obj/machinery/atmospherics/components/trinary/filter/process_atmos()
 	..()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -55,12 +55,6 @@
 	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational
 	icon_state = "mixer_[on_state ? "on" : "off"]-[set_overlay_offset(piping_layer)][flipped ? "_f" : ""]"
 
-/obj/machinery/atmospherics/components/trinary/mixer/power_change()
-	var/old_stat = machine_stat
-	..()
-	if(machine_stat != old_stat)
-		update_icon()
-
 /obj/machinery/atmospherics/components/trinary/mixer/New()
 	..()
 	var/datum/gas_mixture/air3 = airs[3]

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -261,10 +261,6 @@
 
 	update_parents()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/user)
 	if(message_cooldown <= world.time)
 		message_cooldown = world.time + 50

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -57,12 +57,6 @@
 	else
 		icon_state = "inje_on"
 
-/obj/machinery/atmospherics/components/unary/outlet_injector/power_change()
-	var/old_stat = machine_stat
-	..()
-	if(old_stat != machine_stat)
-		update_icon()
-
 /obj/machinery/atmospherics/components/unary/outlet_injector/process_atmos()
 	..()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -129,10 +129,6 @@
 		active_power_usage = idle_power_usage
 	return 1
 
-/obj/machinery/atmospherics/components/unary/thermomachine/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/atmospherics/components/unary/thermomachine/attackby(obj/item/I, mob/user, params)
 	if(!on)
 		if(default_deconstruction_screwdriver(user, icon_state_open, icon_state_off, I))

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -281,7 +281,7 @@
 		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/components/unary/vent_pump/power_change()
-	..()
+	. = ..()
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/can_crawl_through()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -225,7 +225,7 @@
 	return
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/power_change()
-	..()
+	. = ..()
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/welder_act(mob/living/user, obj/item/I)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -41,10 +41,6 @@
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: This unit can hold a maximum of <b>[max_n_of_items]</b> items.</span>"
 
-/obj/machinery/smartfridge/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/smartfridge/update_icon()
 	if(!machine_stat)
 		if (visible_contents)
@@ -310,6 +306,16 @@
 			toggle_drying(FALSE)
 			return TRUE
 	return FALSE
+
+/obj/machinery/smartfridge/drying_rack/powered()
+	if(!anchored)
+		return FALSE
+	return ..()
+
+/obj/machinery/smartfridge/drying_rack/power_change()
+	. = ..()
+	if(!powered())
+		toggle_drying(TRUE)
 
 /obj/machinery/smartfridge/drying_rack/load() //For updating the filled overlay
 	..()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -368,10 +368,6 @@
 	do_sparks(5, TRUE, src)
 	..()
 
-/obj/machinery/mineral/ore_redemption/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/mineral/ore_redemption/update_icon()
 	if(powered())
 		icon_state = initial(icon_state)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -19,10 +19,6 @@
 	if(bound_bank_account && !istype(bound_bank_account))
 		bound_bank_account = SSeconomy.get_budget_account(bound_bank_account, force=TRUE) // grabbing united budget will be bad for this. "force=TRUE" will always grab the correct budget.
 
-/obj/machinery/vendor/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/vendor/update_icon()
 	if(powered())
 		icon_state = initial(icon_state)

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -111,8 +111,7 @@
 		set_machine_stat(machine_stat & ~NOPOWER)
 		update_icon()
 		return
-	..()
-	update_icon()
+	. = ..()
 
 /obj/machinery/modular_computer/screwdriver_act(mob/user, obj/item/tool)
 	if(cpu)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -161,11 +161,6 @@
 		return FALSE
 	return TRUE
 
-
-/obj/machinery/power/generator/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/power/generator/proc/find_circs()
 	kill_circs()
 	var/list/circs = list()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 // Power and Icon States
 
 /obj/machinery/gravity_generator/main/power_change()
-	..()
+	. = ..()
 	investigate_log("has [machine_stat & NOPOWER ? "lost" : "regained"] power.", INVESTIGATE_GRAVITY)
 	set_power()
 

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -640,8 +640,9 @@
 
 // called when area power state changes
 /obj/machinery/light/power_change()
-	var/area/A = get_area(src)
-	seton(A.lightswitch && A.power_light)
+	SHOULD_CALL_PARENT(FALSE)
+	var/area/local_area = get_area(src)
+	seton(local_area.lightswitch && local_area.power_light)
 
 // called when on fire
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -105,17 +105,30 @@
 /obj/machinery/proc/removeStaticPower(value, powerchannel)
 	addStaticPower(-value, powerchannel)
 
-// called whenever the power settings of the containing area change
-// by default, check equipment channel & set flag
-// can override if needed
+/**
+  * Called whenever the power settings of the containing area change
+  *
+  * by default, check equipment channel & set flag, can override if needed
+  *
+  * Returns TRUE if the NOPOWER flag was toggled
+  */
 /obj/machinery/proc/power_change()
 	SIGNAL_HANDLER
+	SHOULD_CALL_PARENT(TRUE)
 
+	if(machine_stat & BROKEN)
+		return
 	if(powered(power_channel))
-		machine_stat &= ~NOPOWER
+		if(machine_stat & NOPOWER)
+			SEND_SIGNAL(src, COMSIG_MACHINERY_POWER_RESTORED)
+			. = TRUE
+		set_machine_stat(machine_stat & ~NOPOWER)
 	else
-		machine_stat |= NOPOWER
-	return
+		if(!(machine_stat & NOPOWER))
+			SEND_SIGNAL(src, COMSIG_MACHINERY_POWER_LOST)
+			. = TRUE
+		set_machine_stat(machine_stat | NOPOWER)
+	update_appearance()
 
 // connect the machine to a powernet if a node cable is present on the turf
 /obj/machinery/power/proc/connect_to_network()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -122,10 +122,6 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/machinery/power/emitter/power_change()
-	. = ..()
-	update_icon()
-
 /obj/machinery/power/emitter/interact(mob/user)
 	add_fingerprint(user)
 	if(state == EMITTER_WELDED)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -58,7 +58,7 @@ field_generator power level display
 	cut_overlays()
 	if(warming_up)
 		add_overlay("+a[warming_up]")
-	if(fields.len)
+	if(LAZYLEN(fields))
 		add_overlay("+on")
 	if(power_level)
 		add_overlay("+p[power_level]")

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -102,7 +102,7 @@
 		investigate_log("decreased to <font color='green'>[strength]</font> by [key_name(usr)] at [AREACOORD(src)]", INVESTIGATE_ENGINES)
 
 /obj/machinery/particle_accelerator/control_box/power_change()
-	..()
+	. = ..()
 	if(machine_stat & NOPOWER)
 		active = FALSE
 		use_power = NO_POWER_USE

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -484,11 +484,6 @@
 	update_icon()
 
 
-/obj/machinery/power/solar_control/power_change()
-	..()
-	update_icon()
-
-
 
 
 //

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -127,10 +127,6 @@
 	if(working_state)
 		flick(working_state,src)
 
-/obj/machinery/chem_dispenser/power_change()
-	..()
-	icon_state = "[(nopower_state && !powered()) ? nopower_state : initial(icon_state)]"
-
 /obj/machinery/chem_dispenser/update_icon()
 	cut_overlays()
 	if(has_panel_overlay && panel_open)

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 /obj/machinery/conveyor
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "conveyor_map"
+	base_icon_state = "conveyor"
 	name = "conveyor belt"
 	desc = "A conveyor belt."
 	layer = BELOW_OPEN_DOOR_LAYER
@@ -142,6 +143,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		if(SOUTHWEST)
 			forwards = WEST
 			backwards = NORTH
+
 	if(verted == -1)
 		var/temp = forwards
 		forwards = backwards
@@ -152,11 +154,15 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		movedir = backwards
 	update()
 
+/obj/machinery/conveyor/update_icon_state()
+	icon_state = "[base_icon_state][(machine_stat & BROKEN) ? "-broken" : (operating * verted)]"
+	return ..()
+
 /obj/machinery/conveyor/proc/set_operating(new_value)
 	if(operating == new_value)
 		return
 	operating = new_value
-	update_icon_state()
+	update_appearance()
 	update_move_direction()
 	//If we ever turn off, disable moveloops
 	if(!operating)
@@ -168,6 +174,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(machine_stat & NOPOWER)
 		set_operating(FALSE)
 		return FALSE
+		
 	if(!operating) //If we're on, start conveying so moveloops on our tile can be refreshed if they stopped for some reason
 		return
 	for(var/atom/movable/movable in get_turf(src))
@@ -216,8 +223,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 					C = locate(/obj/item/stack/conveyor) in loc
 				if(C)
 					transfer_fingerprints_to(C)
-			to_chat(user, "<span class='notice'>You remove the conveyor belt.</span>")
 
+			to_chat(user, "<span class='notice'>You remove the conveyor belt.</span>")
 			qdel(src)
 
 	else if(I.tool_behaviour == TOOL_WRENCH)

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -42,20 +42,9 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	begin_processing()
 
 /obj/machinery/conveyor/auto/update()
-	if(machine_stat & BROKEN)
-		icon_state = "conveyor-broken"
-		set_operating(FALSE)
-		return
-	else if(!operable)
-		set_operating(FALSE)
-	else if(machine_stat & NOPOWER)
-		set_operating(FALSE)
-	else
+	. = ..()
+	if(.)
 		set_operating(TRUE)
-	icon_state = "conveyor[operating * verted]"
-	if(operating)
-		for(var/atom/movable/movable in get_turf(src))
-			start_conveying(movable)
 
 // create a conveyor
 /obj/machinery/conveyor/Initialize(mapload, newdir, newid)
@@ -175,18 +164,14 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 			stop_conveying(movable)
 
 /obj/machinery/conveyor/proc/update()
-	if(machine_stat & BROKEN)
-		icon_state = "conveyor-broken"
-		set_operating(FALSE)
-		return
-	if(!operable)
-		set_operating(FALSE)
+	. = TRUE
 	if(machine_stat & NOPOWER)
 		set_operating(FALSE)
-	icon_state = "conveyor[operating * verted]"
-	if(operating)
-		for(var/atom/movable/movable in get_turf(src))
-			start_conveying(movable)
+		return FALSE
+	if(!operating) //If we're on, start conveying so moveloops on our tile can be refreshed if they stopped for some reason
+		return
+	for(var/atom/movable/movable in get_turf(src))
+		start_conveying(movable)
 
 /obj/machinery/conveyor/proc/conveyable_enter(datum/source, atom/convayable)
 	SIGNAL_HANDLER
@@ -303,7 +288,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/conveyor)
 		C.set_operable(stepdir, id, op)
 
 /obj/machinery/conveyor/power_change()
-	..()
+	. = ..()
 	update()
 
 // the conveyor control switch

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -203,11 +203,6 @@
 /obj/machinery/disposal/proc/flushAnimation()
 	flick("[icon_state]-flush", src)
 
-// called when area power changes
-/obj/machinery/disposal/power_change()
-	..()	// do default setting/reset of stat NOPOWER bit
-	update_icon()	// update icon
-
 // called when holder is expelled from a disposal
 /obj/machinery/disposal/proc/expel(obj/structure/disposalholder/H)
 	H.active = FALSE

--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -138,10 +138,6 @@
 	//running
 	icon_state = initial(icon_state)+ (state_open ? "_open" : "")
 
-/obj/machinery/nanite_chamber/power_change()
-	..()
-	update_icon()
-
 /obj/machinery/nanite_chamber/proc/toggle_open(mob/user)
 	if(panel_open)
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -120,10 +120,6 @@
 	//running
 	icon_state = initial(icon_state)+ (state_open ? "_open" : "")
 
-/obj/machinery/public_nanite_chamber/power_change()
-	. = ..()
-	update_icon()
-
 /obj/machinery/public_nanite_chamber/proc/toggle_open(mob/user)
 	if(panel_open)
 		to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -835,18 +835,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	say(message)
 
 /obj/machinery/vending/power_change()
-	if(machine_stat & BROKEN)
-		icon_state = "[initial(icon_state)]-broken"
-	else
-		if(powered())
-			icon_state = initial(icon_state)
-			machine_stat &= ~NOPOWER
-			START_PROCESSING(SSmachines, src)
-			set_light(2)
-		else
-			icon_state = "[initial(icon_state)]-off"
-			machine_stat |= NOPOWER
-			set_light(0)
+	. = ..()
+	if(powered())
+		START_PROCESSING(SSmachines, src)
 
 //Somebody cut an important wire and now we're following a new definition of "pitch."
 /**


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/46486

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now all relevant uses of `power_change()` call parent, theres a signal sent when a machine changes the NOPOWER flag, all remaining machines that were using `power_change()` instead of `update_icon()` have been fixed.

I also modernized and cleaned up some parts, like conveyors, so they didnt break

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Navigating around this stupid proc while porting is annoying

code quality

should improve performance a little

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Light switches updating properly
https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/3451991e-3cc9-4f2c-9f62-c984440481f2

Conveyors updating properly
https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/97e5f434-b819-4e11-8782-a0008290e187


</details>

## Changelog
:cl: RKz, spookydonut
code: Changes power_change() to respect parent calls. Should generate less edge-cases and be more performant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
