### PR TITLE
Fixes a critical bug that lets you interact through everything

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -96,7 +96,7 @@
 			continue
 
 		//If there's a dense object on the turf, only allow the click to pass if you can throw items over it or it has a special flag.
-		if(O == target || O == mover || (O.pass_flags_self & LETPASSTHROW|LETPASSCLICKS))
+		if(O.pass_flags_self & (LETPASSTHROW|LETPASSCLICKS))
 			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)
 
 		if( O.flags_1&ON_BORDER_1) // windows are on border, check them first

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -96,7 +96,7 @@
 			continue
 
 		//If there's a dense object on the turf, only allow the click to pass if you can throw items over it or it has a special flag.
-		if(O.pass_flags_self & (LETPASSTHROW|LETPASSCLICKS))
+		if(O == target || O == mover || (O.pass_flags_self & (LETPASSTHROW|LETPASSCLICKS)))
 			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)
 
 		if( O.flags_1&ON_BORDER_1) // windows are on border, check them first


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #9867

There was an miswritten if statement introduced with #9700. What was at fault was a miswritten if statement in the ClickCross proc of `code/_onclick/adjacent.dm`

This was the if statement written when porting:
`O == target || O == mover || (O.pass_flags_self & LETPASSTHROW|LETPASSCLICKS)`

This is the if statement from what it was porting [DaedalusDock/daedalusdock#106](https://github.com/DaedalusDock/daedalusdock/pull/106)
`O == target || O == mover || (O.pass_flags_self & (LETPASSTHROW|LETPASSCLICKS))`

Notably, that last part is what's causing the issue, because `O.pass_flags_self & LETPASSTHROW|LETPASSCLICKS` evaluates to `(O.pass_flags_self & LETPASSTHROW) | LETPASSCLICKS`, instead of the intended `O.pass_flags_self & (LETPASSTHROW|LETPASSCLICKS)`, which would *always* evaluate to true.


TL;DR, A lack of parenthesis in the right place can make all the difference in the world

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes what might be the most exploitable thing currently in the game, and only with a pair of these `( )`

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/e9b205eb-6dfb-4cea-aec0-433071323d9e

</details>

## Changelog
:cl:
fix: You can no longer interact with stuff through windows, windoors, and anything that should've blocked you from interacting really.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
