### PR TITLE
Advanced wirebrush fix and small tweak

### DIFF
--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -58,6 +58,10 @@
 			user.balloon_alert(user, "You start scraping off the rust...")
 			if(!do_after(user, 2 SECONDS * item.toolspeed, target = source))
 				return
-			user.balloon_alert(user, "Sucessfully scraped off the rust!")
+			if(istype(item, /obj/item/wirebrush/advanced))
+				var/obj/item/wirebrush/advanced/brush = item
+				brush.irradiate(user)
+			else
+				user.balloon_alert(user, "Sucessfully scraped off the rust!")
 			Detach(source)
 			return

--- a/code/game/objects/items/tools/wirebrush.dm
+++ b/code/game/objects/items/tools/wirebrush.dm
@@ -39,9 +39,7 @@
 	. = ..()
 	. += "<span class='danger'>There is a warning label that indicates extended use of [src] may result in loss of hair, yellowing skin, and death.</span>"
 
-/obj/item/wirebrush/advanced/pre_attack(atom/A, mob/living/user)
-	. = ..()
-
+/obj/item/wirebrush/advanced/proc/irradiate(mob/living/user)
 	if(!istype(user))
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the advanced wirebrush irradiating the user when clicked on anything instead of only after scraping off rust, removes the "Sucessfully scraped off the rust!" popup from the advanced wirebrush.
* closes https://github.com/BeeStation/BeeStation-Hornet/issues/9868
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's kind of stupid how the wirebrush can irradiate you by just clicking on the floor instead of only actually using it. Also because it instantly scrapes off the rust, the "start" and "finish" popup messages for scraping overlap, which looks ugly. So the "finish" message was removed from the advanced wirebrush.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: removed the "Sucessfully scraped off the rust!" message from the advanced wirebrush to prevent text overlap
fix: fixed the advanced wirebrush irradiating the user on any click instead of only after scraping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
