### PR TITLE
Organ manipulation surgery doesnt feed the patient their organs anymore

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -319,6 +319,8 @@ Behavior that's still missing from this component that original food items had t
 
 
 	else //If you're feeding it to someone else.
+		if(eater.surgeries.len)
+			return
 		if(isbrain(eater))
 			to_chat(feeder, "<span class='warning'>[eater] doesn't seem to have a mouth!</span>")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #8845 

Title. Im doing newfood so I might as well fix this stupid thing

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stupid edible component

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I took out their heart, I dont know why it layered below them

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/b7db0939-9507-4289-912c-5b61ed7f6958

</details>

## Changelog
:cl: rkz
fix: inserting an organ during organ manipulation surgery doesnt start a progressbar to feed them it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
