### PR TITLE
Teleporter machinery now autolinks. Adds unit test.

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -37,6 +37,7 @@
 	for(var/direction in GLOB.cardinals)
 		power_station = locate(/obj/machinery/teleport/station, get_step(src, direction))
 		if(power_station)
+			power_station.link_console_and_hub()
 			break
 	ui_update()
 	return power_station

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -44,6 +44,7 @@
 	for(var/direction in GLOB.cardinals)
 		power_station = locate(/obj/machinery/teleport/station, get_step(src, direction))
 		if(power_station)
+			power_station.link_console_and_hub()
 			break
 	return power_station
 
@@ -140,7 +141,7 @@
 	if(!panel_open)
 		. += "<span class='notice'>The panel is <i>screwed</i> in, obstructing the linking device and wiring panel.</span>"
 	else
-		. += "<span class='notice'>The <i>linking</i> device is now able to be <i>scanned</i> with a multitool.<br>The <i>wiring</i> can be <i>connected<i> to a nearby console and hub with a pair of wirecutters.</span>"
+		. += "<span class='notice'>The <i>linking</i> device is now able to be <i>scanned</i> with a multitool.</span>"
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: This station can be linked to <b>[efficiency]</b> other station(s).</span>"
 
@@ -177,12 +178,6 @@
 
 	else if(default_deconstruction_crowbar(W))
 		return
-
-	else if(W.tool_behaviour == TOOL_WIRECUTTER)
-		if(panel_open)
-			link_console_and_hub()
-			to_chat(user, "<span class='notice'>You reconnect the station to nearby machinery.</span>")
-			return
 	else
 		return ..()
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -87,6 +87,7 @@
 #include "subsystem_metric_sanity.dm"
 #include "surgery_linking.dm"
 #include "techweb_sanity.dm"
+#include "teleporters.dm"
 #include "tgui_create_message.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"

--- a/code/modules/unit_tests/teleporters.dm
+++ b/code/modules/unit_tests/teleporters.dm
@@ -1,0 +1,10 @@
+/datum/unit_test/auto_teleporter_linking/Run()
+	// Put down the teleporter machinery
+	var/obj/machinery/teleport/hub/hub = allocate(/obj/machinery/teleport/hub)
+	var/obj/machinery/teleport/station/station = allocate(/obj/machinery/teleport/station, locate(run_loc_floor_bottom_left.x + 1, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z))
+	var/obj/machinery/computer/teleporter/computer = allocate(/obj/machinery/computer/teleporter, locate(run_loc_floor_bottom_left.x + 2, run_loc_floor_bottom_left.y, run_loc_floor_bottom_left.z))
+
+	TEST_ASSERT_EQUAL(hub.power_station, station, "Hub didn't link to the station")
+	TEST_ASSERT_EQUAL(station.teleporter_console, computer, "Station didn't link to the teleporter console")
+	TEST_ASSERT_EQUAL(station.teleporter_hub, hub, "Station didn't link to the hub")
+	TEST_ASSERT_EQUAL(computer.power_station, station, "Teleporter console didn't link to the hub")


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/54325

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Teleporter machinery now autolinks to eachother, no more screwdriver and wirecutters needed.

Adds unit test.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This has annoyed the hell out of mentors for eternity. No more.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/76545603-0835-4ede-b734-b7a3233675b2


</details>

## Changelog
:cl: RKz, Mothblocks
tweak: teleporter machinery now autolinks.
code: adds unit test to ensure this does not regress
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
