### PR TITLE
Being on the Emergency Shuttle now counts as "escaping"

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -362,12 +362,12 @@
 					if(T in shuttle_area)
 						return TRUE
 
+	if(!is_centcom_level(T.z))//if not, don't bother
+		return FALSE
+
 	//Check for centcom itself
 	if(istype(T.loc, /area/centcom))
 		return TRUE
-
-	if(!is_centcom_level(T.z))//if not, don't bother
-			return FALSE
 
 	return onCentComShuttle()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -366,16 +366,28 @@
 	if(istype(T.loc, /area/centcom))
 		return TRUE
 
-	//Check for centcom shuttles
+	if(!is_centcom_level(T.z))//if not, don't bother
+			return FALSE
+
+	return onCentComShuttle()
+
+/**
+ * Is this atom currently on a centcom roundend escape shuttle?
+ */
+/atom/proc/onCentComShuttle()
+	var/turf/T = get_turf(src)
+	if(!T)
+		return FALSE
+
+	var/area/shuttle/A = get_area(T)
+	if(isnull(A))
+		return FALSE
+
 	for(var/A in SSshuttle.mobile)
 		var/obj/docking_port/mobile/M = A
 		if(M.launch_status == ENDGAME_LAUNCHED)
-			for(var/place in M.shuttle_areas)
-				var/area/shuttle/shuttle_area = place
-				if(T in shuttle_area)
-					return TRUE
-
-	return is_centcom_level(T.z)
+			if(A in M.shuttle_areas)
+				return TRUE
 
 /**
   * Is the atom in any of the centcom syndicate areas

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -362,9 +362,6 @@
 					if(T in shuttle_area)
 						return TRUE
 
-	if(is_centcom_level(T.z))
-		return TRUE
-
 	//Check for centcom itself
 	if(istype(T.loc, /area/centcom))
 		return TRUE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -362,9 +362,6 @@
 					if(T in shuttle_area)
 						return TRUE
 
-	if(!is_centcom_level(T.z))//if not, don't bother
-		return FALSE
-
 	//Check for centcom itself
 	if(istype(T.loc, /area/centcom))
 		return TRUE
@@ -377,6 +374,8 @@
 				var/area/shuttle/shuttle_area = place
 				if(T in shuttle_area)
 					return TRUE
+
+	return is_centcom_level(T.z)
 
 /**
   * Is the atom in any of the centcom syndicate areas

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -362,8 +362,8 @@
 					if(T in shuttle_area)
 						return TRUE
 
-	if(!is_centcom_level(T.z))//if not, don't bother
-		return FALSE
+	if(is_centcom_level(T.z))
+		return TRUE
 
 	//Check for centcom itself
 	if(istype(T.loc, /area/centcom))
@@ -379,14 +379,14 @@
 	if(!T)
 		return FALSE
 
-	var/area/shuttle/A = get_area(T)
-	if(isnull(A))
+	var/area/shuttle/loc_area = get_area(T)
+	if(isnull(loc_area))
 		return FALSE
 
 	for(var/A in SSshuttle.mobile)
 		var/obj/docking_port/mobile/M = A
 		if(M.launch_status == ENDGAME_LAUNCHED)
-			if(A in M.shuttle_areas)
+			if(loc_area in M.shuttle_areas)
 				return TRUE
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adjusts the function to determine if someone has escaped or not to properly include if they are on the emergency shuttle, if so, they have "escaped" at round end.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

So that I can make the shuttle dock at funny places and not have everyone maroon/redtext.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/30960302/beb664ff-0499-4541-ad2a-c74e87dabcee)

</details>

## Changelog
:cl:
fix: Being on the Emergency Shuttle now counts as "escaping", instead of just arriving at CentCom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
