### PR TITLE
Attack effects no longer can apply to entire Areas directly

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -856,12 +856,12 @@
 	var/obj/effect/icon/temp/attack_animation_object
 	if(visual_effect_icon)
 		I = image('icons/effects/effects.dmi', A, visual_effect_icon, A.layer + 0.1)
-		attack_animation_object = new(A.loc, I, 10)
+		attack_animation_object = new(get_turf(A), I, 10) //A.loc is an area when A is a turf
 	else if(used_item)
 		I = image(icon = used_item, loc = A, layer = A.layer + 0.1)
 		I.plane = GAME_PLANE
 		I.appearance_flags = NO_CLIENT_COLOR | PIXEL_SCALE
-		attack_animation_object = new(A.loc, I, 10)
+		attack_animation_object = new(get_turf(A), I, 10)
 
 		// Scale the icon.
 		attack_animation_object.transform *= pick(0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55)

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -444,7 +444,7 @@
 	if(resource_gain)
 		resources += resource_gain
 		add_to_total_resources_eaten(resource_gain)
-		do_attack_animation(target)
+		do_attack_animation(target, no_effect = TRUE)
 		changeNext_move(CLICK_CD_MELEE)
 		var/obj/effect/temp_visual/swarmer/integrate/I = new /obj/effect/temp_visual/swarmer/integrate(get_turf(target))
 		I.pixel_x = target.pixel_x
@@ -469,7 +469,7 @@
 
 /mob/living/simple_animal/hostile/swarmer/proc/DisIntegrate(atom/movable/target)
 	new /obj/effect/temp_visual/swarmer/disintegration(get_turf(target))
-	do_attack_animation(target)
+	do_attack_animation(target, no_effect = TRUE)
 	changeNext_move(CLICK_CD_MELEE)
 	SSexplosions.low_mov_atom += target
 
@@ -512,7 +512,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/swarmer/proc/DismantleMachine(obj/machinery/target)
-	do_attack_animation(target)
+	do_attack_animation(target, no_effect = TRUE)
 	to_chat(src, "<span class='info'>We begin to dismantle this machine. We will need to be uninterrupted.</span>")
 	var/obj/effect/temp_visual/swarmer/dismantle/D = new /obj/effect/temp_visual/swarmer/dismantle(get_turf(target))
 	D.pixel_x = target.pixel_x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

*Special Thanks to WhereAmI/O on the discord for helping find this bug*

Noticed that attacks with swarmers did the default mob attack effect despite having its own. And not only that- but disintegrating turfs would lead to the effect being applied to the entire area it was in because of how that effect is spawned in.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I don't think applying effects to entire areas is an intended behaviour. Not doing that would be good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Apparently that was because the animation was using `A.loc`, which when referenced in a turf, returns the area the turf is in- leading to the attack animation being present on the area itself rather than the turf. To remedy that, I replaced the instances of `A.loc` with `get_turf(A)`

In addition; swarmers already provide their own effects, so I passed an argument to the proc call to suppress the creation of said effects where applicable.

<details>
<summary>Videos of the Issue and the Fix</summary>

The issue:

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/8c43b9eb-4583-4541-ac5b-a8862f34a7b5

With the fix:

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/93f299db-5159-48c9-9be2-790e8d9a68ab

</details>

## Changelog
:cl:
fix: Attacks on turfs no longer randomly appear in the area containing it.
fix: Swarmer attacks no longer use the default attack effect, as they already apply their own.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
