### PR TITLE
Add playtime support for removed jobs

### DIFF
--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -56,6 +56,12 @@ GLOBAL_PROTECT(exp_to_update)
 	for(var/job in typelist["titles"])
 		if(job in explist)
 			amount += explist[job]
+	// Removed job support
+	typelist = GLOB.exp_removed_jobsmap[exptype]
+	if(typelist)
+		for(var/job in typelist["titles"])
+			if(job in explist)
+				amount += explist[job]
 	return amount
 
 /client/proc/get_exp_living(pure_numeric = FALSE)
@@ -105,6 +111,9 @@ GLOBAL_PROTECT(exp_to_update)
 	qdel(exp_read)
 
 	for(var/rtype in SSjob.name_occupations)
+		if(!play_records[rtype])
+			play_records[rtype] = 0
+	for(var/rtype in GLOB.exp_removed_jobs)
 		if(!play_records[rtype])
 			play_records[rtype] = 0
 	for(var/rtype in GLOB.exp_specialmap)

--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -29,11 +29,16 @@
 
 	var/list/data = list()
 	data["jobPlaytimes"] = list()
+	data["jobRemovedPlaytimes"] = list()
 	data["specialPlaytimes"] = list()
 
 	for (var/job_name in SSjob.name_occupations)
 		var/playtime = play_records[job_name] ? text2num(play_records[job_name]) : 0
 		data["jobPlaytimes"][job_name] = playtime
+
+	for (var/job_name in GLOB.exp_removed_jobs)
+		var/playtime = play_records[job_name] ? text2num(play_records[job_name]) : 0
+		data["jobRemovedPlaytimes"][job_name] = playtime
 
 	for (var/special_name in GLOB.exp_specialmap[EXP_TYPE_SPECIAL])
 		var/playtime = play_records[special_name] ? text2num(play_records[special_name]) : 0

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -228,7 +228,18 @@ GLOBAL_LIST_INIT(security_positions_hud, list(
 	JOB_HUD_DEPUTY,
 	JOB_HUD_RAWSECURITY))
 
+/// Put any removed jobs here so they can still show in playtime listings.
+GLOBAL_LIST_INIT(exp_removed_jobs, list(
+//	"Virologist",
+))
+GLOBAL_PROTECT(exp_removed_jobs)
 
+/// Put any removed jobs here so they can still show in playtime listings.
+GLOBAL_LIST_INIT(exp_removed_jobsmap, list(
+//	EXP_TYPE_CREW = list("titles" = list("Virologist")),
+//	EXP_TYPE_MEDICAL = list("titles" = list("Virologist")),
+))
+GLOBAL_PROTECT(exp_removed_jobsmap)
 
 GLOBAL_LIST_INIT(exp_jobsmap, list(
 	EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | gimmick_positions | list(JOB_NAME_AI,JOB_NAME_CYBORG)), // crew positions

--- a/tgui/packages/tgui/interfaces/TrackedPlaytime.js
+++ b/tgui/packages/tgui/interfaces/TrackedPlaytime.js
@@ -9,7 +9,7 @@ const JOB_REPORT_MENU_FAIL_REASON_NO_RECORDS = 2;
 const sortByPlaytime = sortBy(([_, playtime]) => -playtime);
 
 const PlaytimeSection = (props) => {
-  const { playtimes } = props;
+  const { playtimes, removedJobs } = props;
   const sortedPlaytimes = sortByPlaytime(Object.entries(playtimes));
   const mostPlayed = sortedPlaytimes[0][1];
   return (
@@ -24,7 +24,7 @@ const PlaytimeSection = (props) => {
               style={{
                 'vertical-align': 'middle',
               }}>
-              <Box align="right">{jobName}</Box>
+              <Box align="right">{jobName + (removedJobs?.includes(jobName) ? ' (Removed)' : '')}</Box>
             </Table.Cell>
             <Table.Cell>
               <ProgressBar maxValue={mostPlayed} value={playtime}>
@@ -49,7 +49,7 @@ const PlaytimeSection = (props) => {
 
 export const TrackedPlaytime = (props, context) => {
   const { data } = useBackend(context);
-  const { failReason, jobPlaytimes, specialPlaytimes, livingTime, ghostTime } = data;
+  const { failReason, jobPlaytimes = {}, jobRemovedPlaytimes = {}, specialPlaytimes, livingTime, ghostTime } = data;
   return (
     <Window title="Tracked Playtime" width={550} height={650}>
       <Window.Content scrollable>
@@ -66,7 +66,10 @@ export const TrackedPlaytime = (props, context) => {
               />
             </Section>
             <Section title="Jobs">
-              <PlaytimeSection playtimes={jobPlaytimes} />
+              <PlaytimeSection
+                playtimes={{ ...jobPlaytimes, ...jobRemovedPlaytimes }}
+                removedJobs={Object.keys(jobRemovedPlaytimes)}
+              />
             </Section>
             <Section title="Special">
               <PlaytimeSection playtimes={specialPlaytimes} />


### PR DESCRIPTION
## About The Pull Request

Jobs can now be removed but will show in the playtime report as (Removed).

Developed for #9817

## Why It's Good For The Game

Removing historical data from being visible to the player is unhelpful. This also prevents loss of access to roles based on their removal (losing access to CMO due to removal of viro hours, for example)

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Tested by removing virologist from the code and adding 100min of playtime in the database.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/2576535d-61e6-4dd2-ae46-c97e37e1d433)

</details>

## Changelog
:cl:
code: Added code support for the ability to view playtime of removed jobs.
/:cl: