### PR TITLE
Cleanup Crew Manifest UI

### DIFF
--- a/tgui/packages/tgui/components/index.js
+++ b/tgui/packages/tgui/components/index.js
@@ -13,6 +13,7 @@ export { Button } from './Button';
 export { ByondUi } from './ByondUi';
 export { Chart } from './Chart';
 export { Collapsible } from './Collapsible';
+export { CollapsibleSection } from './CollapsibleSection';
 export { ColorBox } from './ColorBox';
 export { Dimmer } from './Dimmer';
 export { Divider } from './Divider';

--- a/tgui/packages/tgui/interfaces/CrewManifest.tsx
+++ b/tgui/packages/tgui/interfaces/CrewManifest.tsx
@@ -1,7 +1,7 @@
 import { sortBy } from '../../common/collections';
-import { BooleanLike, classes } from 'common/react';
+import { classes } from 'common/react';
 import { useBackend } from '../backend';
-import { Box, Icon, Section, Table, Tooltip } from '../components';
+import { Box, Icon, CollapsibleSection, Table, Tooltip, Flex } from '../components';
 import { Window } from '../layouts';
 
 type DepartmentCrew = { [department: string]: ManifestEntry[] };
@@ -47,21 +47,36 @@ export const CrewManifest = (_props, context) => {
   } = useBackend<CrewManifestData>(context);
 
   return (
-    <Window title="Crew Manifest" width={350} height={500} theme={user_theme}>
+    <Window title="Crew Manifest" width={450} height={500} theme={user_theme}>
       <Window.Content scrollable>
         {Object.entries(manifest).map(([dept, crew]) => {
           const sorted_jobs = dept === command.dept ? sortSpecific(crew, command.order) : sortSpecific(crew, order);
           return (
-            <Section className={classes(['CrewManifest', `CrewManifest--${dept}`])} key={dept} title={dept}>
+            <CollapsibleSection
+              className={classes(['CrewManifest', `CrewManifest--${dept}`])}
+              key={dept}
+              sectionKey={dept}
+              title={dept}>
               <Table>
                 {Object.entries(sorted_jobs).map(([crewIndex, crewMember]) => {
                   const is_command = command.huds.includes(crewMember.hud) || command.jobs.includes(crewMember.rank);
                   return (
-                    <Table.Row key={crewIndex} className="candystripe">
+                    <Table.Row key={crewIndex} className="candystripe" height="16px">
                       <Table.Cell className={'CrewManifest__Cell'} bold={is_command} pl={0.5}>
-                        {crewMember.name}
+                        <Flex direction="row" style={{ 'align-items': 'center' }}>
+                          <Flex.Item>
+                            <Box
+                              inline
+                              mr={0.5}
+                              ml={-0.5}
+                              style={{ 'vertical-align': 'middle' }}
+                              className={`job-icon16x16 job-icon-hud${crewMember.hud}`}
+                            />
+                          </Flex.Item>
+                          <Flex.Item grow>{crewMember.name}</Flex.Item>
+                        </Flex>
                       </Table.Cell>
-                      <Table.Cell className={classes(['CrewManifest__Cell', 'CrewManifest__Icons'])} collapsing>
+                      <Table.Cell className={classes(['CrewManifest__Cell', 'CrewManifest__Cell--Rank'])} collapsing pr={1}>
                         {is_command && (
                           <Tooltip content="Head of Staff" position="bottom">
                             <Icon
@@ -74,22 +89,13 @@ export const CrewManifest = (_props, context) => {
                             />
                           </Tooltip>
                         )}
-                        <Box
-                          inline
-                          mr={0.5}
-                          ml={-0.5}
-                          style={{ 'vertical-align': 'middle' }}
-                          className={`job-icon16x16 job-icon-hud${crewMember.hud}`}
-                        />
-                      </Table.Cell>
-                      <Table.Cell className={classes(['CrewManifest__Cell', 'CrewManifest__Cell--Rank'])} collapsing pr={1}>
                         {crewMember.rank}
                       </Table.Cell>
                     </Table.Row>
                   );
                 })}
               </Table>
-            </Section>
+            </CollapsibleSection>
           );
         })}
       </Window.Content>

--- a/tgui/packages/tgui/styles/interfaces/CrewManifest.scss
+++ b/tgui/packages/tgui/styles/interfaces/CrewManifest.scss
@@ -20,15 +20,11 @@
 
     &--Rank {
       color: colors.$label;
+      text-align: right;
     }
   }
 
-  &__Icons {
-    text-align: right;
-  }
-
   &__Icon {
-    color: colors.$label;
     position: relative;
 
     &:not(:last-child) {
@@ -36,7 +32,7 @@
     }
 
     &--Chevron {
-      padding-right: 2px;
+      margin-right: 4px;
     }
 
     &--Command {


### PR DESCRIPTION
## About The Pull Request

Tweaks a few UI things to my taste:

- Moves job HUD icons next to the name, for consistency with the orbit panel and ingame HUDs - it makes glancing at names rather than job titles possible. Next to the job, the visual info is mostly redundant as you can just read the job.
- Right-aligns job names, making the flow of the job columns consistent.
- Replaces sections with collapsible ones.
- Increases the default width to better accommodate real-world long names and job titles. 

## Why It's Good For The Game

Better UI flow in my opinion

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Old UI

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/8a2fc20a-3755-47da-b2ce-54dd164816fa)


New UI

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/74877989-6e91-4461-9fc6-a6dc187c04e0)

Collapsing..
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/43cbc975-7b6f-4fe8-929f-a8c3ae753689)

Overflow handling is similar

Old

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/4262427e-adf6-4a43-802e-55f243e7557b)

New

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/2a615d9d-7725-44e0-87bc-2c2f50d157c0)

</details>

## Changelog
:cl:
tweak: Improved the user experience within the crew manifest TGUI - adding collapsible sections, relocating the job icons, and right-aligning job titles for better text flow.
/:cl: