### PR TITLE
Fix ranged holopara fire rate

### DIFF
--- a/code/modules/holoparasite/abilities/weapon/projectile.dm
+++ b/code/modules/holoparasite/abilities/weapon/projectile.dm
@@ -17,6 +17,7 @@
 /datum/holoparasite_ability/weapon/ranged/apply()
 	. = ..()
 	owner.ranged = TRUE
+	owner.ranged_cooldown_time = 17.5 / master_stats.speed
 	owner.melee_damage = 6 + round((master_stats.damage - 1) * 0.8) // barely stronger than a normal human punch
 	owner.obj_damage = 6 + round((master_stats.damage - 1) * 0.8)
 	owner.response_harm = "weakly punches"
@@ -25,6 +26,7 @@
 /datum/holoparasite_ability/weapon/ranged/remove()
 	. = ..()
 	owner.ranged = initial(owner.ranged)
+	owner.ranged_cooldown_time = initial(owner.ranged_cooldown_time)
 	owner.melee_damage = initial(owner.melee_damage)
 	owner.obj_damage = initial(owner.obj_damage)
 	owner.response_harm = initial(owner.response_harm)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot to set `ranged_cooldown_time` in the holopara reworks. My bad.

## Why It's Good For The Game

Because ranged holoparas are nearly useless with this bug

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/2647ef91-51dc-4529-b8a9-7714502440fc

</details>

## Changelog
:cl:
fix: Fixed ranged holoparas having a massively slower fire rate than they should.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
