### PR TITLE
Fixes breaching charges runtiming if they haven't been planted.

### DIFF
--- a/code/modules/exploration_crew/exploration_explosives.dm
+++ b/code/modules/exploration_crew/exploration_explosives.dm
@@ -117,6 +117,9 @@
 		return
 	var/explosives_trigged = 0
 	for(var/obj/item/grenade/exploration/exploration in linked_explosives)
+		// If the C4 hasn't been placed, don't blow it up
+		if (!exploration.target)
+			continue
 		var/turf/T2 = get_turf(exploration.target)
 		if(T2.get_virtual_z_level() == T.get_virtual_z_level() && get_dist(exploration.target, user) <= range)
 			addtimer(CALLBACK(exploration, TYPE_PROC_REF(/obj/item/grenade/exploration, prime)), 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply fixes breaching charges from runtiming if they haven't been planted since I died to this bug.
The runtime happens if you link a breaching charge and don't plant it but then have another breaching charge which is planted.

## Why It's Good For The Game

I died because I made a plan that relied on these working and it didn't work which is very sad and should be fixed at once.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/9e1d8fe2-a7f4-4c06-99c7-f8fb391f6e24)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/41dfe725-97f6-4e41-80d1-2fbd15c5b5f6)


## Changelog
:cl:
fix: Fixes exploration breaching charges failing to detonate if you have some that are linked but not planted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
