### PR TITLE
Single-symptom viruses will no longer have random names

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -575,6 +575,11 @@
 
 
 /datum/disease/advance/proc/random_disease_name(var/atom/diseasesource)//generates a name for a disease depending on its symptoms and where it comes from
+	// If this just has 1 symptom, use that symptom's name.
+	if(length(symptoms) == 1)
+		var/datum/symptom/main_symptom = symptoms[1]
+		if(istype(main_symptom) && length(main_symptom.name))
+			return main_symptom.name
 	var/list/prefixes = list("Spacer's ", "Space ", "Infectious ","Viral ", "The ", "[pick(GLOB.first_names)]'s ", "[pick(GLOB.last_names)]'s ", "Acute ")//prefixes that arent tacked to the body need spaces after the word
 	var/list/bodies = list(pick("[pick(GLOB.first_names)]", "[pick(GLOB.last_names)]"), "Space", "Disease", "Noun", "Cold", "Germ", "Virus")
 	var/list/suffixes = list("ism", "itis", "osis", "itosis", " #[rand(1,10000)]", "-[rand(1,100)]", "s", "y", "ovirus", " Bug", " Infection", " Disease", " Complex", " Syndrome", " Sickness") //suffixes that arent tacked directly on need spaces before the word


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This ensures that, whenever generating a random virus name, if the virus only has 1 symptom, the virus will just have the name of that symptom.

This avoids the problem where you'll extract a symptom and it'll have some random name because a roundstart dormant virus generated with just that symptom.

This is the bugfix from https://github.com/BeeStation/BeeStation-Hornet/pull/9796 split into its own PR (and done better than the original PR anyways)

## Why It's Good For The Game

No more need to use a hand labeler when extracting symptoms due to virus rng giving some single-symptom viruses random names

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/7d9508cc-d349-4715-a720-1e711455b36c)


</details>

## Changelog
:cl:
fix: Single-symptom viruses will no longer have random names — they'll just be named the same as the symptom instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
