### PR TITLE
Fix the Shuttle Designator

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -74,10 +74,10 @@
 // returns true if the area has power on given channel (or doesn't require power).
 // defaults to power_channel
 /obj/machinery/proc/powered(var/chan = -1) // defaults to power_channel
-	if(!loc)
-		return FALSE
 	if(!use_power)
 		return TRUE
+	if(!loc)
+		return FALSE
 	if(machine_stat & EMPED)
 		return FALSE
 	var/area/A = get_area(src)		// make sure it's in an area

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator_console.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator_console.dm
@@ -3,6 +3,7 @@
 	name = "internal shuttle creator console"
 	desc = "You should not have access to this, please report this as a bug"
 	networks = list()
+	use_power = NO_POWER_USE
 	var/obj/item/shuttle_creator/owner_rsd
 	var/datum/action/innate/shuttle_creator/designate_area/area_action = new
 	var/datum/action/innate/shuttle_creator/designate_turf/turf_action = new


### PR DESCRIPTION
## About The Pull Request

Fixes the shuttle designator not working because the internal component lacks power. This happened as a result of #9865 adding a power_change call to LateInitialize, which causes the stat to update to NOPOWER and thus is_operational to be FALSE and the internal console not to function. Simply adding NO_USE_POWER to the internal one fixes it - and then we have to allow items in nullspace to be "powered" by NO_USE_POWER.

## Why It's Good For The Game

Fixes bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/2a91cd06-86f7-4c02-b5a9-fcd0af95742b)

</details>

## Changelog
:cl:
fix: Fixed the Shuttle Designator not working.
/:cl:
