### PR TITLE
Fixes a holoparasite exploit

### DIFF
--- a/code/modules/holoparasite/holoparasite_reset.dm
+++ b/code/modules/holoparasite/holoparasite_reset.dm
@@ -66,6 +66,7 @@
 			to_chat(summoner.current, "<span class='holoparasite bold'>Personality reset <span class='danger'>failed</span>: unknown error!</span>")
 		return
 	to_chat(src, "<span class='holoparasite bold big'>[self ? "A ghost took control of you, at your request." : "Your summoner reset you! Better luck next time!"]</span>")
+	ghostize(can_reenter_corpse = FALSE)
 	key = new_player.key
 	to_chat(summoner.current, "<span class='holoparasite bold big'>Personality reset for [color_name] succeeded!</span>")
 	SSblackbox.record_feedback("tally", "holoparasite_reset", 1, automatic ? "automatic" : (self ? "self" : (cooldown ? "summoner" : "summoner (free)")))


### PR DESCRIPTION
## About The Pull Request

So it, it turns out, whenever a holoparasite is reset, _it sends the player back to the lobby_. This is bad, for obvious reasons. Now, it'll properly ghostize the old player before shoving the new one in.

Credit to @Bieyes for alerting me to this issue after coming across it the other day 💜 

## Why It's Good For The Game

lobby exploit bad. bugfix good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/c8c5ddec-dd0a-487c-90d4-434f7fc59d56)

</details>

## Changelog
:cl: Absolucy, Bieyes
fix: Fixed an exploit where a holoparasite player could be sent back to the lobby after being reset. Thank you Bieyes (Theodore Cooper) for alerting me of this exploit after coming across it!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
