### PR TITLE
removes gatfruit from silver extracts

### DIFF
--- a/code/__HELPERS/randoms.dm
+++ b/code/__HELPERS/randoms.dm
@@ -24,7 +24,13 @@
 		/obj/item/reagent_containers/food/snacks/clothing,
 		/obj/item/reagent_containers/food/snacks/grown/shell, //base types
 		/obj/item/food/bread,
-		/obj/item/reagent_containers/food/snacks/grown/nettle
+		/obj/item/reagent_containers/food/snacks/grown/nettle,
+		/obj/item/food/cakeslice/birthday/energy,
+		/obj/item/food/cake/birthday/energy,
+		/obj/item/reagent_containers/food/snacks/grown/shell/gatfruit,
+		/obj/item/seeds/cherry/bomb,
+		/obj/item/food/burger/roburger,
+		/obj/item/food/burger/roburgerbig
 		)
 		blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 

--- a/code/__HELPERS/randoms.dm
+++ b/code/__HELPERS/randoms.dm
@@ -25,12 +25,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/shell, //base types
 		/obj/item/food/bread,
 		/obj/item/reagent_containers/food/snacks/grown/nettle,
-		/obj/item/food/cakeslice/birthday/energy,
-		/obj/item/food/cake/birthday/energy,
-		/obj/item/reagent_containers/food/snacks/grown/shell/gatfruit,
-		/obj/item/seeds/cherry/bomb,
-		/obj/item/food/burger/roburger,
-		/obj/item/food/burger/roburgerbig
+		/obj/item/reagent_containers/food/snacks/grown/shell/gatfruit
 		)
 		blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds the following to the silver slime extract blacklist, previously limited only to parent foods that shouldn't be seen ingame at all:
- gatfruit



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
xenobio shouldn't have access to these for free, xenobio is argueably one of the most powerful subsepartments in the game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
hard to photograph something that should be removed
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Toasterban
del: Removed the chance for silver slime extracts to spawn gatfruit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
