### PR TITLE
Adds a small vignette that pops up when your laws are changed as AI.

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -110,6 +110,11 @@
 	layer = BLIND_LAYER
 	plane = FULLSCREEN_PLANE
 
+/atom/movable/screen/fullscreen/law_change
+    icon_state = "law_change"
+    layer = BLIND_LAYER
+    plane = FULLSCREEN_PLANE
+
 /atom/movable/screen/fullscreen/curse
 	icon_state = "curse"
 	layer = CURSE_LAYER

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -19,7 +19,7 @@
 		addtimer(CALLBACK(src, PROC_REF(show_laws)), 0)
 		addtimer(CALLBACK(src, PROC_REF(deadchat_lawchange)), 0)
 		// Wait a tick and clear the vignette
-		addtimer(CALLBACK(src, PROC_REF(clear_fullscreen), "law_change"), 2)
+		addtimer(CALLBACK(src, PROC_REF(clear_fullscreen), "law_change"), 0.2 SECONDS)
 		last_lawchange_announce = world.time
 
 /mob/living/silicon/proc/set_law_sixsixsix(law, announce = TRUE)

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -14,9 +14,12 @@
 	throw_alert("newlaw", /atom/movable/screen/alert/newlaw)
 	if(announce && last_lawchange_announce != world.time)
 		to_chat(src, "<b>Your laws have been changed.</b>")
+		overlay_fullscreen("law_change", /atom/movable/screen/fullscreen/law_change, 1)
 		// lawset modules cause this function to be executed multiple times in a tick, so we wait for the next tick in order to be able to see the entire lawset
 		addtimer(CALLBACK(src, PROC_REF(show_laws)), 0)
 		addtimer(CALLBACK(src, PROC_REF(deadchat_lawchange)), 0)
+		// Wait a tick and clear the vignette
+		addtimer(clear_fullscreen("law_change"), 10)
 		last_lawchange_announce = world.time
 
 /mob/living/silicon/proc/set_law_sixsixsix(law, announce = TRUE)

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -19,7 +19,7 @@
 		addtimer(CALLBACK(src, PROC_REF(show_laws)), 0)
 		addtimer(CALLBACK(src, PROC_REF(deadchat_lawchange)), 0)
 		// Wait a tick and clear the vignette
-		addtimer(clear_fullscreen("law_change"), 10)
+		addtimer(CALLBACK(src, PROC_REF(clear_fullscreen), "law_change"), 2)
 		last_lawchange_announce = world.time
 
 /mob/living/silicon/proc/set_law_sixsixsix(law, announce = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a small vignette that appears momentarily on the screen when laws are changed.
The vignette appears and then immediately fades out, similar to other notifier vignettes.
Created as a result of the following discussion on the forums:
https://forums.beestation13.com/t/please-can-we-make-law-changes-more-obvious-as-ai/

Happy to alter the actual style of the vignette if necessary, but just remember it's only meant to flash up momentarily on the screen!

## Why It's Good For The Game

Because AIs should change their behaviour immediately upon getting a law change, and sometimes they happen to be focusing on the game window rather than the chat window while playing.
This very minor alteration will not disrupt game flow in the slightest, whilst making it even harder to miss the law changes.

"Played a lot of AI, and I still would miss law changes from time to time, sometimes on highpop the chat goes so quick that if you don’t pay attention to it for a few seconds because you’re in a shell for instance, you just end up missing it..." - Haliris

"What if there was just a big annyoing pop up for law changes
it’d suck ass when theres lots of rapid law changes but as AI players arent we masochists anyways?" - llol111



## Testing Photographs and Procedure
Hard to screenshot it to be honest because it pops up then immediately disappears, but it looks like this:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/39484008/cfa05a21-2f92-44e0-81c2-120a04e797e7)

And the raw file looks like this:
![lawchangevignette_red](https://github.com/BeeStation/BeeStation-Hornet/assets/39484008/e32f7e6a-84fd-45b1-a2c7-2ae1d320e142)

Edit: Added video at request:

https://github.com/BeeStation/BeeStation-Hornet/assets/39484008/802d0f46-37e1-4900-b659-938e912ca8c6


</details>

## Changelog
:cl:
add: Added a vignette that appears momentarily when your laws are changed as AI.
imageadd: added the "law_change" fullscreen vignette.
/:cl: