### PR TITLE
Ghost QoL: invisible things are visible to ghosts (uses SSvis_overlay)

### DIFF
--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -6,11 +6,14 @@ SUBSYSTEM_DEF(vis_overlays)
 
 	var/list/vis_overlay_cache
 	var/list/unique_vis_overlays
+	/// vis overlays that is used to project half-transparent mob appearance
+	var/list/mob_alpha_vis_overlays
 	var/list/currentrun
 
 /datum/controller/subsystem/vis_overlays/Initialize()
 	vis_overlay_cache = list()
 	unique_vis_overlays = list()
+	mob_alpha_vis_overlays = list()
 	return ..()
 
 /datum/controller/subsystem/vis_overlays/fire(resumed = FALSE)
@@ -32,18 +35,18 @@ SUBSYSTEM_DEF(vis_overlays)
 			return
 
 //the "thing" var can be anything with vis_contents which includes images
-/datum/controller/subsystem/vis_overlays/proc/add_vis_overlay(atom/movable/thing, icon, iconstate, layer, plane, dir, alpha = 255, add_appearance_flags = NONE, unique = FALSE)
+/datum/controller/subsystem/vis_overlays/proc/add_vis_overlay(atom/movable/thing, icon, iconstate, layer, plane, dir, alpha = 255, add_appearance_flags = NONE, unique = FALSE, invisibility = -1)
 	var/obj/effect/overlay/vis/overlay
 	if(!unique)
-		. = "[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]|[add_appearance_flags]"
+		. = "[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]|[add_appearance_flags][invisibility]"
 		overlay = vis_overlay_cache[.]
 		if(!overlay)
-			overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)
+			overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags, invisibility)
 			vis_overlay_cache[.] = overlay
 		else
 			overlay.unused = 0
 	else
-		overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)
+		overlay = _create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags, invisibility)
 		overlay.cache_expiration = -1
 		var/cache_id = "[FAST_REF(overlay)]@{[world.time]}"
 		unique_vis_overlays += overlay
@@ -60,7 +63,7 @@ SUBSYSTEM_DEF(vis_overlays)
 	else
 		thing.managed_vis_overlays += overlay
 
-/datum/controller/subsystem/vis_overlays/proc/_create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags)
+/datum/controller/subsystem/vis_overlays/proc/_create_new_vis_overlay(icon, iconstate, layer, plane, dir, alpha, add_appearance_flags, invisibility = -1)
 	var/obj/effect/overlay/vis/overlay = new
 	overlay.icon = icon
 	overlay.icon_state = iconstate
@@ -69,8 +72,9 @@ SUBSYSTEM_DEF(vis_overlays)
 	overlay.dir = dir
 	overlay.alpha = alpha
 	overlay.appearance_flags |= add_appearance_flags
+	if(invisibility > -1)
+		overlay.invisibility = invisibility
 	return overlay
-
 
 /datum/controller/subsystem/vis_overlays/proc/remove_vis_overlay(atom/movable/thing, list/overlays)
 	thing.vis_contents -= overlays
@@ -89,10 +93,77 @@ SUBSYSTEM_DEF(vis_overlays)
 	var/rotation = dir2angle(old_dir) - dir2angle(new_dir)
 	var/list/overlays_to_remove = list()
 	for(var/i in thing.managed_vis_overlays - unique_vis_overlays)
+		if(istype(i, /obj/effect/overlay/vis/mob_alpha))
+			continue
 		var/obj/effect/overlay/vis/overlay = i
 		add_vis_overlay(thing, overlay.icon, overlay.icon_state, overlay.layer, overlay.plane, turn(overlay.dir, rotation), overlay.alpha, overlay.appearance_flags)
 		overlays_to_remove += overlay
 	for(var/i in thing.managed_vis_overlays & unique_vis_overlays)
+		if(istype(i, /obj/effect/overlay/vis/mob_alpha))
+			continue
 		var/obj/effect/overlay/vis/overlay = i
 		overlay.dir = turn(overlay.dir, rotation)
 	remove_vis_overlay(thing, overlays_to_remove)
+
+
+/// just add_vis_overlay() but only visible to observers
+/datum/controller/subsystem/vis_overlays/proc/add_obj_alpha(atom/movable/thing, icon=null, iconstate=null, alpha=150)
+	add_vis_overlay(thing, icon || thing.icon, iconstate || thing.icon_state, thing.layer+0.1, thing.plane, thing.dir, alpha=alpha, add_appearance_flags=RESET_ALPHA, invisibility=INVISIBILITY_OBSERVER)
+
+/// identical to procs above, but mob alpha version
+/datum/controller/subsystem/vis_overlays/proc/add_mob_alpha(atom/movable/thing, mob/target_mob, alpha=150, invisibility=INVISIBILITY_OBSERVER)
+	var/obj/effect/overlay/vis/mob_alpha/overlay
+	var/mob_alpha_id = "[REF(target_mob)][alpha][invisibility]"
+	overlay = mob_alpha_vis_overlays[mob_alpha_id]
+	if(!overlay)
+		overlay = _create_mob_alpha(FLY_LAYER, target_mob.plane, target_mob.dir, alpha, add_appearance_flags=RESET_ALPHA, invisibility=invisibility)
+		mob_alpha_vis_overlays[mob_alpha_id] = overlay
+		overlay.mob_alpha_id = mob_alpha_id
+		overlay.mob_owner_ref = "[REF(target_mob)]"
+	overlay.cut_overlays()
+	overlay.add_overlay(target_mob)
+
+	if(overlay in thing.vis_contents) // don't do this again
+		return overlay.mob_owner_ref
+
+	thing.vis_contents += overlay
+
+	// copy-pasta from the above
+	if(!isatom(thing))
+		return overlay.mob_owner_ref
+
+	if(!thing.managed_vis_overlays)
+		thing.managed_vis_overlays = list(overlay)
+		// RegisterSignal(thing, COMSIG_ATOM_DIR_CHANGE, PROC_REF(rotate_vis_overlay))
+		// mob alpha overlay doesn't support dir rotation
+	else
+		thing.managed_vis_overlays += overlay
+
+	return overlay.mob_owner_ref
+
+/datum/controller/subsystem/vis_overlays/proc/remove_mob_alpha(atom/movable/thing, list/exception_mobs=list())
+	for(var/obj/effect/overlay/vis/mob_alpha/overlay in thing.managed_vis_overlays)
+		if(overlay.mob_owner_ref in exception_mobs)
+			continue
+		thing.vis_contents -= overlay
+		mob_alpha_vis_overlays -= overlay.mob_alpha_id
+		if(isatom(thing))
+			thing.managed_vis_overlays -= overlay
+		qdel(overlay)
+
+	if(isatom(thing) && !length(thing.managed_vis_overlays))
+		thing.managed_vis_overlays = null
+		// UnregisterSignal(thing, COMSIG_ATOM_DIR_CHANGE)
+
+/datum/controller/subsystem/vis_overlays/proc/_create_mob_alpha(layer, plane, dir, alpha, add_appearance_flags, invisibility = -1)
+	var/obj/effect/overlay/vis/mob_alpha/overlay = new
+	overlay.icon = null
+	overlay.icon_state = null
+	overlay.layer = layer
+	overlay.plane = plane
+	overlay.dir = dir
+	overlay.alpha = alpha
+	overlay.appearance_flags |= add_appearance_flags
+	if(invisibility > -1)
+		overlay.invisibility = invisibility
+	return overlay

--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -126,6 +126,7 @@ SUBSYSTEM_DEF(vis_overlays)
 	if(overlay in thing.vis_contents) // don't do this again
 		return overlay.mob_owner_ref
 
+	overlay.use_count++
 	thing.vis_contents += overlay
 
 	// copy-pasta from the above
@@ -146,6 +147,9 @@ SUBSYSTEM_DEF(vis_overlays)
 		if(overlay.mob_owner_ref in exception_mobs)
 			continue
 		thing.vis_contents -= overlay
+		overlay.use_count--
+		if(overlay.use_count) // only remove it when it's used in nowhere
+			continue
 		mob_alpha_vis_overlays -= overlay.mob_alpha_id
 		if(isatom(thing))
 			thing.managed_vis_overlays -= overlay

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -38,3 +38,7 @@
 	name = "invisible blockade"
 	desc = "You're gonna be here awhile."
 	timeleft = 600
+
+/obj/effect/forcefield/mime/Initialize(mapload, ntimeleft)
+	. = ..()
+	SSvis_overlays.add_obj_alpha(src, 'icons/turf/walls/snow_wall.dmi', "snow_wall-0")

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -54,6 +54,11 @@
 	var/cache_expiration = 2 MINUTES // overlays which go unused for 2 minutes get cleaned up
 	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE
 
+/obj/effect/overlay/vis/mob_alpha
+	/// this separately exists because "mob_alpha_id" is to reference this single, but "mob_owner_ref" is to reference multiple things to a mob
+	var/mob_owner_ref
+	var/mob_alpha_id
+
 /obj/effect/overlay/airlock_part
 	anchored = TRUE
 	plane = FLOAT_PLANE

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -58,6 +58,7 @@
 	/// this separately exists because "mob_alpha_id" is to reference this single, but "mob_owner_ref" is to reference multiple things to a mob
 	var/mob_owner_ref
 	var/mob_alpha_id
+	var/use_count = 0
 
 /obj/effect/overlay/airlock_part
 	anchored = TRUE

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -22,7 +22,7 @@
 /obj/structure/closet/cardboard/agent/Initialize(mapload)
 	. = ..()
 	go_invisible()
-
+	SSvis_overlays.add_obj_alpha(src)
 
 /obj/structure/closet/cardboard/agent/open()
 	. = ..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -470,3 +470,12 @@
 		obj_flags ^= EMAGGED
 	else
 		obj_flags |= EMAGGED
+
+/// shows mobs in its contents to ghosts. can be used to update
+/obj/proc/update_mob_alpha()
+	if(!length(contents))
+		SSvis_overlays.remove_mob_alpha(src)
+	var/list/exception_mobs = list()
+	for(var/mob/each_mob in contents)
+		exception_mobs += SSvis_overlays.add_mob_alpha(src, each_mob)
+	SSvis_overlays.remove_mob_alpha(src, exception_mobs)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -91,6 +91,7 @@
 				add_overlay("[icon_door]_open")
 			else
 				add_overlay("[icon_state]_open")
+	update_mob_alpha()
 
 /obj/structure/closet/proc/animate_door(var/closing = FALSE)
 	if(!door_anim_time)

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -219,6 +219,7 @@
 	GLOB.reality_smash_track.smashes += src
 	heretic_image = image(icon, src, real_icon_state, OBJ_LAYER)
 	generate_name()
+	SSvis_overlays.add_obj_alpha(src, 'icons/effects/heretic.dmi', "pierced_illusion")
 
 /obj/effect/heretic_influence/Destroy()
 	GLOB.reality_smash_track.smashes -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ghost QoL PR
* Through SSvis_overlay Subsystem, now it applies ghost-only-visible overlays to specific things
  * mime invisible walls
  * agent stealth box
  * heretic influence
* added mob_alpha related procs in vis_overlay subsystem. This is also used to show mobs in a locker to ghosts

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes us easier notice what's going on

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/32c7f3d3-01cb-45a8-8657-26651a2b147c)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/7805c02b-9846-4553-81f1-9384ab5ac68f)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/b9055c24-4f8d-4fba-8c88-70bf40456df5)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/8b60eda4-7815-4d42-8b00-b4dfb443f311)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/8096e04d-46c1-4b2c-851f-43d33f58ed79)


## Changelog
:cl:
add: mime invisible walls, agent stealth box, heretic influence, and mobs in lockers/closets will be visible to ghosts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
