### PR TITLE
Fixes Particle Accelerators being unable to activate tesla/singulo engine.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -570,10 +570,10 @@
  * Return PROJECTILE_DELETE_WITHOUT_HITTING to delete projectile without hitting at all!
  */
 /obj/projectile/proc/prehit_pierce(atom/A)
-	if((projectile_phasing & A.pass_flags_self) && (!phasing_ignore_direct_target || original != A))
-		return PROJECTILE_PIERCE_PHASE
 	if(projectile_piercing & A.pass_flags_self)
 		return PROJECTILE_PIERCE_HIT
+	if((projectile_phasing & A.pass_flags_self) && (!phasing_ignore_direct_target || original != A))
+		return PROJECTILE_PIERCE_PHASE
 	if(ismovable(A))
 		var/atom/movable/AM = A
 		if(AM.throwing)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -61,7 +61,7 @@
 	var/phasing_ignore_direct_target = FALSE
 	/// Bitflag for things the projectile should just phase through entirely - No hitting unless direct target and [phasing_ignore_direct_target] is FALSE. Uses pass_flags flags.
 	var/projectile_phasing = NONE
-	/// Bitflag for things the projectile should hit, but pierce through without deleting itself. Defers to projectile_phasing. Uses pass_flags flags.
+	/// Bitflag for things the projectile should hit, but pierce through without deleting itself. Considered before just purely phasing. Uses pass_flags flags.
 	var/projectile_piercing = NONE
 	/// number of times we've pierced something. Incremented BEFORE bullet_act and on_hit proc!
 	var/pierces = 0

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -23,7 +23,7 @@
 	damage = 60
 	projectile_piercing = PASSMOB | PASSMACHINE | PASSTRANSPARENT | PASSGRILLE | PASSDOORS | PASSFLAPS | PASSSTRUCTURE
 	// Phase directly through everything else
-	projectile_phasing = ALL
+	projectile_phasing = (ALL & (~PASSMOB) & (~PASSMACHINE) & (~PASSTRANSPARENT) & (~PASSGRILLE) & (~PASSDOORS) & (~PASSFLAPS) & (~PASSSTRUCTURE))
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 	breakthings = FALSE

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -23,7 +23,7 @@
 	damage = 60
 	projectile_piercing = PASSMOB | PASSMACHINE | PASSTRANSPARENT | PASSGRILLE | PASSDOORS | PASSFLAPS | PASSSTRUCTURE
 	// Phase directly through everything else
-	projectile_phasing = (ALL & (~PASSMOB) & (~PASSMACHINE) & (~PASSTRANSPARENT) & (~PASSGRILLE) & (~PASSDOORS) & (~PASSFLAPS) & (~PASSSTRUCTURE))
+	projectile_phasing = (ALL & ~(PASSMOB | PASSMACHINE | PASSTRANSPARENT | PASSGRILLE | PASSDOORS | PASSFLAPS | PASSSTRUCTURE))
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 	breakthings = FALSE

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -23,7 +23,7 @@
 	damage = 60
 	projectile_piercing = PASSMOB | PASSMACHINE | PASSTRANSPARENT | PASSGRILLE | PASSDOORS | PASSFLAPS | PASSSTRUCTURE
 	// Phase directly through everything else
-	projectile_phasing = (ALL & ~(PASSMOB | PASSMACHINE | PASSTRANSPARENT | PASSGRILLE | PASSDOORS | PASSFLAPS | PASSSTRUCTURE))
+	projectile_phasing = ALL
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 	breakthings = FALSE

--- a/code/modules/projectiles/projectile/energy/accelerator_particle.dm
+++ b/code/modules/projectiles/projectile/energy/accelerator_particle.dm
@@ -5,7 +5,7 @@
 	range = 10
 	speed = 1
 	projectile_piercing = PASSMOB | PASSANOMALY | PASSMACHINE
-	projectile_phasing = (ALL & (~PASSMOB) & (~PASSBLOB) & (~PASSANOMALY) & (~PASSMACHINE))
+	projectile_phasing = (ALL & (~PASSMOB) & (~PASSBLOB) & (~PASSANOMALY) & (~PASSMACHINE) & (~LETPASSCLICKS))
 	suppressed = SUPPRESSED_VERY //we don't want every machine that gets hit to spam chat
 	hitsound = null
 	irradiate = 60

--- a/code/modules/projectiles/projectile/energy/accelerator_particle.dm
+++ b/code/modules/projectiles/projectile/energy/accelerator_particle.dm
@@ -5,7 +5,7 @@
 	range = 10
 	speed = 1
 	projectile_piercing = PASSMOB | PASSANOMALY | PASSMACHINE
-	projectile_phasing = (ALL & (~PASSMOB) & (~PASSBLOB) & (~PASSANOMALY) & (~PASSMACHINE) & (~LETPASSCLICKS))
+	projectile_phasing = ALL
 	suppressed = SUPPRESSED_VERY //we don't want every machine that gets hit to spam chat
 	hitsound = null
 	irradiate = 60

--- a/code/modules/projectiles/projectile/energy/accelerator_particle.dm
+++ b/code/modules/projectiles/projectile/energy/accelerator_particle.dm
@@ -5,7 +5,7 @@
 	range = 10
 	speed = 1
 	projectile_piercing = PASSMOB | PASSANOMALY | PASSMACHINE
-	projectile_phasing = (ALL & (~PASSBLOB))
+	projectile_phasing = (ALL & ~(PASSMOB | PASSBLOB | PASSANOMALY | PASSMACHINE))
 	suppressed = SUPPRESSED_VERY //we don't want every machine that gets hit to spam chat
 	hitsound = null
 	irradiate = 60

--- a/code/modules/projectiles/projectile/energy/accelerator_particle.dm
+++ b/code/modules/projectiles/projectile/energy/accelerator_particle.dm
@@ -5,7 +5,7 @@
 	range = 10
 	speed = 1
 	projectile_piercing = PASSMOB | PASSANOMALY | PASSMACHINE
-	projectile_phasing = ALL
+	projectile_phasing = (ALL & (~PASSBLOB))
 	suppressed = SUPPRESSED_VERY //we don't want every machine that gets hit to spam chat
 	hitsound = null
 	irradiate = 60


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #9887

This fixes a bug that prevented players from making singulos/teslaballs, due to some bad projectile code. So I touched it up and made it so that Piercing behaviour comes before Phasing behaviour- since they're identical but one hits and the other doesn't.

So now the game will try to hit something while passing through before doing nothing while passing through.

```dm
projectile_piercing = PASSMOB | PASSANOMALY | PASSMACHINE
projectile_phasing = (ALL & (~PASSBLOB))
```
as opposed to 
```dm
projectile_piercing = PASSMOB | PASSANOMALY | PASSMACHINE
projectile_phasing = (ALL & (~PASSMOB) & (~PASSBLOB) & (~PASSANOMALY) & (~PASSMACHINE))
```

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Touches up some bad code behaviour so that's it's less so, *and* fixes a feature that is supposed to work.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/35765038-00ea-4d62-afb3-cce28adc2eb3

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/db4f7064-3bbf-4cf3-92e6-09a59f48a344

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/0e66211f-9b69-45f9-9f31-ba11d170d979

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/852038f6-6cb1-412b-8643-bc88e293d71d

Also touched the sniper penetrating rounds while cleaning up too- so here's evidence that it still works:

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/45176f65-134a-4c84-97cf-7d5670942893

</details>

## Changelog
:cl:
fix: The Particles shot out of the Particle Accelerator no longer phase through machines
code: In Projectiles, Piercing behaviour is now prioritized over Phasing behaviour (the difference between the two is whether it deals damage as it's passing through)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
