### PR TITLE
Fix simplemobs not properly disabling AI when using set_playable

### DIFF
--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -31,17 +31,17 @@
 
 /mob/living/proc/give_mind(mob/user)
 	if(key || !playable || stat)
-		return 0
+		return FALSE
 	var/question = alert("Do you want to become [name]?", "[name]", "Yes", "No")
 	if(question != "Yes" || !src || QDELETED(src))
-		return TRUE
+		return FALSE
 	if(key)
 		to_chat(user, "<span class='notice'>Someone else already took [name].</span>")
-		return TRUE
+		return FALSE
 	if(!SSticker.HasRoundStarted())
-		return
+		return FALSE
 	if(!user?.client?.can_take_ghost_spawner(playable_bantype, TRUE, flags_1 & ADMIN_SPAWNED_1))
-		return
+		return FALSE
 	key = user.key
 	log_game("[key_name(src)] took control of [name].")
 	remove_from_spawner_menu()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -642,3 +642,8 @@
 	if (AIStatus == AI_Z_OFF)
 		SSidlenpcpool.idle_mobs_by_zlevel[old_z] -= src
 		toggle_ai(initial(AIStatus))
+
+/mob/living/simple_animal/give_mind(mob/user)
+	. = ..()
+	if(.)
+		sentience_act(user)


### PR DESCRIPTION
## About The Pull Request

This applies to blob zombies, they use AI even when sentient which is super annoying.

## Why It's Good For The Game

Not having AI fuck around while you're trying to play is nice.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/314da622-02cb-4f55-8302-f70427544e43)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/45ff2cef-d665-4f17-be58-eef70588c1a9)


</details>

## Changelog
:cl:
fix: Fixed AI not being disabled on certain ghost role simplemobs when a player takes control, such as blob zombies.
/:cl: