### PR TITLE
Robotized/Roundstart borgs now transfer DNA and quirks from their old body correctly

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -443,6 +443,7 @@ SUBSYSTEM_DEF(ticker)
 
 	for(var/mob/dead/new_player/N in GLOB.player_list)
 		var/mob/living/carbon/human/player = N.new_character
+		var/datum/mind/player_mind = player.mind
 		if(istype(player) && player.mind && player.mind.assigned_role)
 			if(player.mind.assigned_role == JOB_NAME_CAPTAIN)
 				captainless = FALSE
@@ -461,8 +462,8 @@ SUBSYSTEM_DEF(ticker)
 							spare_id_candidates += N
 			if(player.mind.assigned_role != player.mind.special_role)
 				SSjob.EquipRank(N, player.mind.assigned_role, FALSE)
-			if(CONFIG_GET(flag/roundstart_traits) && ishuman(N.new_character))
-				SSquirks.AssignQuirks(player.mind, N.client, TRUE)
+			if(CONFIG_GET(flag/roundstart_traits))
+				SSquirks.AssignQuirks(player_mind, N.client, TRUE)
 		CHECK_TICK
 	if(length(spare_id_candidates))			//No captain, time to choose acting captain
 		if(!enforce_coc)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -443,16 +443,16 @@ SUBSYSTEM_DEF(ticker)
 
 	for(var/mob/dead/new_player/N in GLOB.player_list)
 		var/mob/living/carbon/human/player = N.new_character
-		var/datum/mind/player_mind = player.mind
-		if(istype(player) && player.mind && player.mind.assigned_role)
-			if(player.mind.assigned_role == JOB_NAME_CAPTAIN)
+		var/datum/mind/mind = player?.mind
+		if(istype(player) && mind && mind.assigned_role)
+			if(mind.assigned_role == JOB_NAME_CAPTAIN)
 				captainless = FALSE
 				spare_id_candidates += N
-			else if(captainless && (player.mind.assigned_role in GLOB.command_positions) && !(is_banned_from(N.ckey, JOB_NAME_CAPTAIN)))
+			else if(captainless && (mind.assigned_role in GLOB.command_positions) && !(is_banned_from(N.ckey, JOB_NAME_CAPTAIN)))
 				if(!enforce_coc)
 					spare_id_candidates += N
 				else
-					var/spare_id_priority = SSjob.chain_of_command[player.mind.assigned_role]
+					var/spare_id_priority = SSjob.chain_of_command[mind.assigned_role]
 					if(spare_id_priority)
 						if(spare_id_priority < highest_rank)
 							spare_id_candidates.Cut()
@@ -460,10 +460,10 @@ SUBSYSTEM_DEF(ticker)
 							highest_rank = spare_id_priority
 						else if(spare_id_priority == highest_rank)
 							spare_id_candidates += N
-			if(player.mind.assigned_role != player.mind.special_role)
-				SSjob.EquipRank(N, player.mind.assigned_role, FALSE)
+			if(mind.assigned_role != mind.special_role)
+				SSjob.EquipRank(N, mind.assigned_role, FALSE)
 			if(CONFIG_GET(flag/roundstart_traits))
-				SSquirks.AssignQuirks(player_mind, N.client, TRUE)
+				SSquirks.AssignQuirks(mind, N.client, TRUE)
 		CHECK_TICK
 	if(length(spare_id_candidates))			//No captain, time to choose acting captain
 		if(!enforce_coc)

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -144,6 +144,7 @@
 	if(is_species(H, /datum/species/moth) && prob(50))
 		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
 	else
+		//surely there is a better way to do this
 		switch(quirk_holder.assigned_role)
 			//Service jobs
 			if(JOB_NAME_CLOWN)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -370,8 +370,8 @@
 						SSticker.mode.make_antag_chance(humanc)
 						SSticker.mode.make_special_antag_chance(humanc)
 
-	if(humanc && CONFIG_GET(flag/roundstart_traits))
-		SSquirks.AssignQuirks(character.mind, humanc.client, TRUE)
+	if(CONFIG_GET(flag/roundstart_traits))
+		SSquirks.AssignQuirks(character.mind, character.client, TRUE)
 
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -127,25 +127,30 @@
 
 
 /obj/item/mmi/proc/transfer_identity(mob/living/L) //Same deal as the regular brain proc. Used for human-->robot people.
-	if(!brainmob)
-		brainmob = new(src)
-	brainmob.name = L.real_name
-	brainmob.real_name = L.real_name
-	if(L.has_dna())
-		var/mob/living/carbon/C = L
-		if(!brainmob.stored_dna)
-			brainmob.stored_dna = new /datum/dna/stored(brainmob)
-		C.dna.copy_dna(brainmob.stored_dna)
-	brainmob.container = src
-
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		var/obj/item/organ/brain/newbrain = H.getorgan(/obj/item/organ/brain)
-		newbrain.forceMove(src)
-		brain = newbrain
-	else if(!brain)
+		if(newbrain)
+			. = TRUE
+			newbrain.Remove(H, TRUE) //this calls newbrain.transfer_identity()
+			newbrain.forceMove(src)
+			if(brain)
+				qdel(brain)
+			if(brainmob)
+				qdel(brainmob)
+			brain = newbrain
+
+	if(!brain)
 		brain = new(src)
-		brain.name = "[L.real_name]'s brain"
+
+	if(!brain.brainmob)
+		if(brainmob)
+			qdel(brainmob) //hopefully this isn't incredibly short sighted and ignorant and breaks everything
+		brain.transfer_identity(L)
+
+	brainmob = brain.brainmob
+	brainmob.container = src
+	brain.name = "[brainmob.real_name]'s brain"
 	brain.organ_flags |= ORGAN_FROZEN
 
 	name = "[initial(name)]: [brainmob.real_name]"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -80,8 +80,6 @@
 	name = "[L.name]'s brain"
 	if(brainmob || decoy_override)
 		return
-	if(!L.mind)
-		return
 	brainmob = new(src)
 	brainmob.name = L.real_name
 	brainmob.real_name = L.real_name

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -481,8 +481,6 @@
 	regenerate_icons()
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
-	for(var/t in bodyparts)
-		qdel(t)
 
 /mob/living/carbon/AIize(transfer_after = TRUE, client/preference_source)
 	return pre_transform() ? null : ..()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -540,6 +540,8 @@
 	if(R.mmi)
 		R.mmi.transfer_identity(src)
 
+	R.notify_ai(NEW_BORG)
+	
 	. = R
 	if(R.ckey && is_banned_from(R.ckey, JOB_NAME_CYBORG))
 		INVOKE_ASYNC(R, TYPE_PROC_REF(/mob/living/silicon/robot, replace_banned_cyborg))

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -523,6 +523,7 @@
 
 	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
 
+	R.job = JOB_NAME_CYBORG
 	R.gender = gender
 	R.invisibility = 0
 
@@ -537,15 +538,7 @@
 		R.key = key
 
 	if(R.mmi)
-		R.mmi.name = "[initial(R.mmi.name)]: [real_name]"
-		if(R.mmi.brain)
-			R.mmi.brain.name = "[real_name]'s brain"
-		if(R.mmi.brainmob)
-			R.mmi.brainmob.real_name = real_name //the name of the brain inside the cyborg is the robotized human's name.
-			R.mmi.brainmob.name = real_name
-
-	R.job = JOB_NAME_CYBORG
-	R.notify_ai(NEW_BORG)
+		R.mmi.transfer_identity(src)
 
 	. = R
 	if(R.ckey && is_banned_from(R.ckey, JOB_NAME_CYBORG))


### PR DESCRIPTION
## About The Pull Request

Closes #9900

* the ticker's `equip_characters()` proc no longer checks if the character is a `mob/living/carbon/human/` at the quirk step
  * This means that the non-human jobs (AI, cyborg) will still have quirk preferences assigned
  * They will continue to not handle their quirks, however, so this shouldn't affect gameplay
* rewrites `robotize()` to use the MMI's `transfer_identity()`
* rewrites the MMI's `transfer_identity()` proc to use the `brain_item`'s `transfer_identity()`
* removed some redundant (hopefully) lines of code

## Why It's Good For The Game

this is expected behaviour

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/39193182/09342232-6b38-4d84-9b1f-7efa911fd521

</details>

## Changelog
:cl:
tweak: spawning characters will now have their quirks assigned regardless of what mob type they are
fix: roundstart cyborgs should now keep the DNA and quirks of their character
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
