### PR TITLE
Rebalances Meteor Shields, more of them and faster deployment

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1114,7 +1114,7 @@
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains seven bluespace capsules which a single unit of Shield Generator Satellite is compressed within each."
 	cost = 7000
-	max_supply = 2
+	max_supply = 4
 	access_budget = ACCESS_HEADS
 	contains = list(
 					/obj/item/meteor_shield,

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -136,7 +136,7 @@
 
 /obj/item/meteor_shield/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/deployable, /obj/machinery/satellite/meteor_shield, time_to_deploy = 10 SECONDS)
+	AddComponent(/datum/component/deployable, /obj/machinery/satellite/meteor_shield, time_to_deploy = 3 SECONDS)
 
 /obj/machinery/satellite/meteor_shield
 	name = "\improper Meteor Shield Satellite"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Doubles the meteor shield satellite crate supply amount to 4 (totaling 28 shield satellites if all of them are deployed), and makes the deployment time 3 seconds (down from 10 seconds).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

With https://github.com/BeeStation/BeeStation-Hornet/pull/9239 keyed, it is stated that meteor satellite deployment should be made easier, this makes it way more easier to rapidly acquire and deploy meteor satellites in the very limited amount of time we're forcing everyone to have to prepare. 10 seconds per satellite to deploy is ludicrous in my opinion, and is objectively worse than just dragging around a meteor crate from before. I have also added more supply to the meteor satellites, as it should not be as supply limited as other items due to the imminent emergency, no one is scalping the sats off the market.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Only cooldown and supply changes for now, if I need to prove this works in game then we aren't trusting the rest of the code to work.

</details>

## Changelog
:cl:
balance: Meteor shield satellites now take 3 seconds to deploy, down from 10.
balance: Meteor shield satellites now have double the supply, up to 4 packs of 28 total, from 2 packs of 14.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
