### PR TITLE
fixes hide action_buttons clearing overlays

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -43,7 +43,7 @@
 
 /atom/movable/screen/movable/action_button/Click(location,control,params)
 	if (!can_use(usr))
-		return
+		return FALSE
 
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK))
@@ -75,10 +75,26 @@
 	desc = "Shift-click any button to reset its position, and Control-click it to lock it in place. Alt-click this button to reset all buttons to their default positions."
 	icon = 'icons/mob/actions.dmi'
 	icon_state = "bg_default"
-	var/hidden = 0
+	var/hidden = FALSE
 	var/hide_icon = 'icons/mob/actions.dmi'
 	var/hide_state = "hide"
 	var/show_state = "show"
+	var/mutable_appearance/hide_appearance
+	var/mutable_appearance/show_appearance
+
+/atom/movable/screen/movable/action_button/hide_toggle/Initialize(mapload)
+	. = ..()
+	var/static/list/icon_cache = list()
+
+	var/cache_key = "[hide_icon][hide_state]"
+	hide_appearance = icon_cache[cache_key]
+	if(!hide_appearance)
+		hide_appearance = icon_cache[cache_key] = mutable_appearance(hide_icon, hide_state)
+
+	cache_key = "[hide_icon][show_state]"
+	show_appearance = icon_cache[cache_key]
+	if(!show_appearance)
+		show_appearance = icon_cache[cache_key] = mutable_appearance(hide_icon, show_state)
 
 /atom/movable/screen/movable/action_button/hide_toggle/Click(location,control,params)
 	if (!can_use(usr))
@@ -121,7 +137,7 @@
 		name = "Show Buttons"
 	else
 		name = "Hide Buttons"
-	update_icon()
+	update_appearance()
 	usr.update_action_buttons()
 
 /atom/movable/screen/movable/action_button/hide_toggle/AltClick(mob/user)
@@ -142,12 +158,11 @@
 	hide_icon = settings["toggle_icon"]
 	hide_state = settings["toggle_hide"]
 	show_state = settings["toggle_show"]
-	update_icon()
+	update_appearance()
 
-/atom/movable/screen/movable/action_button/hide_toggle/update_icon()
-	cut_overlays()
-	add_overlay(mutable_appearance(hide_icon, hidden ? show_state : hide_state))
-
+/atom/movable/screen/movable/action_button/hide_toggle/update_overlays()
+	. = ..()
+	. += hidden ? show_appearance : hide_appearance
 
 /atom/movable/screen/movable/action_button/MouseEntered(location,control,params)
 	if(!QDELETED(src))


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/47091

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ancient fix to action_buttons, making it so hide_toggle doesn't clear overlays it shouldn't

Modernized update_icon to update_appearance standards, fixed a bool or two

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix.

Modernizes our action_buttons to about mid 2021 TG, more refactors and performance fixes to come

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/7a47e00c-7dcd-46f2-9b51-870df01c0132



</details>

## Changelog
:cl: rkz, ninjanomnom
fix: hiding action_buttons will no longer clear all overlays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
