### PR TITLE
"Fixes" small pockets, Nerfs hat storage, Limits candleboxes, Removes sign storage

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -17,6 +17,7 @@
 
 /datum/component/storage/concrete/pockets/small
 	max_items = 1
+	max_w_class = WEIGHT_CLASS_SMALL
 	attack_hand_interact = FALSE
 
 /datum/component/storage/concrete/pockets/tiny

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -109,6 +109,7 @@
 	icon_state = "candlebox5"
 	icon_type = "candle"
 	item_state = "candlebox5"
+	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 2
 	slot_flags = ITEM_SLOT_BELT
 	spawn_type = /obj/item/candle

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -109,9 +109,8 @@
 	icon_state = "candlebox5"
 	icon_type = "candle"
 	item_state = "candlebox5"
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 2
-	slot_flags = ITEM_SLOT_BELT
 	spawn_type = /obj/item/candle
 	fancy_open = TRUE
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -118,6 +118,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 5
+	STR.can_hold = typecacheof(list(/obj/item/candle, /obj/item/lighter, /obj/item/storage/box/matches))
 
 /obj/item/storage/fancy/candle_box/attack_self(mob_user)
 	return

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -579,6 +579,7 @@
 	body_parts_covered = CHEST|GROIN
 	attack_verb = list("warned", "cautioned", "smashed")
 	armor = list(MELEE = 5,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, STAMINA = 0)
+	pocket_storage_component_path = null
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modifies small pockets (/datum/component/storage/concrete/pockets/small) to only allow storing small items instead of normal items, bringing it in line with how tiny pockets work for storage. Makes it so the candlepack can only store candles, lighters, and matchboxes instead of _any_ five tiny or small sized items and ~~are now small sized themselves~~ cannot be stored on belts anymore. Removed the exo storage component from the janitor's wet floor signs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As it stands, the fedora and taqiyahs (which are a type of skullcap, mind you) allow storing a medium/normal sized item, which includes such comical events of a detective pulling; A sawn-off shotgun, a skateboard, an entire mop, the cap's jetpack, a batong, a wooden buckler, a _silenced_ Stechkin, or a laptop out from under their hat, where you were none the wiser to it being there. This is a frankly insanely strong level of smuggling, as most people don't even check boots or cloaks, let alone hats.

Candleboxes can basically be used at bootleg omnibelts/gear harnesses right now. It's a 5 slot belt item that can hold any small or tiny item without any restrictions, it's frankly too strong IMO. ~~This also changes them to be small-sized, to make up for the lost utility and now that 'storage-maxxing' isn't possible with them anymore.~~

While it's funny for wet floor signs to grant exo storage as they are a type of suit, it doesn't exactly make sense (it's two flaps of plastic) and can currently lead to some disgusting storage maxxing as they're also small items. You could nest 7 in a box and sudden double its storage to 14, or one in each of your pockets to have 4 small items instead of just two.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Clothing Storage Tweaks](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/0cb6b5cf-54bf-4e5e-a334-feac137615ed)

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/d10c40fd-0922-479a-a171-10743e17921b

</details>

## Changelog
:cl: Impish_Delights
balance: Fedoras (Regular and All Det subtypes) and Taqiyahs only store upto small items (down from normal-sized).
balance: Candle packs now only hold candles, lighters, and matchboxes, and cannot be stored on belts.
balance: Wet Floor Signs no longer have exo storage like other suit items do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
