### PR TITLE
Fixes Z-Copy breaking stat tabs & Adds in validation for MC stat panels

### DIFF
--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -122,7 +122,7 @@ SUBSYSTEM_DEF(zcopy)
 		"\tT: { T: [openspace_turfs] O: [openspace_overlays] } Sk: { T: [multiqueue_skips_turf] O: [multiqueue_skips_object] }",
 		"\tF: { H: [fixup_hit] M: [fixup_miss] N: [fixup_noop] FC: [fixup_cache.len] FKG: [fixup_known_good.len] }",	// Fixup stats.
 	)
-	return ..() + entries.Join("\n")
+	return ..(entries.Join("\n"))
 
 // 1, 2, 3..=7, 8
 /datum/controller/subsystem/zcopy/proc/build_zstack_display()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -83,6 +83,7 @@
 #include "ntnetwork_tests.dm"
 #include "preference_species.dm"
 #include "projectiles.dm"
+#include "stat_mc.dm"
 #include "subsystem_init.dm"
 #include "subsystem_metric_sanity.dm"
 #include "surgery_linking.dm"

--- a/code/modules/unit_tests/stat_mc.dm
+++ b/code/modules/unit_tests/stat_mc.dm
@@ -1,0 +1,55 @@
+/datum/unit_test/stat_mc_validation/Run()
+	var/list/failures = list()
+	main_loop:
+		for (var/datum/controller/subsystem/ss in Master.subsystems)
+			var/list/result = ss.stat_entry()
+			// Accepted
+			if (isnull(result))
+				continue
+			// Rejected for not returning a list
+			if (!islist(result))
+				failures += "The subsystem [ss.name] has an invalid stat_entry proc, it did not return a list."
+				continue
+			// The list should be associative and contain stat types
+			for (var/key in result)
+				var/list/value = result[key]
+				var/comp_type = value["type"]
+				if (!islist(value) || !comp_type)
+					failures += "The subsystem [ss.name] has an invalid stat_entry proc, it does not properly use the new system of stat panel component types."
+					continue main_loop
+				switch (comp_type)
+					if (STAT_TEXT)
+						var/text = value["text"]
+						if (isnull(text))
+							failures += "The subsystem [ss.name] has an invalid stat_entry proc, it contains a text component with no text parameter."
+							continue main_loop
+						continue
+					if (STAT_BUTTON)
+						var/text = value["text"]
+						var/action = value["action"]
+						if (isnull(text) || isnull(action))
+							failures += "The subsystem [ss.name] has an invalid stat_entry proc, it has a button which has either no text, or no action."
+							continue main_loop
+						continue
+					if (STAT_ATOM)
+						var/text = value["text"]
+						if (isnull(text))
+							failures += "The subsystem [ss.name] has an invalid stat_entry proc, it contains an atom component with no text parameter."
+							continue main_loop
+						continue
+					if (STAT_DIVIDER)
+						continue
+					if (STAT_VERB)
+						var/action = value["action"]
+						if (isnull(action))
+							failures += "The subsystem [ss.name] has an invalid stat_entry proc, it has a verb which has no action."
+							continue main_loop
+						continue
+					if (STAT_BLANK)
+						continue
+					else
+						failures += "The subsystem [ss.name] has an invalid stat_entry proc, it attempted to display a component with a type that was not recognised."
+						continue main_loop
+	if (!length(failures))
+		return
+	Fail(jointext(failures, "\n"))

--- a/code/modules/unit_tests/stat_mc.dm
+++ b/code/modules/unit_tests/stat_mc.dm
@@ -13,8 +13,11 @@
 			// The list should be associative and contain stat types
 			for (var/key in result)
 				var/list/value = result[key]
+				if (!islist(value))
+					failures += "The subsystem [ss.name] has an invalid stat_entry proc, it does not properly use the new system of stat panel component types."
+					continue main_loop
 				var/comp_type = value["type"]
-				if (!islist(value) || !comp_type)
+				if (!comp_type)
 					failures += "The subsystem [ss.name] has an invalid stat_entry proc, it does not properly use the new system of stat panel component types."
 					continue main_loop
 				switch (comp_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The MC stat panel broke due to Z-Copy having an invalid MC stat panel. This adds in unit tests to ensure that broken MC tabs don't get created.

## Why It's Good For The Game

Unit testing to prevent future MC panel breaks.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/0903893e-70d1-48fc-8fe6-961b33a7192c)

Unit test successfully picks up the failing subsystem.

Unit test suceeds after fixing:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/acf53818-e6d2-4e62-83e6-2cce054c4644)

Z-Copy stat tab now works.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/48f6d014-65bf-47ef-9235-3dd8740d0acf)


## Changelog
:cl:
add: Adds in unit testing for MC stat panels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
