### PR TITLE
Steal objectives now check holoparasite inventories

### DIFF
--- a/code/game/gamemodes/objectives/basic/steal.dm
+++ b/code/game/gamemodes/objectives/basic/steal.dm
@@ -81,9 +81,12 @@ GLOBAL_LIST_EMPTY(possible_items)
 		if(!isliving(M.current))
 			continue
 
-		var/list/all_items = M.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
+		var/list/all_items = M.current.GetAllContents(/obj/item)	//this should get things in cheesewheels, books, etc.
 
-		for(var/obj/I in all_items) //Check for items
+		for(var/mob/living/simple_animal/hostile/holoparasite/holopara as() in M.holoparasite_holder?.holoparasites)
+			all_items |= holopara.GetAllContents(/obj/item)
+
+		for(var/obj/I as() in all_items) //Check for items
 			if(istype(I, steal_target))
 				if(!targetinfo) //If there's no targetinfo, then that means it was a custom objective. At this point, we know you have the item, so return 1.
 					return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This ensures steal objectives also check holoparasites - as dextrous holoparasites can have items in their inventories.

## Why It's Good For The Game

i redtexted bc my dextrous holopara that was holding my objective item was manifested on the escape pod in order to rp rather than being recalled. this is bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/21faa3cf-bf35-454e-a7df-71c26944b5e7)


</details>

## Changelog
:cl:
fix: Steal objectives now properly check holoparasite inventories for the objective item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
