### PR TITLE
Fix negative eye_blind leading to permanent blindness

### DIFF
--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -28,7 +28,7 @@
   */
 /mob/proc/adjust_blindness(amount)
 	var/old_eye_blind = eye_blind
-	eye_blind += amount
+	eye_blind = max(eye_blind + amount, 0)
 	if(!old_eye_blind || !eye_blind && !HAS_TRAIT(src, TRAIT_BLIND))
 		update_blindness()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so you can't get negative `eye_blind` anymore, which would result in permanent blindness. This was usually caused by healing holoparas with the debuff healing threshold.

## Why It's Good For The Game

Because healing holoparas _blinding people_ is bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/98851740-1a52-4631-adde-c20f789c5b18

</details>

## Changelog
:cl:
fix: You can no longer obtain a negative temporary blindness duration, which would lead to permanent blindness. As a result, healing holoparas don't blind people anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
