### PR TITLE
Zombie tumors now do brain damage instead of toxin

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -66,8 +66,9 @@
 		var/heal_amt = heal_rate
 		if(C.InCritical())
 			heal_amt *= 2
-		C.heal_overall_damage(heal_amt,heal_amt)
+		C.heal_overall_damage(heal_amt,heal_amt,heal_amt)
 		C.adjustToxLoss(-heal_amt)
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -heal_amt)
 	if(!C.InCritical() && prob(4))
 		playsound(C, pick(spooks), 50, TRUE, 10)
 

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -66,7 +66,7 @@
 		var/heal_amt = heal_rate
 		if(C.InCritical())
 			heal_amt *= 2
-		C.heal_overall_damage(heal_amt,heal_amt,heal_amt)
+		C.heal_overall_damage(heal_amt,heal_amt)
 		C.adjustToxLoss(-heal_amt)
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -heal_amt)
 	if(!C.InCritical() && prob(4))

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -9,8 +9,8 @@
 	var/living_transformation_time = 30
 	var/converts_living = FALSE
 
-	var/revive_time_min = 45 SECONDS
-	var/revive_time_max = 70 SECONDS
+	var/revive_time_min = 60 SECONDS
+	var/revive_time_max = 100 SECONDS
 	var/timer_id
 
 /obj/item/organ/zombie_infection/Initialize(mapload)
@@ -46,7 +46,7 @@
 	if(!(src in owner.internal_organs))
 		Remove(owner, TRUE)
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
-		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5 * delta_time)
+		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1 * delta_time)
 	if(timer_id)
 		return
 	if(owner.suiciding)
@@ -78,7 +78,7 @@
 	//Fully heal the zombie's damage the first time they rise
 	C.setToxLoss(0, 0)
 	C.setOxyLoss(0, 0)
-	C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -200)
+	C.setOrganLoss(ORGAN_SLOT_BRAIN, 0)
 	C.heal_overall_damage(INFINITY, INFINITY, INFINITY, null, TRUE)
 
 	C.revive()

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -9,8 +9,8 @@
 	var/living_transformation_time = 30
 	var/converts_living = FALSE
 
-	var/revive_time_min = 450
-	var/revive_time_max = 700
+	var/revive_time_min = 45 SECONDS
+	var/revive_time_max = 70 SECONDS
 	var/timer_id
 
 /obj/item/organ/zombie_infection/Initialize(mapload)
@@ -46,9 +46,7 @@
 	if(!(src in owner.internal_organs))
 		Remove(owner, TRUE)
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
-		owner.adjustToxLoss(0.5 * delta_time, forced = TRUE)
-		if(DT_PROB(5, delta_time))
-			to_chat(owner, "<span class='danger'>You feel sick...</span>")
+		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5 * delta_time)
 	if(timer_id)
 		return
 	if(owner.suiciding)
@@ -80,12 +78,12 @@
 	//Fully heal the zombie's damage the first time they rise
 	C.setToxLoss(0, 0)
 	C.setOxyLoss(0, 0)
+	C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -200)
 	C.heal_overall_damage(INFINITY, INFINITY, INFINITY, null, TRUE)
 
 	C.revive()
-
-
 	C.grab_ghost()
+
 	C.visible_message("<span class='danger'>[owner] suddenly convulses, as [owner.p_they()][stand_up ? " stagger to [owner.p_their()] feet and" : ""] gain a ravenous hunger in [owner.p_their()] eyes!</span>", "<span class='alien'>You HUNGER!</span>")
 	playsound(C.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 	C.do_jitter_animation(living_transformation_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Damaging zombie tumors deal brain damage instead of toxin damage.
* Hostile zombies now heal brain damage over time as well, and fully heal brain damage upon conversion
* Brain damage progresses twice as fast as toxin damage so patients die sooner (this is done because brain damage cannot cause crit) 
* The delay between death and resurrection as a zombie has been increased by 50% to make up for the lack of time spent in crit. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This change will make it a bit less immediately obvious what is wrong when a player is chosen to become patient zero for a zombie outbreak - patients will experience lightheadedness and then an onset of various brain traumas before finally succumbing to death. 

Brain damage is easily treated just like toxin damage, but is not as instantly visible on the health HUD.  The associated traumas are not so easily treated - however the traumas are automatically cured upon becoming a zombie, adding a level of meta-incentive not to meta-rush for treatment. *This is not something I changed, this is just a consequence of the zombie transformation for better or worse that's already in the game.*

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/44b209f0-5be4-4436-932a-cb9e6abf024b)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/2cf66fd6-796d-40bb-b073-35510fff505b)


## Changelog
:cl:
tweak: Damaging zombie tumors deal brain damage instead of toxin damage.
tweak: Hostile zombies now heal brain damage over time as well, and fully heal brain damage upon conversion
tweak: Brain damage progresses twice as fast as toxin damage so patients die sooner (this is done because brain damage cannot cause crit) 
tweak: The delay between death and resurrection as a zombie has been increased by 50% to make up for the lack of time spent in crit. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
