### PR TITLE
Removes a useless duplicate of the spell burger recipe

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
@@ -202,15 +202,6 @@
 /datum/crafting_recipe/food/spellburger
 	name = "Spell burger"
 	reqs = list(
-		/obj/item/clothing/head/wizard/fake = 1,
-		/obj/item/reagent_containers/food/snacks/bun = 1
-	)
-	result = /obj/item/food/burger/spell
-	subcategory = CAT_BURGER
-
-/datum/crafting_recipe/food/spellburger2
-	name = "Spell burger"
-	reqs = list(
 		/obj/item/clothing/head/wizard = 1,
 		/obj/item/reagent_containers/food/snacks/bun = 1
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the crafting menu, there were two recipes to make a spell burger. The first one only accepted fake wizard hats as ingredients, and the second one accepted both real and fake ones. This PR removes the first recipe, leaving only the one that accepts any wizard hat.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The removed recipe was completely useless.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/6c922176-fa20-44c8-9b44-b645041e4a71


</details>

## Changelog
:cl:
fix: Duplicate spell burger recipe has been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
