### PR TITLE
Fixes a runtime associated with touch spells

### DIFF
--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -16,7 +16,7 @@
 	catchphrase = "R'CH T'H TR'TH!"
 	on_use_sound = 'sound/items/welder.ogg'
 
-/obj/item/melee/touch_attack/mansus_fist/Initialize(mapload)
+/obj/item/melee/touch_attack/mansus_fist/Initialize(mapload, obj/effect/proc_holder/spell/targeted/touch/_spell)
 	. = ..()
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You remove %THEEFFECT.", \

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -17,7 +17,7 @@
 	throw_speed = 0
 	var/charges = 1
 
-/obj/item/melee/touch_attack/Initialize(_mapload, obj/effect/proc_holder/spell/targeted/touch/_spell)
+/obj/item/melee/touch_attack/Initialize(mapload, obj/effect/proc_holder/spell/targeted/touch/_spell)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 	if(istype(_spell))
@@ -197,7 +197,7 @@
 	catchphrase = null
 	var/datum/mutation/parent_mutation
 
-/obj/item/melee/touch_attack/mutation/Initialize(_mapload, datum/mutation/_parent)
+/obj/item/melee/touch_attack/mutation/Initialize(_mapload, obj/effect/proc_holder/spell/targeted/touch/_spell, datum/mutation/_parent)
 	. = ..()
 	if(!istype(_parent))
 		return INITIALIZE_HINT_QDEL

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -44,7 +44,7 @@
 	return ..()
 
 /obj/effect/proc_holder/spell/targeted/touch/proc/create_hand()
-	return new hand_path(src)
+	return new hand_path(null, src)
 
 /obj/effect/proc_holder/spell/targeted/touch/proc/charge_hand(mob/living/carbon/user)
 	attached_hand = create_hand()
@@ -96,4 +96,4 @@
 	parent_mutation = _parent
 
 /obj/effect/proc_holder/spell/targeted/touch/mutation/create_hand()
-	return new hand_path(src, parent_mutation)
+	return new hand_path(null, src, parent_mutation)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a runtime associated with touch spells, preventing them from having a cooldown.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
https://github.com/BeeStation/BeeStation-Hornet/pull/9831 had a small oversight where it had the wrong args passed to new(), which caused a runtime that made touch spells have no cooldown.
And hey, less bugs is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/110184118/a3b2756d-d8aa-43bf-8695-aa1e1ea590d8

</details>

## Changelog
:cl:
fix: fixed a runtime in godhand.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
