### PR TITLE
Oozelings no longer autocannibalize inorganic limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -104,11 +104,15 @@
 /datum/species/oozeling/proc/Cannibalize_Body(mob/living/carbon/human/H)
 	var/list/limbs_to_consume = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG) - H.get_missing_limbs()
 	var/obj/item/bodypart/consumed_limb
+	var/L
+	for(L in limbs_to_consume) //Check every bodypart the oozeling has, see if they're organic or not
+		if(!IS_ORGANIC_LIMB(H.get_bodypart(L))) //Get actual limb, list only has body zone
+			limbs_to_consume -= list(L) //If it's inorganic, remove it from the consumption list
 	if(!limbs_to_consume.len)
 		H.losebreath++
 		return
-	if(H.get_num_legs(FALSE)) //Legs go before arms
-		limbs_to_consume -= list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+	if((BODY_ZONE_L_LEG in limbs_to_consume) || (BODY_ZONE_R_LEG in limbs_to_consume)) //Check if there are any organic legs left
+		limbs_to_consume -= list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM) //If there are, autocannibalize those first
 	consumed_limb = H.get_bodypart(pick(limbs_to_consume))
 	consumed_limb.drop_limb()
 	to_chat(H, "<span class='userdanger'>Your [consumed_limb] is drawn back into your body, unable to maintain its shape!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -104,10 +104,9 @@
 /datum/species/oozeling/proc/Cannibalize_Body(mob/living/carbon/human/H)
 	var/list/limbs_to_consume = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG) - H.get_missing_limbs()
 	var/obj/item/bodypart/consumed_limb
-	var/L
-	for(L in limbs_to_consume) //Check every bodypart the oozeling has, see if they're organic or not
+	for(var/L in limbs_to_consume) //Check every bodypart the oozeling has, see if they're organic or not
 		if(!IS_ORGANIC_LIMB(H.get_bodypart(L))) //Get actual limb, list only has body zone
-			limbs_to_consume -= list(L) //If it's inorganic, remove it from the consumption list
+			limbs_to_consume -= L //If it's inorganic, remove it from the consumption list
 	if(!limbs_to_consume.len)
 		H.losebreath++
 		return

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -2,6 +2,7 @@
 	return
 
 /mob/living/carbon/get_bodypart(zone)
+	RETURN_TYPE(/obj/item/bodypart)
 	if(!zone)
 		zone = BODY_ZONE_CHEST
 	for(var/obj/item/bodypart/L as() in bodyparts)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oozelings that have low enough blood to start autocannibalizing/reabsorbing limbs will no longer absorb limbs that are flagged as inorganic (such as prosthetics). Otherwise, they still follow the same behavior of cannibalizing legs, followed by arms, and then causing breathloss if there are no limbs to consume.

Adds an explicit return type to get_bodypart() because it was complaining about field access while running IS_ORGANIC_LIMB() while writing this change.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

While it is funny conceptually, and horrifying on an in-character note to watch an oozeling absorb and directly convert a hunk of metal into more blood and food, it doesn't really make sense (especially with how the description of reabsorbing limbs is written).

Closes #9988
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/410916fe-2dc5-4f75-b0da-9a9ca8bd9a1a

</details>

## Changelog
:cl: Impish_Delights
fix: Oozelings no longer autocannibalize inorganic limbs while at low blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
