### PR TITLE
FARTIN' SHARTIN' CLOWNS (SOVLFUL PR #10000)

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -213,6 +213,14 @@
 		if(COOLDOWN_FINISHED(fartee, special_emote_cooldown))
 			..()
 			COOLDOWN_START(fartee, special_emote_cooldown, 20 SECONDS)
+		else if(HAS_TRAIT(fartee, TRAIT_CLUMSY) && prob(5))
+			var/turf/T = get_turf(fartee)
+			fartee.spew_organ(0, 1)
+			fartee.add_splatter_floor(T)
+			playsound(T, 'sound/effects/splat.ogg', 50, 1)
+			fartee.visible_message("<span class='warning'>[fartee] sprays a bloody mess out of their rear!</span>", "<span class='warning'>You manage to strain out more than just a fart!</span>")
+			..()
+			COOLDOWN_START(fartee, special_emote_cooldown, 20 SECONDS)
 		else
 			to_chat(user, "<span class='warning'>You strain, but can't seem to fart again just yet.</span>")
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## ABOUT PULL REQUEST NUMBER 10,000

Adds the soul back to the fart cooldown. 

<details>

There is a 5% chance for anyone with the clumsy trait to shart out a random organ when they try to fart while farting is on cooldown

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Who doesn't love it when a clown with bad jokes accidentally sharts their own lungs out and dies. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/57db94b5-5e8f-4f39-9c0b-c04fd0540e54)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/a643898d-8d0c-48cf-9cb2-db4204fe8d03)


## Changelog
:cl:
add: The server repo has officially reached 10,000 pull requests. Thank you everyone for all the contributions you make to the game!
add: To honor this momentous occasion, clowns struggling to fart when they shouldn't be able to may now occasionally fart a random organ out instead. This may be lethal. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
