### PR TITLE
Fixes MC tab breaking 2

### DIFF
--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(profiler)
 /datum/controller/subsystem/profiler/stat_entry(msg)
 	msg += "F:[round(fetch_cost,1)]ms"
 	msg += "|W:[round(write_cost,1)]ms"
-	..(msg)
+	return ..(msg)
 
 /datum/controller/subsystem/profiler/Initialize()
 	if(CONFIG_GET(flag/auto_profile))

--- a/code/modules/unit_tests/stat_mc.dm
+++ b/code/modules/unit_tests/stat_mc.dm
@@ -3,8 +3,9 @@
 	main_loop:
 		for (var/datum/controller/subsystem/ss in Master.subsystems)
 			var/list/result = ss.stat_entry()
-			// Accepted
+			// Rejected
 			if (isnull(result))
+				failures += "The subsystem [ss.name] has an invalid stat_entry proc, it returns null."
 				continue
 			// Rejected for not returning a list
 			if (!islist(result))

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -21,7 +21,7 @@ export const StatText = (props, context) => {
       <Box>
         {statPanelData
           ? Object.keys(statPanelData)
-            .filter(x => x !== null)
+            .filter((x) => x !== null)
             .sort((a, b) => {
               return StatTagToPriority(statPanelData[b].tag) - StatTagToPriority(statPanelData[a].tag);
             })

--- a/tgui/packages/tgui-panel/stat/StatText.js
+++ b/tgui/packages/tgui-panel/stat/StatText.js
@@ -21,6 +21,7 @@ export const StatText = (props, context) => {
       <Box>
         {statPanelData
           ? Object.keys(statPanelData)
+            .filter(x => x !== null)
             .sort((a, b) => {
               return StatTagToPriority(statPanelData[b].tag) - StatTagToPriority(statPanelData[a].tag);
             })


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The unit test accepted anything that returned null, although null returns are also not allowed. This makes it so that the MC stat panel unit test will reject null will also result in failure.
On top of this, the actual stat panel will filter away nulls, so that it should be more robust against failure.

Previously, it was working fine on local for me likely due to not updating so it seemed to be working.

## Why It's Good For The Game

This fixes the stat MC panel from breaking and prevents even more future mistakes.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/1cff9e8d-18b2-4122-b159-800b219f8159)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/9bbab278-e185-4ff5-bdbe-8e189ca6fdd3)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/204065a7-b24f-41f3-a7a3-23d8d8e866e7)


## Changelog
:cl:
fix: Fixes the MC tab breaking in stat again due to a null returned stat entry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
