### PR TITLE
Makes automatic shotguns semi-automatic (and fixes a sound runtime)

### DIFF
--- a/_maps/shuttles/pirate/pirate_default.dmm
+++ b/_maps/shuttles/pirate/pirate_default.dmm
@@ -748,7 +748,7 @@
 /obj/item/ammo_box/magazine/m12g,
 /obj/item/ammo_box/magazine/m12g,
 /obj/item/ammo_box/magazine/m12g,
-/obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
+/obj/item/gun/ballistic/shotgun/automatic/bulldog/unrestricted,
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "wR" = (

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -172,7 +172,7 @@
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
 	internals_slot = ITEM_SLOT_RPOCKET
 	belt = /obj/item/storage/belt/military
-	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
+	r_hand = /obj/item/gun/ballistic/shotgun/automatic/bulldog
 	backpack_contents = list(/obj/item/storage/box/syndie=1,\
 		/obj/item/tank/jetpack/oxygen/harness=1,\
 		/obj/item/gun/ballistic/automatic/pistol=1,\

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -581,7 +581,7 @@
 	desc = "A large duffel bag containing a Bulldog, some drums, and a pair of thermal imaging glasses."
 
 /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle/PopulateContents()
-	new /obj/item/gun/ballistic/shotgun/bulldog(src)
+	new /obj/item/gun/ballistic/shotgun/automatic/bulldog(src)
 	new /obj/item/ammo_box/magazine/m12g(src)
 	new /obj/item/ammo_box/magazine/m12g(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -118,7 +118,7 @@
 
 		if("metaops")
 			new /obj/item/clothing/suit/space/hardsuit/syndi(src) // 8 tc
-			new /obj/item/gun/ballistic/shotgun/bulldog/unrestricted(src) // 8 tc
+			new /obj/item/gun/ballistic/shotgun/automatic/bulldog/unrestricted(src) // 8 tc
 			new /obj/item/implanter/explosive(src) // 2 tc
 			new /obj/item/ammo_box/magazine/m12g(src) // 2 tc
 			new /obj/item/ammo_box/magazine/m12g(src) // 2 tc

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -67,9 +67,15 @@
 	update_icon()
 
 /obj/item/gun/ballistic/fire_sounds()
-	var/frequency_to_use = sin((90/magazine?.max_ammo) * get_ammo())
+	var/frequency_to_use
+	var/play_click
+	if(magazine)
+		frequency_to_use = sin((90/magazine?.max_ammo) * get_ammo())
+		play_click = round(sqrt(magazine?.max_ammo * 2)) > get_ammo()
+	else
+		frequency_to_use = sin((90) * get_ammo())
+		play_click = round(sqrt(2)) > get_ammo()
 	var/click_frequency_to_use = 1 - frequency_to_use * 0.75
-	var/play_click = round(sqrt(magazine?.max_ammo * 2)) > get_ammo()
 
 	if(suppressed)
 		playsound(src, suppressed_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -165,13 +165,10 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	mag_type = /obj/item/ammo_box/magazine/m12g
-	can_suppress = FALSE
-	burst_size = 1
 	fire_delay = 0
 	pin = /obj/item/firing_pin/implant/pindicate
 	spread_unwielded = 15
 	actions_types = list()
-	casing_ejector = TRUE
 	mag_display = TRUE
 	empty_indicator = TRUE
 	empty_alarm = TRUE

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -64,12 +64,6 @@
 	semi_auto = TRUE
 	casing_ejector = TRUE
 
-/*
-/obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
-	..()
-	rack()
-*/
-
 /obj/item/gun/ballistic/shotgun/automatic/combat
 	name = "combat shotgun"
 	desc = "A semi automatic shotgun with tactical furniture and a six-shell capacity underneath."
@@ -159,7 +153,7 @@
 
 // Bulldog shotgun //
 
-/obj/item/gun/ballistic/shotgun/bulldog
+/obj/item/gun/ballistic/shotgun/automatic/bulldog
 	name = "\improper Bulldog Shotgun"
 	desc = "A semi-auto, mag-fed shotgun for combat in narrow corridors with a built in recoil dampening system, nicknamed 'Bulldog' by boarding parties. Compatible only with specialized 8-round drum magazines."
 	icon_state = "bulldog"
@@ -177,11 +171,11 @@
 	pin = /obj/item/firing_pin/implant/pindicate
 	spread_unwielded = 15
 	actions_types = list()
+	casing_ejector = TRUE
 	mag_display = TRUE
 	empty_indicator = TRUE
 	empty_alarm = TRUE
 	special_mags = TRUE
-	semi_auto = TRUE
 	internal_magazine = FALSE
 	tac_reloads = TRUE
 	fire_rate = 2
@@ -190,7 +184,7 @@
 	bolt_type = BOLT_TYPE_STANDARD	//Not using a pump
 	full_auto = TRUE
 
-/obj/item/gun/ballistic/shotgun/bulldog/unrestricted
+/obj/item/gun/ballistic/shotgun/automatic/bulldog/unrestricted
 	pin = /obj/item/firing_pin
 /////////////////////////////
 // DOUBLE BARRELED SHOTGUN //

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -77,6 +77,7 @@
 		if(!user.is_holding(src))
 			return
 		semi_auto = !semi_auto
+		playsound(src, 'sound/weapons/effects/ballistic_click.ogg', 20, FALSE)
 		to_chat(user, "<span class='notice'>You toggle \the [src] to [semi_auto ? "automatic" : "manual"] operation.</span>")
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/examine(mob/user)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -61,10 +61,14 @@
 
 /obj/item/gun/ballistic/shotgun/automatic
 	weapon_weight = WEAPON_HEAVY
+	semi_auto = TRUE
+	casing_ejector = TRUE
 
+/*
 /obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
 	..()
 	rack()
+*/
 
 /obj/item/gun/ballistic/shotgun/automatic/combat
 	name = "combat shotgun"
@@ -73,6 +77,18 @@
 	item_state = "shotgun_combat"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
+
+/obj/item/gun/ballistic/shotgun/automatic/combat/AltClick(mob/user)
+	if(loc == user)
+		if(!user.is_holding(src))
+			return
+		semi_auto = !semi_auto
+		to_chat(user, "<span class='notice'>You toggle \the [src] to [semi_auto ? "automatic" : "manual"] operation.</span>")
+
+/obj/item/gun/ballistic/shotgun/automatic/combat/examine(mob/user)
+	. = ..()
+	. += "You can select the firing mode with <b>alt+click</b>"
+	. += "It is operating in [semi_auto ? "automatic" : "manual"] mode."
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	name = "compact combat shotgun"
@@ -108,7 +124,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	var/toggled = FALSE
 	var/obj/item/ammo_box/magazine/internal/shot/alternate_magazine
-	semi_auto = TRUE
+	//semi_auto = TRUE
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/examine(mob/user)
 	. = ..()

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/energy/plasmacutter/adv,
 	/obj/item/gun/energy/wormhole_projector,
 	/obj/item/gun/ballistic/automatic/wt550,
-	/obj/item/gun/ballistic/shotgun/bulldog,
+	/obj/item/gun/ballistic/shotgun/automatic/bulldog,
 	/obj/item/gun/ballistic/revolver/grenadelauncher,
 	/obj/item/gun/ballistic/revolver/golden,
 	/obj/item/gun/ballistic/sniper_rifle,

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -519,7 +519,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Bulldog Shotgun"
 	desc = "A fully-loaded semi-automatic drum-fed shotgun. Compatible with all 12g rounds. Designed for close \
 			quarter anti-personnel engagements."
-	item = /obj/item/gun/ballistic/shotgun/bulldog
+	item = /obj/item/gun/ballistic/shotgun/automatic/bulldog
 	cost = 8
 	surplus = 40
 	purchasable_from = UPLINK_NUKE_OPS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/dd660878-0d45-4959-8bdd-bd367eb44a15)

## About The Pull Request
I am not joking, this removes the `shotgun/automatic/shoot_live_shot()` proc that would call `rack()` after firing, which would automatically pump the shotgun for you _if and only if you are wielding the shotgun._ This guts that, and sets `semi_auto` & `casing_ejector` to TRUE instead, so they function like how an semi-automatic shotgun would. This fixes a bug that was off-handedly mentioned in #3646 (which I found after making sure this was not an intentional **"fuck you"** to the Warden) and the weird issue with Warden's shotgun, where it is clearly meant to be able to be used one-handed (what with the additional recoil when firing one-handed) but will not automatically cycle.

Combat shotguns (both the Warden's compact shotgun and regular sized ones) can now be alt-click toggled to fire in "Manual" mode, functioning as a traditional pump-action shotgun. This has equivalent fire-rate to automatic, but gives slightly more control to the user (as a few people have mentioned not enjoying combat shotguns as their muscle memory from riot shotguns fucks them over).

Fixes a runtime that would occur when a gun without a magazine installed is fired (such as removing the mag from a Stechkin or Bulldog and firing the single chambered round). This runtime would prevent the sound from playing during that final shot as well, this fixes that.

Retypes the Bulldog from `/obj/item/gun/ballistic/shotgun/bulldog` to `/obj/item/gun/ballistic/automatic/shotgun/bulldog` as it is a true automatic shotgun. Updates all other files and the one map (Pirate shuttle) that references the Bulldog.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1. Combat shotguns functioning in a way that makes sense both in-game-wise and code-wise is better. This also fixes the peculiarity with the compact combat shotgun where it can be fired one-handed but doesn't cycle.
2. Adding an alternative fire-mode to the combat shotguns that does not add a mechanical advantage, but makes it feel nicer to use is, nice.
3. Less runtimes is good, especially when they could be exploited in-game (firing a gun with no gunshot sound, without needing a suppressor, is kinda nasty).
4. Consistency as the bulldog is the only real "automatic" shotgun, it makes sense for it to be a child of the shotgun/automatic type.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/b26ca3a3-f586-4ab1-a0ce-8d30ff0f4e9c)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/520775c3-8a63-43df-8d09-2c0d3f53d06c)

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/07761fc2-4219-4eab-b05b-9a6554b5fecf

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/4b4154ef-323d-4c8a-82b0-c986f2164e58

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Impish_Delights
add: Combat shotguns can now be toggled in-hand to function like manual pump-action shotguns
add: Combat shotguns will 'click' when cycling firing modes.
fix: Compact combat shotgun will now cycle properly when fired one-handed
code: Fixes runtime when firing a ballistic gun without a magazine installed
code: Removes unneeded proc for automatic shotguns, functionally the same
code: Retypes bulldog to be a child of shotgun/automatic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
