### PR TITLE
Tweaks Mosin & Nagant Revolver (a762 & n762 Projectile) Damage

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -163,6 +163,11 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	chameleon_extras = list(/obj/item/gun/energy/disabler, /obj/item/clothing/glasses/hud/security/sunglasses, /obj/item/clothing/head/helmet)
 	//The helmet is necessary because /obj/item/clothing/head/helmet/sec is overwritten in the chameleon list by the standard helmet, which has the same name and icon state
 
+/datum/outfit/job/security_officer/bulletproof
+	name = "Security Officer (Bulletproof)"
+	head = /obj/item/clothing/head/helmet/alt
+	suit = /obj/item/clothing/suit/armor/bulletproof
+
 
 /obj/item/radio/headset/headset_sec/alt/department/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -2,7 +2,8 @@
 
 /obj/projectile/bullet/n762
 	name = "7.62x38mmR bullet"
-	damage = 60
+	damage = 55
+	armour_penetration = 12
 
 // .50AE (Desert Eagle)
 

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -8,7 +8,8 @@
 
 /obj/projectile/bullet/a762
 	name = "7.62 bullet"
-	damage = 60
+	damage = 40
+	armour_penetration = 50
 
 /obj/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62 bullet"

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -9,7 +9,7 @@
 /obj/projectile/bullet/a762
 	name = "7.62 bullet"
 	damage = 40
-	armour_penetration = 50
+	armour_penetration = 30
 
 /obj/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62 bullet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the amount of damage for the Mosin Nagant from 60 brute to 40 brute, gives it ~~50%~~ 30% armor penetration to balance it out and make it function as a high-power rifle instead of a physically larger syndicate revolver.

Very *slightly* tweaks the damage of the Nagant Revolver from 60 to 55 brute, with 10% AP. This diversifies the ammo type, while keeping it very close to the Syndie Revolver damage-wise, and without just making it interchangeable with the Mosin

This also adds a new debug/testing outfit, "Security Officer (Bulletproof)" to be used. This is identical to the regular security officer, but comes pre-equipped with a bulletproof vest and helmet instead of the standard security vest and helmet. Because of how outfits work, this also adds it as a new option for the chameleon outfit selector.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This balances the Mosin to make it explicitly worse than the Syndicate revolver against unarmored targets, but "level" in regards to armored targets. I tested against 4 sets of "armor" that it should commonly run against and compared it to the revolver; no armor, Standard SecOff armor, Bulletproof armor, and the Captain's SWAT suit.

In order for each, first listing damage and then shots to crit;
```
Unarmored / Standard Sec (30 Bullet) / Bulletproof Sec (60 Bullet) / Cap SWAT Suit & Bloodred Hardsuit (50 Bullet)

Mosin; 40 Damage, 30 AP
Damage: 40/32/23/26
To Crit: 3/4/5/4

Nagant Revolver; 55 Damage, 10 AP
Damage: 55/41/26/31
To Crit: 2/3/4/4

Revolver; 60 Damage, 0 AP
Damage: 60/42/25/30
To Crit: 2/3/5/4
```

As for the changes to the Nagant Revolver, it has its own bespoke ammo but is just a copy-paste from the .357 ammo. This keeps it in the same damage class but *spices* it up a bit. The Nagant is really only accessible to the Russian Hunters, or if you get *very* lucky with mail as Captain, or get the Russian Cargo Shuttle event ~~and the ammo can't be printed anyways~~.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/067878b9-bbba-4e7d-a4ac-7f6a17b9c21f)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/ad431aee-8da9-48c8-ba68-e7915d4293db)

</details>

## Changelog
:cl: Impish_Delights
add: New outfit preset; Bulletproof SecOff. Can be chosen via the select equipment menu, and through chameleon clothing
balance: Mosin Nagant deals less damage (40 down from 60) but has armor penetration (30% AP)
balance: Nagant Revolver deals less damage (55 down from 60) but has armor penetration (10% AP)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
