### PR TITLE
Fix Index Table Component

### DIFF
--- a/code/modules/wiremod/components/list/index_table.dm
+++ b/code/modules/wiremod/components/list/index_table.dm
@@ -35,4 +35,9 @@
 		output_list.set_output(null)
 		return
 
-	output_list.set_output(target_list[index])
+	var/list/new_list = new /list()
+	for(var/target_list_column as anything in target_list[index])
+		//Add the actual value of the column to the list, rather than the table index itself
+		new_list += target_list[index][target_list_column]
+
+	output_list.set_output(new_list)


### PR DESCRIPTION
## About The Pull Request

The Index Table Component has been broken for a very long time. Instead of returning the values in a single row of the table, it returns the column names instead.
![initialBug](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/7c0e48c1-bf35-4427-88a4-fe0ca80ebc73)

This fix flattens the table into a list that is the same length as the width of the table, with each index corresponding to one column of the row.

An alternate fix is to convert the output of this component into a table component, and then use Get Column, but then you have to chain index lists or Pops at the end, which adds unnecessary complexity, as this will only ever be one row deep.

## Why It's Good For The Game

Bugs Bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![test1](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/700e76ee-39f0-48bc-9b93-639539be4a9b)

![test2](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/be932ce2-9ff0-4bf7-b335-acc07479570c)

![full Run](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/b8c662da-93b2-4aa3-a100-63bbeae8dbdb)

</details>

## Changelog
:cl:
fix: Fixes the Index Table Component not outputting the values of the table row.
/:cl:

