### PR TITLE
Fixes tablecrafted newfood recipes not getting reagents from ingredients

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -200,14 +200,14 @@ Behavior that's still missing from this component that original food items had t
 	for(var/obj/item/crafted_part in this_food.contents)
 		crafted_part.reagents?.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume, CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER)
 
-	var/list/objects_to_delete = list()
+	var/list/objects_to_delete = this_food.contents.Copy()
 
 	// Remove all non recipe objects from the contents
 	for(var/content_object in this_food.contents)
-		for(var/recipe_object in recipe.real_parts)
+		for(var/recipe_object in recipe.parts)
 			if(istype(content_object, recipe_object))
-				continue
-		objects_to_delete += content_object
+				objects_to_delete -= content_object
+				break
 
 	QDEL_LIST(objects_to_delete)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -427,7 +427,6 @@
   * Otherwise it simply forceMoves the atom into this atom
   */
 /atom/proc/CheckParts(list/parts_list, datum/crafting_recipe/R)
-	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 	if(parts_list)
 		for(var/A in parts_list)
 			if(istype(A, /datum/reagent))
@@ -443,6 +442,7 @@
 				else
 					M.forceMove(src)
 		parts_list.Cut()
+	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 
 ///Take air from the passed in gas mixture datum
 /atom/proc/assume_air(datum/gas_mixture/giver)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Newfood (#8748) introduced a new way to calculate reagents to put into tablecrafted recipes. This way takes 70% of the reagents of a list given by the crafted item's type, and 50% of the reagents inside the ingredients used to craft it. However, since the proc to add the ingredients' reagents was executed before the ingredients were added to the item's contents, the only reagents put in were the 70% from the item type. This PR makes it so all of the reagents are put in the resulting item as intended. It also fixes a part of the on_craft proc that would accidentally delete every ingredient from the contents.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a bug, tablecrafted food should get some reagents from the ingredients and the code was already trying to do it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

In this tablecrafted pizza margherita, 17.5 (25*0.7) nutriment was given by the "pizza margherita" type, and 12.5 ((7+3+3+3+3+6)*0.5) was given by the ingredients, for a total of 30 (see "volume" variable).
![nutriment](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/ca008e84-10ff-4a7e-9e5e-885948ec2e1e)

This tablecrafted pizza margherita keeps all of its ingredients in its contents.
![contents](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/9e9ab66b-6cc8-44fd-9c56-12a8e1f7db5b)

</details>

## Changelog
:cl:
fix: Some recipes that wouldn't get reagents from their ingredients now do
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
