### PR TITLE
Fix Sabotage and Explosion Objectives For Telecommunications

### DIFF
--- a/code/game/gamemodes/objectives/open/destroy_equipment.dm
+++ b/code/game/gamemodes/objectives/open/destroy_equipment.dm
@@ -8,7 +8,7 @@
 		"security" = list(/area/security),
 		"the cargo bay" = list(/area/quartermaster, /area/cargo),
 		"the bridge" = list(/area/bridge),
-		"the communications relay" = list(/area/comms, /area/server),
+		"the communications relay" = list(/area/comms, /area/server, /area/tcommsat),
 		"the science lab" = list(/area/science),
 		"the research division server room" = list(/area/science/server),
 		// Anywhere monitored by the AI will do

--- a/code/game/gamemodes/objectives/open/explosion.dm
+++ b/code/game/gamemodes/objectives/open/explosion.dm
@@ -9,7 +9,7 @@
 		"security" = list(/area/security),
 		"the cargo bay" = list(/area/quartermaster, /area/cargo),
 		"the bridge" = list(/area/bridge),
-		"the communications relay" = list(/area/comms, /area/server),
+		"the communications relay" = list(/area/comms, /area/server, /area/tcommsat),
 		"the science lab" = list(/area/science),
 		"the research division server room" = list(/area/science/server),
 		// Anywhere monitored by the AI will do


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Sabotage Machines Objective and Explosives Objectives that target Telecomms are broken. The Telecomms Area in Bee is tcommsat, not comms or server. I added that area to the list of allowed areas so the objective can complete as intended.

## Why It's Good For The Game

Bugs bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixes the Sabotage and Explosives Objective for "the telecommunications relay".
/:cl:
