### PR TITLE
Durathread buff

### DIFF
--- a/code/modules/clothing/head/beanie.dm
+++ b/code/modules/clothing/head/beanie.dm
@@ -87,7 +87,7 @@
 	name = "durathread beanie"
 	desc = "A beanie made from durathread, its resilient fibres provide some protection to the wearer."
 	icon_state = "beaniedurathread"
-	armor = list(MELEE = 15,  BULLET = 5, LASER = 15, ENERGY = 5, BOMB = 10, BIO = 0, RAD = 0, FIRE = 30, ACID = 5, STAMINA = 20)
+	armor = list(MELEE = 15,  BULLET = 25, LASER = 15, ENERGY = 5, BOMB = 10, BIO = 0, RAD = 0, FIRE = 30, ACID = 5, STAMINA = 20)
 
 /obj/item/clothing/head/beanie/waldo
 	name = "red striped bobble hat"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -389,11 +389,11 @@
 
 /obj/item/clothing/head/helmet/durathread
 	name = "durathread helmet"
-	desc = "A helmet made from durathread and leather."
+	desc = "A helmet made from durathread, a strong material commonly used for ballistic protection."
 	icon_state = "durathread"
 	item_state = "durathread"
 	resistance_flags = FLAMMABLE
-	armor = list(MELEE = 20,  BULLET = 10, LASER = 30, ENERGY = 5, BOMB = 15, BIO = 0, RAD = 0, FIRE = 40, ACID = 50, STAMINA = 30)
+	armor = list(MELEE = 20,  BULLET = 40, LASER = 30, ENERGY = 5, BOMB = 15, BIO = 0, RAD = 0, FIRE = 40, ACID = 50, STAMINA = 30)
 	strip_delay = 60
 
 /obj/item/clothing/head/helmet/rus_helmet

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -145,7 +145,7 @@
 	name = "durathread beret"
 	desc =  "A beret made from durathread, its resilient fibres provide some protection to the wearer."
 	icon_state = "beretdurathread"
-	armor = list(MELEE = 15,  BULLET = 5, LASER = 15, ENERGY = 20, BOMB = 10, BIO = 0, RAD = 0, FIRE = 30, ACID = 5, STAMINA = 20)
+	armor = list(MELEE = 15,  BULLET = 25, LASER = 15, ENERGY = 20, BOMB = 10, BIO = 0, RAD = 0, FIRE = 30, ACID = 5, STAMINA = 20)
 
 //Security
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -285,14 +285,14 @@
 
 /obj/item/clothing/suit/armor/vest/durathread
 	name = "durathread vest"
-	desc = "A vest made of durathread with strips of leather acting as trauma plates."
+	desc = "A bulletproof vest made from durathread, an inexpesive but relatively effective form of protection."
 	icon_state = "durathread"
 	item_state = "durathread"
 	strip_delay = 60
 	equip_delay_other = 40
 	max_integrity = 200
 	resistance_flags = FLAMMABLE
-	armor = list(MELEE = 20,  BULLET = 10, LASER = 30, ENERGY = 40, BOMB = 15, BIO = 0, RAD = 0, FIRE = 40, ACID = 50, STAMINA = 30)
+	armor = list(MELEE = 20,  BULLET = 40, LASER = 30, ENERGY = 40, BOMB = 15, BIO = 0, RAD = 0, FIRE = 40, ACID = 50, STAMINA = 30)
 
 /obj/item/clothing/suit/armor/vest/russian
 	name = "russian vest"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -970,11 +970,11 @@
 	name = "durathread hoodie"
 	desc = "A hoodie made from durathread, its resilient fibres provide some protection to the wearer."
 	color = "#8291a1"
-	armor = list(MELEE = 15, LASER = 10, FIRE = 40, ACID = 10, BOMB = 5, STAMINA = 30)
+	armor = list(MELEE = 15, BULLET = 25, LASER = 10, FIRE = 40, ACID = 10, BOMB = 5, STAMINA = 30)
 	hoodtype = /obj/item/clothing/head/hooded/hoodie/durathread
 
 /obj/item/clothing/head/hooded/hoodie/durathread
 	name = "durathread hoodie hood"
 	desc = "A duratread hood attached to your hoodie, robust as."
-	armor = list(MELEE = 5, LASER = 5, FIRE = 20, ACID = 5, BOMB = 5, STAMINA = 15)
+	armor = list(MELEE = 5, BULLET = 5, LASER = 5, FIRE = 20, ACID = 5, BOMB = 5, STAMINA = 15)
 	color = "#8291a1"

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -213,13 +213,13 @@
 	name = "durathread jumpsuit"
 	desc = "A jumpsuit made from durathread, its resilient fibres provide some protection to the wearer."
 	greyscale_colors = "#8291a1"
-	armor = list(MELEE = 10, LASER = 10, FIRE = 40, ACID = 10, BOMB = 5, ENERGY = 20, STAMINA = 20)
+	armor = list(MELEE = 10, BULLET = 15, LASER = 10, FIRE = 40, ACID = 10, BOMB = 5, ENERGY = 20, STAMINA = 20)
 
 /obj/item/clothing/under/color/jumpskirt/durathread
 	name = "durathread jumpskirt"
 	desc = "A jumpskirt made from durathread, its resilient fibres provide some protection to the wearer."
 	greyscale_colors = "#8291a1"
-	armor = list(MELEE = 10, LASER = 10, FIRE = 40, ACID = 10, BOMB = 5, ENERGY = 20, STAMINA = 20)
+	armor = list(MELEE = 10, BULLET = 15, LASER = 10, FIRE = 40, ACID = 10, BOMB = 5, ENERGY = 20, STAMINA = 20)
 
 /obj/item/clothing/under/color/rainbow
 	name = "rainbow jumpsuit"

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -48,7 +48,7 @@
 //reinforced mutated variant
 /obj/item/seeds/cotton/durathread
 	name = "pack of durathread seeds"
-	desc = "A pack of seeds that'll grow into an extremely durable thread that could easily rival plasteel if woven properly."
+	desc = "A pack of seeds that'll grow into an extremely durable thread that could easily rival plasteel if woven properly. In its woven state, it is incredibly effectivev at resisting high-energy ballistic attacks making it sought after by organisations that specialise in personal defense."
 	icon_state = "seed-durathread"
 	species = "durathread"
 	plantname = "Durathread"

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -48,7 +48,7 @@
 //reinforced mutated variant
 /obj/item/seeds/cotton/durathread
 	name = "pack of durathread seeds"
-	desc = "A pack of seeds that'll grow into an extremely durable thread that could easily rival plasteel if woven properly. In its woven state, it is incredibly effectivev at resisting high-energy ballistic attacks making it sought after by organisations that specialise in personal defense."
+	desc = "A pack of seeds that'll grow into an extremely durable thread that could easily rival plasteel if woven properly. In its woven state, it is incredibly effective at resisting high-energy ballistic attacks making it sought after by organisations that specialise in personal defense."
 	icon_state = "seed-durathread"
 	species = "durathread"
 	plantname = "Durathread"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs the bullet protection aspect of durathread, making it a very strong material for making bulletproof armour with.
Kevlar is a woven fabric, duratherad is a woven fabric; it makes sense that durathread would be used for bulletproof armours.

Durathread Jumpsuit: 15 Bullet
Durathread Armour: 40 Bullet
Durathread Helmet: 40 Bullet
Durathread Beanie: 25 Bullet
Durathread Beret: 25 Bullet
Durathread Hoodie: 25 Bullet

This means the best protection you can get is from a durathread jumpsuit and armour, which gives you a total of 49 bullet protect (40 & 15 armour protection = 49 total)

## Why It's Good For The Game

It is pretty difficult for anyone outside of security to get their hands on effective forms of armour, this provides non-security crew members with the ability to put some work in and get a makeshift bulletproof vest to protect them against shotguns, nukies or whatever else sec might come up with.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/54ec338b-b380-4899-bf4c-f9f0c305326b)


## Changelog
:cl:
balance: Increased durathread bullet armour (40 from armour, 15 from jumpsuit; 49 total bullet protection from both)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
