### PR TITLE
Fixes stat atom light mode

### DIFF
--- a/tgui/packages/tgui-panel/styles/components/Stat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Stat.scss
@@ -60,7 +60,6 @@ $border-color: color.scale(colors.fg(colors.$primary), $lightness: 75%) !default
 
 .StatAtomElement {
   cursor: pointer;
-  color: lighten($color: $background-color, $amount: 65%);
 }
 
 .StatAtomTag {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so you can actually read the atom tabs on the stat panel.

## Why It's Good For The Game

Light mode users couldn't read it.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/92335252-69aa-4ee0-b28b-1fe5b9914a34)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/1cf1d758-1baf-4ead-9d06-4c1e69237d3e)

We should really make testing evidence for TGUI panel changes mandatory to show both light and dark mode.

## Changelog
:cl:
fix: Light mode stat panel atom tab will now be readable (Text when you alt click a tile)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
