### PR TITLE
Updates deprecated config entry in config.txt

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -499,7 +499,7 @@ MINUTE_CLICK_LIMIT 500
 #ERROR_MSG_DELAY 50
 
 ## Send a message to IRC when starting a new game
-#IRC_ANNOUNCE_NEW_GAME
+#CHAT_ANNOUNCE_NEW_GAME
 
 ## Allow admin hrefs that don't use the new token system, will eventually be removed
 DEBUG_ADMIN_HREFS


### PR DESCRIPTION
## About The Pull Request
Just a small change in the default config to indicate the proper entry: `CHAT_ANNOUNCE_NEW_GAME`

## Why It's Good For The Game

Testing and setting up a server is easier when the config template matches the code

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
One line code change moment
</details>

## Changelog
:cl:
config: Changed new game announce entry in the default config to match new code
/:cl: