### PR TITLE
Fixes there being an internal radio implant instead of a radio in the metastation's medbay security post

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37349,6 +37349,7 @@
 "gRa" = (
 /obj/structure/cable/white,
 /obj/machinery/power/emitter/welded{
+	
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
@@ -64797,8 +64798,8 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
-/obj/item/implant/radio,
 /obj/machinery/firealarm/directional/north,
+/obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "sql" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37348,9 +37348,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "gRa" = (
 /obj/structure/cable/white,
-/obj/machinery/power/emitter/welded{
-	
-	},
+/obj/machinery/power/emitter/welded,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/engine/engineering)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes there being an internal radio implant instead of a radio in the metastation's medbay security post
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
syndicate internal radio being in plain sight on mapstart bad


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: XeonMations
fix: Replaced metastation's medbay post's radio implant with a radio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
