### PR TITLE
Adds quick & easy admin event tool, the teambuilder machine!

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1080,6 +1080,7 @@
 #include "code\game\machinery\suit_storage_unit.dm"
 #include "code\game\machinery\syndicatebeacon.dm"
 #include "code\game\machinery\syndicatebomb.dm"
+#include "code\game\machinery\teambuilder.dm"
 #include "code\game\machinery\teleporter.dm"
 #include "code\game\machinery\transformer.dm"
 #include "code\game\machinery\washing_machine.dm"

--- a/code/game/machinery/teambuilder.dm
+++ b/code/game/machinery/teambuilder.dm
@@ -1,0 +1,61 @@
+/**
+  * Simple admin tool that enables players to be assigned to a VERY SHITTY, very visually distinct team, quickly and affordably.
+  */
+/obj/machinery/teambuilder
+	name = "Teambuilding Machine"
+	desc = "A machine that, when passed, colors you based on the color of your team. Lead free!"
+	icon = 'icons/obj/telescience.dmi'
+	icon_state = "lpad-idle"
+	density = FALSE
+	can_buckle = FALSE
+	resistance_flags = INDESTRUCTIBLE // Just to be safe.
+	use_power = NO_POWER_USE
+	///Are non-humans allowed to use this?
+	var/humans_only = FALSE
+	///What color is your mob set to when crossed?
+	var/team_color = COLOR_WHITE
+	///What radio station is your radio set to when crossed (And human)?
+	var/team_radio = FREQ_COMMON
+
+/obj/machinery/teambuilder/Initialize()
+	. = ..()
+	add_filter("teambuilder", 2, list("type" = "outline", "color" = team_color, "size" = 2))
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+/*
+/obj/machinery/teambuilder/examine_more(mob/user)
+	. = ..()
+	. += "<span class='notice'>You see a hastily written note on the side, it says '1215-1217, PICK A SIDE'.</span>"
+*/
+
+/obj/machinery/teambuilder/proc/on_entered(datum/source, atom/movable/AM)
+	SIGNAL_HANDLER
+	if(!ishuman(AM) && humans_only)
+		return
+	if(AM.get_filter("teambuilder"))
+		return
+	if(isliving(AM) && team_color)
+		AM.add_filter("teambuilder", 2, list("type" = "outline", "color" = team_color, "size" = 2))
+	if(ishuman(AM) && team_radio)
+		var/mob/living/carbon/human/human = AM
+		var/obj/item/radio/Radio = human.ears
+		if(!Radio)
+			return
+		Radio.set_frequency(team_radio)
+
+/obj/machinery/teambuilder/red
+	name = "Teambuilding Machine (Red)"
+	desc = "A machine that, when passed, colors you based on the color of your team. Go red team!"
+	humans_only = TRUE
+	team_color = COLOR_RED
+	team_radio = FREQ_CTF_RED
+
+/obj/machinery/teambuilder/blue
+	name = "Teambuilding Machine (Blue)"
+	desc = "A machine that, when passed, colors you based on the color of your team. Go blue team!"
+	humans_only = TRUE
+	team_color = COLOR_BLUE
+	team_radio = FREQ_CTF_BLUE


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/53147
- https://github.com/tgstation/tgstation/pull/55424 (Filters on teambuilders only)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new admin-only machine, the teambuilder! When a player walks through, it adds two things to them:
- A colored outline, determined by a var.
- A team radio, determined by a var.

One, or the other, or both can be assigned and it will enforce that, color won't override an existing one but in most cases players won't override their own color.



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/da8af470-65ad-4e02-b0a4-f4bfe5eaa0ad)


It makes events with custom teams a lot easier to set up. Dirt-easy.

If you say, want to spawn multiple groups of pirates, you can throw them all through a teambuilder. They both get their own channels and an outline around them so they can differentiate whos on what team very easily.

Furthermore, if you want to make even *more* teams, you just need to edit two vars in the machine and it will give you a whole new team color & radio

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Video showing walkthrough

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/6304f9c2-0f15-4c2f-bb9c-0bb8291adf7e

Radio being added after walking over

![Screenshot 2023-10-19 164525](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/8b819f62-8f1f-488c-92fc-44c368bddb13)


</details>

## Changelog
:cl: rkz, ArcaneMusic, Tralezab
admin: adds new admin tool, the teambuilder! Admins can now easily put identifiable markings on any player and give them a new custom radio, all with a simple machine. Useful for events, or if you want multiple rival syndicates to face each other with the same gear, but also know whos on what team!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
