### PR TITLE
Revert "Closed valves and pumps and vents now block ventcrawling and other tweaks"

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -316,8 +316,6 @@
 				if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
 					user.last_played_vent = world.time
 					playsound(src, 'sound/machines/ventcrawl.ogg', 50, 1, -3)
-					if(prob(1))
-						audible_message("<span class='warning'>You hear something crawling through the ducts...</span>")
 	else if(is_type_in_typecache(src, GLOB.ventcrawl_machinery) && can_crawl_through()) //if we move in a way the pipe can connect, but doesn't - or we're in a vent
 		user.forceMove(loc)
 		user.visible_message("<span class='notice'>You hear something squeezing through the ducts...</span>", "<span class='notice'>You climb out the ventilation system.")
@@ -330,17 +328,8 @@
 		L.handle_ventcrawl(src)
 		return
 
-/// Whether ventcrawling creatures can move in or out of this machine.
+
 /obj/machinery/atmospherics/proc/can_crawl_through()
-	// If it's broken, nothing can pass through
-	if(machine_stat & BROKEN)
-		return FALSE
-
-	// If it is powered on, but off, nothing can pass through
-	if(powered() && !on)
-		return FALSE
-
-	// All else, things can pass
 	return TRUE
 
 /obj/machinery/atmospherics/proc/returnPipenets()

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -202,7 +202,7 @@
 		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/can_crawl_through()
-	return (machine_stat & ~BROKEN) && !welded
+	return !welded
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/attack_alien(mob/user)
 	if(!welded || !(do_after(user, 20, target = src)))

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -177,9 +177,6 @@
 		to_chat(user, "<span class='warning'>You cannot unwrench [src], turn it off first!</span>")
 		return FALSE
 
-/obj/machinery/atmospherics/components/binary/pump/can_crawl_through()
-	. = ..()
-	return . && on // If a pump is off, it'll block even when not powered
 
 /obj/machinery/atmospherics/components/binary/pump/layer2
 	piping_layer = 2

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -40,9 +40,6 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 		flick("[valve_type]valve_[on][!on]-[set_overlay_offset(piping_layer)]", src)
 	icon_state = "[valve_type]valve_[on ? "on" : "off"]-[set_overlay_offset(piping_layer)]"
 
-/obj/machinery/atmospherics/components/binary/valve/can_crawl_through()
-	return (machine_stat & ~BROKEN) && on // valves should block whatever is trying to go through them, regardless of power
-
 /**
  * Called by finish_interact(), switch between open and closed, reconcile the air between two pipelines
  */

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -194,10 +194,6 @@
 		to_chat(user, "The pump quiets down as you turn its limiters back on.")
 	return TRUE
 
-/obj/machinery/atmospherics/components/binary/volume_pump/can_crawl_through()
-	. = ..()
-	return . && on // If a pump is off, it'll block even when not powered
-
 // mapping
 
 /obj/machinery/atmospherics/components/binary/volume_pump/layer2

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -455,7 +455,7 @@
 	user.overlay_fullscreen("remote_view", /atom/movable/screen/fullscreen/impaired, 1)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/can_crawl_through()
-	return FALSE // can't ventcrawl in or out of cryo.
+	return // can't ventcrawl in or out of cryo.
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/can_see_pipes()
 	return 0 // you can't see the pipe network when inside a cryo cell.

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -42,7 +42,7 @@
 		update_parents()
 
 /obj/machinery/atmospherics/components/unary/passive_vent/can_crawl_through()
-	return TRUE // we don't care about power or being broken
+	return TRUE
 
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2
 	piping_layer = 2

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -280,16 +280,12 @@
 	if(welded)
 		. += "It seems welded shut."
 
-/obj/machinery/atmospherics/components/unary/vent_pump/can_crawl_through()
-	return (machine_stat & ~BROKEN) && !welded
-
 /obj/machinery/atmospherics/components/unary/vent_pump/power_change()
 	. = ..()
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/can_crawl_through()
-	. = ..()
-	return . && !welded
+	return !welded
 
 /obj/machinery/atmospherics/components/unary/vent_pump/attack_alien(mob/user)
 	if(!welded || !(do_after(user, 20, target = src)))

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -256,7 +256,7 @@
 		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/can_crawl_through()
-	return (machine_stat & ~BROKEN) && !welded
+	return !welded
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/attack_alien(mob/user)
 	if(!welded || !(do_after(user, 20, target = src)))


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#9257

Confirmed to be causing mobs to be unable to ventcrawl due to pipes being off but powered.

:cl:
del: Reverts previous ventcrawling changes.
/:cl:
