### PR TITLE
Fixes ventcrawling

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -332,15 +332,6 @@
 
 /// Whether ventcrawling creatures can move in or out of this machine.
 /obj/machinery/atmospherics/proc/can_crawl_through()
-	// If it's broken, nothing can pass through
-	if(machine_stat & BROKEN)
-		return FALSE
-
-	// If it is powered on, but off, nothing can pass through
-	if(powered() && !on)
-		return FALSE
-
-	// All else, things can pass
 	return TRUE
 
 /obj/machinery/atmospherics/proc/returnPipenets()

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -202,7 +202,7 @@
 		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/can_crawl_through()
-	return (machine_stat & ~BROKEN) && !welded
+	return !(machine_stat & BROKEN) && !welded
 
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/attack_alien(mob/user)
 	if(!welded || !(do_after(user, 20, target = src)))

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -178,8 +178,7 @@
 		return FALSE
 
 /obj/machinery/atmospherics/components/binary/pump/can_crawl_through()
-	. = ..()
-	return . && on // If a pump is off, it'll block even when not powered
+	return on // If a pump is off, it'll block even when not powered
 
 /obj/machinery/atmospherics/components/binary/pump/layer2
 	piping_layer = 2

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -41,7 +41,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	icon_state = "[valve_type]valve_[on ? "on" : "off"]-[set_overlay_offset(piping_layer)]"
 
 /obj/machinery/atmospherics/components/binary/valve/can_crawl_through()
-	return (machine_stat & ~BROKEN) && on // valves should block whatever is trying to go through them, regardless of power
+	return !(machine_stat & BROKEN) && on // valves should block whatever is trying to go through them, regardless of power
 
 /**
  * Called by finish_interact(), switch between open and closed, reconcile the air between two pipelines

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -195,8 +195,7 @@
 	return TRUE
 
 /obj/machinery/atmospherics/components/binary/volume_pump/can_crawl_through()
-	. = ..()
-	return . && on // If a pump is off, it'll block even when not powered
+	return on
 
 // mapping
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -281,15 +281,11 @@
 		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/components/unary/vent_pump/can_crawl_through()
-	return (machine_stat & ~BROKEN) && !welded
+	return !(machine_stat & BROKEN) && !welded
 
 /obj/machinery/atmospherics/components/unary/vent_pump/power_change()
 	. = ..()
 	update_icon_nopipes()
-
-/obj/machinery/atmospherics/components/unary/vent_pump/can_crawl_through()
-	. = ..()
-	return . && !welded
 
 /obj/machinery/atmospherics/components/unary/vent_pump/attack_alien(mob/user)
 	if(!welded || !(do_after(user, 20, target = src)))

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -256,7 +256,7 @@
 		. += "It seems welded shut."
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/can_crawl_through()
-	return (machine_stat & ~BROKEN) && !welded
+	return !(machine_stat & BROKEN) && !welded
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/attack_alien(mob/user)
 	if(!welded || !(do_after(user, 20, target = src)))

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -35,8 +35,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 
 	if(!vent_found)
 		for(var/obj/machinery/atmospherics/machine in range(1,src))
-			if(is_type_in_typecache(machine, GLOB.ventcrawl_machinery))
-				vent_found = machine
+			if(!is_type_in_typecache(machine, GLOB.ventcrawl_machinery))
+				continue
+			vent_found = machine
 
 			if(!vent_found.can_crawl_through())
 				vent_found = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes ventcrawling not working due to #9257

Does 3 seperate things:
- Fixes some unsafe underlying logic which will break if you vent crawl in a lone machine.
- Fixes the bitflag checks being incorrect (They were checking if any bit apart from the broken flag was set, rather than if the broken flag wasn't set)
- Removes the logic that broken and powered but off machines get by default (Machines like pipes shouldn't have this logic)

## Why It's Good For The Game

Vent crawling just didn't work because pipes are powered but turned off and have no way to be turned on .
Re-test your PRs.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/114e94a1-af0e-4e17-b03c-5f93992220a3)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/12467236-8d7a-489e-968c-eb139b9275e9)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/4d2cb8c9-fe5a-44a8-8c48-95d781f37587)


## Changelog
:cl:
fix: Ventcrawling works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
