### PR TITLE
Replaces inconsistent implementations of the square root of 2

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -8,8 +8,6 @@
 #define INFINITY				1e31	//closer then enough
 #define SYSTEM_TYPE_INFINITY					1.#INF //only for isinf check
 
-#define SQRT_TWO 1.414214
-
 #define SHORT_REAL_LIMIT 16777216
 
 /// A 32 bit single-precision floating point number's mantissa gives us 7 significant digits

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -163,7 +163,7 @@
 		Unbuckle(user)
 		return
 
-	if(world.time < last_vehicle_move + ((last_move_diagonal? SQRT_TWO : 1) * vehicle_move_delay * vehicle_move_multiplier))
+	if(world.time < last_vehicle_move + ((last_move_diagonal? sqrt(2) : 1) * vehicle_move_delay * vehicle_move_multiplier))
 		return
 	last_vehicle_move = world.time
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -140,7 +140,7 @@
 	. = ..()
 
 	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
-		add_delay *= 1.414214 // sqrt(2)
+		add_delay *= sqrt(2)
 	// Record any time that we gained due to sub-tick slowdown
 	var/move_delta = move_delay - floored_move_delay
 	add_delay += move_delta


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

in the code, the define SQRT_TWO was used at one place to approximate the square root of 2. At another place, the value was written directly. this PR replaces these inconsistent implementations with the inbuilt proc sqrt(2), which constant folds to 1.4142135.

Although this is not a port, this PR does the same thing as https://github.com/tgstation/tgstation/pull/72913, which is listed in the "Things to Port" project: https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-88347615

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

using sqrt(2) is more readable and concise than a magic number or an obsolete define, and the computational cost is not increased.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/d028cc8a-b285-4f09-a5d0-3fc3cacda5fb

According to approximate timing, the diagonal movement took about 1.4 times longer than the straight movement, which matches the expected value of sqrt(2).

</details>

## Changelog
:cl:
code: Square root of 2 is now only written as sqrt(2) in the code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
