### PR TITLE
Fixes impossible radio uplink codewords for lizardpeople

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -320,8 +320,15 @@
 	if(channel != RADIO_CHANNEL_UPLINK)
 		return
 
-	if(!findtext(lowertext(message), lowertext(unlock_code)))
-		if(failsafe_code && findtext(lowertext(message), lowertext(failsafe_code)))
+	// Remove lizard accent for cases where the uplink code is Oscar ("Ossscar"), Whiskey ("Whissskey") or X-ray ("ECKS-ray")
+	var/static/regex/reverse_hiss = new("sss", "ig")
+	var/static/regex/reverse_ecks = new("ecks", "ig")
+	var/msg_noaccent = message
+	msg_noaccent = reverse_hiss.Replace(msg_noaccent, "s")
+	msg_noaccent = reverse_ecks.Replace(msg_noaccent, "x")
+
+	if(!findtext(lowertext(msg_noaccent), lowertext(unlock_code)))
+		if(failsafe_code && findtext(lowertext(msg_noaccent), lowertext(failsafe_code)))
 			failsafe()
 		return
 	locked = FALSE

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -320,12 +320,16 @@
 	if(channel != RADIO_CHANNEL_UPLINK)
 		return
 
-	// Remove lizard accent for cases where the uplink code is Oscar ("Ossscar"), Whiskey ("Whissskey") or X-ray ("ECKS-ray")
+	// Remove species accent for cases where the uplink code is Oscar ("Ossscar") or X-ray ("ECKS-ray"), for example
 	var/static/regex/reverse_hiss = new("sss", "ig")
+	var/static/regex/reverse_kss = new("kss", "ig")
 	var/static/regex/reverse_ecks = new("ecks", "ig")
+	var/static/regex/reverse_buzz = new("zzz", "ig")  // From flypeople
 	var/msg_noaccent = message
 	msg_noaccent = reverse_hiss.Replace(msg_noaccent, "s")
+	msg_noaccent = reverse_kss.Replace(msg_noaccent, "x")
 	msg_noaccent = reverse_ecks.Replace(msg_noaccent, "x")
+	msg_noaccent = reverse_buzz.Replace(msg_noaccent, "z")
 
 	if(!findtext(lowertext(msg_noaccent), lowertext(unlock_code)))
 		if(failsafe_code && findtext(lowertext(msg_noaccent), lowertext(failsafe_code)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR closes https://github.com/BeeStation/BeeStation-Hornet/issues/9932

A lizardperson couldn't unlock a radio uplink when the codeword was Oscar, Whiskey or X-ray because of their accent, as the uplink wouldn't recognize "Ossscar", "Whissskey" and "ECKS-ray" as valid. This PR removes the accent before parsing the codeword.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is a bug, lizardpeople should be able to unlock their uplink.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Oscar
![oscar](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/8c93ad14-c795-4cce-a17d-4244e7a61e16)
Whiskey
![whiskey](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/12967397-5b03-48fc-b970-d3e6704ec243)
X-ray
![x-ray](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/fa5f0778-2461-4dfb-a230-71cf864561f4)

</details>

## Changelog
:cl:
fix: Lizardperson's accent no longer prevents them from unlocking a radio uplink when the codeword contains an s or an x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
