### PR TITLE
Glowing goo can be destroyed by the lighteater.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -253,6 +253,15 @@
 	if(pulling)
 		pulling.lighteater_act(light_eater)
 
+/obj/effect/decal/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
+	..()
+	if(!light_range || !light_power || !light_on)
+		return
+	if(light_eater)
+		visible_message("<span class='danger'>[src] is disintegrated by [light_eater]!</span>")
+	qdel(src)
+	playsound(src, 'sound/items/welder.ogg', 50, 1)
+
 /mob/living/carbon/human/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	if(isethereal(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Glowing goo can now be destroyed by the light eater.

## Why It's Good For The Game

The lighteater cannot destroy glowing goo. Now it can.
If decals are going to have lights, the light eater should be able to eat them.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2015baf0-830b-4f6c-8c13-4e6804e77c98)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e849aad6-7947-458c-97c0-ab6e11261d81)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/b1986a50-1760-4c20-88a2-6a056d901855)


## Changelog
:cl:
balance: Lighteater can now destroy glowing decals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
