### PR TITLE
Spiderlings no longer Initialize twice

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -227,7 +227,6 @@
 	START_PROCESSING(SSobj, src)
 	AddElement(/datum/element/point_of_interest)
 	AddComponent(/datum/component/swarming)
-	return ..()
 
 /obj/structure/spider/spiderling/hunter
 	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes spiderlings not initialize twice
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things shouldn't initialize twice, I hate runtimes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![Screenshot_1980](https://github.com/BeeStation/BeeStation-Hornet/assets/53474257/30d6d180-f672-4bdc-81a1-d22be0b63e2c)
No Runtimes!

## Changelog
:cl:
code: Fixes spiderlings initializing twice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
