### PR TITLE
Flashes don't ignore the blindness check anymore

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -245,7 +245,7 @@
 		to_chat(M, "<span class='disarm'>[src] emits a blinding light!</span>")
 	if(targeted)
 		//No flash protection, blind and stun
-		if(M.flash_act(1, TRUE))
+		if(M.flash_act(1))
 			if(user)
 				terrible_conversion_proc(M, user)
 				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ignoring of the blindness check from flash_carbon, I'm not sure why it was there in the first place
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
How does it make sense to flash someone that is completely blind or wearing a blindfold? Or even better, flashing someone with no eyes at all?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Blind person being flashed
![Screenshot_1986](https://github.com/BeeStation/BeeStation-Hornet/assets/53474257/94b9b918-6250-4cef-955d-b876150a5737)

Non blind person being flashed
![Screenshot_1985](https://github.com/BeeStation/BeeStation-Hornet/assets/53474257/41b1e7ed-5d6e-4a4b-aa28-7972bb1b3d7b)


</details>

## Changelog
:cl:
fix: Blind people can't be flashed anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
