### PR TITLE
Integrated headwear (from hooded and hard suits) are now Fireproofed by the Fireproof chaplain spell

### DIFF
--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -238,8 +238,8 @@
 	..()
 	if(!QDELETED(chosen_clothing) && get_turf(religious_tool) == chosen_clothing.loc) //check if the same clothing is still there
 		if(istype(chosen_clothing,/obj/item/clothing/suit/hooded))
-			for(var/obj/item/clothing/head/integrated_helmet in chosen_clothing.contents) //check if the clothing has a hood/helmet integrated and fireproof it if there is one.
-				apply_fireproof(integrated_helmet)
+			if(chosen_clothing.hood) //check if the clothing has a hood/helmet integrated and fireproof it if there is one.
+				apply_fireproof(chosen_clothing.hood)
 		apply_fireproof(chosen_clothing)
 		playsound(get_turf(religious_tool), 'sound/magic/fireball.ogg', 50, TRUE)
 		chosen_clothing = null //our lord and savior no longer cares about this apparel

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -238,8 +238,9 @@
 	..()
 	if(!QDELETED(chosen_clothing) && get_turf(religious_tool) == chosen_clothing.loc) //check if the same clothing is still there
 		if(istype(chosen_clothing,/obj/item/clothing/suit/hooded))
-			if(chosen_clothing.hood) //check if the clothing has a hood/helmet integrated and fireproof it if there is one.
-				apply_fireproof(chosen_clothing.hood)
+			var/obj/item/clothing/suit/hooded/as_hooded = chosen_clothing
+			if(as_hooded.hood) //check if the clothing has a hood/helmet integrated and fireproof it if there is one.
+				apply_fireproof(as_hooded.hood)
 		apply_fireproof(chosen_clothing)
 		playsound(get_turf(religious_tool), 'sound/magic/fireball.ogg', 50, TRUE)
 		chosen_clothing = null //our lord and savior no longer cares about this apparel

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -239,8 +239,12 @@
 	if(!QDELETED(chosen_clothing) && get_turf(religious_tool) == chosen_clothing.loc) //check if the same clothing is still there
 		if(istype(chosen_clothing,/obj/item/clothing/suit/hooded))
 			var/obj/item/clothing/suit/hooded/as_hooded = chosen_clothing
-			if(as_hooded.hood) //check if the clothing has a hood/helmet integrated and fireproof it if there is one.
+			if(as_hooded.hood)
 				apply_fireproof(as_hooded.hood)
+		else if(istype(chosen_clothing,/obj/item/clothing/suit/space/hardsuit))
+			var/obj/item/clothing/suit/space/hardsuit/suit = chosen_clothing
+			if(suit.helmet)
+				apply_fireproof(suit.helmet)
 		apply_fireproof(chosen_clothing)
 		playsound(get_turf(religious_tool), 'sound/magic/fireball.ogg', 50, TRUE)
 		chosen_clothing = null //our lord and savior no longer cares about this apparel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When hoods were changed to be stored in nullspace with #9686, apparently there was still one thing that relies on the clothing's contents. That thing was apparently the fireproofing ritual of the candle religious sect.

Update: Decided to add hardsuit support

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Something that just makes sense because the helmet/hood is inseparable from the suit.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

### Hooded

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/4c7acfcd-406d-4678-87a5-475dd9302922)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/92f331b9-76ee-43a3-9556-b843ad2a48f1)

---
### Hardsuit

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/8c2c7237-5ff0-46d8-b8f6-5cbe98b3db0e)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/328a9cc8-eed7-4e62-99e2-5931851c592d)

</details>

## Changelog
:cl:
fix: The chaplain Fireproof ritual now fireproofs hoods in hooded clothing again.
add: Integrated hardsuit helmets now can be fireproofed in the fireproof ritual.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
