### PR TITLE
Space dragons are no longer instantly killed by devestating explosions

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -182,7 +182,7 @@
 	contents_explosion(severity, target)
 	SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, target)
 	// Run bomb armour
-	var/bomb_armor = getarmor(null, BOMB)
+	var/bomb_armor = (100 - getarmor(null, BOMB)) / 100
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			adjustBruteLoss(180 * bomb_armor)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -174,6 +174,23 @@
 	empty_contents()
 	. = ..()
 
+/mob/living/simple_animal/hostile/space_dragon/ex_act(severity, target, origin)
+	set waitfor = FALSE
+	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))
+		return
+	// Deal with parent operations
+	contents_explosion(severity, target)
+	SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, target)
+	// Run bomb armour
+	var/bomb_armor = getarmor(null, BOMB)
+	switch (severity)
+		if (EXPLODE_DEVASTATE)
+			adjustBruteLoss(180 * bomb_armor)
+		if (EXPLODE_HEAVY)
+			adjustBruteLoss(80 * bomb_armor)
+		if(EXPLODE_LIGHT)
+			adjustBruteLoss(30 * bomb_armor)
+
 /**
   * Allows space dragon to choose its own name.
   *


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

First and foremost, this is an ided PR however I hope to convince you that I have good reasoning.
This overrides ex_act on the space dragon and removes the instant gibbing behaviours. Instead the dragon will take:
- 180 damage from a devestating explosion. (Down from infinity)
- 80 damage from a major explosion (Up from 60)
- 30 damage from a minor explosion (No change)

## Why It's Good For The Game

While bombs make sense to gib weaker targets, major threats such as the space dragon and megafauna derivatives should not be able to be instantly killed by them. It is a little bit unfair when a bomb with 1 radius devestation range is hidden on a dark tile that you cannot see and instantly gibs you. (Max-cap range has been reduced however the 3x3 explosion area is an instant kill for anyone standing near it which is extremely strange for such a small explosive.)

Human antagonists can access bomb protecting armours, however simple animals cannot which results in the complete inability to get protections from the instant gibbing effect of explosives.

Space dragons used to not be instantly killed from explosions due to being a derivative of megafauna, however when they were made into their own species the explosion insta-kill prevention was not copied across.

Explosives should be a weapon against the space dragon which enhances the fight and makes it more intense, rather than something which ends it immediately.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/28959bdc-1fc0-4c5a-aacb-e6bfb793eaab)

Small bomb (1,2,3,0) no longer instakills me.

## Changelog
:cl:
balance: Space-dragons will no longer be instantly killed by devastating explosives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
