### PR TITLE
Fixes saying codeword to uplink for all cases

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_item.dm
@@ -58,7 +58,7 @@
 
 // /obj/item/radio signals
 #define COMSIG_RADIO_NEW_FREQUENCY "radio_new_frequency"		//! called from base of /obj/item/radio/proc/set_frequency(): (list/args)
-#define COMSIG_RADIO_MESSAGE "radio_message"
+#define COMSIG_RADIO_MESSAGE "radio_message"					//! called from radio subtype procs in /obj/item/radio/talk_into(): (mob/living/user, treated_message, channel, list/message_mods)
 
 // /obj/item/pen signals
 #define COMSIG_PEN_ROTATED "pen_rotated"						//! called after rotation in /obj/item/pen/attack_self(): (rotation, mob/living/carbon/user)

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -50,6 +50,7 @@
 #define MODE_SING "sing"
 #define MODE_CUSTOM_SAY_EMOTE "custom_say"
 #define MODE_CUSTOM_SAY_ERASE_INPUT "erase_input"
+#define MODE_UNTREATED_MESSAGE "untreated_message" /// This is used to store untreated message for specific cases because lizardperssson sssaysss thingsss incorrectly
 
 //Spans. Robot speech, italics, etc. Applied in compose_message().
 #define SPAN_ROBOT "robot"

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -314,14 +314,15 @@
 		interact(null, master.loc)
 
 
-/datum/component/uplink/proc/radio_message(datum/source, mob/living/user, message, channel)
+/datum/component/uplink/proc/radio_message(datum/source, mob/living/user, treated_message, channel, list/message_mods)
 	SIGNAL_HANDLER
+	var/message_to_use = message_mods[MODE_UNTREATED_MESSAGE]
 
 	if(channel != RADIO_CHANNEL_UPLINK)
 		return
 
-	if(!findtext(lowertext(message), lowertext(unlock_code)))
-		if(failsafe_code && findtext(lowertext(message), lowertext(failsafe_code)))
+	if(!findtext(lowertext(message_to_use), lowertext(unlock_code)))
+		if(failsafe_code && findtext(lowertext(message_to_use), lowertext(failsafe_code)))
 			failsafe()
 		return
 	locked = FALSE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -225,7 +225,7 @@
 		spans = list(M.speech_span)
 	if(!language)
 		language = M.get_selected_language()
-	SEND_SIGNAL(src, COMSIG_RADIO_MESSAGE, M, message, channel)
+	SEND_SIGNAL(src, COMSIG_RADIO_MESSAGE, M, message, channel, message_mods)
 	INVOKE_ASYNC(src, PROC_REF(talk_into_impl), M, message, channel, spans.Copy(), language, message_mods)
 	return ITALICS | REDUCE_RANGE
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -175,6 +175,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		else
 			log_talk(message, LOG_SAY, forced_by = forced, custom_say_emote = message_mods[MODE_CUSTOM_SAY_EMOTE])
 
+	if(message_mods[RADIO_KEY] == RADIO_KEY_UPLINK) // only uplink needs this
+		message_mods[MODE_UNTREATED_MESSAGE] = message // let's store the original message before treating those
 	message = treat_message(message) // unfortunately we still need this
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
 	if(sigreturn & COMPONENT_UPPERCASE_SPEECH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* closes #10077

The say system is complex to explain how they can fix it, so I just made it myself...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lizardpeople can say codeword.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/bb0f0213-d603-4a18-aa96-9314962e915d)

The test case uses "Foxtrot"


## Changelog
:cl:
fix: Saying a codeword to radio uplink accepts a message before it gets treated. Lizardpeople can use it now!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
