### PR TITLE
Lethal shotgun ammo rebalance 2

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -84,12 +84,12 @@
 
 /obj/item/ammo_casing/shotgun/improvised
 	name = "improvised shell"
-	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
+	desc = "A shotgun shell improvised from small metal shards. It won't travel as far as a regular shotgun shell, but it will still pack a punch against unarmoured opponents at close ranges."
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	materials = list(/datum/material/iron=250)
 	pellets = 10
-	variance = 25
+	variance = 15
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -88,7 +88,7 @@
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	materials = list(/datum/material/iron=250)
-	pellets = 10
+	pellets = 9
 	variance = 15
 
 /obj/item/ammo_casing/shotgun/ion

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -64,7 +64,7 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 9
+	damage = 8
 	tile_dropoff = 0.5
 	armour_penetration = 20
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 60
-	armour_penetration = -20
+	damage = 41
+	armour_penetration = 0
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
@@ -66,6 +66,7 @@
 	name = "buckshot pellet"
 	damage = 9
 	tile_dropoff = 0.5
+	armour_penetration = 20
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
@@ -87,8 +88,8 @@
 		qdel(src)
 
 /obj/projectile/bullet/pellet/shotgun_improvised
-	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.
-	damage = 6
+	tile_dropoff = 0.3		//Come on it does 6 damage don't be like that.
+	damage = 5
 
 /obj/projectile/bullet/pellet/shotgun_improvised/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

|Ammo Type|Variable|Old|New|
|-|-|-|-|
|Slug|Damage|60|41|
|Slug|Armour Penetration|-20|0|
|Buckshot|Damage|9|8|
|Buckshot|Armour Penetration|0|20|
|Improvised|Tile Dropoff|0.55|0.3|
|Improvised|Spread|25|15|
|Improvised|Damage|6|5|
|Improvised|Pellet Count|10|9|

Makes the minimum amount of shots to kill with the most common ammo types 3. No shotgun will be able to 2 shot unarmoured targets anymore.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/671cb85c-bfea-4421-9dbb-f195dee366ca)

Time to kill at certain ranges before and after. There are some quirks with the graph due to the amount of shells hitting a target being discrete and there may be some minor inaccuracies which we will verify in testing.

- Buckshot: Minimum of 3 shots to kill, falls off after a good amount of distance however inaccuracies will smooth the graph out in non-testing environments, particularly with the harsh drop off that happens at 15 and 8 units. (People won't aim directly at a target)
- Slugs: Balanced around buckshot, the same or worse at close ranges but either the same or always better at ranges above 7 units.
- Improvised: Just generally a worse version of buckshot.

## Why It's Good For The Game

This is a follow up PR to #3152 made to address some of the faults that the original PR has.
Many things have changed since the original PR which require addressing with a small rebalance:
- The assumption that antagonists will generally be pretty well armoured doesn't hold
  - Threats such as nightmares who cannot take armour and traitors who get caught off-guard are significantly more common.
- Negative armour penetration has strange behaviours and isn't tested for sanity.
- Getting killed in 2 hits feels very unfair, especially for the antagonists which cannot wear or obtain powerful armour.
- Improvised shells are almost entirely useless and super inconsistent. This makes them a bit more consistent as just all-round worse buckshot shells.

This PR aims to reduce the imbalance between shotguns feeling unfair against unarmoured opponents, the primary goal being to **make the minimum amount of shots fired to kill a target 3** while not reducing the impact of shotguns on more armoured targets too much.

For the most part, the damage will just be lower however due to the shotguns being a lot easier to use when compared to laser weapons due to the distrbution chance to hit rather than discrete hit/miss of laser guns I don't think this will make them worse than laser guns even if in a testing environment their time to kill is now lower against an unmoving, unarmoured target.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f94ffe62-ef31-4f8f-8ebc-9af81584714a)

3 shots to kill a human point blank with buckshot.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/d25db5b9-dbde-43cb-bc0b-a233e786508c)

4 shots to kill a human in bulletproof armour (This is lower than the table predicted, probably since that is 0 range instead of 1)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/26ca426d-ccc6-4d50-b7b4-0ec3cee9a17f)

5 shots to kill bulletproof armour at a slight range

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/85e734e9-dcc3-4056-8e55-f24ed7816ea6)

All hit at this range, takes around a range of 6-7 before bullets start to miss as predicted by the graph

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/06cdeee6-6861-4e5d-a43e-692a437b7127)

3 shots to kill at a good range with slugs

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f541b827-dd2e-4a65-b96b-c3ff4337ccd9)

6 shots to kill a highly armoured oppent with slugs

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/d43f519c-5ff7-49b2-a131-e0bffc9f3131)

Improvised is actually 2 shots to kill at close range. This is because 10 x 5 is 50. The pellet count has been reduced to 9 to make it a maximum of 45 damage instead.

## Changelog
:cl:
balance: Shotguns now require a minimum of 3 shots to kill unarmoured targets with slugs, buckshot and improvied buckshot.
balance: Improvised shotgun shells are now less consistent and more reliable.
/:cl:
