### PR TITLE
Fixes a runtime with bots in closets

### DIFF
--- a/_maps/shuttles/emergency/emergency_corg.dmm
+++ b/_maps/shuttles/emergency/emergency_corg.dmm
@@ -1031,7 +1031,9 @@
 "ID" = (
 /obj/structure/closet/crate/internals,
 /mob/living/simple_animal/bot/medbot,
-/mob/living/simple_animal/bot/atmosbot,
+/mob/living/simple_animal/bot/atmosbot{
+	on = 0
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -832,6 +832,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 // given an optional turf to avoid
 /mob/living/simple_animal/bot/proc/calc_path(turf/avoid)
 	check_bot_access()
+	if(!isturf(src.loc))
+		return
 	if(!is_reserved_level(z))
 		if(patrol_target != null)
 			if(z > patrol_target.z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Thanks to @Tsar-Salat for bringing it up.
As the title says- fixes a runtime. Also turns off the atmosbot in Corg's emergency shuttle roundstart for good measure.

The issue was bots attempting to pathfind their way out of objects while having a z level of 0, causing runtime errors involving out of bound list operations.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix Good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Before: Bot related runtimes on Corgstation
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/7f44263b-24a5-45a7-a7a8-7a141214d9ce)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/cab611f2-a7cd-4d37-a340-e47798066d7d)

After: No bot related runtimes about list indexes
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/1c90a418-acb5-4339-92b1-804e782862d0)
(The runtime pictured is a separate issue due to datum components)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/d659bd6c-e179-4a79-a5cf-2f981e18238a)

</details>

## Changelog
:cl:
fix: Bots will no longer runtime due to trying to pathfind their way out of an object.
tweak: The atmosbot on the Corg Station Emergency Shuttle now starts off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
