### PR TITLE
Clockcult execute failure protection

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -608,6 +608,11 @@
 	main_cult.setup_objectives()
 	//Create team
 	for(var/datum/mind/servant_mind in assigned)
+		if(!ismob(servant_mind?.current)) // user disconnected and was not assigned a mob.
+			log_game("DYNAMIC: Clockcult mind \"[servant_mind?.key]\" was lost during execute() - adding a cogscarab.")
+			assigned -= servant_mind
+			var/obj/effect/mob_spawn/drone/cogscarab = new(pick_n_take(spawns))
+			continue
 		servant_mind.current.forceMove(pick_n_take(spawns))
 		servant_mind.current.set_species(/datum/species/human)
 		var/datum/antagonist/servant_of_ratvar/S = add_servant_of_ratvar(servant_mind.current, team=main_cult)


### PR DESCRIPTION
## About The Pull Request

Clockcult has one of the longest pre-executes of any ruleset (Reebe loading is synchronous for some reason)

As such it is VERY easy to disconnect between pre_execute and execute, making it especially susceptible to null client runtimes / having people assigned to it not be given bodies. This simply spawns a mindless cogscarab in the place of any disconnecting players.

Closes #10075

## Why It's Good For The Game

Prevents clockcult from being totally messed up by one person disconnecting.

## Testing Photographs and Procedure

Hard to test.

## Changelog
:cl:
fix: Clockcult is no longer royally broken by disconnections during Reebe load.
/:cl:
