### PR TITLE
Death notice message

### DIFF
--- a/code/controllers/configuration/entries/policies.dm
+++ b/code/controllers/configuration/entries/policies.dm
@@ -3,3 +3,8 @@
 
 /datum/config_entry/string/policy_polymorph
 	config_entry_value = "<span class='boldannounce'>Even if you take the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>"
+
+/datum/config_entry/string/death_message
+	config_entry_value = "<span class='death_message'><span class='big bold'>You have died!</span><br/>\
+		Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab.<br/>\
+		<span class = 'bold red'>You do not remember the circumstances leading up to your death!</span></span>"

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -97,7 +97,9 @@
 			<b>Brain damage</b>: [src.getOrganLoss(ORGAN_SLOT_BRAIN) || "0"]<br>\
 			<b>Blood volume</b>: [src.blood_volume]cl ([round((src.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 0.1)]%)<br>\
 			<b>Reagents</b>:<br>[reagents_readout()]", INVESTIGATE_DEATHS)
-	to_chat(src, "<span_class='warning'>You have died. Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab.</span>")
+	var/death_message = CONFIG_GET(string/death_message)
+	if (death_message)
+		to_chat(src, death_message)
 
 /mob/living/carbon/human/proc/reagents_readout()
 	var/readout = "Blood:"

--- a/config/policies.txt
+++ b/config/policies.txt
@@ -4,3 +4,6 @@
 # When a mob is polymorphed
 POLICY_POLYMORPH <span class='boldannounce'>Even if you take the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>
 POLICY_POSTCLONETEXT <span class='boldannounce'>You have forgotten all the knowledge you gained while being a ghost aswell as the five minutes leading up to your death!</span>
+
+# Message displayd on death
+DEATH_MESSAGE <span class='death_message'><span class='big bold'>You have died!</span><br/>Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the "Do Not Resuscitate" verb in the ghost tab.<br/><span class = 'bold purple'>You do not remember the circumstances leading up to your death!</span></span>

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -93,6 +93,16 @@ h1.alert, h2.alert		{color: #000000;}
   padding: 10px;
   margin: 10px 20px;
 }
+.death_message {
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: 2px solid rgb(240, 62, 225);
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px 20px;
+}
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -621,6 +621,16 @@ em {
   padding: 10px;
   margin: 10px 20px;
 }
+.death_message {
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: 2px solid rgb(240, 62, 225);
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px 20px;
+}
 .unconscious {
   color: #a4bad6;
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -621,6 +621,16 @@ h2.alert {
   padding: 10px;
   margin: 10px 20px;
 }
+.death_message {
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: 2px solid rgb(240, 62, 225);
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px 20px;
+}
 .unconscious {
   color: #0000ff;
   font-weight: bold;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a configurable message for when a user dies. This is set by default to the new policy on death, which is that you do not remember events leading up to your death.

See Rule 14.3

## Why It's Good For The Game

We have new rules about the death message, however these are not codified which will lead to people accidentally breaking the rules and a disconnect between game and rules. We do not want that!

This is completely configurable so downstreams with different policies can change this as they see fit.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e91eaac3-be6b-49f6-ad22-b483ea21f016)


## Changelog
:cl:
add: Adds in a new death notice message to reflect the policy changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
