### PR TITLE
Reverts donk pocket reagent changes added in #9937

### DIFF
--- a/code/game/objects/items/food/donkpockets.dm
+++ b/code/game/objects/items/food/donkpockets.dm
@@ -29,7 +29,6 @@
 	microwaved_type = /obj/item/food/donkpocket/warm
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2, //uhhh lorewise microwaving donkpockets makes the proteins into omnizine or somethin idk
 		/datum/reagent/consumable/maltodextrin = 3
 	)
 	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
@@ -54,8 +53,7 @@
 	desc = "The heated food of choice for the seasoned traitor."
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
-		/datum/reagent/medicine/omnizine = 6,
+		/datum/reagent/medicine/omnizine = 3,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
 	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
@@ -86,7 +84,6 @@
 	icon_state = "donkpocketspicy"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
 		/datum/reagent/consumable/capsaicin = 2,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
@@ -102,8 +99,7 @@
 	icon_state = "donkpocketspicy"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
-		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/capsaicin = 5,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
@@ -116,7 +112,6 @@
 	icon_state = "donkpocketteriyaki"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
 		/datum/reagent/consumable/soysauce = 2,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
@@ -132,8 +127,7 @@
 	icon_state = "donkpocketteriyaki"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 3,
-		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/soysauce = 2,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
@@ -146,7 +140,6 @@
 	icon_state = "donkpocketpizza"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
 		/datum/reagent/consumable/tomatojuice = 2,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
@@ -162,8 +155,7 @@
 	icon_state = "donkpocketpizza"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
-		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/tomatojuice = 2,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
@@ -191,7 +183,7 @@
 	icon_state = "donkpocketbanana"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 4,
-		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/banana = 4,
 		/datum/reagent/consumable/laughter = 6,
 		/datum/reagent/consumable/maltodextrin = 4
@@ -220,7 +212,7 @@
 	icon_state = "donkpocketberry"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 4,
-		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/berryjuice = 3,
 		/datum/reagent/consumable/maltodextrin = 4
 	)
@@ -233,7 +225,6 @@
 	icon_state = "donkpocketgondola"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
 		/datum/reagent/tranquility = 5,
 		/datum/reagent/consumable/maltodextrin = 3
 	)
@@ -249,8 +240,7 @@
 	icon_state = "donkpocketgondola"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/nutriment/protein = 2,
-		/datum/reagent/medicine/omnizine = 2,
+		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/tranquility = 10,
 		/datum/reagent/consumable/maltodextrin = 3
 	)


### PR DESCRIPTION
## About The Pull Request

Reverts the donk pocket reagent changes added in #9937
* Omnizine in donk pockets was doubled, meaning a normal donk pocket can now heal 60 of ALL damage types. 
* Protein was added on top of omnizine to most donk pockets making them heal even more. 

## Why It's Good For The Game

Undocumented change + this makes donk pockets an absurdly strong healing item. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/4ec4da1c-429e-42c5-854e-206c01119a22)

## Changelog
:cl:
fix: Donk pockets now have an appropriate amount of omnizine and no protein again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
