### PR TITLE
Fixes more foodstuff caused by 9937 + 10103

### DIFF
--- a/code/game/objects/items/food/donkpockets.dm
+++ b/code/game/objects/items/food/donkpockets.dm
@@ -41,6 +41,10 @@
 	/// The upper end for how long it takes to bake
 	var/baking_time_long = 30 SECONDS
 
+/*
+/obj/item/food/donkpocket/make_microwaveable()
+	AddElement(/datum/element/microwavable, warm_type)
+*/
 
 /obj/item/food/donkpocket/warm
 	name = "warm Donk-pocket"

--- a/code/game/objects/items/food/donkpockets.dm
+++ b/code/game/objects/items/food/donkpockets.dm
@@ -73,7 +73,7 @@
 
 /obj/item/food/donkpocket/warm/dankpocket
 	name = "warm Dank-pocket"
-	desc = "The food of choice for the seasoned botanist."
+	desc = "The food of choice for the baked botanist."
 	icon_state = "dankpocket"
 	food_reagents = list(
 		/datum/reagent/medicine/omnizine = 1,

--- a/code/game/objects/items/food/donkpockets.dm
+++ b/code/game/objects/items/food/donkpockets.dm
@@ -28,50 +28,57 @@
 	icon_state = "donkpocket"
 	microwaved_type = /obj/item/food/donkpocket/warm
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/nutriment = 4,
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
 	foodtypes = GRAIN
 	food_flags = FOOD_FINGER_FOOD
 	w_class = WEIGHT_CLASS_SMALL
 
-	/// What type of donk pocket we're warmed into via baking or microwaving.
-	//var/warm_type = /obj/item/food/donkpocket/warm
 	/// The lower end for how long it takes to bake
 	var/baking_time_short = 25 SECONDS
 	/// The upper end for how long it takes to bake
 	var/baking_time_long = 30 SECONDS
 
-/*
-/obj/item/food/donkpocket/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type)
-*/
 
 /obj/item/food/donkpocket/warm
 	name = "warm Donk-pocket"
 	desc = "The heated food of choice for the seasoned traitor."
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/medicine/omnizine = 3,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
 	foodtypes = GRAIN
 
-	// Warmed donk pockets will burn if you leave them in the oven or microwave.
-	//warm_type = /obj/item/reagent_containers/food/snacks/badrecipe
 	microwaved_type = /obj/item/reagent_containers/food/snacks/badrecipe
 	baking_time_short = 10 SECONDS
 	baking_time_long = 15 SECONDS
 
-/obj/item/food/dankpocket
+/obj/item/food/donkpocket/dankpocket
 	name = "\improper Dank-pocket"
 	desc = "The food of choice for the seasoned botanist."
 	icon_state = "dankpocket"
+	microwaved_type = /obj/item/food/donkpocket/warm/dankpocket
 	food_reagents = list(
+		/datum/reagent/drug/space_drugs = 2,
 		/datum/reagent/toxin/lipolicide = 3,
-		/datum/reagent/drug/space_drugs = 3,
+		/datum/reagent/consumable/nutriment = 4,
+		/datum/reagent/consumable/maltodextrin = 4
+	)
+	tastes = list("meat" = 2, "dough" = 2)
+	foodtypes = GRAIN | VEGETABLES
+
+/obj/item/food/donkpocket/warm/dankpocket
+	name = "warm Dank-pocket"
+	desc = "The food of choice for the seasoned botanist."
+	icon_state = "dankpocket"
+	food_reagents = list(
+		/datum/reagent/medicine/omnizine = 1,
+		/datum/reagent/drug/space_drugs = 2,
+		/datum/reagent/toxin/lipolicide = 3,
 		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/consumable/maltodextrin = 4
 	)
@@ -83,14 +90,13 @@
 	desc = "The classic snack food, now with a heat-activated spicy flair."
 	icon_state = "donkpocketspicy"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/consumable/capsaicin = 2,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "spice" = 1)
 	foodtypes = GRAIN
 
-	//warm_type = /obj/item/food/donkpocket/warm/spicy
 	microwaved_type = /obj/item/food/donkpocket/warm/spicy
 
 /obj/item/food/donkpocket/warm/spicy
@@ -98,10 +104,10 @@
 	desc = "The classic snack food, now maybe a bit too spicy."
 	icon_state = "donkpocketspicy"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/capsaicin = 5,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "weird spices" = 2)
 	foodtypes = GRAIN
@@ -111,14 +117,13 @@
 	desc = "An east-asian take on the classic stationside snack."
 	icon_state = "donkpocketteriyaki"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/consumable/soysauce = 2,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "soy sauce" = 2)
 	foodtypes = GRAIN
 
-	//warm_type = /obj/item/food/donkpocket/warm/teriyaki
 	microwaved_type = /obj/item/food/donkpocket/warm/teriyaki
 
 /obj/item/food/donkpocket/warm/teriyaki
@@ -126,10 +131,10 @@
 	desc = "An east-asian take on the classic stationside snack, now steamy and warm."
 	icon_state = "donkpocketteriyaki"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/soysauce = 2,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "soy sauce" = 2)
 	foodtypes = GRAIN
@@ -139,14 +144,13 @@
 	desc = "Delicious, cheesy and surprisingly filling."
 	icon_state = "donkpocketpizza"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/consumable/tomatojuice = 2,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "cheese"= 2)
 	foodtypes = GRAIN
 
-	//warm_type = /obj/item/food/donkpocket/warm/pizza
 	microwaved_type = /obj/item/food/donkpocket/warm/pizza
 
 /obj/item/food/donkpocket/warm/pizza
@@ -154,10 +158,10 @@
 	desc = "Delicious, cheesy, and even better when hot."
 	icon_state = "donkpocketpizza"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/consumable/tomatojuice = 2,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "melty cheese"= 2)
 	foodtypes = GRAIN
@@ -174,7 +178,6 @@
 	tastes = list("banana" = 2, "dough" = 2, "children's antibiotics" = 1)
 	foodtypes = GRAIN
 
-	//warm_type = /obj/item/food/donkpocket/warm/honk
 	microwaved_type = /obj/item/food/donkpocket/warm/honk
 
 /obj/item/food/donkpocket/warm/honk
@@ -203,7 +206,6 @@
 	tastes = list("dough" = 2, "jam" = 2)
 	foodtypes = GRAIN
 
-	//warm_type = /obj/item/food/donkpocket/warm/berry
 	microwaved_type = /obj/item/food/donkpocket/warm/berry
 
 /obj/item/food/donkpocket/warm/berry
@@ -224,14 +226,13 @@
 	desc = "The choice to use real gondola meat in the recipe is controversial, to say the least." //Only a monster would craft this.
 	icon_state = "donkpocketgondola"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/tranquility = 5,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "inner peace" = 1)
 	foodtypes = GRAIN
 
-	//warm_type = /obj/item/food/donkpocket/warm/gondola
 	microwaved_type = /obj/item/food/donkpocket/warm/gondola
 
 /obj/item/food/donkpocket/warm/gondola
@@ -239,10 +240,10 @@
 	desc = "The choice to use real gondola meat in the recipe is controversial, to say the least."
 	icon_state = "donkpocketgondola"
 	food_reagents = list(
-		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/medicine/omnizine = 1,
 		/datum/reagent/tranquility = 10,
-		/datum/reagent/consumable/maltodextrin = 3
+		/datum/reagent/consumable/maltodextrin = 4
 	)
 	tastes = list("meat" = 2, "dough" = 2, "inner peace" = 1)
 	foodtypes = GRAIN

--- a/code/game/objects/items/food/donuts.dm
+++ b/code/game/objects/items/food/donuts.dm
@@ -67,7 +67,7 @@
 		/datum/reagent/consumable/nutriment = 3,
 		/datum/reagent/consumable/sprinkles = 1,
 		/datum/reagent/consumable/sugar = 2,
-		/datum/reagent/consumable/maltodextrin = 6
+		/datum/reagent/consumable/maltodextrin = 3.65
 	)
 
 /obj/item/food/donut/chaos

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -278,7 +278,7 @@
 	list_reagents = list(
 		/datum/reagent/consumable/dry_ramen = 15,
 		/datum/reagent/consumable/sodiumchloride = 3,
-		/datum/reagent/consumable/maltodextrin = 10
+		/datum/reagent/consumable/maltodextrin = 5
 	)
 	foodtype = GRAIN
 	isGlass = FALSE

--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -7,7 +7,11 @@
 	desc = "Nougat love it or hate it."
 	icon_state = "candy"
 	trash = /obj/item/trash/candy
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sugar = 3, /datum/reagent/consumable/maltodextrin = 2)
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 1,
+		/datum/reagent/consumable/sugar = 3,
+		/datum/reagent/consumable/maltodextrin = 2
+	)
 	junkiness = 25
 	filling_color = "#D2691E"
 	tastes = list("candy" = 1)
@@ -20,7 +24,12 @@
 	icon_state = "sosjerky"
 	desc = "Beef jerky made from the finest space cows."
 	trash = /obj/item/trash/sosjerky
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sugar = 3, /datum/reagent/consumable/sodiumchloride = 2, /datum/reagent/consumable/maltodextrin = 2)
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 1,
+		/datum/reagent/consumable/sugar = 3,
+		/datum/reagent/consumable/sodiumchloride = 2,
+		/datum/reagent/consumable/maltodextrin = 2
+	)
 	junkiness = 25
 	filling_color = "#8B0000"
 	tastes = list("dried meat" = 1)
@@ -38,7 +47,12 @@
 	icon_state = "chips"
 	trash = /obj/item/trash/chips
 	bitesize = 1
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sugar = 3, /datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/consumable/maltodextrin = 2)
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 1,
+		/datum/reagent/consumable/sugar = 3,
+		/datum/reagent/consumable/sodiumchloride = 1,
+		/datum/reagent/consumable/maltodextrin = 2
+	)
 	junkiness = 20
 	filling_color = "#FFD700"
 	tastes = list("salt" = 1, "crisps" = 1)
@@ -49,7 +63,11 @@
 	icon_state = "4no_raisins"
 	desc = "Best raisins in the universe. Not sure why."
 	trash = /obj/item/trash/raisins
-	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/sugar = 4, /datum/reagent/consumable/maltodextrin = 3.35)
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 2,
+		/datum/reagent/consumable/sugar = 4,
+		/datum/reagent/consumable/maltodextrin = 3.35
+	)
 	junkiness = 25
 	filling_color = "#8B0000"
 	tastes = list("dried raisins" = 1)
@@ -69,7 +87,10 @@
 	name = "space twinkie"
 	icon_state = "space_twinkie"
 	desc = "Guaranteed to survive longer than you will."
-	list_reagents = list(/datum/reagent/consumable/sugar = 4, /datum/reagent/consumable/maltodextrin = 1.35)
+	list_reagents = list(
+		/datum/reagent/consumable/sugar = 4,
+		/datum/reagent/consumable/maltodextrin = 1.35
+	)
 	junkiness = 25
 	filling_color = "#FFD700"
 	foodtype = JUNKFOOD | GRAIN | SUGAR
@@ -82,7 +103,11 @@
 	desc = "Bite sized cheesie snacks that will honk all over your mouth."
 	icon_state = "cheesie_honkers"
 	trash = /obj/item/trash/cheesie
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sugar = 3, /datum/reagent/consumable/maltodextrin = 2)
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 1,
+		/datum/reagent/consumable/sugar = 3,
+		/datum/reagent/consumable/maltodextrin = 2
+	)
 	junkiness = 25
 	filling_color = "#FFD700"
 	tastes = list("cheese" = 5, "crisps" = 2)
@@ -94,7 +119,11 @@
 	icon_state = "syndi_cakes"
 	desc = "An extremely moist snack cake that tastes just as good after being nuked."
 	trash = /obj/item/trash/syndi_cakes
-	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/doctor_delight = 5, /datum/reagent/consumable/maltodextrin = 4)
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 4,
+		/datum/reagent/consumable/doctor_delight = 5,
+		/datum/reagent/consumable/maltodextrin = 4
+	)
 	filling_color = "#F5F5DC"
 	tastes = list("sweetness" = 3, "cake" = 1)
 	foodtype = GRAIN | FRUIT | VEGETABLES
@@ -105,7 +134,11 @@
 	icon_state = "energybar"
 	desc = "An energy bar with a lot of punch, you probably shouldn't eat this if you're not an Ethereal."
 	trash = /obj/item/trash/energybar
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 10, /datum/reagent/consumable/maltodextrin = 3)
+	list_reagents = list(
+		/datum/reagent/consumable/nutriment = 3,
+		/datum/reagent/consumable/liquidelectricity = 10,
+		/datum/reagent/consumable/maltodextrin = 3
+	)
 	filling_color = "#97ee63"
 	tastes = list("pure electricity" = 3, "fitness" = 2)
 	foodtype = TOXIC

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -327,14 +327,14 @@
 	result = /obj/item/food/donkpocket
 	subcategory = CAT_PASTRY
 
-/datum/crafting_recipe/food/dankpocket
+/datum/crafting_recipe/food/donkpocket/dankpocket
 	time = 15
 	name = "Dank-pocket"
 	reqs = list(
 		/obj/item/food/pastrybase = 1,
 		/obj/item/reagent_containers/food/snacks/grown/cannabis = 1
 	)
-	result = /obj/item/food/dankpocket
+	result = /obj/item/food/donkpocket/dankpocket
 	subcategory = CAT_PASTRY
 
 /datum/crafting_recipe/food/donkpocket/spicy


### PR DESCRIPTION
## About The Pull Request

* Makes dank pockets a sub-type of donk pockets again
* Re-adds warm dank pockets which were removed in #9937
* By extension of the above, Closes #10119
* Fixes more undocumented reagent changes as a result of #9937 (I overlooked the fact nutriment had also been changed when I was fixing Omnizine and Protein being adjusted/added)
* Re-adjusts maltodextrin values to match the above bullet point.
* Fixes some mistakes I made when a merge conflict occurred with #10103, specifically some maltodextrin values that got inadvertantly reversed for premade donuts and ramen
* Adds proper list spacing to snacks_and_vend.dm items containing maltodextrin for ease of reading
* Cleans the donkpockets of unused variables

## Why It's Good For The Game

Bugs are bad
Undocumented changes are bad
Maltodextrin should be applied correctly to all foods it is contained within. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/b3248e3d-edb7-4c59-badd-1e3de22ff4bb)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/ac8da0db-2f26-4fa2-a42d-5102d8c4e4fb)

### The tooltip for warm dank pockets has been updated since this screenshot to say "baked botanist" again. 

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/f06fd734-7c59-4640-bbfc-272b5a6cc553)



## Changelog
:cl:
fix: Donk pockets now have their old nutriment value again, and their maltodextrin value has been updated to match this new (old) value as it should. 
fix: Dank pockets can now be microwaved again
tweak: The amount of maltodextrin in premade donuts and ramen is now correct after having been missed in the previous PR.
code: Adds proper list spacing to snacks_and_vend.dm items containing maltodextrin and cleans up some unused variables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
