### PR TITLE
Fixes a couple of alien embryo runtimes

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -118,8 +118,8 @@
 	var/mob/living/carbon/host = owner
 	if(kill_on_success)
 		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner] in a shower of gore!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
-		var/obj/item/bodypart/BP = owner.get_bodypart(BODY_ZONE_CHEST)
 		owner.investigate_log("has been killed by an alien larva chestburst.", INVESTIGATE_DEATHS)
+		var/obj/item/bodypart/BP = owner.get_bodypart(BODY_ZONE_CHEST)
 		if(BP)
 			BP.receive_damage(brute = 200) // Kill them dead
 			BP.dismember()

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -19,7 +19,6 @@
 			AttemptGrow(0)
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
-	. = ..()
 	switch(stage)
 		if(2, 3)
 			if(prob(2))
@@ -46,6 +45,8 @@
 		if(5)
 			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your stomach.</span>")
 			owner.adjustToxLoss(10)
+	// egg_process() happens here, if we put this beforehand there's a chance we lose our owner there and runtime.
+	. = ..()
 
 /obj/item/organ/body_egg/alien_embryo/on_death()
 	. = ..()
@@ -118,6 +119,7 @@
 	if(kill_on_success)
 		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner] in a shower of gore!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 		var/obj/item/bodypart/BP = owner.get_bodypart(BODY_ZONE_CHEST)
+		owner.investigate_log("has been killed by an alien larva chestburst.", INVESTIGATE_DEATHS)
 		if(BP)
 			BP.receive_damage(brute = 200) // Kill them dead
 			BP.dismember()
@@ -127,7 +129,6 @@
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)
 	host.cut_overlay(overlay)
-	owner.investigate_log("has been killed by an alien larva chestburst.", INVESTIGATE_DEATHS)
 	qdel(src)
 
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -19,6 +19,9 @@
 			AttemptGrow(0)
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
+	. = ..()
+	if(!owner)
+		return
 	switch(stage)
 		if(2, 3)
 			if(prob(2))
@@ -45,8 +48,6 @@
 		if(5)
 			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your stomach.</span>")
 			owner.adjustToxLoss(10)
-	// egg_process() happens here, if we put this beforehand there's a chance we lose our owner there and runtime.
-	. = ..()
 
 /obj/item/organ/body_egg/alien_embryo/on_death()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes 2 runtimes present in alien_embryo.dm.

Runtime 1: Cannot execute null.adjustToxLoss() (line 48)
This was fixed by moving alien_embryo's on_life() parent call to after the stage call. Since on_life() calls egg_process(), we can lose our owner when it's called, so we do it after the toxloss handling.

Runtime 2: Cannot execute null.investigate_log() (line 130)
Here, investigate_log was placed after the chest dismemberment, which causes it to call on a null owner if the chestburst actually happened (and log a false death if it didn't). This was moved a bit higher to make sure owner is still set.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Squashes a bug.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Chestburst succeeds with no embryo-related runtimes and no left-behind embryo, growth functions normally. 
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9423435/ac1223ef-2e57-4bdc-a8c1-e94f630d8767)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9423435/b267b7da-290a-4bfb-aec3-7d31d4931f97)


</details>

## Changelog
:cl:
fix: Alien embryos properly delete themselves when chestbursting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
