### PR TITLE
Adds Bandanas to the Bee Shop

### DIFF
--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -176,6 +176,38 @@
 	display_name = "red glasses"
 	path = /obj/item/clothing/glasses/red
 
+//BANDANAS (masks)
+
+/datum/gear/accessory/bandana
+	slot = ITEM_SLOT_MASK
+	subtype_path = /datum/gear/accessory/bandana
+	cost = 1500
+
+/datum/gear/accessory/bandana/red
+	display_name = "red bandana"
+	path = /obj/item/clothing/mask/bandana/red
+
+/datum/gear/accessory/bandana/blue
+	display_name = "blue bandana"
+	path = /obj/item/clothing/mask/bandana/blue
+
+/datum/gear/accessory/bandana/green
+	display_name = "green bandana"
+	path = /obj/item/clothing/mask/bandana/green
+
+/datum/gear/accessory/bandana/gold
+	display_name = "gold bandana"
+	path = /obj/item/clothing/mask/bandana/gold
+
+/datum/gear/accessory/bandana/black
+	display_name = "black bandana"
+	path = /obj/item/clothing/mask/bandana/black
+
+/datum/gear/accessory/bandana/skull
+	display_name = "skull bandana"
+	path = /obj/item/clothing/mask/bandana/skull
+	cost = 2000
+
 //LIPSTICK
 
 /datum/gear/accessory/cosmetics


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds Red, Blue, Green, Gold, Black and Skull bandanas to the Bee Shop.
They cost 1500 coins each except Skull which costs 2000 because it's awesome.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Customization.
In certain maps (noticeable in Rad Station) it is impossible to acquire bandanas since they aren't on the lockers.
I thought it was silly you couldn't get them and since they are an important part of one of my character's personality I did notice their absence.
I considered adding them to the normal clothing vendor but that would just limit the possibility for low paycheck roles to get their silly outfits in order.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/94647521/511efa0e-f174-4b2f-ab34-2ad4605a1270)


</details>

## Changelog
:cl: PinkSuzuki
Adds Bandanas to the Beeshop under the Accessories Tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
