### PR TITLE
Fixes radio channels defaulting to common when no encryption key

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -261,8 +261,8 @@
 
 	// From the channel, determine the frequency and get a reference to it.
 	var/freq
-	if(channel && channels && channels.len > 0)
-		if(channel == MODE_DEPARTMENT)
+	if(channel && channels)
+		if(channel == MODE_DEPARTMENT && channels.len > 0)
 			channel = channels[1]
 		freq = secure_radio_connections[channel]
 		if (!channels[channel]) // if the channel is turned off, don't broadcast

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -265,6 +265,8 @@
 		if(channel == MODE_DEPARTMENT && channels.len > 0)
 			channel = channels[1]
 		freq = secure_radio_connections[channel]
+		if(istype(M, /mob) && !freq && channel != RADIO_CHANNEL_UPLINK)
+			to_chat(M, "<span class='warning'>You can't access this channel without an encryption key!</span>")
 		if (!channels[channel]) // if the channel is turned off, don't broadcast
 			return
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When using a radio headset, if no encryption key was installed, the headset would transmit to its frequency (common channel by default) no matter the channel code (:e, :m, :n...) used. This PR makes it so the behaviour is the same as when an encryption key is installed, which is not transmitting at all if the channel is invalid. It also adds a warning message if you try to transmit to a channel without the proper encryption key.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It makes no sense for headsets to work differently if there is or isn't an encryption key installed. This can also cause problems in cases where a civilian crewmember (assistant, chaplain, curator...) has a traitor uplink in their headset, where they would transmit the password over common when unlocking their uplink.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/62ec2f3b-7cdd-41b1-89a5-1db5fd5e76eb

</details>

## Changelog
:cl:
fix: Radio channels no longer always default to common when no encryption key is installed
add: There is now a warning message when you try to transmit to a channel without the proper encryption key
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
