### PR TITLE
Removes extra Initialize() proc from safes

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -32,10 +32,6 @@ FLOOR SAFES
 	tumbler_2_pos = rand(0, 71)
 	tumbler_2_open = rand(0, 71)
 
-
-/obj/structure/safe/Initialize(mapload)
-	. = ..()
-
 	if(!mapload)
 		return
 


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/5ab598a3-d48c-4d11-a378-abf0f94f5811)

## Why It's Good For The Game

Why in god's name are there two side-by-side `Initialize()` procs???

## Testing Photographs and Procedure

This is not actually tested. 

## Changelog
:cl:
code: Cleaned up safe Initialization code slightly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
