### PR TITLE
Makes the heretic blademaking ritual shatter blades over the limit when new ones are made

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -209,6 +209,7 @@
 				var/atom/prospective = ref.resolve()
 				if(get_dist(user, prospective)>closest_distance)
 					closest = prospective
+		playsound(closest, "shatter", 75, TRUE)
 		if(!QDELETED(closest))
 			qdel(closest)
 

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -209,7 +209,7 @@
 				var/atom/prospective = ref.resolve()
 				if(get_dist(user, prospective)>closest_distance)
 					closest = prospective
-		playsound(closest, "shatter", 75, TRUE)
+		playsound(closest, "shatter", 100, TRUE)
 		if(!QDELETED(closest))
 			qdel(closest)
 

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -199,19 +199,19 @@
 		loc.balloon_alert(user, "ritual failed, at limit!")
 		return FALSE
 	else if(LAZYLEN(created_items) >= limit && destroy_if_over_limit)
-		var/atom/closest
-		var/closest_distance
+		var/atom/furthest
+		var/furthest_distance
 		for(var/datum/weakref/ref in created_items)
-			if(!closest)
-				closest = ref.resolve()
-				closest_distance = get_dist(user, closest)
+			if(!furthest)
+				furthest = ref.resolve()
+				furthest_distance = get_dist(user, furthest)
 			else
 				var/atom/prospective = ref.resolve()
-				if(get_dist(user, prospective)>closest_distance)
-					closest = prospective
-		playsound(closest, "shatter", 100, TRUE)
-		if(!QDELETED(closest))
-			qdel(closest)
+				if(get_dist(user, prospective)>furthest_distance)
+					furthest = prospective
+		playsound(furthest, "shatter", 100, TRUE)
+		if(!QDELETED(furthest))
+			qdel(furthest)
 
 	return TRUE
 

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -28,7 +28,7 @@
 	name = "Nightwatcher's Secret"
 	desc = "Opens up the Path of Ash to you. \
 		Allows you to transmute a match and a knife into an Ashen Blade. \
-		You can only create two at a time."
+		You can only create two at a time. Destroys the blade furthest from you if you invoke this ritual at the limit."
 	gain_text = "The City Guard know their watch. If you ask them at night, they may tell you about the ashy lantern."
 	next_knowledge = list(/datum/heretic_knowledge/ashen_grasp)
 	banned_knowledge = list(
@@ -45,6 +45,7 @@
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/ash)
 	limit = 2
+	destroy_if_over_limit = TRUE
 	cost = 1
 	priority = MAX_KNOWLEDGE_PRIORITY - 5
 	route = HERETIC_PATH_ASH

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -33,7 +33,7 @@
 	name = "Principle of Hunger"
 	desc = "Opens up the Path of Flesh to you. \
 		Allows you to transmute a knife and a pool of blood into a Bloody Blade. \
-		You can only create three at a time."
+		You can only create three at a time. Destroys the blade furthest from you if you invoke this ritual at the limit."
 	gain_text = "Hundreds of us starved, but not me... I found strength in my greed."
 	next_knowledge = list(/datum/heretic_knowledge/limited_amount/flesh_grasp)
 	banned_knowledge = list(
@@ -50,6 +50,7 @@
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/flesh)
 	limit = 3 // Bumped up so they can arm up their ghouls too.
+	destroy_if_over_limit = TRUE
 	cost = 1
 	priority = MAX_KNOWLEDGE_PRIORITY - 5
 	route = HERETIC_PATH_FLESH

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -28,7 +28,7 @@
 	name = "Blacksmith's Tale"
 	desc = "Opens up the Path of Rust to you. \
 		Allows you to transmute a knife with any trash item into a Rusty Blade. \
-		You can only create two at a time."
+		You can only create two at a time. Destroys the blade furthest from you if you invoke this ritual at the limit."
 	gain_text = "\"Let me tell you a story\", said the Blacksmith, as he gazed deep into his rusty blade."
 	next_knowledge = list(/datum/heretic_knowledge/rust_fist)
 	banned_knowledge = list(
@@ -45,6 +45,7 @@
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/rust)
 	limit = 2
+	destroy_if_over_limit = TRUE
 	cost = 1
 	priority = MAX_KNOWLEDGE_PRIORITY - 5
 	route = HERETIC_PATH_RUST

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -28,7 +28,7 @@
 	name = "Glimmer of Winter"
 	desc = "Opens up the path of void to you. \
 		Allows you to transmute a knife in sub-zero temperatures into a Void Blade. \
-		You can only create two at a time."
+		You can only create two at a time. Destroys the blade furthest from you if you invoke this ritual at the limit."
 	gain_text = "I feel a shimmer in the air, the air around me gets colder. \
 		I start to realize the emptiness of existence. Something's watching me."
 	next_knowledge = list(/datum/heretic_knowledge/void_grasp)
@@ -43,6 +43,7 @@
 	required_atoms = list(/obj/item/knife = 1)
 	result_atoms = list(/obj/item/melee/sickly_blade/void)
 	limit = 2
+	destroy_if_over_limit = TRUE
 	cost = 1
 	priority = MAX_KNOWLEDGE_PRIORITY - 5
 	route = HERETIC_PATH_VOID


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the heretic blademaking ritual shatter blades over the limit when new ones are made, instead of preventing the creation of new ones.

Closes #9327 

## Why It's Good For The Game

Right now if heretics get caught by sec with all their blades it's basically over for them, and a lot of players have expressed their frustration with this situation since the antag, which revolves around the blade, basically loses its capabilities. This limit was originally introduced to prevent people from having 10 blades and basically snapping them with little consequence, so shattering the blade that's most far away from the ritual seems fair.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Video, a bit big but and I couldn't embed it for some reason

https://cdn.discordapp.com/attachments/943311132007997490/1170381132232130632/Desktop_2023.11.04_-_16.14.34.02.mp4?ex=6558d55e&is=6546605e&hm=3ea0149ca4b8019c1c0a2f546c3bdb68f95496f016f50449cf8c20c796fff960&

Discord message link so you don't have to download the whole thing:

https://discord.com/channels/427337870844362753/943311132007997490/1170381136447410217)
</details>

## Changelog
:cl:
tweak: Heretics now shatter the blade farthest away from them when they make a new blade at the limit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
