### PR TITLE
Fixed some heretic spells restarting the cooldown even though they failed 

### DIFF
--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -12,10 +12,12 @@
 	range = 9
 
 /obj/effect/proc_holder/spell/pointed/cleave/cast(list/targets, mob/user)
-	if(!targets.len)
+	if(!length(targets))
+		revert_cast()
 		user.balloon_alert(user, "No targets")
 		return FALSE
 	if(!can_target(targets[1], user))
+		revert_cast()
 		return FALSE
 
 	for(var/mob/living/carbon/human/nearby_human in range(1, targets[1]))

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -10,35 +10,37 @@
 	clothes_req = FALSE
 	range = 9
 
-/obj/effect/proc_holder/spell/pointed/blood_siphon/cast(list/targets, mob/user)
-	if(!isliving(user))
+/obj/effect/proc_holder/spell/pointed/blood_siphon/cast(list/targets, mob/living/user)
+	if(!istype(user))
+		revert_cast()
 		return
-
-	var/mob/living/real_target = targets[1]
-	var/mob/living/living_user = user
-	playsound(user, 'sound/magic/demon_attack1.ogg', 75, TRUE)
-	if(real_target.anti_magic_check())
+	var/mob/living/target = targets[1]
+	if(!istype(target))
+		user.balloon_alert(user, "Invalid target")
+		return
+	playsound(user, 'sound/magic/demon_attack1.ogg', vol = 75, vary = TRUE)
+	if(target.anti_magic_check())
 		user.balloon_alert(user, "Spell blocked")
-		real_target.visible_message(
-			"<span class='danger'>The spell bounces off of [real_target]!</span>",
+		target.visible_message(
+			"<span class='danger'>The spell bounces off of [target]!</span>",
 			"<span class='danger'>The spell bounces off of you!</span>",
 		)
 		return
 
-	real_target.visible_message(
-		"<span class='danger'>[real_target] turns pale as a red glow envelops [real_target.p_them()]!</span>",
+	target.visible_message(
+		"<span class='danger'>[target] turns pale as a red glow envelops [target.p_them()]!</span>",
 		"<span class='danger'>You turn pale as a red glow enevelops you!</span>",
 	)
 
-	real_target.adjustBruteLoss(20)
-	living_user.adjustBruteLoss(-20)
+	target.take_overall_damage(brute = 20)
+	user.heal_overall_damage(brute = 20)
 
-	if(!living_user.blood_volume)
+	if(!user.blood_volume)
 		return
 
-	real_target.blood_volume -= 20
-	if(living_user.blood_volume < BLOOD_VOLUME_MAXIMUM) // we dont want to explode from casting
-		living_user.blood_volume += 20
+	target.blood_volume -= 20
+	if(user.blood_volume < BLOOD_VOLUME_MAXIMUM) // we dont want to explode from casting
+		user.blood_volume += 20
 
 /obj/effect/proc_holder/spell/pointed/blood_siphon/can_target(atom/target, mob/user, silent)
 	if(!isliving(target))

--- a/code/modules/antagonists/heretic/magic/manse_link.dm
+++ b/code/modules/antagonists/heretic/magic/manse_link.dm
@@ -24,8 +24,10 @@
 	to_chat(originator, "<span class='notice'>You begin linking [target]'s mind to yours...</span>")
 	to_chat(target, "<span class='warning'>You feel your mind being pulled... connected... intertwined with the very fabric of reality...</span>")
 	if(!do_after(originator, 6 SECONDS, target = target))
+		revert_cast()
 		return
 	if(!originator.link_mob(target))
+		revert_cast()
 		to_chat(originator, "<span class='warning'>You can't seem to link [target]'s mind...</span>")
 		to_chat(target, "<span class='warning'>The foreign presence leaves your mind.</span>")
 		return

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -17,7 +17,7 @@
 	if(!istype(user))
 		revert_cast()
 		return
-	var/did_something = user.on_fire
+	var/did_something = user.on_fire // This might be a false negative if the user has items on fire but they themselves are not.
 	user.ExtinguishMob()
 
 	for(var/mob/living/carbon/target in view(7, user))

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -13,11 +13,12 @@
 	action_icon = 'icons/mob/actions/actions_ecult.dmi'
 	action_icon_state = "smoke"
 
-/obj/effect/proc_holder/spell/targeted/fiery_rebirth/cast(list/targets, mob/user)
-	if(!ishuman(user))
+/obj/effect/proc_holder/spell/targeted/fiery_rebirth/cast(list/targets, mob/living/carbon/human/user)
+	if(!istype(user))
+		revert_cast()
 		return
-	var/mob/living/carbon/human/human_user = user
-	human_user.ExtinguishMob()
+	var/did_something = user.on_fire
+	user.ExtinguishMob()
 
 	for(var/mob/living/carbon/target in view(7, user))
 		if(!target.mind || !target.client || target.stat == DEAD || !target.on_fire || IS_HERETIC_OR_MONSTER(target))
@@ -27,13 +28,15 @@
 			target.investigate_log("has been killed by fiery rebirth.", INVESTIGATE_DEATHS)
 			target.death()
 
-		target.adjustFireLoss(20)
+		target.take_overall_damage(burn = 20)
 		new /obj/effect/temp_visual/eldritch_smoke(target.drop_location())
-		human_user.adjustBruteLoss(-10, FALSE)
-		human_user.adjustFireLoss(-10, FALSE)
-		human_user.adjustToxLoss(-10, FALSE)
-		human_user.adjustOxyLoss(-10, FALSE)
-		human_user.adjustStaminaLoss(-10)
+		user.heal_overall_damage(brute = 10, burn = 10, stamina = 10, updating_health = FALSE)
+		user.adjustToxLoss(-10, updating_health = FALSE, forced = TRUE)
+		user.adjustOxyLoss(-10)
+		did_something = TRUE
+
+	if(!did_something)
+		revert_cast()
 
 /obj/effect/temp_visual/eldritch_smoke
 	icon = 'icons/effects/heretic.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes up some heretic spells, mainly spells that force you to go through the cooldown again even though the spell didn't do anything (cleave, blood siphon, mansus link, nightwatcher's rebirth)

Also changed some adjust brute/burn/stamina loss procs to use heal/take overall damage instead.

## Why It's Good For The Game

Annoying having to wait for a cooldown again bc u misclicked cleave and tried to cleave the floor instead

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/6fda305d-45c7-417d-a8b0-d0d6fc00d037

</details>

## Changelog
:cl:
fix: Fixed some heretic spells restarting the cooldown even though they failed (cleave, blood siphon, mansus link, nightwatcher's rebirth)
fix: Fixed Nightwatcher's Rebirth causing toxin damage to oozeling users, when it should be healing them of toxin damage.
fix: Fixed a runtime error when accidentally using Blood Siphon on a non-living target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
