### PR TITLE
Morphs can no longer perform stomach functions inside of pipes

### DIFF
--- a/code/modules/antagonists/morph/morph_stomach.dm
+++ b/code/modules/antagonists/morph/morph_stomach.dm
@@ -72,6 +72,9 @@
 /datum/morph_stomach/ui_act(action, params)
 	if(..())
 		return
+	if(morph.movement_type & VENTCRAWLING)
+		to_chat(morph, "<span class='danger'>You cannot do that while ventcrawling.</span></span>")
+		return
 	var/ref = params["id"]
 	var/atom/movable/target = locate(ref) in morph.contents
 	if(!target || (!isliving(target) && !isitem(target)))

--- a/code/modules/antagonists/morph/morph_stomach.dm
+++ b/code/modules/antagonists/morph/morph_stomach.dm
@@ -73,7 +73,7 @@
 	if(..())
 		return
 	if(morph.movement_type & VENTCRAWLING)
-		to_chat(morph, "<span class='danger'>You cannot do that while ventcrawling.</span></span>")
+		to_chat(morph, "<span class='danger'>It's too cramped, you can't do that here!.</span></span>")
 		return
 	var/ref = params["id"]
 	var/atom/movable/target = locate(ref) in morph.contents


### PR DESCRIPTION
## About The Pull Request

Morph stomach functions no longer work inside of pipes. This includes dropping and digesting victims/items so that they are almost unrecoverable/undetectable. 

Closes #9929 

## Why It's Good For The Game

Removing all evidence of kills is cringe in the best of times, but this is pretty much an exploit. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_pCOokfPmlT](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/10d6cd67-27af-4ce7-8728-988ce497e9a6)

## Changelog
:cl:
fix: Morphs may no longer utilize stomach abilities while ventcrawling. This means no more victims or items left inside of atmos pipes where they are nearly impossible to find. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
