### PR TITLE
Fixes scanner gate and server shell

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -121,7 +121,7 @@
  */
 /datum/component/shell/proc/on_unfasten(atom/source, anchored)
 	SIGNAL_HANDLER
-	attached_circuit?.on = anchored
+	attached_circuit?.set_on(anchored)
 /**
  * Called when an item hits the parent. This is the method to add the circuitboard to the component.
  */

--- a/code/modules/wiremod/shell/scanner_gate.dm
+++ b/code/modules/wiremod/shell/scanner_gate.dm
@@ -1,6 +1,6 @@
 /obj/structure/scanner_gate_shell
 	name = "circuit scanner gate"
-	desc = "A gate able to perform mid-depth scans on any organisms who pass under it. Requires to be secured to work."
+	desc = "A gate able to perform mid-depth scans on any organisms who pass under it. Needs to be secured to work."
 	icon = 'icons/obj/machines/scangate.dmi'
 	icon_state = "scangate"
 	var/scanline_timer

--- a/code/modules/wiremod/shell/scanner_gate.dm
+++ b/code/modules/wiremod/shell/scanner_gate.dm
@@ -1,6 +1,6 @@
 /obj/structure/scanner_gate_shell
 	name = "circuit scanner gate"
-	desc = "A gate able to perform mid-depth scans on any organisms who pass under it. Requires to be anchored to work."
+	desc = "A gate able to perform mid-depth scans on any organisms who pass under it. Requires to be secured to work."
 	icon = 'icons/obj/machines/scangate.dmi'
 	icon_state = "scangate"
 	var/scanline_timer

--- a/code/modules/wiremod/shell/scanner_gate.dm
+++ b/code/modules/wiremod/shell/scanner_gate.dm
@@ -1,6 +1,6 @@
 /obj/structure/scanner_gate_shell
 	name = "circuit scanner gate"
-	desc = "A gate able to perform mid-depth scans on any organisms who pass under it."
+	desc = "A gate able to perform mid-depth scans on any organisms who pass under it. Requires to be anchored to work."
 	icon = 'icons/obj/machines/scangate.dmi'
 	icon_state = "scangate"
 	var/scanline_timer
@@ -27,15 +27,13 @@
 /obj/structure/scanner_gate_shell/wrench_act(mob/living/user, obj/item/tool)
 	if(locked)
 		return
-	anchored = !anchored
-	tool.play_tool_sound(src)
-	balloon_alert(user, "You [anchored?"secure":"unsecure"] [src].")
+	default_unfasten_wrench(user, tool)
 	return TRUE
 
-/obj/structure/scanner_gate_shell/proc/on_entered(atom/movable/AM)
+/obj/structure/scanner_gate_shell/proc/on_entered(atom/movable/source, atom/movable/entered)
 	SIGNAL_HANDLER
 	set_scanline("scanning", 10)
-	SEND_SIGNAL(src, COMSIG_SCANGATE_SHELL_PASS, AM)
+	SEND_SIGNAL(src, COMSIG_SCANGATE_SHELL_PASS, entered)
 
 /obj/structure/scanner_gate_shell/proc/set_scanline(type, duration)
 	cut_overlays()

--- a/code/modules/wiremod/shell/server.dm
+++ b/code/modules/wiremod/shell/server.dm
@@ -7,7 +7,7 @@
 /obj/structure/server
 	name = "server"
 	icon = 'icons/obj/wiremod.dmi'
-	desc = "A server shell able to host advanced circuits. Requires to be secured to work."
+	desc = "A server shell able to host advanced circuits. Needs to be secured to work."
 	icon_state = "setup_stationary"
 
 	density = TRUE

--- a/code/modules/wiremod/shell/server.dm
+++ b/code/modules/wiremod/shell/server.dm
@@ -7,7 +7,7 @@
 /obj/structure/server
 	name = "server"
 	icon = 'icons/obj/wiremod.dmi'
-	desc = "A server shell able to host advanced circuits. Requires to be anchored to work."
+	desc = "A server shell able to host advanced circuits. Requires to be secured to work."
 	icon_state = "setup_stationary"
 
 	density = TRUE

--- a/code/modules/wiremod/shell/server.dm
+++ b/code/modules/wiremod/shell/server.dm
@@ -7,6 +7,7 @@
 /obj/structure/server
 	name = "server"
 	icon = 'icons/obj/wiremod.dmi'
+	desc = "A server shell able to host advanced circuits. Requires to be anchored to work."
 	icon_state = "setup_stationary"
 
 	density = TRUE
@@ -18,7 +19,5 @@
 	AddComponent(/datum/component/shell, null, SHELL_CAPACITY_VERY_LARGE, SHELL_FLAG_REQUIRE_ANCHOR|SHELL_FLAG_USB_PORT)
 
 /obj/structure/server/wrench_act(mob/living/user, obj/item/tool)
-	anchored = !anchored
-	tool.play_tool_sound(src)
-	balloon_alert(user, "You [anchored ? "secure" : "unsecure"] [src].")
+	default_unfasten_wrench(user, tool)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #10140 
Previously you needed to secure the shell before inserting the circuit, this fixes that.
Also fixes scanner gate outputting turf it is on instead of the scanned object.
Added description to both shells saying that they need to be secured to work
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Working content good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
1. Make a circuit inside scanner gate shell that will output scanned entity
2. it will output scanned entity instead of the turf it is on

And

1. Insert any circuit into scanner gate/server shell
2. secure it
3. it works
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Added information about needing to be secured to server and scanner gate shell
fix: Fixed scanner gate shell outputting turf instead of scanned object
fix: made securing a shell after inserting circuit work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
