### PR TITLE
Adds a short do_after to unwrapping wrapped stuff

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -13,7 +13,7 @@
 	RegisterSignal(src, COMSIG_MOVABLE_DISPOSING, PROC_REF(disposal_handling))
 
 /obj/structure/big_delivery/interact(mob/user)
-	if(do_after(user, 30, src, progress = TRUE))
+	if(do_after(user, 3, src, progress = TRUE))
 		playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
 		qdel(src)
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -13,8 +13,9 @@
 	RegisterSignal(src, COMSIG_MOVABLE_DISPOSING, PROC_REF(disposal_handling))
 
 /obj/structure/big_delivery/interact(mob/user)
-	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
-	qdel(src)
+	if(do_after(user, 30, src, progress = TRUE))
+		playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
+		qdel(src)
 
 /obj/structure/big_delivery/Destroy()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simple short do_after to unwrap stuff

## Why It's Good For The Game
People will open your crates while you're dragging them, easy way to prevent this since cargo will be dragging many more crates when the silos get departmentalized

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Keep in mind I messed it up, it's 10 times faster now

https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/ab4915c9-981e-4bcf-b58a-50de4d728a34



</details>

## Changelog
:cl:
tweak: Unwrapping crates takes 0.3 seconds now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
