### PR TITLE
Fix light boxes being unable to store lights again

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -814,7 +814,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	foldable = /obj/item/stack/sheet/cardboard //BubbleWrap
 
-/obj/item/storage/box/lights/ComponentInitialize()
+/obj/item/storage/box/lights/Initialize(mapload)
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 21


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so light boxes can store lights again after they have been removed (it gives somewhere for broken lights to go)

For some reason changes applied during componentInitialize() are being overwritten. 

## Why It's Good For The Game

This was working just fine before #9337 and even during testing it continued to work so I'm not really sure that this is where it broke, but I'm fixing it anyway. 

## Testing Photographs and Procedure

![dreamseeker_j2rCk7kIi5](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/f24107dd-1380-470e-a9fc-ad7890aa0f4b)



## Changelog
:cl:
fix: Boxes of lights are now able to store the right number of lights again before saying they are full. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
