### PR TITLE
Minor refactor to machine construction + Fake Computer Toy

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1106,6 +1106,7 @@
 #include "code\game\machinery\computer\communications.dm"
 #include "code\game\machinery\computer\crew.dm"
 #include "code\game\machinery\computer\dna_console.dm"
+#include "code\game\machinery\computer\fake_toy_computer.dm"
 #include "code\game\machinery\computer\launchpad_control.dm"
 #include "code\game\machinery\computer\law.dm"
 #include "code\game\machinery\computer\medical.dm"

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -146,13 +146,16 @@ Class Procs:
 	/// Maximum time an EMP will disable this machine for
 	var/emp_disable_time = 2 MINUTES
 
-/obj/machinery/Initialize(mapload)
+/obj/machinery/Initialize(mapload, list/building_parts = null)
 	if(!armor)
 		armor = list(MELEE = 25,  BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 70, STAMINA = 0)
 	. = ..()
 	GLOB.machines += src
 
-	if(ispath(circuit, /obj/item/circuitboard))
+	if(building_parts)
+		InitializeOnMachineBuild(building_parts)
+		RefreshParts()
+	else if(ispath(circuit, /obj/item/circuitboard))
 		circuit = new circuit(src)
 		circuit.apply_default_parts(src)
 
@@ -166,6 +169,16 @@ Class Procs:
 		seller_department = dept_req_for_free
 
 	return INITIALIZE_HINT_LATELOAD
+
+/// This is important because every machine has different part component to store it to different variable when built when initialized
+/// but Init() proc can only handle the basic.
+/obj/machinery/proc/InitializeOnMachineBuild(list/building_parts)
+	component_parts = list()
+	for(var/atom/movable/each_part in building_parts)
+		each_part.forceMove(src)
+		component_parts += each_part
+		if(istype(each_part, /obj/item/circuitboard))
+			circuit = each_part
 
 /obj/machinery/proc/set_occupant(atom/movable/new_occupant)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -48,6 +48,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/hot_potato/harmless/toy = 1,
 		/obj/item/card/emagfake = 1,
 		/obj/item/disk/nuclear/fake/obvious = 1,
+		/obj/machinery/computer/fake = 1,
 		/obj/item/clothing/shoes/wheelys = 2,
 		/obj/item/clothing/shoes/kindleKicks = 2,
 		/obj/item/toy/plush/moth/random = 2,

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -110,44 +110,14 @@
 				P.play_tool_sound(src)
 				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
 
-				var/obj/machinery/new_machine = new circuit.build_path(loc)
+				var/obj/machinery/new_machine = new circuit.build_path(loc, src.contents)
 				new_machine.setDir(dir)
 				transfer_fingerprints_to(new_machine)
 
 				if(istype(new_machine, /obj/machinery/computer))
 					var/obj/machinery/computer/new_computer = new_machine
-
-					// Machines will init with a set of default components.
-					// Triggering handle_atom_del will make the machine realise it has lost a component_parts and then deconstruct.
-					// Move to nullspace so we don't trigger handle_atom_del, then qdel.
-					// Finally, replace new machine's parts with this frame's parts.
-					if(new_computer.circuit)
-						// Move to nullspace and delete.
-						new_computer.circuit.moveToNullspace()
-						QDEL_NULL(new_computer.circuit)
-					for(var/old_part in new_computer.component_parts)
-						var/atom/movable/movable_part = old_part
-						// Move to nullspace and delete.
-						movable_part.moveToNullspace()
-						qdel(movable_part)
-
-					// Set anchor state and move the frame's parts over to the new machine.
-					// Then refresh parts and call on_construction().
 					new_computer.anchored = anchored
-					new_computer.component_parts = list()
-
-					circuit.forceMove(new_computer)
-					new_computer.component_parts += circuit
-					new_computer.circuit = circuit
-
-					for(var/new_part in src)
-						var/atom/movable/movable_part = new_part
-						movable_part.forceMove(new_computer)
-						new_computer.component_parts += movable_part
-
-					new_computer.RefreshParts()
 					new_computer.on_construction()
-
 				qdel(src)
 				return
 	if(user.a_intent == INTENT_HARM)

--- a/code/game/machinery/computer/fake_toy_computer.dm
+++ b/code/game/machinery/computer/fake_toy_computer.dm
@@ -55,7 +55,7 @@
 	notify_silicon(user)
 
 /obj/machinery/computer/fake/proc/notify_silicon(mob/user)
-	to_chat(user, "<span class='notice'>After you tab the screen a few times, you notice it's not functional.</span>")
+	to_chat(user, "<span class='notice'>The computer doesn't return any signal. How abnormal.</span>")
 
 /obj/item/circuitboard/computer/fake
 	name = "DonkCo. Screenhonker"

--- a/code/game/machinery/computer/fake_toy_computer.dm
+++ b/code/game/machinery/computer/fake_toy_computer.dm
@@ -24,16 +24,9 @@
 	else
 		desc = initial(circuit_board.fake_preset.desc)
 
+	desc += " Oh, wait. It's just a screensaver."
+
 	update_icon()
-
-/obj/machinery/computer/fake/examine(mob/user)
-	. = ..()
-	if(get_dist(src, user) <= 2)
-		. += " Oh, wait. It's just a screensaver."
-
-/obj/machinery/computer/fake/interact(obj/item/C, mob/user)
-	. = ..()
-	to_chat(user, "<span class='notice'>After you tab the screen a few times, you notice it's not functional.</span>")
 
 /obj/machinery/computer/fake/attackby(obj/item/I, mob/user, params)
 	var/obj/item/circuitboard/computer/fake/circuit_board = circuit
@@ -42,6 +35,27 @@
 			update_fake()
 			return
 	..()
+
+/obj/machinery/computer/fake/attack_hand(mob/user)
+	. = ..()
+	if(.)
+		return
+	to_chat(user, "<span class='notice'>After you tab the screen a few times, you notice it's not functional.</span>")
+
+/obj/machinery/computer/fake/attack_ai(mob/user)
+	. = ..()
+	if(.)
+		return
+	notify_silicon(user)
+
+/obj/machinery/computer/fake/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
+	notify_silicon(user)
+
+/obj/machinery/computer/fake/proc/notify_silicon(mob/user)
+	to_chat(user, "<span class='notice'>After you tab the screen a few times, you notice it's not functional.</span>")
 
 /obj/item/circuitboard/computer/fake
 	name = "DonkCo. Screenhonker"

--- a/code/game/machinery/computer/fake_toy_computer.dm
+++ b/code/game/machinery/computer/fake_toy_computer.dm
@@ -1,0 +1,121 @@
+/obj/machinery/computer/fake
+	circuit = /obj/item/circuitboard/computer/fake
+
+/obj/machinery/computer/fake/Initialize(mapload)
+	. = ..()
+	update_fake()
+
+/obj/machinery/computer/fake/proc/update_fake()
+	var/obj/item/circuitboard/computer/fake/circuit_board = circuit
+	smoothing_flags = initial(circuit_board.fake_preset.smoothing_flags)
+	if(!initial(circuit_board.fake_preset.smoothing_groups))
+		smoothing_groups = null
+	icon = initial(circuit_board.fake_preset.icon)
+	icon_state = initial(circuit_board.fake_preset.icon_state)
+	base_icon_state = initial(circuit_board.fake_preset.base_icon_state)
+	icon_screen = initial(circuit_board.fake_preset.icon_screen)
+	icon_keyboard = initial(circuit_board.fake_preset.icon_keyboard)
+	if(circuit_board.fake_name)
+		name = circuit_board.fake_name
+	else
+		name = initial(circuit_board.fake_preset.name)
+	if(circuit_board.fake_desc)
+		desc = circuit_board.fake_desc
+	else
+		desc = initial(circuit_board.fake_preset.desc)
+
+	update_icon()
+
+/obj/machinery/computer/fake/examine(mob/user)
+	. = ..()
+	if(get_dist(src, user) <= 2)
+		. += " Oh, wait. It's just a screensaver."
+
+/obj/machinery/computer/fake/interact(obj/item/C, mob/user)
+	. = ..()
+	to_chat(user, "<span class='notice'>After you tab the screen a few times, you notice it's not functional.</span>")
+
+/obj/machinery/computer/fake/attackby(obj/item/I, mob/user, params)
+	var/obj/item/circuitboard/computer/fake/circuit_board = circuit
+	if(I.tool_behaviour == TOOL_MULTITOOL) // kinda QoL. Deconstruction is pain
+		if(circuit_board.adjust_fake_info(user))
+			update_fake()
+			return
+	..()
+
+/obj/item/circuitboard/computer/fake
+	name = "DonkCo. Screenhonker"
+	desc = "This computer circuit only serves a purpose of a screensaver. You can adjust it with a multitool."
+
+	var/fake_name
+	var/fake_desc
+	var/obj/machinery/computer/fake_preset = /obj/machinery/computer/upload/ai // funny default
+
+	var/static/list/available_list
+	var/static/list/blacklist // not really blacklist. Some computers are a bit glitchy
+
+	build_path = /obj/machinery/computer/fake
+
+/obj/item/circuitboard/computer/fake/Initialize(mapload)
+	. = ..()
+
+	if(!blacklist)
+		blacklist = typecacheof(list(
+			/obj/machinery/computer/fake,
+			/obj/machinery/computer/upload, // subtype whitelisted
+			/obj/machinery/computer/arcade,
+			/obj/machinery/computer/arcade/orion_trail/kobayashi,
+
+		), only_root_path = TRUE)
+
+	if(!available_list)
+		available_list = list()
+		for(var/obj/machinery/computer/each_computer as anything in subtypesof(/obj/machinery/computer))
+			if(!initial(each_computer.name) \
+				|| !initial(each_computer.desc) \
+				|| !initial(each_computer.icon_screen) \
+				|| is_type_in_typecache(each_computer, blacklist))
+				continue
+			var/actual_key = "[initial(each_computer.name)] ([each_computer])"
+			available_list[actual_key] = each_computer
+
+/obj/item/circuitboard/computer/fake/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_MULTITOOL)
+		adjust_fake_info(user)
+	. = ..()
+
+/obj/item/circuitboard/computer/fake/proc/adjust_fake_info(mob/user)
+	var/taken_action = input("Select options", "Multitool toying") as null|anything in list("Get a preset", "Change name", "Change desc", "Reset name and desc")
+	if(!taken_action)
+		return
+
+	switch(taken_action)
+		if("Get a preset")
+			var/chosen_circuit = tgui_input_list(user, "Preset circuits", "Multitool toying", available_list)
+			if(!chosen_circuit)
+				return
+			fake_preset = available_list[chosen_circuit]
+			to_chat(user, "<span class='notice'>You have set the fake preset of the circuit as [chosen_circuit].</span>")
+			return TRUE
+
+		if("Change name")
+			fake_name = stripped_input(user, "Fake name:", "Put a fake name", "", MAX_NAME_LEN)
+			if(OOC_FILTER_CHECK(fake_name))
+				to_chat(user, "<span class='warning'>Your input contains prohibited word(s)!</span>")
+				return
+			to_chat(user, "<span class='notice'>You have set the fake name of the circuit.</span>")
+			return TRUE
+
+		if("Change desc")
+			fake_desc = stripped_input(user, "Fake desc:", "Put a fake description", "", MAX_MESSAGE_LEN)
+			if(OOC_FILTER_CHECK(fake_desc))
+				to_chat(user, "<span class='warning'>Your input contains prohibited word(s)!</span>")
+				return
+			to_chat(user, "<span class='notice'>You have set the fake description of the circuit.</span>")
+			return TRUE
+
+		if("Reset name and desc")
+			fake_name = null
+			fake_desc = null
+			to_chat(user, "<span class='notice'>You have reset the fake name and description of the circuit.</span>")
+			return TRUE

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -179,34 +179,9 @@
 						break
 				if(component_check)
 					P.play_tool_sound(src)
-					var/obj/machinery/new_machine = new circuit.build_path(loc)
+					var/obj/machinery/new_machine = new circuit.build_path(loc, src.contents)
 					if(istype(new_machine))
-						// Machines will init with a set of default components. Move to nullspace so we don't trigger handle_atom_del, then qdel.
-						// Finally, replace with this frame's parts.
-						if(new_machine.circuit)
-							// Move to nullspace and delete.
-							new_machine.circuit.moveToNullspace()
-							QDEL_NULL(new_machine.circuit)
-						for(var/obj/old_part in new_machine.component_parts)
-							// Move to nullspace and delete.
-							old_part.moveToNullspace()
-							qdel(old_part)
-
-						// Set anchor state and move the frame's parts over to the new machine.
-						// Then refresh parts and call on_construction().
-
 						new_machine.anchored = anchored
-						new_machine.component_parts = list()
-
-						circuit.forceMove(new_machine)
-						new_machine.component_parts += circuit
-						new_machine.circuit = circuit
-
-						for(var/obj/new_part in src)
-							new_part.forceMove(new_machine)
-							new_machine.component_parts += new_part
-						new_machine.RefreshParts()
-
 						new_machine.on_construction()
 					qdel(src)
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Minor refactor to machine construction
* When a machine(computer) is Initialized, it makes new parts regardless it's made by a player. Making new parts isn't necessary. Also, this makes machines to refer circuit data during initialized.

Fake Computer Toy
* just clowning tool. Available from Arcade randomly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Refactor good. fooling people around is good too.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d24fd247-6cd2-433e-a602-8d04fd27f7e2)

machine construction is fine

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d64a5079-0b55-4932-8076-db53d33162b2)

fake computer

## Changelog
:cl:
code: Machines (and computers) will not needlessly create parts and circuit at Initialized() when it's made by a player.
add: Fake computer circuit board. Available from Arcade rewards. Use multitool to adjust the fake info.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
