### PR TITLE
Fixes GetComponents() returning a list with a null entry when there's no component of a given type

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -214,12 +214,10 @@
 	return null
 
 /datum/proc/GetComponents(c_type)
-	var/list/dc = datum_components
-	if(!dc)
-		return null
-	. = dc[c_type]
-	if(!length(.))
-		return list(.)
+	var/list/components = datum_components?[c_type]
+	if(!components)
+		return list()
+	return islist(components) ? components : list(components)
 
 /datum/proc/_AddComponent(list/raw_args)
 	var/new_type = raw_args[1]


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/61267

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title

closes #10149 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a runtime that occurs EVERY time when a client takes control of a mob or observer

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Epico](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/75553cf7-b597-45bc-8f60-b7f06799e73e)


</details>

## Changelog
:cl: rkz, Ghommie
server: Fixes GetComponents() returning a list with a null entry when there's no component of a given type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
