### PR TITLE
Tweaks to observers and ghost antags

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -138,9 +138,13 @@
 		if(!length(candidates))
 			break
 		var/mob/applicant = pick(candidates)
-		// 50% chance to reroll the candidate, anti observermain action
-		if(isobserver(applicant)&&prob(50))
+
+		var/depth_counter
+		while(isobserver(applicant)&&prob(50)&&depth_counter<10)
+			// 50% chance to reroll the candidate, anti observermain action
 			applicant = pick(candidates)
+			depth_counter +=1
+
 		candidates -= applicant
 		if(!isobserver(applicant))
 			if(applicant.stat == DEAD) // Not an observer? If they're dead, make them one.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -138,6 +138,9 @@
 		if(!length(candidates))
 			break
 		var/mob/applicant = pick(candidates)
+		// 50% chance to reroll the candidate, anti observermain action
+		if(isobserver(applicant)&&prob(50))
+			applicant = pick(candidates)
 		candidates -= applicant
 		if(!isobserver(applicant))
 			if(applicant.stat == DEAD) // Not an observer? If they're dead, make them one.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it less likely for observers (not dead people) to roll ghost antags by rerolling the picked person on a 50% chance (subject to change) if they're an observer. 

## Why It's Good For The Game

Currently there's a group of people who observe since roundstart to roll ghost antagonists exclusively. These roles are made to make round removal matter less to players, and having people hog those rolls by observing kind of defeats the purpose

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

One line change that I cannot test

## Changelog
:cl:
tweak: Made it less likely for observers (not dead people) to roll a ghost antag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
