### PR TITLE
KiloSatation service maintenance access fix + Addition of windows in the protolathe room

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15315,7 +15315,7 @@
 /area/space/nearstation)
 "bib" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "25;26;35;28;22;37;46;38"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15411,7 +15411,6 @@
 	dir = 4
 	},
 /obj/structure/grille/broken,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -15420,6 +15419,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "biq" = (
@@ -25013,7 +25013,7 @@
 /area/hallway/primary/starboard)
 "bVl" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "25;26;35;28;22;37;46"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -64136,6 +64136,10 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel,
 /area/security/warden)
+"nbl" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "nbw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -123800,7 +123804,7 @@ vHs
 hrM
 ajt
 bic
-aox
+bpq
 apX
 aox
 aox
@@ -124057,7 +124061,7 @@ boT
 beM
 bhd
 bie
-bpq
+nbl
 aHX
 bsk
 tOa
@@ -124314,11 +124318,11 @@ hUV
 beN
 afd
 bij
-apX
 bqb
+nbl
 bsl
+nbl
 aIN
-aox
 bvZ
 bAB
 apA

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15315,7 +15315,7 @@
 /area/space/nearstation)
 "bib" = (
 /obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "25;26;35;28;22;37;46;38"
+	req_one_access_txt = "12;25;26;35;28;22;37;46;38"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -25013,7 +25013,7 @@
 /area/hallway/primary/starboard)
 "bVl" = (
 /obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "25;26;35;28;22;37;46"
+	req_one_access_txt = "12;25;26;35;28;22;37;46"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -124061,7 +124061,7 @@ boT
 beM
 bhd
 bie
-nbl
+aox
 aHX
 bsk
 tOa


### PR DESCRIPTION
## About The Pull Request

Fixes the access in these doors.  Now all service members have access to the 2 doors above the protolathe. Also the protolathe have 2 windows around the door,

![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/92889d1d-a027-4dd8-bfb2-b474948843ab)


## Why It's Good For The Game
Service people should be able to access service maintenance.  Currently, no one in service can open the these doors. clowns and mimes have access to the maintenance connected to their theatre, but they don't have access to anything inside of it. Bartenders , clowns and mimes can't access the protolathe. So giving the access to the door fixes all of this.  The windows help the protolathe to be seen from outside so people unfamiliar with the layout can see it.

## Testing Photographs and Procedure

![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/ac205fc8-8c43-41eb-80e2-1002ea7667e4)
![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/2a712f89-4739-4eee-835e-7fbd979b954e)

This next image of testing is outdated. The upper window is no longer there, so you wouldn't see through there, to help kilo theme of feeling cramped stay in this room too
![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/23ff5535-96c7-4cb0-82df-2341e9ec9874)

![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/17f0127c-f543-4718-b7b2-6121c9ab96f6)

</details>

## Changelog
:cl: Varo
tweak:[KiloStation] Adds windows to service protolathe room, gives service people actual access to service maintenance
/:cl:

