### PR TITLE
Adminsay color is now choices instead of color pick

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -88,17 +88,57 @@
 #define COLOR_ASSEMBLY_BLUE    "#38559E"
 #define COLOR_ASSEMBLY_PURPLE  "#6F6192"
 
+
 // check "chat-light-theme.scss" and "chat-dark-theme.scss"
+#define CFC_RED "cfc_red"
+#define CFC_REDORANGE "cfc_redorange"
+#define CFC_ORANGE "cfc_orange"
+#define CFC_YELLOW "cfc_yellow"
+#define CFC_LIME "cfc_lime"
+#define CFC_GREEN "cfc_green"
+#define CFC_CYAN "cfc_cyan"
+#define CFC_BLUESKY "cfc_bluesky"
+#define CFC_DARKBLUESKY "cfc_darkbluesky"
+#define CFC_NAVY "cfc_navy"
+#define CFC_BLUE "cfc_blue"
+#define CFC_INDIGO "cfc_indigo"
+#define CFC_PURPLE "cfc_purple"
+#define CFC_VIOLET "cfc_violet"
+#define CFC_MAGENTA "cfc_magenta"
+#define CFC_REDPURPLE "cfc_redpurple"
+
 GLOBAL_LIST_INIT(color_list_blood_brothers, shuffle(list(
-	"cfc_red",\
-	"cfc_purple",\
-	"cfc_navy",\
-	"cfc_darkbluesky",\
-	"cfc_bluesky",\
-	"cfc_cyan",\
-	"cfc_lime",\
-	"cfc_orange",\
-	"cfc_redorange")))
+	CFC_RED,\
+	CFC_PURPLE,\
+	CFC_NAVY,\
+	CFC_DARKBLUESKY,\
+	CFC_BLUESKY,\
+	CFC_CYAN,\
+	CFC_LIME,\
+	CFC_ORANGE,\
+	CFC_REDORANGE)))
+
+GLOBAL_LIST_INIT(color_list_full_cfc, list(
+	CFC_RED,\
+	CFC_REDORANGE,\
+	CFC_ORANGE,\
+	CFC_YELLOW,\
+	CFC_LIME,\
+	CFC_GREEN,\
+	CFC_CYAN,\
+	CFC_BLUESKY,\
+	CFC_DARKBLUESKY,\
+	CFC_NAVY,\
+	CFC_BLUE,\
+	CFC_INDIGO,\
+	CFC_PURPLE,\
+	CFC_VIOLET,\
+	CFC_MAGENTA,\
+	CFC_REDPURPLE
+))
+
+/// The default color for admin say, used as a fallback when the preference is not enabled
+#define DEFAULT_ASAY_COLOR CFC_RED
 
 // Color Filters
 /// Icon filter that creates ambient occlusion
@@ -106,8 +146,6 @@ GLOBAL_LIST_INIT(color_list_blood_brothers, shuffle(list(
 /// Icon filter that creates gaussian blur
 #define GAUSSIAN_BLUR(filter_size) filter(type="blur", size=filter_size)
 
-/// The default color for admin say, used as a fallback when the preference is not enabled
-#define DEFAULT_ASAY_COLOR "#FF4500"
 /// The default color for Byond Member / ADMIN OOC, used as a fallback when the preference is not enabled
 #define DEFAULT_BONUS_OOC_COLOR "#c43b23"
 

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "headset"
 	/// BB implant colour is different per team, and is set by brother antag datum
-	var/span_implant_colour = "cfc_redpurple"
+	var/span_implant_colour = CFC_REDPURPLE
 	var/list/linked_implants // All other implants that this communicates to
 
 /obj/item/implant/bloodbrother/Initialize(mapload)

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -16,9 +16,8 @@
 	mob.log_talk(msg, LOG_ASAY)
 	msg = keywords_lookup(msg)
 
-	var/asay_color_pref = (CONFIG_GET(flag/allow_admin_asaycolor) && prefs.read_player_preference(/datum/preference/choiced/asay_color)) || DEFAULT_ASAY_COLOR
-	var/asay_cfc_format = asay_color_pref
-	msg = "<span class='adminsay'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='[asay_cfc_format] message linkify'>[msg]</span>"
+	var/cfc_adminsay = (CONFIG_GET(flag/allow_admin_asaycolor) && prefs.read_player_preference(/datum/preference/choiced/asay_color)) || DEFAULT_ASAY_COLOR
+	msg = "<span class='adminsay'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='[cfc_adminsay] message linkify'>[msg]</span>"
 	to_chat(GLOB.admins, msg, allow_linkify = TRUE, type = MESSAGE_TYPE_ADMINCHAT)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Asay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -15,9 +15,10 @@
 
 	mob.log_talk(msg, LOG_ASAY)
 	msg = keywords_lookup(msg)
-	var/asay_color = prefs.read_player_preference(/datum/preference/color/asay_color)
-	var/custom_asay_color = (CONFIG_GET(flag/allow_admin_asaycolor) && asay_color) ? "<font color=[asay_color]>" : "<font color='[DEFAULT_ASAY_COLOR]'>"
-	msg = "<span class='adminsay'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: [custom_asay_color]<span class='message linkify'>[msg]</span></span>[custom_asay_color ? "</font>":null]"
+
+	var/asay_color_pref = (CONFIG_GET(flag/allow_admin_asaycolor) && prefs.read_player_preference(/datum/preference/choiced/asay_color)) || DEFAULT_ASAY_COLOR
+	var/asay_cfc_format = asay_color_pref
+	msg = "<span class='adminsay'><span class='prefix'>ADMIN:</span> <EM>[key_name(usr, 1)]</EM> [ADMIN_FLW(mob)]: <span class='[asay_cfc_format] message linkify'>[msg]</span>"
 	to_chat(GLOB.admins, msg, allow_linkify = TRUE, type = MESSAGE_TYPE_ADMINCHAT)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Asay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -77,7 +77,7 @@
 	if(team.team_id <= length(GLOB.color_list_blood_brothers))
 		I.span_implant_colour = GLOB.color_list_blood_brothers[team.team_id]
 	else
-		I.span_implant_colour = "cfc_redpurple"
+		I.span_implant_colour = CFC_REDPURPLE
 		stack_trace("Blood brother teams exist more than [length(GLOB.color_list_blood_brothers)] teams, and colour preset is ran out")
 	for(var/datum/mind/M in team.members) // Link the implants of all team members
 		var/obj/item/implant/bloodbrother/T = locate() in M.current.implants

--- a/code/modules/client/preferences/entries/player/admin.dm
+++ b/code/modules/client/preferences/entries/player/admin.dm
@@ -1,16 +1,22 @@
-/datum/preference/color/asay_color
+/datum/preference/choiced/asay_color
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	db_key = "asaycolor"
 	preference_type = PREFERENCE_PLAYER
 
-/datum/preference/color/asay_color/create_default_value()
+/datum/preference/choiced/asay_color/create_default_value()
 	return DEFAULT_ASAY_COLOR
 
-/datum/preference/color/asay_color/is_accessible(datum/preferences/preferences, ignore_page = FALSE)
+/datum/preference/choiced/asay_color/init_possible_values()
+	return GLOB.color_list_full_cfc
+
+/datum/preference/choiced/asay_color/is_accessible(datum/preferences/preferences, ignore_page = FALSE)
 	if (!..())
 		return FALSE
 
 	return is_admin(preferences.parent) && CONFIG_GET(flag/allow_admin_asaycolor)
+
+/datum/preference/choiced/asay_color/is_valid(value)
+	return (value in GLOB.color_list_full_cfc)
 
 /datum/preference/toggle/announce_login
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -105,8 +105,12 @@ export const CheckboxInputInverse = (props: FeatureValueProps<BooleanLike, boole
 export const createDropdownInput = <T extends string | number = string>(
   // Map of value to display texts
   choices: Record<T, InfernoNode>,
-  dropdownProps?: DropdownOptionalProps
+  dropdownProps?: DropdownOptionalProps,
+  noSort?: boolean // snowflake flag to stop sorting choices alphabetically
 ): FeatureValue<T> => {
+  const getSortedChoices = (sortableChoices) => {
+    return noSort ? Object.entries(sortableChoices) : sortChoices(Object.entries(sortableChoices));
+  };
   return (props: FeatureValueProps<T>) => {
     return (
       <Dropdown
@@ -114,7 +118,7 @@ export const createDropdownInput = <T extends string | number = string>(
         displayText={choices[props.value]}
         onSelected={props.handleSetValue}
         width="100%"
-        options={sortChoices(Object.entries(choices)).map(([dataValue, label]) => {
+        options={getSortedChoices(choices).map(([dataValue, label]) => {
           return {
             displayText: label,
             value: dataValue,

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -1,11 +1,34 @@
-import { FeatureColorInput, Feature, FeatureToggle, CheckboxInput } from '../base';
+import { createDropdownInput, Feature, FeatureToggle, CheckboxInput } from '../base';
 
 export const asaycolor: Feature<string> = {
   name: 'Admin chat color',
   category: 'ADMIN',
   subcategory: 'Chat',
   description: 'The color of your messages in Adminsay.',
-  component: FeatureColorInput,
+  component: createDropdownInput(
+    {
+      cfc_red: 'Red',
+      cfc_redorange: 'Redorange',
+      cfc_orange: 'Orange',
+      cfc_yellow: 'Yellow',
+      cfc_lime: 'Lime',
+      cfc_green: 'Green',
+      cfc_cyan: 'Cyan',
+      cfc_bluesky: 'Bluesky',
+      cfc_darkbluesky: 'Dark Bluesky',
+      cfc_navy: 'Navy',
+      cfc_blue: 'Blue',
+      cfc_indigo: 'Indigo',
+      cfc_purple: 'Purple',
+      cfc_violet: 'Violet',
+      cfc_magenta: 'Magenta',
+      cfc_redpurple: 'Redpurple', // pain. manual addition is innevitable
+    },
+    {
+      buttons: true,
+    },
+    true // snowflake flag to stop sorting choices alphabetically
+  ),
 };
 
 export const announce_login: FeatureToggle = {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adminsay color is now choices instead of color pick
* closes #10159
* a player chat color pick is bad. chat color should be standised.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bad chat readability bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/79898096-ee4e-42c9-b736-8112eceac3ed)


## Changelog
:cl:
code: Adminsay color is now choices instead of color pick
code: added cfc color defines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
