### PR TITLE
optimises /obj/effect

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -39,6 +39,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PREVENT_CONTENTS_EXPLOSION_1 (1<<16)
 #define UNPAINTABLE_1 				(1<<17)
 #define HTML_USE_INITAL_ICON_1		(1<<18) 			//! Should we use the initial icon for display? Mostly used by overlay only objects
+#define OPTIMIZE_NECESSARY_1		(1<<19)		//! This is used to prevent new() of list or datum from an atom. i.e.) obj/effect don't need armor datum   (note: not necessary to "DEFINE_BITFIELD flags_1")
 
 /// If the thing can reflect light (lasers/energy)
 #define RICOCHET_SHINY			(1<<0)

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -64,3 +64,19 @@
 /// Flags for the pod_flags var on /obj/structure/closet/supplypod
 
 #define FIRST_SOUNDS (1<<0) // If it shouldn't play sounds the first time it lands, used for reverse mode
+
+
+/// this isn't really a bitflag define, but it's used to help when an object doesn't have to have those variables...
+#define BRAINDEAD_OBJECT_OPTIMIZATION\
+	flags_1 = OPTIMIZE_NECESSARY_1\
+	damtype = null\
+	req_access_txt = null\
+	req_one_access_txt = null\
+	verb_ask = null\
+	verb_exclaim = null\
+	verb_say = null\
+	verb_sing = null\
+	verb_whisper = null\
+	verb_yell = null\
+	speech_span = null\
+	initial_language_holder = null\

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -68,15 +68,15 @@
 
 /// this isn't really a bitflag define, but it's used to help when an object doesn't have to have those variables...
 #define BRAINDEAD_OBJECT_OPTIMIZATION\
-	flags_1 = OPTIMIZE_NECESSARY_1\
-	damtype = null\
-	req_access_txt = null\
-	req_one_access_txt = null\
-	verb_ask = null\
-	verb_exclaim = null\
-	verb_say = null\
-	verb_sing = null\
-	verb_whisper = null\
-	verb_yell = null\
-	speech_span = null\
-	initial_language_holder = null\
+	flags_1 = OPTIMIZE_NECESSARY_1;\
+	damtype = null;\
+	req_access_txt = null;\
+	req_one_access_txt = null;\
+	verb_ask = null;\
+	verb_exclaim = null;\
+	verb_say = null;\
+	verb_sing = null;\
+	verb_whisper = null;\
+	verb_yell = null;\
+	speech_span = null;\
+	initial_language_holder = null;

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -64,19 +64,3 @@
 /// Flags for the pod_flags var on /obj/structure/closet/supplypod
 
 #define FIRST_SOUNDS (1<<0) // If it shouldn't play sounds the first time it lands, used for reverse mode
-
-
-/// this isn't really a bitflag define, but it's used to help when an object doesn't have to have those variables...
-#define BRAINDEAD_OBJECT_OPTIMIZATION\
-	flags_1 = OPTIMIZE_NECESSARY_1;\
-	damtype = null;\
-	req_access_txt = null;\
-	req_one_access_txt = null;\
-	verb_ask = null;\
-	verb_exclaim = null;\
-	verb_say = null;\
-	verb_sing = null;\
-	verb_whisper = null;\
-	verb_yell = null;\
-	speech_span = null;\
-	initial_language_holder = null;

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -9,8 +9,20 @@
 	vis_flags = VIS_INHERIT_PLANE
 	var/forensic_protected = FALSE
 
-	// these shouldn't exist to effects
-	BRAINDEAD_OBJECT_OPTIMIZATION
+	// effects don't need this.
+	// There might be more to include, but for now, these are safe to be null
+	flags_1 = OPTIMIZE_NECESSARY_1
+	damtype = null
+	req_access_txt = null
+	req_one_access_txt = null
+	verb_ask = null
+	verb_exclaim = null
+	verb_say = null
+	verb_sing = null
+	verb_whisper = null
+	verb_yell = null
+	speech_span = null
+	initial_language_holder = null
 
 /obj/effect/attackby(obj/item/weapon, mob/user, params)
 	if(SEND_SIGNAL(weapon, COMSIG_ITEM_ATTACK_EFFECT, src, user, params) & COMPONENT_NO_AFTERATTACK)

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -9,6 +9,9 @@
 	vis_flags = VIS_INHERIT_PLANE
 	var/forensic_protected = FALSE
 
+	// these shouldn't exist to effects
+	BRAINDEAD_OBJECT_OPTIMIZATION
+
 /obj/effect/attackby(obj/item/weapon, mob/user, params)
 	if(SEND_SIGNAL(weapon, COMSIG_ITEM_ATTACK_EFFECT, src, user, params) & COMPONENT_NO_AFTERATTACK)
 		return TRUE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -67,12 +67,13 @@
 
 /obj/Initialize(mapload)
 	. = ..()
-	if (islist(armor))
-		armor = getArmor(arglist(armor))
-	else if (!armor)
-		armor = getArmor()
-	else if (!istype(armor, /datum/armor))
-		stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize()")
+	if(!(flags_1 & OPTIMIZE_NECESSARY_1)) // an obj shouldn't get this...
+		if (islist(armor))
+			armor = getArmor(arglist(armor))
+		else if (!armor)
+			armor = getArmor()
+		else if (!istype(armor, /datum/armor))
+			stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize()")
 
 	if(obj_integrity == null)
 		obj_integrity = max_integrity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
optimises /obj/effect
It creates unnecessary data when it's initialized. We really don't need armor to `/obj/effect` right?
If it somehow happens to use it, then you just need to remove the bitflag `OPTIMIZE_NECESSARY_1`
(This bitflag will be useful in the future.)

There might be more unused variables, but for now, I'd like to put those to be safe from runtime perhaps...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
optimisation good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/a0121bac-6204-4af7-a6e4-24154d64b59f)

Both cases created 65000 objects.
Obviously the bottom one is faster.


Also, I did some fuckery on metastation, and it didn't throw any runtime.

## Changelog
:cl:
code: optimized /obj/effect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
