### PR TITLE
makes `/turm/var/armor_generated = null` for optimisation

### DIFF
--- a/code/game/turfs/turf_integrity.dm
+++ b/code/game/turfs/turf_integrity.dm
@@ -8,7 +8,7 @@
 	/// Can this turf be hit by players?
 	var/can_hit = TRUE
 	/// Has armour been generated yet?
-	var/armor_generated = FALSE
+	var/armor_generated
 	/// The armour of the turf. Capable of being null for optimisation purposes
 	var/datum/armor/armor
 	/// The integrity that the turf starts at, defaulting to max_integrity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes /turm/var/armor_generated = null

the variable was introduced by:
* #9503

The PR was near perfect except that `armor_generated  = FALSE` means you're assigning a value to the variable. The variable has no different from between null and FALSE. It's better to be null because it can save a very little time to assign a value when it's newly created.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
optimisation
This will help to initialise turfs very little

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
It's var change.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/45e2972c-9496-44b1-bced-c3564e7ad5c4)

It has very a few place to check, so it's fine to be null
compile is fine.

## Changelog
:cl:
code: optimised /turf/var/armor_generated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
