### PR TITLE
Fixes the write component

### DIFF
--- a/code/modules/wiremod/components/list/write.dm
+++ b/code/modules/wiremod/components/list/write.dm
@@ -15,6 +15,7 @@
 	output_port_type = PORT_TYPE_LIST
 
 /obj/item/circuit_component/indexer/write/populate_ports()
+	. = ..()
 	value_port = add_input_port("Value", PORT_TYPE_ANY)
 
 /obj/item/circuit_component/indexer/write/Destroy()
@@ -22,7 +23,6 @@
 	return ..()
 
 /obj/item/circuit_component/indexer/write/calculate_output(var/index, var/list/list_input)
-
 	list_input[index] = islist(value_port.value) ? null : value_port.value
 	output.set_output(list_input)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Readds a single line of code to let the wiremod write to list component able to write to lists again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Restores functionality to a component that was broken.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing video</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/51838176/e8a05702-cc93-4502-a672-66da13b8c0f0


Write component changing values in a list.

</details>

## Changelog
:cl:
fix: The wiremod write component has been given the proper ports to function again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
