### PR TITLE
Tracking implant nerfs + fixes

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -170,17 +170,6 @@
 			else
 				var/area/area = get_area(beacon)
 				targets[avoid_assoc_duplicate_keys(area.name, area_index)] = beacon
-
-		for (var/obj/item/implant/tracking/tracking_implant in GLOB.tracked_implants)
-			if (!tracking_implant.imp_in || !isliving(tracking_implant.loc) || !tracking_implant.allow_teleport)
-				continue
-
-			var/mob/living/implanted = tracking_implant.loc
-			if (implanted.stat == DEAD && implanted.timeofdeath + tracking_implant.lifespan_postmortem < world.time)
-				continue
-
-			if (is_eligible(tracking_implant))
-				targets[avoid_assoc_duplicate_keys("[implanted.real_name] ([get_area(implanted)])", area_index)] = tracking_implant
 	else
 		for (var/obj/machinery/teleport/station/station as anything in power_station.linked_stations)
 			if (is_eligible(station) && station.teleporter_hub)
@@ -213,17 +202,6 @@
 				else
 					var/area/A = get_area(R)
 					L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
-
-		for(var/obj/item/implant/tracking/I in GLOB.tracked_implants)
-			if(!I.imp_in || !isliving(I.loc) || !I.allow_teleport)
-				continue
-			else
-				var/mob/living/M = I.loc
-				if(M.stat == DEAD)
-					if(M.timeofdeath + I.lifespan_postmortem < world.time)
-						continue
-				if(is_eligible(I))
-					L[avoid_assoc_duplicate_keys("[M.real_name] ([get_area(M)])", areaindex)] = I
 
 		var/desc = input("Please select a location to lock in.", "Locking Computer") as null|anything in sort_list(L)
 		target_ref = WEAKREF(L[desc])

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -3,34 +3,47 @@
 	desc = "Track with this."
 	activated = FALSE
 	///for how many deciseconds after user death will the implant work?
-	var/lifespan_postmortem = 6000
-	///will people implanted with this act as teleporter beacons?
-	var/allow_teleport = TRUE
+	var/lifespan_postmortem = 10 MINUTES
 	///The id of the timer that's qdeleting us
-	var/timerid
+	var/deletion_timer
+
+/obj/item/implant/tracking/Initialize()
+	. = ..()
+	GLOB.tracked_implants += src
+
+/obj/item/implant/tracking/Destroy()
+	deltimer(deletion_timer)
+	GLOB.tracked_implants -= src
+	return ..()
+
+/obj/item/implant/tracking/on_implanted(mob/living/user)
+	. = ..()
+	if(!istype(user) || !lifespan_postmortem)
+		return
+	RegisterSignal(user, COMSIG_LIVING_REVIVE, PROC_REF(on_user_revive))
+
+/obj/item/implant/tracking/removed(mob/living/source, silent, special)
+	. = ..()
+	UnregisterSignal(source, COMSIG_LIVING_REVIVE)
+
+/obj/item/implant/tracking/on_mob_death()
+	if(!deletion_timer && lifespan_postmortem)
+		deletion_timer = QDEL_IN(src, lifespan_postmortem)
+
+/obj/item/implant/tracking/proc/on_user_revive(full_heal, admin_revive)
+	SIGNAL_HANDLER
+	deltimer(deletion_timer)
+	deletion_timer = null
 
 /obj/item/implant/tracking/c38
 	name = "TRAC implant"
 	desc = "A smaller tracking implant that supplies power for only a few minutes."
-	var/lifespan = 3000 //how many deciseconds does the implant last?
-	allow_teleport = FALSE
+	lifespan_postmortem = null
+	var/lifespan = 5 MINUTES //how many deciseconds does the implant last?
 
-/obj/item/implant/tracking/c38/Initialize(mapload)
+/obj/item/implant/tracking/c38/Initialize()
 	. = ..()
-	timerid = QDEL_IN(src, lifespan)
-
-/obj/item/implant/tracking/c38/Destroy()
-	deltimer(timerid)
-	return ..()
-
-/obj/item/implant/tracking/New()
-	..()
-	GLOB.tracked_implants += src
-
-/obj/item/implant/tracking/Destroy()
-	. = ..()
-	GLOB.tracked_implants -= src
-
+	deletion_timer = QDEL_IN(src, lifespan)
 /obj/item/implanter/tracking
 	imp_type = /obj/item/implant/tracking
 
@@ -41,7 +54,6 @@
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Tracking Beacon<BR>
 				<b>Life:</b> 10 minutes after death of host.<BR>
-				<b>Important Notes:</b> Implant also works as a teleporter beacon.<BR>
 				<HR>
 				<b>Implant Details:</b> <BR>
 				<b>Function:</b> Continuously transmits low power signal. Useful for tracking.<BR>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes tracking implants not dissolving post-death, and removes the built-in teleporter beacon that they have.

## Why It's Good For The Game

Well, it's always said it decayed 10 minutes after death, but that was seemingly _never implemented_.

Also, a tracking implant is effectively _game over_ for antags, as now sec has the ability to just teleport an armed militia on top of you at any moment, without warning, and instakill you with a shotgun.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-11-19-1700451163-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/7390dfc1-33a6-43ea-b10d-0495355e3e6d)
![23-11-19-1700451189-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ca3b20d0-ef81-44bf-b73a-bda7c949551d)
![23-11-19-1700451193-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/1167ce50-335d-4fa4-8c74-27fb1f126bff)
![23-11-19-1700451565-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/114b055e-44af-4294-bdcc-0afd97e171e4)
![23-11-19-1700451577-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/4e0a77da-8037-48ed-bb1f-c89d94aff5b7)

</details>

## Changelog
:cl:
fix: Tracking implants now actually dissolve 10 minutes after death like they're supposed to.
balance: Removed the teleporter beacon from tracking implants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
