### PR TITLE
Revert "Fixes GetComponents() returning a list with a null entry when there's no component of a given type"

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -214,10 +214,12 @@
 	return null
 
 /datum/proc/GetComponents(c_type)
-	var/list/components = datum_components?[c_type]
-	if(!components)
-		return list()
-	return islist(components) ? components : list(components)
+	var/list/dc = datum_components
+	if(!dc)
+		return null
+	. = dc[c_type]
+	if(!length(.))
+		return list(.)
 
 /datum/proc/_AddComponent(list/raw_args)
 	var/new_type = raw_args[1]


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#10150

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/c5ce4c11-0f97-4504-9e57-1b03fd087a3a)

This appears to be the source of +60k runtimes every round. After this was merged, kibana has recieved runtime spikes.
The runtime started after the round 46622 since the first reports were from round 46623

> https://discord.com/channels/427337870844362753/943643394658402354/1174535876626350123

Right before this round, there was a PR merged, and luckily there was only one PR that was merged at the whole day.



:cl:
code: Revert "Fixes GetComponents() returning a list with a null entry when there's no component of a given type" #10150
/:cl: