### PR TITLE
Fixes a moved relay bug

### DIFF
--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -33,7 +33,7 @@
 	var/datum/component/moved_relay/move_relay = associated_relay
 	move_relay.depth --
 	if (move_relay.depth == 0)
-		move_relay.RemoveComponent()
+		qdel(moved_relay)
 		associated_relay = null
 
 /datum/component/jam_receiver/proc/on_move(...)

--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -33,7 +33,7 @@
 	var/datum/component/moved_relay/move_relay = associated_relay
 	move_relay.depth --
 	if (move_relay.depth == 0)
-		qdel(moved_relay)
+		qdel(move_relay)
 		associated_relay = null
 
 /datum/component/jam_receiver/proc/on_move(...)

--- a/code/datums/components/moved_relay.dm
+++ b/code/datums/components/moved_relay.dm
@@ -75,7 +75,7 @@
 	if (!position)
 		return
 	ordered_parents -= A
-	if (position == length(ordered_parents))
+	if (position >= length(ordered_parents))
 		return
 	var/atom/next = ordered_parents[position + 1]
 	//Recursively unregister parents

--- a/code/datums/components/moved_relay.dm
+++ b/code/datums/components/moved_relay.dm
@@ -18,7 +18,7 @@
 	depth ++
 	return TRUE
 
-/datum/component/moved_relay/Initialize(...)
+/datum/component/moved_relay/RegisterWithParent()
 	var/atom/A = parent
 	//Start tracking from the parent
 	//We will relay the parents move to itself for convenience
@@ -28,12 +28,20 @@
 	//Recursively register parents
 	if(A.loc && !isturf(A.loc))
 		register_parent(A.loc)
+	return ..()
 
 /datum/component/moved_relay/Destroy(force, silent)
 	for(var/atom/A as() in ordered_parents)
 		UnregisterSignal(A, COMSIG_PARENT_QDELETING)
 		UnregisterSignal(A, COMSIG_MOVABLE_MOVED)
 	ordered_parents = null
+	return ..()
+
+/datum/component/moved_relay/UnregisterFromParent()
+	for(var/atom/A as() in ordered_parents)
+		UnregisterSignal(A, COMSIG_PARENT_QDELETING)
+		UnregisterSignal(A, COMSIG_MOVABLE_MOVED)
+	ordered_parents.Cut()
 	return ..()
 
 /datum/component/moved_relay/proc/register_parent(atom/A)

--- a/code/datums/components/moved_relay.dm
+++ b/code/datums/components/moved_relay.dm
@@ -38,10 +38,11 @@
 	return ..()
 
 /datum/component/moved_relay/UnregisterFromParent()
-	for(var/atom/A as() in ordered_parents)
-		UnregisterSignal(A, COMSIG_PARENT_QDELETING)
-		UnregisterSignal(A, COMSIG_MOVABLE_MOVED)
-	ordered_parents.Cut()
+	if (ordered_parents)
+		for(var/atom/A as() in ordered_parents)
+			UnregisterSignal(A, COMSIG_PARENT_QDELETING)
+			UnregisterSignal(A, COMSIG_MOVABLE_MOVED)
+		ordered_parents.Cut()
 	return ..()
 
 /datum/component/moved_relay/proc/register_parent(atom/A)

--- a/code/datums/components/moved_relay.dm
+++ b/code/datums/components/moved_relay.dm
@@ -63,7 +63,13 @@
 /datum/component/moved_relay/proc/unregister_parent(atom/A)
 	UnregisterSignal(A, COMSIG_PARENT_QDELETING)
 	UnregisterSignal(A, COMSIG_MOVABLE_MOVED)
+	var/position = ordered_parents.Find(A)
+	if (!position)
+		return
 	ordered_parents -= A
+	if (position == length(ordered_parents))
+		return
+	var/atom/next = ordered_parents[position + 1]
 	//Recursively unregister parents
-	if(A.loc && !isturf(A.loc))
-		unregister_parent(A.loc)
+	if(!isturf(next))
+		unregister_parent(next)

--- a/code/datums/components/radio_jamming.dm
+++ b/code/datums/components/radio_jamming.dm
@@ -29,7 +29,7 @@
 	var/datum/component/moved_relay/move_relay = associated_relay
 	move_relay.depth --
 	if (move_relay.depth == 0)
-		move_relay.RemoveComponent()
+		qdel(move_relay)
 		associated_relay = null
 	return ..()
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -15,6 +15,6 @@
 			CB.Invoke()
 
 	for (var/datum/component/comp in GetComponents(/datum/component/moved_relay))
-		comp.RemoveComponent()
+		qdel(comp)
 
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug that was in moved relay where if the parent of a moved relay left its container, its parents wouldn't be unregistered successfully.
This was rare when it was used with mobs, since mobs are unlikely to be inside a parent which is inside another parent, before the first parent gets removed from its parent. This is much more likely with radio jammers and backpacks however meaning it increased in frequency recently.

## Why It's Good For The Game

This is causing runtimes.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/d12c31d9-000f-45b6-9c57-69116c453363)

Parallax is working, ghosting and unghosting isn't causing runtimes, cameras are disabling when signal jammer is in bag

## Changelog
:cl:
fix: Fixes moved relay issue
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
