### PR TITLE
Buckled mobs will now be checked for access alongside the mount

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -37,7 +37,7 @@
 	. = FALSE
 	// check if someone riding on / buckled to them has access
 	for(var/mob/living/buckled in accessor.buckled_mobs)
-		if(src == buckled)
+		if(accessor == buckled || buckled == src)
 			continue
 		if(allowed(buckled))
 			return TRUE

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -37,6 +37,8 @@
 	. = FALSE
 	// check if someone riding on / buckled to them has access
 	for(var/mob/living/buckled in accessor.buckled_mobs)
+		if(src == buckled)
+			continue
 		if(allowed(buckled))
 			return TRUE
 

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -7,6 +7,10 @@
 	//check if it doesn't require any access at all
 	if(src.check_access(null))
 		return TRUE
+	// check if someone riding on / buckled to them has access
+	for(var/mob/living/buckled in accessor.buckled_mobs)
+		if(allowed(buckled))
+			return TRUE
 	if(issilicon(accessor))
 		var/mob/living/silicon/S = accessor
 		return check_access(S.internal_id_card)	//AI can do whatever it wants

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -7,11 +7,8 @@
 	//check if it doesn't require any access at all
 	if(src.check_access(null))
 		return TRUE
-	if(length(accessor.buckled_mobs) && allow_buckled_access(accessor))
-		// check if someone riding on / buckled to them has access
-		for(var/mob/living/buckled in accessor.buckled_mobs)
-			if(allowed(buckled))
-				return TRUE
+	if(length(accessor.buckled_mobs) && handle_buckled_access(accessor))
+		return TRUE
 	if(issilicon(accessor))
 		var/mob/living/silicon/S = accessor
 		return check_access(S.internal_id_card)	//AI can do whatever it wants
@@ -36,8 +33,12 @@
 			return TRUE
 	return FALSE
 
-/obj/proc/allow_buckled_access(mob/accessor)
-	return TRUE
+/obj/proc/handle_buckled_access(mob/accessor)
+	. = FALSE
+	// check if someone riding on / buckled to them has access
+	for(var/mob/living/buckled in accessor.buckled_mobs)
+		if(allowed(buckled))
+			return TRUE
 
 /obj/item/proc/GetAccess()
 	return list()

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -7,10 +7,11 @@
 	//check if it doesn't require any access at all
 	if(src.check_access(null))
 		return TRUE
-	// check if someone riding on / buckled to them has access
-	for(var/mob/living/buckled in accessor.buckled_mobs)
-		if(allowed(buckled))
-			return TRUE
+	if(length(accessor.buckled_mobs) && allow_buckled_access(accessor))
+		// check if someone riding on / buckled to them has access
+		for(var/mob/living/buckled in accessor.buckled_mobs)
+			if(allowed(buckled))
+				return TRUE
 	if(issilicon(accessor))
 		var/mob/living/silicon/S = accessor
 		return check_access(S.internal_id_card)	//AI can do whatever it wants
@@ -34,6 +35,9 @@
 		if(check_access(A.get_active_held_item()) || check_access(A.access_card))
 			return TRUE
 	return FALSE
+
+/obj/proc/allow_buckled_access(mob/accessor)
+	return TRUE
 
 /obj/item/proc/GetAccess()
 	return list()

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -37,7 +37,7 @@
 	. = FALSE
 	// check if someone riding on / buckled to them has access
 	for(var/mob/living/buckled in accessor.buckled_mobs)
-		if(accessor == buckled || buckled == src)
+		if(accessor == buckled || buckled == src) // just in case to prevent a possible infinite loop scenario (but it won't happen)
 			continue
 		if(allowed(buckled))
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

whenever a mob's access is checked (i.e for doors), it will now also take into account the access of any mobs buckled to them.

the main result is that your ID now works properly when bumping into doors if you're riding a carp or goliath or something.

## Why It's Good For The Game

because it's annoying having to manually click-open doors when you're riding a carp or goliath or something, and in fact this has confused me in the past into thinking my ID got fucked up somehow

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/13494b74-d011-4b9a-8b9d-4365f6b2fc1c


</details>

## Changelog
:cl:
tweak: Whenever a mob's access is checked (i.e for doors), it will now also take into account the access of any mobs buckled to them. Basically, your ID now works properly when bumping into doors if you're riding a carp or goliath or something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
