### PR TITLE
absolute value component for wiremod

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -4065,6 +4065,7 @@
 #include "code\modules\wiremod\components\list\select.dm"
 #include "code\modules\wiremod\components\list\split.dm"
 #include "code\modules\wiremod\components\list\write.dm"
+#include "code\modules\wiremod\components\math\absolute.dm"
 #include "code\modules\wiremod\components\math\arithmetic.dm"
 #include "code\modules\wiremod\components\math\bitflag.dm"
 #include "code\modules\wiremod\components\math\bitwise.dm"

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -53,6 +53,12 @@
 		var/obj/item/circuit_component/component_path = build_path
 		desc = initial(component_path.desc)
 
+/datum/design/component/abs
+	name = "Absolute Component"
+	id = "comp_abs"
+	build_path = /obj/item/circuit_component/abs
+	category = list(WIREMOD_CIRCUITRY, WIREMOD_MATH_COMPONENTS)
+
 /datum/design/component/arbitrary_input_amount/arithmetic
 	name = "Arithmetic Component"
 	id = "comp_arithmetic"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -746,6 +746,7 @@
 		"comp_bitwise",
 		"comp_hyper_trig",
 		"comp_trig",
+		"comp_abs",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 

--- a/code/modules/wiremod/components/math/absolute.dm
+++ b/code/modules/wiremod/components/math/absolute.dm
@@ -1,0 +1,24 @@
+/**
+ * # Abs Component
+ *
+ * This component outputs the absolute value of the input.
+ */
+/obj/item/circuit_component/abs
+	display_name = "Absolute"
+	desc = "A component that outputs the absolute value of the input."
+
+	/// The input port
+	var/datum/port/input/input_port
+
+	/// The result from the output
+	var/datum/port/output/result
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+/obj/item/circuit_component/abs/populate_ports()
+	input_port = add_input_port("Input", PORT_TYPE_NUMBER)
+
+	result = add_output_port("Result", PORT_TYPE_NUMBER)
+
+/obj/item/circuit_component/abs/input_received(datum/port/input/port)
+	result.set_output(abs(input_port.value))
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds absolute value component to wiremod
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
lets people do absolute numbers without having to use workarounds
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
1. Make a circuit with abs component
2. "Push" a negative number to the input
3. trigger the component
4. output says absolute value of that number
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/9d9621bf-c506-4d37-a368-1fefe0881178

or https://streamable.com/ql2v1w

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Added absolute value component for wiremod
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
