### PR TITLE
Fixes Nanite Nutrition Sensor Rule Display

### DIFF
--- a/code/modules/research/nanites/rules.dm
+++ b/code/modules/research/nanites/rules.dm
@@ -205,7 +205,7 @@
 	return rule
 
 /datum/nanite_rule/nutrition/display()
-	return "Nutrition [above ? ">=" : "<"] [min(round(threshold / NUTRITION_LEVEL_FAT, 5), 100)]%"
+	return "Nutrition [above ? ">=" : "<"] [min(round(( threshold / NUTRITION_LEVEL_FAT )*100, 5), 100)]%"
 
 /datum/nanite_rule/blood
 	name = "Blood"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #10184

Nutrition Rule display code was not multiplying by 100 to convert a decimal percent to human readable percent.

Now it does.


## Why It's Good For The Game

Bugs Bad

## Testing Photographs and Procedure

<details>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/4c688aa0-1549-450f-9b0e-e143ef591006)

</details>

## Changelog
:cl:
fix: Nutrition Sensor Nanite Rule now displays properly.
/:cl:
