### PR TITLE
Adds "Remove All Overlays" Input to BCI Object Overlay

### DIFF
--- a/code/modules/research/nanites/rules.dm
+++ b/code/modules/research/nanites/rules.dm
@@ -205,7 +205,7 @@
 	return rule
 
 /datum/nanite_rule/nutrition/display()
-	return "Nutrition [above ? ">=" : "<"] [min(round(threshold / NUTRITION_LEVEL_FAT, 5), 100)]%"
+	return "Nutrition [above ? ">=" : "<"] [min(round(( threshold / NUTRITION_LEVEL_FAT )*100, 5), 100)]%"
 
 /datum/nanite_rule/blood
 	name = "Blood"

--- a/code/modules/wiremod/components/bci/hud/object_overlay.dm
+++ b/code/modules/wiremod/components/bci/hud/object_overlay.dm
@@ -26,6 +26,7 @@
 	/// On/Off signals
 	var/datum/port/input/signal_on
 	var/datum/port/input/signal_off
+	var/datum/port/input/signal_all_off
 
 	var/obj/item/organ/cyberimp/bci/bci
 	var/list/active_overlays = list()
@@ -36,6 +37,7 @@
 
 	signal_on = add_input_port("Create Overlay", PORT_TYPE_SIGNAL)
 	signal_off = add_input_port("Remove Overlay", PORT_TYPE_SIGNAL)
+	signal_all_off = add_input_port("Remove All Overlays", PORT_TYPE_SIGNAL)
 
 	image_pixel_x = add_input_port("X-Axis Shift", PORT_TYPE_NUMBER)
 	image_pixel_y = add_input_port("Y-Axis Shift", PORT_TYPE_NUMBER)
@@ -87,6 +89,12 @@
 	if(COMPONENT_TRIGGERED_BY(signal_off, port) && (target_atom in active_overlays))
 		QDEL_NULL(active_overlays[target_atom])
 		active_overlays.Remove(target_atom)
+
+	// Clear all overlays
+	if(COMPONENT_TRIGGERED_BY(signal_all_off, port))
+		for(var/atom/active_overlay in active_overlays)
+			QDEL_NULL(active_overlays[active_overlay])
+			active_overlays.Remove(active_overlay)
 
 /obj/item/circuit_component/object_overlay/proc/show_to_owner(atom/target_atom, mob/living/owner)
 	if(LAZYLEN(active_overlays) >= OBJECT_OVERLAY_LIMIT)


### PR DESCRIPTION

## About The Pull Request

Without storing a list of active entities with overlays, there is no way to clear out all of the overlays in a BCI Object Overlay, so you get the effects of #10211.

This PR adds another input signal, which clears all active overlays in the object. This reused the same code as the code used to remove all the overlays if the implant is removed.

## Why It's Good For The Game

Adds a feature to the circuit module which should have existed in the first place, to cleanup active overlays without needing to keep a list of the active overlays.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/b62ef58a-7472-401e-b4fa-646c4463f61d)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/8cfa2ffe-ae31-4988-ae26-7c944a065928)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/100493881/470840a8-8cfe-4a94-a2a9-db1df2adab2c)

</details>

## Changelog
:cl:
add: Adds a "Remove All Overlays" input to the BCI Object Overlay. This does what it says on the box.
/:cl:
