### PR TITLE
Fixed deadminning in round not giving old mentors mentor status

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -85,7 +85,7 @@ GLOBAL_PROTECT(href_token)
 	deadmined = FALSE
 	if (GLOB.directory[target])
 		associate(GLOB.directory[target])	//find the client for a ckey if they are connected and associate them with us
-
+	load_mentors()
 
 /datum/admins/proc/deactivate()
 	if(IsAdminAdvancedProcCall())
@@ -101,6 +101,7 @@ GLOBAL_PROTECT(href_token)
 		disassociate()
 		C.add_verb(/client/proc/readmin)
 		C.update_special_keybinds()
+	load_mentors()
 
 /datum/admins/proc/associate(client/C)
 	if(IsAdminAdvancedProcCall())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes deadminning not reloading the mentor list. 

## Why It's Good For The Game

Deadmins should be able to mentor.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/d4f48118-7116-4b21-8662-523c7f50db70)

</details>

## Changelog
:cl:
fix: deadminning gives you mentor status if you were a mentor before becoming an admin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
