### PR TITLE
Turf damage propogation changes & Plating health increase

### DIFF
--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -17,7 +17,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	max_integrity = 600
+	max_integrity = 900
 	var/attachment_holes = TRUE
 
 	FASTDMM_PROP(\
@@ -123,6 +123,7 @@
 	name = "metal foam plating"
 	desc = "Thin, fragile flooring created with metal foam."
 	icon_state = "foam_plating"
+	max_integrity = 300
 
 /turf/open/floor/plating/foam/burn_tile()
 	return //jetfuel can't melt steel foam

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -11,6 +11,7 @@
 	name = "alien floor"
 	icon_state = "alienpod1"
 	tiled_dirt = FALSE
+	max_integrity = 1800
 
 /turf/open/floor/plating/abductor/Initialize(mapload)
 	. = ..()
@@ -21,6 +22,7 @@
 	name = "alien plating"
 	icon_state = "alienplating"
 	tiled_dirt = FALSE
+	max_integrity = 1800
 
 /turf/open/floor/plating/abductor2/break_tile()
 	return //unbreakable
@@ -112,6 +114,7 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	max_integrity = 100
 	resistance_flags = INDESTRUCTIBLE
+	max_integrity = 300
 
 /turf/open/floor/plating/beach/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return

--- a/code/game/turfs/turf_integrity.dm
+++ b/code/game/turfs/turf_integrity.dm
@@ -117,7 +117,8 @@
 		return
 	// Cascade turf damage downwards on destruction
 	if (additional_damage > 0)
-		take_damage(additional_damage, BRUTE, damage_flag, FALSE)
+		if (damage_flag == BOMB || damage_flag == ACID || damage_flag == FIRE)
+			take_damage(additional_damage, BRUTE, damage_flag, FALSE)
 
 //====================================
 // Generic Hits


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Increases the health of plating from 600 to 900.
- Only certain types of damage will propogate additional damage onto their baseturfs.

## Why It's Good For The Game

Light explosions shouldn't be able to break plating. Now that their health is above 700, they should never break to a light explosion.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/a9c5fee4-2791-40eb-b144-3221474fe350)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/ad57ce8f-d854-47df-8d62-0698ea0e1974)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/74067189-137f-4e9f-8ddf-63adedce1803)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8ed7cb59-2bea-485f-8b0e-5a82cb9ab97a)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/18e3f28d-fae7-4991-8606-f6393dc9f36a)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/24ae017f-5126-4305-917e-cfb26a4f645b)


## Changelog
:cl:
tweak: Light explosions will no longer destroy undamaged plating and now only acid, bombs and heat will propogate their damage to the baseturfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
