### PR TITLE
Bluespace launchpad nerf

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -137,8 +137,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/launchpad)
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 25, TRUE)
 	teleporting = TRUE
 
-	if (!sending)
-		new /obj/effect/temp_visual/launchpad(target)
+	new /obj/effect/temp_visual/launchpad(target, teleport_speed)
 
 	sleep(teleport_speed)
 
@@ -248,6 +247,19 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/launchpad)
 	if(closed)
 		return FALSE
 	return ..()
+
+/obj/machinery/launchpad/briefcase/attack_hand(mob/living/user)
+	. = ..()
+	if(!briefcase || !usr.can_hold_items())
+		return
+	if(!usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)))
+		return
+	usr.visible_message("<span class='notice'>[usr] starts closing [src]...</span>", "<span class='notice'>You start closing [src]...</span>")
+	if(do_after(usr, 30, target = usr))
+		usr.put_in_hands(briefcase)
+		moveToNullspace() //hides it from suitcase contents
+		closed = TRUE
+		update_indicator()
 
 /obj/machinery/launchpad/briefcase/MouseDrop(over_object, src_location, over_location)
 	. = ..()

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -137,6 +137,8 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/launchpad)
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 25, TRUE)
 	teleporting = TRUE
 
+	if (!sending)
+		new /obj/effect/temp_visual/launchpad(target)
 
 	sleep(teleport_speed)
 
@@ -186,6 +188,9 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/launchpad)
 			var/mob/T = ROI
 			log_msg += "[key_name(T)][on_chair]"
 		else
+			// Non-mobs can be sent if placed on the powerful pad, but cannot be pulled
+			if (!sending)
+				continue
 			log_msg += "[ROI.name]"
 			if (istype(ROI, /obj/structure/closet))
 				log_msg += " ("

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -562,3 +562,12 @@
 	layer = FLY_LAYER
 	duration = 4.8
 	mouse_opacity = 0
+
+/obj/effect/temp_visual/launchpad
+	icon_state = "shield"
+	alpha = 0
+
+/obj/effect/temp_visual/launchpad/Initialize(mapload, time)
+	duration = time
+	animate(src, time=time, alpha=255)
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The following changes have been made to the bluespace launchpad:
- Teleporting in and out will now display a visual effect that fades in.
- Only mobs can be retrieved (Objects can still be sent from the pad)

Oh, and left clicking on the placed briefcase will now pick it up since I found the pickup to be unintuitive.

## Why It's Good For The Game

- Players are using these to kidnap people without any warning only to kill or brainwash them.
- Players are using these to completely empty the armour or steal unsecured lockers or items from across the map, also without warning.
- These actions are mostly fine on the traitor item due to its small range, however the machine/computer combo has a range of 60 which allows it to take from basically anywhere, especially when placed on shuttles.

These changes:
- Stealing items now requires the person to go into the room, which has some risk involved as you don't know who or what might be in the room.
- Retrieving mobs now requires that mob to want to be retrieved as there is an effect played. This means that free kidnapping will now be much harder.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/496ea59a-bcee-4d26-a02a-d84a19bb9f02

I tested the click pickup and teleport in effect in the abandoned office of meta. No issues there.

## Changelog
:cl:
balance: Bluespace launchpad can no longer pull objects (but can send it). Bluespace launch pad will now play an effect when pulling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
