### PR TITLE
Fixes holopara code using blood brothers chat format color (cfc)

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -100,6 +100,16 @@ GLOBAL_LIST_INIT(color_list_blood_brothers, shuffle(list(
 	"cfc_orange",\
 	"cfc_redorange")))
 
+// Do not use this as a font color. try cfc color formats.
+GLOBAL_LIST_INIT(color_list_rainbow, list(
+	"#FF5050",\
+	"#FF902A",\
+	"#D6B20C",\
+	"#88d818",\
+	"#42c9eb",\
+	"#422ED8",\
+	"#D977FD"))
+
 // Color Filters
 /// Icon filter that creates ambient occlusion
 #define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, color="#04080FAA")

--- a/code/modules/holoparasite/_holoparasite.dm
+++ b/code/modules/holoparasite/_holoparasite.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_EMPTY_TYPED(holoparasites, /mob/living/simple_animal/hostile/holopar
 		stack_trace("Holoparasite initialized without a valid theme!")
 		return INITIALIZE_HINT_QDEL
 	GLOB.holoparasites += src
-	set_accent_color(_accent_color || pick(GLOB.color_list_blood_brothers), silent = TRUE)
+	set_accent_color(_accent_color || pick(GLOB.color_list_rainbow), silent = TRUE)
 	set_theme(_theme)
 	if(length(_name))
 		set_name(_name, internal = TRUE)

--- a/code/modules/holoparasite/holoparasite_builder.dm
+++ b/code/modules/holoparasite/holoparasite_builder.dm
@@ -43,7 +43,7 @@
 	if(isnum_safe(_uses))
 		uses = max(round(_uses), 1)
 	debug_mode = _debug_mode
-	accent_color = pick(GLOB.color_list_blood_brothers)
+	accent_color = pick(GLOB.color_list_rainbow)
 
 /datum/holoparasite_builder/Destroy()
 	QDEL_NULL(saved_stats)
@@ -195,7 +195,7 @@
 			var/color = params["color"]
 			if(!istext(color) || length(color) != 7)
 				return
-			var/new_accent_color = sanitize_hexcolor(color, desired_format = 6, include_crunch = TRUE, default = (length(accent_color) == 7 && accent_color != initial(accent_color)) ? accent_color : pick(GLOB.color_list_blood_brothers))
+			var/new_accent_color = sanitize_hexcolor(color, desired_format = 6, include_crunch = TRUE, default = (length(accent_color) == 7 && accent_color != initial(accent_color)) ? accent_color : pick(GLOB.color_list_rainbow))
 			if(is_color_dark(new_accent_color, HOLOPARA_MAX_ACCENT_LIGHTNESS))
 				to_chat(usr, "<span class='warning'>Selected accent color is too dark!</span>")
 				return

--- a/code/modules/holoparasite/holoparasite_setters.dm
+++ b/code/modules/holoparasite/holoparasite_setters.dm
@@ -72,7 +72,7 @@
 	if(!new_color)
 		return FALSE
 	var/old_accent_color = accent_color
-	new_color = sanitize_hexcolor(new_color, desired_format = 6, include_crunch = TRUE, default = (length(old_accent_color) == 7 && old_accent_color != initial(accent_color)) ? old_accent_color : pick(GLOB.color_list_blood_brothers))
+	new_color = sanitize_hexcolor(new_color, desired_format = 6, include_crunch = TRUE, default = (length(old_accent_color) == 7 && old_accent_color != initial(accent_color)) ? old_accent_color : pick(GLOB.color_list_rainbow))
 	accent_color = new_color
 	chat_color = new_color
 	if(tracking_beacon)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes holopara code using blood brothers chat format color (cfc)

This was overlooked from a colour standisation PR:
* https://github.com/BeeStation/BeeStation-Hornet/pull/9908

I didn't notice holopara was using BB color, and changing it to cfc made the holopara random color pick wrong


Note: I don't like holopara using the color as their chat, but there's no way to make it sane for now...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/5af6a225-c006-4b94-8e68-0f83b356ddfe)


## Changelog
:cl:
code: Holopara color check no longer throws runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
