### PR TITLE
Adds Bloom

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2300,6 +2300,7 @@
 #include "code\modules\client\preferences\entries\player\admin.dm"
 #include "code\modules\client\preferences\entries\player\ambient_occlusion.dm"
 #include "code\modules\client\preferences\entries\player\auto_fit_viewport.dm"
+#include "code\modules\client\preferences\entries\player\bloom.dm"
 #include "code\modules\client\preferences\entries\player\buttons_locked.dm"
 #include "code\modules\client\preferences\entries\player\chat.dm"
 #include "code\modules\client\preferences\entries\player\crew_objectives.dm"

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -107,6 +107,7 @@
 //---------- LIGHTING -------------
 ///Normal 1 per turf dynamic lighting objects
 #define LIGHTING_PLANE 100
+#define LIGHTING_PLANE_ADDITIVE 101
 
 /// The plane for managing the global starlight effect
 #define STARLIGHT_PLANE 105

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -14,7 +14,7 @@
 #define MINIMUM_USEFUL_LIGHT_RANGE 1.4
 
 #define LIGHTING_HEIGHT         1 //! height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
-#define LIGHTING_ROUND_VALUE    (1 / 128) //! Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
+#define LIGHTING_ROUND_VALUE    (1 / 64) //! Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 
 #define LIGHTING_ICON 'icons/effects/lighting_object.dmi' //! icon used for lighting shading effects
 
@@ -65,6 +65,10 @@
 #define LIGHT_COLOR_HALOGEN    "#F0FAFA" //! Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 
 #define LIGHT_RANGE_FIRE		3 //! How many tiles standard fires glow.
+
+#define ADDITIVE_LIGHTING_PLANE_ALPHA_MAX 255
+#define ADDITIVE_LIGHTING_PLANE_ALPHA_NORMAL 128
+#define ADDITIVE_LIGHTING_PLANE_ALPHA_INVISIBLE 0
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
 #define LIGHTING_PLANE_ALPHA_NV_TRAIT 250

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -11,13 +11,8 @@
 ///This light doesn't affect turf's lumcount calculations. Set to 1<<15 to ignore conflicts
 #define LIGHT_NO_LUMCOUNT (1<<15)
 
-//Bay lighting engine shit, not in /code/modules/lighting because BYOND is being shit about it
-#define LIGHTING_INTERVAL       5 // frequency, in 1/10ths of a second, of the lighting process
-
 #define MINIMUM_USEFUL_LIGHT_RANGE 1.4
 
-#define LIGHTING_FALLOFF        1 //! type of falloff to use for lighting; 1 for circular, 2 for square
-#define LIGHTING_LAMBERTIAN     0 //! use lambertian shading for light sources
 #define LIGHTING_HEIGHT         1 //! height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
 #define LIGHTING_ROUND_VALUE    (1 / 128) //! Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -19,7 +19,7 @@
 #define LIGHTING_FALLOFF        1 //! type of falloff to use for lighting; 1 for circular, 2 for square
 #define LIGHTING_LAMBERTIAN     0 //! use lambertian shading for light sources
 #define LIGHTING_HEIGHT         1 //! height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
-#define LIGHTING_ROUND_VALUE    (1 / 64) //! Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
+#define LIGHTING_ROUND_VALUE    (1 / 128) //! Value used to round lumcounts, values smaller than 1/129 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 
 #define LIGHTING_ICON 'icons/effects/lighting_object.dmi' //! icon used for lighting shading effects
 

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -114,6 +114,12 @@
 	add_filter("emissives", 1, alpha_mask_filter(render_source = EMISSIVE_RENDER_TARGET, flags = MASK_INVERSE))
 	add_filter("lighting", 3, alpha_mask_filter(render_source = O_LIGHTING_VISUAL_RENDER_TARGET, flags = MASK_INVERSE))
 
+/atom/movable/screen/plane_master/additive_lighting
+	name = "additive lighting plane master"
+	plane = LIGHTING_PLANE_ADDITIVE
+	blend_mode_override = BLEND_ADD
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
 /**
  * Renders extremely blurred white stuff over space to give the effect of starlight lighting.
  */

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -94,4 +94,5 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		GHOST_PLANE,
 		POINT_PLANE,
 		LIGHTING_PLANE,
+		LIGHTING_PLANE_ADDITIVE,
 	)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -37,7 +37,8 @@
 	blend_mode = BLEND_ADD
 	light_system = MOVABLE_LIGHT
 	light_range = LIGHT_RANGE_FIRE
-	light_power = 1
+	// increase power for more bloom
+	light_power = 4
 	light_color = LIGHT_COLOR_FIRE
 
 	var/volume = 125
@@ -112,18 +113,22 @@
 		heat_b = LERP(heat_b,255,normal_amt)
 		heat_a -= gauss_lerp(temperature, -5000, 5000) * 128
 		greyscale_fire -= normal_amt
+		light_power = 4
 	if(temperature > 40000) //Past this temperature the fire will gradually turn a bright purple
 		var/purple_amt = temperature < LERP(40000,200000,0.5) ? gauss_lerp(temperature, 40000, 200000) : 1
 		heat_r = LERP(heat_r,255,purple_amt)
+		light_power = 5
 	if(temperature > 200000 && temperature < 500000) //Somewhere at this temperature nitryl happens.
 		var/sparkle_amt = gauss_lerp(temperature, 200000, 500000)
 		var/mutable_appearance/sparkle_overlay = mutable_appearance('icons/effects/effects.dmi', "shieldsparkles")
 		sparkle_overlay.blend_mode = BLEND_ADD
 		sparkle_overlay.alpha = sparkle_amt * 255
+		light_power = 6
 		add_overlay(sparkle_overlay)
 	if(temperature > 400000 && temperature < 1500000) //Lightning because very anime.
 		var/mutable_appearance/lightning_overlay = mutable_appearance(icon, "overcharged")
 		lightning_overlay.blend_mode = BLEND_ADD
+		light_power = 6
 		add_overlay(lightning_overlay)
 	if(temperature > 4500000) //This is where noblium happens. Some fusion-y effects.
 		var/fusion_amt = temperature < LERP(4500000,12000000,0.5) ? gauss_lerp(temperature, 4500000, 12000000) : 1
@@ -139,6 +144,7 @@
 		heat_b = LERP(heat_b,150,fusion_amt)
 		add_overlay(fusion_overlay)
 		add_overlay(rainbow_overlay)
+		light_power = 8
 
 	set_light_color(rgb(LERP(250, heat_r, greyscale_fire), LERP(160, heat_g, greyscale_fire), LERP(25, heat_b, greyscale_fire)))
 

--- a/code/modules/client/preferences/entries/player/bloom.dm
+++ b/code/modules/client/preferences/entries/player/bloom.dm
@@ -1,8 +1,12 @@
-/datum/preference/toggle/bloom
+/datum/preference/numeric/bloom
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	db_key = "see_bloom"
+	db_key = "bloom_amount"
 	preference_type = PREFERENCE_PLAYER
-	default_value = TRUE
+	minimum = 0
+	maximum = 100
 
-/datum/preference/toggle/bloom/apply_to_client(client/client, value)
+/datum/preference/numeric/bloom/create_default_value()
+	return round((ADDITIVE_LIGHTING_PLANE_ALPHA_NORMAL / 255) * 100)
+
+/datum/preference/numeric/bloom/apply_to_client(client/client, value)
 	client.mob?.update_sight()

--- a/code/modules/client/preferences/entries/player/bloom.dm
+++ b/code/modules/client/preferences/entries/player/bloom.dm
@@ -1,0 +1,8 @@
+/datum/preference/toggle/bloom
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	db_key = "see_bloom"
+	preference_type = PREFERENCE_PLAYER
+	default_value = TRUE
+
+/datum/preference/toggle/bloom/apply_to_client(client/client, value)
+	client.mob?.update_sight()

--- a/code/modules/client/preferences/preference_entry.dm
+++ b/code/modules/client/preferences/preference_entry.dm
@@ -527,7 +527,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 		"step" = step,
 	)
 
-/// A prefernece whose value is always TRUE or FALSE
+/// A preference whose value is always TRUE or FALSE
 /datum/preference/toggle
 	abstract_type = /datum/preference/toggle
 

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -28,6 +28,13 @@
 	var/cache_r  = LIGHTING_SOFT_THRESHOLD
 	var/cache_g  = LIGHTING_SOFT_THRESHOLD
 	var/cache_b  = LIGHTING_SOFT_THRESHOLD
+
+	//additive light values
+	var/add_r = 0
+	var/add_g = 0
+	var/add_b = 0
+	var/applying_additive = FALSE
+
 	///the maximum of sum_r, sum_g, and sum_b. if this is > 1 then the three cached color values are divided by this
 	var/largest_color_luminosity = 0
 
@@ -111,9 +118,22 @@
 	self_r += delta_r
 	self_g += delta_g
 	self_b += delta_b
+
 	UPDATE_SUM_LUM(r)
 	UPDATE_SUM_LUM(g)
 	UPDATE_SUM_LUM(b)
+
+	add_r = clamp((self_r - 1.1) * 0.3, 0, 0.22)
+	add_g = clamp((self_g - 1.1) * 0.3, 0, 0.22)
+	add_b = clamp((self_b - 1.1) * 0.3, 0, 0.22)
+
+	// Client-shredding, does not cull any additive overlays.
+	//applying_additive = add_r || add_g || add_b
+	// Cull additive overlays that would be below 0.03 alpha in any color.
+	applying_additive = max(add_r, add_g, add_b) > 0.03
+	// Cull additive overlays whose color alpha sum is lower than 0.03
+	//applying_additive = (add_r + add_g + add_b) > 0.03
+
 
 	#ifdef ZMIMIC_LIGHT_BLEED
 	var/turf/T

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -123,9 +123,9 @@
 	UPDATE_SUM_LUM(g)
 	UPDATE_SUM_LUM(b)
 
-	add_r = clamp((self_r - 1.1) * 0.3, 0, 0.22)
-	add_g = clamp((self_g - 1.1) * 0.3, 0, 0.22)
-	add_b = clamp((self_b - 1.1) * 0.3, 0, 0.22)
+	add_r = clamp((self_r - 1.3) * 0.25, 0, 0.22)
+	add_g = clamp((self_g - 1.3) * 0.25, 0, 0.22)
+	add_b = clamp((self_b - 1.3) * 0.25, 0, 0.22)
 
 	// Client-shredding, does not cull any additive overlays.
 	//applying_additive = add_r || add_g || add_b

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -12,6 +12,7 @@
 
 	var/needs_update = FALSE
 	var/turf/myturf
+	var/mutable_appearance/additive_underlay
 
 /atom/movable/lighting_object/Initialize(mapload)
 	. = ..()
@@ -23,6 +24,9 @@
 		qdel(myturf.lighting_object, force = TRUE)
 	myturf.lighting_object = src
 	myturf.luminosity = 0
+
+	additive_underlay = mutable_appearance(LIGHTING_ICON, "light", FLOAT_LAYER, LIGHTING_PLANE_ADDITIVE, 255, RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM)
+	additive_underlay.blend_mode = BLEND_ADD
 
 	needs_update = TRUE
 	SSlighting.objects_queue += src
@@ -37,6 +41,7 @@
 		if (isturf(myturf))
 			myturf.lighting_object = null
 			myturf.luminosity = initial(myturf.luminosity)
+			myturf.underlays -= additive_underlay
 		myturf = null
 
 		return ..()
@@ -112,6 +117,36 @@
 			ar, ag, ab, 00,
 			00, 00, 00, 01
 		)
+
+	if(cr.applying_additive || cg.applying_additive || cb.applying_additive || ca.applying_additive)
+		myturf.underlays -= additive_underlay
+		additive_underlay.icon_state = "light"
+		var/arr = cr.add_r
+		var/arb = cr.add_b
+		var/arg = cr.add_g
+
+		var/agr = cg.add_r
+		var/agb = cg.add_b
+		var/agg = cg.add_g
+
+		var/abr = cb.add_r
+		var/abb = cb.add_b
+		var/abg = cb.add_g
+
+		var/aarr = ca.add_r
+		var/aarb = ca.add_b
+		var/aarg = ca.add_g
+
+		additive_underlay.color = list(
+			arr, arg, arb, 00,
+			agr, agg, agb, 00,
+			abr, abg, abb, 00,
+			aarr, aarg, aarb, 00,
+			00, 00, 00, 01
+		)
+		myturf.underlays += additive_underlay
+	else
+		myturf.underlays -= additive_underlay
 
 	luminosity = set_luminosity
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1083,6 +1083,13 @@
 		var/atom/movable/screen/plane_master/lighting/L = hud_used.plane_masters["[LIGHTING_PLANE]"]
 		if (L)
 			L.alpha = lighting_alpha
+		var/atom/movable/screen/plane_master/additive_lighting/LA = hud_used.plane_masters["[LIGHTING_PLANE_ADDITIVE]"]
+		if(LA)
+			//If this ever doesn't work for some reason add update_sight() to /mob/living/Login()
+			if(client && !client.prefs.read_preference(/datum/preference/toggle/bloom))
+				LA.alpha = 0
+				return
+			LA.alpha = lighting_alpha
 
 ///Update the mouse pointer of the attached client in this mob
 /mob/proc/update_mouse_pointer()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1085,11 +1085,10 @@
 			L.alpha = lighting_alpha
 		var/atom/movable/screen/plane_master/additive_lighting/LA = hud_used.plane_masters["[LIGHTING_PLANE_ADDITIVE]"]
 		if(LA)
-			//If this ever doesn't work for some reason add update_sight() to /mob/living/Login()
-			if(client && !client.prefs.read_preference(/datum/preference/toggle/bloom))
-				LA.alpha = 0
-				return
-			LA.alpha = lighting_alpha
+			var/bloom = ADDITIVE_LIGHTING_PLANE_ALPHA_NORMAL
+			if(client?.prefs) //If this ever doesn't work for some reason add update_sight() to /mob/living/Login()
+				bloom = client.prefs.read_preference(/datum/preference/numeric/bloom) * (ADDITIVE_LIGHTING_PLANE_ALPHA_MAX / 100)
+			LA.alpha = lighting_alpha * (bloom / 255)
 
 ///Update the mouse pointer of the attached client in this mob
 /mob/proc/update_mouse_pointer()

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -20,6 +20,8 @@
 	layer = ABOVE_WINDOW_LAYER
 	zmm_flags = ZMM_MANGLE_PLANES
 
+	light_power = 0.85
+
 
 
 	FASTDMM_PROP(\

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -18,7 +18,7 @@
 	var/on_gs = FALSE
 	var/static_power_used = 0
 	var/brightness = 10			// luminosity when on, also used in power calculation
-	var/bulb_power = 0.85			// basically the alpha of the emitted light source
+	var/bulb_power = 1			// basically the alpha of the emitted light source
 	var/bulb_colour = "#FFF6ED"	// default colour of the light.
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = FALSE
@@ -35,15 +35,15 @@
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
 	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
 	var/nightshift_brightness = 7
-	var/nightshift_light_power = 0.7
+	var/nightshift_light_power = 0.75
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
 	var/bulb_emergency_brightness_mul = 0.25	// multiplier for this light's base brightness in emergency power mode
 	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
-	var/bulb_emergency_pow_mul = 0.7	// the multiplier for determining the light's power in emergency mode
-	var/bulb_emergency_pow_min = 0.45	// the minimum value for the light's power in emergency mode
+	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
+	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
 
 	var/bulb_vacuum_colour = "#4F82FF"	// colour of the light when air alarm is set to severe
 	var/bulb_vacuum_brightness = 8

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -18,7 +18,7 @@
 	var/on_gs = FALSE
 	var/static_power_used = 0
 	var/brightness = 10			// luminosity when on, also used in power calculation
-	var/bulb_power = 1			// basically the alpha of the emitted light source
+	var/bulb_power = 0.85			// basically the alpha of the emitted light source
 	var/bulb_colour = "#FFF6ED"	// default colour of the light.
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = FALSE
@@ -35,15 +35,15 @@
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
 	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
 	var/nightshift_brightness = 7
-	var/nightshift_light_power = 0.75
+	var/nightshift_light_power = 0.7
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
 	var/bulb_emergency_brightness_mul = 0.25	// multiplier for this light's base brightness in emergency power mode
 	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
-	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
-	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
+	var/bulb_emergency_pow_mul = 0.7	// the multiplier for determining the light's power in emergency mode
+	var/bulb_emergency_pow_min = 0.45	// the minimum value for the light's power in emergency mode
 
 	var/bulb_vacuum_colour = "#4F82FF"	// colour of the light when air alarm is set to severe
 	var/bulb_vacuum_brightness = 8

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -16,6 +16,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/uid = 1
 	var/static/gl_uid = 1
 	light_range = 4
+	// this thing bright as hell (to increase bloom)
+	light_power = 5
+	light_color = "#ffe016"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	critical_machine = TRUE
@@ -291,26 +294,41 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			distort.icon_state = "SM_base"
 			distort.pixel_x = -32
 			distort.pixel_y = -32
+			light_range = 4
+			light_power = 5
+			light_color = "#ffe016"
 		if(SUPERMATTER_NORMAL, SUPERMATTER_NOTIFY, SUPERMATTER_WARNING)
 			distort.icon = 'icons/effects/96x96.dmi'
 			distort.icon_state = "SM_base_active"
 			distort.pixel_x = -32
 			distort.pixel_y = -32
+			light_range = 4
+			light_power = 7
+			light_color = "#ffe016"
 		if(SUPERMATTER_DANGER)
 			distort.icon = 'icons/effects/160x160.dmi'
 			distort.icon_state = "SM_delam_1"
 			distort.pixel_x = -64
 			distort.pixel_y = -64
+			light_range = 5
+			light_power = 10
+			light_color = "#ffb516"
 		if(SUPERMATTER_EMERGENCY)
 			distort.icon = 'icons/effects/224x224.dmi'
 			distort.icon_state = "SM_delam_2"
 			distort.pixel_x = -96
 			distort.pixel_y = -96
+			light_range = 6
+			light_power = 10
+			light_color = "#ff9208"
 		if(SUPERMATTER_DELAMINATING)
 			distort.icon = 'icons/effects/288x288.dmi'
 			distort.icon_state = "SM_delam_3"
 			distort.pixel_x = -128
 			distort.pixel_y = -128
+			light_range = 7
+			light_power = 15
+			light_color = "#ff5006"
 	return distort
 
 /obj/machinery/power/supermatter_crystal/proc/countdown()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bloom.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bloom.tsx
@@ -1,9 +1,10 @@
-import { CheckboxInput, FeatureToggle } from '../base';
+import { FeatureNumberInput, FeatureNumeric } from '../base';
 
-export const see_bloom: FeatureToggle = {
-  name: 'See Bloom',
+export const bloom_amount: FeatureNumeric = {
+  name: 'Bloom Level',
   category: 'GRAPHICS',
   subcategory: 'Misc',
-  description: 'Enable Bloom, a lighting effect that gives bright lights a whiteout effect',
-  component: CheckboxInput,
+  description:
+    'What percentage of bloom to show. Bloom is a lighting effect that gives bright lights a whiteout effect. Disabling it entirely may increase client performance, if needed.',
+  component: FeatureNumberInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bloom.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bloom.tsx
@@ -1,0 +1,9 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const see_bloom: FeatureToggle = {
+  name: 'See Bloom',
+  category: 'GRAPHICS',
+  subcategory: 'Misc',
+  description: 'Enable Bloom, a lighting effect that gives bright lights a whiteout effect',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

Adds bloom, an effect that adds a 'whiteout' around bright light sources, making rooms appear bright overall and have more texture.

The alpha of the bloom layer can be adjusted per-user in game preferences. It defaults at 50%.

Ports:
- https://github.com/DaedalusDock/daedalusdock/pull/128
- https://github.com/DaedalusDock/daedalusdock/pull/213
- https://github.com/DaedalusDock/daedalusdock/pull/353
- https://github.com/DaedalusDock/daedalusdock/pull/586

## Why It's Good For The Game

Improves visuals in many cases, with minimal client impact.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Comparison (fire alarm)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/ef6c6a04-250f-4bec-a74c-fcbc4e7f4d8d)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/4bcb6f5a-ad6f-418d-b60d-4a0a8145b52e)

Comparison (normal light area, warm)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/66e246cc-cf8a-4d16-a289-75915c5ebc5e)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/5f422ced-9cc3-4fd3-a3a8-ff04b27e807f)

Comparison (normal light area, cold)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/5be166cb-1f3c-4d7a-a701-760e1957226c)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/622040a0-56fd-4eb4-b26a-379b2206855d)


Comparison (heavy light area, warm)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/fb5048ac-6f58-4e49-a778-51b79c037cca)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/67530e06-8aec-4a11-a9af-8c033c71c3fb)

Comparison (heavy light area, cold)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/3c87f646-ab34-4f43-b6a6-93fd6f661bba)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/e7e2b6d1-1f83-45b5-99da-baeb1e50fa0c)

</details>

## Changelog
:cl: Kapu1178, itsmeow
add: Added bloom, an effect that adds a 'whiteout' around bright light sources, making rooms appear bright overall and have more texture.
add: Added "Bloom Level" preference under Graphics, defaulting at 50%.
tweak: Slightly reduced the lighting power of APCs, as they were causing too much bloom.
code: Removed some unused lighting code.
/:cl:
