### PR TITLE
Strangles some severe BSRPED grief exploits in the crib

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_datum/signals_datum.dm
+++ b/code/__DEFINES/dcs/signals/signals_datum/signals_datum.dm
@@ -17,6 +17,11 @@
 /// Sent when the amount of materials in material_container changes
 #define COMSIG_MATERIAL_CONTAINER_CHANGED "material_container_changed"
 
+///from base of [/datum/reagents/proc/add_reagent] - Sent before the reagent is added: (reagenttype, amount, reagtemp, data, no_react)
+#define COMSIG_REAGENTS_PRE_ADD_REAGENT "reagents_pre_add_reagent"
+	/// Prevents the reagent from being added.
+	#define COMPONENT_CANCEL_REAGENT_ADD (1<<0)
+
 // /datum/species signals
 #define COMSIG_SPECIES_GAIN "species_gain"						//! from datum/species/on_species_gain(): (datum/species/new_species, datum/species/old_species)
 #define COMSIG_SPECIES_LOSS "species_loss"						//! from datum/species/on_species_loss(): (datum/species/lost_species)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -686,6 +686,13 @@ Class Procs:
 						break
 				for(var/obj/item/B in W.contents)
 					if(istype(B, P) && istype(A, P))
+						// If it's a corrupt or rigged cell, attempting to send it through Bluespace could have unforeseen consequences.
+						if(istype(B, /obj/item/stock_parts/cell) && W.works_from_distance)
+							var/obj/item/stock_parts/cell/checked_cell = B
+							// If it's rigged or corrupted, max the charge. Then explode it.
+							if(checked_cell.rigged || checked_cell.corrupted)
+								checked_cell.charge = checked_cell.maxcharge
+								checked_cell.explode()
 						if(B.get_part_rating() > A.get_part_rating())
 							if(istype(B,/obj/item/stack)) //conveniently this will mean A is also a stack and I will kill the first person to prove me wrong
 								var/obj/item/stack/SA = A

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -16,8 +16,10 @@
 	var/maxcharge = 1000
 	materials = list(/datum/material/iron=700, /datum/material/glass=50)
 	grind_results = list(/datum/reagent/lithium = 15, /datum/reagent/iron = 5, /datum/reagent/silicon = 5)
-	/// true if rigged to explode
+	/// If the cell has been booby-trapped by injecting it with plasma. Chance on use() to explode.
 	var/rigged = FALSE
+	/// If the power cell was damaged by an explosion, chance for it to become corrupted and function the same as rigged.
+	var/corrupted = FALSE
 	///how much power is given every tick in a recharger
 	var/chargerate = 100
 	///does it self recharge, over time, or not?
@@ -112,8 +114,8 @@
 	return FIRELOSS
 
 /obj/item/stock_parts/cell/on_reagent_change(changetype)
-	rigged = !isnull(reagents.has_reagent(/datum/reagent/toxin/plasma, 5)) //has_reagent returns the reagent datum
-	..()
+	rigged = (corrupted || reagents.has_reagent(/datum/reagent/toxin/plasma, 5)) //has_reagent returns the reagent datum
+	return ..()
 
 
 /obj/item/stock_parts/cell/proc/explode()
@@ -141,6 +143,7 @@
 	maxcharge = max(maxcharge/2, chargerate)
 	if (prob(10))
 		rigged = TRUE //broken batterys are dangerous
+		corrupted = TRUE
 
 /obj/item/stock_parts/cell/emp_act(severity)
 	. = ..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -128,6 +128,10 @@
 		rigged = FALSE
 		corrupt()
 		return
+
+	message_admins("[ADMIN_LOOKUPFLW(usr)] has triggered a rigged/corrupted power cell explosion at [AREACOORD(T)].")
+	log_game("[key_name(usr)] has triggered a rigged/corrupted power cell explosion at [AREACOORD(T)].")
+
 	//explosion(T, 0, 1, 2, 2)
 	explosion(T, devastation_range, heavy_impact_range, light_impact_range, flash_range)
 	qdel(src)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -199,7 +199,8 @@
 			var/transfer_amount = T.volume * part
 			if(preserve_data)
 				trans_data = copy_data(T)
-			R.add_reagent(T.type, transfer_amount * multiplier, trans_data, chem_temp, no_react = 1) //we only handle reaction after every reagent has been transfered.
+			if(!R.add_reagent(T.type, transfer_amount * multiplier, trans_data, chem_temp, no_react = TRUE)) //we only handle reaction after every reagent has been transfered.
+				continue
 			if(method)
 				R.react_single(T, target_atom, method, part, show_message)
 				T.on_transfer(target_atom, method, transfer_amount * multiplier)
@@ -218,7 +219,8 @@
 			var/transfer_amount = amount
 			if(amount > T.volume)
 				transfer_amount = T.volume
-			R.add_reagent(T.type, transfer_amount * multiplier, trans_data, chem_temp, no_react = 1)
+			if(!R.add_reagent(T.type, transfer_amount * multiplier, trans_data, chem_temp, no_react = TRUE)) //we only handle reaction after every reagent has been transfered.
+				continue
 			to_transfer = max(to_transfer - transfer_amount , 0)
 			if(method)
 				R.react_single(T, target_atom, method, transfer_amount, show_message)
@@ -638,6 +640,9 @@
 		return FALSE
 
 	if(amount <= 0)
+		return FALSE
+
+	if(SEND_SIGNAL(src, COMSIG_REAGENTS_PRE_ADD_REAGENT, reagent, amount, reagtemp, data, no_react) & COMPONENT_CANCEL_REAGENT_ADD)
 		return FALSE
 
 	var/datum/reagent/D = GLOB.chemical_reagents_list[reagent]

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -94,11 +94,16 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 
 	RegisterSignal(src, COMSIG_ATOM_ENTERED, .proc/on_part_entered)
 
-/obj/item/storage/part_replacer/bluespace/proc/on_part_entered(datum/source, obj/item/I)
-	if(!istype(I, /obj/item/stock_parts/cell))
+/obj/item/storage/part_replacer/bluespace/proc/on_part_entered(datum/source, obj/item/inserted_component)
+	SIGNAL_HANDLER
+	if(inserted_component.reagents && length(inserted_component.reagents.reagent_list))
+		inserted_component.reagents.clear_reagents()
+		to_chat(usr, span_notice("[src] churns as [inserted_component] has its reagents emptied into bluespace."))
+
+	if(!istype(inserted_component, /obj/item/stock_parts/cell))
 		return
 
-	var/obj/item/stock_parts/cell/inserted_cell = I
+	var/obj/item/stock_parts/cell/inserted_cell = inserted_component
 
 	if(inserted_cell.rigged || inserted_cell.corrupted)
 		message_admins("[ADMIN_LOOKUPFLW(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -21,7 +21,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	if(!user.Adjacent(attacked_object)) // no TK upgrading.
 		return ..()
 
-	if(istype(attacked_object, /obj/machinery))
+	if(ismachinery(attacked_object))
 		var/obj/machinery/attacked_machinery = attacked_object
 
 		if(!attacked_machinery.component_parts)
@@ -36,13 +36,14 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 
 	if(!attacked_frame.components)
 		return ..()
-	attacked_frame.attackby(src, user)
+
 	if(works_from_distance)
 		user.Beam(attacked_frame, icon_state = "rped_upgrade", time = 5)
+	attacked_frame.attackby(src, user)
 	return TRUE
 
 /obj/item/storage/part_replacer/afterattack(obj/attacked_object, mob/living/user, adjacent, params)
-	if(!istype(attacked_object, /obj/machinery) && !istype(attacked_object, /obj/structure/frame/machine))
+	if(!ismachinery(attacked_object) && !istype(attacked_object, /obj/structure/frame/machine))
 		return ..()
 
 	if(adjacent)
@@ -60,14 +61,15 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		return
 
 	var/obj/structure/frame/machine/attacked_frame = attacked_object
+
 	if(!adjacent && !works_from_distance)
 		return
 	if(!attacked_frame.components)
 		return ..()
 
-	attacked_frame.attackby(src, user)
 	if(works_from_distance)
 		user.Beam(attacked_frame, icon_state = "rped_upgrade", time = 5)
+	attacked_frame.attackby(src, user)
 
 /obj/item/storage/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exhanging or installing parts.
@@ -86,6 +88,22 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	pshoom_or_beepboopblorpzingshadashwoosh = 'sound/items/pshoom.ogg'
 	alt_sound = 'sound/items/pshoom_2.ogg'
 	component_type = /datum/component/storage/concrete/bluespace/rped
+
+/obj/item/storage/part_replacer/bluespace/Initialize()
+	. = ..()
+
+	RegisterSignal(src, COMSIG_ATOM_ENTERED, .proc/on_part_entered)
+
+/obj/item/storage/part_replacer/bluespace/proc/on_part_entered(datum/source, obj/item/I)
+	if(!istype(I, /obj/item/stock_parts/cell))
+		return
+
+	var/obj/item/stock_parts/cell/inserted_cell = I
+
+	if(inserted_cell.rigged || inserted_cell.corrupted)
+		message_admins("[ADMIN_LOOKUPFLW(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")
+		log_game("[key_name(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")
+		usr.log_message("inserted rigged/corrupted [inserted_cell] into [src]", LOG_ATTACK)
 
 /obj/item/storage/part_replacer/bluespace/tier1
 

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -89,16 +89,28 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	alt_sound = 'sound/items/pshoom_2.ogg'
 	component_type = /datum/component/storage/concrete/bluespace/rped
 
-/obj/item/storage/part_replacer/bluespace/Initialize()
+/obj/item/storage/part_replacer/bluespace/Initialize(mapload)
 	. = ..()
 
 	RegisterSignal(src, COMSIG_ATOM_ENTERED, .proc/on_part_entered)
+	RegisterSignal(src, COMSIG_ATOM_EXITED, .proc/on_part_exited)
 
+/**
+ * Signal handler for when a part has been inserted into the BRPED.
+ *
+ * If the inserted item is a rigged or corrupted cell, does some logging.
+ *
+ * If it has a reagent holder, clears the reagents and registers signals to prevent new
+ * reagents being added and registers clean up signals on inserted item's removal from
+ * the BRPED.
+ */
 /obj/item/storage/part_replacer/bluespace/proc/on_part_entered(datum/source, obj/item/inserted_component)
 	SIGNAL_HANDLER
-	if(inserted_component.reagents && length(inserted_component.reagents.reagent_list))
-		inserted_component.reagents.clear_reagents()
-		to_chat(usr, span_notice("[src] churns as [inserted_component] has its reagents emptied into bluespace."))
+	if(inserted_component.reagents)
+		if(length(inserted_component.reagents.reagent_list))
+			inserted_component.reagents.clear_reagents()
+			to_chat(usr, span_notice("[src] churns as [inserted_component] has its reagents emptied into bluespace."))
+		RegisterSignal(inserted_component.reagents, COMSIG_REAGENTS_PRE_ADD_REAGENT, .proc/on_insered_component_reagent_pre_add)
 
 	if(!istype(inserted_component, /obj/item/stock_parts/cell))
 		return
@@ -109,6 +121,31 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		message_admins("[ADMIN_LOOKUPFLW(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")
 		log_game("[key_name(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")
 		usr.log_message("inserted rigged/corrupted [inserted_cell] into [src]", LOG_ATTACK)
+
+/**
+ * Signal handler for when the reagents datum of an inserted part has reagents added to it.
+ *
+ * Registers the PRE_ADD variant which allows the signal handler to stop reagents being
+ * added.
+ *
+ * Simply returns COMPONENT_CANCEL_REAGENT_ADD. We never want to allow people to add
+ * reagents to beakers in BRPEDs as they can then be used for spammable remote bombing.
+ */
+/obj/item/storage/part_replacer/bluespace/proc/on_insered_component_reagent_pre_add(datum/source, reagent, amount, reagtemp, data, no_react)
+	SIGNAL_HANDLER
+
+	return COMPONENT_CANCEL_REAGENT_ADD
+
+/**
+ * Signal handler for a part is removed from the BRPED.
+ *
+ * Does signal registration cleanup on its reagents, if it has any.
+ */
+/obj/item/storage/part_replacer/bluespace/proc/on_part_exited(datum/source, obj/item/removed_component)
+	SIGNAL_HANDLER
+
+	if(removed_component.reagents)
+		UnregisterSignal(removed_component.reagents, COMSIG_REAGENTS_PRE_ADD_REAGENT)
 
 /obj/item/storage/part_replacer/bluespace/tier1
 

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -109,7 +109,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	if(inserted_component.reagents)
 		if(length(inserted_component.reagents.reagent_list))
 			inserted_component.reagents.clear_reagents()
-			to_chat(usr, span_notice("[src] churns as [inserted_component] has its reagents emptied into bluespace."))
+			to_chat(usr, "<span class='notice'>[src] churns as [inserted_component] has its reagents emptied into bluespace.</span>")
 		RegisterSignal(inserted_component.reagents, COMSIG_REAGENTS_PRE_ADD_REAGENT, .proc/on_insered_component_reagent_pre_add)
 
 	if(!istype(inserted_component, /obj/item/stock_parts/cell))

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -92,8 +92,8 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 /obj/item/storage/part_replacer/bluespace/Initialize(mapload)
 	. = ..()
 
-	RegisterSignal(src, COMSIG_ATOM_ENTERED, .proc/on_part_entered)
-	RegisterSignal(src, COMSIG_ATOM_EXITED, .proc/on_part_exited)
+	RegisterSignal(src, COMSIG_ATOM_ENTERED, PROC_REF(on_part_entered))
+	RegisterSignal(src, COMSIG_ATOM_EXITED,PROC_REF(on_part_exited))
 
 /**
  * Signal handler for when a part has been inserted into the BRPED.
@@ -119,7 +119,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		if(length(inserted_component.reagents.reagent_list))
 			inserted_component.reagents.clear_reagents()
 			to_chat(usr, "<span class='warning'>[src] churns as [inserted_component] has its reagents emptied into bluespace.</span>")
-		RegisterSignal(inserted_component.reagents, COMSIG_REAGENTS_PRE_ADD_REAGENT, .proc/on_insered_component_reagent_pre_add)
+		RegisterSignal(inserted_component.reagents, COMSIG_REAGENTS_PRE_ADD_REAGENT, PROC_REF(on_insered_component_reagent_pre_add))
 
 /**
  * Signal handler for when the reagents datum of an inserted part has reagents added to it.

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -106,21 +106,20 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
  */
 /obj/item/storage/part_replacer/bluespace/proc/on_part_entered(datum/source, obj/item/inserted_component)
 	SIGNAL_HANDLER
+
+	if(istype(inserted_component, /obj/item/stock_parts/cell))
+		var/obj/item/stock_parts/cell/inserted_cell = inserted_component
+		if(inserted_cell.rigged || inserted_cell.corrupted)
+			message_admins("[ADMIN_LOOKUPFLW(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")
+			usr.log_message("has inserted rigged/corrupted [inserted_cell] into [src].", LOG_GAME)
+			usr.log_message("inserted rigged/corrupted [inserted_cell] into [src]", LOG_ATTACK)
+		return
+
 	if(inserted_component.reagents)
 		if(length(inserted_component.reagents.reagent_list))
 			inserted_component.reagents.clear_reagents()
-			to_chat(usr, "<span class='notice'>[src] churns as [inserted_component] has its reagents emptied into bluespace.</span>")
+			to_chat(usr, "<span class='warning'>[src] churns as [inserted_component] has its reagents emptied into bluespace.</span>")
 		RegisterSignal(inserted_component.reagents, COMSIG_REAGENTS_PRE_ADD_REAGENT, .proc/on_insered_component_reagent_pre_add)
-
-	if(!istype(inserted_component, /obj/item/stock_parts/cell))
-		return
-
-	var/obj/item/stock_parts/cell/inserted_cell = inserted_component
-
-	if(inserted_cell.rigged || inserted_cell.corrupted)
-		message_admins("[ADMIN_LOOKUPFLW(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")
-		log_game("[key_name(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")
-		usr.log_message("inserted rigged/corrupted [inserted_cell] into [src]", LOG_ATTACK)
 
 /**
  * Signal handler for when the reagents datum of an inserted part has reagents added to it.


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/52213
- https://github.com/tgstation/tgstation/pull/55447
- https://github.com/tgstation/tgstation/pull/60017
- https://github.com/tgstation/tgstation/pull/62447
- https://github.com/tgstation/tgstation/pull/78363

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### PR 1

Fixes powercells not inheriting corruption correctly. This would lead to them exploding, even without plasma in them

### PR 2 

Rigged powercells could be sent to nearly any machine on the station to explode proportional to its cell size. This has been changed to explode the BSRPED instead, when next targetting a machine.

### PR 3 

Removes the ability to transfer containers with reagents through the BSRPED. Bomb mixes can no longer be sent wirelessly to instantly explode. Instead, the reagents are removed upon inserting the beaker.

### PR 4

Reagent containers already inside BSPREDs cannot have reagents inserted into them. See previous PR.

### PR 5 

Fixes cell rigging broken in previous pr

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As a result of the machine components to contents refactor, BSRPEDs became much more viable for antag-play.

This has opened a host of griefing methods, however, that are not intended in the original PR. This PR's purpose is to nix all the easy "instant-kill" uses. 

The two methods are beakers, which could be set with bombmixes and sent to Lathes to explode, or powercells which could be corrupted with plasma and sent to machines that have powercells.

These methods are still generally esoteric, but they are becoming more common knowledge, and I would like to strangle any would-be easy griefing methods in the crib as fast as possible.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Reagent removal upon beaker insertion

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/3aed196b-1163-416f-b2dd-9c9cfc0d8a30)

Corrupted Bluespace battery blowing up the BSRPED user

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/a46373c6-7f05-4b68-a702-129ceb322fd5

Proof that RPED works normally


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/89af1484-dd15-4cbd-b5fa-b262f4d72cfd



</details>

## Changelog
:cl: rkz, ShizCalev, Timberpoes, rdagan
balance: corrupted cells will now blow up the BSRPED user instead of being sent when targeting a machine.
balance: reagents will be removed from beakers upon insertion into a BSRPED
fix: fixes cells not inheriting plasma corruption correctly, and blowing up even with no plasma inside
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
