### PR TITLE
Fix inconsistent changelog generation

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from github import Github, InputGitAuthor
 from ruamel import yaml
 
-CL_BODY = re.compile(r":cl:(.+)?\r\n((.|\n|\r)+?)\r\n\/:cl:", re.MULTILINE)
+CL_BODY = re.compile(r":cl:(.+)?[\r\n]+((.|\n|\r)+?)[\r\n]+/:cl", re.MULTILINE)
 CL_SPLIT = re.compile(r"(^\w+):\s+(\w.+)", re.MULTILINE)
 
 git_email = os.getenv("GIT_EMAIL")

--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from github import Github, InputGitAuthor
 from ruamel import yaml
 
-CL_BODY = re.compile(r":cl:(.+)?[\r\n]+((.|\n|\r)+?)[\r\n]+/:cl", re.MULTILINE)
+CL_BODY = re.compile(r":cl:(.+)?[\r\n]+((.|\n|\r)+?)[\r\n]+/:cl:", re.MULTILINE)
 CL_SPLIT = re.compile(r"(^\w+):\s+(\w.+)", re.MULTILINE)
 
 git_email = os.getenv("GIT_EMAIL")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes up the PR changelog regex, it now works with both CRLF and LF line endings, and won't get confused by using LF instead of CRLF.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-11-29-1701287705-firefox](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/b574c74f-c780-4a3a-abbd-c828f7bc6cc6)
![23-11-29-1701287735-firefox](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/f21393e4-ab39-4f62-9864-049ce9f11d8b)

</details>

## Changelog

No changelog, as this only affects github workflows.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
