### PR TITLE
The Dish-Drive no longer disembowels its stock parts upon attack_hand

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -10,22 +10,28 @@
 	density = FALSE
 	circuit = /obj/item/circuitboard/machine/dish_drive
 	pass_flags = PASSTABLE
-	var/static/list/collectable_items = list(/obj/item/trash/waffles,
+	var/static/list/collectable_items = list(
+		/obj/item/trash/waffles,
 		/obj/item/trash/plate,
 		/obj/item/trash/tray,
 		/obj/item/reagent_containers/glass/bowl,
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
 		/obj/item/kitchen/fork,
 		/obj/item/shard,
-		/obj/item/broken_bottle)
-	var/static/list/disposable_items = list(/obj/item/trash/waffles,
+		/obj/item/broken_bottle
+	)
+
+	var/static/list/disposable_items = list(
+		/obj/item/trash/waffles,
 		/obj/item/trash/plate,
 		/obj/item/trash/tray,
 		/obj/item/shard,
-		/obj/item/broken_bottle)
+		/obj/item/broken_bottle
+	)
 	var/time_since_dishes = 0
 	var/suction_enabled = TRUE
 	var/transmit_enabled = TRUE
+	var/list/dish_drive_contents
 
 /obj/machinery/dish_drive/Initialize(mapload)
 	. = ..()
@@ -37,10 +43,11 @@
 		. += "<span class='notice'>Alt-click it to beam its contents to any nearby disposal bins.</span>"
 
 /obj/machinery/dish_drive/attack_hand(mob/living/user)
-	if(!contents.len)
+	if(!LAZYLEN(dish_drive_contents))
 		to_chat(user, "<span class='warning'>There's nothing in [src]!</span>")
 		return
-	var/obj/item/I = contents[contents.len] //the most recently-added item
+	var/obj/item/I = LAZYACCESS(dish_drive_contents, LAZYLEN(dish_drive_contents))
+	LAZYREMOVE(dish_drive_contents, I)
 	user.put_in_hands(I)
 	to_chat(user, "<span class='notice'>You take out [I] from [src].</span>")
 	playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
@@ -50,6 +57,7 @@
 	if(is_type_in_list(I, collectable_items) && user.a_intent != INTENT_HARM)
 		if(!user.transferItemToLoc(I, src))
 			return
+		LAZYADD(dish_drive_contents, I)
 		to_chat(user, "<span class='notice'>You put [I] in [src], and it's beamed into energy!</span>")
 		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 		flick("synthesizer_beam", src)
@@ -88,6 +96,7 @@
 	for(var/obj/item/I in view(4, src))
 		if(is_type_in_list(I, collectable_items) && I.loc != src && (!I.reagents || !I.reagents.total_volume))
 			if(I.Adjacent(src))
+				LAZYADD(dish_drive_contents, I)
 				visible_message("<span class='notice'>[src] beams up [I]!</span>")
 				I.forceMove(src)
 				playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
@@ -106,7 +115,9 @@
 		do_the_dishes(TRUE)
 
 /obj/machinery/dish_drive/proc/do_the_dishes(manual)
-	if(!contents.len)
+	if(!LAZYLEN(dish_drive_contents))
+		if(manual)
+			visible_message("<span class='notice'>[src] is empty!</span>")
 		return
 	var/obj/machinery/disposal/bin/bin = locate() in view(7, src)
 	if(!bin)
@@ -115,8 +126,9 @@
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 		return
 	var/disposed = 0
-	for(var/obj/item/I in contents)
+	for(var/obj/item/I in dish_drive_contents)
 		if(is_type_in_list(I, disposable_items))
+			LAZYREMOVE(dish_drive_contents, I)
 			I.forceMove(bin)
 			use_power(active_power_usage)
 			disposed++
@@ -127,4 +139,8 @@
 		Beam(bin, icon_state = "rped_upgrade", time = 5)
 		bin.update_icon()
 		flick("synthesizer_beam", src)
+	else
+		if(manual)
+			visible_message("<span class='notice'>There are no disposable items in [src]!</span>")
+		return
 	time_since_dishes = world.time + 600


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

closes #10249 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unintended behavior.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/0ea2bc0a-fa67-4718-a805-1304f667c323



</details>

## Changelog
:cl: rkz
fix: Fixes Dish-drives dispensing their stock parts upon attack_hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
