### PR TITLE
Revert "Revert "Fixes GetComponents() returning a list with a null entry when there's no component of a given type""

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -214,12 +214,10 @@
 	return null
 
 /datum/proc/GetComponents(c_type)
-	var/list/dc = datum_components
-	if(!dc)
-		return null
-	. = dc[c_type]
-	if(!length(.))
-		return list(.)
+	var/list/components = datum_components?[c_type]
+	if(!components)
+		return list()
+	return islist(components) ? components : list(components)
 
 /datum/proc/_AddComponent(list/raw_args)
 	var/new_type = raw_args[1]


### PR DESCRIPTION
* reverts #10201

It was actually running correctly.



:cl:
code: Reverted PR "Fixes GetComponents() returning a list with a null entry when there's no component of a given type" #10150 is now applied again.
/:cl: