### PR TITLE
Fixes "/datum/component/jam_receiver" throwing runtime

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_EMPTY(zombie_infection_list) 		// A list of all zombie_infection org
 GLOBAL_LIST_EMPTY(meteor_list)				// List of all meteors.
 GLOBAL_LIST_EMPTY(active_jammers)             // List of active radio jammers
 GLOBAL_LIST_EMPTY(jam_receivers_by_z)		// List of jam receivers by Z
+GLOBAL_LIST_EMPTY(jam_receivers_by_nullz)	// List of jam receivers that aren't in real Z
 GLOBAL_LIST_EMPTY(ladders)
 GLOBAL_LIST_EMPTY(bot_elevator)
 GLOBAL_LIST_EMPTY(janitor_devices)

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -31,7 +31,6 @@ GLOBAL_LIST_EMPTY(zombie_infection_list) 		// A list of all zombie_infection org
 GLOBAL_LIST_EMPTY(meteor_list)				// List of all meteors.
 GLOBAL_LIST_EMPTY(active_jammers)             // List of active radio jammers
 GLOBAL_LIST_EMPTY(jam_receivers_by_z)		// List of jam receivers by Z
-GLOBAL_LIST_EMPTY(jam_receivers_by_nullz)	// List of jam receivers that aren't in real Z
 GLOBAL_LIST_EMPTY(ladders)
 GLOBAL_LIST_EMPTY(bot_elevator)
 GLOBAL_LIST_EMPTY(janitor_devices)

--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -14,7 +14,8 @@
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	associated_z = get_sanitized_z()
+	var/turf/myturf = get_turf(parent)
+	associated_z = myturf?.z
 
 	// Register this receiver. Clump them together by Z since there will be more of them then jammers.
 	add_self_to_list(associated_z)
@@ -42,13 +43,9 @@
 	check_z_changed()
 	check_jammed()
 
-/// gets z of the parent, but possibly not as 0
-/datum/component/jam_receiver/proc/get_sanitized_z()
-	var/turf/myturf = get_turf(parent)
-	return myturf?.z || 0 // null is bad here.
-
 /datum/component/jam_receiver/proc/check_z_changed()
-	var/current_z = get_sanitized_z()
+	var/turf/myturf = get_turf(parent)
+	var/current_z = myturf?.z
 	if(current_z != associated_z) // z is changed. we change this.
 		remove_self_from_list(associated_z)
 		add_self_to_list(current_z)

--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -44,10 +44,8 @@
 
 /// gets z of the parent, but possibly not as 0
 /datum/component/jam_receiver/proc/get_sanitized_z()
-	var/atom/parent_atom = parent
-	while(parent_atom.z == 0 && !isarea(parent_atom.loc)) // we try to find a true Z value
-		parent_atom = parent_atom.loc
-	return parent_atom.z
+	var/turf/myturf = get_turf(parent)
+	return myturf?.z || 0 // null is bad here.
 
 /datum/component/jam_receiver/proc/check_z_list_sanity()
 	var/current_z = get_sanitized_z()

--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -59,15 +59,11 @@
 /datum/component/jam_receiver/proc/add_self_to_list(target_z)
 	while (length(GLOB.jam_receivers_by_z) < target_z)
 		GLOB.jam_receivers_by_z += list(list())
-	if(target_z == 0)
-		GLOB.jam_receivers_by_nullz += src
-	else
+	if(target_z > 0)
 		GLOB.jam_receivers_by_z[target_z] += src
 
 /datum/component/jam_receiver/proc/remove_self_from_list(target_z)
-	if(target_z == 0)
-		GLOB.jam_receivers_by_nullz -= src
-	else
+	if(target_z > 0)
 		GLOB.jam_receivers_by_z[target_z] -= src
 
 /datum/component/jam_receiver/proc/check_jammed()

--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -39,7 +39,7 @@
 
 /datum/component/jam_receiver/proc/on_move(...)
 	SIGNAL_HANDLER
-	check_z_list_sanity()
+	check_z_changed()
 	check_jammed()
 
 /// gets z of the parent, but possibly not as 0
@@ -47,7 +47,7 @@
 	var/turf/myturf = get_turf(parent)
 	return myturf?.z || 0 // null is bad here.
 
-/datum/component/jam_receiver/proc/check_z_list_sanity()
+/datum/component/jam_receiver/proc/check_z_changed()
 	var/current_z = get_sanitized_z()
 	if(current_z != associated_z) // z is changed. we change this.
 		remove_self_from_list(associated_z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes "/datum/component/jam_receiver" throwing runtime
The code had 3 issues
* parent z can be possibly 0 z. -> added a code of loc loop to get true z value.
* a global list doesn't recognise z(0) value.
* The component wasn't removed from the global list when it's destroyed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/1aa625df-ac92-4b57-837b-d755554d5b30)

No runtime on spawning.

--------------

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/bbc139de-4cda-423d-bcee-97d3847a3891)

Moving z refreshes it.

## Changelog
:cl:
code: datum/component/jam_receiver no longer throws a runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
