### PR TITLE
Fixes sends_insanity_pulse() proc using a wrong proc ref macro + minor pop change

### DIFF
--- a/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
+++ b/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
@@ -46,7 +46,7 @@
 		if(!length(edge_turfs)) // it looks everything reached the end of world map. No need to run more.
 			break
 		var/datum/enumerator/turf_enumerator = get_dereferencing_enumerator(edge_turfs)
-		SSenumeration.tickcheck(turf_enumerator.foreach(CALLBACK(GLOBAL_PROC, PROC_REF(_insanity_pulse_on_turf))))
+		SSenumeration.tickcheck(turf_enumerator.foreach(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_insanity_pulse_on_turf))))
 		sleep(1)
 
 /proc/_insanity_pulse_on_turf(turf/target_turf)

--- a/code/modules/events/anomaly_insanitypulse.dm
+++ b/code/modules/events/anomaly_insanitypulse.dm
@@ -2,9 +2,9 @@
 	name = "Anomaly: Sanity Disruptor"
 	typepath = /datum/round_event/anomaly/insanity_pulse
 
-	min_players = 30
+	min_players = 15
 	max_occurrences = 2
-	weight = 30
+	weight = 25
 	// This has a high chance to appear, but needs more players
 
 /datum/round_event/anomaly/insanity_pulse


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Follow up of #10172
Fixes sends_insanity_pulse() proc using a wrong proc ref macro
It wasn't using global proc ref...

also, changes pop lock

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
and pop lock made the anomaly hard to see. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
The testing evidence can't suggest anything because the code before the fix works too, and it works too.

## Changelog
:cl:
fix: Insanity anomaly now properly works
tweak: insanity pulse anomaly event now less requires player pop (15)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
