### PR TITLE
Adding a player limit on the most over played maps

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -22,12 +22,13 @@ map corgstation
 endmap
 
 map boxstation
-	maxplayers 60
+	maxplayers 30
 	votable
 endmap
 
 map metastation
 	default
+	maxplayers 30
 	votable
 endmap
 
@@ -37,7 +38,7 @@ map deltastation
 endmap
 
 map kilostation
-	maxplayers 50
+	maxplayers 30
 	votable
 endmap
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -32,7 +32,7 @@ map metastation
 endmap
 
 map deltastation
-	minplayers 40
+	minplayers 30
 	votable
 endmap
 
@@ -42,7 +42,7 @@ map kilostation
 endmap
 
 map flandstation
-	minplayers 40
+	minplayers 30
 	votable
 endmap
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -22,13 +22,12 @@ map corgstation
 endmap
 
 map boxstation
-	maxplayers 30
+	maxplayers 40
 	votable
 endmap
 
 map metastation
 	default
-	maxplayers 30
 	votable
 endmap
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The map vote maximum player count for each of the most played maps (Kilo, Meta and Box Station) has been set to 30. You can still get 30+ rounds but that will be from late-joins rather than round-start. Map vote occurs at the end of a round, usually prior to people leaving so the player count could drop significantly when the server restarts to change the map.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Box Station, Meta Station, Box Station, Meta Station, Box Station, Meta Station, Box Station, Meta Station.

Enough is enough, at least during the rare high-pop times let us play high-pop maps which aren't ancient by SS13 standards.

Show some love for the other maps and not just the same two or three maps rotating between them over and over again with the VERY occasional different map. You can still vote for your favourite map, you just can't bring an entire 40+ lobby to maps like Kilo, Meta and Box Station. No matter if you're the majority or by any luck the one guy to vote for a map.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Markus Larsson
tweak: Maxplayers on map votes for Kilo, Meta and Box Station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
