### PR TITLE
Locks the labeler action to v4.3

### DIFF
--- a/.github/workflows/extra_pr_labels.yml
+++ b/.github/workflows/extra_pr_labels.yml
@@ -18,7 +18,7 @@ jobs:
           commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
       - name: Apply labels based on changed files
         if: github.event_name != 'push'
-        uses: actions/labeler@main
+        uses: actions/labeler@v4.3.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true


### PR DESCRIPTION
The labeler action bumped to v5 which entirely changes the config. This locks us to v4 until we decide to update everything else.

https://github.com/actions/labeler