### PR TITLE
Day night cycle map config setting

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -422,6 +422,7 @@
 #include "code\controllers\subsystem\minor_mapping.dm"
 #include "code\controllers\subsystem\mobs.dm"
 #include "code\controllers\subsystem\moods.dm"
+#include "code\controllers\subsystem\natural_light_cycle.dm"
 #include "code\controllers\subsystem\nightshift.dm"
 #include "code\controllers\subsystem\npcpool.dm"
 #include "code\controllers\subsystem\overlays.dm"

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -154,3 +154,6 @@ require only minor tweaks.
 #define SHELTER_DEPLOY_BAD_AREA "bad area"
 /// Shelter spot has anchored objects that restrict deployment
 #define SHELTER_DEPLOY_ANCHORED_OBJECTS "anchored objects"
+
+#define STARLIGHT_MODE_STARLIGHT "starlight"
+#define STARLIGHT_MODE_CYCLE "cycle"

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -152,6 +152,7 @@
 #define INIT_ORDER_PATH				-50
 #define INIT_ORDER_EXPLOSIONS		-69
 #define INIT_ORDER_ELEVATOR	  -70
+#define INIT_ORDER_NATURAL_LIGHT	-120
 #define INIT_ORDER_CHAT				-150 //Should be last to ensure chat remains smooth during init.
 
 // Subsystem fire priority, from lowest to highest priority

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -1,3 +1,5 @@
+
+#define DECISECONDS_IN_DAY 864000	//number of deciseconds in a day
 #define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
 
 #define JANUARY		1
@@ -59,3 +61,4 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 
 /// Amount of years from the current year to offset in-universe
 #define YEAR_OFFSET 540
+

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -15,7 +15,7 @@
 
 /// Returns the station time in deciseconds
 /proc/station_time(display_only = FALSE, wtime=world.time)
-	return (((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000
+	return (((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % DECISECONDS_IN_DAY
 
 /// Returns the station time in hh:mm:ss
 /proc/station_time_timestamp(format = "hh:mm:ss", wtime)
@@ -25,7 +25,7 @@
 	if(isnum_safe(force_set))
 		SSticker.gametime_offset = force_set
 		return
-	SSticker.gametime_offset = rand(0, 864000)		//hours in day * minutes in hour * seconds in minute * deciseconds in second
+	SSticker.gametime_offset = rand(0, DECISECONDS_IN_DAY)		//hours in day * minutes in hour * seconds in minute * deciseconds in second
 	if(prob(50))
 		SSticker.gametime_offset = FLOOR(SSticker.gametime_offset, 3600)
 	else

--- a/code/controllers/subsystem/natural_light_cycle.dm
+++ b/code/controllers/subsystem/natural_light_cycle.dm
@@ -1,0 +1,28 @@
+SUBSYSTEM_DEF(natural_light_cycle)
+	name = "Natural Light Cycle"
+	wait = 600
+	flags = SS_KEEP_TIMING
+	init_order = INIT_ORDER_NATURAL_LIGHT
+	var/list/cycle_colours = null
+
+/datum/controller/subsystem/natural_light_cycle/Initialize(start_timeofday)
+	. = ..()
+	if (SSmapping.config.starlight_mode != STARLIGHT_MODE_CYCLE)
+		flags |= SS_NO_FIRE
+		return
+	cycle_colours = SSmapping.config.cycle_colours
+	if (!islist(cycle_colours) || !length(cycle_colours))
+		to_chat(world, "<span class='boldannounce'>WARNING: Starlight is set to cycle, yet the colours that are set to be cycled is undefined.</span>");
+		log_world("WARNING: Starlight is set to cycle, yet the colours that are set to be cycled is undefined.")
+		flags |= SS_NO_FIRE
+		return
+
+/datum/controller/subsystem/natural_light_cycle/fire(resumed)
+	var/time = station_time()
+	var/next_proportion = min((((time + wait) % DECISECONDS_IN_DAY) / DECISECONDS_IN_DAY) * length(cycle_colours) + 1, length(cycle_colours))
+	var/next_index = FLOOR(next_proportion, 1)
+	var/next_offset = next_proportion - next_index
+	var/lower_colour = cycle_colours[next_index]
+	var/upper_colour = cycle_colours[((next_index + 1) % length(cycle_colours)) + 1]
+	var/blended_colour = BlendRGB(lower_colour, upper_colour, next_offset)
+	set_starlight_colour(blended_colour, wait)

--- a/code/controllers/subsystem/natural_light_cycle.dm
+++ b/code/controllers/subsystem/natural_light_cycle.dm
@@ -23,6 +23,6 @@ SUBSYSTEM_DEF(natural_light_cycle)
 	var/next_index = FLOOR(next_proportion, 1)
 	var/next_offset = next_proportion - next_index
 	var/lower_colour = cycle_colours[next_index]
-	var/upper_colour = cycle_colours[((next_index + 1) % length(cycle_colours)) + 1]
+	var/upper_colour = cycle_colours[((next_index - 1) % length(cycle_colours)) + 1]
 	var/blended_colour = BlendRGB(lower_colour, upper_colour, next_offset)
 	set_starlight_colour(blended_colour, wait)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -41,6 +41,13 @@
 	var/allow_night_lighting = TRUE
 
 	//======
+	// Starlight Settings
+	//======
+
+	var/starlight_mode = STARLIGHT_MODE_STARLIGHT
+	var/list/cycle_colours = null
+
+	//======
 	// planetary Settings
 	//======
 
@@ -163,6 +170,9 @@
 		map_link = json["map_link"]
 	else
 		log_world("map_link missing from json!")
+
+	starlight_mode = json["starlight"] || STARLIGHT_MODE_STARLIGHT
+	cycle_colours = json["starlight_colours"] || null
 
 	allow_custom_shuttles = json["allow_custom_shuttles"] != FALSE
 	allow_night_lighting = json["allow_night_lighting"] != FALSE

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -488,7 +488,7 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 */
 
 /datum/holiday/ramadan/shouldCelebrate(dd, mm, yy, ww, ddd)
-	if (round(((world.realtime - 285984000) / 864000) % 354.373435326843) == 0)
+	if (round(((world.realtime - 285984000) / DECISECONDS_IN_DAY) % 354.373435326843) == 0)
 		return TRUE
 	return FALSE
 
@@ -499,7 +499,7 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 	name = "End of Ramadan"
 
 /datum/holiday/ramadan/end/shouldCelebrate(dd, mm, yy, ww, ddd)
-	if (round(((world.realtime - 312768000) / 864000) % 354.373435326843) == 0)
+	if (round(((world.realtime - 312768000) / DECISECONDS_IN_DAY) % 354.373435326843) == 0)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in the ability to set a day night cycle in the map config. An example config is given below:
```json
"starlight": "cycle",
"starlight_colours": [
  "#4A709E",
  "#99AFCC",
  "#FDF7DD",
  "#FFEDB5",
  "#EF9D69",
  "#E96C74",
  "#964A79",
  "#343D70"
]
```

Starlight can be set to either starlight, or cycle. It will interpolate between the colours, with the first colour being midnight, and the last colour being midnight the next day. The median colour will be noon.

## Why It's Good For The Game

Planettary maps probably want their starlight to be a day/night cycle rather than just purple and what-not. Due to the configurability of the starlight system, this is the logical next step since you can set the outside areas to be starlight.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/126393fa-34b7-47d1-b242-66e2ec7e2e2c

In the video it's not perfectly smooth due to the subsystems being a bit behind but when this system is played over 2 hours instead of 20 seconds it will be barely noticable.

## Changelog
:cl:
add: Adds a day/night cycle config setting for maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
