### PR TITLE
Bug Fix: Flypeople and eating.

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -132,14 +132,7 @@
 		if(isflyperson(H))
 			playsound(get_turf(src), 'sound/items/drink.ogg', 50, 1) //slurp
 			H.visible_message("<span class='alert'>[H] extends a small proboscis into the vomit pool, sucking it with a slurping sound.</span>")
-			if(reagents)
-				for(var/datum/reagent/R in reagents.reagent_list)
-					if (istype(R, /datum/reagent/consumable))
-						var/datum/reagent/consumable/nutri_check = R
-						if(nutri_check.nutriment_factor > 0)
-							H.adjust_nutrition(nutri_check.nutriment_factor * nutri_check.volume * 15) //Volume is typically really low so it needs a multiplier
-							reagents.remove_reagent(nutri_check.type,nutri_check.volume)
-			reagents.trans_to(H, reagents.total_volume, transfered_by = user)
+			H.adjust_nutrition(20) //This wasn't working before, it was very complex, I made it painfully simple so it just WORKS.
 			qdel(src)
 
 /obj/effect/decal/cleanable/vomit/old

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -33,7 +33,8 @@
 		var/datum/reagent/consumable/nutri_check = chem
 		if(nutri_check.nutriment_factor > 0)
 			var/turf/pos = get_turf(H)
-			H.vomit(0, FALSE, FALSE, 2, TRUE)
+			H.vomit(10, FALSE, FALSE, 2, TRUE)
+			H.reagents.remove_reagent(chem.type, chem.metabolization_rate)
 			playsound(pos, 'sound/effects/splat.ogg', 50, 1)
 			H.visible_message("<span class='danger'>[H] vomits on the floor!</span>", \
 						"<span class='userdanger'>You throw up on the floor!</span>")


### PR DESCRIPTION
## About The Pull Request

Before this PR fly people wouldn't stop barfing after taking one bite of a food.
Vomit wasn't feeding them either.

Thats fixed now.

Also kind of made the barfing costing nutrition because it makes sense, this does make it so if the fly has nothing in its stomach to barf they just wont, which means they wont be able to eat their own barf.

But at that point I think the fly should get creative?
I don't know, I'm not too sure about this one, I don't mind reverting it to 0 but it felt weird. Up to you.

one reason to keep it like this is so people wont be able to just non stop barf as before, but that's also kinda funny and unrealistic, don't know.

## Why It's Good For The Game

Its a bug fix that makes the fly a bit less absolutely awful to have happen.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



https://github.com/BeeStation/BeeStation-Hornet/assets/94647521/de0cdd56-cd57-4d93-b5f9-bdcfa8a00bd8


</details>

## Changelog
:cl: PinkSuzuki
fix: Flypeople will no longer be permanently locked in vomiting. They also now feed by drinking vomit as intended.
tweak: Vomiting will now cause flypeople to lose nutrition.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
