### PR TITLE
Ports a fix for the supply console contraband feature

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -748,6 +748,8 @@ Class Procs:
 
 //called on machinery construction (i.e from frame to machinery) but not on initialization
 /obj/machinery/proc/on_construction()
+	if(circuit)
+		circuit.configure_machine(src)
 	return
 
 //called on deconstruction before the final deletion

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -40,6 +40,15 @@
 
 	return
 
+/**
+  * Used to allow the circuitboard to configure a machine in some way, shape or form.
+  *
+  * Arguments:
+  * * machine - The machine to attempt to configure.
+  */
+/obj/item/circuitboard/proc/configure_machine(obj/machinery/machine)
+	return
+
 // Circuitboard/machine
 /*Common Parts: Parts List: Ignitor, Timer, Infra-red laser, Infra-red sensor, t_scanner, Capacitor, Valve, sensor unit,
 micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -465,6 +465,16 @@
 	contraband = TRUE
 	to_chat(user, "<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>")
 
+/obj/item/circuitboard/computer/cargo/configure_machine(obj/machinery/computer/cargo/machine)
+	if(!istype(machine))
+		CRASH("Cargo board attempted to configure incorrect machine type: [machine] ([machine?.type])")
+
+	machine.contraband = contraband
+	if (obj_flags & EMAGGED)
+		machine.obj_flags |= EMAGGED
+	else
+		machine.obj_flags &= ~EMAGGED
+
 /obj/item/circuitboard/computer/cargo/express
 	name = "express supply console (Computer Board)"
 	icon_state = "supply"

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -65,10 +65,6 @@
 	board.obj_flags |= EMAGGED
 	update_static_data(user)
 
-/obj/machinery/computer/cargo/on_construction()
-	. = ..()
-	circuit.configure_machine(src)
-
 /obj/machinery/computer/cargo/ui_state(mob/user)
 	return GLOB.default_state
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -35,12 +35,6 @@
 /obj/machinery/computer/cargo/Initialize(mapload)
 	. = ..()
 	radio = new /obj/item/radio/headset/headset_cargo(src)
-	var/obj/item/circuitboard/computer/cargo/board = circuit
-	contraband = board.contraband
-	if (board.obj_flags & EMAGGED)
-		obj_flags |= EMAGGED
-	else
-		obj_flags &= ~EMAGGED
 	RegisterSignal(SSdcs, COMSIG_GLOB_RESUPPLY, PROC_REF(update_static_ui))
 
 /obj/machinery/computer/cargo/Destroy()
@@ -71,6 +65,9 @@
 	board.obj_flags |= EMAGGED
 	update_static_data(user)
 
+/obj/machinery/computer/cargo/on_construction()
+	. = ..()
+	circuit.configure_machine(src)
 
 /obj/machinery/computer/cargo/ui_state(mob/user)
 	return GLOB.default_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #10270 by porting https://github.com/tgstation/tgstation/pull/54177.

#9314 ported a change to machine components that broke the feature where you enabled contraband on a supply console by multitooling the circuit board. This PR ports the fix that tgstation implemented.

From https://github.com/tgstation/tgstation/pull/54177:

Added an abstract proc for circuits intended to be used to allow a circuit to configure a machine.

Overrode this proc for supply console boards (behaviour inherited by express boards)

Call this proc in supply console on_construction (behaviour inherited by express supply consoles)

Allows all supply consoles to inherit their circuit's emag and contraband status.

Doesn't look like any other circuits use this sort of functionality, but if they do I'll fix 'em up too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix, contraband should be available.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Contraband on: 
![caption-contraband](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/98be88ab-5b15-44d0-9a50-34cf22dbae53)
![contraband](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/fc75a657-f692-4028-97cb-2d6c1ef74875)

Contraband off: 
![caption-normal](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/37167120-fcb2-4d40-9bf2-fdf437fe40d8)
![normal](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/b57764d2-60e0-4527-8579-cbd4625363e8)

Emag: 
![caption-emag](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/b32ba0db-4c20-42e8-a09e-ae9f119b5b7b)
![emag](https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/87a1d5d9-6797-4113-8317-3e873017cb5c)


</details>

## Changelog
:cl: Timberpoes, BeeLover
fix: Supply Consoles and Express Supply Consoles will once again be built pre-emagged if their boards used to build them are emagged.
fix: Supply Consoles will now once again allow Cargonia to buy contraband when their circuit boards are appropriately configured with a multitool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
