### PR TITLE
Launchpad recall

### DIFF
--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -5,109 +5,12 @@
 	icon_keyboard = "teleport_key"
 	circuit = /obj/item/circuitboard/computer/launchpad_console
 
-
+	/// If set, then the launchpad will automatically call itself back after this tiem.
+	var/recall_time = 0
 
 	var/selected_id
 	var/list/obj/machinery/launchpad/launchpads
 	var/maximum_pads = 4
-
-/obj/machinery/computer/launchpad/Initialize(mapload)
-	launchpads = list()
-	. = ..()
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/bluespace_launchpad,
-	))
-
-/obj/item/circuit_component/bluespace_launchpad
-	display_name = "Bluespace Launchpad Console"
-	desc = "Teleports anything to and from any location on the station. Doesn't use actual GPS coordinates, but rather offsets from the launchpad itself. Can only go as far as the launchpad can go, which depends on its parts."
-
-	var/datum/port/input/launchpad_id
-	var/datum/port/input/x_pos
-	var/datum/port/input/y_pos
-	var/datum/port/input/send_trigger
-	var/datum/port/input/retrieve_trigger
-
-	var/datum/port/output/sent
-	var/datum/port/output/retrieved
-	var/datum/port/output/on_fail
-	var/datum/port/output/why_fail
-
-	var/obj/machinery/computer/launchpad/attached_console
-
-/obj/item/circuit_component/bluespace_launchpad/get_ui_notices()
-	. = ..()
-	var/current_launchpad = launchpad_id.value
-	if(isnull(current_launchpad))
-		return
-
-	var/obj/machinery/launchpad/the_pad = attached_console.launchpads[current_launchpad]
-	if(isnull(the_pad))
-		return
-
-	. += create_ui_notice("Minimum Range: [-the_pad.range]", "orange", "minus")
-	. += create_ui_notice("Maximum Range: [the_pad.range]", "orange", "plus")
-
-/obj/item/circuit_component/bluespace_launchpad/populate_ports()
-	launchpad_id = add_input_port("Launchpad ID", PORT_TYPE_NUMBER, trigger = null, default = 1)
-	x_pos = add_input_port("X offset", PORT_TYPE_NUMBER)
-	y_pos = add_input_port("Y offset", PORT_TYPE_NUMBER)
-	send_trigger = add_input_port("Send", PORT_TYPE_SIGNAL)
-	retrieve_trigger = add_input_port("Retrieve", PORT_TYPE_SIGNAL)
-
-	sent = add_output_port("Sent", PORT_TYPE_SIGNAL)
-	retrieved = add_output_port("Retrieved", PORT_TYPE_SIGNAL)
-	why_fail = add_output_port("Fail reason", PORT_TYPE_STRING)
-	on_fail = add_output_port("Failed", PORT_TYPE_SIGNAL)
-
-/obj/item/circuit_component/bluespace_launchpad/register_usb_parent(atom/movable/parent)
-	. = ..()
-	if(istype(parent, /obj/machinery/computer/launchpad))
-		attached_console = parent
-
-/obj/item/circuit_component/bluespace_launchpad/unregister_usb_parent(atom/movable/parent)
-	attached_console = null
-	return ..()
-
-/obj/item/circuit_component/bluespace_launchpad/input_received(datum/port/input/port)
-	if(!attached_console || length(attached_console.launchpads) == 0)
-		why_fail.set_output("No launchpads connected!")
-		on_fail.set_output(COMPONENT_SIGNAL)
-		return
-
-
-	if(!launchpad_id.value)
-		return
-
-	var/obj/machinery/launchpad/the_pad = KEYBYINDEX(attached_console.launchpads, launchpad_id.value)
-	if(isnull(the_pad))
-		why_fail.set_output("Invalid launchpad selected!")
-		on_fail.set_output(COMPONENT_SIGNAL)
-		return
-
-	the_pad.set_offset(x_pos.value, y_pos.value)
-
-	if(COMPONENT_TRIGGERED_BY(port, x_pos))
-		x_pos.set_value(the_pad.x_offset)
-		return
-
-	if(COMPONENT_TRIGGERED_BY(port, y_pos))
-		y_pos.set_value(the_pad.y_offset)
-		return
-
-	var/checks = attached_console.teleport_checks(the_pad)
-	if(!isnull(checks))
-		why_fail.set_output(checks)
-		on_fail.set_output(COMPONENT_SIGNAL)
-		return
-
-	if(COMPONENT_TRIGGERED_BY(send_trigger, port))
-		INVOKE_ASYNC(the_pad, TYPE_PROC_REF(/obj/machinery/launchpad, doteleport), null, TRUE, parent.get_creator())
-		sent.set_output(COMPONENT_SIGNAL)
-
-	if(COMPONENT_TRIGGERED_BY(retrieve_trigger, port))
-		INVOKE_ASYNC(the_pad, TYPE_PROC_REF(/obj/machinery/launchpad, doteleport), null, FALSE, parent.get_creator())
-		retrieved.set_output(COMPONENT_SIGNAL)
 
 /obj/machinery/computer/launchpad/attack_paw(mob/user)
 	to_chat(user, "<span class='warning'>You are too primitive to use this computer!</span>")
@@ -206,6 +109,8 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/launchpad)
 			pad_list += list(this_pad)
 		else
 			launchpads -= get_pad(i)
+	data["recall_time"] = recall_time
+	data["can_adjust_recall_time"] = TRUE
 	data["launchpads"] = pad_list
 	data["selected_id"] = selected_id
 	if(selected_id)
@@ -243,6 +148,12 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/launchpad)
 				y = current_pad.y_offset + plus_y
 			)
 			. = TRUE
+		if("set_recall")
+			var/recall_timer = tgui_input_number(usr, "How long until the machine automatically recalls? (0 to disable)", "Recall time", 0, 300, 0)
+			if (isnull(recall_timer) || recall_timer < 0 || recall_timer > 300)
+				return FALSE
+			recall_time = recall_timer
+			. = TRUE
 		if("rename")
 			var/new_name = params["name"]
 			if(!new_name)
@@ -256,8 +167,110 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/launchpad)
 			. = TRUE
 		if("launch")
 			teleport(usr, current_pad, TRUE)
+			if (recall_time)
+				addtimer(CALLBACK(src, PROC_REF(teleport), usr, current_pad, FALSE), recall_time * 10)
 			. = TRUE
 
 		if("pull")
 			teleport(usr, current_pad, FALSE)
+			if (recall_time)
+				addtimer(CALLBACK(src, PROC_REF(teleport), usr, current_pad, TRUE), recall_time * 10)
 			. = TRUE
+
+/obj/machinery/computer/launchpad/Initialize(mapload)
+	launchpads = list()
+	. = ..()
+	AddComponent(/datum/component/usb_port, list(
+		/obj/item/circuit_component/bluespace_launchpad,
+	))
+
+/obj/item/circuit_component/bluespace_launchpad
+	display_name = "Bluespace Launchpad Console"
+	desc = "Teleports anything to and from any location on the station. Doesn't use actual GPS coordinates, but rather offsets from the launchpad itself. Can only go as far as the launchpad can go, which depends on its parts."
+
+	var/datum/port/input/launchpad_id
+	var/datum/port/input/x_pos
+	var/datum/port/input/y_pos
+	var/datum/port/input/send_trigger
+	var/datum/port/input/retrieve_trigger
+
+	var/datum/port/output/sent
+	var/datum/port/output/retrieved
+	var/datum/port/output/on_fail
+	var/datum/port/output/why_fail
+
+	var/obj/machinery/computer/launchpad/attached_console
+
+/obj/item/circuit_component/bluespace_launchpad/get_ui_notices()
+	. = ..()
+	var/current_launchpad = launchpad_id.value
+	if(isnull(current_launchpad))
+		return
+
+	var/obj/machinery/launchpad/the_pad = attached_console.launchpads[current_launchpad]
+	if(isnull(the_pad))
+		return
+
+	. += create_ui_notice("Minimum Range: [-the_pad.range]", "orange", "minus")
+	. += create_ui_notice("Maximum Range: [the_pad.range]", "orange", "plus")
+
+/obj/item/circuit_component/bluespace_launchpad/populate_ports()
+	launchpad_id = add_input_port("Launchpad ID", PORT_TYPE_NUMBER, trigger = null, default = 1)
+	x_pos = add_input_port("X offset", PORT_TYPE_NUMBER)
+	y_pos = add_input_port("Y offset", PORT_TYPE_NUMBER)
+	send_trigger = add_input_port("Send", PORT_TYPE_SIGNAL)
+	retrieve_trigger = add_input_port("Retrieve", PORT_TYPE_SIGNAL)
+
+	sent = add_output_port("Sent", PORT_TYPE_SIGNAL)
+	retrieved = add_output_port("Retrieved", PORT_TYPE_SIGNAL)
+	why_fail = add_output_port("Fail reason", PORT_TYPE_STRING)
+	on_fail = add_output_port("Failed", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/bluespace_launchpad/register_usb_parent(atom/movable/parent)
+	. = ..()
+	if(istype(parent, /obj/machinery/computer/launchpad))
+		attached_console = parent
+
+/obj/item/circuit_component/bluespace_launchpad/unregister_usb_parent(atom/movable/parent)
+	attached_console = null
+	return ..()
+
+/obj/item/circuit_component/bluespace_launchpad/input_received(datum/port/input/port)
+	if(!attached_console || length(attached_console.launchpads) == 0)
+		why_fail.set_output("No launchpads connected!")
+		on_fail.set_output(COMPONENT_SIGNAL)
+		return
+
+
+	if(!launchpad_id.value)
+		return
+
+	var/obj/machinery/launchpad/the_pad = KEYBYINDEX(attached_console.launchpads, launchpad_id.value)
+	if(isnull(the_pad))
+		why_fail.set_output("Invalid launchpad selected!")
+		on_fail.set_output(COMPONENT_SIGNAL)
+		return
+
+	the_pad.set_offset(x_pos.value, y_pos.value)
+
+	if(COMPONENT_TRIGGERED_BY(port, x_pos))
+		x_pos.set_value(the_pad.x_offset)
+		return
+
+	if(COMPONENT_TRIGGERED_BY(port, y_pos))
+		y_pos.set_value(the_pad.y_offset)
+		return
+
+	var/checks = attached_console.teleport_checks(the_pad)
+	if(!isnull(checks))
+		why_fail.set_output(checks)
+		on_fail.set_output(COMPONENT_SIGNAL)
+		return
+
+	if(COMPONENT_TRIGGERED_BY(send_trigger, port))
+		INVOKE_ASYNC(the_pad, TYPE_PROC_REF(/obj/machinery/launchpad, doteleport), null, TRUE, parent.get_creator())
+		sent.set_output(COMPONENT_SIGNAL)
+
+	if(COMPONENT_TRIGGERED_BY(retrieve_trigger, port))
+		INVOKE_ASYNC(the_pad, TYPE_PROC_REF(/obj/machinery/launchpad, doteleport), null, FALSE, parent.get_creator())
+		retrieved.set_output(COMPONENT_SIGNAL)

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -173,8 +173,6 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/computer/launchpad)
 
 		if("pull")
 			teleport(usr, current_pad, FALSE)
-			if (recall_time)
-				addtimer(CALLBACK(src, PROC_REF(teleport), usr, current_pad, TRUE), recall_time * 10)
 			. = TRUE
 
 /obj/machinery/computer/launchpad/Initialize(mapload)

--- a/tgui/packages/tgui/interfaces/LaunchpadConsole.js
+++ b/tgui/packages/tgui/interfaces/LaunchpadConsole.js
@@ -118,7 +118,14 @@ const LaunchpadButtonPad = (props, context) => {
 export const LaunchpadControl = (props, context) => {
   const { topLevel } = props;
   const { act, data } = useBackend(context);
-  const { x, y, pad_name, range } = data;
+  const {
+    x,
+    y,
+    pad_name,
+    range,
+    can_adjust_recall_time = false,
+    recall_time = 0,
+  } = data;
   return (
     <Section
       title={
@@ -187,6 +194,15 @@ export const LaunchpadControl = (props, context) => {
           </Section>
         </Grid.Column>
       </Grid>
+      {can_adjust_recall_time && (
+        <Button
+          content={"Recall Time: " + recall_time + "s"}
+          icon="clock"
+          textAlign="center"
+          onClick={() => {
+            act('set_recall');
+          }} />
+      )}
       <Grid>
         <Grid.Column>
           <Button fluid icon="upload" content="Launch" textAlign="center" onClick={() => act('launch')} />
@@ -201,7 +217,10 @@ export const LaunchpadControl = (props, context) => {
 
 export const LaunchpadConsole = (props, context) => {
   const { act, data } = useBackend(context);
-  const { launchpads = [], selected_id } = data;
+  const {
+    launchpads = [],
+    selected_id,
+  } = data;
   return (
     <Window width={475} height={260}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/LaunchpadConsole.js
+++ b/tgui/packages/tgui/interfaces/LaunchpadConsole.js
@@ -118,14 +118,7 @@ const LaunchpadButtonPad = (props, context) => {
 export const LaunchpadControl = (props, context) => {
   const { topLevel } = props;
   const { act, data } = useBackend(context);
-  const {
-    x,
-    y,
-    pad_name,
-    range,
-    can_adjust_recall_time = false,
-    recall_time = 0,
-  } = data;
+  const { x, y, pad_name, range, can_adjust_recall_time = false, recall_time = 0 } = data;
   return (
     <Section
       title={
@@ -196,12 +189,13 @@ export const LaunchpadControl = (props, context) => {
       </Grid>
       {can_adjust_recall_time && (
         <Button
-          content={"Recall Time: " + recall_time + "s"}
+          content={'Recall Time: ' + recall_time + 's'}
           icon="clock"
           textAlign="center"
           onClick={() => {
             act('set_recall');
-          }} />
+          }}
+        />
       )}
       <Grid>
         <Grid.Column>
@@ -217,10 +211,7 @@ export const LaunchpadControl = (props, context) => {
 
 export const LaunchpadConsole = (props, context) => {
   const { act, data } = useBackend(context);
-  const {
-    launchpads = [],
-    selected_id,
-  } = data;
+  const { launchpads = [], selected_id } = data;
   return (
     <Window width={475} height={260}>
       <Window.Content scrollable>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a recall timer to the bluespace launchpad computer.

## Why It's Good For The Game

This means that the computer is now useful if you are a solo antagonist and want to do a heist on part of the station, but it has an extreme amount of risk:
- If you miss the teleport, you are stuck
- You are forced to wait for the timer you set, so if you need to teleport out FAST then you will have to wait.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/16a59a29-2348-42f3-94d3-0445615b3518

(I made it so that the UI auto-updates when the number changes)

## Changelog
:cl:
balance: Launchad computer can now set a timer to automatically recall after a set amount of time, up to 5 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
