### PR TITLE
Icewing watcher fixes

### DIFF
--- a/code/datums/status_effects/gas.dm
+++ b/code/datums/status_effects/gas.dm
@@ -11,9 +11,21 @@
 	if(!.)
 		return
 	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, TRAIT_STATUS_EFFECT(id))
+	RegisterSignal(owner, COMSIG_LIVING_RESIST, PROC_REF(owner_resist))
+	if(!owner.stat)
+		to_chat(owner, "<span class='userdanger'>You become frozen in a cube!</span>")
+	cube = icon('icons/effects/freeze.dmi', "ice_cube")
+	owner.add_overlay(cube)
+	owner.update_mobility()
 
 /datum/status_effect/freon/on_remove()
+	if(!owner.stat)
+		to_chat(owner, "The cube melts!")
+	UnregisterSignal(owner, COMSIG_LIVING_RESIST)
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, TRAIT_STATUS_EFFECT(id))
+	owner.cut_overlay(cube)
+	owner.adjust_bodytemperature(100)
+	owner.update_mobility()
 	return ..()
 
 /atom/movable/screen/alert/status_effect/freon
@@ -21,14 +33,14 @@
 	desc = "You're frozen inside an ice cube, and cannot move! You can still do stuff, like shooting. Resist out of the cube!"
 	icon_state = "frozen"
 
-/datum/status_effect/freon/on_apply()
-	RegisterSignal(owner, COMSIG_LIVING_RESIST, PROC_REF(owner_resist))
-	if(!owner.stat)
-		to_chat(owner, "<span class='userdanger'>You become frozen in a cube!</span>")
-	cube = icon('icons/effects/freeze.dmi', "ice_cube")
-	owner.add_overlay(cube)
-	owner.update_mobility()
-	return ..()
+/atom/movable/screen/alert/status_effect/freon/Click(location, control, params)
+	. = ..()
+	var/mob/living/L = usr
+	if(!istype(L) || !L.can_resist() || L != owner)
+		return
+	if(L.last_special <= world.time)
+		return L.resist()
+
 
 /datum/status_effect/freon/tick()
 	owner.update_mobility()
@@ -42,20 +54,12 @@
 
 /datum/status_effect/freon/proc/do_resist()
 	to_chat(owner, "You start breaking out of the ice cube!")
-	if(do_after(owner, 40))
+	if(do_after(owner, 4 SECONDS))
 		if(!QDELETED(src))
 			to_chat(owner, "You break out of the ice cube!")
 			owner.remove_status_effect(/datum/status_effect/freon)
 			owner.update_mobility()
 
-/datum/status_effect/freon/on_remove()
-	if(!owner.stat)
-		to_chat(owner, "The cube melts!")
-	owner.cut_overlay(cube)
-	owner.adjust_bodytemperature(100)
-	owner.update_mobility()
-	UnregisterSignal(owner, COMSIG_LIVING_RESIST)
-
 /datum/status_effect/freon/watcher
-	duration = 8
+	duration = 8 SECONDS
 	can_melt = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this PR fixes a couple of issues with the icewing watcher's freezing blast: 

- The on_apply and on_remove procs of the freezing status effect had duplicates that weren't executed properly, which caused targets to stay immobilized even after the effect was deleted. The consequences of this bug are documented in #10188. Those duplicates have now been combined, and mobility is restored correctly when the status effect ends.
- The duration of the effect was set to only 0.8 seconds, which makes no sense considering breaking out of the ice takes 4 seconds. The duration is now 8 seconds, which I assume was the original intent.
- It was possible to resist out of the ice, but only by pressing the resist hotkey. It is now possible to resist by clicking the status icon as well, just like handcuffs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's good when the icewing watcher freezes players for the correct amount of time

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/5da0d939-e27e-4054-abf8-e80b6f53f88a

https://github.com/BeeStation/BeeStation-Hornet/assets/78232749/f82824e3-ef2d-467e-9343-fbe09641cfe7

</details>

## Changelog
:cl:
fix: Icewing watchers no longer freeze their targets indefinitely
tweak: Changed the duration of the icewing watcher's freezing blast from 0.8 seconds to 8 seconds
fix: You can now resist being frozen by clicking the status icon in the top right
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
