### PR TITLE
Ports 'Save 0.6-0.7s of init time by splitting registering lists of signals into its own proc' and micro-optimizes the SEND_SIGNAL() define

### DIFF
--- a/code/__DEFINES/dcs/helpers.dm
+++ b/code/__DEFINES/dcs/helpers.dm
@@ -2,7 +2,7 @@
 /// The datum hosting the signal is automaticaly added as the first argument
 /// Returns a bitfield gathered from all registered procs
 /// Arguments given here are packaged in a list and given to _SendSignal
-#define SEND_SIGNAL(target, sigtype, arguments...) ( !target.comp_lookup || !target.comp_lookup[sigtype] ? NONE : target._SendSignal(sigtype, list(target, ##arguments)) )
+#define SEND_SIGNAL(target, sigtype, arguments...) ( !target.comp_lookup?[sigtype] ? NONE : target._SendSignal(sigtype, list(target, ##arguments)) )
 
 #define SEND_GLOBAL_SIGNAL(sigtype, arguments...) ( SEND_SIGNAL(SSdcs, sigtype, ##arguments) )
 

--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -37,6 +37,6 @@
 #define GC_CURRENTLY_BEING_QDELETED -2
 
 #define QDELING(X) (X.gc_destroyed)
-#define QDELETED(X) (!X || QDELING(X))
+#define QDELETED(X) (isnull(X) || QDELING(X))
 #define QDESTROYING(X) (!X || X.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
 

--- a/code/datums/ai/dog/dog_controller.dm
+++ b/code/datums/ai/dog/dog_controller.dm
@@ -29,7 +29,7 @@
 	RegisterSignal(new_pawn, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand))
 	RegisterSignal(new_pawn, COMSIG_PARENT_EXAMINE, PROC_REF(on_examined))
 	RegisterSignal(new_pawn, COMSIG_CLICK_ALT, PROC_REF(check_altclicked))
-	RegisterSignal(new_pawn, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(on_death))
+	RegisterSignals(new_pawn, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(on_death))
 	RegisterSignal(SSdcs, COMSIG_GLOB_CARBON_THROW_THING, PROC_REF(listened_throw))
 	return ..() //Run parent at end
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -199,7 +199,10 @@
 	var/list/lookup = (target.comp_lookup ||= list())
 
 	if(!override && target_procs[signal_type])
-		log_signal("[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]")
+		var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]"
+		// I need to split singals into their own logs eventually
+		//log_signal(override_message)
+		stack_trace(override_message)
 
 	target_procs[signal_type] = proctype
 	var/list/looked_up = lookup[signal_type]
@@ -216,7 +219,7 @@
 /// Registers multiple signals to the same proc.
 /datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE)
 	for (var/signal_type in signal_types)
-		RegisterSignal(target, signal_type, proctype)
+		RegisterSignal(target, signal_type, proctype, override)
 
 /**
  * Stop listening to a given signal from target

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -218,6 +218,10 @@
 
 /// Registers multiple signals to the same proc.
 /datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE)
+	if(!islist(signal_types))
+		stack_trace("[target] called RegisterSignals() with non-list signal: [signal_types]")
+		RegisterSignal(target, signal_types, proctype, override)
+		return
 	for (var/signal_type in signal_types)
 		RegisterSignal(target, signal_type, proctype, override)
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -1,12 +1,51 @@
+/**
+ * # Component
+ *
+ * The component datum
+ *
+ * A component should be a single standalone unit
+ * of functionality, that works by receiving signals from it's parent
+ * object to provide some single functionality (i.e a slippery component)
+ * that makes the object it's attached to cause people to slip over.
+ * Useful when you want shared behaviour independent of type inheritance
+ */
 /datum/component
+	/**
+	  * Defines how duplicate existing components are handled when added to a datum
+	  *
+	  * See [COMPONENT_DUPE_*][COMPONENT_DUPE_ALLOWED] definitions for available options
+	  */
 	var/dupe_mode = COMPONENT_DUPE_HIGHLANDER
+
+	/**
+	  * The type to check for duplication
+	  *
+	  * `null` means exact match on `type` (default)
+	  *
+	  * Any other type means that and all subtypes
+	  */
 	var/dupe_type
+
+	/// The datum this components belongs to
 	var/datum/parent
-	//only set to true if you are able to properly transfer this component
-	//At a minimum RegisterWithParent and UnregisterFromParent should be used
-	//Make sure you also implement PostTransfer for any post transfer handling
+
+	/**
+	  * Only set to true if you are able to properly transfer this component
+	  *
+	  * At a minimum [RegisterWithParent][/datum/component/proc/RegisterWithParent] and [UnregisterFromParent][/datum/component/proc/UnregisterFromParent] should be used
+	  *
+	  * Make sure you also implement [PostTransfer][/datum/component/proc/PostTransfer] for any post transfer handling
+	  */
 	var/can_transfer = FALSE
 
+/**
+ * Create a new component.
+ *
+ * Additional arguments are passed to [Initialize()][/datum/component/proc/Initialize]
+ *
+ * Arguments:
+ * * datum/P the parent datum this component reacts to signals from
+ */
 /datum/component/New(list/raw_args)
 	parent = raw_args[1]
 	var/list/arguments = raw_args.Copy(2)
@@ -17,6 +56,32 @@
 
 	_JoinParent(parent)
 
+/**
+ * Called during component creation with the same arguments as in new excluding parent.
+ *
+ * Do not call `qdel(src)` from this function, `return COMPONENT_INCOMPATIBLE` instead
+ */
+/datum/component/proc/Initialize(...)
+	return
+
+/**
+ * Properly removes the component from `parent` and cleans up references
+ *
+ * Arguments:
+ * * force - makes it not check for and remove the component from the parent
+ * * silent - deletes the component without sending a [COMSIG_COMPONENT_REMOVING] signal
+ */
+/datum/component/Destroy(force=FALSE, silent=FALSE)
+	if(!force && parent)
+		_RemoveFromParent()
+	if(parent && !silent)
+		SEND_SIGNAL(parent, COMSIG_COMPONENT_REMOVING, src)
+	parent = null
+	return ..()
+
+/**
+ * Internal proc to handle behaviour of components when joining a parent
+ */
 /datum/component/proc/_JoinParent()
 	var/datum/P = parent
 	//lazy init the parent's dc list
@@ -52,70 +117,118 @@
 
 	RegisterWithParent()
 
-// If you want/expect to be moving the component around between parents, use this to register on the parent for signals
-/datum/component/proc/RegisterWithParent()
-	return
-
-/datum/component/proc/Initialize(...)
-	return
-
-/datum/component/Destroy(force=FALSE, silent=FALSE)
-	if(!force && parent)
-		_RemoveFromParent()
-	if(parent && !silent)
-		SEND_SIGNAL(parent, COMSIG_COMPONENT_REMOVING, src)
-	parent = null
-	return ..()
-
+/**
+ * Internal proc to handle behaviour when being removed from a parent
+ */
 /datum/component/proc/_RemoveFromParent()
-	var/datum/P = parent
-	var/list/dc = P.datum_components
+	var/datum/parent = src.parent
+	var/list/parents_components = parent.datum_components
 	for(var/I in _GetInverseTypeList())
-		var/list/components_of_type = dc[I]
-		if(length(components_of_type))	//
+		var/list/components_of_type = parents_components[I]
+
+		if(length(components_of_type)) //
 			var/list/subtracted = components_of_type - src
-			if(subtracted.len == 1)	//only 1 guy left
-				dc[I] = subtracted[1]	//make him special
+
+			if(subtracted.len == 1) //only 1 guy left
+				parents_components[I] = subtracted[1] //make him special
 			else
-				dc[I] = subtracted
-		else	//just us
-			dc -= I
-	if(!dc.len)
-		P.datum_components = null
+				parents_components[I] = subtracted
+
+		else //just us
+			parents_components -= I
+
+	if(!parents_components.len)
+		parent.datum_components = null
 
 	UnregisterFromParent()
 
+/**
+ * Register the component with the parent object
+ *
+ * Use this proc to register with your parent object
+ *
+ * Overridable proc that's called when added to a new parent
+ */
+/datum/component/proc/RegisterWithParent()
+	return
+
+/**
+ * Unregister from our parent object
+ *
+ * Use this proc to unregister from your parent object
+ *
+ * Overridable proc that's called when removed from a parent
+ * *
+ */
 /datum/component/proc/UnregisterFromParent()
 	return
 
-/datum/proc/RegisterSignal(datum/target, sig_type_or_types, proctype, override = FALSE)
+/**
+ * Register to listen for a signal from the passed in target
+ *
+ * This sets up a listening relationship such that when the target object emits a signal
+ * the source datum this proc is called upon, will receive a callback to the given proctype
+ * Use PROC_REF(procname), TYPE_PROC_REF(type,procname) or GLOBAL_PROC_REF(procname) macros to validate the passed in proc at compile time.
+ * PROC_REF for procs defined on current type or it's ancestors, TYPE_PROC_REF for procs defined on unrelated type and GLOBAL_PROC_REF for global procs.
+ * Return values from procs registered must be a bitfield
+ *
+ * Arguments:
+ * * datum/target The target to listen for signals from
+ * * signal_type A signal name
+ * * proctype The proc to call back when the signal is emitted
+ * * override If a previous registration exists you must explicitly set this
+ */
+/datum/proc/RegisterSignal(datum/target, signal_type, proctype, override = FALSE)
 	if(QDELETED(src) || QDELETED(target))
 		return
 
-	var/list/procs = signal_procs
-	if(!procs)
-		signal_procs = procs = list()
-	var/list/target_procs = procs[target] || (procs[target] = list())
-	var/list/lookup = target.comp_lookup
-	if(!lookup)
-		target.comp_lookup = lookup = list()
+	if (islist(signal_type))
+		var/static/list/known_failures = list()
+		var/list/signal_type_list = signal_type
+		var/message = "([target.type]) is registering [signal_type_list.Join(", ")] as a list, the older method. Change it to RegisterSignals."
 
-	for(var/sig_type in (islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)))
-		if(!override && target_procs[sig_type])
-			stack_trace("[sig_type] overridden on [target.type]. Use override = TRUE to suppress this warning")
+		if (!(message in known_failures))
+			known_failures[message] = TRUE
+			stack_trace("[target] [message]")
 
-		target_procs[sig_type] = proctype
-		var/list/looked_up = lookup[sig_type]
+		RegisterSignals(target, signal_type, proctype, override)
+		return
 
-		if(!looked_up) // Nothing has registered here yet
-			lookup[sig_type] = src
-		else if(looked_up == src) // We already registered here
-			continue
-		else if(!length(looked_up)) // One other thing registered here
-			lookup[sig_type] = list((looked_up) = TRUE, (src) = TRUE)
-		else // Many other things have registered here
-			looked_up[src] = TRUE
+	var/list/procs = (signal_procs ||= list())
+	var/list/target_procs = (procs[target] ||= list())
+	var/list/lookup = (target.comp_lookup ||= list())
 
+	if(!override && target_procs[signal_type])
+		log_signal("[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]")
+
+	target_procs[signal_type] = proctype
+	var/list/looked_up = lookup[signal_type]
+
+	if(isnull(looked_up)) // Nothing has registered here yet
+		lookup[signal_type] = src
+	else if(looked_up == src) // We already registered here
+		return
+	else if(!length(looked_up)) // One other thing registered here
+		lookup[signal_type] = list((looked_up) = TRUE, (src) = TRUE)
+	else // Many other things have registered here
+		looked_up[src] = TRUE
+
+/// Registers multiple signals to the same proc.
+/datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE)
+	for (var/signal_type in signal_types)
+		RegisterSignal(target, signal_type, proctype)
+
+/**
+ * Stop listening to a given signal from target
+ *
+ * Breaks the relationship between target and source datum, removing the callback when the signal fires
+ *
+ * Doesn't care if a registration exists or not
+ *
+ * Arguments:
+ * * datum/target Datum to stop listening to signals from
+ * * sig_typeor_types Signal string key or list of signal keys to stop listening to specifically
+ */
 /datum/proc/UnregisterSignal(datum/target, sig_type_or_types)
 	var/list/lookup = target.comp_lookup
 	if(!signal_procs || !signal_procs[target] || !lookup)

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	return ..()
 
 /datum/component/creamed/RegisterWithParent()
-	RegisterSignal(parent, list(
+	RegisterSignals(parent, list(
 		COMSIG_COMPONENT_CLEAN_ACT,
 		COMSIG_COMPONENT_CLEAN_FACE_ACT),
 		PROC_REF(clean_up))

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -89,7 +89,7 @@
 
 	limb.embedded_objects |= weapon // on the inside... on the inside...
 	weapon.forceMove(victim)
-	RegisterSignal(weapon, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(weaponDeleted))
+	RegisterSignals(weapon, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(weaponDeleted))
 	victim.visible_message("<span class='danger'>[weapon] [harmful ? "embeds" : "sticks"] itself [harmful ? "in" : "to"] [victim]'s [limb.name]!</span>", "<span class='userdanger'>[weapon] [harmful ? "embeds" : "sticks"] itself [harmful ? "in" : "to"] your [limb.name]!</span>")
 
 	if(harmful)

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -17,7 +17,7 @@
 		RegisterSignal(parent, COMSIG_MOVABLE_IMPACT, PROC_REF(explodable_impact))
 		RegisterSignal(parent, COMSIG_MOVABLE_BUMP, PROC_REF(explodable_bump))
 		if(isitem(parent))
-			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), PROC_REF(explodable_attack))
+			RegisterSignals(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), PROC_REF(explodable_attack))
 			RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 			RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -8,7 +8,7 @@
 		return COMPONENT_INCOMPATIBLE
 	volume = volume_
 	e_range = e_range_
-	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(play_footstep))
+	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(play_footstep))
 
 /datum/component/footstep/proc/play_footstep()
 	SIGNAL_HANDLER

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -102,7 +102,7 @@
 				spread = round((i / num_pellets - 0.5) * distro)
 
 		RegisterSignal(shell.BB, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(pellet_hit))
-		RegisterSignal(shell.BB, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PARENT_QDELETING), PROC_REF(pellet_range))
+		RegisterSignals(shell.BB, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PARENT_QDELETING), PROC_REF(pellet_range))
 		pellets += shell.BB
 		var/turf/current_loc = get_turf(user)
 		if(!istype(targloc) || !istype(current_loc))
@@ -225,7 +225,7 @@
 	P.suppressed = SUPPRESSED_VERY // set the projectiles to make no message so we can do our own aggregate message
 	P.preparePixelProjectile(target, parent)
 	RegisterSignal(P, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(pellet_hit))
-	RegisterSignal(P, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PARENT_QDELETING), PROC_REF(pellet_range))
+	RegisterSignals(P, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_PARENT_QDELETING), PROC_REF(pellet_range))
 	pellets += P
 	P.fire()
 

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -27,10 +27,10 @@
 	reagents = parent_movable.reagents
 	turn_connects = _turn_connects
 
-	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED,COMSIG_PARENT_PREQDELETED), PROC_REF(disable))
-	RegisterSignal(parent, list(COMSIG_OBJ_DEFAULT_UNFASTEN_WRENCH), PROC_REF(toggle_active))
-	RegisterSignal(parent, list(COMSIG_OBJ_HIDE), PROC_REF(hide))
-	RegisterSignal(parent, list(COMSIG_ATOM_UPDATE_OVERLAYS), PROC_REF(create_overlays)) //create overlays also gets called after init (no idea by what it just happens)
+	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED,COMSIG_PARENT_PREQDELETED), PROC_REF(disable))
+	RegisterSignals(parent, list(COMSIG_OBJ_DEFAULT_UNFASTEN_WRENCH), PROC_REF(toggle_active))
+	RegisterSignals(parent, COMSIG_OBJ_HIDE, PROC_REF(hide))
+	RegisterSignals(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(create_overlays)) //create overlays also gets called after init (no idea by what it just happens)
 
 	if(start)
 		//timer 0 so it can finish returning initialize, after which we're added to the parent.

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -29,8 +29,8 @@
 
 	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED,COMSIG_PARENT_PREQDELETED), PROC_REF(disable))
 	RegisterSignals(parent, list(COMSIG_OBJ_DEFAULT_UNFASTEN_WRENCH), PROC_REF(toggle_active))
-	RegisterSignals(parent, COMSIG_OBJ_HIDE, PROC_REF(hide))
-	RegisterSignals(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(create_overlays)) //create overlays also gets called after init (no idea by what it just happens)
+	RegisterSignal(parent, COMSIG_OBJ_HIDE, PROC_REF(hide))
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(create_overlays)) //create overlays also gets called after init (no idea by what it just happens)
 
 	if(start)
 		//timer 0 so it can finish returning initialize, after which we're added to the parent.
@@ -38,7 +38,7 @@
 		addtimer(CALLBACK(src, PROC_REF(enable)), 0)
 
 /datum/component/plumbing/process()
-	if(!demand_connects || !reagents)		// This actually shouldn't happen, but better safe than sorry
+	if(!demand_connects || !reagents) // This actually shouldn't happen, but better safe than sorry
 		return PROCESS_KILL
 	if(reagents.total_volume < reagents.maximum_volume)
 		for(var/D in GLOB.cardinals)

--- a/code/datums/components/shuttle_cling.dm
+++ b/code/datums/components/shuttle_cling.dm
@@ -38,7 +38,7 @@
 
 	ADD_TRAIT(parent, TRAIT_HYPERSPACED, src)
 
-	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_UNBUCKLE, COMSIG_MOVABLE_NO_LONGER_PULLED, COMSIG_MOVABLE_POST_THROW), PROC_REF(update_state))
+	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_UNBUCKLE, COMSIG_MOVABLE_NO_LONGER_PULLED, COMSIG_MOVABLE_POST_THROW), PROC_REF(update_state))
 
 	//Items have this cool thing where they're first put on the floor if you grab them from storage, and then into your hand, which isn't caught by movement signals that well
 	if(isitem(parent))

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -89,7 +89,7 @@
 
 	RegisterSignal(parent, COMSIG_ATOM_BLOB_ACT, PROC_REF(block_blob))
 
-	RegisterSignal(parent, list(
+	RegisterSignals(parent, list(
 		COMSIG_ATOM_ATTACK_ANIMAL,
 		COMSIG_ATOM_ATTACK_HAND,
 		COMSIG_ATOM_ATTACK_PAW,

--- a/code/datums/components/snail_crawl.dm
+++ b/code/datums/components/snail_crawl.dm
@@ -2,7 +2,7 @@
 	var/mob/living/carbon/snail
 
 /datum/component/snailcrawl/Initialize()
-	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(lubricate))
+	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(lubricate))
 	snail = parent
 
 /datum/component/snailcrawl/proc/lubricate()

--- a/code/datums/components/snail_crawl.dm
+++ b/code/datums/components/snail_crawl.dm
@@ -2,7 +2,7 @@
 	var/mob/living/carbon/snail
 
 /datum/component/snailcrawl/Initialize()
-	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(lubricate))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(lubricate))
 	snail = parent
 
 /datum/component/snailcrawl/proc/lubricate()

--- a/code/datums/components/sound_player.dm
+++ b/code/datums/components/sound_player.dm
@@ -21,7 +21,7 @@
 	src.sounds = sounds
 	src.uses = uses
 
-	RegisterSignal(parent, signal_list, PROC_REF(play_sound))
+	RegisterSignals(parent, signal_list, PROC_REF(play_sound))
 
 /**
  * Attempt to play the sound on parent

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -21,7 +21,7 @@
 	if(_max_mobs)
 		max_mobs=_max_mobs
 
-	RegisterSignal(parent, list(COMSIG_PARENT_QDELETING), PROC_REF(stop_spawning))
+	RegisterSignals(parent, list(COMSIG_PARENT_QDELETING), PROC_REF(stop_spawning))
 	START_PROCESSING(SSprocessing, src)
 
 /datum/component/spawner/process()

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -21,7 +21,7 @@
 	if(_max_mobs)
 		max_mobs=_max_mobs
 
-	RegisterSignals(parent, list(COMSIG_PARENT_QDELETING), PROC_REF(stop_spawning))
+	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(stop_spawning))
 	START_PROCESSING(SSprocessing, src)
 
 /datum/component/spawner/process()

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -28,15 +28,15 @@
 /datum/component/squeak/Initialize(custom_sounds, volume_override, chance_override, step_delay_override, use_delay_override, extrarange, falloff_exponent, fallof_distance)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_BLOB_ACT, COMSIG_ATOM_HULK_ATTACK, COMSIG_PARENT_ATTACKBY), PROC_REF(play_squeak))
+	RegisterSignals(parent, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_BLOB_ACT, COMSIG_ATOM_HULK_ATTACK, COMSIG_PARENT_ATTACKBY), PROC_REF(play_squeak))
 	if(ismovable(parent))
-		RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT), PROC_REF(play_squeak))
+		RegisterSignals(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT), PROC_REF(play_squeak))
 
 		AddComponent(/datum/component/connect_loc_behalf, parent, item_connections)
 		RegisterSignal(parent, COMSIG_ATOM_EMINENCE_ACT, PROC_REF(play_squeak_crossed))
 		RegisterSignal(parent, COMSIG_MOVABLE_DISPOSING, PROC_REF(disposing_react))
 		if(isitem(parent))
-			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), PROC_REF(play_squeak))
+			RegisterSignals(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), PROC_REF(play_squeak))
 			RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(use_squeak))
 			RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 			RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -7,11 +7,12 @@
 /datum/component/stationloving/Initialize(inform_admins = FALSE, allow_death = FALSE)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignals(parent, list(COMSIG_MOVABLE_Z_CHANGED), PROC_REF(z_check))
-	RegisterSignals(parent, list(COMSIG_MOVABLE_SECLUDED_LOCATION), PROC_REF(relocate))
-	RegisterSignals(parent, list(COMSIG_PARENT_PREQDELETED), PROC_REF(check_deletion))
-	RegisterSignals(parent, list(COMSIG_ITEM_IMBUE_SOUL), PROC_REF(check_soul_imbue))
-	RegisterSignals(parent, list(COMSIG_ITEM_MARK_RETRIEVAL), PROC_REF(check_mark_retrieval))
+
+	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(z_check))
+	RegisterSignal(parent, COMSIG_MOVABLE_SECLUDED_LOCATION, PROC_REF(relocate))
+	RegisterSignal(parent, COMSIG_PARENT_PREQDELETED, PROC_REF(check_deletion))
+	RegisterSignal(parent, COMSIG_ITEM_IMBUE_SOUL, PROC_REF(check_soul_imbue))
+	RegisterSignal(parent, COMSIG_ITEM_MARK_RETRIEVAL, PROC_REF(check_mark_retrieval))
 	src.inform_admins = inform_admins
 	src.allow_death = allow_death
 	check_in_bounds() // Just in case something is being created outside of station/centcom

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -7,11 +7,11 @@
 /datum/component/stationloving/Initialize(inform_admins = FALSE, allow_death = FALSE)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, list(COMSIG_MOVABLE_Z_CHANGED), PROC_REF(z_check))
-	RegisterSignal(parent, list(COMSIG_MOVABLE_SECLUDED_LOCATION), PROC_REF(relocate))
-	RegisterSignal(parent, list(COMSIG_PARENT_PREQDELETED), PROC_REF(check_deletion))
-	RegisterSignal(parent, list(COMSIG_ITEM_IMBUE_SOUL), PROC_REF(check_soul_imbue))
-	RegisterSignal(parent, list(COMSIG_ITEM_MARK_RETRIEVAL), PROC_REF(check_mark_retrieval))
+	RegisterSignals(parent, list(COMSIG_MOVABLE_Z_CHANGED), PROC_REF(z_check))
+	RegisterSignals(parent, list(COMSIG_MOVABLE_SECLUDED_LOCATION), PROC_REF(relocate))
+	RegisterSignals(parent, list(COMSIG_PARENT_PREQDELETED), PROC_REF(check_deletion))
+	RegisterSignals(parent, list(COMSIG_ITEM_IMBUE_SOUL), PROC_REF(check_soul_imbue))
+	RegisterSignals(parent, list(COMSIG_ITEM_MARK_RETRIEVAL), PROC_REF(check_mark_retrieval))
 	src.inform_admins = inform_admins
 	src.allow_death = allow_death
 	check_in_bounds() // Just in case something is being created outside of station/centcom

--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -6,9 +6,9 @@
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
 	if(isliving(parent))
-		RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(LivingWaddle))
+		RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(LivingWaddle))
 	else
-		RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(Waddle))
+		RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED), PROC_REF(Waddle))
 
 /datum/component/waddling/proc/LivingWaddle()
 	SIGNAL_HANDLER

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -19,14 +19,24 @@
 
 	/// Active timers with this datum as the target
 	var/list/active_timers
-	/// Components attached to this datum
-	var/list/datum_components
-	/// Status traits attached to this datum
+	/// Status traits attached to this datum. associative list of the form: list(trait name (string) = list(source1, source2, source3,...))
 	var/list/status_traits
-	/// Any datum registered to receive signals from this datum is in this list
+
+	/**
+	  * Components attached to this datum
+	  *
+	  * Lazy associated list in the structure of `type:component/list of components`
+	  */
+	var/list/datum_components
+	/**
+	  * Any datum registered to receive signals from this datum is in this list
+	  *
+	  * Lazy associated list in the structure of `signal:registree/list of registrees`
+	  */
 	var/list/comp_lookup
-	/// List of callbacks for signal procs
+	/// Lazy associated list in the structure of `signals:proctype` that are run when the datum receives that signal
 	var/list/list/datum/callback/signal_procs
+
 	/// Datum level flags
 	var/datum_flags = NONE
 	/// A cached version of our \ref

--- a/code/datums/elements/earhealing.dm
+++ b/code/datums/elements/earhealing.dm
@@ -10,11 +10,11 @@
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 
-	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED), PROC_REF(equippedChanged))
+	RegisterSignals(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED), PROC_REF(equippedChanged))
 
 /datum/element/earhealing/Detach(datum/target)
 	. = ..()
-	UnregisterSignals(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
+	UnregisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 	user_by_item -= target
 
 /datum/element/earhealing/proc/equippedChanged(datum/source, mob/living/carbon/user, slot)

--- a/code/datums/elements/earhealing.dm
+++ b/code/datums/elements/earhealing.dm
@@ -14,7 +14,7 @@
 
 /datum/element/earhealing/Detach(datum/target)
 	. = ..()
-	UnregisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
+	UnregisterSignals(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 	user_by_item -= target
 
 /datum/element/earhealing/proc/equippedChanged(datum/source, mob/living/carbon/user, slot)

--- a/code/datums/elements/item_scaling.dm
+++ b/code/datums/elements/item_scaling.dm
@@ -39,9 +39,9 @@
 	src.storage_scaling = storage_scaling
 
 	// Object scaled when dropped/thrown OR when exiting a storage component.
-	RegisterSignal(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), PROC_REF(scale_overworld))
+	RegisterSignals(target, list(COMSIG_ITEM_DROPPED, COMSIG_STORAGE_EXITED), PROC_REF(scale_overworld))
 	// Object scaled when placed in an inventory slot OR when entering a storage component.
-	RegisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), PROC_REF(scale_storage))
+	RegisterSignals(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_STORAGE_ENTERED), PROC_REF(scale_storage))
 
 /**
  * Detach proc for the item_scaling element.

--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -17,7 +17,7 @@
 	ADD_TRAIT(target, TRAIT_RUSTY, src)
 	RegisterSignal(target, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(apply_rust_overlay))
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, PROC_REF(handle_examine))
-	RegisterSignal(target, list(COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), COMSIG_ATOM_TOOL_ACT(TOOL_RUSTSCRAPER)), PROC_REF(secondary_tool_act))
+	RegisterSignals(target, list(COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), COMSIG_ATOM_TOOL_ACT(TOOL_RUSTSCRAPER)), PROC_REF(secondary_tool_act))
 	// Unfortunately registering with parent sometimes doesn't cause an overlay update
 	target.update_icon()
 

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -180,7 +180,7 @@
 		return
 
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(check_owner_in_range))
-	RegisterSignal(offered_item, list(COMSIG_PARENT_QDELETING, COMSIG_ITEM_DROPPED), PROC_REF(dropped_item))
+	RegisterSignals(offered_item, list(COMSIG_PARENT_QDELETING, COMSIG_ITEM_DROPPED), PROC_REF(dropped_item))
 
 /datum/status_effect/offering/Destroy()
 	for(var/i in possible_takers)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -10,7 +10,7 @@
 
 /obj/machinery/computer/station_alert/Initialize(mapload)
 	alert_control = new(src, list(ALARM_ATMOS, ALARM_FIRE, ALARM_POWER), list(z), title = name)
-	RegisterSignal(alert_control.listener, list(COMSIG_ALARM_TRIGGERED, COMSIG_ALARM_CLEARED), PROC_REF(update_alarm_display))
+	RegisterSignals(alert_control.listener, list(COMSIG_ALARM_TRIGGERED, COMSIG_ALARM_CLEARED), PROC_REF(update_alarm_display))
 	return ..()
 
 /obj/machinery/computer/station_alert/Destroy()

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -430,7 +430,7 @@
 	var/mob/living/carbon/human/H = user
 	tank = H.s_store
 	air_contents = tank.air_contents
-	RegisterSignal(tank, list(COMSIG_ITEM_DROPPED, COMSIG_PARENT_QDELETING), PROC_REF(on_tank_drop))
+	RegisterSignals(tank, list(COMSIG_ITEM_DROPPED, COMSIG_PARENT_QDELETING), PROC_REF(on_tank_drop))
 	START_PROCESSING(SSobj, src)
 	..()
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -387,7 +387,7 @@
 		if(B)
 			B.organ_flags &= ~ORGAN_VITAL
 			B.decoy_override = TRUE
-		RegisterSignal(C, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), PROC_REF(stingAtom))
+		RegisterSignals(C, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), PROC_REF(stingAtom))
 	update_changeling_icons_added()
 
 /datum/antagonist/changeling/remove_innate_effects()

--- a/code/modules/antagonists/holoparasite/holoparasite_antag.dm
+++ b/code/modules/antagonists/holoparasite/holoparasite_antag.dm
@@ -144,8 +144,8 @@
 /datum/antagonist/holoparasite/apply_innate_effects()
 	. = ..()
 	RegisterSignal(owner, COMSIG_HOLOPARA_SET_SUMMONER, PROC_REF(on_set_summoner))
-	RegisterSignal(owner, list(COMSIG_HOLOPARA_SET_ACCENT_COLOR, COMSIG_HOLOPARA_SET_THEME), PROC_REF(do_update_static_data))
-	RegisterSignal(stats, list(COMSIG_HOLOPARA_STATS_SET_MAJOR_ABILITY, COMSIG_HOLOPARA_STATS_ADD_LESSER_ABILITY, COMSIG_HOLOPARA_STATS_TAKE_LESSER_ABILITY, COMSIG_HOLOPARA_STATS_SET_WEAPON), PROC_REF(do_update_static_data))
+	RegisterSignals(owner, list(COMSIG_HOLOPARA_SET_ACCENT_COLOR, COMSIG_HOLOPARA_SET_THEME), PROC_REF(do_update_static_data))
+	RegisterSignals(stats, list(COMSIG_HOLOPARA_STATS_SET_MAJOR_ABILITY, COMSIG_HOLOPARA_STATS_ADD_LESSER_ABILITY, COMSIG_HOLOPARA_STATS_TAKE_LESSER_ABILITY, COMSIG_HOLOPARA_STATS_SET_WEAPON), PROC_REF(do_update_static_data))
 
 /datum/antagonist/holoparasite/remove_innate_effects()
 	. = ..()

--- a/code/modules/holoparasite/abilities/major/scout.dm
+++ b/code/modules/holoparasite/abilities/major/scout.dm
@@ -63,7 +63,7 @@
 	RegisterSignal(owner, COMSIG_MOB_CLICKON, PROC_REF(on_click))
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(owner, COMSIG_HOLOPARA_SETUP_HUD, PROC_REF(on_hud_setup))
-	RegisterSignal(owner, list(COMSIG_HOLOPARA_SET_HUD_HEALTH, COMSIG_HOLOPARA_SET_HUD_STATUS), PROC_REF(on_medhud))
+	RegisterSignals(owner, list(COMSIG_HOLOPARA_SET_HUD_HEALTH, COMSIG_HOLOPARA_SET_HUD_STATUS), PROC_REF(on_medhud))
 	RegisterSignal(owner, COMSIG_HOLOPARA_POST_MANIFEST, PROC_REF(on_post_manifest))
 	RegisterSignal(owner, COMSIG_HOLOPARA_RECALL, PROC_REF(on_recall))
 	RegisterSignal(owner, COMSIG_HOLOPARA_STAT, PROC_REF(on_stat))
@@ -351,7 +351,7 @@
 	owner.incorporeal_move = FALSE
 	stalking = target
 	to_chat(owner, "<span class='notice'>You begin to stalk <span class='name'>[target]</span>, following [target.p_their()] every move from behind your cloak.</span>")
-	RegisterSignal(target, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_DIR_CHANGE), PROC_REF(on_stalked_moved))
+	RegisterSignals(target, list(COMSIG_MOVABLE_MOVED, COMSIG_ATOM_DIR_CHANGE), PROC_REF(on_stalked_moved))
 	RegisterSignal(target, COMSIG_PARENT_PREQDELETED, PROC_REF(on_stalked_pre_qdel))
 	on_stalked_moved(target)
 	deadchat_broadcast("<span class='ghostalert'><span class='name'>[owner.real_name]</span> has begun to stalk <span class='name'>[target.real_name]</span>!</span>", follow_target = owner, turf_target = get_turf(owner))

--- a/code/modules/holoparasite/abilities/weapon/dextrous.dm
+++ b/code/modules/holoparasite/abilities/weapon/dextrous.dm
@@ -133,7 +133,7 @@
 /datum/holoparasite_ability/weapon/dextrous/register_signals()
 	..()
 	RegisterSignal(owner, COMSIG_HOLOPARA_SETUP_HUD, PROC_REF(on_hud_setup))
-	RegisterSignal(owner, list(COMSIG_HOLOPARA_PRE_SNAPBACK, COMSIG_HOLOPARA_PRE_RECALL), PROC_REF(drop_items))
+	RegisterSignals(owner, list(COMSIG_HOLOPARA_PRE_SNAPBACK, COMSIG_HOLOPARA_PRE_RECALL), PROC_REF(drop_items))
 	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(on_death))
 	RegisterSignal(owner, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
 	RegisterSignal(owner, COMSIG_HOLOPARA_CAN_FIRE_GUN, PROC_REF(can_fire_gun))

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -24,7 +24,7 @@
 /obj/machinery/mineral/proc/register_input_turf()
 	input_turf = get_step(src, input_dir)
 	if(input_turf) // make sure there is actually a turf
-		RegisterSignal(input_turf, list(COMSIG_ATOM_CREATED, COMSIG_ATOM_ENTERED), PROC_REF(pickup_item))
+		RegisterSignals(input_turf, list(COMSIG_ATOM_CREATED, COMSIG_ATOM_ENTERED), PROC_REF(pickup_item))
 
 /// Unregisters signals that are registered the machine's input turf, if it has one.
 /obj/machinery/mineral/proc/unregister_input_turf()

--- a/code/modules/mob/living/simple_animal/heretic_monsters.dm
+++ b/code/modules/mob/living/simple_animal/heretic_monsters.dm
@@ -114,7 +114,7 @@
 	linked_mobs[mob_linked] = action
 	action.Grant(mob_linked)
 
-	RegisterSignal(mob_linked, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETING, SIGNAL_ADDTRAIT(TRAIT_MINDSHIELD)), PROC_REF(unlink_mob))
+	RegisterSignals(mob_linked, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETING, SIGNAL_ADDTRAIT(TRAIT_MINDSHIELD)), PROC_REF(unlink_mob))
 
 	return TRUE
 

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -20,7 +20,7 @@
 	//Or if we're on station. Otherwise, die.
 	var/list/allowed_areas = GLOB.the_station_areas + typesof(/area/mine)
 	alert_control = new(computer, list(ALARM_ATMOS, ALARM_FIRE, ALARM_POWER), listener_areas = allowed_areas)
-	RegisterSignal(alert_control.listener, list(COMSIG_ALARM_TRIGGERED, COMSIG_ALARM_CLEARED), PROC_REF(update_alarm_display))
+	RegisterSignals(alert_control.listener, list(COMSIG_ALARM_TRIGGERED, COMSIG_ALARM_CLEARED), PROC_REF(update_alarm_display))
 	return ..()
 
 /datum/computer_file/program/alarm_monitor/Destroy()

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -34,7 +34,7 @@
 		var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
 		rotcomp.BaseRot(null,ROTATION_FLIP)
 
-	update_icon()
+	update_appearance(UPDATE_ICON)
 
 	if(!initial(pipe_type.density)) //This prevents dense disposals machinery from being hidable under floor tiles
 		AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/61319
- https://github.com/tgstation/tgstation/pull/71056

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Signal Optimizations for faster init, supposedly


PR 1

if(list?[index]) is very slightly faster than if(list && list[index]), so we converts the SEND_SIGNAL() define to that. 

PR 2

> - Makes QDELETED use isnull(x) instead of !x, giving about 0.2 to 0.25s of speed.
> - Make disposal constructs only update icon state rather than go through expensive overlay code. Unfortunately did not have - much effect, but is something they should've been doing nonetheless.
> - Makes RegisterSignal only take signals directly as opposed to allocating a fresh list of signals. Very few consumers actually used this and it costs about 0.4s. Also I think this is just a bad API anyway and that separate procs are important
> 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Faster init

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/cceeba4b-830c-4e97-aa36-0fc21f746c86)


</details>

## Changelog
:cl: rkz, Mothblocks, Kylerace
refactor: speeds up init by ~0.8s by splitting registering lists of signals
code: documents component code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
