### PR TITLE
[Port] Fixes Embeds from being blocked by shields and adds the ability to see embeds in health analyzer scans

### DIFF
--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -70,10 +70,10 @@
 
 
 /// Checking to see if we're gonna embed into a human
-/datum/element/embed/proc/checkEmbed(obj/item/weapon, mob/living/carbon/victim, hit_zone, datum/thrownthing/throwingdatum, forced=FALSE)
+/datum/element/embed/proc/checkEmbed(obj/item/weapon, mob/living/carbon/victim, hit_zone, blocked, datum/thrownthing/throwingdatum, forced=FALSE)
 	SIGNAL_HANDLER
 
-	if(!istype(victim) || HAS_TRAIT(victim, TRAIT_PIERCEIMMUNE))
+	if((!forced && blocked) || !istype(victim) || HAS_TRAIT(victim, TRAIT_PIERCEIMMUNE))
 		return
 
 	var/flying_speed = throwingdatum ? throwingdatum.speed : weapon.throw_speed

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -398,6 +398,11 @@ GENE SCANNER
 			if(H.has_status_effect(STATUS_EFFECT_LING_TRANSFORMATION))
 				message += "\t<span class='info'>Subject's DNA appears to be in an unstable state.</span>"
 
+		// Embedded Items
+		for(var/obj/item/bodypart/limb as anything in H.bodyparts)
+			for(var/obj/item/embed as anything in limb.embedded_objects)
+				message += "\t<span class='alert'>Foreign object embedded in subject's [limb.name].</span>"
+
 	// Species and body temperature
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -91,7 +91,7 @@
 		var/zone = ran_zone(BODY_ZONE_CHEST, 65)//Hits a random part of the body, geared towards the chest
 		var/dtype = BRUTE
 		var/volume = I.get_volume_by_throwforce_and_or_w_class()
-		var/nosell_hit = SEND_SIGNAL(I, COMSIG_MOVABLE_IMPACT_ZONE, src, zone, throwingdatum) // TODO: find a better way to handle hitpush and skipcatch for humans
+		var/nosell_hit = SEND_SIGNAL(I, COMSIG_MOVABLE_IMPACT_ZONE, src, zone, blocked, throwingdatum) // TODO: find a better way to handle hitpush and skipcatch for humans
 		if(nosell_hit)
 			skipcatch = TRUE
 			hitpush = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Ports TG Station's with minor code tweaks:
https://github.com/tgstation/tgstation/pull/71334
https://github.com/tgstation/tgstation/pull/75113

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Embeds should be able to be blocked properly by shields. And health analyzers showing embedded items is just nice QoL.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/fb63d19a-f9ee-4d0b-b40a-ccac97ab5ea4


</details>

## Changelog
:cl:
add: Added the ability for health analyzers to see embedded items inside of a person.4
fix: Fixed embeds not properly being blocked by shields.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
