### PR TITLE
*ONLY* adds an Icecream Vat to Radstation freezer where a food cart is (brain working 2023)

### DIFF
--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -76950,7 +76950,7 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "yde" = (
-/obj/machinery/food_cart,
+/obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "ydt" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Take two, I fudged up the previous one by branching off a dirty branch #10256

## About The Pull Request

I think the food cart here wasn't intended as per this message. No other way to get an ice cream vat exists.
Source: BeeStation Discord https://discord.com/channels/427337870844362753/559239578158891009/1180228452792672358

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ice Cream vats are otherwise unobtainable, and every other map has them. It seems to be clear that their absence from RadStation was unintended

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/31d35738-0a1f-44f4-82d9-54579f983e8c)

</details>

## Changelog
/:cl:
fix: (RadStation) The foodcart in the freezer is now an Ice Cream Vat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
