### PR TITLE
CMO Stamp no longer missing from Meta and Delta + fixes the lower airlock in Delta secondary engine room

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54747,6 +54747,10 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/item/stamp/cmo{
+	pixel_y = 14;
+	pixel_x = -8
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "kpI" = (
@@ -93657,10 +93661,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "xzS" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37972,6 +37972,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/item/stamp/cmo{
+	pixel_x = 10;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "heJ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently DeltaStation has been missing a CMO stamp the *entire* time that it's been around.
And Meta has been missing it since the big Delta+Meta medbay rework.

Resolves #10293

Also taking the opportunity to fix an external airlock problem in lower engineering while doing this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes are good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Engine Room Lower airlock now gets air from distro (Previously an unconnected vent was in it's place.)

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/a5a33461-7dbb-4899-9039-59ddd28f315b


CMO Stamp now here on DeltaStation.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/7e5c1a20-e683-416c-96f8-bb027a3d5ed8)

and here on MetaStation.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/d8404ecf-b699-46a5-b757-27464ce35395)

</details>

## Changelog
/:cl:
fix: (DeltaStation - Engineering) Fixed some disconnected piping near the southern secondary engine exterior access
fix: (Delta + Meta - CMO Office) Both now have the CMO stamps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
