### PR TITLE
Fix: SecTech refill canister now has the right name

### DIFF
--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -39,4 +39,5 @@
 		F.update_brightness()
 
 /obj/item/vending_refill/security
+	machine_name = "SecTech"
 	icon_state = "refill_sec"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Resolves  #10221

SecTechs didn't override the "Generic" machine name used by default

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Having a proper name is better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/01a8a2d8-b206-4a1f-84b2-967f6865ee31)

</details>

## Changelog
/:cl:
fix: SecTech vending refill canisters now have the right name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
