### PR TITLE
Adds a warning to C4/X4 being planted on you

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -118,6 +118,9 @@
 	if(ismob(AM) && !can_attach_mob)
 		return
 
+	if(ismob(AM))
+		to_chat(AM, "<span class='userdanger'>[user.name] is trying to plant [name] on you!</span>")
+
 	to_chat(user, "<span class='notice'>You start planting [src]. The timer is set to [det_time]...</span>")
 
 	if(do_after(user, 30, target = AM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title
Fixes #10284 

Marked as balance because I don't know if this is necessarily even a bug.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nearly guaranteed death after a 3 second do_after() with no alert is terrible design lmao
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->



![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/5bd86073-37db-44bf-b476-093f86313b3c)


## Changelog
:cl:
balance: Planting C4/X4 on someone now gives them an alert
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
