### PR TITLE
Returning from Ninja Dojo now checks for bad atmosphere + fixes another tiny unrelated issue

### DIFF
--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -112,7 +112,8 @@ It is possible to destroy the net by the occupant or someone else.
 		// After we remove items, at least give them what they need to live.
 		H.dna.species.give_important_for_life(H)
 	// Teleport
-	var/turf/safe_location = get_safe_random_station_turfs()
+	var/turf/picked_station_level = get_random_station_turf()	//Don't want to limit this specifically to z 2 in case we get multi-z in rotation
+	var/turf/safe_location = find_safe_turf(picked_station_level.z, extended_safety_checks = TRUE, dense_atoms = FALSE)
 	do_teleport(target, safe_location, channel = TELEPORT_CHANNEL_FREE, forced = TRUE)
 	target.Unconscious(3 SECONDS)
 

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -39,4 +39,5 @@
 		F.update_brightness()
 
 /obj/item/vending_refill/security
+	machine_name = "SecTech"
 	icon_state = "refill_sec"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
get_safe_random_station_turfs() does ***not*** account for atmospheric conditions at all; 
find_safe_turf ***does***, so we're using that instead.

Also gives an unnamed vending restocker a name.

Fixes #10210 
Fixes #10221 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You shouldn't be placed in somewhere that's going to kill you upon returning from the Ninja Dojo

Unnamed items are lame
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


Bombed the shit out of the station and then sent a bunch of carbons into Ninja Prison to see where they returned.

Before this PR bodies are in space and only a small group survived:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/a690e806-5122-406b-a096-cdf15fa97f1e)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/6b65fab6-3b1a-47bc-ac0d-9b9a61993400)

Only 32 out of 123 stayed above 50 health upon their return.

___

After this PR every one of them survived, having arrived in the safe parts of the station:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/214273cf-8c60-4411-bbbe-f443290b0d9d)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/9321758c-45cf-4502-a3eb-e14851bcde30)

___

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/80382633/e5311f9e-c120-40f5-9062-e5f7f99a4a87)




</details>

## Changelog
:cl:
fix: Returning from the Ninja Dojo now accounts for (most) unsafe atmospheric conditions
fix: SecTech vendor restocker now has an actual name instead of being 'Generic'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
