### PR TITLE
Caps Kilo at 20 max players.

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -37,7 +37,7 @@ map deltastation
 endmap
 
 map kilostation
-	maxplayers 50
+	maxplayers 20
 	votable
 endmap
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes the max pop for kilo to appear in the vote 20 players.

I'm fully aware that https://github.com/BeeStation/BeeStation-Hornet/pull/10264 does something similar, but that also touches several other maps, so it's far more likely to be bikeshedded to hell and back for much longer compared to just changing Kilo.

## Why It's Good For The Game

Because Kilo is a lowpop map, and it _without fail_ drives down pop whenever it wins due to weighted vote bullshit on higher pops.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

i can't screenshot an arbitrary limit

</details>

## Changelog
:cl:
config: Set the max population for Kilo Station to appear in the roundend vote as 20 players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
