### PR TITLE
Psyphoza soul glimmer changes, TGUI chat support

### DIFF
--- a/code/_globalvars/soul_glimmer.dm
+++ b/code/_globalvars/soul_glimmer.dm
@@ -32,4 +32,19 @@ GLOBAL_LIST_INIT(soul_glimmer_cfc_list, list(
 	"Humour" = "cfc_soul_glimmer_humour"))
 
 #define SOUL_GLIMMER_MINIMUM_POP_COLOR 3 // regardless of the pop, 3 colours will always come
-#define SOUL_GLIMMER_POP_COUNT_INTERVAL 4 // Starting from 13, for every INTERVAL value, the round will spawn more soul colour
+#define SOUL_GLIMMER_POP_REQ_CREEP_STARTING 4 // Starting value. The pop requirement for additional colour will be increased by +1. (4, 5, 6, 7...) eventually you need 73 pop for Humour.
+
+/*
+	Summary for pop count (based on 4 interval)
+		Color amount / Pop requirement
+			1	0 (0)
+			2	0 (5)
+			3	0 (10)
+			4	16 -- Starts to get a new color since 16 pop
+			5	23
+			6	31
+			7	40
+			8	50
+			9	61
+			10	73
+*/

--- a/code/_globalvars/soul_glimmer.dm
+++ b/code/_globalvars/soul_glimmer.dm
@@ -32,19 +32,19 @@ GLOBAL_LIST_INIT(soul_glimmer_cfc_list, list(
 	"Humour" = "cfc_soul_glimmer_humour"))
 
 #define SOUL_GLIMMER_MINIMUM_POP_COLOR 3 // regardless of the pop, 3 colours will always come
-#define SOUL_GLIMMER_POP_REQ_CREEP_STARTING 4 // Starting value. The pop requirement for additional colour will be increased by +1. (4, 5, 6, 7...) eventually you need 73 pop for Humour.
+#define SOUL_GLIMMER_POP_REQ_CREEP_STARTING 6 // Starting value. The pop requirement for additional colour will be increased by +1. (6, 7, 8, 9...) eventually you need 91 pop for Humour.
 
 /*
-	Summary for pop count (based on 4 interval)
+	Summary for pop count (based on 6 interval)
 		Color amount / Pop requirement
 			1	0 (0)
-			2	0 (5)
-			3	0 (10)
-			4	16 -- Starts to get a new color since 16 pop
-			5	23
-			6	31
-			7	40
-			8	50
-			9	61
-			10	73
+			2	0 (7)
+			3	0 (14)
+			4	22	-- Starts to get a new color since 22 pop
+			5	31
+			6	41
+			7	52
+			8	64
+			9	77
+			10	91
 */

--- a/code/_globalvars/soul_glimmer.dm
+++ b/code/_globalvars/soul_glimmer.dm
@@ -6,12 +6,30 @@
 */
 
 //ALL the psychic soul colours
-GLOBAL_LIST_INIT(SOUL_GLIMMER_COLORS, list("Azure" = "#0091ff", "Vermilion" = "#ff3a1c", "Sage" = "#1fff5e", "Teal" = "#00ffe5", "Terracotta" = "#ffa600", "Champagne" = "#ff009d"))
+GLOBAL_LIST_INIT(soul_glimmer_colors, list(
+	"Azure" = "#0091ff",
+	"Vermilion" = "#ff3a1c",
+	"Sage" = "#1fff5e",
+	"Teal" = "#00ffe5",
+	"Terracotta" = "#ffa600",
+	"Champagne" = "#ff009d",
+	"Sunshine" = "#fff12c",
+	"Melancholia" = "#8100FF",
+	"Submarine" = "#1f1bff",
+	"Humour" = "#e876ff"))
 
-//Low pop colours
-#define SOUL_GLIMMER_LOWER_POP 10
-GLOBAL_LIST_INIT(SOUL_GLIMMER_COLORS_LOW, list("Azure" = "#0091ff", "Vermilion" = "#ff3a1c", "Sage" = "#1fff5e"))
-//mid pop colours
-#define SOUL_GLIMMER_MID_POP 20
-GLOBAL_LIST_INIT(SOUL_GLIMMER_COLORS_MID, list("Teal" = "#00ffe5", "Terracotta" = "#ffa600", "Champagne" = "#ff009d"))
+/// TGUI chat colours
+GLOBAL_LIST_INIT(soul_glimmer_cfc_list, list(
+	"Azure" = "cfc_soul_glimmer_azure",
+	"Vermilion" = "cfc_soul_glimmer_vermilion",
+	"Sage" = "cfc_soul_glimmer_sage",
+	"Teal" = "cfc_soul_glimmer_teal",
+	"Terracotta" = "cfc_soul_glimmer_terracotta",
+	"Champagne" = "cfc_soul_glimmer_champagne",
+	"Sunshine" = "cfc_soul_glimmer_sunshine",
+	"Melancholia" = "cfc_soul_glimmer_melancholia",
+	"Submarine" = "cfc_soul_glimmer_submarine",
+	"Humour" = "cfc_soul_glimmer_humour"))
 
+#define SOUL_GLIMMER_MINIMUM_POP_COLOR 3 // regardless of the pop, 3 colours will always come
+#define SOUL_GLIMMER_POP_COUNT_INTERVAL 4 // Starting from 13, for every INTERVAL value, the round will spawn more soul colour

--- a/code/datums/components/blind_sense.dm
+++ b/code/datums/components/blind_sense.dm
@@ -95,7 +95,7 @@
 	var/_color = "#fff"
 	if(HAS_TRAIT(parent, TRAIT_PSYCHIC_SENSE) && ishuman(target))
 		var/mob/living/carbon/human/H = target
-		_color = GLOB.SOUL_GLIMMER_COLORS[H.mind?.soul_glimmer]
+		_color = GLOB.soul_glimmer_colors[H.mind?.soul_glimmer]
 	M.color = _color
 
 	//Animate fade & delete

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -891,8 +891,8 @@
 		max_soul_pool = clamp(max_soul_pool, SOUL_GLIMMER_MINIMUM_POP_COLOR, length(GLOB.soul_glimmer_colors))
 
 	// build a list for colours to give
-	var/static/list/options_to_give = list()
+	var/static/list/options_to_give
 	if(!length(options_to_give))
-		options_to_give += GLOB.soul_glimmer_colors.Copy(1, max_soul_pool+1) // Copy(1, 3) = copy items 1-2. Not 3. Be careful.
+		options_to_give = GLOB.soul_glimmer_colors.Copy(1, max_soul_pool+1) // Copy(1, 3) = copy items 1-2. Not 3. Be careful.
 
 	soul_glimmer = pick_n_take(options_to_give)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -878,5 +878,12 @@
 	return holoparasite_holder
 
 /datum/mind/proc/setup_soul_glimmer()
-	var/rand_result = rand(1, clamp(ROUND_UP(max(length(GLOB.player_list), length(SSticker.minds)) / SOUL_GLIMMER_POP_COUNT_INTERVAL), SOUL_GLIMMER_MINIMUM_POP_COLOR, length(GLOB.soul_glimmer_colors)))
+	var/value_to_check = max(length(GLOB.player_list), length(SSticker.minds))
+	var/decrement = SOUL_GLIMMER_POP_REQ_CREEP_STARTING
+	var/count = 0
+	while(value_to_check > 0)
+		value_to_check -= decrement++
+		count++
+
+	var/rand_result = rand(1, clamp(count, SOUL_GLIMMER_MINIMUM_POP_COLOR, length(GLOB.soul_glimmer_colors)))
 	soul_glimmer = GLOB.soul_glimmer_colors[rand_result]

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -878,7 +878,5 @@
 	return holoparasite_holder
 
 /datum/mind/proc/setup_soul_glimmer()
-	var/list/options = GLOB.SOUL_GLIMMER_COLORS_LOW
-	if(length(SSticker.minds) >= SOUL_GLIMMER_LOWER_POP)
-		options += GLOB.SOUL_GLIMMER_COLORS_MID
-	soul_glimmer = pick(options)
+	var/rand_result = rand(1, clamp(ROUND_UP(max(length(GLOB.player_list), length(SSticker.minds)) / SOUL_GLIMMER_POP_COUNT_INTERVAL), SOUL_GLIMMER_MINIMUM_POP_COLOR, length(GLOB.soul_glimmer_colors)))
+	soul_glimmer = GLOB.soul_glimmer_colors[rand_result]

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -878,12 +878,21 @@
 	return holoparasite_holder
 
 /datum/mind/proc/setup_soul_glimmer()
-	var/value_to_check = max(length(GLOB.player_list), length(SSticker.minds))
-	var/decrement = SOUL_GLIMMER_POP_REQ_CREEP_STARTING
-	var/count = 0
-	while(value_to_check > 0)
-		value_to_check -= decrement++
-		count++
+	// initialise to calculate how many soul colours will be given to people
+	var/static/max_soul_pool
+	if(!max_soul_pool)
+		var/pop_value = length(GLOB.player_list)
+		var/decrement = SOUL_GLIMMER_POP_REQ_CREEP_STARTING
+		while(pop_value > 0)
+			pop_value -= decrement++ // 4, 5, 6, 7...
+			max_soul_pool++
+			if(max_soul_pool >= length(GLOB.soul_glimmer_colors))
+				break // Failsafe loop even if our codebase won't have +100 pop count...
+		max_soul_pool = clamp(max_soul_pool, SOUL_GLIMMER_MINIMUM_POP_COLOR, length(GLOB.soul_glimmer_colors))
 
-	var/rand_result = rand(1, clamp(count, SOUL_GLIMMER_MINIMUM_POP_COLOR, length(GLOB.soul_glimmer_colors)))
-	soul_glimmer = GLOB.soul_glimmer_colors[rand_result]
+	// build a list for colours to give
+	var/static/list/options_to_give = list()
+	if(!length(options_to_give))
+		options_to_give += GLOB.soul_glimmer_colors.Copy(1, max_soul_pool+1) // Copy(1, 3) = copy items 1-2. Not 3. Be careful.
+
+	soul_glimmer = pick_n_take(options_to_give)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -660,10 +660,10 @@
 			present_souls[soul] += 1
 		//Display the total soul count
 		for(var/soul in present_souls)
-			if(!present_souls[soul] || !GLOB.SOUL_GLIMMER_COLORS[soul])
+			if(!present_souls[soul] || !GLOB.soul_glimmer_colors[soul])
 				continue
-			to_chat(user, "<span class='notice'><span style='color: [GLOB.SOUL_GLIMMER_COLORS[soul]]'>[soul]</span>, [present_souls[soul] > 1 ? "[present_souls[soul]] times" : "once"].</span>")
-	
+			to_chat(user, "\t<span class='notice'><span class='[GLOB.soul_glimmer_cfc_list[soul]]'>[soul]</span>, [present_souls[soul] > 1 ? "[present_souls[soul]] times" : "once"].</span>")
+
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 
 /**

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -24,8 +24,8 @@
 
 	//Psychic soul stuff
 	if(HAS_TRAIT(user, TRAIT_PSYCHIC_SENSE) && mind)
-		to_chat(user, "<span class='notice'>[src] has a <span style='color: [GLOB.SOUL_GLIMMER_COLORS[mind.soul_glimmer]]'>[mind.soul_glimmer]</span> presence.")
-	
+		to_chat(user, "<span class='notice'>[src] has a <span class='[GLOB.soul_glimmer_cfc_list[mind.soul_glimmer]]'>[mind.soul_glimmer]</span> presence.")
+
 	//uniform
 	if(w_uniform && !(obscured & ITEM_SLOT_ICLOTHING) && !(w_uniform.item_flags & EXAMINE_SKIP))
 		//accessory

--- a/tgui/packages/tgui-panel/styles/chat-format/chat-dark-theme.scss
+++ b/tgui/packages/tgui-panel/styles/chat-format/chat-dark-theme.scss
@@ -55,3 +55,35 @@
 .cfc_redpurple {
   color: #db075f;
 }
+
+// psypoza colors
+.cfc_soul_glimmer_azure {
+  color: #0091ff;
+}
+.cfc_soul_glimmer_vermilion {
+  color: #ff3a1c;
+}
+.cfc_soul_glimmer_sage {
+  color: #1fff5e;
+}
+.cfc_soul_glimmer_teal {
+  color: #00ffe5;
+}
+.cfc_soul_glimmer_terracotta {
+  color: #ffa600;
+}
+.cfc_soul_glimmer_champagne {
+  color: #ff009d;
+}
+.cfc_soul_glimmer_sunshine {
+  color: #fff12c;
+}
+.cfc_soul_glimmer_melancholia {
+  color: #860cff;
+}
+.cfc_soul_glimmer_submarine {
+  color: #302cff;
+}
+.cfc_soul_glimmer_humour {
+  color: #eb89ff;
+}

--- a/tgui/packages/tgui-panel/styles/chat-format/chat-light-theme.scss
+++ b/tgui/packages/tgui-panel/styles/chat-format/chat-light-theme.scss
@@ -55,3 +55,35 @@
 .cfc_redpurple {
   color: #b90c54;
 }
+
+// psypoza colors
+.cfc_soul_glimmer_azure {
+  color: #0a7ed6;
+}
+.cfc_soul_glimmer_vermilion {
+  color: #d12e14;
+}
+.cfc_soul_glimmer_sage {
+  color: #23b64d;
+}
+.cfc_soul_glimmer_teal {
+  color: #03d1c0;
+}
+.cfc_soul_glimmer_terracotta {
+  color: #ec9a02;
+}
+.cfc_soul_glimmer_champagne {
+  color: #c2087b;
+}
+.cfc_soul_glimmer_sunshine {
+  color: #e4d500;
+}
+.cfc_soul_glimmer_melancholia {
+  color: #5b00b6;
+}
+.cfc_soul_glimmer_submarine {
+  color: #1714e0;
+}
+.cfc_soul_glimmer_humour {
+  color: #e562ff;
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Soul glimmer is slightly changed
  * More soul glimmer colours
  * Maximum is 91 pop
* Soul glimmer colour is now TGUI chat reactive.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As I say always, you shouldn't use font colour directly.
And some minor improvement to psyphoza colour thing...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/6d4c9913-6e57-4d15-a65f-c820b6ce50f9)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/e921a8e6-99db-4c2f-abef-dc16e2512030)

</details>

## Changelog
:cl:
add: More soul glimmer colours are added to Psyphoza. If a round started with more player clients, the round will have more colour pool. Max size 10, max pop size +91.
fix: Soul glimmer colour is now TGUI chat reactive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
