### PR TITLE
fix bluespace compression kit

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1458,4 +1458,4 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			w_class = WEIGHT_CLASS_HUGE
 		else
 			return FALSE
-		return TRUE
+	return TRUE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1458,4 +1458,4 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			w_class = WEIGHT_CLASS_HUGE
 		else
 			return FALSE
-
+		return TRUE

--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -41,7 +41,7 @@
 
 /obj/item/compressionkit/afterattack(atom/target, mob/user, proximity)
 	. = ..()
-	if(!proximity || !target)
+	if(!proximity || !target || length(user.progressbars))
 		return
 	else
 		if(charges == 0)
@@ -53,7 +53,7 @@
 		if(O.GetComponent(/datum/component/storage))
 			to_chat(user, "<span class='notice'>You can't make this item any smaller without compromising its storage functions!.</span>")
 			return
-		if(O.w_class == WEIGHT_CLASS_TINY)
+		if(O.w_class == WEIGHT_CLASS_TINY || O.w_class < initial(O.w_class))
 			playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
 			to_chat(user, "<span class='notice'>[target] cannot be compressed smaller!.</span>")
 			return

--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -53,9 +53,13 @@
 		if(O.GetComponent(/datum/component/storage))
 			to_chat(user, "<span class='notice'>You can't make this item any smaller without compromising its storage functions!.</span>")
 			return
-		if(O.w_class == WEIGHT_CLASS_TINY || O.w_class < initial(O.w_class))
+		if(O.w_class < initial(O.w_class))
 			playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
 			to_chat(user, "<span class='notice'>[target] cannot be compressed smaller!.</span>")
+			return
+		if(O.w_class == WEIGHT_CLASS_TINY)
+			playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
+			to_chat(user, "<span class='notice'>[target] is already tiny, it would be a waste to shrink it further!.</span>")
 			return
 		playsound(get_turf(src), 'sound/weapons/flash.ogg', 50, 1)
 		user.visible_message("<span class='warning'>[user] is compressing [O] with their bluespace compression kit!</span>")

--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -53,13 +53,9 @@
 		if(O.GetComponent(/datum/component/storage))
 			to_chat(user, "<span class='notice'>You can't make this item any smaller without compromising its storage functions!.</span>")
 			return
-		if(O.w_class < initial(O.w_class))
-			playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
-			to_chat(user, "<span class='notice'>[target] cannot be compressed smaller!.</span>")
-			return
 		if(O.w_class == WEIGHT_CLASS_TINY)
 			playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
-			to_chat(user, "<span class='notice'>[target] is already tiny, it would be a waste to shrink it further!.</span>")
+			to_chat(user, "<span class='notice'>[target] cannot be compressed smaller!.</span>")
 			return
 		playsound(get_turf(src), 'sound/weapons/flash.ogg', 50, 1)
 		user.visible_message("<span class='warning'>[user] is compressing [O] with their bluespace compression kit!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the bluespace compression kit
* The proc for changing item size down was missing a line to `return TRUE` at its conclusion. 
* The compression kit was missing a check to ensure the user was not already busy compressing something, which could cause all kinds of shenanigans via bypassing checks. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs are bad, working content is good. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/7fee5244-1389-4e67-9557-b5fd75787574)

## Changelog
:cl:
fix: Bluespace compression kit can now shrink items properly again, without returning an error. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
