### PR TITLE
Fixes Carpets Runtime when they get burned by atmospherics

### DIFF
--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -280,10 +280,6 @@
 	if(!broken && !burnt)
 		if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 			QUEUE_SMOOTH(src)
-	else
-		make_plating()
-		if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
-			QUEUE_SMOOTH_NEIGHBORS(src)
 
 /turf/open/floor/carpet/black
 	icon = 'icons/turf/floors/carpet_black.dmi'
@@ -385,12 +381,16 @@
 			A.narsie_act()
 
 /turf/open/floor/carpet/break_tile()
-	broken = TRUE
-	update_icon()
+    broken = TRUE
+    make_plating()
+    if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
+        QUEUE_SMOOTH_NEIGHBORS(src)
 
 /turf/open/floor/carpet/burn_tile()
-	burnt = TRUE
-	update_icon()
+    burnt = TRUE
+    make_plating()
+    if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
+        QUEUE_SMOOTH_NEIGHBORS(src)
 
 /turf/open/floor/carpet/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

This PR address a bug related to carpets burning with atmospheric fires. this bug was discovered by accident when testing Echostation's Holodeck with the fire simulator.

Code fix courtesy of @PowerfulBacon.

## Why It's Good For The Game

Adress a nasty runtime that involves atmospheric fires.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Fixes the following issue:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/5bad823c-dcff-405e-8f98-dafd808ca543)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/e224bf91-9ebf-482c-856b-d981f0f37775)

</details>

## Changelog
:cl: PowerfullBacon
fix: fixed a runtime related to carpet getting burned by atmospheric fires
/:cl:
