### PR TITLE
Optimize windoors, table, and PDA painter init

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -53,7 +53,6 @@
 		"Misc: Prisoner" = "pda-prisoner"
 	)
 	max_integrity = 200
-	var/list/colorlist = list()
 
 /obj/machinery/pdapainter/on_emag(mob/user)
 	..()
@@ -82,23 +81,6 @@
 		icon_state = "coloriser-off"
 
 	return
-
-/obj/machinery/pdapainter/Initialize(mapload)
-	. = ..()
-	var/list/blocked = list(
-		/obj/item/modular_computer/tablet/pda/heads,
-		/obj/item/modular_computer/tablet/pda/clear,
-		/obj/item/modular_computer/tablet/pda/syndicate,
-		/obj/item/modular_computer/tablet/pda/chameleon,
-		/obj/item/modular_computer/tablet/pda/chameleon/broken)
-
-	for(var/P in typesof(/obj/item/modular_computer/tablet/pda) - blocked)
-		var/obj/item/modular_computer/tablet/pda/D = new P
-
-		//D.name = "PDA Style [colorlist.len+1]" //Gotta set the name, otherwise it all comes up as "PDA"
-		D.name = D.icon_state //PDAs don't have unique names, but using the sprite names works.
-
-		src.colorlist += D
 
 /obj/machinery/pdapainter/Destroy()
 	QDEL_NULL(storedpda)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -24,6 +24,7 @@
 	var/shards = 2
 	var/rods = 2
 	var/cable = 1
+	/// Associative list of debris typepaths to counts
 	var/list/debris = list()
 
 /obj/machinery/door/window/Initialize(mapload, set_dir, unres_sides)
@@ -33,12 +34,12 @@
 	if(req_access?.len)
 		icon_state = "[icon_state]"
 		base_state = icon_state
-	for(var/i in 1 to shards)
-		debris += new /obj/item/shard(src)
+	if(shards)
+		debris[/obj/item/shard] = shards
 	if(rods)
-		debris += new /obj/item/stack/rods(src, rods)
+		debris[/obj/item/stack/rods] = rods
 	if(cable)
-		debris += new /obj/item/stack/cable_coil(src, cable)
+		debris[/obj/item/stack/cable_coil] = cable
 
 	if(unres_sides)
 		//remove unres_sides from directions it can't be bumped from
@@ -222,10 +223,16 @@
 
 /obj/machinery/door/window/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1) && !disassembled)
-		for(var/obj/fragment in debris)
-			fragment.forceMove(get_turf(src))
-			transfer_fingerprints_to(fragment)
-			debris -= fragment
+		var/turf/T = get_turf(src)
+		for(var/path in debris)
+			var/amt = debris[path]
+			if(amt <= 0 || amt > 10) // please no more than 10
+				continue
+			if(!ispath(path, /obj))
+				continue
+			for(var/i in 1 to amt)
+				var/obj/fragment = new path(T)
+				transfer_fingerprints_to(fragment)
 	qdel(src)
 
 /obj/machinery/door/window/narsie_act()
@@ -438,8 +445,7 @@
 
 /obj/machinery/door/window/clockwork/Initialize(mapload, set_dir)
 	. = ..()
-	for(var/i in 1 to 2)
-		debris += new/obj/item/clockwork/alloy_shards/medium/gear_bit/large(src)
+	debris[/obj/item/clockwork/alloy_shards/medium/gear_bit/large] = 2
 
 /obj/machinery/door/window/clockwork/setDir(direct)
 	if(!made_glow)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -278,20 +278,17 @@
 	max_integrity = 70
 	resistance_flags = ACID_PROOF
 	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 100, STAMINA = 0)
+	/// Associative list of debris typepaths to counts
 	var/list/debris = list()
 
 /obj/structure/table/glass/Initialize(mapload)
 	. = ..()
-	debris += new frame
-	debris += new /obj/item/shard
+	debris[frame] = 1
+	debris[/obj/item/shard] = 1
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
-
-/obj/structure/table/glass/Destroy()
-	QDEL_LIST(debris)
-	. = ..()
 
 /obj/structure/table/glass/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
@@ -319,14 +316,21 @@
 		"<span class='danger'>You hear breaking glass.</span>")
 	var/turf/T = get_turf(src)
 	playsound(T, "shatter", 50, 1)
-	for(var/I in debris)
-		var/atom/movable/AM = I
-		AM.forceMove(T)
-		debris -= AM
-		if(istype(AM, /obj/item/shard))
-			AM.throw_impact(L)
+	release_debris(T, throw_shards_at = L)
 	L.Paralyze(100)
 	qdel(src)
+
+/obj/structure/table/glass/proc/release_debris(turf/T, atom/throw_shards_at)
+	for(var/path in debris)
+		var/amt = debris[path]
+		if(amt <= 0 || amt > 10) // please no more than 10
+			continue
+		if(!ispath(path, /obj))
+			continue
+		for(var/i in 1 to amt)
+			var/obj/fragment = new path(T)
+			if(istype(fragment, /obj/item/shard) && istype(throw_shards_at))
+				fragment.throw_impact(throw_shards_at)
 
 /obj/structure/table/glass/deconstruct(disassembled = TRUE, wrench_disassembly = 0)
 	if(!(flags_1 & NODECONSTRUCT_1))
@@ -336,16 +340,11 @@
 		else
 			var/turf/T = get_turf(src)
 			playsound(T, "shatter", 50, 1)
-			for(var/X in debris)
-				var/atom/movable/AM = X
-				AM.forceMove(T)
-				debris -= AM
+			release_debris(T)
 	qdel(src)
 
 /obj/structure/table/glass/narsie_act()
 	color = NARSIE_WINDOW_COLOUR
-	for(var/obj/item/shard/S in debris)
-		S.color = NARSIE_WINDOW_COLOUR
 
 /*
  * Plasmaglass tables
@@ -362,7 +361,7 @@
 
 /obj/structure/table/glass/plasma/Initialize(mapload)
 	. = ..()
-	debris += new /obj/item/shard/plasma
+	debris[/obj/item/shard/plasma] = 1
 
 /obj/structure/table/glass/plasma/check_break(mob/living/M)
 	return


### PR DESCRIPTION
## About The Pull Request

Reimplementation of the (reverted) #9481. Cleans up windoor and table debris spawning, and removes unused list init in the PDA painter.

Does not include verb, air alarm broadcast, or admin proccall changes as they were broken and resulted in reversion.

Functionally ports the remainder of:
- https://github.com/tgstation/tgstation/pull/71046

However, this is my own implementation of that. That PR was not referenced in its creation.

## Why It's Good For The Game

Reduces init times

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/21cc08c9-6db6-4572-8c23-69367288adbf)

Windoor
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/09ce2afb-c65c-4166-afc1-53100412c0ff)

Table (yes, plasma tables have apparently always dropped regular glass as well as plasmaglass)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/48dd3d68-87a5-4a9a-92ea-1cf9bb0f8d6c)


</details>

## Changelog
:cl:
code: Slightly reduced init times by optimizing windoor, table, and PDA painter initialization.
/:cl: