### PR TITLE
Hotfix: Fixes holding the perfect amount of sheets erroneously consuming the sheets & not progressing construction

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -359,7 +359,7 @@
 		return FALSE
 	amount -= used
 	if(check && zero_amount())
-		return FALSE
+		return TRUE
 	if(length(mats_per_unit))
 		update_custom_materials()
 	update_icon()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #10350
closes #10345 

Having the perfect amount of materials in your hand would consume it but return FALSE, not allowing one to finish construction of machines/crafting recipes without having an extra amount in the stack.

I dismissed one of them initially, but now that the issue is more clear, this should resolve it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Critical bugfix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/8f11ff2b-78a5-4ac7-8797-77a3aed01e4f

![perfect](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/c41d7687-1e5b-431a-8ffb-f7a24b3a4ce4)


</details>

## Changelog
:cl: rkz, EvilDragonFiend
fix: fixes material stacks not consuming properly in crafting/machine frames
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
