### PR TITLE
Heretic QoL Pass: Lite Edition

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -102,6 +102,9 @@
 /// A define used in ritual priority for heretics.
 #define MAX_KNOWLEDGE_PRIORITY 100
 
+/// The maximum (and optimal) number of sacrifice targets a heretic should roll.
+#define HERETIC_MAX_SAC_TARGETS 4
+
 //Cult Construct defines
 
 #define CONSTRUCT_JUGGERNAUT "Juggernaut"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -766,6 +766,22 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			. = orange(distance,center)
 	return
 
+/**
+ * Gets the mind from a variable, whether it be a mob, or a mind itself.
+ * If [include_last] is true, then it will also return last_mind for carbons if there isn't a current mind.
+ */
+/proc/get_mind(target, include_last = FALSE)
+	if(istype(target, /datum/mind))
+		return target
+	if(ismob(target))
+		var/mob/mob_target = target
+		if(!QDELETED(mob_target.mind))
+			return mob_target.mind
+		if(include_last && iscarbon(mob_target))
+			var/mob/living/carbon/carbon_target = mob_target
+			if(!QDELETED(carbon_target.last_mind))
+				return carbon_target.last_mind
+
 #undef FACING_SAME_DIR
 #undef FACING_EACHOTHER
 #undef FACING_INIT_FACING_TARGET_TARGET_FACING_PERPENDICULAR

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -390,3 +390,26 @@ Turf and target are separate in case you want to teleport some distance from a t
 			if(rail.dir == test_dir || is_fulltile)
 				return FALSE
 	return TRUE
+
+/proc/is_turf_safe(turf/open/floor/floor)
+	// It's probably not safe if it's not a floor.
+	if(!istype(floor))
+		return FALSE
+	var/datum/gas_mixture/air = floor.air
+	// Certainly unsafe if it completely lacks air.
+	if(QDELETED(air))
+		return FALSE
+	// Can most things breathe?
+	for(var/id in air.get_gases())
+		if(id in GLOB.hardcoded_gases)
+			continue
+		return FALSE
+	if(air.get_moles(GAS_O2) < 16 || air.get_moles(GAS_PLASMA) || air.get_moles(GAS_CO2) >= 10)
+		return FALSE
+	var/temperature = air.return_temperature()
+	if(temperature <= 270 || temperature >= 360)
+		return FALSE
+	var/pressure = air.return_pressure()
+	if(pressure <= 20 || pressure >= 550)
+		return FALSE
+	return TRUE

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -137,40 +137,13 @@
 		if(!isfloorturf(random_location))
 			continue
 		var/turf/open/floor/F = random_location
-		if(!F.air)
+		if(!is_turf_safe(F))
 			continue
-
-		var/datum/gas_mixture/A = F.air
-		var/trace_gases
-		for(var/id in A.get_gases())
-			if(id in GLOB.hardcoded_gases)
-				continue
-			trace_gases = TRUE
-			break
-
-		// Can most things breathe?
-		if(trace_gases)
-			continue
-		if(A.get_moles(GAS_O2) < 16)
-			continue
-		if(A.get_moles(GAS_PLASMA))
-			continue
-		if(A.get_moles(GAS_CO2) >= 10)
-			continue
-
-		// Aim for goldilocks temperatures and pressure
-		if((A.return_temperature() <= 270) || (A.return_temperature() >= 360))
-			continue
-		var/pressure = A.return_pressure()
-		if((pressure <= 20) || (pressure >= 550))
-			continue
-
 		if(extended_safety_checks)
 			if(islava(F)) //chasms aren't /floor, and so are pre-filtered
 				var/turf/open/lava/L = F
 				if(!L.is_safe())
 					continue
-
 		// Check that we're not warping onto a table or window
 		if(!dense_atoms)
 			var/density_found = FALSE
@@ -180,7 +153,6 @@
 					break
 			if(density_found)
 				continue
-
 		// DING! You have passed the gauntlet, and are "probably" safe.
 		return F
 

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -16,6 +16,7 @@
 	name = "\improper Heretic"
 	roundend_category = "Heretics"
 	antagpanel_category = "Heretic"
+	ui_name = "AntagInfoHeretic"
 	antag_moodlet = /datum/mood_event/heretics
 	banning_key = ROLE_HERETIC
 	required_living_playtime = 4
@@ -33,8 +34,12 @@
 	var/total_sacrifices = 0
 	/// A list of TOTAL how many high value sacrifices completed.
 	var/high_value_sacrifices = 0
-	/// Lazy assoc list of [weakrefs to humans] to [image previews of the human]. Humans that we have as sacrifice targets.
+	/// Weakrefs to the minds of monsters have been successfully summoned. Includes ghouls.
+	var/list/datum/weakref/monsters_summoned
+	/// Lazy assoc list of [weakrefs to minds] to [image previews of the human]. Humans that we have as sacrifice targets.
 	var/list/datum/weakref/sac_targets
+	/// A list of minds we won't pick as targets.
+	var/list/datum/mind/target_blacklist
 	/// Whether we're drawing a rune or not
 	var/drawing_rune = FALSE
 	/// A static typecache of all tools we can scribe with.
@@ -42,7 +47,10 @@
 	/// A blacklist of turfs we cannot scribe on.
 	var/static/list/blacklisted_rune_turfs = typecacheof(list(/turf/open/space, /turf/open/openspace, /turf/open/lava, /turf/open/chasm))
 	var/datum/action/innate/hereticmenu/menu
-	ui_name = "AntagInfoHeretic"
+
+/datum/antagonist/heretic/Destroy()
+	. = ..()
+	LAZYCLEARLIST(target_blacklist)
 
 /datum/antagonist/heretic/ui_data(mob/user)
 	var/list/data = list()
@@ -128,13 +136,15 @@
 
 /datum/antagonist/heretic/greet()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ecult_op.ogg', vol = 100, vary = FALSE, channel = CHANNEL_ANTAG_GREETING, pressure_affected = FALSE, use_reverb = FALSE)//subject to change
-	to_chat(owner, "<span class='boldannounce'>You are the Heretic!</span><br>\
-	<B>The old ones gave you these tasks to fulfill:</B>")
-	owner.announce_objectives()
-	to_chat(owner, "<span class='cult'>The book whispers, the forbidden knowledge walks once again!<br>\
-	The Forbidden Knowledge panel allows you to research abilities, read it very carefully! You cannot undo what has been done!<br>\
-	You gain charges by either collecting influences or sacrificing people tracked by the living heart<br> \
-	You can find a basic guide at: https://wiki.beestation13.com/view/Heretics </span>")
+	var/list/msg = list()
+	msg += "<span class='big'>You are the <span class='bold umbra'>Heretic</span>!</span>"
+	msg += "The book whispers, the forbidden knowledge walks once again!"
+	msg += "The Forbidden Knowledge panel allows you to research abilities, read it very carefully! You cannot undo what has been done!"
+	msg += "You gain charges by either collecting influences or sacrificing people tracked by the living heart"
+	msg += "You can find a basic guide at: https://wiki.beestation13.com/view/Heretics"
+	if(locate(/datum/objective/major_sacrifice) in objectives)
+		msg += "<span class='bold'><i>Any</i> head of staff can be sacrificed to complete your objective!</span>"
+	to_chat(owner.current, EXAMINE_BLOCK("<span class='cult'>[msg.Join("\n")]</span>"))
 	owner.current.client?.tgui_panel?.give_antagonist_popup("Heretic",
 		"Collect influences or sacrifice targets to expand your forbidden knowledge.")
 
@@ -331,16 +341,17 @@
 
 	var/num_heads = 0
 	for(var/mob/player in SSticker.mode.current_players[CURRENT_LIVING_PLAYERS])
-		if(player.mind.assigned_role in list("Captain", "Head of Personnel", "Chief Engineer", "Head of Security", "Research Director", "Chief Medical Officer"))
+		if(player.client && (player.mind.assigned_role in GLOB.command_positions))
 			num_heads++
-
+	// Give normal sacrifice objective
 	var/datum/objective/minor_sacrifice/sac_objective = new()
 	sac_objective.owner = owner
-	if(num_heads < 2) // They won't get major sacrifice, so bump up minor sacrifice a bit
+	// They won't get major sacrifice, so bump up minor sacrifice a bit
+	if(num_heads < 2)
 		sac_objective.target_amount += 2
 		sac_objective.update_explanation_text()
 	objectives += sac_objective
-
+	// Give command sacrifice objective (if there's at least 2 command staff)
 	if(num_heads >= 2)
 		var/datum/objective/major_sacrifice/other_sac_objective = new()
 		other_sac_objective.owner = owner
@@ -348,24 +359,78 @@
 
 /**
  * Add [target] as a sacrifice target for the heretic.
- * Generates a preview image and associates it with a weakref of the mob.
+ * Generates a preview image and associates it with a weakref of the mob's mind.
  */
-/datum/antagonist/heretic/proc/add_sacrifice_target(mob/living/carbon/human/target)
+/datum/antagonist/heretic/proc/add_sacrifice_target(target)
+	var/datum/mind/target_mind = get_mind(target, TRUE)
+	if(QDELETED(target_mind))
+		return FALSE
+	var/mob/living/carbon/target_body = target_mind.current
+	if(!istype(target_body))
+		return FALSE
+	RegisterSignal(target_mind, COMSIG_MIND_CRYOED, PROC_REF(on_sac_target_cryoed))
+	LAZYSET(sac_targets, WEAKREF(target_mind), getFlatIcon(target_body, defdir = SOUTH))
+	return TRUE
 
-	var/image/target_image = image(icon = target.icon, icon_state = target.icon_state)
-	target_image.overlays = target.overlays
+/**
+ * Remove [target] as a sacrifice target for the heretic.
+ */
+/datum/antagonist/heretic/proc/remove_sacrifice_target(target)
+	var/datum/mind/target_mind = get_mind(target, TRUE)
+	if(!QDELETED(target_mind))
+		UnregisterSignal(target_mind, COMSIG_MIND_CRYOED)
+		LAZYREMOVE(sac_targets, WEAKREF(target_mind))
 
-	LAZYSET(sac_targets, WEAKREF(target), target_image)
+/**
+ * Returns a list of valid sacrifice targets from the current living players.
+ */
+/datum/antagonist/heretic/proc/possible_sacrifice_targets(include_current_targets = TRUE)
+	. = list()
+	for(var/mob/living/carbon/human/player in SSticker.mode.current_players[CURRENT_LIVING_PLAYERS])
+		if(!player.mind || !player.client || player.client.is_afk())
+			continue
+		var/datum/mind/possible_target = player.mind
+		if(!include_current_targets && (WEAKREF(possible_target) in sac_targets))
+			continue
+		if(possible_target == src)
+			continue
+		if(!SSjob.name_occupations[possible_target.assigned_role])
+			continue
+		var/turf/player_loc = get_turf(player)
+		if(!is_station_level(player_loc.z))
+			continue
+		if(possible_target in target_blacklist)
+			continue
+		if(player.stat == DEAD || player.InFullCritical())
+			continue
+		. += possible_target
+
+/datum/antagonist/heretic/proc/on_sac_target_cryoed(datum/mind/sac_mind)
+	SIGNAL_HANDLER
+	if(!istype(sac_mind) || !LAZYLEN(sac_targets))
+		return
+	remove_sacrifice_target(sac_mind)
+	var/list/candidates = possible_sacrifice_targets(include_current_targets = FALSE)
+	if(!length(candidates))
+		to_chat(owner, "<span class='warning'>You feel one of your sacrifice targets leave your reach... but the Mansus remains silent.</span>")
+		return
+	var/datum/mind/new_target = pick(candidates)
+	add_sacrifice_target(new_target)
+	to_chat(owner, "<span class='danger'>The Mansus whispers to you a new name as one of your previous sacrifice targets exits your grasp... <span class='hypnophrase'>[new_target.name]</span>. Go forth and sacrifice [new_target.current.p_them()]!</span>")
 
 /**
  * Increments knowledge by one.
  * Used in callbacks for passive gain over time.
  */
 /datum/antagonist/heretic/proc/passive_influence_gain()
-	knowledge_points++
+	adjust_knowledge_points(1)
 	if(owner.current.stat <= SOFT_CRIT)
 		to_chat(owner.current, "<span class='hear'>You hear a whisper...</span> <span class = 'hypnophrase'>[pick(strings(HERETIC_INFLUENCE_FILE, "drain_message"))]</span>")
 	addtimer(CALLBACK(src, PROC_REF(passive_influence_gain)), passive_gain_timer)
+
+/datum/antagonist/heretic/proc/adjust_knowledge_points(amount)
+	knowledge_points += amount
+	ui_update()
 
 /datum/antagonist/heretic/roundend_report()
 	var/list/parts = list()
@@ -406,76 +471,63 @@
 
 /datum/antagonist/heretic/get_admin_commands()
 	. = ..()
-
 	switch(has_living_heart())
 		if(HERETIC_NO_LIVING_HEART)
-			.["Give Living Heart"] = CALLBACK(src, PROC_REF(give_living_heart))
+			.["Give Living Heart"] = CALLBACK(src, PROC_REF(admin_give_living_heart))
 		if(HERETIC_HAS_LIVING_HEART)
-			.["Add Heart Target (Marked Mob)"] = CALLBACK(src, PROC_REF(add_marked_as_target))
-			.["Remove Heart Target"] = CALLBACK(src, PROC_REF(remove_target))
-
+			.["Add Heart Target (Marked Mob)"] = CALLBACK(src, PROC_REF(admin_add_marked_target))
+			.["Remove Heart Target"] = CALLBACK(src, PROC_REF(admin_remove_target))
 	.["Adjust Knowledge Points"] = CALLBACK(src, PROC_REF(admin_change_points))
 
 /*
  * Admin proc for giving a heretic a Living Heart easily.
  */
-/datum/antagonist/heretic/proc/give_living_heart(mob/admin)
+/datum/antagonist/heretic/proc/admin_give_living_heart(mob/admin)
 	if(!admin.client?.holder)
 		to_chat(admin, "<span class='warning'>You shouldn't be using this!</span>")
 		return
-
 	var/datum/heretic_knowledge/living_heart/heart_knowledge = get_knowledge(/datum/heretic_knowledge/living_heart)
 	if(!heart_knowledge)
 		to_chat(admin, "<span class='warning'>The heretic doesn't have a living heart knowledge for some reason. What?</span>")
 		return
-
 	heart_knowledge.on_research(owner.current)
 
 /*
  * Admin proc for adding a marked mob to a heretic's sac list.
  */
-/datum/antagonist/heretic/proc/add_marked_as_target(mob/admin)
+/datum/antagonist/heretic/proc/admin_add_marked_target(mob/admin)
 	if(!admin.client?.holder)
 		to_chat(admin, "<span class='warning'>You shouldn't be using this!</span>")
 		return
-
 	var/mob/living/carbon/human/new_target = admin.client?.holder.marked_datum
 	if(!istype(new_target))
 		to_chat(admin, "<span class='warning'>You need to mark a human to do this!</span>")
 		return
-
-	if(alert(admin, "Let them know their targets have been updated?", "Whispers of the Mansus", "Yes", "No") == "Yes")
+	if(tgui_alert(admin, "Let them know their targets have been updated?", "Whispers of the Mansus", list("Yes", "No")) == "Yes")
 		to_chat(owner.current, "<span class='danger'>The Mansus has modified your targets. Go find them!</span>")
 		to_chat(owner.current, "<span class='danger'>[new_target.real_name], the [new_target.mind?.assigned_role || "human"].</span>")
-
 	add_sacrifice_target(new_target)
 
 /*
  * Admin proc for removing a mob from a heretic's sac list.
  */
-/datum/antagonist/heretic/proc/remove_target(mob/admin)
+/datum/antagonist/heretic/proc/admin_remove_target(mob/admin)
 	if(!admin.client?.holder)
 		to_chat(admin, "<span class='warning'>You shouldn't be using this!</span>")
 		return
-
 	var/list/removable = list()
 	for(var/datum/weakref/ref as anything in sac_targets)
-		var/mob/living/carbon/human/old_target = ref.resolve()
+		var/datum/mind/old_target = ref.resolve()
 		if(!QDELETED(old_target))
 			removable[old_target.name] = old_target
-
-	var/name_of_removed = input(admin, "Choose a human to remove", "Who to Spare") as null|anything in removable
+	var/name_of_removed = tgui_input_list(admin, "Choose a human to remove", "Who to Spare", removable)
 	if(QDELETED(src) || !admin.client?.holder || isnull(name_of_removed))
 		return
-	var/mob/living/carbon/human/chosen_target = removable[name_of_removed]
-	if(QDELETED(chosen_target) || !ishuman(chosen_target))
+	var/datum/mind/chosen_target = removable[name_of_removed]
+	if(!istype(chosen_target) || !(WEAKREF(chosen_target) in sac_targets))
 		return
-	if(!(WEAKREF(chosen_target) in sac_targets))
-		return
-
 	LAZYREMOVE(sac_targets, WEAKREF(chosen_target))
-
-	if(alert(admin, "Let them know their targets have been updated?", "Whispers of the Mansus", "Yes", "No") == "Yes")
+	if(tgui_alert(admin, "Let them know their targets have been updated?", "Whispers of the Mansus", list("Yes", "No")) == "Yes")
 		to_chat(owner.current, "<span class='danger'>The Mansus has modified your targets.</span>")
 
 /*
@@ -486,10 +538,10 @@
 		to_chat(admin, "<span class='warning'>You shouldn't be using this!</span>")
 		return
 
-	var/change_num = input(admin, "Add or remove knowledge points", "Points") as null|num
+	var/change_num = tgui_input_number(admin, "Add or remove knowledge points", "Points", 0)
 	if(!change_num || QDELETED(src))
 		return
-	knowledge_points += change_num
+	adjust_knowledge_points(change_num)
 	message_admins("[admin] modified [src]'s knowledge points by [change_num].")
 
 /datum/antagonist/heretic/antag_panel_data()
@@ -506,15 +558,14 @@
 
 /datum/antagonist/heretic/antag_panel_objectives()
 	. = ..()
-
 	. += "<br>"
 	. += "<i><b>Current Targets:</b></i><br>"
 	if(LAZYLEN(sac_targets))
 		for(var/datum/weakref/ref as anything in sac_targets)
-			var/mob/living/carbon/human/actual_target = ref.resolve()
-			if(QDELETED(actual_target))
+			var/datum/mind/actual_target = ref.resolve()
+			if(istype(actual_target))
 				continue
-			. += " - <b>[actual_target.real_name]</b>, the [actual_target.mind?.assigned_role || "Unknown"].<br>"
+			. += " - <b>[actual_target.name]</b>, the [actual_target.assigned_role || "Unknown"].<br>"
 	else
 		. += "<i>None!</i><br>"
 	. += "<br>"
@@ -555,6 +606,21 @@
  */
 /datum/antagonist/heretic/proc/get_knowledge(wanted)
 	return researched_knowledge[wanted]
+
+/*
+ * Check to see if the given mob can be sacrificed.
+ */
+/datum/antagonist/heretic/proc/can_sacrifice(target)
+	. = FALSE
+	var/datum/mind/target_mind = get_mind(target, include_last = TRUE)
+	if(!istype(target_mind))
+		return
+	if(LAZYACCESS(sac_targets, WEAKREF(target_mind)))
+		return TRUE
+	// You can ALWAYS sacrifice heads of staff if you need to do so.
+	var/datum/objective/major_sacrifice/major_sacc_objective = locate() in objectives
+	if(major_sacc_objective && !major_sacc_objective.check_completion() && (target_mind.assigned_role in GLOB.command_positions))
+		return TRUE
 
 /*
  * Get a list of all rituals this heretic can invoke on a rune.
@@ -627,13 +693,11 @@
 /datum/objective/major_sacrifice
 	name = "major sacrifice"
 	target_amount = 1
-	explanation_text = "Sacrifice 1 head of staff."
+	explanation_text = "Sacrifice at least 1 head of staff."
 
 /datum/objective/major_sacrifice/check_completion()
 	var/datum/antagonist/heretic/heretic_datum = owner?.has_antag_datum(/datum/antagonist/heretic)
-	if(!heretic_datum)
-		return FALSE
-	return heretic_datum.high_value_sacrifices >= target_amount
+	return completed || length(heretic_datum?.high_value_sacrifices) >= target_amount
 
 /// Heretic's research objective. "Research" is heretic knowledge nodes (You start with some).
 /datum/objective/heretic_research
@@ -668,9 +732,7 @@
 
 /datum/objective/heretic_research/check_completion()
 	var/datum/antagonist/heretic/heretic_datum = owner?.has_antag_datum(/datum/antagonist/heretic)
-	if(!heretic_datum)
-		return FALSE
-	return length(heretic_datum.researched_knowledge) >= target_amount
+	return ..() || length(heretic_datum?.researched_knowledge) >= target_amount
 
 /datum/objective/heretic_summon
 	name = "summon monsters"
@@ -678,19 +740,8 @@
 	explanation_text = "Summon 2 monsters from the Mansus into this realm."
 
 /datum/objective/heretic_summon/check_completion()
-
-	var/num_we_have = 0
-	for(var/datum/antagonist/heretic_monster/monster in GLOB.antagonists)
-		if(!monster.master)
-			continue
-		if(ishuman(monster.owner.current))
-			continue
-		if(monster.master != owner)
-			continue
-
-		num_we_have++
-
-	return completed || (num_we_have >= target_amount)
+	var/datum/antagonist/heretic/heretic_datum = owner?.has_antag_datum(/datum/antagonist/heretic)
+	return ..() || (LAZYLEN(heretic_datum?.monsters_summoned) >= target_amount)
 
 /datum/action/antag_info/heretic
 	name = "Forbidden Knowledge"

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -408,7 +408,7 @@
 
 /datum/heretic_knowledge/knowledge_ritual/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
-	our_heretic.knowledge_points += KNOWLEDGE_RITUAL_POINTS
+	our_heretic.adjust_knowledge_points(KNOWLEDGE_RITUAL_POINTS)
 	was_completed = TRUE
 
 	var/drain_message = pick(strings(HERETIC_INFLUENCE_FILE, "drain_message"))

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -72,26 +72,22 @@
 	desc = "Track a Sacrifice Target"
 	check_flags = AB_CHECK_CONSCIOUS
 	background_icon_state = "bg_ecult"
-	/// The real name of the last mob we tracked
-	var/last_tracked_name
 	/// Whether the target radial is currently opened.
 	var/radial_open = FALSE
 	/// How long we have to wait between tracking uses.
-	var/track_cooldown_lenth = 8 SECONDS
+	var/track_cooldown_length = 8 SECONDS
 	/// The cooldown between button uses.
 	COOLDOWN_DECLARE(track_cooldown)
 
 /datum/action/item_action/organ_action/track_target/Grant(mob/granted)
 	if(!IS_HERETIC(granted))
 		return
-
 	return ..()
 
 /datum/action/item_action/organ_action/track_target/IsAvailable()
 	. = ..()
 	if(!.)
 		return
-
 	if(!IS_HERETIC(owner))
 		return FALSE
 	if(!HAS_TRAIT(target, TRAIT_LIVING_HEART))
@@ -112,17 +108,16 @@
 		return TRUE
 
 	var/list/targets_to_choose = list()
-	var/list/mob/living/carbon/human/human_targets = list()
+	var/list/mob/living/carbon/tracked_targets = list()
 	for(var/datum/weakref/target_ref as anything in heretic_datum.sac_targets)
-		var/mob/living/carbon/human/real_target = target_ref.resolve()
-		if(QDELETED(real_target))
+		var/datum/mind/target_mind = target_ref.resolve()
+		if(!istype(target_mind) || !iscarbon(target_mind.current))
 			continue
-
-		human_targets[real_target.real_name] = real_target
-		targets_to_choose[real_target.real_name] = heretic_datum.sac_targets[target_ref]
+		tracked_targets[target_mind.name] = target_mind.current
+		targets_to_choose[target_mind.name] = heretic_datum.sac_targets[target_ref]
 
 	radial_open = TRUE
-	last_tracked_name = show_radial_menu(
+	var/tracked = show_radial_menu(
 		owner,
 		owner,
 		targets_to_choose,
@@ -132,41 +127,49 @@
 		tooltips = TRUE,
 	)
 	radial_open = FALSE
-
 	// If our last tracked name is still null, skip the trigger
-	if(isnull(last_tracked_name))
+	if(isnull(tracked))
 		return FALSE
 
-	var/mob/living/carbon/human/tracked_mob = human_targets[last_tracked_name]
+	var/mob/living/carbon/tracked_mob = tracked_targets[tracked]
 	if(QDELETED(tracked_mob))
-		last_tracked_name = null
 		return FALSE
+	. = track_sacrifice_target(tracked_mob)
 
-	COOLDOWN_START(src, track_cooldown, track_cooldown_lenth)
+	if(.)
+		COOLDOWN_START(src, track_cooldown, track_cooldown_length)
+		playsound(owner, 'sound/effects/singlebeat.ogg', vol = 50, vary = TRUE, extrarange = SILENCED_SOUND_EXTRARANGE)
+
+/datum/action/item_action/organ_action/track_target/proc/track_sacrifice_target(mob/living/carbon/tracked)
+	var/turf/owner_turf = get_turf(owner)
+	var/turf/tracked_turf = get_turf(tracked)
 	var/balloon_message = "Your target is "
-
-	playsound(owner, 'sound/effects/singlebeat.ogg', 50, TRUE, SILENCED_SOUND_EXTRARANGE)
-	if(isturf(tracked_mob.loc) && owner.z != tracked_mob.z)
-		balloon_message += "on another plane"
+	if(tracked.stat == DEAD)
+		balloon_message += "dead and "
+	else if(!tracked.ckey)
+		balloon_message += "catatonic and "
+	if(owner_turf.get_virtual_z_level() != tracked_turf.get_virtual_z_level())
+		if(is_reserved_level(tracked_turf.z))
+			balloon_message += "traveling through space"
+		else
+			balloon_message += "on another plane"
 	else
-		var/dist = get_dist(get_turf(owner), get_turf(tracked_mob))
-		var/dir = get_dir(get_turf(owner), get_turf(tracked_mob))
-
-		switch(dist)
-			if(0 to 15)
-				balloon_message += "very near, [dir2text(dir)]"
-			if(16 to 31)
-				balloon_message += "near, [dir2text(dir)]"
-			if(32 to 127)
-				balloon_message += "far, [dir2text(dir)]"
-			else
-				balloon_message += "very far"
-
-	if(tracked_mob.stat == DEAD)
-		balloon_message += "dead, they're " + balloon_message
-
+		balloon_message += distance_hint(owner_turf, tracked_turf)
 	owner.balloon_alert(owner, balloon_message)
 	return TRUE
+
+/datum/action/item_action/organ_action/track_target/proc/distance_hint(turf/source, turf/target)
+	var/dist = get_dist(source, target)
+	var/dir = get_dir(source, target)
+	switch(dist)
+		if(0 to 15)
+			return "very near, [dir2text(dir)]"
+		if(16 to 31)
+			return "near, [dir2text(dir)]"
+		if(32 to 127)
+			return "far away, [dir2text(dir)]"
+		else
+			return "very far away"
 
 /// Callback for the radial to ensure it's closed when not allowed.
 /datum/action/item_action/organ_action/track_target/proc/check_menu()

--- a/code/modules/antagonists/heretic/heretic_monsters.dm
+++ b/code/modules/antagonists/heretic/heretic_monsters.dm
@@ -32,6 +32,9 @@
  */
 /datum/antagonist/heretic_monster/proc/set_owner(datum/mind/master)
 	src.master = master
+	var/datum/antagonist/heretic/master_heretic = master.has_antag_datum(/datum/antagonist/heretic)
+	if(master_heretic)
+		LAZYOR(master_heretic.monsters_summoned, WEAKREF(owner))
 
 	var/datum/objective/master_obj = new()
 	master_obj.owner = owner

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -277,7 +277,7 @@
 	balloon_alert(user, "Influence drained")
 
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
-	heretic_datum.knowledge_points += knowledge_to_gain
+	heretic_datum.adjust_knowledge_points(knowledge_to_gain)
 
 	// Aaand now we delete it
 	after_drain(user)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -22,14 +22,11 @@
 	var/skip_this_ritual = FALSE
 	/// A weakref to the mind of our heretic.
 	var/datum/mind/heretic_mind
-	/// Lazylist of minds that we won't pick as targets.
-	var/list/datum/mind/target_blacklist
 	/// An assoc list of [ref] to [timers] - a list of all the timers of people in the shadow realm currently
 	var/return_timers
 
 /datum/heretic_knowledge/hunt_and_sacrifice/Destroy(force, ...)
 	heretic_mind = null
-	LAZYCLEARLIST(target_blacklist)
 	return ..()
 
 /datum/heretic_knowledge/hunt_and_sacrifice/on_research(mob/user, regained = FALSE)
@@ -67,7 +64,7 @@
 	// Let's remove any humans in our atoms list that aren't a sac target
 	for(var/mob/living/carbon/human/sacrifice in atoms)
 		// If the mob's not in soft crit or worse, or isn't one of the sacrifices, remove it from the list
-		if(sacrifice.stat < SOFT_CRIT || !(WEAKREF(sacrifice) in heretic_datum.sac_targets))
+		if(sacrifice.stat < SOFT_CRIT || !heretic_datum.can_sacrifice(sacrifice))
 			atoms -= sacrifice
 
 	// Finally, return TRUE if we have a target in the list
@@ -97,24 +94,10 @@
  * Returns FALSE if no targets are found, TRUE if the targets list was populated.
  */
 /datum/heretic_knowledge/hunt_and_sacrifice/proc/obtain_targets(mob/living/user, silent = FALSE)
+	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
 
 	// First construct a list of minds that are valid objective targets.
-	var/list/datum/mind/valid_targets = list()
-	for(var/mob/player in SSticker.mode.current_players[CURRENT_LIVING_PLAYERS])
-		if(player.mind)
-			var/datum/mind/possible_target = player.mind
-			if(possible_target == user.mind)
-				continue
-			if(possible_target in target_blacklist)
-				continue
-			if(!ishuman(player))
-				continue
-			if(player.stat == DEAD)
-				continue
-			valid_targets += possible_target
-		else
-			continue
-
+	var/list/datum/mind/valid_targets = heretic_datum.possible_sacrifice_targets()
 	if(!length(valid_targets))
 		if(!silent)
 			to_chat(user,"<span class='hierophant'>No sacrifice targets could be found!</span>")
@@ -129,14 +112,14 @@
 
 	// First target, any command.
 	for(var/datum/mind/head_mind as anything in shuffle_inplace(valid_targets))
-		if(head_mind.assigned_role in list("Captain", "Head of Personnel", "Chief Engineer", "Head of Security", "Research Director", "Chief Medical Officer"))
+		if(head_mind.assigned_role in GLOB.command_positions)
 			final_targets += head_mind
 			valid_targets -= head_mind
 			break
 
 	// Second target, any security
 	for(var/datum/mind/sec_mind as anything in shuffle_inplace(valid_targets))
-		if(sec_mind.assigned_role in list("Security Officer", "Warden", "Detective", "Head of Security", "Brig Physician", "Deputy"))
+		if(sec_mind.assigned_role in GLOB.security_positions)
 			final_targets += sec_mind
 			valid_targets -= sec_mind
 			break
@@ -154,11 +137,9 @@
 	// If any of our targets failed to aquire,
 	// Let's run a loop until we get four total, grabbing random targets.
 	var/target_sanity = 0
-	while(length(final_targets) < 4 && length(valid_targets) > 4 && target_sanity < 25)
+	while(length(final_targets) < HERETIC_MAX_SAC_TARGETS && length(valid_targets) > HERETIC_MAX_SAC_TARGETS && target_sanity < 25)
 		final_targets += pick_n_take(valid_targets)
 		target_sanity++
-
-	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
 
 	if(!silent)
 		to_chat(user, "<span class='danger'>Your targets have been determined. Your Living Heart will allow you to track their position. Go forth, and sacrifice them!</span>")
@@ -184,21 +165,21 @@
 	var/mob/living/carbon/human/sacrifice = locate() in selected_atoms
 	if(!sacrifice)
 		CRASH("[type] sacrifice_process didn't have a human in the atoms list. How'd it make it so far?")
-	if(!(WEAKREF(sacrifice) in heretic_datum.sac_targets))
+	var/datum/mind/sacrifice_mind = get_mind(sacrifice, TRUE)
+	if(!heretic_datum.can_sacrifice(sacrifice_mind))
 		CRASH("[type] sacrifice_process managed to get a non-target human. This is incorrect.")
 
-	if(sacrifice.mind)
-		LAZYADD(target_blacklist, sacrifice.mind)
-	LAZYREMOVE(heretic_datum.sac_targets, WEAKREF(sacrifice))
+	LAZYADD(heretic_datum.target_blacklist, sacrifice_mind)
+	heretic_datum.remove_sacrifice_target(sacrifice_mind)
 
 	to_chat(user, "<span class='hypnophrase'>Your patron accepts your offer.</span>")
 
-	if(sacrifice.mind?.assigned_role in list("Captain", "Head of Personnel", "Chief Engineer", "Head of Security", "Research Director", "Chief Medical Officer"))
-		heretic_datum.knowledge_points++
+	if(sacrifice_mind.assigned_role in GLOB.command_positions)
+		heretic_datum.adjust_knowledge_points(1)
 		heretic_datum.high_value_sacrifices++
 
 	heretic_datum.total_sacrifices++
-	heretic_datum.knowledge_points += 2
+	heretic_datum.adjust_knowledge_points(2)
 
 	if(!begin_sacrifice(sacrifice))
 		disembowel_target(sacrifice)
@@ -243,6 +224,8 @@
 	addtimer(CALLBACK(sac_target, TYPE_PROC_REF(/mob/living/carbon, do_jitter_animation), 100), SACRIFICE_SLEEP_DURATION * (1/3))
 	addtimer(CALLBACK(sac_target, TYPE_PROC_REF(/mob/living/carbon, do_jitter_animation), 100), SACRIFICE_SLEEP_DURATION * (2/3))
 
+	// Grab their ghost, just in case they're dead or something.
+	sac_target.grab_ghost()
 	// If our target is dead, try to revive them
 	// and if we fail to revive them, don't proceede the chain
 	if(!sac_target.heal_and_revive(50, "<span class='danger'>[sac_target]'s heart begins to beat with an unholy force as they return from death!</span>"))
@@ -274,6 +257,8 @@
 	if(QDELETED(sac_target))
 		return
 
+	// Grab ghost again, just to be safe.
+	sac_target.grab_ghost()
 	// The target disconnected or something, we shouldn't bother sending them along.
 	if(!sac_target.client || !sac_target.mind)
 		disembowel_target(sac_target)
@@ -482,7 +467,6 @@
 	sac_target.spill_organs()
 	sac_target.apply_damage(250, BRUTE)
 	if(sac_target.stat != DEAD)
-		sac_target.investigate_log("has been killed by heretic sacrifice.", INVESTIGATE_DEATHS)
 		sac_target.death()
 	sac_target.visible_message(
 		"<span class='danger'>[sac_target]'s organs are pulled out of [sac_target.p_their()] chest by shadowy hands!</span>",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes a bunch of QoL additions and tweaks to make reworked heretics much more enjoyable.

This is basically just https://github.com/BeeStation/BeeStation-Hornet/pull/9880 without the balance stuff.

## Why It's Good For The Game

Makes heretic less of a chore to play

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![23-09-22-1695422461-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/2398f45d-c354-4a18-af5c-0be83d1a374a)
![23-09-22-1695422465-dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/446173c7-5feb-4203-bd90-834b776744d4)
![2023-12-20 (1703056316) ~ dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/ab1a2b92-1606-4676-b170-40d9fe0dd249)


</details>

## Changelog
:cl:
add: Heretics with an objective to sacrifice a head of staff can now sacrifice ANY head of staff, even non-living heart targets, if they haven't met that goal already.
tweak: Ghouls and voiceless dead now count towards the "summon X monsters from the Mansus" objective for flesh heretics.
tweak: Heretic sacrifice now grabs the ghost of the victim during revival.
tweak: Heretic living heart tracking now specifies if the target is catatonic or currently on a moving shuttle.
tweak: If a heretic's sacrifice target enters cryo, it will try to roll a new sacrifice target for them.
fix: Fixed text formatting when tracking dead living heart targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
