### PR TITLE
Adds more lights to BoxStation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -39829,6 +39829,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mJR" = (
@@ -45540,6 +45541,14 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"pJk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/primary/starboard)
 "pJv" = (
 /turf/open/floor/grass,
 /area/hallway/primary/central)
@@ -100645,7 +100654,7 @@ aVz
 aVz
 aYJ
 aJI
-bbz
+pJk
 aYV
 aYV
 aYV
@@ -102444,7 +102453,7 @@ aVH
 aXn
 aYN
 aJI
-bbz
+pJk
 aYV
 aYV
 aYV
@@ -103218,7 +103227,7 @@ aRJ
 kRy
 aYV
 aYV
-aYV
+beE
 xJf
 xJf
 ddd
@@ -103990,7 +103999,7 @@ aYV
 aYV
 aYV
 aYV
-beE
+aYV
 xJf
 biE
 bpL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds more lighs to boxstation east hallway

## Why It's Good For The Game
Because it sucks how dark that hallway is for no reason, the kitchen counter is always surrounded by darkness

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/ecbffbc9-6ccf-4158-8f7c-9152c5d8b76f)

</details>

## Changelog
:cl:
add:[BoxStation] Adds 3 new lights to the starboard hallway
tweak:[BoxStation] Moves one light a couple tiles to the right by starboard hallway
/:cl:
