### PR TITLE
Adjusts the gold slime core to not spawn blobbernaut and wumborian fugu anymore.

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -320,5 +320,5 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/independent
 	independent = TRUE
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN
 

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -28,7 +28,7 @@
 	aggro_vision_range = 9
 	mob_size = MOB_SIZE_SMALL
 	environment_smash = ENVIRONMENT_SMASH_NONE
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN
 	var/wumbo = 0
 	var/inflate_cooldown = 0
 	var/datum/action/innate/fugu/expand/E


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes neutral blobblernaut and wumborian fugu from being able to be spawned by the xenobiology gold slime core.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Hostile mobs from the gold slime core are very strong and annoying already. Seeing a neutral blobbernaut fight a real blob is really stupid. This change doesn't remove the neutral blob from the game, so it can still be used in maps or be admin spawned.

For the wumborian fugu, the gland is just too strong. Giving any mob the ability to two hit r-walls on top of other buffs is too much in my opinion. Especially with how easy it is to aquire gold slimes. 
"Then nerf the gland instead". I'd say no, the fugu can also spawn on space ruins. I feel like the reward for killing a fugu in space should be worth it. In that case, the fugu gland is fine. The same can't be said about gold slimes that can be rushed within the first 20 minutes of the shift.

Before people get mad, the gold slimes still spawn a ton of interesting and weird mobs. I don't think this change would impact this in any major way.


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Not sure what type of testing is necessary here, as I just changed two flags(?).
## Changelog
:cl:

tweak: Adjusted the gold slime core to not spawn blobbernaut and wumborian fugu anymore.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
