### PR TITLE
Fixes a runtime related to brig doors and a runtime related to roaches

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -36,7 +36,7 @@
 	///List of weakrefs to nearby closets
 	var/list/closets = list()
 
-	var/obj/item/radio/Radio //needed to send messages to sec radio
+	var/obj/item/radio/sec_radio //needed to send messages to sec radio
 
 	maptext_height = 26
 	maptext_width = 32
@@ -47,8 +47,8 @@
 /obj/machinery/door_timer/Initialize(mapload)
 	. = ..()
 
-	Radio = new/obj/item/radio(src)
-	Radio.listening = 0
+	sec_radio = new/obj/item/radio(src)
+	sec_radio.listening = FALSE
 
 /obj/machinery/door_timer/Initialize(mapload)
 	. = ..()
@@ -120,8 +120,8 @@
 		return 0
 
 	if(!forced)
-		Radio.set_frequency(FREQ_SECURITY)
-		Radio.talk_into(src, "Timer has expired. Releasing prisoner.", FREQ_SECURITY)
+		sec_radio.set_frequency(FREQ_SECURITY)
+		sec_radio.talk_into(src, "Timer has expired. Releasing prisoner.", FREQ_SECURITY)
 
 	timing = FALSE
 	activation_time = null

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -220,23 +220,23 @@
 					recalculateChannels()
 				. = TRUE
 
-/obj/item/radio/talk_into(atom/movable/M, message, channel, list/spans, datum/language/language, list/message_mods)
+/obj/item/radio/talk_into(atom/movable/talking_movable, message, channel, list/spans, datum/language/language, list/message_mods)
 	if(!spans)
-		spans = list(M.speech_span)
+		spans = list(talking_movable.speech_span)
 	if(!language)
-		language = M.get_selected_language()
-	SEND_SIGNAL(src, COMSIG_RADIO_MESSAGE, M, message, channel, message_mods)
-	INVOKE_ASYNC(src, PROC_REF(talk_into_impl), M, message, channel, spans.Copy(), language, message_mods)
+		language = talking_movable.get_selected_language()
+	SEND_SIGNAL(src, COMSIG_RADIO_MESSAGE, talking_movable, message, channel, message_mods)
+	INVOKE_ASYNC(src, PROC_REF(talk_into_impl), talking_movable, message, channel, spans.Copy(), language, message_mods)
 	return ITALICS | REDUCE_RANGE
 
-/obj/item/radio/proc/talk_into_impl(atom/movable/M, message, channel, list/spans, datum/language/language, list/message_mods)
+/obj/item/radio/proc/talk_into_impl(atom/movable/talking_movable, message, channel, list/spans, datum/language/language, list/message_mods)
 	if(!on)
 		return // the device has to be on
-	if(!M || !message)
+	if(!talking_movable || !message)
 		return
 	if(wires.is_cut(WIRE_TX))  // Permacell and otherwise tampered-with radios
 		return
-	if(!M.IsVocal())
+	if(!talking_movable.IsVocal())
 		return
 
 	if(!radio_silent)//Radios make small static noises now
@@ -261,12 +261,12 @@
 
 	// From the channel, determine the frequency and get a reference to it.
 	var/freq
-	if(channel && channels)
-		if(channel == MODE_DEPARTMENT && channels.len > 0)
+	if(channel && channels && channels.len > 0)
+		if(channel == MODE_DEPARTMENT)
 			channel = channels[1]
 		freq = secure_radio_connections[channel]
-		if(istype(M, /mob) && !freq && channel != RADIO_CHANNEL_UPLINK)
-			to_chat(M, "<span class='warning'>You can't access this channel without an encryption key!</span>")
+		if(istype(talking_movable, /mob) && !freq && channel != RADIO_CHANNEL_UPLINK)
+			to_chat(talking_movable, "<span class='warning'>You can't access this channel without an encryption key!</span>")
 		if (!channels[channel]) // if the channel is turned off, don't broadcast
 			return
 	else
@@ -278,7 +278,7 @@
 		return
 
 	// Determine the identity information which will be attached to the signal.
-	var/atom/movable/virtualspeaker/speaker = new(null, M, src)
+	var/atom/movable/virtualspeaker/speaker = new(null, talking_movable, src)
 
 	// Construct the signal
 	var/datum/signal/subspace/vocal/signal = new(src, freq, speaker, language, message, spans, message_mods)
@@ -326,8 +326,8 @@
 	if(message_mods[RADIO_EXTENSION] == MODE_L_HAND || message_mods[RADIO_EXTENSION] == MODE_R_HAND)
 		// try to avoid being heard double
 		if (loc == speaker && ismob(speaker))
-			var/mob/M = speaker
-			var/idx = M.get_held_index_of_item(src)
+			var/mob/talking_movable = speaker
+			var/idx = talking_movable.get_held_index_of_item(src)
 			// left hands are odd slots
 			if (idx && (idx % 2) == (message_mods[RADIO_EXTENSION] == MODE_L_HAND))
 				return

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -36,7 +36,7 @@
 	AddComponent(/datum/component/squashable, squash_chance = 50, squash_damage = 1)
 
 /mob/living/basic/cockroach/death(gibbed)
-	if(!null && SSticker.mode.station_was_nuked) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
+	if(SSticker.mode?.station_was_nuked) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
 		return
 	..()
 

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -36,7 +36,7 @@
 	AddComponent(/datum/component/squashable, squash_chance = 50, squash_damage = 1)
 
 /mob/living/basic/cockroach/death(gibbed)
-	if(SSticker.mode.station_was_nuked) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
+	if(!null && SSticker.mode.station_was_nuked) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
 		return
 	..()
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes two annoying runtimes, one is related to the brig cells timers expiring, which, as soon they expired, they caused the display's radio to runtime as it was throwing the list index out of bounds.
The other fix, which is more related to the developement enviroment, is to cockroackes' nature to survive nuclear blasts to the next round, ~~which in this case, due to many developer not having a database set up, it would throw a runtime~~ which is related to the gamemode.

## Why It's Good For The Game

Removing runtimes good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Adresses these runtimes:

![immagine](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/9a9b366a-9d53-4369-8be1-ed5080df3fd1)


</details>

## Changelog
:cl:
fix: fixed a runtime related to Brig cells timers
fix: fixed a runtime related to cockroaches
/:cl:

