### PR TITLE
Fixes is_station_level(z) macro throwing out of index runtime when it's given 0z, and minor fix to explo artefact

### DIFF
--- a/code/__HELPERS/level_traits.dm
+++ b/code/__HELPERS/level_traits.dm
@@ -10,13 +10,13 @@ GLOBAL_VAR(station_level_z_scratch)
 
 // Called a lot, somewhat slow, so has its own cache
 #define is_station_level(z) \
-	( ##z && \
+	( z && \
 		( \
 			/* The right hand side of this guarantees that we'll have the space to fill later on, while also not failing the condition */ \
-			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = ##z) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \
+			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = z) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \
 			|| isnull(GLOB.station_levels_cache[GLOB.station_level_z_scratch]) \
 		) \
-			? (GLOB.station_levels_cache[GLOB.station_level_z_scratch] = !!SSmapping.level_trait(##z, ZTRAIT_STATION)) \
+			? (GLOB.station_levels_cache[GLOB.station_level_z_scratch] = !!SSmapping.level_trait(z, ZTRAIT_STATION)) \
 			: GLOB.station_levels_cache[GLOB.station_level_z_scratch] \
 	)
 

--- a/code/__HELPERS/level_traits.dm
+++ b/code/__HELPERS/level_traits.dm
@@ -10,15 +10,15 @@ GLOBAL_VAR(station_level_z_scratch)
 
 // Called a lot, somewhat slow, so has its own cache
 #define is_station_level(z) \
-	( z && \
+	( !z ? 0 : ( \
 		( \
 			/* The right hand side of this guarantees that we'll have the space to fill later on, while also not failing the condition */ \
 			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = z) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \
 			|| isnull(GLOB.station_levels_cache[GLOB.station_level_z_scratch]) \
 		) \
-			? (GLOB.station_levels_cache[GLOB.station_level_z_scratch] = !!SSmapping.level_trait(z, ZTRAIT_STATION)) \
-			: GLOB.station_levels_cache[GLOB.station_level_z_scratch] \
-	)
+		? (GLOB.station_levels_cache[GLOB.station_level_z_scratch] = !!SSmapping.level_trait(z, ZTRAIT_STATION)) \
+		: GLOB.station_levels_cache[GLOB.station_level_z_scratch] \
+	) )
 
 #define is_mining_level(z) SSmapping.level_trait(z, ZTRAIT_MINING)
 

--- a/code/__HELPERS/level_traits.dm
+++ b/code/__HELPERS/level_traits.dm
@@ -13,10 +13,10 @@ GLOBAL_VAR(station_level_z_scratch)
 	( ##z && \
 		( \
 			/* The right hand side of this guarantees that we'll have the space to fill later on, while also not failing the condition */ \
-			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = z) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \
+			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = ##z) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \
 			|| isnull(GLOB.station_levels_cache[GLOB.station_level_z_scratch]) \
 		) \
-			? (GLOB.station_levels_cache[GLOB.station_level_z_scratch] = !!SSmapping.level_trait(z, ZTRAIT_STATION)) \
+			? (GLOB.station_levels_cache[GLOB.station_level_z_scratch] = !!SSmapping.level_trait(##z, ZTRAIT_STATION)) \
 			: GLOB.station_levels_cache[GLOB.station_level_z_scratch] \
 	)
 

--- a/code/__HELPERS/level_traits.dm
+++ b/code/__HELPERS/level_traits.dm
@@ -10,7 +10,7 @@ GLOBAL_VAR(station_level_z_scratch)
 
 // Called a lot, somewhat slow, so has its own cache
 #define is_station_level(z) \
-	( \
+	( ##z && \
 		( \
 			/* The right hand side of this guarantees that we'll have the space to fill later on, while also not failing the condition */ \
 			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = z) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -1,13 +1,11 @@
 /datum/orbital_objective/artifact
 	name = "Artifact Recovery"
-	var/generated = FALSE
 	//The blackbox required to recover.
 	var/obj/item/xenoartifact/objective/linked_artifact
 	min_payout = 5000
 	max_payout = 25000
 
 /datum/orbital_objective/artifact/generate_objective_stuff(turf/chosen_turf)
-	generated = TRUE
 	linked_artifact = new(chosen_turf)
 	var/list/turfs = RANGE_TURFS(30, linked_artifact)
 	var/list/valid_turfs = list()
@@ -31,7 +29,7 @@
 		. += " The station is located at the beacon marked [linked_beacon.name]. Good luck."
 
 /datum/orbital_objective/artifact/check_failed()
-	if(!generated)
+	if(!(linked_artifact?.flags_1 & INITIALIZED_1))
 		return FALSE
 	if(is_station_level(linked_artifact.z))
 		complete_objective()

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -1,12 +1,12 @@
 /datum/orbital_objective/artifact
 	name = "Artifact Recovery"
-	var/datum/weakref/weakref_artifect
+	var/datum/weakref/weakref_artifact
 	min_payout = 5000
 	max_payout = 25000
 
 /datum/orbital_objective/artifact/generate_objective_stuff(turf/chosen_turf)
 	var/obj/item/xenoartifact/objective/linked_artifact = new(chosen_turf)
-	weakref_artifect = WEAKREF(linked_artifact)
+	weakref_artifact = WEAKREF(linked_artifact)
 
 	var/list/turfs = RANGE_TURFS(30, linked_artifact)
 	var/list/valid_turfs = list()
@@ -32,9 +32,9 @@
 /datum/orbital_objective/artifact/check_failed()
 	. = TRUE // To return TRUE when CRASH
 
-	if(!weakref_artifect) // It looks fail-check is executed before we fully initialise the explo mission.
+	if(!weakref_artifact) // It looks fail-check is executed before we fully initialise the explo mission.
 		return FALSE
-	var/obj/item/xenoartifact/objective/linked_artifact = weakref_artifect.resolve()
+	var/obj/item/xenoartifact/objective/linked_artifact = weakref_artifact.resolve()
 	if(!linked_artifact)
 		CRASH("Something's wrong with the explo mission weakref.")
 	if(QDELETED(linked_artifact)) // a deleted item means they'll never make it success.

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -30,20 +30,15 @@
 		. += " The station is located at the beacon marked [linked_beacon.name]. Good luck."
 
 /datum/orbital_objective/artifact/check_failed()
-	. = TRUE // To return TRUE when CRASH
-
 	if(!weakref_artifact) // It looks fail-check is executed before we fully initialise the explo mission.
 		return FALSE
 	var/obj/item/xenoartifact/objective/linked_artifact = weakref_artifact.resolve()
-	if(!linked_artifact)
-		CRASH("Something's wrong with the explo mission weakref.")
-	if(QDELETED(linked_artifact)) // a deleted item means they'll never make it success.
+	if(QDELETED(linked_artifact)) // failed to resolve or qdeleted means it never success
 		return TRUE
 	if(!(linked_artifact?.flags_1 & INITIALIZED_1)) // We checked this too early.
 		return FALSE
-	if(is_station_level(linked_artifact.z))
-		complete_objective()
+	if(!is_station_level(linked_artifact.z)) // It's not a real failure. Let's wait...
 		return FALSE
 
-	// failsafe. It shouldn't happen.
-	CRASH("For unknown reason, check_failed() proc reached the end of the code. It shouldn't happen.")
+	complete_objective()
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes is_station_level(z) macro throwing out of index runtime when it's given 0z, and minor fix to explo artefact
* the macro is not capable of failproof index 0 to the list. I don't think we want to throw runtime for this. 
  It should return 0 anyway if it's not station, not throwing runtime.
* the artefact mission has been throwing that runtime. fixed it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
annoying runtime

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/bd98efe4-4787-487a-a184-c2b06f44d4a5)

I see no runtime.

## Changelog
:cl:
fix: is_station_level(z) macro now has a 0 index failproof
fix: alien artifact explo mission no longer throws is_station_level() runtime with 0z index with minor code change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
