### PR TITLE
Fixes Briefcase Launchpad traitor item has 0 range

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -20,11 +20,10 @@
 	var/indicator_icon = "launchpad_target"
 
 /obj/machinery/launchpad/RefreshParts()
-	var/E = 0
+	var/efficiency = 0
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		E += M.rating
-	range = initial(range)
-	range *= E
+		efficiency += M.rating
+	range = initial(range) * max(1, efficiency)
 	//Update to viewers
 	ui_update()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes Briefcase Launchpad traitor item has 0 range
It appears my machine construction refactor caused an issue?
but it shouldn't happen anyway.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/0fcce394-c9a9-4a5a-898b-9d290185f346)


## Changelog
:cl:
fix: fixed Briefcase Launchpad traitor item has 0 range. It now has 8 range as default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
