### PR TITLE
Random events no longer indicate whether they were triggered by the random event system

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -122,7 +122,7 @@
 	if(random)
 		log_game("Random Event triggering: [name] ([typepath])")
 	if (alert_observers)
-		deadchat_broadcast("<span class='deadsay'><b>[name]</b> has just been[random ? " randomly" : ""] triggered!</span>") //STOP ASSUMING IT'S BADMINS!
+		deadchat_broadcast("<span class='deadsay'><b>[name]</b> has just been triggered!</span>") //STOP ASSUMING IT'S BADMINS!
 	return E
 
 //Special admins setup

--- a/code/modules/events/special_antag_event.dm
+++ b/code/modules/events/special_antag_event.dm
@@ -25,7 +25,7 @@
 	if(random)
 		log_game("Random Event triggering: [name] ([typepath])")
 	if (alert_observers)
-		deadchat_broadcast("<span class='deadsay'><b>[name]</b> has just been[random ? " randomly" : ""] triggered!</span>") //STOP ASSUMING IT'S BADMINS!
+		deadchat_broadcast("<span class='deadsay'><b>[name]</b> has just been triggered!</span>")
 	return E
 
 ////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the indicator of whether an event was triggered "randomly" or not because players are erroneously assuming that anytime "randomly" isn't present that it is admins who are sending the event because of misinformation that has propagated from the time when this used to be true before dynamic. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Misplaced ire against admins is bad

Giving a voice to people who believe admins should never do anything but tickets is also bad - and this is why I'm removing the indicator instead of fixing it. If an admin is actually abusing things, it's not going to be through forcing events which they are expected to start doing once rounds approach the desired length with no sign of conclusion. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

There is no testing evidence for this, it is two line change that purely affects text displayed.

## Changelog
:cl:
del: Removed the indicator that determines whether or not events were triggered "randomly" to prevent confusion and harassment of administrative staff moving forward. All event triggers will share the same message regardless of whether they were triggered by the random event system, an admin or dynamic. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
