### PR TITLE
Ports post-basemat fixes to cyborg stacks

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -12,6 +12,9 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 40
 	novariants = FALSE
+	item_flags = NOBLUDGEON
+	cost = 250
+	source = /datum/robot_energy_storage/medical
 	///What reagent does it apply?
 	var/list/reagent
 	///Is this for bruises?
@@ -40,7 +43,7 @@
 	if(!iscarbon(M) && !isanimal(M))
 		to_chat(user, "<span class='danger'>You don't know how to apply \the [src] to [M]!</span>")
 		return
-	
+
 	if(M in user.do_afters) //One at a time, please.
 		return
 
@@ -207,8 +210,3 @@
 
 /obj/item/stack/medical/gauze/adv/one
 	amount = 1
-
-/obj/item/stack/medical/gauze/cyborg
-	custom_materials = null
-	is_cyborg = TRUE
-	cost = 250

--- a/code/game/objects/items/stacks/rods/rods.dm
+++ b/code/game/objects/items/stacks/rods/rods.dm
@@ -18,6 +18,8 @@
 	embedding = list()
 	novariants = TRUE
 	matter_amount = 2
+	cost = 250
+	source = /datum/robot_energy_storage/metal
 
 /obj/item/stack/rods/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins to stuff \the [src] down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")//it looks like theyre ur mum

--- a/code/game/objects/items/stacks/rods/rods_recipes.dm
+++ b/code/game/objects/items/stacks/rods/rods_recipes.dm
@@ -8,9 +8,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	))
 
 /obj/item/stack/rods/cyborg
-	mats_per_unit = null
-	is_cyborg = 1
-	cost = 250
+	merge_type = /obj/item/stack/rods
 
 /obj/item/stack/rods/cyborg/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/stacks/sheets/mineral/glass.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/glass.dm
@@ -81,20 +81,24 @@
 	..()
 
 /obj/item/stack/sheet/rglass/cyborg
-	custom_materials = null
-	var/datum/robot_energy_storage/glasource
-	var/metcost = 250
+	mats_per_unit = null
+	cost = 250
+	source = /datum/robot_energy_storage/metal
+
+	/// What energy storage this draws glass from as a robot module.
+	var/datum/robot_energy_storage/glasource = /datum/robot_energy_storage/glass
+	/// The amount of energy this draws from the glass source per stack unit.
 	var/glacost = 500
 
 /obj/item/stack/sheet/rglass/cyborg/get_amount()
-	return min(round(source.energy / metcost), round(glasource.energy / glacost))
+	return min(round(source.energy / cost), round(glasource.energy / glacost))
 
 /obj/item/stack/sheet/rglass/cyborg/use(used, transfer = FALSE) // Requires special checks, because it uses two storages
-	source.use_charge(used * metcost)
+	source.use_charge(used * cost)
 	glasource.use_charge(used * glacost)
 
 /obj/item/stack/sheet/rglass/cyborg/add(amount)
-	source.add_charge(amount * metcost)
+	source.add_charge(amount * cost)
 	glasource.add_charge(amount * glacost)
 
 /obj/item/stack/sheet/rglass/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/mineral/glass_recipes.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/glass_recipes.dm
@@ -7,12 +7,6 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 
 STACKSIZE_MACRO(/obj/item/stack/sheet/glass)
 
-/obj/item/stack/sheet/glass/cyborg
-	mats_per_unit = null
-	is_cyborg = TRUE
-	cost = 500
-
-
 /* Reinforced glass sheets */
 GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	new/datum/stack_recipe("windoor frame", /obj/structure/windoor_assembly, 5, on_floor = TRUE, window_checks = TRUE), \

--- a/code/game/objects/items/stacks/sheets/mineral/metals.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/metals.dm
@@ -29,6 +29,8 @@ Metals Sheets
 	point_value = 2
 	material_type = /datum/material/iron
 	matter_amount = 4
+	cost = 500
+	source = /datum/robot_energy_storage/metal
 
 /obj/item/stack/sheet/iron/ratvar_act()
 	new /obj/item/stack/sheet/brass(loc, amount)

--- a/code/game/objects/items/stacks/sheets/mineral/metals_recipes.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/metals_recipes.dm
@@ -106,11 +106,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 
 STACKSIZE_MACRO(/obj/item/stack/sheet/iron)
 
-/obj/item/stack/sheet/iron/cyborg
-	mats_per_unit = null
-	is_cyborg = 1
-	cost = 500
-
 /* Plasteel */
 
 GLOBAL_LIST_INIT(plasteel_recipes, list ( \

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -97,7 +97,13 @@
 /** Updates the custom materials list of this stack.
   */
 /obj/item/stack/proc/update_custom_materials()
-	set_custom_materials(mats_per_unit, amount)
+	set_custom_materials(mats_per_unit, amount, is_update=TRUE)
+
+/**
+ * Override to make things like metalgen accurately set custom materials
+ */
+/obj/item/stack/set_custom_materials(list/materials, multiplier=1, is_update=FALSE)
+	return is_update ? ..() : set_mats_per_unit(materials, multiplier/(amount || 1))
 
 /obj/item/stack/on_grind()
 	for(var/i in 1 to length(grind_results)) //This should only call if it's ground, so no need to check if grind_results exists
@@ -411,7 +417,9 @@
 /obj/item/stack/proc/can_merge(obj/item/stack/check)
 	if(!istype(check, merge_type))
 		return FALSE
-	if(!check.is_cyborg && (mats_per_unit != check.mats_per_unit)) // Cyborg stacks don't have materials. This lets them recycle sheets and floor tiles.
+	if(mats_per_unit != check.mats_per_unit)
+		return FALSE
+	if(is_cyborg)	// No merging cyborg stacks into other stacks
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -411,7 +411,7 @@
 /obj/item/stack/proc/can_merge(obj/item/stack/check)
 	if(!istype(check, merge_type))
 		return FALSE
-	if(mats_per_unit != check.mats_per_unit)
+	if(!check.is_cyborg && (mats_per_unit != check.mats_per_unit)) // Cyborg stacks don't have materials. This lets them recycle sheets and floor tiles.
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -498,12 +498,8 @@
 	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 70, STAMINA = 0)
 	resistance_flags = FIRE_PROOF
 	matter_amount = 1
-
-/obj/item/stack/tile/plasteel/cyborg
-	desc = "The ground you walk on." //Not the usual floor tile desc as that refers to throwing, Cyborgs can't do that - RR
-	mats_per_unit = null // All other Borg versions of items have no Metal or Glass - RR
-	is_cyborg = 1
 	cost = 125
+	source = /datum/robot_energy_storage/metal
 
 //Monotiles
 

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -23,6 +23,8 @@ GLOBAL_LIST_INIT(marker_beacon_colors, sort_list(list(
 	merge_type = /obj/item/stack/marker_beacon
 	max_amount = 100
 	novariants = TRUE
+	cost = 1
+	source = /datum/robot_energy_storage/beacon
 	var/picked_color = "random"
 
 /obj/item/stack/marker_beacon/ten //miners start with 10 of these

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -79,51 +79,26 @@
 		if(!(m in R.held_items))
 			. += m
 
-/obj/item/robot_module/proc/get_or_create_estorage(var/storage_type)
-	for(var/datum/robot_energy_storage/S in storages)
-		if(istype(S, storage_type))
-			return S
+/obj/item/robot_module/proc/get_or_create_estorage(storage_type)
+	return (locate(storage_type) in storages) || new storage_type(src)
 
 	return new storage_type(src)
 
 /obj/item/robot_module/proc/add_module(obj/item/I, nonstandard, requires_rebuild)
 	if(istype(I, /obj/item/stack))
-		var/obj/item/stack/S = I
+		var/obj/item/stack/sheet_module = I
+		if(ispath(sheet_module.source, /datum/robot_energy_storage))
+			sheet_module.source = get_or_create_estorage(sheet_module.source)
 
-		if(is_type_in_list(S, list(/obj/item/stack/sheet/iron, /obj/item/stack/rods, /obj/item/stack/tile/plasteel, /obj/item/stack/tile/light)))
-			if(S.custom_materials && custom_materials.len)
-				if(S.custom_materials[SSmaterials.GetMaterialRef(/datum/material/iron)])
-					S.cost = S.custom_materials[SSmaterials.GetMaterialRef(/datum/material/iron)] * 0.25
-			S.source = get_or_create_estorage(/datum/robot_energy_storage/metal)
+		if(istype(sheet_module, /obj/item/stack/sheet/rglass/cyborg))
+			var/obj/item/stack/sheet/rglass/cyborg/rglass_module = sheet_module
+			if(ispath(rglass_module.glasource, /datum/robot_energy_storage))
+				rglass_module.glasource = get_or_create_estorage(rglass_module.glasource)
 
-		else if(istype(S, /obj/item/stack/sheet/glass))
-			S.cost = 500
-			S.source = get_or_create_estorage(/datum/robot_energy_storage/glass)
-
-		else if(istype(S, /obj/item/stack/sheet/rglass/cyborg))
-			var/obj/item/stack/sheet/rglass/cyborg/G = S
-			G.source = get_or_create_estorage(/datum/robot_energy_storage/metal)
-			G.glasource = get_or_create_estorage(/datum/robot_energy_storage/glass)
-
-		else if(istype(S, /obj/item/stack/sheet/brass))
-			S.cost = 500
-			S.source = get_or_create_estorage(/datum/robot_energy_storage/brass)
-
-		else if(istype(S, /obj/item/stack/medical))
-			S.cost = 250
-			S.source = get_or_create_estorage(/datum/robot_energy_storage/medical)
-
-		else if(istype(S, /obj/item/stack/cable_coil))
-			S.cost = 1
-			S.source = get_or_create_estorage(/datum/robot_energy_storage/wire)
-
-		else if(istype(S, /obj/item/stack/marker_beacon))
-			S.cost = 1
-			S.source = get_or_create_estorage(/datum/robot_energy_storage/beacon)
-
-		if(S?.source)
-			S.set_custom_materials(null)
-			S.is_cyborg = 1
+		if(istype(sheet_module.source))
+			sheet_module.cost = max(sheet_module.cost, 1) // Must not cost 0 to prevent div/0 errors.
+			sheet_module.set_mats_per_unit(null)
+			sheet_module.is_cyborg = TRUE
 
 	if(I.loc != src)
 		I.forceMove(src)
@@ -270,9 +245,9 @@
 		/obj/item/weldingtool/cyborg,
 		/obj/item/wrench/cyborg,
 		/obj/item/crowbar/cyborg,
-		/obj/item/stack/sheet/iron/cyborg,
+		/obj/item/stack/sheet/iron,
 		/obj/item/stack/rods/cyborg,
-		/obj/item/stack/tile/plasteel/cyborg,
+		/obj/item/stack/tile/plasteel,
 		/obj/item/extinguisher,
 		/obj/item/pickaxe,
 		/obj/item/t_scanner/adv_mining_scanner,
@@ -313,7 +288,7 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/rollerbed/robo,
 		/obj/item/borg/cyborghug/medical,
-		/obj/item/stack/medical/gauze/cyborg,
+		/obj/item/stack/medical/gauze,
 		/obj/item/organ_storage,
 		/obj/item/borg/lollipop)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/hacked)
@@ -348,12 +323,12 @@
 		/obj/item/assembly/signaler/cyborg,
 		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/electroadaptive_pseudocircuit,
-		/obj/item/stack/sheet/iron/cyborg,
-		/obj/item/stack/sheet/glass/cyborg,
+		/obj/item/stack/sheet/iron,
+		/obj/item/stack/sheet/glass,
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/rods/cyborg,
-		/obj/item/stack/tile/plasteel/cyborg,
-		/obj/item/stack/cable_coil/cyborg,
+		/obj/item/stack/tile/plasteel,
+		/obj/item/stack/cable_coil,
 		/obj/item/holosign_creator/atmos)
 	emag_modules = list(/obj/item/borg/stun)
 	ratvar_modules = list(
@@ -464,7 +439,7 @@
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/crowbar/cyborg,
-		/obj/item/stack/tile/plasteel/cyborg,
+		/obj/item/stack/tile/plasteel,
 		/obj/item/soap/nanotrasen,
 		/obj/item/borg/charger,
 		/obj/item/weldingtool/cyborg/mini,
@@ -713,7 +688,7 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/extinguisher/mini,
 		/obj/item/pinpointer/syndicate_cyborg,
-		/obj/item/stack/medical/gauze/cyborg,
+		/obj/item/stack/medical/gauze,
 		/obj/item/gun/medbeam,
 		/obj/item/organ_storage)
 	cyborg_base_icon = "synd_medical"
@@ -737,13 +712,13 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/multitool/cyborg,
-		/obj/item/stack/sheet/iron/cyborg,
-		/obj/item/stack/sheet/glass/cyborg,
+		/obj/item/stack/sheet/iron,
+		/obj/item/stack/sheet/glass,
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/rods/cyborg,
-		/obj/item/stack/tile/plasteel/cyborg,
+		/obj/item/stack/tile/plasteel,
 		/obj/item/dest_tagger/borg,
-		/obj/item/stack/cable_coil/cyborg,
+		/obj/item/stack/cable_coil,
 		/obj/item/card/emag,
 		/obj/item/pinpointer/syndicate_cyborg,
 		/obj/item/borg_chameleon,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -82,8 +82,6 @@
 /obj/item/robot_module/proc/get_or_create_estorage(storage_type)
 	return (locate(storage_type) in storages) || new storage_type(src)
 
-	return new storage_type(src)
-
 /obj/item/robot_module/proc/add_module(obj/item/I, nonstandard, requires_rebuild)
 	if(istype(I, /obj/item/stack))
 		var/obj/item/stack/sheet_module = I
@@ -97,7 +95,6 @@
 
 		if(istype(sheet_module.source))
 			sheet_module.cost = max(sheet_module.cost, 1) // Must not cost 0 to prevent div/0 errors.
-			sheet_module.set_mats_per_unit(null)
 			sheet_module.is_cyborg = TRUE
 
 	if(I.loc != src)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -485,7 +485,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	max_amount = MAXCOIL
 	amount = MAXCOIL
 	merge_type = /obj/item/stack/cable_coil // This is here to let its children merge between themselves
-	var/cable_color = "red"
 	desc = "A coil of insulated power cable."
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
@@ -499,13 +498,11 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	full_w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/copper = 2) //2 copper per cable in the coil
 	usesound = 'sound/items/deconstruct.ogg'
-
-/obj/item/stack/cable_coil/cyborg
-	is_cyborg = 1
-	mats_per_unit = null
 	cost = 1
+	source = /datum/robot_energy_storage/wire
+	var/cable_color = "red"
 
-/obj/item/stack/cable_coil/cyborg/attack_self(mob/user)
+/obj/item/stack/cable_coil/attack_self(mob/user)
 	var/picked = input(user,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
 	cable_color = picked
 	update_icon()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -821,9 +821,9 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	icon_state = "coil2"
 
 /obj/item/stack/cable_coil/cut/Initialize(mapload)
-	. = ..()
 	if(!amount)
 		amount = rand(1,2)
+	. = ..()
 	pixel_x = rand(-2,2)
 	pixel_y = rand(-2,2)
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Ports:
- https://github.com/tgstation/tgstation/pull/54935
- https://github.com/tgstation/tgstation/pull/55858


## About The Pull Request

Fixes bugs to cyborgs stacks introduced by the basemats expansion, specifically the behavior of greyscale tiles and material stacks.

Fixes cyborgs being unable to refill their inventory stacks from loose stacks in the world. 

This also includes a fix for cyborgs making material tiles, but it won't be apparent until material tiles are actually supported.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unintended behavior change, cyborgs should be able to pick up loose stacks.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Alt-clicking cyborg stacks does nothing

![Screenshot 2023-12-22 105938](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/9b1cb1e8-d49a-4448-a08c-f6f0488c4a47)

Cannot insert cyborg stacks into autolathe for infinite mats

![Screenshot 2023-12-22 105959](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/bfbd319f-8745-41e4-b765-85ef1f4b026e)

Refilling from loose stacks

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/32c63877-df13-46f8-9e8f-59eb98697d7d



</details>

## Changelog
:cl: rkz, TemporalOroboros, Cowbin
fix: fixes cyborgs being unable to refill from loose stacks
code: removes redundant cyborg typepaths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
