### PR TITLE
Lowers the default bloom level to 30

### DIFF
--- a/code/modules/client/preferences/entries/player/bloom.dm
+++ b/code/modules/client/preferences/entries/player/bloom.dm
@@ -6,7 +6,7 @@
 	maximum = 100
 
 /datum/preference/numeric/bloom/create_default_value()
-	return round((ADDITIVE_LIGHTING_PLANE_ALPHA_NORMAL / 255) * 100)
+	return 30
 
 /datum/preference/numeric/bloom/apply_to_client(client/client, value)
 	client.mob?.update_sight()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Loweres the default bloom level to 30, down from 50.

## Why It's Good For The Game

This makes it way more subtle, areas such as science and medbay seem far to bright on many maps. Unfortunately this will not update for players who are on the default but don't know about it I think, but that's fine.
I have seen multiple people complaining about how bright some areas look, so I think toning it down is sensible and 30 was the best number I tried that balanced out the nice effect and not looking too overwhelming.

The 30% was selected based on using a laptop screen with standard display settings, higher bloom looks better on monitors that have had their contrast levels turned up but causes all the areas to look white and washed out if the monitors are using factory contrast settings.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e328467c-0afc-4a43-9a81-d3a8a5e3d8d6)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/cc3ff37b-f89e-49da-9fb5-7337cf7ca03c)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/3834e5b9-c60b-4bed-b19f-15398f489cd3)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/adeb1d1c-799e-4fa6-bf71-88dca138c652)

It's almost impossible to tell the difference via screenshot, so I recommend just testing the settings by moving around in game.
Also the screenshots were taken as a ghost, which is not affected by colour correction. Colour correction has a significant impact on how bright the areas look.

50:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/bce225fe-9eac-4859-b6b1-fc0dca822dec)

I have a cheap monitor and a factory settings laptop monitor on low brightness, trying to make the cheap monitor look like my laptop monitor makes it look something like this:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/1e0edb54-9384-41a1-abef-d1bc4893cebc)

30:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/72ee3be1-ad28-4a4d-8621-fca732a42d3a)

Again, it is still impossible to tell the effect of this so I recommend just trying it in game.

## Changelog
:cl:
tweak: Default bloom level lowered from 50% to 30%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
