### PR TITLE
Fix stacked client colors not being removed

### DIFF
--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -84,7 +84,6 @@
 		var/datum/client_colour/colour = cc
 		if(colour.type == colour_type)
 			qdel(colour)
-			break
 
 /**
   * Gets the resulting colour/tone from client_colours.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

if there's multiple client colors of the same type stacked, `remove_client_colour` would only remove one of them per call. VV on the live server has confirmed that people can get _several_ stacked `/datum/client_colour/monochrome/blind` at the same time, which I believe leads to the permanent monochrome bug.

 Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/10335

## Why It's Good For The Game

bugs that impact playability super bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/0b3164e0-cdbf-4779-984c-8be2bf526aea

## Changelog
:cl:
fix: Fix stacked client colors not being removed, hopefully fixing the perma-monochrome bug.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
