### PR TITLE
Weakref VV QoL - View the original reference, ports weakref docs from TG

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -76,6 +76,9 @@
 #define VV_HK_ADDCOMPONENT "addcomponent"
 #define VV_HK_MODIFY_TRAITS "modtraits"
 
+// /datum/weakref
+#define VV_HK_TRACK_REF "track_ref"
+
 // /atom
 #define VV_HK_MODIFY_TRANSFORM "atom_transform"
 #define VV_HK_MODIFY_GREYSCALE "modify_greyscale"

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -13,8 +13,18 @@
 /datum/weakref
 	var/reference
 
+	/*
+		variables to store some helpful information by opening vv window
+		"aa_" makes them placed at top, so we can see it at glance.
+	*/
+	var/aa0_hint_ref_path
+	var/aa1_hint_ref_creation_worldtime
+
 /datum/weakref/New(datum/thing)
 	reference = REF(thing)
+	aa1_hint_ref_creation_worldtime = world.time
+	if(istype(thing))
+		aa0_hint_ref_path = thing.type
 
 /datum/weakref/Destroy(force)
 	var/datum/target = resolve()
@@ -28,3 +38,17 @@
 	var/datum/D = locate(reference)
 	return (!QDELETED(D) && D.weak_reference == src) ? D : null
 
+/datum/weakref/vv_get_dropdown()
+	. = list()
+	VV_DROPDOWN_OPTION(VV_HK_TRACK_REF, "View the original reference")
+	. += ..()
+
+/datum/weakref/vv_do_topic(list/href_list)
+	. = ..()
+
+	if(href_list[VV_HK_TRACK_REF])
+		var/datum/original = resolve()
+		if(!original)
+			to_chat(usr, "<span class='warning'>Failed to resolve. It might be qdeleted already.</span>")
+			return
+		usr.client.debug_variables(original)

--- a/code/datums/weakrefs.dm
+++ b/code/datums/weakrefs.dm
@@ -1,3 +1,5 @@
+/// Creates a weakref to the given input.
+/// See /datum/weakref's documentation for more information.
 /proc/WEAKREF(datum/input)
 	if(istype(input) && !QDELETED(input))
 		if(istype(input, /datum/weakref))
@@ -10,6 +12,46 @@
 /datum/proc/create_weakref()		//Forced creation for admin proccalls
 	return WEAKREF(src)
 
+/**
+ * A weakref holds a non-owning reference to a datum.
+ * The datum can be referenced again using `resolve()`.
+ *
+ * To figure out why this is important, you must understand how deletion in
+ * BYOND works.
+ *
+ * Imagine a datum as a TV in a living room. When one person enters to watch
+ * TV, they turn it on. Others can come into the room and watch the TV.
+ * When the last person leaves the room, they turn off the TV because it's
+ * no longer being used.
+ *
+ * A datum being deleted tells everyone who's watching the TV to stop.
+ * If everyone leaves properly (AKA cleaning up their references), then the
+ * last person will turn off the TV, and everything is well.
+ * However, if someone is resistant (holds a hard reference after deletion),
+ * then someone has to walk in, drag them away, and turn off the TV forecefully.
+ * This process is very slow, and it's known as hard deletion.
+ *
+ * This is where weak references come in. Weak references don't count as someone
+ * watching the TV. Thus, when what it's referencing is destroyed, it will
+ * hopefully clean up properly, and limit hard deletions.
+ *
+ * A common use case for weak references is holding onto what created itself.
+ * For example, if a machine wanted to know what its last user was, it might
+ * create a `var/mob/living/last_user`. However, this is a strong reference to
+ * the mob, and thus will force a hard deletion when that mob is deleted.
+ * It is often better in this case to instead create a weakref to the user,
+ * meaning this type definition becomes `var/datum/weakref/last_user`.
+ *
+ * A good rule of thumb is that you should hold strong references to things
+ * that you *own*. For example, a dog holding a chew toy would be the owner
+ * of that chew toy, and thus a `var/obj/item/chew_toy` reference is fine
+ * (as long as it is cleaned up properly).
+ * However, a chew toy does not own its dog, so a `var/mob/living/dog/owner`
+ * might be inferior to a weakref.
+ * This is also a good rule of thumb to avoid circular references, such as the
+ * chew toy example. A circular reference that doesn't clean itself up properly
+ * will always hard delete.
+ */
 /datum/weakref
 	var/reference
 
@@ -34,10 +76,17 @@
 	target?.weak_reference = null
 	return ..()
 
+/**
+ * Retrieves the datum that this weakref is referencing.
+ *
+ * This will return `null` if the datum was deleted. This MUST be respected.
+ */
 /datum/weakref/proc/resolve()
 	var/datum/D = locate(reference)
 	return (!QDELETED(D) && D.weak_reference == src) ? D : null
 
+
+// QoL stuff
 /datum/weakref/vv_get_dropdown()
 	. = list()
 	VV_DROPDOWN_OPTION(VV_HK_TRACK_REF, "View the original reference")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Weakref VV QoL - View the original reference

This PR adds a new VV option to view the reference of a weakref, and 2 variables for QoL diagnosis
Also, ports from
* https://github.com/tgstation/tgstation/pull/57330

It's clueless for new coders when there's no explanation for weakrefs

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
debug qol

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/3dd5b63f-9bc6-48f8-92f4-08435a974e28)

## Changelog
:cl: EvilDragonfiend (QoL), Mothblocks (TG weakref docs)
code: Weakref VV QoL - View the original reference. Available from weakref vv window
code: added 2 variables at weakref datum to diagnose at glance
code: added weakref docs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
