### PR TITLE
Fixes 'random arcade machines' bug

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6049,7 +6049,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aTk" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -7143,7 +7143,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/apothecary)
 "bdi" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bdq" = (
@@ -32569,7 +32569,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jnT" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel/cafeteria_red,
 /area/crew_quarters/bar)
 "jnY" = (
@@ -34523,7 +34523,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kiu" = (

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -20070,7 +20070,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "gvo" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/carpet,
 /area/security/prison)
 "gvN" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8151,7 +8151,7 @@
 	},
 /area/security/prison)
 "aRi" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plating,
 /area/security/prison)
 "aRj" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -49894,7 +49894,7 @@
 	},
 /area/maintenance/starboard/fore)
 "mZk" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
@@ -90983,7 +90983,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/structure/window/reinforced{
 	dir = 4
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -52288,7 +52288,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "hZy" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/camera{
@@ -53223,7 +53223,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "iww" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -74247,7 +74247,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -456,7 +456,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abm" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
@@ -14215,7 +14215,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "buT" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -29980,7 +29980,7 @@
 /turf/open/floor/plasteel,
 /area/science/shuttledock)
 "dTL" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -55320,7 +55320,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "oju" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -4433,7 +4433,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/security)
 "bwe" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/structure/window/reinforced{
 	dir = 8
 	},

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -612,7 +612,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bT" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bU" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -11334,7 +11334,7 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "UV" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "UW" = (

--- a/beestation.dme
+++ b/beestation.dme
@@ -1255,6 +1255,7 @@
 #include "code\game\objects\effects\effect_system\effects_smoke.dm"
 #include "code\game\objects\effects\effect_system\effects_sparks.dm"
 #include "code\game\objects\effects\effect_system\effects_water.dm"
+#include "code\game\objects\effects\spawners\arcade.dm"
 #include "code\game\objects\effects\spawners\bombspawner.dm"
 #include "code\game\objects\effects\spawners\bundle.dm"
 #include "code\game\objects\effects\spawners\gibspawner.dm"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -88,14 +88,6 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	return
 
 /obj/machinery/computer/arcade/Initialize(mapload)
-	// If it's a generic arcade machine, pick a random arcade
-	// circuit board for it
-	if(!circuit)
-		var/list/gameodds = list(/obj/item/circuitboard/computer/arcade/battle = 49,
-							/obj/item/circuitboard/computer/arcade/orion_trail = 49,
-							/obj/item/circuitboard/computer/arcade/amputation = 2)
-		circuit = pick_weight(gameodds)
-
 	. = ..()
 
 	Reset()

--- a/code/game/objects/effects/spawners/arcade.dm
+++ b/code/game/objects/effects/spawners/arcade.dm
@@ -1,0 +1,25 @@
+/obj/effect/spawner/randomarcade
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "arcade"
+	name = "spawn random arcade machine"
+	desc = "Automagically transforms into a random arcade machine. If you see this while in a shift, please create a bug report."
+
+/obj/effect/spawner/randomarcade/Initialize(mapload)
+	..()
+
+	var/static/list/gameodds = list(
+		/obj/item/circuitboard/computer/arcade/battle = 49,
+		/obj/item/circuitboard/computer/arcade/orion_trail = 49,
+		/obj/item/circuitboard/computer/arcade/amputation = 2)
+	var/obj/item/circuitboard/circuit = pick_weight(gameodds)
+	var/new_build_path = initial(circuit.build_path)
+
+	if(!ispath(new_build_path))
+		stack_trace("Circuit with incorrect build path: [circuit]")
+		return INITIALIZE_HINT_QDEL
+
+	var/obj/arcade = new new_build_path(loc)
+	arcade.setDir(dir)
+
+	// tell them to qdel us
+	return INITIALIZE_HINT_QDEL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Random arcade machines created during mapload use spawners, and thus do not break horribly.

closes #10152 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/0fe918a0-952a-432d-afaf-be9e4d866c6c)


</details>

## Changelog
:cl: rkz
fix:fixed randomized arcade machines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
