### PR TITLE
Adds a stupid interaction between drunkeness and cult stun

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -440,12 +440,13 @@
 				target.visible_message("<span class='warning'>[L] is utterly unphased by your utterance!</span>", \
 									   "<span class='userdanger'>[GLOB.deity] protects you from the heresy of [user]!</span>")
 		else if(henderson)
+			var/mob/living/carbon/carbon_target = L
 			to_chat(user, "<span class='cultitalic'>[L] is barely phased by your utterance, rambling with drunken annoyance instead!</span>")
-			to_chat(L, "<span class='cultitalic'>Eldritch horrors try to flood your thoughts, before being drowned out by an intense alcoholic haze!</span>") // yeah nobody's gonna be able to understand you through the slurring but it's funny anyways
-			L.say("MUCKLE DAMRED CULT! 'AIR EH NAMBLIES BE KEEPIN' ME WEE MEN!?!!", forced = "drunk cult stun")
-			L.silent += 15
-			L.confused += 15
-			L.Jitter(15)
+			to_chat(carbon_target, "<span class='cultitalic'>Eldritch horrors try to flood your thoughts, before being drowned out by an intense alcoholic haze!</span>") // yeah nobody's gonna be able to understand you through the slurring but it's funny anyways
+			carbon_target.say("MUCKLE DAMRED CULT! 'AIR EH NAMBLIES BE KEEPIN' ME WEE MEN!?!!", forced = "drunk cult stun")
+			carbon_target.silent += 15
+			carbon_target.confused += 15
+			carbon_target.Jitter(15)
 		else if(!HAS_TRAIT(target, TRAIT_MINDSHIELD) && !istype(L.get_item_by_slot(ITEM_SLOT_HEAD), /obj/item/clothing/head/foilhat))
 			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
 			L.Paralyze(160)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -443,6 +443,9 @@
 			to_chat(user, "<span class='cultitalic'>[L] is barely phased by your utterance, rambling with drunken annoyance instead!</span>")
 			to_chat(L, "<span class='cultitalic'>Eldritch horrors try to flood your thoughts, before being drowned out by an intense alcoholic haze!</span>") // yeah nobody's gonna be able to understand you through the slurring but it's funny anyways
 			L.say("MUCKLE DAMRED CULT! 'AIR EH NAMBLIES BE KEEPIN' ME WEE MEN!?!!", forced = "drunk cult stun")
+			L.silent += 15
+			L.confused += 15
+			L.Jitter(15)
 		else if(!HAS_TRAIT(target, TRAIT_MINDSHIELD) && !istype(L.get_item_by_slot(ITEM_SLOT_HEAD), /obj/item/clothing/head/foilhat))
 			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
 			L.Paralyze(160)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -424,10 +424,13 @@
 							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
 
 		user.mob_light(_range = 3, _color = LIGHT_COLOR_BLOOD_MAGIC, _duration = 0.2 SECONDS)
+		var/henderson = FALSE
+		if(iscarbon(L))
+			var/mob/living/carbon/carbon_target = L
+			henderson = carbon_target.drunkenness >= 41 // you're not going to actually be able to fight very well at this point
 
 		var/anti_magic_source = L.anti_magic_check(holy = TRUE)
 		if(anti_magic_source)
-
 			L.mob_light(_range = 2, _color = LIGHT_COLOR_HOLY_MAGIC, _duration = 10 SECONDS)
 			var/mutable_appearance/forbearance = mutable_appearance('icons/effects/genetics.dmi', "servitude", CALCULATE_MOB_OVERLAY_LAYER(MUTATIONS_LAYER))
 			L.add_overlay(forbearance)
@@ -436,6 +439,10 @@
 			if(istype(anti_magic_source, /obj/item))
 				target.visible_message("<span class='warning'>[L] is utterly unphased by your utterance!</span>", \
 									   "<span class='userdanger'>[GLOB.deity] protects you from the heresy of [user]!</span>")
+		else if(henderson)
+			to_chat(user, "<span class='cultitalic'>[L] is barely phased by your utterance, rambling with drunken annoyance instead!</span>")
+			to_chat(L, "<span class='cultitalic'>Eldritch horrors try to flood your thoughts, before being drowned out by an intense alcoholic haze!</span>") // yeah nobody's gonna be able to understand you through the slurring but it's funny anyways
+			L.say("MUCKLE DAMRED CULT! 'AIR EH NAMBLIES BE KEEPIN' ME WEE MEN!?!!", forced = "drunk cult stun")
 		else if(!HAS_TRAIT(target, TRAIT_MINDSHIELD) && !istype(L.get_item_by_slot(ITEM_SLOT_HEAD), /obj/item/clothing/head/foilhat))
 			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
 			L.Paralyze(160)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

People who are shitfaced drunk will now tank a cult stun, instead only getting mildly annoyance and shouting some nonsense about lawn gnomes... This doesn't change the fact they're shitfaced drunk and have zero protection against having a cult sword shoved up their ass.

## Why It's Good For The Game

It's funny. Unlikely to be abused, because at the drunkenness threshold required for this, you're not really going to be able to fight, given that you'll barely be able to walk straight.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![2023-12-27 (1703695657) ~ dreamseeker](https://github.com/BeeStation/BeeStation-Hornet/assets/65794972/8d215d3d-3ce1-4dfb-a588-dd9335656688)

</details>

## Changelog
:cl:
add: If one gets drunk enough, they can channel the energy of the Old Ones' worst enemy to protect them from horrors beyond their comprehension.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
