### PR TITLE
Fixes broken tableframe logic & Kills an unnecessary material var

### DIFF
--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -8,8 +8,6 @@ Simple datum which is instanced once per type and is used for every object of sa
 /datum/material
 	var/name = "material"
 	var/desc = "its..stuff."
-	///Var that's mostly used by science machines to identify specific materials, should most likely be phased out at some point
-	var/id = "mat"
 	///Base color of the material, is used for greyscale. Item isn't changed in color if this is null.
 	///Deprecated, use greyscale_color instead.
 	var/color

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -1,7 +1,6 @@
 ///Has no special properties.
 /datum/material/iron
 	name = "iron"
-	id = "iron"
 	desc = "Common iron ore often found in sedimentary and igneous layers of the crust."
 	color = "#878687"
 	greyscale_colors = "#878687"
@@ -12,7 +11,6 @@
 ///Breaks extremely easily but is transparent.
 /datum/material/glass
 	name = "glass"
-	id = "glass"
 	desc = "Glass forged by melting sand."
 	color = "#88cdf1"
 	greyscale_colors = "#88cdf196"
@@ -30,7 +28,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Has no special properties. Could be good against vampires in the future perhaps.
 /datum/material/silver
 	name = "silver"
-	id = "silver"
 	desc = "Silver"
 	color = list(255/255, 284/255, 302/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	greyscale_colors = "#e3f1f8"
@@ -41,7 +38,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Slight force increase
 /datum/material/gold
 	name = "gold"
-	id = "gold"
 	desc = "Gold"
 	color = list(340/255, 240/255, 50/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0) //gold is shiny, but not as bright as bananium
 	greyscale_colors = "#dbdd4c"
@@ -53,7 +49,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Has no special properties
 /datum/material/diamond
 	name = "diamond"
-	id = "diamond"
 	desc = "Highly pressurized carbon"
 	color = list(48/255, 272/255, 301/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	greyscale_colors = "#71c8f784"
@@ -65,7 +60,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Is slightly radioactive
 /datum/material/uranium
 	name = "uranium"
-	id = "uranium"
 	desc = "Uranium"
 	color = rgb(48, 237, 26)
 	greyscale_colors = rgb(48, 237, 26)
@@ -84,7 +78,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Adds firestacks on hit (Still needs support to turn into gas on destruction)
 /datum/material/plasma
 	name = "plasma"
-	id = "plasma"
 	desc = "Isn't plasma a state of matter? Oh whatever."
 	color = list(298/255, 46/255, 352/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	greyscale_colors = "#c162ec"
@@ -106,7 +99,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Can cause bluespace effects on use. (Teleportation) (Not yet implemented)
 /datum/material/bluespace
 	name = "bluespace crystal"
-	id = "bluespace_crystal"
 	desc = "Crystals with bluespace properties"
 	color = list(119/255, 217/255, 396/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
 	greyscale_colors = "#4e7dffC8"
@@ -118,7 +110,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Honks and slips
 /datum/material/bananium
 	name = "bananium"
-	id = "bananium"
 	desc = "Material with hilarious properties"
 	color = list(460/255, 464/255, 0, 0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0) //obnoxiously bright yellow
 	greyscale_colors = "#ffff00"
@@ -140,7 +131,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Mediocre force increase
 /datum/material/titanium
 	name = "titanium"
-	id = "titanium"
 	desc = "Titanium"
 	color = "#b3c0c7"
 	greyscale_colors = "#b3c0c7"
@@ -164,7 +154,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Force decrease
 /datum/material/plastic
 	name = "plastic"
-	id = "plastic"
 	desc = "Plastic"
 	color = "#caccd9"
 	greyscale_colors = "#caccd9"
@@ -176,7 +165,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Force decrease and mushy sound effect. (Not yet implemented)
 /datum/material/biomass
 	name = "biomass"
-	id = "biomass"
 	desc = "Organic matter"
 	color = "#735b4d"
 	greyscale_colors = "#735b4d"
@@ -186,7 +174,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 ///Stronk force increase
 /datum/material/adamantine
 	name = "adamantine"
-	id = "adamantine"
 	desc = "A powerful material made out of magic, I mean science!"
 	color = "#6d7e8e"
 	greyscale_colors = "#6d7e8e"
@@ -198,7 +185,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/copper
 	name = "copper"
-	id = "copper"
 	desc = "Copper is a soft, malleable, and ductile metal with very high thermal and electrical conductivity."
 	color = "#d95802"
 	greyscale_colors = "#d95802"

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -41,7 +41,7 @@
 				to_chat(user, "<span class='warning'>There's already a table built here!</span>")
 				return
 			to_chat(user, "<span class='notice'>You start adding [material] to [src]...</span>")
-			if(!do_after(user, 2 SECONDS, target = src) && material.use(1) || (locate(/obj/structure/table) in loc))
+			if(!do_after(user, 2 SECONDS, target = src) || !material.use(1) || (locate(/obj/structure/table) in loc))
 				return
 			make_new_table(material.tableVariant)
 		else if(istype(material, /obj/item/stack/sheet))

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -160,10 +160,9 @@
 
 	var/list/L = list()
 	for(var/datum/material/material as() in materials.mat_container.materials)
-		L[material.id] = list(
+		L[material.name] = list(
 				name = material.name,
 				amount = materials.mat_container.materials[material]/MINERAL_MATERIAL_AMOUNT,
-				id = material.id,
 			)
 
 	return list(
@@ -250,7 +249,7 @@
 	if(action == "ejectsheet" && materials && materials.mat_container)
 		var/datum/material/M
 		for(var/datum/material/potential_material as() in materials.mat_container.materials)
-			if(potential_material.id == params["material_id"])
+			if(potential_material.name == params["material_id"])
 				M = potential_material
 				break
 		if(M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Tableframe 

I used the wrong operator, which made it so some materials could be inconsistently consumed when making tables. The most consistently not-consumed material being plasteel. No more mat dupes.

### Material Var

var/id communicates the exact same string as the name var for every single datum material. 

The var can simply be removed, and places where it is called(rnd production) can just call the name instead, with no change ingame.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes possible material dupe

Simple removal of unnecessary var with no behavior change. (the vars doc also said it was bloat that should probably be removed)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Production works correctly, showing that using name in place of id has no changes in behavior

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/c5df8a8a-7481-47e5-b6a9-c073a59c061d

Plasteel consumed during tableframe construction

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/502e4165-6e96-4e03-aced-cd29f410efbd



</details>

## Changelog
:cl:
code: removes unnecessary material var, no player facing changes
fix: fixes inconsistent material consumption while crafting tables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
