### PR TITLE
Fixes Bandoliers not Holding Shotgun Ammo (sorry)

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -706,15 +706,14 @@
 	name = "sheriff's bandolier"
 	desc = "A bandolier that has been retrofitted for .38 cartridges"
 
-/obj/item/storage/belt/bandolier/ComponentInitialize()
+/obj/item/storage/belt/bandolier/western/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 21
-	STR.display_numerical_stacking = TRUE
-	var/static/list/can_hold = typecacheof(list(
+	var/static/list/can_western_hold = typecacheof(list(
 		/obj/item/ammo_casing/c38
 		))
-	STR.can_hold = can_hold
+	STR.can_hold = can_western_hold
 
 /obj/item/storage/belt/bandolier/western/filled/PopulateContents()
 	for(var/i in 1 to 21)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/e121fbd6-977a-4d06-8a62-9041e16d49ae)

## About The Pull Request

Accidental double ComponentInitialize(), I was too hasty with my copy and pasting and failed to update a typepath. Regular bandoliers now hold shotguns shells again, and the western bandolier retains holding (slightly more) .38 special ammo as well.

Also is there a reason the `can_hold` list in the `ComponentInitialize()` procs are static? I added another static list to the western bandolier 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes my fuckup, stuff working properly is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/8a3b16f6-93f1-4f56-adc5-bb9f64154733

</details>

## Changelog
:cl: Impish_Delights
fix: Regular bandoliers hold shotgun ammo again. Whoops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
