### PR TITLE
Fix mentor deadminning and admin loading

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -85,7 +85,6 @@ GLOBAL_PROTECT(href_token)
 	deadmined = FALSE
 	if (GLOB.directory[target])
 		associate(GLOB.directory[target])	//find the client for a ckey if they are connected and associate them with us
-	load_mentors()
 
 /datum/admins/proc/deactivate()
 	if(IsAdminAdvancedProcCall())
@@ -101,7 +100,6 @@ GLOBAL_PROTECT(href_token)
 		disassociate()
 		C.add_verb(/client/proc/readmin)
 		C.update_special_keybinds()
-	load_mentors()
 
 /datum/admins/proc/associate(client/C)
 	if(IsAdminAdvancedProcCall())
@@ -110,20 +108,23 @@ GLOBAL_PROTECT(href_token)
 		log_admin("[key_name(usr)][msg]")
 		return
 
-	if(istype(C))
-		if(C.ckey != target)
-			var/msg = " has attempted to associate with [target]'s admin datum"
-			message_admins("[key_name_admin(C)][msg]")
-			log_admin("[key_name(C)][msg]")
-			return
-		if (deadmined)
-			activate()
-		owner = C
-		owner.holder = src
-		owner.add_admin_verbs()	//TODO <--- todo what? the proc clearly exists and works since its the backbone to our entire admin system
-		owner.remove_verb(/client/proc/readmin)
-		owner.update_special_keybinds()
-		GLOB.admins |= C
+	if(!istype(C))
+		return
+	if(C.ckey != target)
+		var/msg = " has attempted to associate with [target]'s admin datum"
+		message_admins("[key_name_admin(C)][msg]")
+		log_admin("[key_name(C)][msg]")
+		return
+	if (deadmined)
+		activate()
+	owner = C
+	owner.holder = src
+	owner.add_admin_verbs()	//TODO <--- todo what? the proc clearly exists and works since its the backbone to our entire admin system
+	owner.remove_verb(/client/proc/readmin)
+	owner.update_special_keybinds()
+	GLOB.admins |= C
+	if(istype(owner.mentor_datum))
+		owner.mentor_datum.activate()
 
 /datum/admins/proc/disassociate()
 	if(IsAdminAdvancedProcCall())
@@ -131,11 +132,14 @@ GLOBAL_PROTECT(href_token)
 		message_admins("[key_name_admin(usr)][msg]")
 		log_admin("[key_name(usr)][msg]")
 		return
-	if(owner)
-		GLOB.admins -= owner
-		owner.remove_admin_verbs()
-		owner.holder = null
-		owner = null
+	if(!owner)
+		return
+	GLOB.admins -= owner
+	owner.remove_admin_verbs()
+	if(istype(owner.mentor_datum))
+		owner.mentor_datum.deactivate()
+	owner.holder = null
+	owner = null
 
 /datum/admins/proc/check_for_rights(rights_required)
 	if(rights_required && !(rights_required & rank.rights))

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -10,6 +10,8 @@
 	var/href_token
 	/// The Mentor Ticket Manager interface
 	var/datum/help_ui/mentor/mentor_interface
+	/// If this mentor datum is inactive due to de-adminning.
+	var/dementored = FALSE
 
 /datum/mentors/New(ckey)
 	if(!ckey)
@@ -37,7 +39,7 @@
 		return
 	owner = C
 	owner.mentor_datum = src
-	owner.add_mentor_verbs()
+	activate()
 	if(!check_rights_for(owner, R_ADMIN)) // add nonadmins to the mentor list.
 		GLOB.mentors |= owner
 
@@ -77,6 +79,9 @@
 		log_href_exploit(usr, " Tried to use the mentor panel without having the correct mentor datum.")
 		return
 
+	if(dementored)
+		return
+
 	if(!CheckMentorHREF(href, href_list))
 		return
 
@@ -90,3 +95,21 @@
 	else if(href_list["mhelp_tickets"])
 		GLOB.mhelp_tickets.BrowseTickets(usr)
 
+
+/datum/mentors/proc/activate()
+	if(IsAdminAdvancedProcCall())
+		var/msg = " has tried to elevate permissions!"
+		message_admins("[key_name_admin(usr)][msg]")
+		log_admin("[key_name(usr)][msg]")
+		return
+	dementored = FALSE
+	owner.add_mentor_verbs()
+
+/datum/mentors/proc/deactivate()
+	if(IsAdminAdvancedProcCall())
+		var/msg = " has tried to elevate permissions!"
+		message_admins("[key_name_admin(usr)][msg]")
+		log_admin("[key_name(usr)][msg]")
+		return
+	dementored = TRUE
+	owner.remove_mentor_verbs()

--- a/code/modules/mentor/mentor_loading.dm
+++ b/code/modules/mentor/mentor_loading.dm
@@ -28,7 +28,7 @@
 			continue
 		if(findtextEx(line, "#", 1, 2))
 			continue
-		new /datum/mentors(line)
+		new /datum/mentors(line, for_admin = FALSE)
 	return TRUE
 
 /// Loads mentors from the ss13_mentors table
@@ -51,7 +51,7 @@
 		if(!ckey)
 			stack_trace("Invalid mentor row in database with null ckey with id: [id] and raw data: [raw_ckey]")
 			continue
-		new /datum/mentors(ckey)
+		new /datum/mentors(ckey, for_admin = FALSE)
 	qdel(query_load_mentors)
 	return TRUE
 
@@ -69,6 +69,6 @@
 		return TRUE
 	// They're an admin, but not a mentor. Create them a mentor datum. This is automatically assigned.
 	else if(check_rights_for(src, R_ADMIN))
-		new /datum/mentors(ckey)
+		new /datum/mentors(ckey, for_admin = TRUE)
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## About The Pull Request 

Previously the mentor system would just regenerate *all* mentor datums whenever an admin changed their status. This was really wasteful because the database never actually changes when an admin does this, it's just trying to delete the datum.

Instead of deleting and regenerating the datums, I just keep them associated now and remove the verbs + hrefs from deadminned admins.

Also added some early returns to admin procs.

## Why It's Good For The Game

Less time wasted reloading mentors, admins no longer have mentor-only verbs that don't work.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Before
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/6bfaa778-5e86-4fa5-ba83-21d9bb1788e2)

After
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/6f134e04-25cd-49e1-afc8-02b31360f890)

No wasted load_mentors:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/a4b30929-f7ae-4fe3-b3ed-fcb5b2551ebf)

</details>

## Changelog
:cl:
fix: Mentors are no longer reloaded when admin datums are created.
tweak: Admins can no longer see mentor-only verbs when deadminned.
/:cl: