### PR TITLE
Speed up ByondUI mounting

### DIFF
--- a/tgui/packages/tgui/components/ByondUi.js
+++ b/tgui/packages/tgui/components/ByondUi.js
@@ -27,6 +27,7 @@ const createByondUiElement = (elementId) => {
     render: (params) => {
       logger.log(`rendering '${id}'`);
       byondUiStack[index] = id;
+      params['is-visible'] = 'true';
       Byond.winset(id, params);
       Byond.sendMessage('byondui_update', { mounting: true, id: id });
     },
@@ -34,7 +35,7 @@ const createByondUiElement = (elementId) => {
       logger.log(`unmounting '${id}'`);
       byondUiStack[index] = null;
       Byond.winset(id, {
-        parent: '',
+        'is-visible': 'false',
       });
       Byond.sendMessage('byondui_update', { mounting: false, id: id });
     },
@@ -49,7 +50,7 @@ window.addEventListener('beforeunload', () => {
       logger.log(`unmounting '${id}' (beforeunload)`);
       byondUiStack[index] = null;
       Byond.winset(id, {
-        parent: '',
+        'is-visible': 'false',
       });
       Byond.sendMessage('byondui_update', { mounting: false, id: id });
     }


### PR DESCRIPTION
## About The Pull Request

This greatly speeds up the remounting process of ByondUIs, making the process of switching tabs in the preference menu much snappier on the clientside. It won't open any faster, but just switching off of loadouts and the character editor should feel much better.

The way this works is rather than *removing* the element from the skin by changing the parent, it just sets it non-visible. This process is apparently much faster within BYOND's skin code, so it renders much faster.

## Why It's Good For The Game

Less client lag when using the preference menu.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Before

https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/e9d13fbd-f328-48a2-ae84-ea910cb39f43

After

https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/b17d22bd-da75-4565-93cc-9875bdde3073

</details>

## Changelog
:cl:
code: Optimized ByondUI rendering, making the preferences preview remount much faster when changing tabs in the preference menu. This should be most apparent when switching from the Character or Loadout tab to another.
/:cl:
