### PR TITLE
Port TG ban improvements

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -394,6 +394,7 @@
 #include "code\controllers\subsystem\atoms.dm"
 #include "code\controllers\subsystem\augury.dm"
 #include "code\controllers\subsystem\autotransfer.dm"
+#include "code\controllers\subsystem\ban_cache.dm"
 #include "code\controllers\subsystem\blackbox.dm"
 #include "code\controllers\subsystem\callback.dm"
 #include "code\controllers\subsystem\chat.dm"

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -150,7 +150,8 @@
 #define INIT_ORDER_MINOR_MAPPING	-40
 #define INIT_ORDER_PATH				-50
 #define INIT_ORDER_EXPLOSIONS		-69
-#define INIT_ORDER_ELEVATOR	  -70
+#define INIT_ORDER_ELEVATOR			-70
+#define INIT_ORDER_BAN_CACHE		-98
 #define INIT_ORDER_NATURAL_LIGHT	-120
 #define INIT_ORDER_CHAT				-150 //Should be last to ensure chat remains smooth during init.
 

--- a/code/controllers/subsystem/ban_cache.dm
+++ b/code/controllers/subsystem/ban_cache.dm
@@ -1,0 +1,84 @@
+/// Subsystem that batches a ban cache list for clients on initialize
+/// This way we don't need to do ban checks in series later in the code
+SUBSYSTEM_DEF(ban_cache)
+
+/datum/controller/subsystem/ban_cache
+	name = "Ban Cache"
+	init_order = INIT_ORDER_BAN_CACHE
+	flags = SS_NO_FIRE
+	var/query_started = FALSE
+
+/datum/controller/subsystem/ban_cache/Initialize(start_timeofday)
+	generate_queries()
+	return ..()
+
+/// Generates ban caches for any logged in clients. This ensures the amount of in-series ban checking we have to do that actually involves sleeps is VERY low
+/datum/controller/subsystem/ban_cache/proc/generate_queries()
+	query_started = TRUE
+	if(!SSdbcore.Connect())
+		return
+	var/current_time = REALTIMEOFDAY
+	var/list/look_for = list()
+
+	var/list/query_args = list()
+	var/list/query_arg_keys = list()
+
+	var/num_keys = 0
+	for(var/ckey in GLOB.directory)
+		var/client/lad = GLOB.directory[ckey]
+		// If they've already got a ban cached, or a request goin, don't do it
+		if(lad.ban_cache || lad.ban_cache_start)
+			continue
+
+		look_for += ckey
+		lad.ban_cache_start = current_time
+
+		query_args += list("key[num_keys]" = ckey)
+		query_arg_keys += ":key[num_keys]"
+		num_keys++
+
+	// We're gonna try and make a query for clients
+	var/datum/DBQuery/query_batch_ban_cache = SSdbcore.NewQuery(
+		"SELECT ckey, role, applies_to_admins FROM [format_table_name("ban")] WHERE ckey IN ([query_arg_keys.Join(",")]) AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())",
+		query_args
+	)
+
+	var/succeeded = query_batch_ban_cache.Execute()
+	for(var/ckey in look_for)
+		var/client/lad = GLOB.directory[ckey]
+		if(!lad || lad.ban_cache_start != current_time)
+			continue
+		lad.ban_cache_start = 0
+
+	if(!succeeded)
+		qdel(query_batch_ban_cache)
+		return
+
+	var/list/ckey_to_bans = list()
+	// Runs after the check for safety, don't want to override anything
+	for(var/ckey in look_for)
+		ckey_to_bans[ckey] = list()
+
+	while(query_batch_ban_cache.NextRow())
+		var/ckey = query_batch_ban_cache.item[1]
+		var/role = query_batch_ban_cache.item[2]
+		var/hits_admins = query_batch_ban_cache.item[3]
+
+		var/list/bans = ckey_to_bans[ckey]
+		if(!bans)
+			continue
+
+		// Yes I know this is slightly unoptimal, no I do not care
+		var/is_admin = GLOB.admin_datums[ckey] || GLOB.deadmins[ckey]
+		if(is_admin && !text2num(hits_admins))
+			continue
+
+		bans[role] = TRUE
+
+	for(var/ckey in ckey_to_bans)
+		var/client/lad = GLOB.directory[ckey]
+		if(!lad)
+			continue
+		lad.ban_cache = ckey_to_bans[ckey]
+
+	qdel(query_batch_ban_cache)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -341,7 +341,7 @@ SUBSYSTEM_DEF(ticker)
 	log_world("Game start took [(world.timeofday - init_start)/10]s")
 	round_start_time = world.time
 	round_start_timeofday = world.timeofday
-	SSdbcore.SetRoundStart()
+	INVOKE_ASYNC(SSdbcore, TYPE_PROC_REF(/datum/controller/subsystem/dbcore, SetRoundStart))
 
 	to_chat(world, "<span class='notice'><B>Welcome to [station_name()], enjoy your stay!</B></span>")
 	SEND_SOUND(world, sound(SSstation.announcer.get_rand_welcome_sound()))

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -20,6 +20,8 @@
 
 	/// Used to cache this client's bans to save on DB queries
 	var/ban_cache = null
+	///If we are currently building this client's ban cache, this var stores the timeofday we started at
+	var/ban_cache_start = 0
 	/// Contains the last message sent by this client - used to protect against copy-paste spamming.
 	var/last_message	= ""
 	/// How many messages sent in the last 10 seconds

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -440,6 +440,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	get_message_output("watchlist entry", ckey)
 	check_ip_intel()
 	validate_key_in_db()
+	// If we aren't already generating a ban cache, fire off a build request
+	// This way hopefully any users of request_ban_cache will never need to yield
+	if(!ban_cache_start && SSban_cache?.query_started)
+		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(build_ban_cache), src)
 
 	fetch_uuid()
 	add_verb(/client/proc/show_account_identifier)


### PR DESCRIPTION
## About The Pull Request 

Ports:
- https://github.com/tgstation/tgstation/pull/60834
- https://github.com/tgstation/tgstation/pull/69376
- https://github.com/tgstation/tgstation/pull/69703

This removes runtimes from disconnects during ban cache loading and reduces the amount of queries needed to build ban caches, since they are now done all in one go rather than per-client.

## Why It's Good For The Game

Should reduce post-roundstart lag, especially on the live server.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Bans working
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/eb42320c-794d-4efa-9ec5-6bacbc0d5e94)

After restart, ban remains.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/29bcb1f6-23fd-4bcd-97d1-50969c71459d)


</details>

## Changelog
:cl: itsmeow, LemonInTheDark, Timberpoes, Rohesie
code: Improved ban cache loading, reducing post-roundstart lag.
/:cl:
