### PR TITLE
Greatly reduces roundstart delay

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -298,7 +298,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		SS.state = SS_IDLE
 		if (SS.flags & SS_TICKER)
 			tickersubsystems += SS
-			timer += world.tick_lag * rand(1, 5)
+			// Timer subsystems aren't allowed to bunch up, so we offset them a bit
+			timer += world.tick_lag * rand(0, 1)
 			SS.next_fire = timer
 			continue
 
@@ -384,14 +385,16 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			var/checking_runlevel = current_runlevel
 			if(cached_runlevel != checking_runlevel)
 				//resechedule subsystems
+				var/list/old_subsystems = current_runlevel_subsystems
 				cached_runlevel = checking_runlevel
 				current_runlevel_subsystems = runlevel_sorted_subsystems[cached_runlevel]
-				var/stagger = world.time
-				for(var/I in current_runlevel_subsystems)
-					var/datum/controller/subsystem/SS = I
-					if(SS.next_fire <= world.time)
-						stagger += world.tick_lag * rand(1, 5)
-						SS.next_fire = stagger
+
+				//now we'll go through all the subsystems we want to offset and give them a next_fire
+				for(var/datum/controller/subsystem/SS as anything in current_runlevel_subsystems)
+					//we only want to offset it if it's new and also behind
+					if(SS.next_fire > world.time || (SS in old_subsystems))
+						continue
+					SS.next_fire = world.time + world.tick_lag * rand(0, DS2TICKS(min(SS.wait, 2 SECONDS)))
 
 			subsystems_to_check = current_runlevel_subsystems
 		else


### PR DESCRIPTION
## About The Pull Request

Ports:
- https://github.com/tgstation/tgstation/pull/71730

## Why It's Good For The Game

This greatly reduces the amount of time between game start and the ability to walk properly.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Game loaded good. Roundstart did appear much snappier.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/2b7f2128-95b5-46d0-902b-16eb78e715d8)

</details>

## Changelog
:cl: LemonInTheDark, MrStonedOne, itsmeow
code: Optimized how the master controller distributes roundstart subsystem initializations, greatly reducing the amount of time between the round starting and gaining the ability to move.
/:cl: