### PR TITLE
Sniper rounds no longer paralyze for 10 seconds.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -4,7 +4,7 @@
 	name =".50 bullet"
 	speed = 0.2
 	damage = 70
-	paralyze = 100
+	knockdown = 5
 	dismemberment = 50
 	armour_penetration = 50
 	// Will penetrate but damage anything not a wall
@@ -25,7 +25,7 @@
 	// Phase directly through everything else
 	projectile_phasing = (ALL & ~(PASSMOB | PASSMACHINE | PASSTRANSPARENT | PASSGRILLE | PASSDOORS | PASSFLAPS | PASSSTRUCTURE))
 	dismemberment = 0 //It goes through you cleanly.
-	paralyze = 0
+	knockdown = 0
 	breakthings = FALSE
 
 /obj/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety
@@ -37,8 +37,9 @@
 /obj/projectile/bullet/p50/utility
 	armour_penetration = 0
 	damage = 20
-	dismemberment = 0
+	knockdown = 0
 	paralyze = 0
+	dismemberment = 0 //Why would EMP and Soporific rounds remove limbs? At 20 damage??
 	breakthings = FALSE
 	// Cannot pass through things like normal rounds
 	projectile_piercing = NONE

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -37,9 +37,8 @@
 /obj/projectile/bullet/p50/utility
 	armour_penetration = 0
 	damage = 20
+	dismemberment = 0
 	knockdown = 0
-	paralyze = 0
-	dismemberment = 0 //Why would EMP and Soporific rounds remove limbs? At 20 damage??
 	breakthings = FALSE
 	// Cannot pass through things like normal rounds
 	projectile_piercing = NONE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<details>

![NoStunPlz](https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/052a8a1c-9cba-42f8-ad58-244cc87bfd5e)
</details>

## About The Pull Request

Regular sniper rounds no longer paralyze targets for upto 10 seconds, instead causing 0.5 seconds of knockdown from the punch of getting hit by a .50 cal bullet. Penetrator and Utility (EMP, Soporific, Explosive, etc.) do not cause knockdown, as they did not previously cause paralyze.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Even though it is a nuke-op item, it can be obtained by regular tots through the syndie kits in the uplink. 70 damage w/ 50 AP is already insanely strong, *10 seconds* of hard stun ontop of that is absolutely absurd, and it just unfun to play against. Doubly so against a weapon that can tag you from off-screen with little to no notice.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Accidentally gave utility rounds a dismember chance for this video. Double-checked and made sure to fix it so I didn't have another oopsie.

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/f3a3937c-f645-4a0c-a6ce-9ed816f04cd1


</details>

## Changelog
:cl: Impish_Delights
balance: Sniper rounds no longer paralyze for 10 seconds, causing half a second of knockdown instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
