### PR TITLE
Fixes a bug with HUDs and Alternate Appearences

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -128,7 +128,6 @@ GLOBAL_LIST_INIT(huds, list(
 	SIGNAL_HANDLER
 
 	remove_hud_from(source, TRUE)
-	remove_from_hud(source)
 
 /datum/atom_hud/proc/show_hud_images_after_cooldown(M)
 	if(queued_to_see[M])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I noticed while holding a plant I'd randomly lose my cover for some reason.

The thing causing this is, whenever anything that is able to see that alternate appearance is deleted it causes the appearance to be removed.

This also extends to things like AI's not being able to see cultist runes and stuff like that.

This small fix stops that.

I wanted to fix it, lucy spotted the error and for some unknown reason Rkz and I entered a telekinetic brain fusion and he made this same fix at the same time me and lucy were, so both of them are guilty of this being possible.

## Why It's Good For The Game

Its a bug fix for a 3 year old bug. Now I can properly sneak around or do plant-type Nanomon cosplay.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I didn't know what to put here, just trust me that it isn't broken anymore.

</details>

## Changelog
:cl: PinkSuzuky, Absolucy, Rkz
fix: Alternate Appearances (Such as when you're holding a potted plant) are no longer removed when a living thing gets gibbed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
