### PR TITLE
Optimize PDA painter init, improve init tracking

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -42,7 +42,10 @@
 #define ZMIMIC_LIGHT_BLEED
 
 /// If this is uncommented, will profile mapload atom initializations
-// #define PROFILE_MAPLOAD_INIT_ATOM
+//#define PROFILE_MAPLOAD_INIT_ATOM
+#ifdef PROFILE_MAPLOAD_INIT_ATOM
+#warn PROFILE_MAPLOAD_INIT_ATOM creates very large profiles, do not leave this on!
+#endif
 
 //#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -48,7 +48,7 @@ SUBSYSTEM_DEF(atoms)
 
 #ifdef PROFILE_MAPLOAD_INIT_ATOM
 #define PROFILE_INIT_ATOM_BEGIN(...) var/__profile_stat_time = TICK_USAGE
-#define PROFILE_INIT_ATOM_END(atom) mapload_init_times[##atom.type] += TICK_USAGE_TO_MS(__profile_stat_time)
+#define PROFILE_INIT_ATOM_END(atom) mapload_init_times += list(list(##atom.type, TICK_USAGE_TO_MS(__profile_stat_time)))
 #else
 #define PROFILE_INIT_ATOM_BEGIN(...)
 #define PROFILE_INIT_ATOM_END(...)
@@ -90,8 +90,9 @@ SUBSYSTEM_DEF(atoms)
 #ifdef PROFILE_MAPLOAD_INIT_ATOM
 	var/list/lines = list()
 	lines += "Atom Path,Initialisation Time (ms)"
-	for (var/atom_type in mapload_init_times)
-		var/time = mapload_init_times[atom_type]
+	for (var/data in mapload_init_times)
+		var/atom_type = data[1]
+		var/time = data[2]
 		lines += "[atom_type],[time]"
 	rustg_file_write(jointext(lines, "\n"), "[GLOB.log_directory]/init_times.csv")
 #endif

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -53,7 +53,6 @@
 		"Misc: Prisoner" = "pda-prisoner"
 	)
 	max_integrity = 200
-	var/list/colorlist = list()
 
 /obj/machinery/pdapainter/on_emag(mob/user)
 	..()
@@ -82,23 +81,6 @@
 		icon_state = "coloriser-off"
 
 	return
-
-/obj/machinery/pdapainter/Initialize(mapload)
-	. = ..()
-	var/list/blocked = list(
-		/obj/item/modular_computer/tablet/pda/heads,
-		/obj/item/modular_computer/tablet/pda/clear,
-		/obj/item/modular_computer/tablet/pda/syndicate,
-		/obj/item/modular_computer/tablet/pda/chameleon,
-		/obj/item/modular_computer/tablet/pda/chameleon/broken)
-
-	for(var/P in typesof(/obj/item/modular_computer/tablet/pda) - blocked)
-		var/obj/item/modular_computer/tablet/pda/D = new P
-
-		//D.name = "PDA Style [colorlist.len+1]" //Gotta set the name, otherwise it all comes up as "PDA"
-		D.name = D.icon_state //PDAs don't have unique names, but using the sprite names works.
-
-		src.colorlist += D
 
 /obj/machinery/pdapainter/Destroy()
 	QDEL_NULL(storedpda)


### PR DESCRIPTION
## About The Pull Request

Optimized PDA painter init (re-implementing part of the reverted #9481). The `colorlist` does literally nothing, it's not used anywhere. lol.

Saves around 65ms and removes dead code.

Improves the atom init tracking by making columns no longer aggregate sums. This allows further data to be extrapolated such as mean-time-per-init and init counts. Adds a little warning since the profiles are now ~20mb

## Why It's Good For The Game

Improve init times.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/1dc28f17-94ac-47b8-9fe6-fbd9d637f58c)

</details>

## Changelog
:cl:
code: Optimized PDA painter init, saving 65ms.
/:cl:
