### PR TITLE
Fixes Arcane Barrage and Lesser Summon Guns, Removes Equip Delay & Recoil

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -63,6 +63,8 @@
 	name = "enchanted bolt action rifle"
 	desc = "Careful not to lose your head."
 	can_sawoff = FALSE
+	equip_time = 0 SECONDS
+	recoil = 0
 	var/guns_left = 30
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/enchanted
 
@@ -80,6 +82,10 @@
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/enchanted/arcane_barrage
+
+/obj/item/gun/ballistic/rifle/boltaction/enchanted/Initialize(mapload)
+	. = ..()
+	chamber_round()
 
 /obj/item/gun/ballistic/rifle/boltaction/enchanted/dropped()
 	guns_left = 0


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Enchanted bolt actions and arcane barrage now properly spawn with a chambered round so they actually function, and have 0 equip_time. Removes the recoil from them as they're magic (づ￣ 3￣)づ

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes an issue that I introduced with the pipe gun & ballistics tweaks PR, and a nitpick brought on by the firearm equip delay PR.

Closes #10440

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

This video was taken before I made the changes to recoil, as it felt slightly off having the screen shake that much for the spell.

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/c7ff764f-bb4b-4374-8320-60f06fea1f07

</details>

## Changelog
:cl: Impish_Delights
balance: Guns summoned by Lesser Summon Gun and Arcane Barrage have no equip delay, and no recoil now.
fix: Guns summoned by Lesser Summon Gun and Arcane Barrage spawn with a chambered round, and function properly again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
