### PR TITLE
Removes unecessary export scanner functionality & ports new paystand functionality

### DIFF
--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -1,6 +1,6 @@
 /obj/item/export_scanner
 	name = "export scanner"
-	desc = "A device used to check objects against Nanotrasen exports and bounty database."
+	desc = "A device used to check objects against Nanotrasen exports database."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "export_scanner"
 	item_state = "radio"
@@ -8,38 +8,19 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	item_flags = NOBLUDGEON
 	w_class = WEIGHT_CLASS_SMALL
-	siemens_coefficient = 1
-	var/obj/machinery/computer/cargo/cargo_console = null
-
-/obj/item/export_scanner/examine(user)
-	. = ..()
-	if(!cargo_console)
-		. += "<span class='notice'>[src] is not currently linked to a cargo console.</span>"
 
 /obj/item/export_scanner/afterattack(obj/O, mob/user, proximity)
 	. = ..()
 	if(!istype(O) || !proximity)
 		return
+	// Before you fix it:
+	// yes, checking manifests is a part of intended functionality.
 
-	if(istype(O, /obj/machinery/computer/cargo))
-		var/obj/machinery/computer/cargo/C = O
-		if(!C.requestonly)
-			cargo_console = C
-			to_chat(user, "<span class='notice'>Scanner linked to [C].</span>")
-	else if(!istype(cargo_console))
-		to_chat(user, "<span class='warning'>You must link [src] to a cargo console first!</span>")
+	var/datum/export_report/ex = export_item_and_contents(O, dry_run=TRUE)
+	var/price = 0
+	for(var/x in ex.total_amount)
+		price += ex.total_value[x]
+	if(price)
+		to_chat(user, "<span class='notice'>Scanned [O], value: <b>[price]</b> credits[O.contents.len ? " (contents included)" : ""].</span>")
 	else
-		// Before you fix it:
-		// yes, checking manifests is a part of intended functionality.
-
-		var/datum/export_report/ex = export_item_and_contents(O, cargo_console.get_export_categories(), dry_run=TRUE)
-		var/price = 0
-		for(var/x in ex.total_amount)
-			price += ex.total_value[x]
-
-		if(price)
-			to_chat(user, "<span class='notice'>Scanned [O], value: <b>[price]</b> credits[O.contents.len ? " (contents included)" : ""].</span>")
-		else
-			to_chat(user, "<span class='warning'>Scanned [O], no export value.</span>")
-		if(bounty_ship_item_and_contents(O, dry_run=TRUE))
-			to_chat(user, "<span class='notice'>Scanned item is eligible for one or more bounties.</span>")
+		to_chat(user, "<span class='warning'>Scanned [O], no export value.</span>")

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -24,6 +24,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/list/exported_atoms = list()	//names of atoms sold/deleted by export
 	var/list/total_amount = list()		//export instance => total count of sold objects of its type, only exists if any were sold
 	var/list/total_value = list()		//export instance => total value of sold objects
+	var/list/exported_atoms_ref = list() //if they're not deleted they go in here for use.
 
 // external_report works as "transaction" object, pass same one in if you're doing more than one export in single go
 /proc/export_item_and_contents(atom/movable/AM, allowed_categories = EXPORT_CARGO, apply_elastic = TRUE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report)
@@ -48,6 +49,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 			if(E.applies_to(thing, allowed_categories, apply_elastic))
 				sold = E.sell_object(thing, report, dry_run, allowed_categories , apply_elastic)
 				report.exported_atoms += " [thing.name]"
+				if(!QDELETED(thing))
+					report.exported_atoms_ref += thing
 				break
 		if(!dry_run && (sold || delete_unsold))
 			if(ismob(thing))

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -193,6 +193,40 @@
 	icon = 'icons/obj/clothing/neck.dmi'
 	icon_state = "bling"
 
+/obj/item/clothing/neck/necklace/dope/merchant
+	desc = "Don't ask how it works, the proof is in the holochips!"
+	/// scales the amount received in case an admin wants to emulate taxes/fees.
+	var/profit_scaling = 1
+	/// toggles between sell (TRUE) and get price post-fees (FALSE)
+	var/selling = FALSE
+
+/obj/item/clothing/neck/necklace/dope/merchant/attack_self(mob/user)
+	. = ..()
+	selling = !selling
+	to_chat(user, "<span class='notice'>[src] has been set to [selling ? "'Sell'" : "'Get Price'"] mode.</span>")
+
+/obj/item/clothing/neck/necklace/dope/merchant/afterattack(obj/item/I, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	var/datum/export_report/ex = export_item_and_contents(I, allowed_categories = (ALL), dry_run=TRUE)
+	var/price = 0
+	for(var/x in ex.total_amount)
+		price += ex.total_value[x]
+
+	if(price)
+		var/true_price = round(price*profit_scaling)
+		to_chat(user, "<span class='notice'>[selling ? "Sold" : "Getting the price of"] [I], value: <b>[true_price]</b> credits[I.contents.len ? " (exportable contents included)" : ""].[profit_scaling < 1 && selling ? "<b>[round(price-true_price)]</b> credit\s taken as processing fee\s." : ""]</span>")
+		if(selling)
+			new /obj/item/holochip(get_turf(user),true_price)
+			for(var/i in ex.exported_atoms_ref)
+				var/atom/movable/AM = i
+				if(QDELETED(AM))
+					continue
+				qdel(AM)
+	else
+		to_chat(user, "<span class='warning'>There is no export value for [I] or any items within it.</span>")
+
 /obj/item/clothing/neck/neckerchief
 	icon = 'icons/obj/clothing/masks.dmi' //In order to reuse the bandana sprite
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -10,27 +10,47 @@
 	var/obj/item/assembly/signaler/signaler //attached signaler, let people attach signalers that get activated if the user's transaction limit is achieved.
 	var/signaler_threshold = 0 //signaler threshold amount
 	var/amount_deposited = 0 //keep track of the amount deposited over time so you can pay multiple times to reach the signaler threshold
+	var/force_fee = 0 //replaces the "pay whatever" functionality with a set amount when non-zero.
 
 /obj/machinery/paystand/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/card/id))
 		if(W == my_card)
+			if(user.a_intent == INTENT_DISARM)
+				var/rename_msg = stripped_input(user, "Rename the Paystand:", "Paystand Naming", name)
+				if(!rename_msg || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+					return
+				name = rename_msg
+				return
+			else if(user.a_intent == INTENT_GRAB)
+				var/force_fee_input = input(user,"Set the fee!","Set a fee!",0) as num|null
+				if(isnull(force_fee_input) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+					return
+				force_fee = force_fee_input
+				return
 			locked = !locked
-			to_chat(user, "<span class='notice'>You [src.locked ? "lock" : "unlock"] the bolts on the paystand.</span>")
+			to_chat(user, "<span class='notice'>You [src.locked ? "lock" : "unlock"] the paystand, protecting the bolts from [anchored ? "loosening" : "tightening"].</span>")
 			return
 		if(!my_card)
 			var/obj/item/card/id/assistant_mains_need_to_die = W
-			if(assistant_mains_need_to_die.registered_account)
-				var/msg = stripped_input(user, "Name of pay stand:", "Paystand Naming", "[user]'s Awesome Paystand")
-				if(!msg)
-					return
-				name = msg
-				desc = "Owned by [assistant_mains_need_to_die.registered_account.account_holder], pays directly into [user.p_their()] account."
-				my_card = assistant_mains_need_to_die
-				to_chat(user, "You link the stand to your account.")
+			if(!assistant_mains_need_to_die.registered_account)
 				return
+			var/msg = stripped_input(user, "Name of pay stand:", "Paystand Naming", "[user]'s Awesome Paystand")
+			if(!msg)
+				return
+			name = msg
+			desc = "Owned by [assistant_mains_need_to_die.registered_account.account_holder], pays directly into [user.p_their()] account."
+			my_card = assistant_mains_need_to_die
+			to_chat(user, "You link the stand to your account.")
+			return
 		var/obj/item/card/id/vbucks = W
 		if(vbucks.registered_account)
-			var/momsdebitcard = input(user, "How much would you like to deposit?", "Money Deposit") as null|num
+			var/momsdebitcard = 0
+			if(!force_fee)
+				momsdebitcard = input(user, "How much would you like to deposit?", "Money Deposit") as null|num
+			else
+				momsdebitcard = force_fee
+			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+				return
 			if(momsdebitcard < 1)
 				to_chat(user, "<span class='warning'>ERROR: Invalid amount designated.</span>")
 				return
@@ -106,6 +126,13 @@
 
 /obj/machinery/paystand/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
 	if(locked)
-		to_chat(user, "<span class='warning'>The anchored bolts on this paystand are currently locked!</span>")
-		return
+		to_chat(user, "<span class='warning'>The bolts on this paystand are currently covered!</span>")
+		return FALSE
 	. = ..()
+
+/obj/machinery/paystand/examine(mob/user)
+	. = ..()
+	if(force_fee)
+		. += "<span class='warning'>This paystand forces a payment of <b>[force_fee]</b> credit\s per swipe instead of a variable amount.</span>"
+	if(user.get_active_held_item() == my_card)
+		. += "<span class='notice'>Paystands can be edited through swiping your card with different intents. <b>Disarm</b> allows editing the name while <b>Grab</b> changes payment functionality.</span>"


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/48205

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Export Scanner

The export scanner can now be used at roundstart w/o linking to a supply console. That is all.

### Paystands 

Paystands now have different functionalities based on which intent you hit them with.

- Help/Harm: Default (Lock it down)
- Disarm: Rename
- Grab: Replace "Pay as much as you want" with an amount you decide. 0 returns it to the old mode.

### Merchant Necklaces

Admin tool. Works as an export scanner, but can also convert anything into their exact material worth. 

Useful for debugging or mechant events.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Removes the export scanner linking because its a useless functionality. Theres one cargo bay, why would you need to link it? 

Adjusts paystands because barely anyone uses them and I want to see more people try them out.

Adds the bling entirely for selfish debug reasons. Also could be fun for setting up merchant events.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Export Scanner works at roundstart

![exportscanner](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/b3646017-6186-47a4-9342-558b72ac9b55)

Paystand

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/ba8a034f-f753-4ba2-95ad-80a8c30d2c02

Merchant Bling

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/692e6bce-6c36-4dd5-b9b6-881ee613f749



</details>

## Changelog
:cl: rkz, ExcessiveUseOfCobblestone
tweak: removed the need to link the export scanner to supply consoles at roundstart. They should function automatically now.
add: new paystand functionality based on what intent you use. From renaming to setting a minimum price.
admin: adds new admin-only merchant bling item that works as an export scanner, but can also sell anything for its exact value in credits. Good as a debug or if running events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
