### PR TITLE
Fixes duplication bug that allows to obtain infinite glass and cable by disassembling and reassembling Disco Tiles.

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral/glass.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/glass.dm
@@ -44,7 +44,7 @@
 		CC.use(5)
 		use(1)
 		to_chat(user, "<span class='notice'>You attach wire to the [name].</span>")
-		new /obj/item/stack/light_w(user.loc, 5, TRUE, user)
+		new /obj/item/stack/light_w(user.loc, 1, TRUE, user)
 	else if(istype(W, /obj/item/stack/rods))
 		var/obj/item/stack/rods/V = W
 		if (V.get_amount() >= 1 && get_amount() >= 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes https://github.com/BeeStation/BeeStation-Hornet/issues/7206
Before when you assembled a wired glass tile you got a stack with 5 tiles, and if you disassemble ONE Wired Glass Tile you got the same wire and glass you need to build 5 (so, you could duplicate materials, not great)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Removing duplication bugs (even they are not used) is good!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Before: 

https://user-images.githubusercontent.com/45698448/177639819-a50cb2ca-898c-4258-8ee9-7fd24cca6788.mp4


After:


https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/49cdd7bc-0651-4bcd-ba2e-9a0f6092bd97



</details>

## Changelog
:cl:
fix: Fixed being able to get infinite glass and wires disassembling Disco Tiles
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
