### PR TITLE
Kills 900+ lines of useless chemistry recipe code

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -2,326 +2,221 @@
 
 
 /datum/chemical_reaction/goldschlager
-	name = "Goldschlager"
-	id = /datum/reagent/consumable/ethanol/goldschlager
 	results = list(/datum/reagent/consumable/ethanol/goldschlager = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 10, /datum/reagent/gold = 1)
 
 /datum/chemical_reaction/patron
-	name = "Patron"
-	id = /datum/reagent/consumable/ethanol/patron
 	results = list(/datum/reagent/consumable/ethanol/patron = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/tequila = 10, /datum/reagent/silver = 1)
 
 /datum/chemical_reaction/bilk
-	name = "Bilk"
-	id = /datum/reagent/consumable/ethanol/bilk
 	results = list(/datum/reagent/consumable/ethanol/bilk = 2)
 	required_reagents = list(/datum/reagent/consumable/milk = 1, /datum/reagent/consumable/ethanol/beer = 1)
 
 /datum/chemical_reaction/icetea
-	name = "Iced Tea"
-	id = /datum/reagent/consumable/icetea
 	results = list(/datum/reagent/consumable/icetea = 4)
 	required_reagents = list(/datum/reagent/consumable/ice = 1, /datum/reagent/consumable/tea = 3)
 
 /datum/chemical_reaction/icecoffee
-	name = "Iced Coffee"
-	id = /datum/reagent/consumable/icecoffee
 	results = list(/datum/reagent/consumable/icecoffee = 4)
 	required_reagents = list(/datum/reagent/consumable/ice = 1, /datum/reagent/consumable/coffee = 3)
 
 /datum/chemical_reaction/nuka_cola
-	name = "Nuka Cola"
-	id = /datum/reagent/consumable/nuka_cola
 	results = list(/datum/reagent/consumable/nuka_cola = 6)
 	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/consumable/space_cola = 6)
 
 /datum/chemical_reaction/moonshine
-	name = "Moonshine"
-	id = /datum/reagent/consumable/ethanol/moonshine
 	results = list(/datum/reagent/consumable/ethanol/moonshine = 10)
 	required_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/sugar = 5)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
 /datum/chemical_reaction/wine
-	name = "Wine"
-	id = /datum/reagent/consumable/ethanol/wine
 	results = list(/datum/reagent/consumable/ethanol/wine = 10)
 	required_reagents = list(/datum/reagent/consumable/grapejuice = 10)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
 /datum/chemical_reaction/spacebeer
-	name = "Space Beer"
-	id = "spacebeer"
 	results = list(/datum/reagent/consumable/ethanol/beer = 10)
 	required_reagents = list(/datum/reagent/consumable/flour = 10)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
 /datum/chemical_reaction/vodka
-	name = "Vodka"
-	id = /datum/reagent/consumable/ethanol/vodka
 	results = list(/datum/reagent/consumable/ethanol/vodka = 10)
 	required_reagents = list(/datum/reagent/consumable/potato_juice = 10)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
 /datum/chemical_reaction/kahlua
-	name = "Kahlua"
-	id = /datum/reagent/consumable/ethanol/kahlua
 	results = list(/datum/reagent/consumable/ethanol/kahlua = 5)
 	required_reagents = list(/datum/reagent/consumable/coffee = 5, /datum/reagent/consumable/sugar = 5)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
 /datum/chemical_reaction/gin_tonic
-	name = "Gin and Tonic"
-	id = /datum/reagent/consumable/ethanol/gintonic
 	results = list(/datum/reagent/consumable/ethanol/gintonic = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/gin = 2, /datum/reagent/consumable/tonic = 1)
 
 /datum/chemical_reaction/rum_coke
-	name = "Rum and Coke"
-	id = /datum/reagent/consumable/ethanol/rum_coke
 	results = list(/datum/reagent/consumable/ethanol/rum_coke = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 2, /datum/reagent/consumable/space_cola = 1)
 
 /datum/chemical_reaction/cuba_libre
-	name = "Cuba Libre"
-	id = /datum/reagent/consumable/ethanol/cuba_libre
 	results = list(/datum/reagent/consumable/ethanol/cuba_libre = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum_coke = 3, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/martini
-	name = "Classic Martini"
-	id = /datum/reagent/consumable/ethanol/martini
 	results = list(/datum/reagent/consumable/ethanol/martini = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/gin = 2, /datum/reagent/consumable/ethanol/vermouth = 1)
 
 /datum/chemical_reaction/vodkamartini
-	name = "Vodka Martini"
-	id = /datum/reagent/consumable/ethanol/vodkamartini
 	results = list(/datum/reagent/consumable/ethanol/vodkamartini = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/ethanol/vermouth = 1)
 
 /datum/chemical_reaction/white_russian
-	name = "White Russian"
-	id = /datum/reagent/consumable/ethanol/white_russian
 	results = list(/datum/reagent/consumable/ethanol/white_russian = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/black_russian = 3, /datum/reagent/consumable/cream = 2)
 
 /datum/chemical_reaction/whiskey_cola
-	name = "Whiskey Cola"
-	id = /datum/reagent/consumable/ethanol/whiskey_cola
 	results = list(/datum/reagent/consumable/ethanol/whiskey_cola = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/consumable/space_cola = 1)
 
 /datum/chemical_reaction/screwdriver
-	name = "Screwdriver"
-	id = /datum/reagent/consumable/ethanol/screwdrivercocktail
 	results = list(/datum/reagent/consumable/ethanol/screwdrivercocktail = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/orangejuice = 1)
 
 /datum/chemical_reaction/bloody_mary
-	name = "Bloody Mary"
-	id = /datum/reagent/consumable/ethanol/bloody_mary
 	results = list(/datum/reagent/consumable/ethanol/bloody_mary = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/tomatojuice = 2, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/gargle_blaster
-	name = "Pan-Galactic Gargle Blaster"
-	id = /datum/reagent/consumable/ethanol/gargle_blaster
 	results = list(/datum/reagent/consumable/ethanol/gargle_blaster = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/ethanol/gin = 1, /datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/ethanol/cognac = 1, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/brave_bull
-	name = "Brave Bull"
-	id = /datum/reagent/consumable/ethanol/brave_bull
 	results = list(/datum/reagent/consumable/ethanol/brave_bull = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/tequila = 2, /datum/reagent/consumable/ethanol/kahlua = 1)
 
 /datum/chemical_reaction/tequila_sunrise
-	name = "Tequila Sunrise"
-	id = /datum/reagent/consumable/ethanol/tequila_sunrise
 	results = list(/datum/reagent/consumable/ethanol/tequila_sunrise = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/tequila = 2, /datum/reagent/consumable/orangejuice = 2, /datum/reagent/consumable/grenadine = 1)
 
 /datum/chemical_reaction/toxins_special
-	name = "Toxins Special"
-	id = /datum/chemical_reaction/toxins_special
 	results = list(/datum/reagent/consumable/ethanol/toxins_special = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 2, /datum/reagent/consumable/ethanol/vermouth = 1, /datum/reagent/toxin/plasma = 2)
 
 /datum/chemical_reaction/beepsky_smash
-	name = "Beepksy Smash"
-	id = "beepksysmash"
 	results = list(/datum/reagent/consumable/ethanol/beepsky_smash = 5)
 	required_reagents = list(/datum/reagent/consumable/limejuice = 2, /datum/reagent/consumable/ethanol/quadruple_sec = 2, /datum/reagent/iron = 1)
 
 /datum/chemical_reaction/doctor_delight
-	name = "The Doctor's Delight"
-	id = "doctordelight"
 	results = list(/datum/reagent/consumable/doctor_delight = 5)
 	required_reagents = list(/datum/reagent/consumable/limejuice = 1, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/consumable/orangejuice = 1, /datum/reagent/consumable/cream = 1, /datum/reagent/medicine/cryoxadone = 1)
 
 /datum/chemical_reaction/irish_cream
-	name = "Irish Cream"
-	id = /datum/reagent/consumable/ethanol/irish_cream
 	results = list(/datum/reagent/consumable/ethanol/irish_cream = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/consumable/cream = 1)
 
 /datum/chemical_reaction/manly_dorf
-	name = "The Manly Dorf"
-	id = /datum/reagent/consumable/ethanol/manly_dorf
 	results = list(/datum/reagent/consumable/ethanol/manly_dorf = 3)
 	required_reagents = list (/datum/reagent/consumable/ethanol/beer = 1, /datum/reagent/consumable/ethanol/ale = 2)
 
 /datum/chemical_reaction/greenbeer
-	name = "Green Beer"
-	id = /datum/reagent/consumable/ethanol/beer/green
 	results = list(/datum/reagent/consumable/ethanol/beer/green = 10)
 	required_reagents = list(/datum/reagent/colorful_reagent/powder/green = 1, /datum/reagent/consumable/ethanol/beer = 10)
 
 /datum/chemical_reaction/greenbeer2 //apparently there's no other way to do this
-	name = "Green Beer"
-	id = /datum/reagent/consumable/ethanol/beer/green
 	results = list(/datum/reagent/consumable/ethanol/beer/green = 10)
 	required_reagents = list(/datum/reagent/colorful_reagent/powder/green/crayon = 1, /datum/reagent/consumable/ethanol/beer = 10)
 
 /datum/chemical_reaction/hooch
-	name = "Hooch"
-	id = /datum/reagent/consumable/ethanol/hooch
 	results = list(/datum/reagent/consumable/ethanol/hooch = 3)
 	required_reagents = list (/datum/reagent/consumable/ethanol = 2, /datum/reagent/fuel = 1)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 1)
 
 /datum/chemical_reaction/irish_coffee
-	name = "Irish Coffee"
-	id = /datum/reagent/consumable/ethanol/irishcoffee
 	results = list(/datum/reagent/consumable/ethanol/irishcoffee = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/irish_cream = 1, /datum/reagent/consumable/coffee = 1)
 
 /datum/chemical_reaction/b52
-	name = "B-52"
-	id = /datum/reagent/consumable/ethanol/b52
 	results = list(/datum/reagent/consumable/ethanol/b52 = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/irish_cream = 1, /datum/reagent/consumable/ethanol/kahlua = 1, /datum/reagent/consumable/ethanol/cognac = 1)
 
 /datum/chemical_reaction/atomicbomb
-	name = "Atomic Bomb"
-	id = /datum/reagent/consumable/ethanol/atomicbomb
 	results = list(/datum/reagent/consumable/ethanol/atomicbomb = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/b52 = 10, /datum/reagent/uranium = 1)
 
 /datum/chemical_reaction/margarita
-	name = "Margarita"
-	id = /datum/reagent/consumable/ethanol/margarita
 	results = list(/datum/reagent/consumable/ethanol/margarita = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/tequila = 2, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/longislandicedtea
-	name = "Long Island Iced Tea"
-	id = /datum/reagent/consumable/ethanol/longislandicedtea
 	results = list(/datum/reagent/consumable/ethanol/longislandicedtea = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/ethanol/gin = 1, /datum/reagent/consumable/ethanol/tequila = 1, /datum/reagent/consumable/ethanol/cuba_libre = 1)
 
 /datum/chemical_reaction/threemileisland
-	name = "Three Mile Island Iced Tea"
-	id = /datum/reagent/consumable/ethanol/threemileisland
 	results = list(/datum/reagent/consumable/ethanol/threemileisland = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/longislandicedtea = 10, /datum/reagent/uranium = 1)
 
 /datum/chemical_reaction/whiskeysoda
-	name = "Whiskey Soda"
-	id = /datum/reagent/consumable/ethanol/whiskeysoda
 	results = list(/datum/reagent/consumable/ethanol/whiskeysoda = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/consumable/sodawater = 1)
 
 /datum/chemical_reaction/black_russian
-	name = "Black Russian"
-	id = /datum/reagent/consumable/ethanol/black_russian
 	results = list(/datum/reagent/consumable/ethanol/black_russian = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 3, /datum/reagent/consumable/ethanol/kahlua = 2)
 
 /datum/chemical_reaction/manhattan
-	name = "Manhattan"
-	id = /datum/reagent/consumable/ethanol/manhattan
 	results = list(/datum/reagent/consumable/ethanol/manhattan = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/consumable/ethanol/vermouth = 1)
 
 /datum/chemical_reaction/manhattan_proj
-	name = "Manhattan Project"
-	id = /datum/reagent/consumable/ethanol/manhattan_proj
 	results = list(/datum/reagent/consumable/ethanol/manhattan_proj = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/manhattan = 10, /datum/reagent/uranium = 1)
 
 /datum/chemical_reaction/vodka_tonic
-	name = "Vodka and Tonic"
-	id = /datum/reagent/consumable/ethanol/vodkatonic
+
 	results = list(/datum/reagent/consumable/ethanol/vodkatonic = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/tonic = 1)
 
 /datum/chemical_reaction/gin_fizz
-	name = "Gin Fizz"
-	id = /datum/reagent/consumable/ethanol/ginfizz
 	results = list(/datum/reagent/consumable/ethanol/ginfizz = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/gin = 2, /datum/reagent/consumable/sodawater = 1, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/bahama_mama
-	name = "Bahama Mama"
-	id = /datum/reagent/consumable/ethanol/bahama_mama
 	results = list(/datum/reagent/consumable/ethanol/bahama_mama = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/creme_de_coconut = 1, /datum/reagent/consumable/ethanol/kahlua = 1, /datum/reagent/consumable/ethanol/rum = 2, /datum/reagent/consumable/pineapplejuice = 1)
 
 /datum/chemical_reaction/painkiller
-	name = "Painkiller"
-	id = /datum/reagent/consumable/ethanol/painkiller
 	results = list(/datum/reagent/consumable/ethanol/painkiller = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/creme_de_coconut = 5, /datum/reagent/consumable/pineapplejuice = 4, /datum/reagent/consumable/orangejuice = 1)
 
 /datum/chemical_reaction/pina_colada
-	name = "Pina Colada"
-	id = /datum/reagent/consumable/ethanol/pina_colada
 	results = list(/datum/reagent/consumable/ethanol/pina_colada = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/creme_de_coconut = 1, /datum/reagent/consumable/pineapplejuice = 3, /datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/singulo
-	name = "Singulo"
-	id = /datum/reagent/consumable/ethanol/singulo
 	results = list(/datum/reagent/consumable/ethanol/singulo = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 5, /datum/reagent/uranium/radium = 1, /datum/reagent/consumable/ethanol/wine = 5)
 
 /datum/chemical_reaction/alliescocktail
-	name = "Allies Cocktail"
-	id = /datum/reagent/consumable/ethanol/alliescocktail
 	results = list(/datum/reagent/consumable/ethanol/alliescocktail = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/martini = 1, /datum/reagent/consumable/ethanol/vodka = 1)
 
 /datum/chemical_reaction/demonsblood
-	name = "Demons Blood"
-	id = /datum/reagent/consumable/ethanol/demonsblood
 	results = list(/datum/reagent/consumable/ethanol/demonsblood = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/consumable/spacemountainwind = 1, /datum/reagent/blood = 1, /datum/reagent/consumable/dr_gibb = 1)
 
 /datum/chemical_reaction/booger
-	name = "Booger"
-	id = /datum/reagent/consumable/ethanol/booger
 	results = list(/datum/reagent/consumable/ethanol/booger = 4)
 	required_reagents = list(/datum/reagent/consumable/cream = 1, /datum/reagent/consumable/banana = 1, /datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/consumable/watermelonjuice = 1)
 
 /datum/chemical_reaction/antifreeze
-	name = "Anti-freeze"
-	id = /datum/reagent/consumable/ethanol/antifreeze
 	results = list(/datum/reagent/consumable/ethanol/antifreeze = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 2, /datum/reagent/consumable/cream = 1, /datum/reagent/consumable/ice = 1)
 
 /datum/chemical_reaction/barefoot
-	name = "Barefoot"
-	id = /datum/reagent/consumable/ethanol/barefoot
 	results = list(/datum/reagent/consumable/ethanol/barefoot = 3)
 	required_reagents = list(/datum/reagent/consumable/berryjuice = 1, /datum/reagent/consumable/cream = 1, /datum/reagent/consumable/ethanol/vermouth = 1)
 
 /datum/chemical_reaction/ftliver
-	name = "Faster-Than-Liver"
-	id = /datum/reagent/consumable/ethanol/ftliver
 	results = list(/datum/reagent/consumable/ethanol/ftliver = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/stable_plasma = 1, /datum/reagent/consumable/ethanol/screwdrivercocktail = 1)
 
@@ -329,165 +224,111 @@
 ////DRINKS THAT REQUIRED IMPROVED SPRITES BELOW:: -Agouri/////
 
 /datum/chemical_reaction/sbiten
-	name = "Sbiten"
-	id = /datum/reagent/consumable/ethanol/sbiten
 	results = list(/datum/reagent/consumable/ethanol/sbiten = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 10, /datum/reagent/consumable/capsaicin = 1)
 
 /datum/chemical_reaction/red_mead
-	name = "Red Mead"
-	id = /datum/reagent/consumable/ethanol/red_mead
 	results = list(/datum/reagent/consumable/ethanol/red_mead = 2)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/consumable/ethanol/mead = 1)
 
 /datum/chemical_reaction/mead
-	name = "Mead"
-	id = /datum/reagent/consumable/ethanol/mead
 	results = list(/datum/reagent/consumable/ethanol/mead = 2)
 	required_reagents = list(/datum/reagent/consumable/honey = 2)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
 /datum/chemical_reaction/iced_beer
-	name = "Iced Beer"
-	id = /datum/reagent/consumable/ethanol/iced_beer
 	results = list(/datum/reagent/consumable/ethanol/iced_beer = 6)
 	required_reagents = list(/datum/reagent/consumable/ethanol/beer = 5, /datum/reagent/consumable/ice = 1)
 
 /datum/chemical_reaction/grog
-	name = "Grog"
-	id = /datum/reagent/consumable/ethanol/grog
 	results = list(/datum/reagent/consumable/ethanol/grog = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/soy_latte
-	name = "Soy Latte"
-	id = /datum/reagent/consumable/soy_latte
 	results = list(/datum/reagent/consumable/soy_latte = 2)
 	required_reagents = list(/datum/reagent/consumable/coffee = 1, /datum/reagent/consumable/soymilk = 1)
 
 /datum/chemical_reaction/cafe_latte
-	name = "Cafe Latte"
-	id = /datum/reagent/consumable/cafe_latte
 	results = list(/datum/reagent/consumable/cafe_latte = 2)
 	required_reagents = list(/datum/reagent/consumable/coffee = 1, /datum/reagent/consumable/milk = 1)
 
 /datum/chemical_reaction/acidspit
-	name = "Acid Spit"
-	id = /datum/reagent/consumable/ethanol/acid_spit
 	results = list(/datum/reagent/consumable/ethanol/acid_spit = 6)
 	required_reagents = list(/datum/reagent/toxin/acid = 1, /datum/reagent/consumable/ethanol/wine = 5)
 
 /datum/chemical_reaction/amasec
-	name = "Amasec"
-	id = /datum/reagent/consumable/ethanol/amasec
 	results = list(/datum/reagent/consumable/ethanol/amasec = 10)
 	required_reagents = list(/datum/reagent/iron = 1, /datum/reagent/consumable/ethanol/wine = 5, /datum/reagent/consumable/ethanol/vodka = 5)
 
 /datum/chemical_reaction/changelingsting
-	name = "Changeling Sting"
-	id = /datum/reagent/consumable/ethanol/changelingsting
 	results = list(/datum/reagent/consumable/ethanol/changelingsting = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/screwdrivercocktail = 1, /datum/reagent/consumable/lemon_lime = 2)
 
 /datum/chemical_reaction/aloe
-	name = "Aloe"
-	id = /datum/reagent/consumable/ethanol/aloe
 	results = list(/datum/reagent/consumable/ethanol/aloe = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/irish_cream = 1, /datum/reagent/consumable/watermelonjuice = 1)
 
 /datum/chemical_reaction/andalusia
-	name = "Andalusia"
-	id = /datum/reagent/consumable/ethanol/andalusia
 	results = list(/datum/reagent/consumable/ethanol/andalusia = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/lemonjuice = 1)
 
 /datum/chemical_reaction/neurotoxin
-	name = "Neurotoxin"
-	id = /datum/reagent/consumable/ethanol/neurotoxin
 	results = list(/datum/reagent/consumable/ethanol/neurotoxin = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/gargle_blaster = 1, /datum/reagent/medicine/morphine = 1)
 
 /datum/chemical_reaction/snowwhite
-	name = "Snow White"
-	id = /datum/reagent/consumable/ethanol/snowwhite
 	results = list(/datum/reagent/consumable/ethanol/snowwhite = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/beer = 1, /datum/reagent/consumable/lemon_lime = 1)
 
 /datum/chemical_reaction/irishcarbomb
-	name = "Irish Car Bomb"
-	id = /datum/reagent/consumable/ethanol/irishcarbomb
 	results = list(/datum/reagent/consumable/ethanol/irishcarbomb = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/ale = 1, /datum/reagent/consumable/ethanol/irish_cream = 1)
 
 /datum/chemical_reaction/syndicatebomb
-	name = "Syndicate Bomb"
-	id = /datum/reagent/consumable/ethanol/syndicatebomb
 	results = list(/datum/reagent/consumable/ethanol/syndicatebomb = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/beer = 1, /datum/reagent/consumable/ethanol/whiskey_cola = 1)
 
 /datum/chemical_reaction/erikasurprise
-	name = "Erika Surprise"
-	id = /datum/reagent/consumable/ethanol/erikasurprise
 	results = list(/datum/reagent/consumable/ethanol/erikasurprise = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/ale = 1, /datum/reagent/consumable/limejuice = 1, /datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/banana = 1, /datum/reagent/consumable/ice = 1)
 
 /datum/chemical_reaction/devilskiss
-	name = "Devils Kiss"
-	id = /datum/reagent/consumable/ethanol/devilskiss
 	results = list(/datum/reagent/consumable/ethanol/devilskiss = 3)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/consumable/ethanol/kahlua = 1, /datum/reagent/consumable/ethanol/rum = 1)
 
 /datum/chemical_reaction/hippiesdelight
-	name = "Hippies Delight"
-	id = /datum/reagent/consumable/ethanol/hippies_delight
 	results = list(/datum/reagent/consumable/ethanol/hippies_delight = 2)
 	required_reagents = list(/datum/reagent/drug/mushroomhallucinogen = 1, /datum/reagent/consumable/ethanol/gargle_blaster = 1)
 
 /datum/chemical_reaction/bananahonk
-	name = "Banana Honk"
-	id = /datum/reagent/consumable/ethanol/bananahonk
 	results = list(/datum/reagent/consumable/ethanol/bananahonk = 2)
 	required_reagents = list(/datum/reagent/consumable/laughter = 1, /datum/reagent/consumable/cream = 1)
 
 /datum/chemical_reaction/silencer
-	name = "Silencer"
-	id = /datum/reagent/consumable/ethanol/silencer
 	results = list(/datum/reagent/consumable/ethanol/silencer = 3)
 	required_reagents = list(/datum/reagent/consumable/nothing = 1, /datum/reagent/consumable/cream = 1, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/driestmartini
-	name = "Driest Martini"
-	id = /datum/reagent/consumable/ethanol/driestmartini
 	results = list(/datum/reagent/consumable/ethanol/driestmartini = 2)
 	required_reagents = list(/datum/reagent/consumable/nothing = 1, /datum/reagent/consumable/ethanol/gin = 1)
 
 /datum/chemical_reaction/thirteenloko
-	name = "Thirteen Loko"
-	id = /datum/reagent/consumable/ethanol/thirteenloko
 	results = list(/datum/reagent/consumable/ethanol/thirteenloko = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/coffee = 1, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/chocolatepudding
-	name = "Chocolate Pudding"
-	id = /datum/reagent/consumable/chocolatepudding
 	results = list(/datum/reagent/consumable/chocolatepudding = 20)
 	required_reagents = list(/datum/reagent/consumable/milk/chocolate_milk = 10, /datum/reagent/consumable/eggyolk = 5)
 
 /datum/chemical_reaction/vanillapudding
-	name = "Vanilla Pudding"
-	id = /datum/reagent/consumable/vanillapudding
 	results = list(/datum/reagent/consumable/vanillapudding = 20)
 	required_reagents = list(/datum/reagent/consumable/vanilla = 5, /datum/reagent/consumable/milk = 5, /datum/reagent/consumable/eggyolk = 5)
 
 /datum/chemical_reaction/cherryshake
-	name = "Cherry Shake"
-	id = /datum/reagent/consumable/cherryshake
 	results = list(/datum/reagent/consumable/cherryshake = 5)
 	required_reagents = list(/datum/reagent/consumable/cherryjelly = 1, /datum/reagent/consumable/milk = 3, /datum/reagent/consumable/cream = 1)
 
 /datum/chemical_reaction/bluecherryshake
-	name = "Blue Cherry Shake"
-	id = /datum/reagent/consumable/bluecherryshake
 	results = list(/datum/reagent/consumable/bluecherryshake = 5)
 	required_reagents = list(/datum/reagent/consumable/bluecherryjelly = 1, /datum/reagent/consumable/milk = 3, /datum/reagent/consumable/cream = 1)
 
@@ -512,244 +353,172 @@
 	required_reagents = list(/datum/reagent/consumable/banana = 1, /datum/reagent/consumable/milk = 3, /datum/reagent/consumable/cream = 1)
 
 /datum/chemical_reaction/drunkenblumpkin
-	name = "Drunken Blumpkin"
-	id = /datum/reagent/consumable/ethanol/drunkenblumpkin
 	results = list(/datum/reagent/consumable/ethanol/drunkenblumpkin = 4)
 	required_reagents = list(/datum/reagent/consumable/blumpkinjuice = 1, /datum/reagent/consumable/ethanol/irish_cream = 2, /datum/reagent/consumable/ice = 1)
 
 /datum/chemical_reaction/pumpkin_latte
-	name = "Pumpkin space latte"
-	id = /datum/reagent/consumable/pumpkin_latte
 	results = list(/datum/reagent/consumable/pumpkin_latte = 15)
 	required_reagents = list(/datum/reagent/consumable/pumpkinjuice = 5, /datum/reagent/consumable/coffee = 5, /datum/reagent/consumable/cream = 5)
 
 /datum/chemical_reaction/gibbfloats
-	name = "Gibb Floats"
-	id = /datum/reagent/consumable/gibbfloats
 	results = list(/datum/reagent/consumable/gibbfloats = 15)
 	required_reagents = list(/datum/reagent/consumable/dr_gibb = 5, /datum/reagent/consumable/ice = 5, /datum/reagent/consumable/cream = 5)
 
 /datum/chemical_reaction/triple_citrus
-	name = /datum/reagent/consumable/triple_citrus
-	id = /datum/reagent/consumable/triple_citrus
 	results = list(/datum/reagent/consumable/triple_citrus = 5)
 	required_reagents = list(/datum/reagent/consumable/lemonjuice = 1, /datum/reagent/consumable/limejuice = 1, /datum/reagent/consumable/orangejuice = 1)
 
 /datum/chemical_reaction/grape_soda
-	name = "grape soda"
-	id = /datum/reagent/consumable/grape_soda
 	results = list(/datum/reagent/consumable/grape_soda = 2)
 	required_reagents = list(/datum/reagent/consumable/grapejuice = 1, /datum/reagent/consumable/sodawater = 1)
 
 /datum/chemical_reaction/grappa
-	name = /datum/reagent/consumable/ethanol/grappa
-	id = /datum/reagent/consumable/ethanol/grappa
 	results = list(/datum/reagent/consumable/ethanol/grappa = 10)
 	required_reagents = list (/datum/reagent/consumable/ethanol/wine = 10)
 	required_catalysts = list (/datum/reagent/consumable/enzyme = 5)
 
 /datum/chemical_reaction/whiskey_sour
-	name = "Whiskey Sour"
-	id = /datum/reagent/consumable/ethanol/whiskey_sour
 	results = list(/datum/reagent/consumable/ethanol/whiskey_sour = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/lemonjuice = 1, /datum/reagent/consumable/sugar = 1)
 	mix_message = "The mixture darkens to a rich gold hue."
 
 /datum/chemical_reaction/fetching_fizz
-	name = "Fetching Fizz"
-	id = /datum/reagent/consumable/ethanol/fetching_fizz
 	results = list(/datum/reagent/consumable/ethanol/fetching_fizz = 3)
 	required_reagents = list(/datum/reagent/consumable/nuka_cola = 1, /datum/reagent/iron = 1) //Manufacturable from only the mining station
 	mix_message = "The mixture slightly vibrates before settling."
 
 /datum/chemical_reaction/hearty_punch
-	name = "Hearty Punch"
-	id = /datum/reagent/consumable/ethanol/hearty_punch
 	results = list(/datum/reagent/consumable/ethanol/hearty_punch = 1)  //Very little, for balance reasons
 	required_reagents = list(/datum/reagent/consumable/ethanol/brave_bull = 5, /datum/reagent/consumable/ethanol/syndicatebomb = 5, /datum/reagent/consumable/ethanol/absinthe = 5)
 	mix_message = "The mixture darkens to a healthy crimson."
 	required_temp = 315 //Piping hot!
 
 /datum/chemical_reaction/bacchus_blessing
-	name = "Bacchus' Blessing"
-	id = /datum/reagent/consumable/ethanol/bacchus_blessing
 	results = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/hooch = 1, /datum/reagent/consumable/ethanol/absinthe = 1, /datum/reagent/consumable/ethanol/manly_dorf = 1, /datum/reagent/consumable/ethanol/syndicatebomb = 1)
 	mix_message = "<span class='warning'>The mixture turns to a sickening froth.</span>"
 
 /datum/chemical_reaction/lemonade
-	name = "Lemonade"
-	id = /datum/reagent/consumable/lemonade
 	results = list(/datum/reagent/consumable/lemonade = 5)
 	required_reagents = list(/datum/reagent/consumable/lemonjuice = 2, /datum/reagent/water = 2, /datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/ice = 1)
 	mix_message = "You're suddenly reminded of home."
 
 /datum/chemical_reaction/arnold_palmer
-	name = "Arnold Palmer"
-	id = /datum/reagent/consumable/tea/arnold_palmer
 	results = list(/datum/reagent/consumable/tea/arnold_palmer = 2)
 	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/consumable/lemonade = 1)
 	mix_message = "The smells of fresh green grass and sand traps waft through the air as the mixture turns a friendly yellow-orange."
 
 /datum/chemical_reaction/chocolate_milk
-	name = "chocolate milk"
-	id = /datum/reagent/consumable/milk/chocolate_milk
 	results = list(/datum/reagent/consumable/milk/chocolate_milk = 2)
 	required_reagents = list(/datum/reagent/consumable/milk = 1, /datum/reagent/consumable/cocoa = 1)
 	mix_message = "The color changes as the mixture blends smoothly."
 
 /datum/chemical_reaction/eggnog
-	name = /datum/reagent/consumable/ethanol/eggnog
-	id = /datum/reagent/consumable/ethanol/eggnog
 	results = list(/datum/reagent/consumable/ethanol/eggnog = 15)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 5, /datum/reagent/consumable/cream = 5, /datum/reagent/consumable/eggyolk = 5)
 
 /datum/chemical_reaction/narsour
-	name = "Nar'sour"
-	id = /datum/reagent/consumable/ethanol/narsour
 	results = list(/datum/reagent/consumable/ethanol/narsour = 1)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/consumable/lemonjuice = 1, /datum/reagent/consumable/ethanol/demonsblood = 1)
 	mix_message = "The mixture develops a sinister glow."
 	mix_sound = 'sound/effects/singlebeat.ogg'
 
 /datum/chemical_reaction/quadruplesec
-	name = "Quadruple Sec"
-	id = /datum/reagent/consumable/ethanol/quadruple_sec
 	results = list(/datum/reagent/consumable/ethanol/quadruple_sec = 15)
 	required_reagents = list(/datum/reagent/consumable/ethanol/triple_sec = 5, /datum/reagent/consumable/triple_citrus = 5, /datum/reagent/consumable/ethanol/creme_de_menthe = 5)
 	mix_message = "The snap of a taser emanates clearly from the mixture as it settles."
 	mix_sound = 'sound/weapons/taser.ogg'
 
 /datum/chemical_reaction/grasshopper
-	name = "Grasshopper"
-	id = /datum/reagent/consumable/ethanol/grasshopper
 	results = list(/datum/reagent/consumable/ethanol/grasshopper = 15)
 	required_reagents = list(/datum/reagent/consumable/cream = 5, /datum/reagent/consumable/ethanol/creme_de_menthe = 5, /datum/reagent/consumable/ethanol/creme_de_cacao = 5)
 	mix_message = "A vibrant green bubbles forth as the mixture emulsifies."
 
 /datum/chemical_reaction/stinger
-	name = "Stinger"
-	id = /datum/reagent/consumable/ethanol/stinger
 	results = list(/datum/reagent/consumable/ethanol/stinger = 15)
 	required_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 10, /datum/reagent/consumable/ethanol/creme_de_menthe = 5 )
 
 /datum/chemical_reaction/quintuplesec
-	name = "Quintuple Sec"
-	id = /datum/reagent/consumable/ethanol/quintuple_sec
 	results = list(/datum/reagent/consumable/ethanol/quintuple_sec = 15)
 	required_reagents = list(/datum/reagent/consumable/ethanol/quadruple_sec = 5, /datum/reagent/consumable/clownstears = 5, /datum/reagent/consumable/ethanol/syndicatebomb = 5)
 	mix_message = "Judgment is upon you."
 	mix_sound = 'sound/items/airhorn2.ogg'
 
 /datum/chemical_reaction/bastion_bourbon
-	name = "Bastion Bourbon"
-	id = /datum/reagent/consumable/ethanol/bastion_bourbon
 	results = list(/datum/reagent/consumable/ethanol/bastion_bourbon = 2)
 	required_reagents = list(/datum/reagent/consumable/tea = 1, /datum/reagent/consumable/ethanol/creme_de_menthe = 1, /datum/reagent/consumable/triple_citrus = 1, /datum/reagent/consumable/berryjuice = 1) //herbal and minty, with a hint of citrus and berry
 	mix_message = "You catch an aroma of hot tea and fruits as the mix blends into a blue-green color."
 
 /datum/chemical_reaction/squirt_cider
-	name = "Squirt Cider"
-	id = /datum/reagent/consumable/ethanol/squirt_cider
 	results = list(/datum/reagent/consumable/ethanol/squirt_cider = 1)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/consumable/nutriment = 1)
 	mix_message = "The mix swirls and turns a bright red that reminds you of an apple's skin."
 
 /datum/chemical_reaction/fringe_weaver
-	name = "Fringe Weaver"
-	id = /datum/reagent/consumable/ethanol/fringe_weaver
 	results = list(/datum/reagent/consumable/ethanol/fringe_weaver = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 9, /datum/reagent/consumable/sugar = 1) //9 karmotrine, 1 adelhyde
 	mix_message = "The mix turns a pleasant cream color and foams up."
 
 /datum/chemical_reaction/sugar_rush
-	name = "Sugar Rush"
-	id = /datum/reagent/consumable/ethanol/sugar_rush
 	results = list(/datum/reagent/consumable/ethanol/sugar_rush = 4)
 	required_reagents = list(/datum/reagent/consumable/sugar = 2, /datum/reagent/consumable/lemonjuice = 1, /datum/reagent/consumable/ethanol/wine = 1) //2 adelhyde (sweet), 1 powdered delta (sour), 1 karmotrine (alcohol)
 	mix_message = "The mixture bubbles and brightens into a girly pink."
 
 /datum/chemical_reaction/crevice_spike
-	name = "Crevice Spike"
-	id = /datum/reagent/consumable/ethanol/crevice_spike
 	results = list(/datum/reagent/consumable/ethanol/crevice_spike = 6)
 	required_reagents = list(/datum/reagent/consumable/limejuice = 2, /datum/reagent/consumable/capsaicin = 4) //2 powdered delta (sour), 4 flanergide (spicy)
 	mix_message = "The mixture stings your eyes as it settles."
 
 /datum/chemical_reaction/sake
-	name = /datum/reagent/consumable/ethanol/sake
-	id = /datum/reagent/consumable/ethanol/sake
 	results = list(/datum/reagent/consumable/ethanol/sake = 10)
 	required_reagents = list(/datum/reagent/consumable/rice = 10)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 	mix_message = "The rice grains ferment into a clear, sweet-smelling liquid."
 
 /datum/chemical_reaction/peppermint_patty
-	name = "Peppermint Patty"
-	id = /datum/reagent/consumable/ethanol/peppermint_patty
 	results = list(/datum/reagent/consumable/ethanol/peppermint_patty = 10)
 	required_reagents = list(/datum/reagent/consumable/cocoa/hot_cocoa = 6, /datum/reagent/consumable/ethanol/creme_de_cacao = 1, /datum/reagent/consumable/ethanol/creme_de_menthe = 1, /datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/menthol = 1)
 	mix_message = "The cocoa turns mint green just as the strong scent hits your nose."
 
 /datum/chemical_reaction/alexander
-	name = "Alexander"
-	id = /datum/reagent/consumable/ethanol/alexander
 	results = list(/datum/reagent/consumable/ethanol/alexander = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/cognac = 1, /datum/reagent/consumable/ethanol/creme_de_cacao = 1, /datum/reagent/consumable/cream = 1)
 
 /datum/chemical_reaction/sidecar
-	name = "Sidecar"
-	id = /datum/reagent/consumable/ethanol/sidecar
 	results = list(/datum/reagent/consumable/ethanol/sidecar = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/cognac = 2, /datum/reagent/consumable/ethanol/triple_sec = 1, /datum/reagent/consumable/lemonjuice = 1)
 
 /datum/chemical_reaction/between_the_sheets
-	name = "Between the Sheets"
-	id = /datum/reagent/consumable/ethanol/between_the_sheets
 	results = list(/datum/reagent/consumable/ethanol/between_the_sheets = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/consumable/ethanol/sidecar = 4)
 
 /datum/chemical_reaction/kamikaze
-	name = "Kamikaze"
-	id = /datum/reagent/consumable/ethanol/kamikaze
 	results = list(/datum/reagent/consumable/ethanol/kamikaze = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/vodka = 1, /datum/reagent/consumable/ethanol/triple_sec = 1, /datum/reagent/consumable/limejuice = 1)
 
 /datum/chemical_reaction/mojito
-	name = "Mojito"
-	id = /datum/reagent/consumable/ethanol/mojito
 	results = list(/datum/reagent/consumable/ethanol/mojito = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/rum = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/limejuice = 1, /datum/reagent/consumable/sodawater = 1, /datum/reagent/consumable/menthol = 1)
 
 /datum/chemical_reaction/fernet_cola
-	name = "Fernet Cola"
-	id = /datum/reagent/consumable/ethanol/fernet_cola
 	results = list(/datum/reagent/consumable/ethanol/fernet_cola = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/fernet = 1, /datum/reagent/consumable/space_cola = 1)
 
 
 /datum/chemical_reaction/fanciulli
-	name = "Fanciulli"
-	id = /datum/reagent/consumable/ethanol/fanciulli
 	results = list(/datum/reagent/consumable/ethanol/fanciulli = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol/manhattan = 1, /datum/reagent/consumable/ethanol/fernet = 1)
 
 /datum/chemical_reaction/branca_menta
-	name = "Branca Menta"
-	id = /datum/reagent/consumable/ethanol/branca_menta
 	results = list(/datum/reagent/consumable/ethanol/branca_menta = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/fernet = 1, /datum/reagent/consumable/ethanol/creme_de_menthe = 1, /datum/reagent/consumable/ice = 1)
 
 /datum/chemical_reaction/blank_paper
-	name = "Blank Paper"
-	id = /datum/reagent/consumable/ethanol/blank_paper
 	results = list(/datum/reagent/consumable/ethanol/blank_paper = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/silencer = 1, /datum/reagent/consumable/nothing = 1, /datum/reagent/consumable/nuka_cola = 1, /datum/reagent/consumable/clownstears = 1)
 
 
 /datum/chemical_reaction/wizz_fizz
-	name = "Wizz Fizz"
-	id = /datum/reagent/consumable/ethanol/wizz_fizz
 	results = list(/datum/reagent/consumable/ethanol/wizz_fizz = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/triple_sec = 1, /datum/reagent/consumable/sodawater = 1, /datum/reagent/consumable/ethanol/champagne = 1)
 	mix_message = "The beverage starts to froth with an almost mystical zeal!"
@@ -757,110 +526,76 @@
 
 
 /datum/chemical_reaction/bug_spray
-	name = "Bug Spray"
-	id = /datum/reagent/consumable/ethanol/bug_spray
 	results = list(/datum/reagent/consumable/ethanol/bug_spray = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/triple_sec = 2, /datum/reagent/consumable/lemon_lime = 1, /datum/reagent/consumable/ethanol/rum = 2, /datum/reagent/consumable/ethanol/vodka = 1)
 	mix_message = "The faint aroma of summer camping trips wafts through the air; but what's that buzzing noise?"
 	mix_sound = 'sound/creatures/bee.ogg'
 
 /datum/chemical_reaction/jack_rose
-	name = "Jack Rose"
-	id = /datum/reagent/consumable/ethanol/jack_rose
 	results = list(/datum/reagent/consumable/ethanol/jack_rose = 4)
 	required_reagents = list(/datum/reagent/consumable/grenadine = 1, /datum/reagent/consumable/ethanol/applejack = 2, /datum/reagent/consumable/limejuice = 1)
 	mix_message = "As the grenadine incorporates, the beverage takes on a mellow, red-orange glow."
 
 /datum/chemical_reaction/turbo
-	name = "Turbo"
-	id = /datum/reagent/consumable/ethanol/turbo
 	results = list(/datum/reagent/consumable/ethanol/turbo = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/moonshine = 2, /datum/reagent/nitrous_oxide = 1, /datum/reagent/consumable/ethanol/sugar_rush = 1, /datum/reagent/consumable/pwr_game = 1)
 
 /datum/chemical_reaction/old_timer
-	name = "Old Timer"
-	id = /datum/reagent/consumable/ethanol/old_timer
 	results = list(/datum/reagent/consumable/ethanol/old_timer = 6)
 	required_reagents = list(/datum/reagent/consumable/ethanol/whiskeysoda = 3, /datum/reagent/consumable/parsnipjuice = 2, /datum/reagent/consumable/ethanol/alexander = 1)
 
 /datum/chemical_reaction/rubberneck
-	name = "Rubberneck"
-	id = /datum/reagent/consumable/ethanol/rubberneck
 	results = list(/datum/reagent/consumable/ethanol/rubberneck = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 4, /datum/reagent/consumable/grey_bull = 5, /datum/reagent/consumable/astrotame = 1)
 
 /datum/chemical_reaction/duplex
-	name = "Duplex"
-	id = /datum/reagent/consumable/ethanol/duplex
 	results = list(/datum/reagent/consumable/ethanol/duplex = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/hcider = 2, /datum/reagent/consumable/applejuice = 1, /datum/reagent/consumable/berryjuice = 1)
 
 /datum/chemical_reaction/trappist
-	name = "Trappist"
-	id = /datum/reagent/consumable/ethanol/trappist
 	results = list(/datum/reagent/consumable/ethanol/trappist = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/ale = 2, /datum/reagent/water/holywater = 2, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/cream_soda
-	name = "Cream Soda"
-	id = /datum/reagent/consumable/cream_soda
 	results = list(/datum/reagent/consumable/cream_soda = 4)
 	required_reagents = list(/datum/reagent/consumable/sugar = 2, /datum/reagent/consumable/sodawater = 2, /datum/reagent/consumable/vanilla = 1)
 
 /datum/chemical_reaction/blazaam
-	name = "Blazaam"
-	id = /datum/reagent/consumable/ethanol/blazaam
 	results = list(/datum/reagent/consumable/ethanol/blazaam = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/gin = 2, /datum/reagent/consumable/peachjuice = 1, /datum/reagent/bluespace = 1)
 
 /datum/chemical_reaction/planet_cracker
-	name = "Planet Cracker"
-	id = /datum/reagent/consumable/ethanol/planet_cracker
 	results = list(/datum/reagent/consumable/ethanol/planet_cracker = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/champagne = 2, /datum/reagent/consumable/ethanol/lizardwine = 2, /datum/reagent/consumable/eggyolk = 1, /datum/reagent/gold = 1)
 	mix_message = "The liquid's color starts shifting as the nanogold is alternately corroded and redeposited."
 
 /datum/chemical_reaction/red_queen
-	name = "Red Queen"
-	id = /datum/reagent/consumable/red_queen
 	results = list(/datum/reagent/consumable/red_queen = 10)
 	required_reagents = list(/datum/reagent/consumable/tea = 6, /datum/reagent/mercury = 2, /datum/reagent/consumable/blackpepper = 1, /datum/reagent/growthserum = 1)
 
 /datum/chemical_reaction/mauna_loa
-	name = "Mauna Loa"
-	id = /datum/reagent/consumable/ethanol/mauna_loa
 	results = list(/datum/reagent/consumable/ethanol/mauna_loa = 5)
 	required_reagents = list(/datum/reagent/consumable/capsaicin = 2, /datum/reagent/consumable/ethanol/kahlua = 1, /datum/reagent/consumable/ethanol/bahama_mama = 2)
 
 /datum/chemical_reaction/plasmaflood
-	name = "Plasma Flood"
-	id = /datum/reagent/consumable/ethanol/plasmaflood
 	results = list(/datum/reagent/consumable/ethanol/plasmaflood = 4)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/napalm = 1, /datum/reagent/consumable/ethanol/tequila = 1, /datum/reagent/consumable/ethanol/demonsblood = 1)
 
 /datum/chemical_reaction/fourthwall
-	name = "Fourth Wall"
-	id = /datum/reagent/consumable/ethanol/fourthwall
 	results = list(/datum/reagent/consumable/ethanol/fourthwall = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/gargle_blaster = 10, /datum/reagent/bluespace = 1)
 
 /datum/chemical_reaction/ratvander
-	name = "Rat'vander Cocktail"
-	id = /datum/reagent/consumable/ethanol/ratvander
 	results = list(/datum/reagent/consumable/ethanol/ratvander = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/wine = 5, /datum/reagent/consumable/ethanol/triple_sec = 5, /datum/reagent/consumable/sugar = 1, /datum/reagent/iron = 1, /datum/reagent/copper = 0.6)
 	mix_message = "The mixture develops a golden glow."
 	mix_sound = 'sound/magic/clockwork/scripture_tier_up.ogg'
 
 /datum/chemical_reaction/icewing
-	name = "Icewing"
-	id = /datum/reagent/consumable/ethanol/icewing
 	results = list(/datum/reagent/consumable/ethanol/icewing = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/antifreeze = 1, /datum/reagent/medicine/mine_salve = 1, /datum/reagent/consumable/ice = 1)
 
 /datum/chemical_reaction/sarsaparilliansunset
-	name = "Sarsaparillian Sunset"
-	id = /datum/reagent/consumable/ethanol/sarsaparilliansunset
 	results = list(/datum/reagent/consumable/ethanol/sarsaparilliansunset = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol/tequila_sunrise = 5, /datum/reagent/consumable/nuka_cola = 1, /datum/reagent/napalm = 1)
 	required_temp = 320
@@ -868,13 +603,9 @@
 	mix_sound = 'sound/items/lighter_on.ogg'
 
 /datum/chemical_reaction/beesknees
-	name = "Bee's Knees"
-	id = /datum/reagent/consumable/ethanol/beesknees
 	results = list(/datum/reagent/consumable/ethanol/beesknees = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol/mead = 1, /datum/reagent/consumable/honey = 1, /datum/reagent/consumable/ethanol/whiskey = 1, /datum/reagent/consumable/lemonjuice = 1)
 
 /datum/chemical_reaction/beeffizz
-	name = "Beef Fizz"
-	id = /datum/reagent/consumable/ethanol/beeffizz
 	results = list(/datum/reagent/consumable/ethanol/beeffizz = 10)
 	required_reagents = list(/datum/reagent/consumable/beefbroth = 7, /datum/reagent/consumable/ice = 2, /datum/reagent/consumable/lemonjuice = 1 )

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -9,8 +9,6 @@
 //////////////////////////////////////////FOOD MIXTURES////////////////////////////////////
 
 /datum/chemical_reaction/tofu
-	name = "Tofu"
-	id = "tofu"
 	required_reagents = list(/datum/reagent/consumable/soymilk = 10)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 	mob_react = FALSE
@@ -22,8 +20,6 @@
 	return
 
 /datum/chemical_reaction/chocolate_bar
-	name = "Chocolate Bar"
-	id = "chocolate_bar"
 	required_reagents = list(/datum/reagent/consumable/soymilk = 2, /datum/reagent/consumable/cocoa = 2, /datum/reagent/consumable/sugar = 2)
 
 /datum/chemical_reaction/chocolate_bar/on_reaction(datum/reagents/holder, created_volume)
@@ -34,8 +30,6 @@
 
 
 /datum/chemical_reaction/chocolate_bar2
-	name = "Chocolate Bar"
-	id = "chocolate_bar"
 	required_reagents = list(/datum/reagent/consumable/milk/chocolate_milk = 4, /datum/reagent/consumable/sugar = 2)
 	mob_react = FALSE
 
@@ -46,55 +40,39 @@
 	return
 
 /datum/chemical_reaction/hot_cocoa
-	name = "Hot Cocoa"
-	id = /datum/reagent/consumable/cocoa/hot_cocoa
 	results = list(/datum/reagent/consumable/cocoa/hot_cocoa = 5)
 	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/consumable/cocoa = 1)
 
 /datum/chemical_reaction/coffee
-	name = "Coffee"
-	id = /datum/reagent/consumable/coffee
 	results = list(/datum/reagent/consumable/coffee = 5)
 	required_reagents = list(/datum/reagent/toxin/coffeepowder = 1, /datum/reagent/water = 5)
 
 /datum/chemical_reaction/tea
-	name = "Tea"
-	id = /datum/reagent/consumable/tea
 	results = list(/datum/reagent/consumable/tea = 5)
 	required_reagents = list(/datum/reagent/toxin/teapowder = 1, /datum/reagent/water = 5)
 
 /datum/chemical_reaction/soysauce
-	name = "Soy Sauce"
-	id = /datum/reagent/consumable/soysauce
 	results = list(/datum/reagent/consumable/soysauce = 5)
 	required_reagents = list(/datum/reagent/consumable/soymilk = 4, /datum/reagent/toxin/acid = 1)
 
 /datum/chemical_reaction/corn_syrup
-	name = /datum/reagent/consumable/corn_syrup
-	id = /datum/reagent/consumable/corn_syrup
 	results = list(/datum/reagent/consumable/corn_syrup = 5)
 	required_reagents = list(/datum/reagent/consumable/corn_starch = 1, /datum/reagent/toxin/acid = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/caramel
-	name = "Caramel"
-	id = /datum/reagent/consumable/caramel
 	results = list(/datum/reagent/consumable/caramel = 1)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1)
 	required_temp = 413.15
 	mob_react = FALSE
 
 /datum/chemical_reaction/caramel_burned
-	name = "Caramel burned"
-	id = "caramel_burned"
 	results = list(/datum/reagent/carbon = 1)
 	required_reagents = list(/datum/reagent/consumable/caramel = 1)
 	required_temp = 483.15
 	mob_react = FALSE
 
 /datum/chemical_reaction/cheesewheel
-	name = "Cheesewheel"
-	id = "cheesewheel"
 	required_reagents = list(/datum/reagent/consumable/milk = 40)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
@@ -104,8 +82,6 @@
 		new /obj/item/reagent_containers/food/snacks/store/cheesewheel(location)
 
 /datum/chemical_reaction/synthmeat
-	name = "synthmeat"
-	id = "synthmeat"
 	required_reagents = list(/datum/reagent/blood = 5, /datum/reagent/medicine/cryoxadone = 1)
 	mob_react = FALSE
 
@@ -115,20 +91,14 @@
 		new /obj/item/food/meat/slab/synthmeat(location)
 
 /datum/chemical_reaction/hot_ramen
-	name = "Hot Ramen"
-	id = /datum/reagent/consumable/hot_ramen
 	results = list(/datum/reagent/consumable/hot_ramen = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/consumable/dry_ramen = 3)
 
 /datum/chemical_reaction/hell_ramen
-	name = "Hell Ramen"
-	id = /datum/reagent/consumable/hell_ramen
 	results = list(/datum/reagent/consumable/hell_ramen = 6)
 	required_reagents = list(/datum/reagent/consumable/capsaicin = 1, /datum/reagent/consumable/hot_ramen = 6)
 
 /datum/chemical_reaction/imitationcarpmeat
-	name = "Imitation Carpmeat"
-	id = "imitationcarpmeat"
 	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5)
 	required_container = /obj/item/food/tofu
 	mix_message = "The mixture becomes similar to carp meat."
@@ -140,8 +110,6 @@
 		qdel(holder.my_atom)
 
 /datum/chemical_reaction/dough
-	name = "Dough"
-	id = "dough"
 	required_reagents = list(/datum/reagent/water = 10, /datum/reagent/consumable/flour = 15)
 	mix_message = "The ingredients form a dough."
 
@@ -151,8 +119,6 @@
 		new /obj/item/food/dough(location)
 
 /datum/chemical_reaction/cakebatter
-	name = "Cake Batter"
-	id = "cakebatter"
 	required_reagents = list(/datum/reagent/consumable/eggyolk = 15, /datum/reagent/consumable/flour = 15, /datum/reagent/consumable/sugar = 5)
 	mix_message = "The ingredients form a cake batter."
 
@@ -162,12 +128,9 @@
 		new /obj/item/food/cakebatter(location)
 
 /datum/chemical_reaction/cakebatter/vegan
-	id = "vegancakebatter"
 	required_reagents = list(/datum/reagent/consumable/soymilk = 15, /datum/reagent/consumable/flour = 15, /datum/reagent/consumable/sugar = 5)
 
 /datum/chemical_reaction/ricebowl
-	name = "Rice Bowl"
-	id = "ricebowl"
 	required_reagents = list(/datum/reagent/consumable/rice = 10, /datum/reagent/water = 10)
 	required_container = /obj/item/reagent_containers/glass/bowl
 	mix_message = "The rice absorbs the water."
@@ -179,7 +142,5 @@
 		qdel(holder.my_atom)
 
 /datum/chemical_reaction/bbqsauce
-	name = "BBQ Sauce"
-	id = /datum/reagent/consumable/bbqsauce
 	results = list(/datum/reagent/consumable/bbqsauce = 5)
 	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/medicine/salglu_solution = 3, /datum/reagent/consumable/blackpepper = 1)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -30,9 +30,11 @@
 		var/datum/chemical_reaction/D = new path()
 		var/list/reaction_ids = list()
 
-		if(D.required_reagents && D.required_reagents.len)
-			for(var/reaction in D.required_reagents)
-				reaction_ids += reaction
+		if(!D.required_reagents || !D.required_reagents.len) //Skip impossible reactions
+			continue
+
+		for(var/reaction in D.required_reagents)
+			reaction_ids += reaction
 
 		// Create filters based on each reagent id in the required reagents list
 		for(var/id in reaction_ids)

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -1,6 +1,4 @@
 /datum/chemical_reaction
-	var/name = null
-	var/id = null
 	var/list/results = new/list()
 	var/list/required_reagents = new/list()
 	var/list/required_catalysts = new/list()
@@ -30,7 +28,7 @@
 	if(holder && holder.my_atom)
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
-		var/message = "A [reaction_name] reaction has occurred in [ADMIN_VERBOSEJMP(T)]"
+		var/message = "Mobs have been spawned in [ADMIN_VERBOSEJMP(T)] by a [reaction_name] reaction."
 		message += " (<A HREF='?_src_=vars;Vars=[REF(A)]'>VV</A>)"
 
 		var/mob/M = get(A, /mob)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -1,12 +1,8 @@
 /datum/chemical_reaction/space_drugs
-	name = "Space Drugs"
-	id = /datum/reagent/drug/space_drugs
 	results = list(/datum/reagent/drug/space_drugs = 3)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1)
 
 /datum/chemical_reaction/crank
-	name = "Crank"
-	id = /datum/reagent/drug/crank
 	results = list(/datum/reagent/drug/crank = 5)
 	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/ammonia = 1, /datum/reagent/lithium = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/fuel = 1)
 	mix_message = "The mixture violently reacts, leaving behind a few crystalline shards."
@@ -14,43 +10,31 @@
 
 
 /datum/chemical_reaction/krokodil
-	name = "Krokodil"
-	id = /datum/reagent/drug/krokodil
 	results = list(/datum/reagent/drug/krokodil = 6)
 	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/potassium = 1, /datum/reagent/phosphorus = 1, /datum/reagent/fuel = 1)
 	mix_message = "The mixture dries into a pale blue powder."
 	required_temp = 380
 
 /datum/chemical_reaction/methamphetamine
-	name = /datum/reagent/drug/methamphetamine
-	id = /datum/reagent/drug/methamphetamine
 	results = list(/datum/reagent/drug/methamphetamine = 4)
 	required_reagents = list(/datum/reagent/medicine/ephedrine = 1, /datum/reagent/iodine = 1, /datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/bath_salts
-	name = /datum/reagent/drug/bath_salts
-	id = /datum/reagent/drug/bath_salts
 	results = list(/datum/reagent/drug/bath_salts = 7)
 	required_reagents = list(/datum/reagent/toxin/bad_food = 1, /datum/reagent/saltpetre = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/consumable/enzyme = 1, /datum/reagent/consumable/tea = 1, /datum/reagent/mercury = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/aranesp
-	name = /datum/reagent/drug/aranesp
-	id = /datum/reagent/drug/aranesp
 	results = list(/datum/reagent/drug/aranesp = 3)
 	required_reagents = list(/datum/reagent/medicine/epinephrine = 1, /datum/reagent/medicine/atropine = 1, /datum/reagent/medicine/morphine = 1)
 
 /datum/chemical_reaction/happiness
-	name = "Happiness"
-	id = /datum/reagent/drug/happiness
 	results = list(/datum/reagent/drug/happiness = 4)
 	required_reagents = list(/datum/reagent/nitrous_oxide = 2, /datum/reagent/medicine/epinephrine = 1, /datum/reagent/consumable/ethanol = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/ketamine
-	name = "Ketamine"
-	id = /datum/reagent/drug/ketamine
 	results = list(/datum/reagent/drug/ketamine = 3)
 	required_reagents = list(/datum/reagent/medicine/morphine = 3, /datum/reagent/toxin/chloralhydrate = 3, /datum/reagent/toxin/fentanyl = 3, /datum/reagent/medicine/epinephrine =3)
 	required_temp = 370

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -1,320 +1,220 @@
 
 /datum/chemical_reaction/leporazine
-	name = "Leporazine"
-	id = /datum/reagent/medicine/leporazine
 	results = list(/datum/reagent/medicine/leporazine = 2)
 	required_reagents = list(/datum/reagent/silicon = 1, /datum/reagent/copper = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/rezadone
-	name = "Rezadone"
-	id = /datum/reagent/medicine/rezadone
 	results = list(/datum/reagent/medicine/rezadone = 3)
 	required_reagents = list(/datum/reagent/toxin/carpotoxin = 1, /datum/reagent/cryptobiolin = 1, /datum/reagent/copper = 1)
 
 /datum/chemical_reaction/spaceacillin
-	name = "Spaceacillin"
-	id = /datum/reagent/medicine/spaceacillin
 	results = list(/datum/reagent/medicine/spaceacillin = 2)
 	required_reagents = list(/datum/reagent/cryptobiolin = 1, /datum/reagent/medicine/epinephrine = 1)
 
 /datum/chemical_reaction/inacusiate
-	name = /datum/reagent/medicine/inacusiate
-	id = /datum/reagent/medicine/inacusiate
 	results = list(/datum/reagent/medicine/inacusiate = 2)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/charcoal = 1)
 
 /datum/chemical_reaction/synaptizine
-	name = "Synaptizine"
-	id = /datum/reagent/medicine/synaptizine
 	results = list(/datum/reagent/medicine/synaptizine = 3)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/lithium = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/charcoal
-	name = "Charcoal"
-	id = /datum/reagent/medicine/charcoal
 	results = list(/datum/reagent/medicine/charcoal = 2)
 	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/consumable/sodiumchloride = 1)
 	mix_message = "The mixture yields a fine black powder."
 	required_temp = 380
 
 /datum/chemical_reaction/silver_sulfadiazine
-	name = "Silver Sulfadiazine"
-	id = /datum/reagent/medicine/silver_sulfadiazine
 	results = list(/datum/reagent/medicine/silver_sulfadiazine = 5)
 	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/silver = 1, /datum/reagent/sulfur = 1, /datum/reagent/oxygen = 1, /datum/reagent/chlorine = 1)
 
 /datum/chemical_reaction/salglu_solution
-	name = "Saline-Glucose Solution"
-	id = /datum/reagent/medicine/salglu_solution
 	results = list(/datum/reagent/medicine/salglu_solution = 3)
 	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/water = 1, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/mine_salve
-	name = "Miner's Salve"
-	id = /datum/reagent/medicine/mine_salve
 	results = list(/datum/reagent/medicine/mine_salve = 3)
 	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/water = 1, /datum/reagent/iron = 1)
 
 /datum/chemical_reaction/mine_salve2
-	name = "Miner's Salve"
-	id = /datum/reagent/medicine/mine_salve
 	results = list(/datum/reagent/medicine/mine_salve = 15)
 	required_reagents = list(/datum/reagent/toxin/plasma = 5, /datum/reagent/iron = 5, /datum/reagent/consumable/sugar = 1) // A sheet of plasma, a twinkie and a sheet of metal makes four of these
 
 /datum/chemical_reaction/synthflesh
-	name = "Synthflesh"
-	id = /datum/reagent/medicine/synthflesh
 	results = list(/datum/reagent/medicine/synthflesh = 4)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1, /datum/reagent/medicine/silver_sulfadiazine = 1)
 
 /datum/chemical_reaction/styptic_powder
-	name = "Styptic Powder"
-	id = /datum/reagent/medicine/styptic_powder
 	results = list(/datum/reagent/medicine/styptic_powder = 4)
 	required_reagents = list(/datum/reagent/aluminium = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/acid = 1)
 	mix_message = "The solution yields an astringent powder."
 
 /datum/chemical_reaction/calomel
-	name = "Calomel"
-	id = /datum/reagent/medicine/calomel
 	results = list(/datum/reagent/medicine/calomel = 2)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/chlorine = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/potass_iodide
-	name = "Potassium Iodide"
-	id = /datum/reagent/medicine/potass_iodide
 	results = list(/datum/reagent/medicine/potass_iodide = 2)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/iodine = 1)
 
 /datum/chemical_reaction/pen_acid
-	name = "Pentetic Acid"
-	id = /datum/reagent/medicine/pen_acid
 	results = list(/datum/reagent/medicine/pen_acid = 6)
 	required_reagents = list(/datum/reagent/fuel = 1, /datum/reagent/chlorine = 1, /datum/reagent/ammonia = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/sodium = 1, /datum/reagent/toxin/cyanide = 1)
 
 /datum/chemical_reaction/sal_acid
-	name = "Salicyclic Acid"
-	id = /datum/reagent/medicine/sal_acid
 	results = list(/datum/reagent/medicine/sal_acid = 5)
 	required_reagents = list(/datum/reagent/sodium = 1, /datum/reagent/phenol = 1, /datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/acid = 1)
 
 /datum/chemical_reaction/oxandrolone
-	name = "Oxandrolone"
-	id = /datum/reagent/medicine/oxandrolone
 	results = list(/datum/reagent/medicine/oxandrolone = 6)
 	required_reagents = list(/datum/reagent/carbon = 3, /datum/reagent/phenol = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/salbutamol
-	name = "Salbutamol"
-	id = /datum/reagent/medicine/salbutamol
 	results = list(/datum/reagent/medicine/salbutamol = 5)
 	required_reagents = list(/datum/reagent/medicine/sal_acid = 1, /datum/reagent/lithium = 1, /datum/reagent/aluminium = 1, /datum/reagent/bromine = 1, /datum/reagent/ammonia = 1)
 
 /datum/chemical_reaction/perfluorodecalin
-	name = "Perfluorodecalin"
-	id = /datum/reagent/medicine/perfluorodecalin
 	results = list(/datum/reagent/medicine/perfluorodecalin = 3)
 	required_reagents = list(/datum/reagent/hydrogen = 1, /datum/reagent/fluorine = 1, /datum/reagent/oil = 1)
 	required_temp = 370
 	mix_message = "The mixture rapidly turns into a dense pink liquid."
 
 /datum/chemical_reaction/ephedrine
-	name = "Ephedrine"
-	id = /datum/reagent/medicine/ephedrine
 	results = list(/datum/reagent/medicine/ephedrine = 4)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/oil = 1, /datum/reagent/hydrogen = 1, /datum/reagent/diethylamine = 1)
 	mix_message = "The solution fizzes and gives off toxic fumes."
 
 /datum/chemical_reaction/diphenhydramine
-	name = "Diphenhydramine"
-	id = /datum/reagent/medicine/diphenhydramine
 	results = list(/datum/reagent/medicine/diphenhydramine = 4)
 	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/carbon = 1, /datum/reagent/bromine = 1, /datum/reagent/diethylamine = 1, /datum/reagent/consumable/ethanol = 1)
 	mix_message = "The mixture dries into a pale blue powder."
 
 /datum/chemical_reaction/oculine
-	name = "Oculine"
-	id = /datum/reagent/medicine/oculine
 	results = list(/datum/reagent/medicine/oculine = 3)
 	required_reagents = list(/datum/reagent/medicine/charcoal = 1, /datum/reagent/carbon = 1, /datum/reagent/hydrogen = 1)
 	mix_message = "The mixture sputters loudly and becomes a pale pink color."
 
 /datum/chemical_reaction/atropine
-	name = "Atropine"
-	id = /datum/reagent/medicine/atropine
 	results = list(/datum/reagent/medicine/atropine = 5)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/phenol = 1, /datum/reagent/toxin/acid = 1)
 
 /datum/chemical_reaction/epinephrine
-	name = "Epinephrine"
-	id = /datum/reagent/medicine/epinephrine
 	results = list(/datum/reagent/medicine/epinephrine = 6)
 	required_reagents = list(/datum/reagent/phenol = 1, /datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/oxygen = 1, /datum/reagent/chlorine = 1, /datum/reagent/hydrogen = 1)
 
 /datum/chemical_reaction/strange_reagent
-	name = "Strange Reagent"
-	id = /datum/reagent/medicine/strange_reagent
 	results = list(/datum/reagent/medicine/strange_reagent = 3)
 	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/mannitol
-	name = "Mannitol"
-	id = /datum/reagent/medicine/mannitol
 	results = list(/datum/reagent/medicine/mannitol = 3)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/hydrogen = 1, /datum/reagent/water = 1)
 	mix_message = "The solution slightly bubbles, becoming thicker."
 
 /datum/chemical_reaction/neurine
-	name = "Neurine"
-	id = /datum/reagent/medicine/neurine
 	results = list(/datum/reagent/medicine/neurine = 3)
 	required_reagents = list(/datum/reagent/medicine/mannitol = 1, /datum/reagent/acetone = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/mutadone
-	name = "Mutadone"
-	id = /datum/reagent/medicine/mutadone
 	results = list(/datum/reagent/medicine/mutadone = 3)
 	required_reagents = list(/datum/reagent/toxin/mutagen = 1, /datum/reagent/acetone = 1, /datum/reagent/bromine = 1)
 
 /datum/chemical_reaction/antihol
-	name = /datum/reagent/medicine/antihol
-	id = /datum/reagent/medicine/antihol
 	results = list(/datum/reagent/medicine/antihol = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/medicine/charcoal = 1, /datum/reagent/copper = 1)
 
 /datum/chemical_reaction/cryoxadone
-	name = "Cryoxadone"
-	id = /datum/reagent/medicine/cryoxadone
 	results = list(/datum/reagent/medicine/cryoxadone = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/acetone = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/pyroxadone
-	name = "Pyroxadone"
-	id = /datum/reagent/medicine/pyroxadone
 	results = list(/datum/reagent/medicine/pyroxadone = 2)
 	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1, /datum/reagent/toxin/slimejelly = 1)
 
 /datum/chemical_reaction/clonexadone
-	name = "Clonexadone"
-	id = /datum/reagent/medicine/clonexadone
 	results = list(/datum/reagent/medicine/clonexadone = 2)
 	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1, /datum/reagent/sodium = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/haloperidol
-	name = "Haloperidol"
-	id = /datum/reagent/medicine/haloperidol
 	results = list(/datum/reagent/medicine/haloperidol = 5)
 	required_reagents = list(/datum/reagent/chlorine = 1, /datum/reagent/fluorine = 1, /datum/reagent/aluminium = 1, /datum/reagent/medicine/potass_iodide = 1, /datum/reagent/oil = 1)
 
 /datum/chemical_reaction/bicaridine
-	name = "Bicaridine"
-	id = /datum/reagent/medicine/bicaridine
 	results = list(/datum/reagent/medicine/bicaridine = 3)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/dexalin
-	name = "Dexalin"
-	id = "dexalin"
 	results = list(/datum/reagent/medicine/dexalin = 5)
 	required_reagents = list(/datum/reagent/oxygen = 5, /datum/reagent/nitrogen = 5)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/dexalinp
-	name = "Dexalin Plus"
-	id = "dexalinp"
 	results = list(/datum/reagent/medicine/dexalinp = 3)
 	required_reagents = list(/datum/reagent/medicine/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
 
 /datum/chemical_reaction/kelotane
-	name = "Kelotane"
-	id = /datum/reagent/medicine/kelotane
 	results = list(/datum/reagent/medicine/kelotane = 2)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/silicon = 1)
 
 /datum/chemical_reaction/antitoxin
-	name = "Antitoxin"
-	id = /datum/reagent/medicine/antitoxin
 	results = list(/datum/reagent/medicine/antitoxin = 3)
 	required_reagents = list(/datum/reagent/nitrogen = 1, /datum/reagent/silicon = 1, /datum/reagent/potassium = 1)
 
 /datum/chemical_reaction/tricordrazine
-	name = "Tricordrazine"
-	id = /datum/reagent/medicine/tricordrazine
 	results = list(/datum/reagent/medicine/tricordrazine = 3)
 	required_reagents = list(/datum/reagent/medicine/bicaridine = 1, /datum/reagent/medicine/kelotane = 1, /datum/reagent/medicine/antitoxin = 1)
 
 /datum/chemical_reaction/regen_jelly
-	name = "Regenerative Jelly"
-	id = /datum/reagent/medicine/regen_jelly
 	results = list(/datum/reagent/medicine/regen_jelly = 2)
 	required_reagents = list(/datum/reagent/medicine/tricordrazine = 1, /datum/reagent/toxin/slimejelly = 1)
 
 /datum/chemical_reaction/corazone
-	name = "Corazone"
-	id = /datum/reagent/medicine/corazone
 	results = list(/datum/reagent/medicine/corazone = 3)
 	required_reagents = list(/datum/reagent/phenol = 2, /datum/reagent/lithium = 1)
 
 /datum/chemical_reaction/morphine
-	name = "Morphine"
-	id = /datum/reagent/medicine/morphine
 	results = list(/datum/reagent/medicine/morphine = 2)
 	required_reagents = list(/datum/reagent/carbon = 2, /datum/reagent/hydrogen = 2, /datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
 	required_temp = 480
 
 /datum/chemical_reaction/modafinil
-	name = "Modafinil"
-	id = /datum/reagent/medicine/modafinil
 	results = list(/datum/reagent/medicine/modafinil = 5)
 	required_reagents = list(/datum/reagent/diethylamine = 1, /datum/reagent/ammonia = 1, /datum/reagent/phenol = 1, /datum/reagent/acetone = 1, /datum/reagent/toxin/acid = 1)
 	required_catalysts = list(/datum/reagent/bromine = 1) // as close to the real world synthesis as possible
 
 /datum/chemical_reaction/psicodine
-	name = "Psicodine"
-	id = /datum/reagent/medicine/psicodine
 	results = list(/datum/reagent/medicine/psicodine = 5)
 	required_reagents = list( /datum/reagent/medicine/mannitol = 2, /datum/reagent/water = 2, /datum/reagent/impedrezene = 1)
 
 /datum/chemical_reaction/system_cleaner
-	name = "System Cleaner"
-	id = /datum/reagent/medicine/system_cleaner
 	results = list(/datum/reagent/medicine/system_cleaner = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/chlorine = 1, /datum/reagent/phenol = 2, /datum/reagent/potassium = 1)
 
 /datum/chemical_reaction/liquid_solder
-	name = "Liquid Solder"
-	id = /datum/reagent/medicine/liquid_solder
 	results = list(/datum/reagent/medicine/liquid_solder = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/copper = 1, /datum/reagent/silver = 1)
 	required_temp = 370
 	mix_message = "The mixture becomes a metallic slurry."
 
 /datum/chemical_reaction/carthatoline
-	name = "Carthatoline"
-	id = "carthatoline"
 	results = list(/datum/reagent/medicine/carthatoline = 3)
 	required_reagents = list(/datum/reagent/medicine/antitoxin = 1, /datum/reagent/carbon = 2)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
 
 /datum/chemical_reaction/meclizine
-	name = "Meclizine"
-	id = /datum/reagent/medicine/meclizine
 	results = list(/datum/reagent/medicine/meclizine = 4)
 	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/chlorine = 1, /datum/reagent/carbon = 2)
 
 /datum/chemical_reaction/hepanephrodaxon
-	name = "Hepanephrodaxon"
-	id = "hepanephrodaxon"
 	results = list(/datum/reagent/medicine/hepanephrodaxon = 5)
 	required_reagents = list(/datum/reagent/medicine/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/liquidelectricity
-	name = "Liquid Electricity"
-	id = /datum/reagent/consumable/liquidelectricity
 	results = list(/datum/reagent/consumable/liquidelectricity = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/consumable/liquidelectricity = 1, /datum/reagent/toxin/plasma = 1)
 	mix_message = "The mixture sparks and then subsides."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -2,62 +2,42 @@
 
 
 /datum/chemical_reaction/sterilizine
-	name = "Sterilizine"
-	id = /datum/reagent/space_cleaner/sterilizine
 	results = list(/datum/reagent/space_cleaner/sterilizine = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/medicine/charcoal = 1, /datum/reagent/chlorine = 1)
 
 /datum/chemical_reaction/cooking_oil
-	name = "Cooking Oil"
-	id = /datum/reagent/consumable/cooking_oil
 	results = list(/datum/reagent/consumable/cooking_oil = 4)
 	required_reagents = list(/datum/reagent/hydrogen = 1, /datum/reagent/oil = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/carbon = 1)
 
 /datum/chemical_reaction/lube
-	name = "Space Lube"
-	id = /datum/reagent/lube
 	results = list(/datum/reagent/lube = 4)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/spraytan
-	name = "Spray Tan"
-	id = /datum/reagent/spraytan
 	results = list(/datum/reagent/spraytan = 2)
 	required_reagents = list(/datum/reagent/consumable/orangejuice = 1, /datum/reagent/oil = 1)
 
 /datum/chemical_reaction/spraytan2
-	name = "Spray Tan"
-	id = /datum/reagent/spraytan
 	results = list(/datum/reagent/spraytan = 2)
 	required_reagents = list(/datum/reagent/consumable/orangejuice = 1, /datum/reagent/consumable/cornoil = 1)
 
 /datum/chemical_reaction/impedrezene
-	name = "Impedrezene"
-	id = /datum/reagent/impedrezene
 	results = list(/datum/reagent/impedrezene = 2)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/cryptobiolin
-	name = "Cryptobiolin"
-	id = /datum/reagent/cryptobiolin
 	results = list(/datum/reagent/cryptobiolin = 3)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/glycerol
-	name = "Glycerol"
-	id = /datum/reagent/glycerol
 	results = list(/datum/reagent/glycerol = 1)
 	required_reagents = list(/datum/reagent/consumable/cornoil = 3, /datum/reagent/toxin/acid = 1)
 
 /datum/chemical_reaction/sodiumchloride
-	name = "Sodium Chloride"
-	id = /datum/reagent/consumable/sodiumchloride
 	results = list(/datum/reagent/consumable/sodiumchloride = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/sodium = 1, /datum/reagent/chlorine = 1)
 
 /datum/chemical_reaction/plasmasolidification
-	name = "Solid Plasma"
-	id = "solidplasma"
 	required_reagents = list(/datum/reagent/iron = 5, /datum/reagent/consumable/frostoil = 5, /datum/reagent/toxin/plasma = 20)
 	mob_react = FALSE
 
@@ -67,8 +47,6 @@
 		new /obj/item/stack/sheet/mineral/plasma(location)
 
 /datum/chemical_reaction/goldsolidification
-	name = "Solid Gold"
-	id = "solidgold"
 	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/gold = 20, /datum/reagent/iron = 1)
 	mob_react = FALSE
 
@@ -78,8 +56,6 @@
 		new /obj/item/stack/sheet/mineral/gold(location)
 
 /datum/chemical_reaction/adamantinesolidification
-	name = "Adamantine Sheet"
-	id = "solidadam"
 	required_reagents = list(/datum/reagent/gold = 5, /datum/reagent/consumable/frostoil = 5, /datum/reagent/liquidadamantine = 10)
 	mob_react = FALSE
 
@@ -89,14 +65,10 @@
 		new /obj/item/stack/sheet/mineral/adamantine(location)
 
 /datum/chemical_reaction/capsaicincondensation
-	name = "Capsaicincondensation"
-	id = "capsaicincondensation"
 	results = list(/datum/reagent/consumable/condensedcapsaicin = 5)
 	required_reagents = list(/datum/reagent/consumable/capsaicin = 1, /datum/reagent/consumable/ethanol = 5)
 
 /datum/chemical_reaction/soapification
-	name = "Soapification"
-	id = "soapification"
 	required_reagents = list(/datum/reagent/liquidgibs = 10, /datum/reagent/lye  = 10) // requires two scooped gib tiles
 	required_temp = 374
 	mob_react = FALSE
@@ -107,8 +79,6 @@
 		new /obj/item/soap/homemade(location)
 
 /datum/chemical_reaction/candlefication
-	name = "Candlefication"
-	id = "candlefication"
 	required_reagents = list(/datum/reagent/liquidgibs = 5, /datum/reagent/oxygen  = 5) //
 	required_temp = 374
 	mob_react = FALSE
@@ -119,8 +89,6 @@
 		new /obj/item/candle(location)
 
 /datum/chemical_reaction/meatification
-	name = "Meatification"
-	id = "meatification"
 	required_reagents = list(/datum/reagent/liquidgibs = 10, /datum/reagent/consumable/nutriment = 10, /datum/reagent/carbon = 10)
 	mob_react = FALSE
 
@@ -131,111 +99,77 @@
 	return
 
 /datum/chemical_reaction/carbondioxide
-	name = "Direct Carbon Oxidation"
-	id = "burningcarbon"
 	results = list(/datum/reagent/carbondioxide = 3)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 2)
 	required_temp = 777 // pure carbon isn't especially reactive.
 
 /datum/chemical_reaction/nitrous_oxide
-	name = "Nitrous Oxide"
-	id = /datum/reagent/nitrous_oxide
 	results = list(/datum/reagent/nitrous_oxide = 5)
 	required_reagents = list(/datum/reagent/ammonia = 2, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 2)
 	required_temp = 525
 
 //Technically a mutation toxin
 /datum/chemical_reaction/mulligan
-	name = "Mulligan"
-	id = /datum/reagent/mulligan
 	results = list(/datum/reagent/mulligan = 1)
 	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/toxin/mutagen = 1)
 
 ////////////////////////////////// VIROLOGY //////////////////////////////////////////
 
 /datum/chemical_reaction/virus_food
-	name = "Virus Food"
-	id = /datum/reagent/consumable/virus_food
 	results = list(/datum/reagent/consumable/virus_food = 15)
 	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/consumable/milk = 5)
 
 /datum/chemical_reaction/virus_food_mutagen
-	name = "mutagenic agar"
-	id = /datum/reagent/toxin/mutagen/mutagenvirusfood
 	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
 	required_reagents = list(/datum/reagent/toxin/mutagen = 1, /datum/reagent/consumable/virus_food = 1)
 
 /datum/chemical_reaction/virus_food_synaptizine
-	name = "virus rations"
-	id = /datum/reagent/medicine/synaptizine/synaptizinevirusfood
 	results = list(/datum/reagent/medicine/synaptizine/synaptizinevirusfood = 1)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/consumable/virus_food = 1)
 
 /datum/chemical_reaction/virus_food_plasma
-	name = "virus plasma"
-	id = /datum/reagent/toxin/plasma/plasmavirusfood
 	results = list(/datum/reagent/toxin/plasma/plasmavirusfood = 1)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/consumable/virus_food = 1)
 
 /datum/chemical_reaction/virus_food_plasma_synaptizine
-	name = "weakened virus plasma"
-	id = /datum/reagent/toxin/plasma/plasmavirusfood/weak
 	results = list(/datum/reagent/toxin/plasma/plasmavirusfood/weak = 2)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
 
 /datum/chemical_reaction/virus_food_mutagen_sugar
-	name = "sucrose agar"
-	id = /datum/reagent/toxin/mutagen/mutagenvirusfood/sugar
 	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 2)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
 
 /datum/chemical_reaction/virus_food_mutagen_salineglucose
-	name = "sucrose agar"
-	id = "salineglucosevirusfood"
 	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 2)
 	required_reagents = list(/datum/reagent/medicine/salglu_solution = 1, /datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
 
 /datum/chemical_reaction/virus_food_uranium
-	name = "Decaying uranium gel"
-	id = /datum/reagent/uranium/uraniumvirusfood
 	results = list(/datum/reagent/uranium/uraniumvirusfood = 1)
 	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/consumable/virus_food = 1)
 
 /datum/chemical_reaction/virus_food_uranium_plasma
-	name = "Unstable uranium gel"
-	id = "uraniumvirusfood_plasma"
 	results = list(/datum/reagent/uranium/uraniumvirusfood/unstable = 1)
 	required_reagents = list(/datum/reagent/uranium = 2, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
 
 /datum/chemical_reaction/virus_food_uranium_plasma_gold
-	name = "Stable uranium gel"
-	id = "uraniumvirusfood_gold"
 	results = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
 	required_reagents = list(/datum/reagent/uranium = 5, /datum/reagent/gold = 5, /datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/virus_food_uranium_plasma_silver
-	name = "Stable uranium gel"
-	id = "uraniumvirusfood_silver"
 	results = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
 	required_reagents = list(/datum/reagent/uranium = 5, /datum/reagent/silver = 5, /datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/virus_food_laughter
-	name = "Anomolous virus food"
-	id = "virusfood_laughter"
 	results = list(/datum/reagent/consumable/laughter/laughtervirusfood = 1)
 	required_reagents = list(/datum/reagent/consumable/laughter = 5, /datum/reagent/consumable/virus_food = 1)
 
 /datum/chemical_reaction/virus_food_admin
-	name = "Highly unstable virus Food"
-	id = "virusfood_admin"
 	results = list(/datum/reagent/consumable/virus_food/advvirusfood = 1)
 	required_reagents = list(/datum/reagent/consumable/virus_food/viralbase = 1, /datum/reagent/uranium = 20)
 	mix_message = "The mixture turns every colour of the rainbow, soon settling on a bright white. There's no way this isn't a good idea."
 
 //Adds a virus symptom from the level_min to level_max range
 /datum/chemical_reaction/mix_virus
-	name = "Mix Virus"
-	id = "mixvirus"
 	required_reagents = list(/datum/reagent/consumable/virus_food = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 	var/level_min = 1
@@ -260,100 +194,72 @@
 		target.logchanges(holder, "EVOLVE")
 
 /datum/chemical_reaction/mix_virus/mix_virus_2
-	name = "Mix Virus 2"
-	id = "mixvirus2"
 	required_reagents = list(/datum/reagent/toxin/mutagen = 1)
 	level_min = 2
 	level_max = 4
 
 /datum/chemical_reaction/mix_virus/mix_virus_3
-	name = "Mix Virus 3"
-	id = "mixvirus3"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	level_min = 4
 	level_max = 6
 
 /datum/chemical_reaction/mix_virus/mix_virus_4
-	name = "Mix Virus 4"
-	id = "mixvirus4"
 	required_reagents = list(/datum/reagent/uranium = 1)
 	level_min = 5
 	level_max = 6
 
 /datum/chemical_reaction/mix_virus/mix_virus_5
-	name = "Mix Virus 5"
-	id = "mixvirus5"
 	required_reagents = list(/datum/reagent/toxin/mutagen/mutagenvirusfood = 1)
 	level_min = 3
 	level_max = 3
 
 /datum/chemical_reaction/mix_virus/mix_virus_6
-	name = "Mix Virus 6"
-	id = "mixvirus6"
 	required_reagents = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 1)
 	level_min = 4
 	level_max = 4
 
 /datum/chemical_reaction/mix_virus/mix_virus_7
-	name = "Mix Virus 7"
-	id = "mixvirus7"
 	required_reagents = list(/datum/reagent/toxin/plasma/plasmavirusfood/weak = 1)
 	level_min = 5
 	level_max = 5
 
 /datum/chemical_reaction/mix_virus/mix_virus_8
-	name = "Mix Virus 8"
-	id = "mixvirus8"
 	required_reagents = list(/datum/reagent/toxin/plasma/plasmavirusfood = 1)
 	level_min = 6
 	level_max = 6
 
 /datum/chemical_reaction/mix_virus/mix_virus_9
-	name = "Mix Virus 9"
-	id = "mixvirus9"
 	required_reagents = list(/datum/reagent/medicine/synaptizine/synaptizinevirusfood = 1)
 	level_min = 1
 	level_max = 1
 
 /datum/chemical_reaction/mix_virus/mix_virus_10
-	name = "Mix Virus 10"
-	id = "mixvirus10"
 	required_reagents = list(/datum/reagent/uranium/uraniumvirusfood = 1)
 	level_min = 6
 	level_max = 7
 
 /datum/chemical_reaction/mix_virus/mix_virus_11
-	name = "Mix Virus 11"
-	id = "mixvirus11"
 	required_reagents = list(/datum/reagent/uranium/uraniumvirusfood/unstable = 1)
 	level_min = 7
 	level_max = 7
 
 /datum/chemical_reaction/mix_virus/mix_virus_12
-	name = "Mix Virus 12"
-	id = "mixvirus12"
 	required_reagents = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
 	level_min = 8
 	level_max = 8
 
 /datum/chemical_reaction/mix_virus/mix_virus_13
-	name = "Mix Virus 13"
-	id = "mixvirus13"
 	required_reagents = list(/datum/reagent/consumable/laughter/laughtervirusfood = 1)
 	level_min = 0
 	level_max = 0
 
 /datum/chemical_reaction/mix_virus/mix_virus_14
-	name = "Mix Virus 14"
-	id = "mixvirus14"
 	required_reagents = list(/datum/reagent/consumable/virus_food/advvirusfood = 1)
 	level_min = 9
 	level_max = 9
 
 //removes a random disease symptom
 /datum/chemical_reaction/mix_virus/rem_virus
-	name = "Devolve Virus"
-	id = "remvirus"
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
@@ -365,8 +271,6 @@
 
 //prevents a random symptom from showing while keeping the stats
 /datum/chemical_reaction/mix_virus/neuter_virus
-	name = "Neuter Virus"
-	id = "neutervirus"
 	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
@@ -378,8 +282,6 @@
 
 //prevents the altering of disease symptoms
 /datum/chemical_reaction/mix_virus/preserve_virus
-	name = "Preserve Virus"
-	id = "preservevirus"
 	required_reagents = list(/datum/reagent/cryostylane = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
@@ -391,8 +293,6 @@
 
 //prevents the disease from spreading via symptoms
 /datum/chemical_reaction/mix_virus/falter_virus
-	name = "Falter Virus"
-	id = "faltervirus"
 	required_reagents = list(/datum/reagent/medicine/spaceacillin = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
@@ -409,14 +309,10 @@
 
 
 /datum/chemical_reaction/surfactant
-	name = "Foam surfactant"
-	id = "foam surfactant"
 	results = list(/datum/reagent/fluorosurfactant = 5)
 	required_reagents = list(/datum/reagent/fluorine = 2, /datum/reagent/carbon = 2, /datum/reagent/toxin/acid = 1)
 
 /datum/chemical_reaction/foam
-	name = "Foam"
-	id = "foam"
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water = 1)
 	mob_react = FALSE
 
@@ -432,8 +328,6 @@
 
 
 /datum/chemical_reaction/metalfoam
-	name = "Metal Foam"
-	id = "metalfoam"
 	required_reagents = list(/datum/reagent/aluminium = 3, /datum/reagent/foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
 	mob_react = FALSE
 
@@ -449,8 +343,6 @@
 	holder.clear_reagents()
 
 /datum/chemical_reaction/smart_foam
-	name = "Smart Metal Foam"
-	id = "smart_metal_foam"
 	required_reagents = list(/datum/reagent/aluminium = 3, /datum/reagent/smart_foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
 	mob_react = TRUE
 
@@ -463,8 +355,6 @@
 	holder.clear_reagents()
 
 /datum/chemical_reaction/ironfoam
-	name = "Iron Foam"
-	id = "ironlfoam"
 	required_reagents = list(/datum/reagent/iron = 3, /datum/reagent/foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
 	mob_react = FALSE
 
@@ -478,14 +368,10 @@
 	holder.clear_reagents()
 
 /datum/chemical_reaction/foaming_agent
-	name = "Foaming Agent"
-	id = /datum/reagent/foaming_agent
 	results = list(/datum/reagent/foaming_agent = 1)
 	required_reagents = list(/datum/reagent/lithium = 1, /datum/reagent/hydrogen = 1)
 
 /datum/chemical_reaction/smart_foaming_agent
-	name = "Smart foaming Agent"
-	id = /datum/reagent/smart_foaming_agent
 	results = list(/datum/reagent/smart_foaming_agent = 3)
 	required_reagents = list(/datum/reagent/foaming_agent = 3, /datum/reagent/acetone = 1, /datum/reagent/iron = 1)
 	mix_message = "The solution mixes into a frothy metal foam and conforms to the walls of its container."
@@ -494,146 +380,100 @@
 /////////////////////////////// Cleaning and hydroponics /////////////////////////////////////////////////
 
 /datum/chemical_reaction/ammonia
-	name = "Ammonia"
-	id = /datum/reagent/ammonia
 	results = list(/datum/reagent/ammonia = 3)
 	required_reagents = list(/datum/reagent/hydrogen = 3, /datum/reagent/nitrogen = 1)
 
 /datum/chemical_reaction/diethylamine
-	name = "Diethylamine"
-	id = /datum/reagent/diethylamine
 	results = list(/datum/reagent/diethylamine = 2)
 	required_reagents = list (/datum/reagent/ammonia = 1, /datum/reagent/consumable/ethanol = 1)
 
 /datum/chemical_reaction/space_cleaner
-	name = "Space cleaner"
-	id = /datum/reagent/space_cleaner
 	results = list(/datum/reagent/space_cleaner = 2)
 	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/plantbgone
-	name = "Plant-B-Gone"
-	id = /datum/reagent/toxin/plantbgone
 	results = list(/datum/reagent/toxin/plantbgone = 5)
 	required_reagents = list(/datum/reagent/toxin = 1, /datum/reagent/water = 4)
 
 /datum/chemical_reaction/weedkiller
-	name = "Weed Killer"
-	id = /datum/reagent/toxin/plantbgone/weedkiller
 	results = list(/datum/reagent/toxin/plantbgone/weedkiller = 5)
 	required_reagents = list(/datum/reagent/toxin = 1, /datum/reagent/ammonia = 4)
 
 /datum/chemical_reaction/pestkiller
-	name = "Pest Killer"
-	id = /datum/reagent/toxin/pestkiller
 	results = list(/datum/reagent/toxin/pestkiller = 5)
 	required_reagents = list(/datum/reagent/toxin = 1, /datum/reagent/consumable/ethanol = 4)
 
 /datum/chemical_reaction/drying_agent
-	name = "Drying agent"
-	id = /datum/reagent/drying_agent
 	results = list(/datum/reagent/drying_agent = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 2, /datum/reagent/consumable/ethanol = 1, /datum/reagent/sodium = 1)
 
 //////////////////////////////////// Other goon stuff ///////////////////////////////////////////
 
 /datum/chemical_reaction/acetone
-	name = /datum/reagent/acetone
-	id = /datum/reagent/acetone
 	results = list(/datum/reagent/acetone = 3)
 	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/fuel = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/carpet
-	name = /datum/reagent/carpet
-	id = /datum/reagent/carpet
 	results = list(/datum/reagent/carpet = 10)
 	required_reagents = list(/datum/reagent/drug/space_drugs = 1, /datum/reagent/blood = 1)
 
 /datum/chemical_reaction/carpet/black
-	name = /datum/reagent/carpet/black
-	id = /datum/reagent/carpet/black
 	results = list(/datum/reagent/carpet/black = 2)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/oil = 0.1)
 
 /datum/chemical_reaction/carpet/blue
-	name = /datum/reagent/carpet/blue
-	id = /datum/reagent/carpet/blue
 	results = list(/datum/reagent/carpet/blue = 2)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/cryostylane = 0.1)
 
 /datum/chemical_reaction/carpet/cyan
-	name = /datum/reagent/carpet/cyan
-	id = /datum/reagent/carpet/cyan
 	results = list(/datum/reagent/carpet/cyan = 2)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/toxin/cyanide = 0.1)
 	//cyan = cyanide get it huehueuhuehuehheuhe
 
 /datum/chemical_reaction/carpet/green
-	name = /datum/reagent/carpet/green
-	id = /datum/reagent/carpet/green
 	results = list(/datum/reagent/carpet/green = 2)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/consumable/ethanol/beer/green = 0.1)
 	//make green beer by grinding up green crayons and mixing with beer
 
 /datum/chemical_reaction/carpet/orange
-	name = /datum/reagent/carpet/orange
-	id = /datum/reagent/carpet/orange
 	results = list(/datum/reagent/carpet/orange = 2)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/consumable/orangejuice = 0.1)
 
 /datum/chemical_reaction/carpet/purple
-	name = /datum/reagent/carpet/purple
-	id = /datum/reagent/carpet/purple
 	results = list(/datum/reagent/carpet/purple = 2)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/medicine/regen_jelly = 0.1)
 	//slimes only party
 
 /datum/chemical_reaction/carpet/red
-	name = /datum/reagent/carpet/red
-	id = /datum/reagent/carpet/red
 	results = list(/datum/reagent/carpet/red = 2)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/liquidgibs = 0.1)
 
 /datum/chemical_reaction/carpet/royalblack
-	name = /datum/reagent/carpet/royal/black
-	id = /datum/reagent/carpet/royal/black
 	results = list(/datum/reagent/carpet/royal/black = 2)
 	required_reagents = list(/datum/reagent/carpet/black = 1, /datum/reagent/royal_bee_jelly = 0.1)
 
 /datum/chemical_reaction/carpet/royalblue
-	name = /datum/reagent/carpet/royal/blue
-	id = /datum/reagent/carpet/royal/blue
 	results = list(/datum/reagent/carpet/royal/blue = 2)
 	required_reagents = list(/datum/reagent/carpet/blue = 1, /datum/reagent/royal_bee_jelly = 0.1)
 
 /datum/chemical_reaction/oil
-	name = "Oil"
-	id = /datum/reagent/oil
 	results = list(/datum/reagent/oil = 3)
 	required_reagents = list(/datum/reagent/fuel = 1, /datum/reagent/carbon = 1, /datum/reagent/hydrogen = 1)
 
 /datum/chemical_reaction/phenol
-	name = /datum/reagent/phenol
-	id = /datum/reagent/phenol
 	results = list(/datum/reagent/phenol = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/chlorine = 1, /datum/reagent/oil = 1)
 
 /datum/chemical_reaction/ash
-	name = "Ash"
-	id = /datum/reagent/ash
 	results = list(/datum/reagent/ash = 1)
 	required_reagents = list(/datum/reagent/oil = 1)
 	required_temp = 480
 
 /datum/chemical_reaction/colorful_reagent
-	name = /datum/reagent/colorful_reagent
-	id = /datum/reagent/colorful_reagent
 	results = list(/datum/reagent/colorful_reagent = 5)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/space_drugs = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/consumable/triple_citrus = 1)
 
 /datum/chemical_reaction/life
-	name = "Life"
-	id = "life"
 	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/blood = 1)
 	required_temp = 374
 
@@ -641,8 +481,6 @@
 	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (hostile)") //defaults to HOSTILE_SPAWN
 
 /datum/chemical_reaction/life_friendly
-	name = "Life (Friendly)"
-	id = "life_friendly"
 	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/consumable/sugar = 1)
 	required_temp = 374
 
@@ -650,8 +488,6 @@
 	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (friendly)", FRIENDLY_SPAWN)
 
 /datum/chemical_reaction/corgium
-	name = "corgium"
-	id = "corgium"
 	required_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/colorful_reagent = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/blood = 1)
 
 /datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, created_volume)
@@ -665,68 +501,46 @@
 	..()
 
 /datum/chemical_reaction/hair_dye
-	name = /datum/reagent/hair_dye
-	id = /datum/reagent/hair_dye
 	results = list(/datum/reagent/hair_dye = 5)
 	required_reagents = list(/datum/reagent/colorful_reagent = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/space_drugs = 1)
 
 /datum/chemical_reaction/barbers_aid
-	name = /datum/reagent/barbers_aid
-	id = /datum/reagent/barbers_aid
 	results = list(/datum/reagent/barbers_aid = 5)
 	required_reagents = list(/datum/reagent/carpet = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/drug/space_drugs = 1)
 
 /datum/chemical_reaction/concentrated_barbers_aid
-	name = /datum/reagent/concentrated_barbers_aid
-	id = /datum/reagent/concentrated_barbers_aid
 	results = list(/datum/reagent/concentrated_barbers_aid = 2)
 	required_reagents = list(/datum/reagent/barbers_aid = 1, /datum/reagent/toxin/mutagen = 1)
 
 /datum/chemical_reaction/barbers_afro_mania
-	name = /datum/reagent/barbers_afro_mania
-	id = /datum/reagent/barbers_afro_mania
 	results = list(/datum/reagent/barbers_afro_mania = 2)
 	required_reagents = list(/datum/reagent/concentrated_barbers_aid = 1, /datum/reagent/colorful_reagent = 1)
 
 /datum/chemical_reaction/barbers_shaving_aid
-	name = /datum/reagent/barbers_shaving_aid
-	id = /datum/reagent/barbers_shaving_aid
 	results = list(/datum/reagent/barbers_shaving_aid = 2)
 	required_reagents = list(/datum/reagent/concentrated_barbers_aid = 1, /datum/reagent/napalm = 1)
 
 /datum/chemical_reaction/saltpetre
-	name = /datum/reagent/saltpetre
-	id = /datum/reagent/saltpetre
 	results = list(/datum/reagent/saltpetre = 3)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 3)
 
 /datum/chemical_reaction/lye
-	name = /datum/reagent/lye
-	id = /datum/reagent/lye
 	results = list(/datum/reagent/lye = 3)
 	required_reagents = list(/datum/reagent/sodium = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/lye2
-	name = /datum/reagent/lye
-	id = /datum/reagent/lye
 	results = list(/datum/reagent/lye = 2)
 	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/water = 1, /datum/reagent/carbon = 1)
 
 /datum/chemical_reaction/royal_bee_jelly
-	name = "royal bee jelly"
-	id = /datum/reagent/royal_bee_jelly
 	results = list(/datum/reagent/royal_bee_jelly = 5)
 	required_reagents = list(/datum/reagent/toxin/mutagen = 10, /datum/reagent/consumable/honey = 40)
 
 /datum/chemical_reaction/laughter
-	name = /datum/reagent/consumable/laughter
-	id = /datum/reagent/consumable/laughter
 	results = list(/datum/reagent/consumable/laughter = 10) // Fuck it. I'm not touching this one.
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/banana = 1)
 
 /datum/chemical_reaction/plastic_polymers
-	name = "plastic polymers"
-	id = /datum/reagent/plastic_polymers
 	required_reagents = list(/datum/reagent/oil = 5, /datum/reagent/toxin/acid = 2, /datum/reagent/ash = 3)
 	required_temp = 374 //lazily consistent with soap & other crafted objects generically created with heat.
 
@@ -736,33 +550,23 @@
 		new /obj/item/stack/sheet/plastic(location)
 
 /datum/chemical_reaction/glitter
-	name = "light pink glitter"
-	id = /datum/reagent/glitter
 	results = list(/datum/reagent/glitter = 10)
 	required_reagents = list(/datum/reagent/oil = 5, /datum/reagent/toxin/acid = 2, /datum/reagent/ash = 3, /datum/reagent/aluminium = 2)
 	required_temp = 340 //arbitrarily lower than plastic to prevent conflict
 
 /datum/chemical_reaction/glitter/pink
-	name = "pink glitter"
-	id = /datum/reagent/glitter/pink
 	results = list(/datum/reagent/glitter/pink = 5)
 	required_reagents = list(/datum/reagent/glitter = 5, /datum/reagent/stable_plasma = 1)
 
 /datum/chemical_reaction/glitter/white
-	name = "white glitter"
-	id = /datum/reagent/glitter/white
 	results = list(/datum/reagent/glitter/white = 5)
 	required_reagents = list(/datum/reagent/glitter = 5, /datum/reagent/consumable/sugar = 1)
 
 /datum/chemical_reaction/glitter/blue
-	name = "blue glitter"
-	id = /datum/reagent/glitter/blue
 	results = list(/datum/reagent/glitter/blue = 5)
 	required_reagents = list(/datum/reagent/glitter = 5, /datum/reagent/nitrogen = 1)
 
 /datum/chemical_reaction/pax
-	name = /datum/reagent/pax
-	id = /datum/reagent/pax
 	results = list(/datum/reagent/pax = 3)
 	required_reagents  = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/water = 1)
 
@@ -770,76 +574,52 @@
 //////////////////EXPANDED MUTATION TOXINS/////////////////////
 
 /datum/chemical_reaction/mutationtoxin/stable
-	name = /datum/reagent/mutationtoxin
-	id = /datum/reagent/mutationtoxin
 	results = list(/datum/reagent/mutationtoxin = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/blood = 10)
 
 /datum/chemical_reaction/mutationtoxin/lizard
-	name = /datum/reagent/mutationtoxin/lizard
-	id = /datum/reagent/mutationtoxin/lizard
 	results = list(/datum/reagent/mutationtoxin/lizard = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/liquidgibs = 10)
 
 /datum/chemical_reaction/mutationtoxin/felinid
-	name = /datum/reagent/mutationtoxin/felinid
-	id = /datum/reagent/mutationtoxin/felinid
 	results = list(/datum/reagent/mutationtoxin/felinid = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/toxin/fentanyl = 10, /datum/reagent/impedrezene = 10)
 
 /datum/chemical_reaction/mutationtoxin/fly
-	name = /datum/reagent/mutationtoxin/fly
-	id = /datum/reagent/mutationtoxin/fly
 	results = list(/datum/reagent/mutationtoxin/fly = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/toxin/mutagen = 10)
 
 /datum/chemical_reaction/mutationtoxin/moth
-	name = /datum/reagent/mutationtoxin/moth
-	id = /datum/reagent/mutationtoxin/moth
 	results = list(/datum/reagent/mutationtoxin/moth = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/toxin/lipolicide = 10) //I know it's the opposite of what moths like, but I am out of ideas for this.
 
 /datum/chemical_reaction/mutationtoxin/apid
-	name = /datum/reagent/mutationtoxin/apid
-	id = /datum/reagent/mutationtoxin/apid
 	results = list(/datum/reagent/mutationtoxin/apid = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/honey = 20) // beeeeeeeeeeeeeeeeeeeeees
 
 /datum/chemical_reaction/mutationtoxin/pod
-	name = /datum/reagent/mutationtoxin/pod
-	id = /datum/reagent/mutationtoxin/pod
 	results = list(/datum/reagent/mutationtoxin/pod = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/plantnutriment/eznutriment = 10)
 
 /datum/chemical_reaction/mutationtoxin/golem
-	name = /datum/reagent/mutationtoxin/golem
-	id = /datum/reagent/mutationtoxin/golem
 	results = list(/datum/reagent/mutationtoxin/golem = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/liquidadamantine = 20)
 
 /datum/chemical_reaction/mutationtoxin/abductor
-	name = /datum/reagent/mutationtoxin/abductor
-	id = /datum/reagent/mutationtoxin/abductor
 	results = list(/datum/reagent/mutationtoxin/abductor = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/medicine/morphine = 10, /datum/reagent/toxin/mutetoxin = 10)
 
 /datum/chemical_reaction/mutationtoxin/ethereal
-	name = /datum/reagent/mutationtoxin/ethereal
-	id = /datum/reagent/mutationtoxin/ethereal
 	results = list(/datum/reagent/mutationtoxin/ethereal = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/liquidelectricity = 20)
 
 /datum/chemical_reaction/mutationtoxin/oozeling
-	name = /datum/reagent/mutationtoxin/oozeling
-	id = /datum/reagent/mutationtoxin/oozeling
 	results = list(/datum/reagent/mutationtoxin/oozeling = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/medicine/calomel = 10, /datum/reagent/toxin/bad_food = 30, /datum/reagent/stable_plasma = 5)
 
 //////////////Mutation toxins made out of advanced toxin/////////////
 
 /datum/chemical_reaction/mutationtoxin/skeleton
-	name = /datum/reagent/mutationtoxin/skeleton
-	id = /datum/reagent/mutationtoxin/skeleton
 	results = list(/datum/reagent/mutationtoxin/skeleton = 5)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/consumable/milk = 30, /datum/reagent/toxin/acid/fluacid = 30) //Because acid melts flesh off.
 
@@ -850,31 +630,21 @@
 //	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/toxin = 1, /datum/reagent/toxin/bad_food = 1) //Because rotting
 
 /datum/chemical_reaction/mutationtoxin/goofzombie //go on. try it with holopara
-	name = /datum/reagent/mutationtoxin/goofzombie
-	id = /datum/reagent/mutationtoxin/goofzombie
 	results = list(/datum/reagent/mutationtoxin/goofzombie = 5)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/drug/krokodil = 10, /datum/reagent/toxin/bad_food = 10) //Because rotting
 
 /datum/chemical_reaction/mutationtoxin/ash
-	name = /datum/reagent/mutationtoxin/ash
-	id = /datum/reagent/mutationtoxin/ash
 	results = list(/datum/reagent/mutationtoxin/ash = 5)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 10, /datum/reagent/consumable/entpoly = 5)
 
 /datum/chemical_reaction/mutationtoxin/shadow
-	name = /datum/reagent/mutationtoxin/shadow
-	id = /datum/reagent/mutationtoxin/shadow
 	results = list(/datum/reagent/mutationtoxin/shadow = 5)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/liquid_dark_matter = 30, /datum/reagent/water/holywater = 10) //You need a tiny bit of thinking how to mix it
 
 /datum/chemical_reaction/mutationtoxin/plasma
-	name = /datum/reagent/mutationtoxin/plasma
-	id = /datum/reagent/mutationtoxin/plasma
 	results = list(/datum/reagent/mutationtoxin/plasma = 5)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/toxin/plasma = 60, /datum/reagent/uranium = 20)
 
 /datum/chemical_reaction/mutationtoxin/psyphoza
-	name = /datum/reagent/mutationtoxin/psyphoza
-	id = /datum/reagent/mutationtoxin/psyphoza
 	results = list(/datum/reagent/mutationtoxin/psyphoza = 5)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/toxin/amatoxin = 5)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -1,6 +1,4 @@
 /datum/chemical_reaction/reagent_explosion
-	name = "Generic explosive"
-	id = "reagent_explosion"
 	var/strengthdiv = 10
 	var/modifier = 0
 
@@ -35,8 +33,6 @@
 	log_game("[src] created at [AREACOORD(T)]. Last Fingerprint: [lastkey ? lastkey : "N/A"]." )
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin
-	name = "Nitroglycerin"
-	id = /datum/reagent/nitroglycerin
 	results = list(/datum/reagent/nitroglycerin = 2)
 	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/toxin/acid/fluacid = 1, /datum/reagent/toxin/acid = 1)
 	strengthdiv = 2
@@ -48,22 +44,16 @@
 	..()
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin_explosion
-	name = "Nitroglycerin explosion"
-	id = "nitroglycerin_explosion"
 	required_reagents = list(/datum/reagent/nitroglycerin = 1)
 	required_temp = 474
 	strengthdiv = 2
 
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
-	name = "Potassium Water explosion"
-	id = "potassium_explosion"
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
 	strengthdiv = 10
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom
-	name = "Holy Explosion"
-	id = "holyboom"
 	required_reagents = list(/datum/reagent/water/holywater = 1, /datum/reagent/potassium = 1)
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom/on_reaction(datum/reagents/holder, created_volume)
@@ -88,8 +78,6 @@
 			C.IgniteMob()
 
 /datum/chemical_reaction/plasma
-	name = "Plasma Flash"
-	id = /datum/reagent/toxin/plasma
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_temp = 320 //extremely volatile
 
@@ -98,8 +86,6 @@
 	holder.clear_reagents()
 
 /datum/chemical_reaction/blackpowder
-	name = "Black Powder"
-	id = /datum/reagent/blackpowder
 	results = list(/datum/reagent/blackpowder = 3)
 	required_reagents = list(/datum/reagent/saltpetre = 1, /datum/reagent/medicine/charcoal = 1, /datum/reagent/sulfur = 1)
 
@@ -107,8 +93,6 @@
 	reaction_alert_admins(holder)
 
 /datum/chemical_reaction/reagent_explosion/blackpowder_explosion
-	name = "Black Powder explosion"
-	id = "blackpowder_explosion"
 	required_reagents = list(/datum/reagent/blackpowder = 1)
 	required_temp = 474
 	strengthdiv = 6
@@ -119,14 +103,10 @@
 	addtimer(CALLBACK(src, PROC_REF(explode), holder, created_volume, modifier, strengthdiv), rand(5,10) SECONDS)
 
 /datum/chemical_reaction/thermite
-	name = "Thermite"
-	id = /datum/reagent/thermite
 	results = list(/datum/reagent/thermite = 3)
 	required_reagents = list(/datum/reagent/aluminium = 1, /datum/reagent/iron = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/emp_pulse
-	name = "EMP Pulse"
-	id = "emp_pulse"
 	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/iron = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
@@ -138,8 +118,6 @@
 
 
 /datum/chemical_reaction/beesplosion
-	name = "Bee Explosion"
-	id = "beesplosion"
 	required_reagents = list(/datum/reagent/consumable/honey = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/uranium/radium = 1)
 
 /datum/chemical_reaction/beesplosion/on_reaction(datum/reagents/holder, created_volume)
@@ -161,14 +139,10 @@
 
 
 /datum/chemical_reaction/stabilizing_agent
-	name = /datum/reagent/stabilizing_agent
-	id = /datum/reagent/stabilizing_agent
 	results = list(/datum/reagent/stabilizing_agent = 3)
 	required_reagents = list(/datum/reagent/iron = 1, /datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 1)
 
 /datum/chemical_reaction/clf3
-	name = "Chlorine Trifluoride"
-	id = /datum/reagent/clf3
 	results = list(/datum/reagent/clf3 = 4)
 	required_reagents = list(/datum/reagent/chlorine = 1, /datum/reagent/fluorine = 3)
 	required_temp = 424
@@ -181,8 +155,6 @@
 	holder.chem_temp = 1000 // hot as shit
 
 /datum/chemical_reaction/reagent_explosion/methsplosion
-	name = "Strong meth explosion"
-	id = "methboom1"
 	required_temp = 380 //slightly above the meth mix time.
 	required_reagents = list(/datum/reagent/drug/methamphetamine = 1)
 	strengthdiv = 6
@@ -198,14 +170,10 @@
 	..()
 
 /datum/chemical_reaction/reagent_explosion/methsplosion/methboom2
-	name = "Weak meth explosion"
-	id = "methboom2"
 	required_reagents = list(/datum/reagent/diethylamine = 1, /datum/reagent/iodine = 1, /datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1) //diethylamine is often left over from mixing the ephedrine.
 	required_temp = 300 //room temperature, chilling it even a little will prevent the explosion
 
 /datum/chemical_reaction/sorium
-	name = "Sorium"
-	id = /datum/reagent/sorium
 	results = list(/datum/reagent/sorium = 4)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/oxygen = 1, /datum/reagent/nitrogen = 1, /datum/reagent/carbon = 1)
 
@@ -218,8 +186,6 @@
 	goonchem_vortex(T, 1, range)
 
 /datum/chemical_reaction/sorium_vortex
-	name = "Sorium vortex"
-	id = "sorium_vortex"
 	required_reagents = list(/datum/reagent/sorium = 1)
 	required_temp = 474
 
@@ -229,8 +195,6 @@
 	goonchem_vortex(T, 1, range)
 
 /datum/chemical_reaction/liquid_dark_matter
-	name = "Liquid Dark Matter"
-	id = /datum/reagent/liquid_dark_matter
 	results = list(/datum/reagent/liquid_dark_matter = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/carbon = 1)
 
@@ -243,8 +207,6 @@
 	goonchem_vortex(T, 0, range)
 
 /datum/chemical_reaction/ldm_vortex
-	name = "LDM Vortex"
-	id = "ldm_vortex"
 	required_reagents = list(/datum/reagent/liquid_dark_matter = 1)
 	required_temp = 474
 
@@ -254,8 +216,6 @@
 	goonchem_vortex(T, 0, range)
 
 /datum/chemical_reaction/flash_powder
-	name = "Flash powder"
-	id = /datum/reagent/flash_powder
 	results = list(/datum/reagent/flash_powder = 3)
 	required_reagents = list(/datum/reagent/aluminium = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1 )
 
@@ -277,8 +237,6 @@
 	holder.remove_reagent(/datum/reagent/flash_powder, created_volume*3)
 
 /datum/chemical_reaction/flash_powder_flash
-	name = "Flash powder activation"
-	id = "flash_powder_flash"
 	required_reagents = list(/datum/reagent/flash_powder = 1)
 	required_temp = 374
 
@@ -297,8 +255,6 @@
 				C.Stun(100)
 
 /datum/chemical_reaction/smoke_powder
-	name = /datum/reagent/smoke_powder
-	id = /datum/reagent/smoke_powder
 	results = list(/datum/reagent/smoke_powder = 3)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1)
 
@@ -318,8 +274,6 @@
 		holder.clear_reagents()
 
 /datum/chemical_reaction/smoke_powder_smoke
-	name = "Smoke powder smoke"
-	id = "smoke_powder_smoke"
 	required_reagents = list(/datum/reagent/smoke_powder = 1)
 	required_temp = 374
 	mob_react = FALSE
@@ -337,8 +291,6 @@
 		holder.clear_reagents()
 
 /datum/chemical_reaction/sonic_powder
-	name = /datum/reagent/sonic_powder
-	id = /datum/reagent/sonic_powder
 	results = list(/datum/reagent/sonic_powder = 3)
 	required_reagents = list(/datum/reagent/oxygen = 1, /datum/reagent/consumable/space_cola = 1, /datum/reagent/phosphorus = 1)
 
@@ -352,8 +304,6 @@
 		C.soundbang_act(1, 100, rand(0, 5))
 
 /datum/chemical_reaction/sonic_powder_deafen
-	name = "Sonic powder deafen"
-	id = "sonic_powder_deafen"
 	required_reagents = list(/datum/reagent/sonic_powder = 1)
 	required_temp = 374
 
@@ -364,8 +314,6 @@
 		C.soundbang_act(1, 100, rand(0, 5))
 
 /datum/chemical_reaction/phlogiston
-	name = "Phlogiston"
-	id = /datum/reagent/phlogiston
 	results = list(/datum/reagent/phlogiston = 3)
 	required_reagents = list(/datum/reagent/phosphorus = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/stable_plasma = 1)
 
@@ -380,14 +328,10 @@
 	return
 
 /datum/chemical_reaction/napalm
-	name = "Napalm"
-	id = /datum/reagent/napalm
 	results = list(/datum/reagent/napalm = 3)
 	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/fuel = 1, /datum/reagent/consumable/ethanol = 1 )
 
 /datum/chemical_reaction/cryostylane
-	name = /datum/reagent/cryostylane
-	id = /datum/reagent/cryostylane
 	results = list(/datum/reagent/cryostylane = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/stable_plasma = 1, /datum/reagent/nitrogen = 1)
 
@@ -396,8 +340,6 @@
 	return
 
 /datum/chemical_reaction/cryostylane_oxygen
-	name = "ephemeral cryostylane reaction"
-	id = "cryostylane_oxygen"
 	results = list(/datum/reagent/cryostylane = 1)
 	required_reagents = list(/datum/reagent/cryostylane = 1, /datum/reagent/oxygen = 1)
 	mob_react = FALSE
@@ -406,8 +348,6 @@
 	holder.chem_temp = max(holder.chem_temp - 10*created_volume,0)
 
 /datum/chemical_reaction/pyrosium_oxygen
-	name = "ephemeral pyrosium reaction"
-	id = "pyrosium_oxygen"
 	results = list(/datum/reagent/pyrosium = 1)
 	required_reagents = list(/datum/reagent/pyrosium = 1, /datum/reagent/oxygen = 1)
 	mob_react = FALSE
@@ -416,8 +356,6 @@
 	holder.chem_temp += 10*created_volume
 
 /datum/chemical_reaction/pyrosium
-	name = /datum/reagent/pyrosium
-	id = /datum/reagent/pyrosium
 	results = list(/datum/reagent/pyrosium = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/uranium/radium = 1, /datum/reagent/phosphorus = 1)
 
@@ -426,23 +364,17 @@
 	return
 
 /datum/chemical_reaction/teslium
-	name = "Teslium"
-	id = /datum/reagent/teslium
 	results = list(/datum/reagent/teslium = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/silver = 1, /datum/reagent/blackpowder = 1)
 	mix_message = "<span class='danger'>A jet of sparks flies from the mixture as it merges into a flickering slurry.</span>"
 	required_temp = 400
 
 /datum/chemical_reaction/energized_jelly
-	name = "Energized Jelly"
-	id = /datum/reagent/teslium/energized_jelly
 	results = list(/datum/reagent/teslium/energized_jelly = 2)
 	required_reagents = list(/datum/reagent/toxin/slimejelly = 1, /datum/reagent/teslium = 1)
 	mix_message = "<span class='danger'>The slime jelly starts glowing intermittently.</span>"
 
 /datum/chemical_reaction/reagent_explosion/teslium_lightning
-	name = "Teslium Destabilization"
-	id = "teslium_lightning"
 	required_reagents = list(/datum/reagent/teslium = 1, /datum/reagent/water = 1)
 	strengthdiv = 100
 	modifier = -100
@@ -472,28 +404,21 @@
 	playsound(holder.my_atom, 'sound/machines/defib_zap.ogg', 50, TRUE)
 
 /datum/chemical_reaction/reagent_explosion/teslium_lightning/heat
-	id = "teslium_lightning2"
 	required_temp = 474
 	required_reagents = list(/datum/reagent/teslium = 1)
 
 /datum/chemical_reaction/reagent_explosion/nitrous_oxide
-	name = "N2O explosion"
-	id = "n2o_explosion"
 	required_reagents = list(/datum/reagent/nitrous_oxide = 1)
 	strengthdiv = 7
 	required_temp = 575
 	modifier = 1
 
 /datum/chemical_reaction/firefighting_foam
-	name = "Firefighting Foam"
-	id = /datum/reagent/firefighting_foam
 	results = list(/datum/reagent/firefighting_foam = 3)
 	required_reagents = list(/datum/reagent/stabilizing_agent = 1,/datum/reagent/fluorosurfactant = 1,/datum/reagent/carbon = 1)
 	required_temp = 200
 	is_cold_recipe = 1
 
 /datum/chemical_reaction/reagent_explosion/cults_explosion
-	name = "Cults Explosion"
-	id = "cults_explosion"
 	required_reagents = list(/datum/reagent/consumable/ethanol/ratvander = 1, /datum/reagent/consumable/ethanol/narsour = 1)
 	strengthdiv = 10

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -17,8 +17,6 @@
 
 //Grey
 /datum/chemical_reaction/slime/slimespawn
-	name = "Slime Spawn"
-	id = "m_spawn"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/grey
 	required_other = TRUE
@@ -29,16 +27,12 @@
 	..()
 
 /datum/chemical_reaction/slime/slimeinaprov
-	name = "Slime epinephrine"
-	id = "m_inaprov"
 	results = list(/datum/reagent/medicine/epinephrine = 3)
 	required_reagents = list(/datum/reagent/water = 5)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/grey
 
 /datum/chemical_reaction/slime/slimemonkey
-	name = "Slime Monkey"
-	id = "m_monkey"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/grey
 	required_other = TRUE
@@ -50,16 +44,12 @@
 
 //Green
 /datum/chemical_reaction/slime/slimemutate
-	name = "Mutation Toxin"
-	id = "slimetoxin"
 	results = list(/datum/reagent/mutationtoxin/jelly = 5)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 
 /datum/chemical_reaction/slime/unstabletoxin
-	name = "Unstable Mutation Toxin"
-	id = "unstablemuttoxin"
 	results = list(/datum/reagent/mutationtoxin/unstable = 5)
 	required_reagents = list(/datum/reagent/uranium/radium = 1)
 	required_other = TRUE
@@ -68,8 +58,6 @@
 
 //Metal
 /datum/chemical_reaction/slime/slimemetal
-	name = "Slime Metal"
-	id = "m_metal"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/metal
 	required_other = TRUE
@@ -81,8 +69,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimeglass
-	name = "Slime Glass"
-	id = "m_glass"
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/metal
 	required_other = TRUE
@@ -95,8 +81,6 @@
 
 //Gold
 /datum/chemical_reaction/slime/slimemobspawn
-	name = "Slime Crit"
-	id = "m_tele"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/gold
 	required_other = TRUE
@@ -115,8 +99,6 @@
 	addtimer(CALLBACK(src, PROC_REF(chemical_mob_spawn), holder, 5, "Gold Slime", HOSTILE_SPAWN), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser
-	name = "Slime Crit Lesser"
-	id = "m_tele3"
 	required_reagents = list(/datum/reagent/blood = 1)
 
 /datum/chemical_reaction/slime/slimemobspawn/lesser/summon_mobs(datum/reagents/holder, turf/T)
@@ -124,8 +106,6 @@
 	addtimer(CALLBACK(src, PROC_REF(chemical_mob_spawn), holder, 3, "Lesser Gold Slime", HOSTILE_SPAWN, "neutral"), 50)
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly
-	name = "Slime Crit Friendly"
-	id = "m_tele5"
 	required_reagents = list(/datum/reagent/water = 1)
 
 /datum/chemical_reaction/slime/slimemobspawn/friendly/summon_mobs(datum/reagents/holder, turf/T)
@@ -134,8 +114,6 @@
 
 //Silver
 /datum/chemical_reaction/slime/slimebork
-	name = "Slime Bork"
-	id = "m_tele2"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/silver
 	required_other = TRUE
@@ -161,8 +139,6 @@
 	return get_random_food()
 
 /datum/chemical_reaction/slime/slimebork/drinks
-	name = "Slime Bork 2"
-	id = "m_tele4"
 	required_reagents = list(/datum/reagent/water = 1)
 
 /datum/chemical_reaction/slime/slimebork/drinks/getbork()
@@ -170,16 +146,12 @@
 
 //Blue
 /datum/chemical_reaction/slime/slimefrost
-	name = "Slime Frost Oil"
-	id = "m_frostoil"
 	results = list(/datum/reagent/consumable/frostoil = 10)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/blue
 	required_other = TRUE
 
 /datum/chemical_reaction/slime/slimestabilizer
-	name = "Slime Stabilizer"
-	id = "m_slimestabilizer"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/blue
 	required_other = TRUE
@@ -189,8 +161,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimefoam
-	name = "Slime Foam"
-	id = "m_foam"
 	results = list(/datum/reagent/fluorosurfactant = 20, /datum/reagent/water = 20)
 	required_reagents = list(/datum/reagent/water = 5)
 	required_container = /obj/item/slime_extract/blue
@@ -198,8 +168,6 @@
 
 //Dark Blue
 /datum/chemical_reaction/slime/slimefreeze
-	name = "Slime Freeze"
-	id = "m_freeze"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/darkblue
 	required_other = TRUE
@@ -221,8 +189,6 @@
 			T.atmos_spawn_air("n2=50;TEMP=2.7")
 
 /datum/chemical_reaction/slime/slimefireproof
-	name = "Slime Fireproof"
-	id = "m_fireproof"
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/darkblue
 	required_other = TRUE
@@ -233,16 +199,12 @@
 
 //Orange
 /datum/chemical_reaction/slime/slimecasp
-	name = "Slime Capsaicin Oil"
-	id = "m_capsaicinoil"
 	results = list(/datum/reagent/consumable/capsaicin = 10)
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/orange
 	required_other = TRUE
 
 /datum/chemical_reaction/slime/slimefire
-	name = "Slime fire"
-	id = "m_fire"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/orange
 	required_other = TRUE
@@ -265,8 +227,6 @@
 
 
 /datum/chemical_reaction/slime/slimesmoke
-	name = "Slime Smoke"
-	id = "m_smoke"
 	results = list(/datum/reagent/phosphorus = 10, /datum/reagent/potassium = 10, /datum/reagent/consumable/sugar = 10)
 	required_reagents = list(/datum/reagent/water = 5)
 	required_container = /obj/item/slime_extract/orange
@@ -274,8 +234,6 @@
 
 //Yellow
 /datum/chemical_reaction/slime/slimeoverload
-	name = "Slime EMP"
-	id = "m_emp"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/yellow
 	required_other = TRUE
@@ -285,8 +243,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimecell
-	name = "Slime Power Cell"
-	id = "m_cell"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/yellow
 	required_other = TRUE
@@ -296,8 +252,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimeglow
-	name = "Slime Glow"
-	id = "m_glow"
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/yellow
 	required_other = TRUE
@@ -310,8 +264,6 @@
 
 //Purple
 /datum/chemical_reaction/slime/slimepsteroid
-	name = "Slime Steroid"
-	id = "m_steroid"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/purple
 	required_other = TRUE
@@ -321,8 +273,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimeregen
-	name = "Slime Regen"
-	id = "m_regen"
 	results = list(/datum/reagent/medicine/regen_jelly = 5)
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/purple
@@ -330,8 +280,6 @@
 
 //Dark Purple
 /datum/chemical_reaction/slime/slimeplasma
-	name = "Slime Plasma"
-	id = "m_plasma"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/darkpurple
 	required_other = TRUE
@@ -342,8 +290,6 @@
 
 //Red
 /datum/chemical_reaction/slime/slimemutator
-	name = "Slime Mutator"
-	id = "m_slimemutator"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/red
 	required_other = TRUE
@@ -353,8 +299,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimebloodlust
-	name = "Bloodlust"
-	id = "m_bloodlust"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/red
 	required_other = TRUE
@@ -371,8 +315,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimespeed
-	name = "Slime Speed"
-	id = "m_speed"
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/red
 	required_other = TRUE
@@ -383,8 +325,6 @@
 
 //Pink
 /datum/chemical_reaction/slime/docility
-	name = "Docility Potion"
-	id = "m_potion"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/pink
 	required_other = TRUE
@@ -394,8 +334,6 @@
 	..()
 
 /datum/chemical_reaction/slime/gender
-	name = "Gender Potion"
-	id = "m_gender"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/pink
 	required_other = TRUE
@@ -406,8 +344,6 @@
 
 //Black
 /datum/chemical_reaction/slime/slimemutate2
-	name = "Advanced Mutation Toxin"
-	id = "mutationtoxin2"
 	results = list(/datum/reagent/aslimetoxin = 5)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_other = TRUE
@@ -415,8 +351,6 @@
 
 //Oil
 /datum/chemical_reaction/slime/slimeexplosion
-	name = "Slime Explosion"
-	id = "m_explosion"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/oil
 	required_other = TRUE
@@ -444,8 +378,6 @@
 
 
 /datum/chemical_reaction/slime/slimecornoil
-	name = "Slime Corn Oil"
-	id = "m_cornoil"
 	results = list(/datum/reagent/consumable/cornoil = 10)
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/oil
@@ -453,8 +385,6 @@
 
 //Light Pink
 /datum/chemical_reaction/slime/slimepotion2
-	name = "Slime Potion 2"
-	id = "m_potion2"
 	required_container = /obj/item/slime_extract/lightpink
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_other = TRUE
@@ -464,8 +394,6 @@
 	..()
 
 /datum/chemical_reaction/slime/renaming
-	name = "Renaming Potion"
-	id = "m_renaming_potion"
 	required_container = /obj/item/slime_extract/lightpink
 	required_reagents = list(/datum/reagent/water = 1)
 	required_other = TRUE
@@ -477,8 +405,6 @@
 
 //Adamantine
 /datum/chemical_reaction/slime/adamantine
-	name = "Adamantine"
-	id = "adamantine"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/adamantine
 	required_other = TRUE
@@ -489,8 +415,6 @@
 
 //Bluespace
 /datum/chemical_reaction/slime/slimefloor2
-	name = "Bluespace Floor"
-	id = "m_floor2"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = TRUE
@@ -501,8 +425,6 @@
 
 
 /datum/chemical_reaction/slime/slimecrystal
-	name = "Slime Crystal"
-	id = "m_crystal"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = TRUE
@@ -513,8 +435,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimeradio
-	name = "Slime Radio"
-	id = "m_radio"
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = TRUE
@@ -525,8 +445,6 @@
 
 //Cerulean
 /datum/chemical_reaction/slime/slimepsteroid2
-	name = "Slime Steroid 2"
-	id = "m_steroid2"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/cerulean
 	required_other = TRUE
@@ -536,8 +454,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slime_territory
-	name = "Slime Territory"
-	id = "s_territory"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/cerulean
 	required_other = TRUE
@@ -548,8 +464,6 @@
 
 //Sepia
 /datum/chemical_reaction/slime/slimestop
-	name = "Slime Stop"
-	id = "m_stop"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/sepia
 	required_other = TRUE
@@ -570,8 +484,6 @@
 	use_slime_core(holder)
 
 /datum/chemical_reaction/slime/slimecamera
-	name = "Slime Camera"
-	id = "m_camera"
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/sepia
 	required_other = TRUE
@@ -582,8 +494,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimefloor
-	name = "Sepia Floor"
-	id = "m_floor"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/sepia
 	required_other = TRUE
@@ -594,8 +504,6 @@
 
 //Pyrite
 /datum/chemical_reaction/slime/slimepaint
-	name = "Slime Paint"
-	id = "s_paint"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_container = /obj/item/slime_extract/pyrite
 	required_other = TRUE
@@ -606,8 +514,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimecrayon
-	name = "Slime Crayon"
-	id = "s_crayon"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_container = /obj/item/slime_extract/pyrite
 	required_other = TRUE
@@ -619,8 +525,6 @@
 
 //Rainbow :o)
 /datum/chemical_reaction/slime/slimeRNG
-	name = "Random Core"
-	id = "slimerng"
 	required_reagents = list(/datum/reagent/toxin/plasma = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/rainbow
@@ -639,8 +543,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slimebomb
-	name = "Clusterblorble"
-	id = "slimebomb"
 	required_reagents = list(/datum/reagent/toxin/slimejelly = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/rainbow
@@ -655,8 +557,6 @@
 	..()
 
 /datum/chemical_reaction/slime/slime_transfer
-	name = "Transfer Potion"
-	id = "slimetransfer"
 	required_reagents = list(/datum/reagent/blood = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/rainbow
@@ -666,8 +566,6 @@
 	..()
 
 /datum/chemical_reaction/slime/flight_potion
-	name = "Flight Potion"
-	id = /datum/reagent/flightpotion
 	required_reagents = list(/datum/reagent/water/holywater = 5, /datum/reagent/uranium = 5)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/rainbow

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -1,121 +1,83 @@
 
 /datum/chemical_reaction/formaldehyde
-	name = /datum/reagent/toxin/formaldehyde
-	id = "Formaldehyde"
 	results = list(/datum/reagent/toxin/formaldehyde = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1, /datum/reagent/silver = 1)
 	required_temp = 420
 
 /datum/chemical_reaction/fentanyl
-	name = /datum/reagent/toxin/fentanyl
-	id = /datum/reagent/toxin/fentanyl
 	results = list(/datum/reagent/toxin/fentanyl = 1)
 	required_reagents = list(/datum/reagent/drug/space_drugs = 1)
 	required_temp = 674
 
 /datum/chemical_reaction/cyanide
-	name = "Cyanide"
-	id = /datum/reagent/toxin/cyanide
 	results = list(/datum/reagent/toxin/cyanide = 3)
 	required_reagents = list(/datum/reagent/oil = 1, /datum/reagent/ammonia = 1, /datum/reagent/oxygen = 1)
 	required_temp = 380
 
 /datum/chemical_reaction/itching_powder
-	name = "Itching Powder"
-	id = /datum/reagent/toxin/itching_powder
 	results = list(/datum/reagent/toxin/itching_powder = 3)
 	required_reagents = list(/datum/reagent/fuel = 1, /datum/reagent/ammonia = 1, /datum/reagent/medicine/charcoal = 1)
 
 /datum/chemical_reaction/facid
-	name = "Fluorosulfuric acid"
-	id = /datum/reagent/toxin/acid/fluacid
 	results = list(/datum/reagent/toxin/acid/fluacid = 4)
 	required_reagents = list(/datum/reagent/toxin/acid = 1, /datum/reagent/fluorine = 1, /datum/reagent/hydrogen = 1, /datum/reagent/potassium = 1)
 	required_temp = 380
 
 /datum/chemical_reaction/sulfonal
-	name = /datum/reagent/toxin/sulfonal
-	id = /datum/reagent/toxin/sulfonal
 	results = list(/datum/reagent/toxin/sulfonal = 3)
 	required_reagents = list(/datum/reagent/medicine/perfluorodecalin = 1, /datum/reagent/diethylamine = 1, /datum/reagent/sulfur = 1)
 
 /datum/chemical_reaction/lipolicide
-	name = /datum/reagent/toxin/lipolicide
-	id = /datum/reagent/toxin/lipolicide
 	results = list(/datum/reagent/toxin/lipolicide = 3)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/diethylamine = 1, /datum/reagent/medicine/ephedrine = 1)
 
 /datum/chemical_reaction/mutagen
-	name = "Unstable mutagen"
-	id = /datum/reagent/toxin/mutagen
 	results = list(/datum/reagent/toxin/mutagen = 3)
 	required_reagents = list(/datum/reagent/uranium/radium = 1, /datum/reagent/phosphorus = 1, /datum/reagent/chlorine = 1)
 
 /datum/chemical_reaction/lexorin
-	name = "Lexorin"
-	id = /datum/reagent/toxin/lexorin
 	results = list(/datum/reagent/toxin/lexorin = 4)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/sulfonal = 1)
 
 /datum/chemical_reaction/chloralhydrate
-	name = "Chloral Hydrate"
-	id = /datum/reagent/toxin/chloralhydrate
 	results = list(/datum/reagent/toxin/chloralhydrate = 1)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/chlorine = 3, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/mutetoxin //i'll just fit this in here snugly between other unfun chemicals :v
-	name = "Mute Toxin"
-	id = /datum/reagent/toxin/mutetoxin
 	results = list(/datum/reagent/toxin/mutetoxin = 2)
 	required_reagents = list(/datum/reagent/uranium = 2, /datum/reagent/water = 1, /datum/reagent/carbon = 1)
 
 /datum/chemical_reaction/zombiepowder
-	name = "Zombie Powder"
-	id = /datum/reagent/toxin/zombiepowder
 	results = list(/datum/reagent/toxin/zombiepowder = 2)
 	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/medicine/morphine = 5, /datum/reagent/copper = 5)
 
 /datum/chemical_reaction/ghoulpowder
-	name = "Ghoul Powder"
-	id = /datum/reagent/toxin/ghoulpowder
 	results = list(/datum/reagent/toxin/ghoulpowder = 2)
 	required_reagents = list(/datum/reagent/toxin/zombiepowder = 1, /datum/reagent/medicine/epinephrine = 1)
 
 /datum/chemical_reaction/mindbreaker
-	name = "Mindbreaker Toxin"
-	id = /datum/reagent/toxin/mindbreaker
 	results = list(/datum/reagent/toxin/mindbreaker = 5)
 	required_reagents = list(/datum/reagent/silicon = 1, /datum/reagent/hydrogen = 1, /datum/reagent/medicine/charcoal = 1)
 
 /datum/chemical_reaction/heparin
-	name = "Heparin"
-	id = "Heparin"
 	results = list(/datum/reagent/toxin/heparin = 4)
 	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1, /datum/reagent/sodium = 1, /datum/reagent/chlorine = 1, /datum/reagent/lithium = 1)
 	mix_message = "<span class='danger'>The mixture thins and loses all color.</span>"
 
 /datum/chemical_reaction/rotatium
-	name = "Rotatium"
-	id = "Rotatium"
 	results = list(/datum/reagent/toxin/rotatium = 3)
 	required_reagents = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/teslium = 1, /datum/reagent/toxin/fentanyl = 1)
 	mix_message = "<span class='danger'>After sparks, fire, and the smell of mindbreaker, the mix is constantly spinning with no stop in sight.</span>"
 
 /datum/chemical_reaction/anacea
-	name = "Anacea"
-	id = /datum/reagent/toxin/anacea
 	results = list(/datum/reagent/toxin/anacea = 3)
 	required_reagents = list(/datum/reagent/medicine/haloperidol = 1, /datum/reagent/impedrezene = 1, /datum/reagent/uranium/radium = 1)
 
 /datum/chemical_reaction/mimesbane
-	name = "Mime's Bane"
-	id = /datum/reagent/toxin/mimesbane
 	results = list(/datum/reagent/toxin/mimesbane = 3)
 	required_reagents = list(/datum/reagent/uranium/radium = 1, /datum/reagent/toxin/mutetoxin = 1, /datum/reagent/consumable/nothing = 1)
 
 /datum/chemical_reaction/bonehurtingjuice
-	name = "Bone Hurting Juice"
-	id = /datum/reagent/toxin/bonehurtingjuice
 	results = list(/datum/reagent/toxin/bonehurtingjuice = 5)
 	required_reagents = list(/datum/reagent/toxin/mutagen = 1, /datum/reagent/toxin/itching_powder = 3, /datum/reagent/consumable/milk = 1)
 	mix_message = "<span class='danger'>The mixture suddenly becomes clear and looks a lot like water. You feel a strong urge to drink it.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes all name and id defines from chemical reactions


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

On TG, id and name were briefly used for their randomized chemistry recipe system, and shortly after replaced entirely.

On Bee, I couldnt find a single thing that actually called ID or Name.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Creating fluorosulfuric acid & using it on a machine

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/4af7977a-caa7-4108-b4c0-8482600efc1d



</details>

## Changelog
:cl: rkz
code: removed 900+ useless chemistry recipe lines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
