### PR TITLE
Restricts changing cable color to cyborgs

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -360,7 +360,7 @@
 
 /*
 	Control+Shift click
-	Unused except for AI
+	Used for AI and Give code
 */
 /mob/proc/CtrlShiftClickOn(atom/A)
 	A.CtrlShiftClick(src)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -502,12 +502,11 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	source = /datum/robot_energy_storage/wire
 	var/cable_color = "red"
 
-/obj/item/stack/cable_coil/verb/change_wirecolor_verb()
-	set name = "Change Cable Color"
-	set category = "Object"
-	set src in usr
-
-	var/picked = input(usr, "Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
+/obj/item/stack/cable_coil/attack_self(mob/user)
+	if(!iscyborg(user))
+		. = ..()
+		return
+	var/picked = input(user,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
 	cable_color = picked
 	update_icon()
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -502,8 +502,15 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	source = /datum/robot_energy_storage/wire
 	var/cable_color = "red"
 
-/obj/item/stack/cable_coil/attack_self(mob/user)
-	var/picked = input(user,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
+/obj/item/stack/cable_coil/verb/change_wirecolor_verb()
+	set name = "Change Cable Color"
+	set category = "Object"
+	set src in usr
+
+	//if(!usr.canUseTopic(src, BE_CLOSE))
+	//	return
+
+	var/picked = input(usr, "Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
 	cable_color = picked
 	update_icon()
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -507,9 +507,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	set category = "Object"
 	set src in usr
 
-	//if(!usr.canUseTopic(src, BE_CLOSE))
-	//	return
-
 	var/picked = input(usr, "Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
 	cable_color = picked
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Restricts changing cable colors to cyborgs, fixing being unable to craft cable coils

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Attackself behavior overrides stackcrafting, so this is needed. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/61ee1b36-1480-4b41-9134-7e88f2a63234





</details>

## Changelog
:cl:
fix: Cable color no longer overrides cable stackcrafting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
