### PR TITLE
Fixes RCDs not being able to build an airlock/windoor in tiles with a Firedoor

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -223,7 +223,7 @@
 			Ladder.anchored = TRUE
 			return TRUE
 		if(RCD_AIRLOCK)
-			if(locate(/obj/machinery/door) in src)
+			if(locate(/obj/machinery/door/airlock) in src || locate(/obj/machinery/door/window) in src)
 				return FALSE
 			if(ispath(the_rcd.airlock_type, /obj/machinery/door/window))
 				to_chat(user, "<span class='notice'>You build a windoor.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process.  -->

## About The Pull Request

This PR fixes #10457 fixes #10459

Since PR #8195 when someone tried to build an airlock with the RCD you couldn't create an airlock if there was a firedoor there, obviously that's not intended, with this PR you can build there, but not a PR on top of another Airlock or a Windoor 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes an annoying RCD bug, that's always cool

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/84a57d08-9d4e-4a82-8807-8d12adf311df



</details>

## Changelog
:cl:
fix: fixed RCD not being able to build airlocks on top of Firedoors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
