### PR TITLE
Left-click unequips trashbags now

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -801,6 +801,9 @@
 		if(locked)
 			var/atom/host = parent
 			host.balloon_alert(user, "[host] is locked.")
+		else if(!can_be_opened)
+			user.doUnEquip(parent, FALSE, null, TRUE, silent = TRUE)
+			user.put_in_active_hand(parent)
 		else
 			show_to(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process . -->

## About The Pull Request

Left clicking a storage item that cannot be opened now unequips the item as if it were any other type of item instead of displaying a cheeky message about rummaging through garbage. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

* QoL improvement for janitors - it's now simpler to remove your trash bag so you can click it directly onto garbage and vacuum the garbage up. 
* Consistency - Other equippable items that don't have a special left click function are unequipped and now so are these. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_PtRaAqQlv9](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/81081702-a88b-4c20-81d1-ebf787ebe99d)

## Changelog
:cl:
tweak: Left clicking an equipped trash bag now unequips it instead of displaying a cheeky message. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
