### PR TITLE
Dynamic: No Lowpop Wizard - Lategame fixes

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -379,7 +379,7 @@
 		parts += "[FOURSPACES]Executed rules:"
 		for(var/datum/dynamic_ruleset/rule in mode.executed_rules)
 			if (rule.lategame_spawned)
-				parts += "[FOURSPACES][FOURSPACES][rule.ruletype] - <b>[rule.name]</b>: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat (Lategame, threat level ignored)"
+				parts += "[FOURSPACES][FOURSPACES][rule.ruletype] - <b>[rule.name]</b>: -0 threat (Lategame, threat cost ignored)"
 			else
 				parts += "[FOURSPACES][FOURSPACES][rule.ruletype] - <b>[rule.name]</b>: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat"
 	return parts.Join("<br>")
@@ -746,7 +746,7 @@
 		discordmsg += "Executed rules:\n"
 		for(var/datum/dynamic_ruleset/rule in mode.executed_rules)
 			if (rule.lategame_spawned)
-				discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat (Lategame, threat level ignored)\n"
+				discordmsg += "[rule.ruletype] - [rule.name]: -0 threat (Lategame, threat cost ignored)\n"
 			else
 				discordmsg += "[rule.ruletype] - [rule.name]: -[rule.cost + rule.scaled_times * rule.scaling_cost] threat\n"
 	var/list/ded = SSblackbox.first_death

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -161,6 +161,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// If there are less than this many players readied, threat level will be lowered.
 	/// This number should be kept fairly low, as there are other measures that population
 	/// impacts Dynamic, such as the requirements variable on rulesets.
+	/// This also affects when 'lategame' round-ending will be disabled
 	var/low_pop_player_threshold = 20
 
 	/// The maximum threat that can roll with *zero* players.
@@ -678,6 +679,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				if(CHECK_BITFIELD(new_rule.flags, ONLY_RULESET))
 					only_ruleset_executed = TRUE
 				log_game("DYNAMIC: Making a call to a specific ruleset...[new_rule.name]!")
+				if((new_rule.flags & LATEGAME_RULESET) && ignore_cost && is_lategame())
+					new_rule.lategame_spawned = TRUE
 				executed_rules += new_rule
 				if (new_rule.persistent)
 					current_rules += new_rule
@@ -864,7 +867,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			return rand(90, 100)
 
 /datum/game_mode/dynamic/proc/is_lategame()
-	return (get_time() - SSticker.round_start_time) > midround_upper_bound
+	return (get_time() - SSticker.round_start_time) > midround_upper_bound && length(current_players[CURRENT_LIVING_PLAYERS]) >= low_pop_player_threshold
 
 /// Log to messages and to the game
 /datum/game_mode/dynamic/proc/dynamic_log(text)

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -48,7 +48,7 @@
 			log_game("DYNAMIC: FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len], threat level: [threat_level]")
 			continue
 
-		if (mid_round_budget < ruleset.cost && !is_lategame())
+		if (mid_round_budget < ruleset.cost && !(is_lategame() && (ruleset.flags & LATEGAME_RULESET)))
 			log_game("DYNAMIC: FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], ruleset cost: [ruleset.cost]")
 			continue
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -179,7 +179,8 @@
 /// Runs from gamemode process() if ruleset fails to start, like delayed rulesets not getting valid candidates.
 /// This one only handles refunding the threat, override in ruleset to clean up the rest.
 /datum/dynamic_ruleset/proc/clean_up()
-	mode.refund_threat(cost + (scaled_times * scaling_cost))
+	if(!lategame_spawned) // lategame execute failures shouldn't refund
+		mode.refund_threat(cost + (scaled_times * scaling_cost))
 	var/msg = "[ruletype] [name] refunded [cost + (scaled_times * scaling_cost)]. Failed to execute."
 	mode.threat_log += "[worldtime2text()]: [msg]"
 	message_admins(msg)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -94,7 +94,6 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	mode = dynamic_mode
-	lategame_spawned = mode.is_lategame()
 	..()
 
 /datum/dynamic_ruleset/roundstart // One or more of those drafted at roundstart
@@ -116,13 +115,12 @@
 		log_game("DYNAMIC: FAIL: [src] failed acceptable: maximum_players ([maximum_players]) < population ([population])")
 		return FALSE
 
-	if (mode.is_lategame())
-		return (flags & LATEGAME_RULESET)
 
 	pop_per_requirement = pop_per_requirement > 0 ? pop_per_requirement : mode.pop_per_requirement
 	indice_pop = min(requirements.len,round(population/pop_per_requirement)+1)
-	if (threat_level < requirements[indice_pop])
-		log_game("DYNAMIC: FAIL: [src] failed acceptable: threat_level ([threat_level]) < requirement ([requirements[indice_pop]])")
+	var/requirement = requirements[indice_pop]
+	if (threat_level < requirement)
+		log_game("DYNAMIC: FAIL: [src] failed acceptable: threat_level ([threat_level]) < requirement ([requirement])")
 		return FALSE
 
 	return TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -366,7 +366,7 @@
 	minimum_round_time = 35 MINUTES
 	weight = 3
 	cost = 12
-	minimum_players = 25
+	minimum_players = 22
 	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
@@ -390,7 +390,7 @@
 	minimum_round_time = 40 MINUTES
 	weight = 3
 	cost = 12
-	minimum_players = 25
+	minimum_players = 22
 	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 	var/list/vents
 
@@ -490,7 +490,7 @@
 	required_candidates = 1
 	weight = 4
 	cost = 11
-	minimum_players = 25
+	minimum_players = 22
 	repeatable = TRUE
 	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
 	var/list/spawn_locs
@@ -536,7 +536,7 @@
 	required_applicants = 2
 	weight = 4
 	cost = 7
-	minimum_players = 25
+	minimum_players = 22
 	repeatable = TRUE
 	var/datum/team/abductor_team/new_team
 
@@ -623,7 +623,7 @@
 	required_candidates = 0
 	weight = 4
 	cost = 8
-	minimum_players = 27
+	minimum_players = 25
 	repeatable = FALSE
 	flags = LATEGAME_RULESET
 
@@ -692,7 +692,7 @@
 	cost = 11
 	repeatable = TRUE
 	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
-	minimum_players = 27
+	minimum_players = 25
 	var/fed = 1
 	var/list/vents
 	var/datum/team/spiders/spider_team

--- a/code/game/gamemodes/dynamic/dynamic_simulations.dm
+++ b/code/game/gamemodes/dynamic/dynamic_simulations.dm
@@ -77,7 +77,7 @@
 			"execution_time" = simulated_time,
 			"remaining_threat" = gamemode.mid_round_budget,
 			"simulated_alive_players" = gamemode.simulated_alive_players,
-			"is_lategame" = gamemode.is_lategame()
+			"is_lategame" = simulated_result.lategame_spawned
 		))
 
 	return list(

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -24,7 +24,7 @@
 		if (ruleset.weight == 0)
 			continue
 
-		if (ruleset.cost > max_threat_level && !is_lategame())
+		if (ruleset.cost > max_threat_level && !(is_lategame() && (ruleset.flags & LATEGAME_RULESET)))
 			continue
 
 		if (!ruleset.acceptable(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len, threat_level))

--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -88,7 +88,12 @@
 /// Mainly here to facilitate delayed rulesets. All midround/latejoin rulesets are executed with a timered callback to this proc.
 /datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)
 	var/datum/dynamic_ruleset/rule = sent_rule
-	spend_midround_budget(rule.cost, threat_log, "[worldtime2text()]: [rule.ruletype] [rule.name]")
+	if(mid_round_budget >= rule.cost)
+		spend_midround_budget(rule.cost, threat_log, "[worldtime2text()]: [rule.ruletype] [rule.name]")
+	else if((rule.flags & LATEGAME_RULESET) && is_lategame())
+		rule.lategame_spawned = TRUE
+	else
+		CRASH("execute_midround_latejoin_rule was somehow called with an invalid state - cost is too high, but it's also not a lategame execution?")
 	if (simulated)
 		if(rule.flags & ONLY_RULESET)
 			only_ruleset_executed = TRUE


### PR DESCRIPTION
## About The Pull Request

Someone ~~**COUGH COUGH** #9858~~ merged a dynamic PR without addressing my reviews, and I was busy with finals and failed to notice.

Because this PR ~~erroneously~~ disabled threat requirement checking, it ~~accidentally~~ removed *all* population checks for anything using `requirements` still after lategame began. This means that Wizard, one of the very few rulesets still using this system, was allowed to spawn on 0 pop. It also did not check for lowpop, completely ruining the natural progression for lowpop which usually involves shuttle votes rather than antag spam, as stations are not equipped to deal with that.

The round-end lategame display was also entirely nonfunctional, meaning that no one could identify this issues' ties to the PR.


I have fixed the lategame display, reverted the removal of threat level checks, and added a population check to lategame.

We have elected to not implement some other threat-level check ignoring system, even though we want some rulesets to trigger at zero roundstart threat in the lategame. This is to keep the population checks intact. 90% of dynamic rounds should have at least 10-20 threat, allowing lategame executions to occur.

## Why It's Good For The Game

Not spawning wizards at deadpop is good.

## Testing Photographs and Procedure

master (10 pop, 40 threat, 50 simulations.)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/ffa3249c-13e9-4366-9f6f-61a49d518e4f)

With changes (10 pop, 40 threat, 50 simulations.)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/f7cd657f-b465-4591-abd8-8a7521cf9779)

lategame actually working (50 pop, 25 threat, 50 simulations)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/af22c84a-5cf9-4f08-9c90-ba406cd7fb3f)

## Changelog
:cl:
fix: Fixed Dynamic spawning Wizard at literally any population.
fix: Fixed the roundend display not showing when something was executed as a 'lategame' round-ender.
tweak: Dynamic will now no longer trigger 'lategame' round-enders below 22 population, to allow rounds to come to their natural end via the shuttle vote.
balance: Tweaked the minimum population for some antagonists, moving most antags that start at 25-pop to 22-pop. This is to improve the overlap between the lategame injector and antagonist variety.
/:cl:
