### PR TITLE
Adjusts Sanity Disruptor anomaly, minor nerf to fake wiz robe

### DIFF
--- a/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
+++ b/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
@@ -1,7 +1,6 @@
 /obj/effect/anomaly/insanity_pulse
 	name = "sanity disruption pulse anomaly"
 	icon_state = "purplecrack"
-	aSignal = null // we don't have this yet
 
 	COOLDOWN_DECLARE(pulse_cooldown)
 	var/pulse_interval = 10 SECONDS
@@ -53,9 +52,13 @@
 	if((!isspaceturf(target_turf) && isopenturf(target_turf)) || isopenspace(target_turf)) // you don't see what's comming...
 		new /obj/effect/temp_visual/mining_scanner(target_turf) // actually, making effects for every turf is laggy. This is good to reduce lags.
 	for(var/mob/living/each_mob in target_turf.get_all_mobs()) // hiding in a closet? No, no, you cheater
+		if(each_mob.anti_artifact_check())
+			to_chat(each_mob, "<span class='notice'>A weird energy from you blocks the pulse.</span>")
+			each_mob.adjust_blurriness(2.5)
+			continue
 		to_chat(each_mob, "<span class='warning'>A wave of dread washes over you...</span>")
-		each_mob.adjust_blindness(30)
-		each_mob.Knockdown(10)
+		each_mob.adjust_blindness(1.5) // very mild blindness
+		each_mob.Knockdown(5)
 		each_mob.emote("scream")
 		each_mob.Jitter(50)
 		each_mob.hallucination = each_mob.hallucination + 20

--- a/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
+++ b/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
@@ -3,7 +3,7 @@
 	icon_state = "purplecrack"
 
 	COOLDOWN_DECLARE(pulse_cooldown)
-	var/pulse_interval = 10 SECONDS
+	var/pulse_interval = 7 SECONDS
 
 	var/weak_pulse_power = 8
 	var/strong_pulse_power = 150

--- a/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
+++ b/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
@@ -58,7 +58,7 @@
 			continue
 		to_chat(each_mob, "<span class='warning'>A wave of dread washes over you...</span>")
 		each_mob.adjust_blindness(1.5) // very mild blindness
-		each_mob.Knockdown(5)
+		each_mob.Knockdown(10)
 		each_mob.emote("scream")
 		each_mob.Jitter(50)
 		each_mob.hallucination = each_mob.hallucination + 20

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -78,7 +78,14 @@
 
 /obj/item/clothing/suit/wizrobe/ComponentInitialize()
 	. = ..()
+	add_anti_artifact()
+
+/obj/item/clothing/suit/wizrobe/proc/add_anti_artifact()
 	AddComponent(/datum/component/anti_artifact, INFINITY, FALSE, 100)
+
+// fake robe can't protect artifact
+/obj/item/clothing/suit/wizrobe/fake/add_anti_artifact()
+	return
 
 /obj/item/clothing/suit/wizrobe/red
 	name = "red wizard robe"

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -83,9 +83,9 @@
 /obj/item/clothing/suit/wizrobe/proc/add_anti_artifact()
 	AddComponent(/datum/component/anti_artifact, INFINITY, FALSE, 100)
 
-// fake robe can't protect artifact
+// fake robe shouldn't be 100% protective
 /obj/item/clothing/suit/wizrobe/fake/add_anti_artifact()
-	return
+	AddComponent(/datum/component/anti_artifact, INFINITY, FALSE, 75)
 
 /obj/item/clothing/suit/wizrobe/red
 	name = "red wizard robe"

--- a/code/modules/events/anomaly_insanitypulse.dm
+++ b/code/modules/events/anomaly_insanitypulse.dm
@@ -4,8 +4,6 @@
 
 	min_players = 15
 	max_occurrences = 2
-	weight = 25
-	// This has a high chance to appear, but needs more players
 
 /datum/round_event/anomaly/insanity_pulse
 	startWhen = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjusts Sanity Disruptor anomaly that's introduced by #10172

* Less chance to appear. it has the same chance to appear like other anomalies, but still has pop cap
* blindness is very short now
* Now it can be neutralised by signal
* you can protect the pulse with artifact protection gears - stuff that you can get from xeno artifact research
* fake wizard robe no longer 100% protective against artefacts. it has 75% chance that bio suit has. zero movement penalty is already effective.
* slight buff to pulse interval

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
people hate this

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/0849c0a1-4efe-4ae7-84fb-dc70a952cff1)

getting blurry instead of blind, and no stun

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d0e3d945-6c04-4378-a398-f3738202b726)

you can see emote is still there - blind is very short

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/6fbf0c51-dc4b-4f5f-93cd-332aec4adb02)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/b6e8fdd0-d56b-4e15-bd00-449b6c279131)

can neutralize


</details>

## Changelog
:cl:
tweak: Sanity Disruptor now less appear on dynamic. it still has pop lock, but has the same chance to all anomalies'
tweak: Sanity Disruptor blinds people very very shortly than +60 seconds
tweak: Sanity Disruptor pulse can be protected by xenoartifact protective gears
tweak: Sanity Disruptor interval pulses a little bit often (10s to 7s)
fix: Sanity Disruptor can be neutralised by signal.
balance: fake wizard robe now protects artifact 75%, instead of 100%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
