### PR TITLE
Sanity Disruptor Anomaly Tweak

### DIFF
--- a/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
+++ b/code/game/objects/effects/anomalies/anomaly_insanitypulse.dm
@@ -54,7 +54,7 @@
 		new /obj/effect/temp_visual/mining_scanner(target_turf) // actually, making effects for every turf is laggy. This is good to reduce lags.
 	for(var/mob/living/each_mob in target_turf.get_all_mobs()) // hiding in a closet? No, no, you cheater
 		to_chat(each_mob, "<span class='warning'>A wave of dread washes over you...</span>")
-		each_mob.adjust_blindness(30)
+		each_mob.adjust_blindness(5)
 		each_mob.Knockdown(10)
 		each_mob.emote("scream")
 		each_mob.Jitter(50)

--- a/code/modules/events/anomaly_insanitypulse.dm
+++ b/code/modules/events/anomaly_insanitypulse.dm
@@ -3,8 +3,8 @@
 	typepath = /datum/round_event/anomaly/insanity_pulse
 
 	min_players = 15
-	max_occurrences = 2
-	weight = 25
+	max_occurrences = 1
+	weight = 20
 	// This has a high chance to appear, but needs more players
 
 /datum/round_event/anomaly/insanity_pulse


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sanity Disruptor was blinding people for 30 seconds.
With lag this sometimes goes up to a minute.
Now its only 5 seconds.

It could happen up to two times in a round which got annoying once it did happen so I made it only one.

And reduced the chance it does in fact happen to the same value as other most common anomalies.

I'm considering also making it so it will never be announced to make it more scary and unexpected but I'll let people opine on that.

## Why It's Good For The Game

No one likes to be blinded for a long time and it has started to impact rounds negatively.

The idea of the anomaly is good but the execution is not the best.
I think this would make the anomaly less annoying and less prevalent (which means it would actually be surprising when it does happen at unexpected times).

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Trust me it works.

</details>

## Changelog
:cl:
tweak: Reduced the Blindness duration, chance to spawn and maximum spawns per round of the Sanity Distruptor Anomaly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
