### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,6 @@ Dockerfile @crossedfall
 /code/game/machinery/shuttle @powerfulbacon
 /code/modules/shuttle/super_cruise @powerfulbacon
 /code/modules/shuttle/shuttle_creation @powerfulbacon
-/_maps/map_files/CorgStation @powerfulbacon
 
 # pestoverde322
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,10 @@ Dockerfile @crossedfall
 /tools @crossedfall
 /config @crossedfall
 
+# crossedfall (explicitly disowned)
+
+/tools/UpdatePaths/Scripts/
+
 # powerfulbacon
 
 /code/game/machinery/shuttle @powerfulbacon
@@ -30,7 +34,6 @@ Dockerfile @crossedfall
 # itsmeow
 
 /code/game/gamemodes/dynamic @itsmeow
-/code/modules/modular_computers @itsmeow
 /tools/MapTileAggregator.py @itsmeow
 /code/modules/admin/player_panel.dm @itsmeow
 /code/modules/tgui/ @itsmeow


### PR DESCRIPTION
## About The Pull Request

Removes ModPCs from my codeowners since it doesn't really need to be exclusive anymore.

Disowns UpdatePaths scripts (only the scripts!) from @Crossedfall since they update more often and aren't part of the build tooling specifically.

Removes Corg from @PowerfulBacon on request.