### PR TITLE
GenPop workshop alignment and air disto removal

### DIFF
--- a/_maps/holodeck/workshop/donut.dmm
+++ b/_maps/holodeck/workshop/donut.dmm
@@ -14,16 +14,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"c" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/holofloor/monotile/light,
-/area/template_noop)
-"e" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/holofloor/monotile/light,
-/area/template_noop)
 "f" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
@@ -33,43 +23,7 @@
 /obj/item/soap,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"g" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/holofloor/monotile/light,
-/area/template_noop)
 "h" = (
-/turf/open/floor/holofloor/monotile/light,
-/area/template_noop)
-"l" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
-"o" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/holofloor/monotile/light,
-/area/template_noop)
-"q" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/holofloor/monotile/light,
 /area/template_noop)
 "r" = (
@@ -81,26 +35,26 @@
 "t" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/moth1{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "u" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "v" = (
@@ -124,44 +78,30 @@
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "y" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/freezer,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"z" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/holofloor/monotile/light,
-/area/template_noop)
 "B" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"D" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/caution/stand_clear/white,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
 "F" = (
 /obj/machinery/light/floor,
+/turf/open/floor/holofloor/monotile/light,
+/area/template_noop)
+"G" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/structure/closet/crate/freezer,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
 /turf/open/floor/holofloor/monotile/light,
 /area/template_noop)
 "H" = (
@@ -191,12 +131,22 @@
 /obj/item/reagent_containers/food/condiment/sugar,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"K" = (
+"J" = (
+/obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/knife/kitchen,
-/obj/item/knife/kitchen,
-/obj/item/lighter,
+/turf/open/floor/holofloor/monotile/steel,
+/area/template_noop)
+"K" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/item/clipboard{
+	name = "menu"
+	},
+/obj/item/paper,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "M" = (
@@ -216,31 +166,28 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/item/toy/figure/chef,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/item/reagent_containers/food/condiment/enzyme,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "P" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "Q" = (
-/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/knife/kitchen,
+/obj/item/knife/kitchen,
+/obj/item/lighter,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/item/clipboard{
-	name = "menu"
-	},
-/obj/item/paper,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/item/hand_labeler,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "V" = (
@@ -258,7 +205,6 @@
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "W" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/crate/freezer,
 /obj/effect/turf_decal/bot,
 /obj/item/food/grown/berries,
@@ -268,21 +214,21 @@
 /obj/item/food/grown/berries,
 /obj/item/food/grown/berries,
 /obj/item/food/grown/berries,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "Y" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/structure/closet/crate/freezer,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
-/obj/item/food/egg,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 
@@ -296,36 +242,36 @@ K
 (2,1,1) = {"
 b
 F
-z
-c
-a
+h
+h
+G
 "}
 (3,1,1) = {"
 N
 h
 r
-g
-D
+h
+a
 "}
 (4,1,1) = {"
 W
 h
 I
-o
-a
+h
+J
 "}
 (5,1,1) = {"
 Y
 h
 x
-o
-l
+h
+a
 "}
 (6,1,1) = {"
 y
 F
-e
-q
+h
+h
 u
 "}
 (7,1,1) = {"

--- a/_maps/holodeck/workshop/donut.dmm
+++ b/_maps/holodeck/workshop/donut.dmm
@@ -71,15 +71,26 @@
 /obj/item/food/grown/apple,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
+"w" = (
+/obj/structure/closet/crate/freezer,
+/obj/effect/turf_decal/bot,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/holofloor/monotile/steel,
+/area/template_noop)
 "x" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
-"y" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "B" = (
@@ -167,7 +178,9 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/item/toy/figure/chef,
 /obj/item/reagent_containers/food/condiment/enzyme,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "P" = (
@@ -205,18 +218,8 @@
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "W" = (
-/obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/bot,
-/obj/item/food/grown/berries,
-/obj/item/food/grown/berries,
-/obj/item/food/grown/berries,
-/obj/item/food/grown/berries,
-/obj/item/food/grown/berries,
-/obj/item/food/grown/berries,
-/obj/item/food/grown/berries,
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/holofloor/monotile/steel,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/holofloor/monotile/light,
 /area/template_noop)
 "Y" = (
 /obj/effect/turf_decal/bot,
@@ -261,14 +264,14 @@ h
 J
 "}
 (5,1,1) = {"
-Y
+w
 h
 x
 h
 a
 "}
 (6,1,1) = {"
-y
+Y
 F
 h
 h

--- a/_maps/holodeck/workshop/plush.dmm
+++ b/_maps/holodeck/workshop/plush.dmm
@@ -25,25 +25,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"i" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
-"j" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
-"m" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
 "n" = (
 /obj/structure/loom,
 /obj/item/stack/sheet/cotton,
@@ -58,22 +39,11 @@
 /area/template_noop)
 "o" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
 /obj/item/stack/sheet/cotton/cloth,
 /obj/item/stack/sheet/cotton/cloth,
 /obj/item/stack/sheet/cotton,
 /obj/item/stack/sheet/cotton,
 /turf/open/floor/holofloor/monotile/dark,
-/area/template_noop)
-"p" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "u" = (
 /obj/effect/turf_decal/caution,
@@ -102,10 +72,6 @@
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/holofloor/monotile/dark,
-/area/template_noop)
-"A" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "D" = (
 /turf/open/floor/holofloor/monotile/dark,
@@ -196,20 +162,20 @@ n
 D
 w
 o
-p
+d
 "}
 (4,1,1) = {"
 E
 c
-j
-i
+d
+d
 a
 "}
 (5,1,1) = {"
 E
 c
-A
-m
+d
+d
 d
 "}
 (6,1,1) = {"

--- a/_maps/holodeck/workshop/plush.dmm
+++ b/_maps/holodeck/workshop/plush.dmm
@@ -1,6 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/caution,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "b" = (
@@ -19,23 +20,19 @@
 "d" = (
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"g" = (
-/obj/structure/closet/crate,
-/obj/item/toy/plush/beeplushie,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
-"n" = (
+"e" = (
 /obj/structure/loom,
 /obj/item/stack/sheet/cotton,
 /obj/item/stack/sheet/cotton,
 /obj/item/stack/sheet/cotton,
 /obj/item/stack/sheet/cotton,
-/obj/item/stack/sheet/cotton,
-/obj/item/stack/sheet/cotton,
-/obj/item/stack/sheet/cotton,
-/obj/item/stack/sheet/cotton,
-/turf/open/floor/holofloor/monotile/dark,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/holofloor/monotile/steel,
+/area/template_noop)
+"n" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "o" = (
 /obj/structure/table/reinforced,
@@ -45,27 +42,8 @@
 /obj/item/stack/sheet/cotton,
 /turf/open/floor/holofloor/monotile/dark,
 /area/template_noop)
-"u" = (
-/obj/effect/turf_decal/caution,
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
 "w" = (
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/holofloor/monotile/dark,
-/area/template_noop)
-"x" = (
-/obj/structure/rack,
-/obj/item/bedsheet,
-/obj/item/bedsheet,
-/obj/item/bedsheet,
-/obj/item/bedsheet/cmo,
-/obj/item/bedsheet/cmo,
-/obj/item/bedsheet/double/blue,
-/obj/item/bedsheet/double/blue,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/gauze,
 /turf/open/floor/holofloor/monotile/dark,
 /area/template_noop)
 "z" = (
@@ -82,10 +60,21 @@
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
-"I" = (
-/obj/structure/loom,
-/obj/item/stack/sheet/cotton,
-/turf/open/floor/holofloor/monotile/dark,
+"F" = (
+/obj/structure/rack,
+/obj/item/bedsheet,
+/obj/item/bedsheet,
+/obj/item/bedsheet,
+/obj/item/bedsheet/cmo,
+/obj/item/bedsheet/cmo,
+/obj/item/bedsheet/double/blue,
+/obj/item/bedsheet/double/blue,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/gauze,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "L" = (
 /obj/structure/reagent_dispensers/watertank/high,
@@ -113,11 +102,14 @@
 /area/template_noop)
 "P" = (
 /obj/structure/closet/crate,
+/obj/item/toy/plush/beeplushie,
 /obj/effect/turf_decal/delivery,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/holofloor/monotile/steel,
+/area/template_noop)
+"R" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/holofloor/monotile/dark,
 /area/template_noop)
 "U" = (
 /obj/structure/table/reinforced,
@@ -127,12 +119,12 @@
 /turf/open/floor/holofloor/monotile/dark,
 /area/template_noop)
 "W" = (
-/obj/machinery/seed_extractor,
-/turf/open/floor/holofloor/monotile/steel,
-/area/template_noop)
-"X" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
-/obj/machinery/light/floor,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 "Z" = (
@@ -140,55 +132,56 @@
 /obj/item/wirecutters,
 /obj/item/wirecutters,
 /obj/item/wirecutters,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/holofloor/monotile/steel,
 /area/template_noop)
 
 (1,1,1) = {"
-x
-O
-z
-U
+L
+E
+M
+E
 Z
 "}
 (2,1,1) = {"
-I
+c
+O
 D
-w
-b
-u
+D
+c
 "}
 (3,1,1) = {"
 n
+D
+z
+U
+d
+"}
+(4,1,1) = {"
+d
+D
+w
+b
+a
+"}
+(5,1,1) = {"
+e
 D
 w
 o
 d
 "}
-(4,1,1) = {"
-E
-c
-d
-d
-a
-"}
-(5,1,1) = {"
-E
-c
-d
-d
-d
-"}
 (6,1,1) = {"
-M
+e
+O
+D
+R
 c
-d
-a
-d
 "}
 (7,1,1) = {"
-L
-X
+F
+c
 W
 P
-g
+c
 "}

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25793,9 +25793,7 @@
 /area/space/nearstation)
 "gAU" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -44755,7 +44753,6 @@
 "pKs" = (
 /mob/living/simple_animal/kalo{
 	desc = "The Perma brig's cute grass snake.";
-	icon = 'icons/mob/animal.dmi';
 	icon_dead = "snake_dead";
 	icon_living = "snake";
 	icon_state = "snake";


### PR DESCRIPTION
## About The Pull Request 

This PR simply align the only two genpop maps to be aligned to the middle and also remove an useless air distro that was on the only two workshop workshop holodeck

## Why It's Good For The Game

Consistency good.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![immagine](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/7cc0deed-fbc0-457e-9078-72f0d54a4188)

</details>

## Changelog
:cl:
fix: Aligned the genpop workshop entrances and remove the useless distros there.
/:cl: