### PR TITLE
Fixes the heavy-duty saline drip getting the wrong icon

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -266,6 +266,9 @@
 	. = ..()
 	AddElement(/datum/element/update_icon_blocker)
 
+/obj/machinery/iv_drip/update_icon()
+	return
+
 /obj/machinery/iv_drip/saline/eject_beaker()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process.  -->

## About The Pull Request
Fixes the heavy-duty saline drip having the wrong icon, it was never meant to be updated with the normal icons
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's the intended icon for it, and makes more sense
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Before:
![Screenshot_2228](https://github.com/BeeStation/BeeStation-Hornet/assets/53474257/4dd37f67-ea6c-4719-af73-d08d3691b7e4)

After:
![Screenshot_2229](https://github.com/BeeStation/BeeStation-Hornet/assets/53474257/048ba7f2-aa80-40ca-b285-6cdaa8f99882)

## Changelog
:cl:
fix: Fixes the heavy-duty saline drip getting the wrong icon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
