### PR TITLE
Fixed bug with catwalks

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -29,6 +29,9 @@
 
 /obj/structure/lattice/catwalk/deconstruct()
 	var/turf/T = loc
+	var/turf/open/floor/plating/P = loc
+	if(istype(P))
+		return ..()
 	for(var/obj/structure/cable/C in T)
 		C.deconstruct()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process.  -->

## About The Pull Request



## Why It's Good For The Game

Wires being removed when you remove a catwalk over them is a mild annoyance. This fixed the issue.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/19766004-5fe5-48c3-af88-6a1c91939d77

 
</details>

## Changelog
:cl: XeonMations
fix: Fixed catwalks removing wiring underneath them despite there being plating
/:cl:

