### PR TITLE
Fix heretics getting themselves as a sacrifice target

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -392,7 +392,7 @@
 		var/datum/mind/possible_target = player.mind
 		if(!include_current_targets && (WEAKREF(possible_target) in sac_targets))
 			continue
-		if(possible_target == src)
+		if(possible_target == owner)
 			continue
 		if(!SSjob.name_occupations[possible_target.assigned_role])
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes a fucky wuckied check that resulted in heretics getting themselves as sacrifice target

## Why It's Good For The Game
bug bad

## Changelog
:cl:
fix: Heretics no longer get themselves as a sacrifice target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
