### PR TITLE
Ports clean qdeletion & handling of progressbars.

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -327,8 +327,8 @@ GLOBAL_LIST_EMPTY(species_list)
 		if(!.)
 			break
 
-	if(progress)
-		qdel(progbar)
+	if(!QDELETED(progbar))
+		progbar.end_progress()
 
 	if(!QDELETED(target))
 		LAZYREMOVE(user.do_afters, target)

--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -46,7 +46,7 @@
 	var/datum/progressbar/progress = new(M, length(things), T)
 	while (do_after(M, 10, progress = FALSE, extra_checks = CALLBACK(src, PROC_REF(mass_remove_from_storage), T, things, progress)))
 		stoplag(1)
-	qdel(progress)
+	progress.end_progress()
 
 /datum/component/storage/concrete/bluespace/rped
 	collection_mode = COLLECT_EVERYTHING
@@ -96,4 +96,4 @@
 	var/datum/progressbar/progress = new(M, length(things), T)
 	while (do_after(M, 10, progress = FALSE, extra_checks = CALLBACK(src, PROC_REF(mass_remove_from_storage), T, things, progress)))
 		stoplag(1)
-	qdel(progress)
+	progress.end_progress()

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -214,7 +214,7 @@
 	var/list/rejections = list()
 	while(do_after(pre_attack_mob, 1 SECONDS, parent, NONE, FALSE, CALLBACK(src, PROC_REF(handle_mass_pickup), things, attack_item.loc, rejections, progress)))
 		stoplag(1)
-	qdel(progress)
+	progress.end_progress()
 	to_chat(pre_attack_mob, "<span class='notice'>You put everything you could [insert_preposition] [parent].</span>")
 	animate_parent()
 
@@ -275,7 +275,7 @@
 	var/datum/progressbar/progress = new(M, length(things), T)
 	while (do_after(M, 1 SECONDS, T, NONE, FALSE, CALLBACK(src, PROC_REF(mass_remove_from_storage), T, things, progress)))
 		stoplag(1)
-	qdel(progress)
+	progress.end_progress()
 
 /datum/component/storage/proc/mass_remove_from_storage(atom/target, list/things, datum/progressbar/progress, trigger_on_found = TRUE)
 	var/atom/real_location = real_location()

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -45,9 +45,9 @@
 		user_client = user.client
 		add_prog_bar_image_to_client()
 
-	RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/on_user_delete)
-	RegisterSignal(user, COMSIG_MOB_LOGOUT, .proc/clean_user_client)
-	RegisterSignal(user, COMSIG_MOB_LOGIN, .proc/on_user_login)
+	RegisterSignal(user, COMSIG_PARENT_QDELETING, PROC_REF(on_user_delete))
+	RegisterSignal(user, COMSIG_MOB_LOGOUT, PROC_REF(clean_user_client))
+	RegisterSignal(user, COMSIG_MOB_LOGIN, PROC_REF(on_user_login))
 
 
 /datum/progressbar/Destroy()

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -17,6 +17,7 @@
 	///Variable to ensure smooth visual stacking on multiple progress bars.
 	var/listindex = 0
 
+
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
 	if (!istype(target))
@@ -31,12 +32,12 @@
 		return
 	goal = goal_number
 	bar_loc = target
-	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0")
+	bar = image('icons/effects/progessbar.dmi', bar_loc, "prog_bar_0")
 	bar.plane = ABOVE_HUD_PLANE
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	user = User
 
-	LAZYADDASSOC(user.progressbars, bar_loc, src)
+	LAZYADDASSOCLIST(user.progressbars, bar_loc, src)
 	var/list/bars = user.progressbars[bar_loc]
 	listindex = bars.len
 
@@ -77,6 +78,8 @@
 
 ///Called right before the user's Destroy()
 /datum/progressbar/proc/on_user_delete(datum/source)
+	SIGNAL_HANDLER
+
 	user.progressbars = null //We can simply nuke the list and stop worrying about updating other prog bars if the user itself is gone.
 	user = null
 	qdel(src)
@@ -84,6 +87,8 @@
 
 ///Removes the progress bar image from the user_client and nulls the variable, if it exists.
 /datum/progressbar/proc/clean_user_client(datum/source)
+	SIGNAL_HANDLER
+
 	if(!user_client) //Disconnected, already gone.
 		return
 	user_client.images -= bar
@@ -92,6 +97,8 @@
 
 ///Called by user's Login(), it transfers the progress bar image to the new client.
 /datum/progressbar/proc/on_user_login(datum/source)
+	SIGNAL_HANDLER
+
 	if(user_client)
 		if(user_client == user.client) //If this was not client handling I'd condemn this sanity check. But clients are fickle things.
 			return
@@ -109,6 +116,7 @@
 	user_client.images += bar
 	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
+
 ///Updates the progress bar image visually.
 /datum/progressbar/proc/update(progress)
 	progress = clamp(progress, 0, goal)
@@ -116,6 +124,7 @@
 		return
 	last_progress = progress
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
+
 
 ///Called on progress end, be it successful or a failure. Wraps up things to delete the datum and bar.
 /datum/progressbar/proc/end_progress()
@@ -125,6 +134,7 @@
 	animate(bar, alpha = 0, time = PROGRESSBAR_ANIMATION_TIME)
 
 	QDEL_IN(src, PROGRESSBAR_ANIMATION_TIME)
+
 
 #undef PROGRESSBAR_ANIMATION_TIME
 #undef PROGRESSBAR_HEIGHT

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -2,81 +2,129 @@
 #define PROGRESSBAR_ANIMATION_TIME 5
 
 /datum/progressbar
-	var/goal = 1
-	var/last_progress = 0
+	///The progress bar visual element.
 	var/image/bar
-	var/shown = 0
+	///The target where this progress bar is applied and where it is shown.
+	var/atom/bar_loc
+	///The mob whose client sees the progress bar.
 	var/mob/user
-	var/client/client
-	var/listindex
+	///The client seeing the progress bar.
+	var/client/user_client
+	///Effectively the number of steps the progress bar will need to do before reaching completion.
+	var/goal = 1
+	///Control check to see if the progress was interrupted before reaching its goal.
+	var/last_progress = 0
+	///Variable to ensure smooth visual stacking on multiple progress bars.
+	var/listindex = 0
 
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
 	if (!istype(target))
 		EXCEPTION("Invalid target given")
-	if (goal_number)
-		goal = goal_number
+	if(QDELETED(User) || !istype(User))
+		stack_trace("/datum/progressbar created with [isnull(User) ? "null" : "invalid"] user")
+		qdel(src)
+		return
+	if(!isnum(goal_number))
+		stack_trace("/datum/progressbar created with [isnull(User) ? "null" : "invalid"] goal_number")
+		qdel(src)
+		return
+	goal = goal_number
+	bar_loc = target
 	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0")
 	bar.plane = ABOVE_HUD_PLANE
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	user = User
-	if(user)
-		client = user.client
 
-	LAZYINITLIST(user.progressbars)
-	LAZYINITLIST(user.progressbars[bar.loc])
-	var/list/bars = user.progressbars[bar.loc]
-	bars.Add(src)
+	LAZYADDASSOC(user.progressbars, bar_loc, src)
+	var/list/bars = user.progressbars[bar_loc]
 	listindex = bars.len
-	bar.pixel_y = 0
-	bar.alpha = 0
-	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
-/datum/progressbar/proc/update(progress)
-	if (!user || !user.client)
-		shown = FALSE
-		return
-	if (user.client != client)
-		if (client)
-			client.images -= bar
-		if (user.client)
-			user.client.images += bar
+	if(user.client)
+		user_client = user.client
+		add_prog_bar_image_to_client()
 
-	progress = clamp(progress, 0, goal)
-	last_progress = progress
-	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
-	if (!shown)
-		user.client.images += bar
-		shown = TRUE
+	RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/on_user_delete)
+	RegisterSignal(user, COMSIG_MOB_LOGOUT, .proc/clean_user_client)
+	RegisterSignal(user, COMSIG_MOB_LOGIN, .proc/on_user_login)
 
-/datum/progressbar/proc/shiftDown()
-	--listindex
-	bar.pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1))
-	var/dist_to_travel = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)) - PROGRESSBAR_HEIGHT
-	animate(bar, pixel_y = dist_to_travel, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
 /datum/progressbar/Destroy()
+	if(user)
+		for(var/pb in user.progressbars[bar_loc])
+			var/datum/progressbar/progress_bar = pb
+			if(progress_bar == src || progress_bar.listindex <= listindex)
+				continue
+			progress_bar.listindex--
+
+			progress_bar.bar.pixel_y = 32 + (PROGRESSBAR_HEIGHT * (progress_bar.listindex - 1))
+			var/dist_to_travel = 32 + (PROGRESSBAR_HEIGHT * (progress_bar.listindex - 1)) - PROGRESSBAR_HEIGHT
+			animate(progress_bar.bar, pixel_y = dist_to_travel, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
+
+		LAZYREMOVEASSOC(user.progressbars, bar_loc, src)
+		user = null
+
+	if(user_client)
+		clean_user_client()
+
+	bar_loc = null
+
+	if(bar)
+		QDEL_NULL(bar)
+
+	return ..()
+
+
+///Called right before the user's Destroy()
+/datum/progressbar/proc/on_user_delete(datum/source)
+	user.progressbars = null //We can simply nuke the list and stop worrying about updating other prog bars if the user itself is gone.
+	user = null
+	qdel(src)
+
+
+///Removes the progress bar image from the user_client and nulls the variable, if it exists.
+/datum/progressbar/proc/clean_user_client(datum/source)
+	if(!user_client) //Disconnected, already gone.
+		return
+	user_client.images -= bar
+	user_client = null
+
+
+///Called by user's Login(), it transfers the progress bar image to the new client.
+/datum/progressbar/proc/on_user_login(datum/source)
+	if(user_client)
+		if(user_client == user.client) //If this was not client handling I'd condemn this sanity check. But clients are fickle things.
+			return
+		clean_user_client()
+	if(!user.client) //Clients can vanish at any time, the bastards.
+		return
+	user_client = user.client
+	add_prog_bar_image_to_client()
+
+
+///Adds a smoothly-appearing progress bar image to the player's screen.
+/datum/progressbar/proc/add_prog_bar_image_to_client()
+	bar.pixel_y = 0
+	bar.alpha = 0
+	user_client.images += bar
+	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
+
+///Updates the progress bar image visually.
+/datum/progressbar/proc/update(progress)
+	progress = clamp(progress, 0, goal)
+	if(progress == last_progress)
+		return
+	last_progress = progress
+	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
+
+///Called on progress end, be it successful or a failure. Wraps up things to delete the datum and bar.
+/datum/progressbar/proc/end_progress()
 	if(last_progress != goal)
 		bar.icon_state = "[bar.icon_state]_fail"
-	for(var/I in user?.progressbars[bar.loc])
-		var/datum/progressbar/P = I
-		if(P != src && P.listindex > listindex)
-			P.shiftDown()
-
-	var/list/bars = user.progressbars[bar.loc]
-	bars.Remove(src)
-	if(!bars.len)
-		LAZYREMOVE(user.progressbars, bar.loc)
 
 	animate(bar, alpha = 0, time = PROGRESSBAR_ANIMATION_TIME)
-	addtimer(CALLBACK(src, PROC_REF(remove_from_client)), PROGRESSBAR_ANIMATION_TIME, TIMER_CLIENT_TIME)
-	QDEL_IN(bar, PROGRESSBAR_ANIMATION_TIME * 2) //for garbage collection safety
-	. = ..()
 
-/datum/progressbar/proc/remove_from_client()
-	if(client)
-		client.images -= bar
-		client = null
+	QDEL_IN(src, PROGRESSBAR_ANIMATION_TIME)
 
 #undef PROGRESSBAR_ANIMATION_TIME
 #undef PROGRESSBAR_HEIGHT

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1035,7 +1035,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	while (do_after(user, 1 SECONDS, src, NONE, FALSE, CALLBACK(STR, TYPE_PROC_REF(/datum/component/storage, handle_mass_item_insertion), things, src_object, user, progress)))
 		stoplag(1)
-	qdel(progress)
+	progress.end_progress()
 	to_chat(user, "<span class='notice'>You dump as much of [src_object.parent]'s contents into [STR.insert_preposition]to [src] as you can.</span>")
 	STR.orient2hud(user)
 	src_object.orient2hud(user)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -371,7 +371,7 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 	var/datum/progressbar/progress = new(user, things.len, src)
 	while (do_after(usr, 10, src, progress = FALSE, extra_checks = CALLBACK(src_object, TYPE_PROC_REF(/datum/component/storage, mass_remove_from_storage), src, things, progress)))
 		stoplag(1)
-	qdel(progress)
+	progress.end_progress()
 
 	return TRUE
 

--- a/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
@@ -214,7 +214,7 @@
 		deltimer(loop_timer_id)
 		loop_timer_id = null
 	to_chat(invoker, "<span class='brass'>You are no longer invoking <b>[name]</b></span>")
-	qdel(progress)
+	progress.end_progress()
 	PH.remove_ranged_ability()
 	invoking_slab.charge_overlay = null
 	invoking_slab.update_icon()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -30,6 +30,9 @@
 	remove_from_alive_mob_list()
 	remove_from_mob_suicide_list()
 	focus = null
+	if(length(progressbars))
+		stack_trace("[src] destroyed with elements in its progressbars list")
+		progressbars = null
 	for (var/alert in alerts)
 		clear_alert(alert, TRUE)
 	if(observers?.len)


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/50316

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cleans up the code surrounding handling of progressbars, especially deletion.

Deletion of progressbars is now handled snowflaked. Instead of going through `qdel()`, it should go through the `end_progress()` proc.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Progressbars are not being properly GC'd.

Addition of stack traces for fucked up progressbar scenarios should help identify future issues.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Progressbars being cleanly completed, but also interrupted, without causing issues.

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/1dbad91a-38ff-4759-ae7e-2730dc9448dc



</details>

## Changelog
:cl: rkz, Rohesie
refactor: progressbar handling, especially deletion
code: adds stack traces & code docs to progressbars
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
