### PR TITLE
nukies can do war below the pop limit without the extra TC

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -21,7 +21,7 @@
 		return
 
 	declaring_war = TRUE
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? [check_pop()? "" : "You will not be provided with any additional equipment given the small size of the crew. "]You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time + SSticker.round_start_time)] to decide", "Declare war?", "Yes", "No")
+	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? [check_pop()? "" : "You will not be provided with any additional equipment given the small size of the crew. "]You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time + SSticker.round_start_time)] to decide", "Declare war?", list("Yes", "No"))
 	declaring_war = FALSE
 
 	if(!check_allowed(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Allows nuclear operatives to enter war when the pop is below the required amount, without the extra TC that warops would normally afford.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Warops makes the nukie gamemode much more interesting by providing a warning to the station so they can prepare. Countless times stealth nukies have steamrolled the station, and every nukie gimmick is completely exhausted.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->


<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/9c4c92da-9a41-4eb7-aed4-1c170772ec9f

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/e8651021-9361-47f9-8ec8-dea44e91d975)

</details>

## Changelog
:cl: Ratón
tweak: Nukies can do war without the TC if the pop is below the required amount
tweak: TGUIfied the nukie war prompt
fix: The nukie war time limit display now works properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
