### PR TITLE
Randomized shift for thrown items

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -284,6 +284,8 @@
 		if(I.loc != real_location)
 			continue
 		remove_from_storage(I, target)
+		I.pixel_x = rand(-10,10)
+		I.pixel_y = rand(-10,10)
 		if(trigger_on_found && I.on_found())
 			return FALSE
 		if(TICK_CHECK)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -885,6 +885,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if (callback) //call the original callback
 		. = callback.Invoke()
 	item_flags &= ~PICKED_UP
+	if(!pixel_y && !pixel_x)
+		pixel_x = rand(-8,8)
+		pixel_y = rand(-8,8)
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
 	if(!newLoc)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -885,7 +885,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if (callback) //call the original callback
 		. = callback.Invoke()
 	item_flags &= ~PICKED_UP
-	if(!pixel_y && !pixel_x)
+	if(!pixel_y && !pixel_x && !(item_flags & NO_PIXEL_RANDOM_DROP))
 		pixel_x = rand(-8,8)
 		pixel_y = rand(-8,8)
 

--- a/code/game/objects/items/bedsheets.dm
+++ b/code/game/objects/items/bedsheets.dm
@@ -37,6 +37,8 @@
 	if(layer == initial(layer))
 		layer = ABOVE_MOB_LAYER
 		to_chat(user, "<span class='notice'>You cover yourself with [src].</span>")
+		pixel_x = 0
+		pixel_y = 0
 	else
 		layer = initial(layer)
 		to_chat(user, "<span class='notice'>You smooth [src] out beneath you.</span>")

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -14,6 +14,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
+	item_flags = NO_PIXEL_RANDOM_DROP
 	throwforce = 5
 	throw_speed = 1
 	throw_range = 2

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -12,12 +12,12 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
+	canSmoothWith = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
 
 	thermal_conductivity = 0.04
 	heat_capacity = 10000
 	tiled_dirt = TRUE
-	smoothing_groups = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
-	canSmoothWith = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
 
 	overfloor_placed = TRUE
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -296,7 +296,7 @@
 	. = doUnEquip(I, force, drop_location(), FALSE, silent = silent)
 	if(!. || !I) //ensure the item exists and that it was dropped properly.
 		return
-	if(!(I.item_flags & NO_PIXEL_RANDOM_DROP) && !(I.item_flags & WAS_THROWN))
+	if(!(I.item_flags & NO_PIXEL_RANDOM_DROP))
 		I.pixel_x = rand(-6, 6)
 		I.pixel_y = rand(-6, 6)
 	I.do_drop_animation(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Ports:
- https://github.com/tgstation/tgstation/pull/45155

## About The Pull Request

This is an expansion of Wilson's #8587 

This PR randomizes the pixel shift of items when thrown. This applies to all items, except those with the existing item_flag NO_PIXEL_RANDOM_DROP. 
The flag can be used for items that would get really fucky if they were shifted (The fake singulo toy for example)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Items traveling in a perfect arc and landing center tile is... nonsensical. If you have many items thrown by and explosion or spacewind, they all stack on top of eachother and it doesnt look organic at all. 
A lot of items can get hidden under eachother.

If players specifically want to layer items perfectly center, both the rack and alt-clicking a table perform this behavior fine.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/201ba4de-7bdf-4e51-8b7c-8bf02579dd71



</details>

## Changelog
:cl: rkz, mickyan
add: randomized pixel shifting when throwing items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
