### PR TITLE
Screwdriver on Lathe - What she doin?

### DIFF
--- a/code/game/machinery/fabricators/autolathe.dm
+++ b/code/game/machinery/fabricators/autolathe.dm
@@ -81,6 +81,11 @@
 			security_interface_locked = TRUE
 			. = TRUE
 
+/obj/machinery/modular_fabricator/autolathe/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/I)
+	if(user.a_intent == INTENT_HELP || user.a_intent == INTENT_HARM)
+		return
+	. = .. ()
+
 /obj/machinery/modular_fabricator/autolathe/attackby(obj/item/O, mob/user, params)
 
 	if((ACCESS_SECURITY in O.GetAccess()) && !(obj_flags & EMAGGED))
@@ -92,7 +97,7 @@
 		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
 		return TRUE
 
-	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O) && user.a_intent != INTENT_HELP && user.a_intent != INTENT_HARM)
 		return TRUE
 
 	if(default_deconstruction_crowbar(O))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now you can put screwdriver in lathe.
Or beat lathe with screwdriver.
Life is fun

## Why It's Good For The Game

I want screwdriver in lathe.
Also if you aciddently printed lots of screwdrivers suddenly you have clutter you can't easily undo.

Screwdriver should go on lathe. Let me PUT IT IN THE LATHE.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/94647521/1f0260a3-6806-4923-80bc-fd24ee7f6978


</details>

## Changelog
:cl: Orange Cat Activity Yoon
tweak: Attacking a lathe with a screwdriver on help intent now recycles the screwdriver.
tweak: Attacking a lathe with a screwdriver on harm intent now beats the lathe's ass.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
