### PR TITLE
Lowers zombie infection chance when hit

### DIFF
--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -12,7 +12,7 @@
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
 	force = 21 // Just enough to break airlocks with melee attacks
-	var/infection_chance = 50
+	var/base_infection_chance = 80
 	damtype = BRUTE
 
 /obj/item/zombie_hand/Initialize(mapload)
@@ -38,7 +38,7 @@
 			var/flesh_wound = ran_zone(user.get_combat_bodyzone(target))
 			if(H.check_shields(src, 0))
 				return
-			if(prob(100-H.getarmor(flesh_wound, MELEE, armour_penetration)))
+			if(prob(base_infection_chance-H.getarmor(flesh_wound, MELEE, armour_penetration)))
 				try_to_zombie_infect(target)
 		else
 			check_feast(target, user)
@@ -49,9 +49,6 @@
 	if(NOZOMBIE in target.dna.species.species_traits)
 		// cannot infect any NOZOMBIE subspecies (such as high functioning
 		// zombies)
-		return
-
-	if(prob(100-infection_chance))
 		return
 
 	var/obj/item/organ/zombie_infection/infection

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -12,7 +12,7 @@
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
 	force = 21 // Just enough to break airlocks with melee attacks
-	infection_chance = 50
+	var/infection_chance = 50
 	damtype = BRUTE
 
 /obj/item/zombie_hand/Initialize(mapload)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -12,7 +12,8 @@
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
 	force = 21 // Just enough to break airlocks with melee attacks
-	var/base_infection_chance = 80 // Base infection chance of 80%, gets lowered with armour
+	/// Base infection chance of 80%, gets lowered with armour
+	var/base_infection_chance = 80
 	damtype = BRUTE
 
 /obj/item/zombie_hand/Initialize(mapload)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -12,7 +12,7 @@
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
 	force = 21 // Just enough to break airlocks with melee attacks
-	var/base_infection_chance = 80
+	var/base_infection_chance = 80 // Base infection chance of 80%, gets lowered with armour
 	damtype = BRUTE
 
 /obj/item/zombie_hand/Initialize(mapload)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -12,6 +12,7 @@
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
 	force = 21 // Just enough to break airlocks with melee attacks
+	infection_chance = 50
 	damtype = BRUTE
 
 /obj/item/zombie_hand/Initialize(mapload)
@@ -48,6 +49,9 @@
 	if(NOZOMBIE in target.dna.species.species_traits)
 		// cannot infect any NOZOMBIE subspecies (such as high functioning
 		// zombies)
+		return
+
+	if(prob(100-infection_chance))
 		return
 
 	var/obj/item/organ/zombie_infection/infection


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so the zombie hand infects on a 80% chance instead of being a one hit infection.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Zombie infections are much more difficult to fight off now that the tumor deals brain damage, this makes it so getting hit once by a zombie (without armour) doesn't mean you're instantly infected.

## Testing Photographs and Procedure
Literally just a probability early return, untested.

## Changelog
:cl: Ratón
tweak: Zombies infect on a 80% chance (+armor) instead of instantly infecting on hit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
