### PR TITLE
Fixed Detectives Office and AI Upload Connection

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1165,9 +1165,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"apd" = (
-/turf/closed/wall,
-/area/security/detectives_office)
 "apf" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -5111,9 +5108,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
@@ -8260,10 +8254,13 @@
 	dir = 6
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/structure/filingcabinet/security{
+	pixel_x = 8
 	},
-/turf/open/floor/carpet/grimy,
+/obj/structure/filingcabinet{
+	pixel_x = -8
+	},
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "bzJ" = (
 /obj/machinery/computer/mecha{
@@ -20652,7 +20649,7 @@
 	buildstackamount = 0;
 	dir = 8
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/wood,
 /area/security/detectives_office)
 "edc" = (
 /obj/structure/cable/yellow{
@@ -20927,6 +20924,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/item/folder/red{
+	pixel_y = 1
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
@@ -21230,7 +21230,7 @@
 	dir = 4;
 	pixel_y = -3
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "eqT" = (
 /obj/structure/extinguisher_cabinet{
@@ -25355,13 +25355,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "gqx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/carpet/grimy,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/detectives_office)
 "gqQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -25966,9 +25966,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria_red,
 /area/crew_quarters/bar)
-"gFs" = (
-/turf/open/floor/carpet/grimy,
-/area/security/detectives_office)
 "gGm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -26998,7 +26995,7 @@
 	pixel_x = -11;
 	pixel_y = -21
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/wood,
 /area/security/detectives_office)
 "hhB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27923,6 +27920,15 @@
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hFX" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hGa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -28535,6 +28541,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/effect/landmark/start/detective,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "hVk" = (
@@ -30352,9 +30359,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "iPH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
@@ -32164,7 +32168,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "jMr" = (
 /obj/machinery/computer/slot_machine,
@@ -35851,7 +35855,7 @@
 /obj/item/clothing/glasses/hud/security/sunglasses{
 	pixel_y = 6
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "lvl" = (
 /obj/effect/turf_decal/tile/red{
@@ -36536,10 +36540,6 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
-"lIq" = (
-/obj/structure/lattice,
-/turf/open/floor/carpet/grimy,
 /area/space/nearstation)
 "lIF" = (
 /obj/structure/disposalpipe/segment,
@@ -38664,7 +38664,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "mJR" = (
 /obj/structure/cable/yellow{
@@ -42175,7 +42175,7 @@
 /obj/item/pen/fountain{
 	pixel_y = 5
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "ooI" = (
 /obj/effect/turf_decal/tile/red,
@@ -52424,19 +52424,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "tit" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /obj/item/storage/secure/safe{
 	pixel_x = -22
 	},
-/obj/machinery/vending/wardrobe/det_wardrobe,
 /obj/machinery/requests_console{
 	department = "Detective's office";
 	pixel_x = -1;
 	pixel_y = -35
 	},
-/turf/open/floor/carpet/grimy,
+/obj/machinery/vending/boozeomat/all_access{
+	req_access_txt = "4"
+	},
+/turf/closed/wall,
 /area/security/detectives_office)
 "tjd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -52827,10 +52826,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"tsU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/carpet/grimy,
-/area/security/detectives_office)
 "tsY" = (
 /turf/closed/wall,
 /area/medical/virology)
@@ -53245,12 +53240,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
-"tBy" = (
-/obj/machinery/vending/boozeomat/all_access{
-	req_access_txt = "4"
-	},
-/turf/closed/wall/r_wall,
-/area/security/detectives_office)
 "tBH" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -55129,7 +55118,7 @@
 /area/chapel/main)
 "uwU" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "uwZ" = (
 /turf/closed/wall,
@@ -55392,8 +55381,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/filingcabinet/security,
-/turf/open/floor/carpet/grimy,
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "uFg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -59623,6 +59612,9 @@
 "wWf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wWy" = (
@@ -59876,10 +59868,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "xcE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -60981,10 +60970,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xzc" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/detective,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -60994,7 +60979,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/turf/open/floor/carpet/grimy,
+/turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "xzi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -61310,9 +61295,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
-"xGO" = (
-/turf/open/floor/carpet/grimy,
-/area/maintenance/fore)
 "xGT" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -86998,7 +86980,7 @@ yeN
 meS
 tcO
 wWf
-bBi
+hFX
 aJq
 cMI
 aJq
@@ -89291,9 +89273,9 @@ jnN
 aOr
 gXs
 gXs
-lIq
-lIq
-lIq
+gXs
+gXs
+gXs
 uau
 uwU
 aqR
@@ -89548,11 +89530,11 @@ maf
 wQj
 wQj
 svF
-tsU
-tsU
-gFs
-gFs
-xGO
+svF
+svF
+wQj
+wQj
+aqR
 aqR
 sse
 ayL
@@ -89808,8 +89790,8 @@ vVa
 eqI
 uEX
 tit
-gFs
-xGO
+wQj
+aqR
 aqR
 pUk
 wMt
@@ -90322,7 +90304,7 @@ luA
 ooG
 xcD
 bzH
-tBy
+wQj
 aqR
 aqR
 sse
@@ -90830,9 +90812,9 @@ aai
 anz
 anz
 anz
-apd
-apd
-apd
+wQj
+wQj
+wQj
 cuy
 nTf
 cuy


### PR DESCRIPTION
## About The Pull Request
Fixed the Detective Office and reconnects AI upload with the station grid. Also some minor changes to Detectives office.

Fixes issue #10514 after after #10515 was non-responsive.

## Why It's Good For The Game
Dying on-round start is bad.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/30a85578-4552-49b7-ab6d-365428d7af51)

</details>

## Changelog
:cl:
fix: Detectives office is no longer a vacuum on round start.
fix: Reconnects AI upload.
fix: Detective Booze-O-Mat is no longer maintenance accessible.
/:cl: