### PR TITLE
Nerfs fugu gland somewhat

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -138,6 +138,7 @@
 		A.maxHealth *= 1.5
 		A.health = min(A.maxHealth,A.health*1.5)
 		A.melee_damage = max((A.melee_damage * 1.5), 10)
+		A.obj_damage = max(A.melee_damage, A.obj_damage) //Some mobs already have turbo object damage, and this doesn't need to be boosted. This ensures it's never less than their basic damage though.
 		A.transform *= 2
 		to_chat(user, "<span class='info'>You increase the size of [A], giving it a surge of strength!</span>")
 		qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -137,9 +137,8 @@
 		A.buffed++
 		A.maxHealth *= 1.5
 		A.health = min(A.maxHealth,A.health*1.5)
-		A.melee_damage = max((A.melee_damage * 2), 10)
+		A.melee_damage = max((A.melee_damage * 1.5), 10)
 		A.transform *= 2
-		A.environment_smash |= ENVIRONMENT_SMASH_STRUCTURES | ENVIRONMENT_SMASH_RWALLS
 		to_chat(user, "<span class='info'>You increase the size of [A], giving it a surge of strength!</span>")
 		qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Reduces damage buff of fugu gland by 50% (It now boosts damage by 50% instead of doubling it)
* Removes the immediate destruction flags from fugu gland buff, so mobs cannot bypass destruction checks with fugu gland
* Checks if object damage is lower than combat damage and sets it to match if it is. This means certain mobs that already have boosted object damage will see less of a buff to their object damage from fugu gland, or potentially no buff at all. For mobs which do not have 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fugu glands were overlooked when environmental damage was updated. Mobs do not need the ability to instantly destroy reinforced walls in a single click. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

There is no testing evidence at this time, it will be provided upon request if necessary - The PR changes are minimal and I do not believe testing is necessary in this case. 

</details>

## Changelog
:cl:
balance: Fugu gland now increases the damage output of the mob it is applied to by 50% instead of 100%
balance: Fugu gland no longer bypasses environmental damage checks for mobs it is applied to. The gland will still increase object damage to equal the newly buffed combat damage if it is higher. 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
