### PR TITLE
Customize your milk!

### DIFF
--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -170,3 +170,13 @@
 		made_something = TRUE
 	if(made_something && on_generate_callback)
 		on_generate_callback.Invoke(reagents.total_volume, reagents.maximum_volume)
+
+/**
+ * # venom udder subtype
+ *
+ * Used by snakes, I guess other venomous creatures if you want to.
+ */
+/obj/item/udder/venom
+	name = "venom gland"
+
+

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -9,10 +9,11 @@
 	///optional proc to callback to when the udder is milked
 	var/datum/callback/on_milk_callback
 
-/datum/component/udder/Initialize(udder_type = /obj/item/udder, on_milk_callback, on_generate_callback)
+//udder_type and reagent_produced_typepath are typepaths, not reference
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, on_milk_callback, on_generate_callback, reagent_produced_typepath = /datum/reagent/consumable/milk)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
-	udder = new udder_type(null, parent)
+	udder = new udder_type(null, parent, on_generate_callback, reagent_produced_typepath)
 	src.on_milk_callback = on_milk_callback
 
 /datum/component/udder/RegisterWithParent()
@@ -60,6 +61,8 @@
  */
 /obj/item/udder
 	name = "udder"
+	///typepath of reagent produced by the udder
+	var/reagent_produced_typepath = /datum/reagent/consumable/milk
 	///how much the udder holds
 	var/size = 50
 	///mob that has the udder component
@@ -67,16 +70,19 @@
 	///optional proc to callback to when the udder generates milk
 	var/datum/callback/on_generate_callback
 
-/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback)
+/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback, reagent_produced_typepath = /datum/reagent/consumable/milk)
 	src.udder_mob = udder_mob
 	src.on_generate_callback = on_generate_callback
 	create_reagents(size/*, REAGENT_HOLDER_ALIVE*/)
+	src.reagent_produced_typepath = reagent_produced_typepath
 	initial_conditions()
 	. = ..()
 
 /obj/item/udder/Destroy()
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
+	udder_mob = null
+	on_generate_callback = null
 
 /obj/item/udder/process(delta_time)
 	if(udder_mob.stat != DEAD)
@@ -87,7 +93,7 @@
  * also useful for changing initial amounts in reagent holder (cows start with milk, gutlunches start empty)
  */
 /obj/item/udder/proc/initial_conditions()
-	reagents.add_reagent(/datum/reagent/consumable/milk, 20)
+	reagents.add_reagent(reagent_produced_typepath, 20)
 	START_PROCESSING(SSobj, src)
 
 /**
@@ -95,7 +101,7 @@
  */
 /obj/item/udder/proc/generate()
 	if(prob(5))
-		reagents.add_reagent(/datum/reagent/consumable/milk, rand(5, 10))
+		reagents.add_reagent(reagent_produced_typepath, rand(5, 10))
 		if(on_generate_callback)
 			on_generate_callback.Invoke(reagents.total_volume, reagents.maximum_volume)
 

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -10,7 +10,7 @@
 	var/datum/callback/on_milk_callback
 
 //udder_type and reagent_produced_typepath are typepaths, not reference
-/datum/component/udder/Initialize(udder_type = /obj/item/udder, on_milk_callback, on_generate_callback, reagent_produced_typepath = /datum/reagent/consumable/milk)
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, datum/callback/on_milk_callback, datum/callback/on_generate_callback, reagent_produced_typepath = /datum/reagent/consumable/milk)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
 	udder = new udder_type(null, parent, on_generate_callback, reagent_produced_typepath)
@@ -22,6 +22,7 @@
 
 /datum/component/udder/UnregisterFromParent()
 	QDEL_NULL(udder)
+	on_milk_callback = null
 	UnregisterSignal(parent, list(COMSIG_PARENT_EXAMINE, COMSIG_PARENT_ATTACKBY))
 
 ///signal called on parent being examined
@@ -116,8 +117,8 @@
 	if(milk_holder.reagents.total_volume >= milk_holder.volume)
 		to_chat(user, "<span class='warning'>[milk_holder] is full.</span>")
 		return
-	var/transfered = reagents.trans_to(milk_holder, rand(5,10))
-	if(transfered)
+	var/transferred = reagents.trans_to(milk_holder, rand(5,10))
+	if(transferred)
 		user.visible_message("<span class='notice'>[user] milks [src] using \the [milk_holder].</span>", "<span class='notice'>You milk [src] using \the [milk_holder].</span>")
 	else
 		to_chat(user, "<span class='warning'>The udder is dry. Wait a bit longer...</span>")
@@ -137,10 +138,6 @@
 	if(udder_mob.gender == FEMALE)
 		START_PROCESSING(SSobj, src)
 	RegisterSignal(udder_mob, COMSIG_HOSTILE_ATTACKINGTARGET, PROC_REF(on_mob_attacking))
-
-/obj/item/udder/gutlunch/Destroy()
-	. = ..()
-	UnregisterSignal(udder_mob, COMSIG_HOSTILE_ATTACKINGTARGET)
 
 /obj/item/udder/gutlunch/process(delta_time)
 	var/mob/living/simple_animal/hostile/asteroid/gutlunch/gutlunch = udder_mob

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -67,15 +67,21 @@
 		names += componentsubtypes
 		names += "---Elements---"
 		names += sort_list(subtypesof(/datum/element), GLOBAL_PROC_REF(cmp_typepaths_asc))
-		var/result = input(usr, "Choose a component/element to add","better know what ur fuckin doin pal") as null|anything in names
-		if(!usr || !result || result == "---Components---" || result == "---Elements---")
+
+		var/result = tgui_input_list(usr, "Choose a component/element to add", "Add Component", names)
+		if(isnull(result))
 			return
+		if(!usr || result == "---Components---" || result == "---Elements---")
+			return
+
 		if(QDELETED(target))
 			to_chat(usr, "That thing doesn't exist anymore!")
 			return
+
 		var/list/lst = get_callproc_args()
 		if(!lst)
 			return
+
 		var/datumname = "error"
 		lst.Insert(1, result)
 		if(result in componentsubtypes)

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -41,6 +41,11 @@
 	held_state = "snake"
 
 
+/mob/living/simple_animal/hostile/retaliate/poison/snake/Initialize(mapload)
+	AddComponent(/datum/component/udder, /obj/item/udder/venom, reagent_produced_typepath = /datum/reagent/toxin/venom)
+	. = ..()
+
+
 /mob/living/simple_animal/hostile/retaliate/poison/snake/ListTargets(atom/the_target)
 	var/atom/target_from = GET_TARGETS_FROM(src)
 	var/list/living_mobs = list()


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/61224
- https://github.com/tgstation/tgstation/pull/62034

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes hardcoding of the reagent in the milkable(udder) component

Adds snake udder "venom gland".

Fixes a few bad qdels with the component

Converts VV Component list to tgui because It's tedious to scroll through.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Modular things like components should be, y'know, modular.

This was requested by players in the discord. I think its funny & adds more stuff to ghetto chemistry/traitoring.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/68d8d334-895e-47bd-869a-80f79ef2e386)


</details>

## Changelog
:cl: rkz, Seris02, ExcessiveUseOfCobblestone
code: Dehardcodes milkable component reagent
add: Snakes can now be milked for venom. They don't seem to mind.
fix: fixed bad qdels with milkable component
admin: converted VV component list input to TGUI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
