### PR TITLE
Stops gibtonite (and colossus) from making lava.

### DIFF
--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -87,6 +87,7 @@
 	icon_plating = "basalt"
 	environment_type = "basalt"
 	available_states = 12
+	resistance_flags = INDESTRUCTIBLE
 	digResult = /obj/item/stack/ore/glass/basalt
 
 /turf/open/floor/plating/asteroid/basalt/lava //lava underneath


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stops gibtonite from making lava on explosion (and colossus too) by making the lavaland floor indestructible.
The floor can still be deconstructed and dug into, which are the only other interactions I know.
Players are not able to obtain this floor tile, so while a more specialized fix might be possible, this works fine and is a whopping 1 line of code, easy to revert if needed later.

## Why It's Good For The Game

Gibtonite was designed as a fairly dangerous ore that can also help you mine faster. The turf damage change turned it into an annoying hazard with no upside, as it would destroy the floor and create lava which would:
-kill you immediately even if you'd survive otherwise
-smelt and then destroy any ores instead of mining them
-leave the patch of lava for the rest of the round until RCD'd

TLDR: Bad and unfun.

Colossus would also destroy the floor with his bolts and even melee attack though this is rarer. Clearly unintended.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![yea](https://github.com/BeeStation/BeeStation-Hornet/assets/64592313/97eef1cf-8057-4dc0-988c-6d2dcb7c6a32)

</details>

## Changelog
:cl:
tweak: lavaland floor is indestructible
/:cl: