### PR TITLE
Re-adds voltaic to the list of languages multilingual quirk users can choose.

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -61,5 +61,6 @@ GLOBAL_LIST_INIT(multilingual_language_list, typecacheof(list(
 	/datum/language/slime,
 	/datum/language/sylvan,
 	/datum/language/terrum,
-	/datum/language/uncommon
+	/datum/language/uncommon,
+	/datum/language/voltaic
 )))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-adds voltaic into the list of multilingual languages, allowing them to be picked by multilingual quirk users again. Multilingual was originally able to roll voltaic but that was apparently removed by accident with the addition of https://github.com/BeeStation/BeeStation-Hornet/pull/10357

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Fixes what seems to be an oversight considering that multilingual was originally able to roll voltaic.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
works on my machine
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_unHhWLcqJ8](https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/361e2ce2-aa0b-40dd-808f-97924f642a14)

![jZuybSEZWE](https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/85d65c34-a875-4914-8078-c8cfe809b4c8)

</details>

## Changelog
:cl: Hardly
fix: Re-added voltaic to the list of languages multilingual quirk users can choose.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
