### PR TITLE
More Security areas

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1195,10 +1195,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_job_reverse = TRUE
 	mood_message = "<span class='warning'>Hope they don't have a file on me.\n</span>"
 	
-/area/security/brig/brig_medbay/
+/area/security/brig/brig_medbay
 	name = "Brig Bay"
 	
-/area/security/brig/interrogation/
+/area/security/brig/interrogation
 	name = "Brig Interrogation"
 	mood_bonus = -1
 	mood_job_allowed = list(JOB_NAME_HEADOFSECURITY,JOB_NAME_WARDEN,JOB_NAME_SECURITYOFFICER,JOB_NAME_DETECTIVE)

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1203,7 +1203,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_bonus = -1
 	mood_job_allowed = list(JOB_NAME_HEADOFSECURITY,JOB_NAME_WARDEN,JOB_NAME_SECURITYOFFICER,JOB_NAME_DETECTIVE)
 	mood_job_reverse = TRUE
-	mood_message = "<span class='warning'>Oh God, what do they know?\n</span>"
+	mood_message = "<span class='warning'>Oh God, what do they know? \n</span>"
 
 /area/security/prison
 	name = "Prison Wing"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1169,6 +1169,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	
 /area/security/shuttle_dock
 	name = "Security Shuttle Dock"
+	
+/area/security/eva
+	name = "Security E.V.A. Storage"
 
 /area/security/courtroom
 	name = "Courtroom"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1166,6 +1166,15 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/main
 	name = "Security Office"
 	icon_state = "security"
+	
+/area/security/shuttle_dock
+	name = "Security Shuttle Dock"
+
+/area/security/courtroom
+	name = "Courtroom"
+	icon_state = "courtroom"
+	sound_environment = SOUND_AREA_LARGE_ENCLOSED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
 
 /area/security/brig
 	name = "Brig"
@@ -1175,12 +1184,23 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_job_reverse = TRUE
 
 	mood_message = "<span class='warning'>I hate cramped brig cells.\n</span>"
-
-/area/security/courtroom
-	name = "Courtroom"
-	icon_state = "courtroom"
-	sound_environment = SOUND_AREA_LARGE_ENCLOSED
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_ADVANCED
+	
+/area/security/brig/evidence
+	name = "Brig Evidencce"
+	mood_bonus = -1
+	mood_job_allowed = list(JOB_NAME_HEADOFSECURITY, JOB_NAME_RESEARCHDIRECTOR, JOB_NAME_CHIEFENGINEER, JOB_NAME_CAPTAIN, JOB_NAME_HEADOFPERSONNEL, JOB_NAME_CHIEFMEDICALOFFICER)
+	mood_job_reverse = TRUE
+	mood_message = "<span class='warning'>Hope they don't have a file on me.\n</span>"
+	
+/area/security/brig/brig_bay/
+	name = "Brig Bay"
+	
+/area/security/brig/interrogation/
+	name = "Brig Interrogation"
+	mood_bonus = -1
+	mood_job_allowed = list(JOB_NAME_HEADOFSECURITY,JOB_NAME_WARDEN,JOB_NAME_SECURITYOFFICER,JOB_NAME_DETECTIVE)
+	mood_job_reverse = TRUE
+	mood_message = "<span class='warning'>OH GOD OH FUCK!\n</span>"
 
 /area/security/prison
 	name = "Prison Wing"
@@ -1192,6 +1212,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/security/prison/shielded
 	name = "Prison Wing Shielded area"
+	icon_state = "sec_prison"
+	
+/area/security/prison/processing
+	name = "Prison Processing"
 	icon_state = "sec_prison"
 
 /area/security/processing

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1203,7 +1203,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_bonus = -1
 	mood_job_allowed = list(JOB_NAME_HEADOFSECURITY,JOB_NAME_WARDEN,JOB_NAME_SECURITYOFFICER,JOB_NAME_DETECTIVE)
 	mood_job_reverse = TRUE
-	mood_message = "<span class='warning'>OH GOD OH FUCK!\n</span>"
+	mood_message = "<span class='warning'>Oh God, what do they know?\n</span>"
 
 /area/security/prison
 	name = "Prison Wing"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1195,7 +1195,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_job_reverse = TRUE
 	mood_message = "<span class='warning'>Hope they don't have a file on me.\n</span>"
 	
-/area/security/brig/brig_bay/
+/area/security/brig/brig_medbay/
 	name = "Brig Bay"
 	
 /area/security/brig/interrogation/


### PR DESCRIPTION
## About The Pull Request

Adds more Security and Brig areas for us to designate. This PR has no actual mapping changes and is for future or current mappers to implement with their current Brig reworks.

Areas added: Security Shuttle Dock, Security EVA, Brig Evidence, Brig Bay (Brig Physician room), Brig Interrogation, Prison Processing.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/25d9ef97-7b68-4240-ad45-dd4d9d15e2b8) 

## Why It's Good For The Game

On Rad Station for example this entire marked out area is on one single APC. If it runs out of power or is destroyed this entire area is immediately shut down.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/ba72ccc1-a46f-414c-bb6a-4bbf522f8a56) 

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
</details>

## Changelog
:cl:
add: The following areas: Security Shuttle Dock, Security EVA, Brig Evidence, Brig Bay (Brig Physician room), Brig Interrogation, Prison Processing.
/:cl: