### PR TITLE
Fixes z-clear not throwing zombie announcements when it should

### DIFF
--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(zclear)
 		if(!L)
 			continue
 		//Dead mobs get sent to new ruins
-		if(L.ckey || L.client || L.mind)
+		if(L.ckey || L.client || (L.mind && L.stat == DEAD))
 			var/turf/T = get_turf(L)
 			mob_levels["[T.z]"] = TRUE
 			if(L.stat != DEAD)

--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -70,12 +70,14 @@ SUBSYSTEM_DEF(zclear)
 		if(!L)
 			continue
 		//Dead mobs get sent to new ruins
-		if(L.ckey || L.mind || L.client)
+		if(L.ckey || L.client)
 			var/turf/T = get_turf(L)
 			mob_levels["[T.z]"] = TRUE
 			if(L.stat != DEAD)
 				active_levels["[T.z]"] = TRUE
-				living_levels["[T.z]"] = TRUE
+				// Give the announcement if there are only non-humans left.
+				if (ishuman(L))
+					living_levels["[T.z]"] = TRUE
 	//Check active nukes
 	for(var/obj/machinery/nuclearbomb/decomission/bomb in GLOB.decomission_bombs)
 		if(bomb.timing)

--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(zclear)
 		if(!L)
 			continue
 		//Dead mobs get sent to new ruins
-		if(L.ckey || L.client || (L.mind && L.stat == DEAD))
+		if(L.ckey || L.client || L.mind)
 			var/turf/T = get_turf(L)
 			mob_levels["[T.z]"] = TRUE
 			if(L.stat != DEAD)

--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(zclear)
 		if(!L)
 			continue
 		//Dead mobs get sent to new ruins
-		if(L.ckey || L.client)
+		if(L.ckey || L.client || L.mind)
 			var/turf/T = get_turf(L)
 			mob_levels["[T.z]"] = TRUE
 			if(L.stat != DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ZClear will now throw zombie level announcements if there are only non-humans left on a z-level.

## Why It's Good For The Game

The announcement should now show when there are only things like blob zombies on a ruin.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Z-Clear announcement will now be thrown when there are only non-living player controlled mobs left on a ruin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
