### PR TITLE
Holodeck offline template fix

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -56,11 +56,11 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	var/area/holodeck/linked
 
 	///what program is loaded right now or is about to be loaded
-	var/program = "offline"
+	var/program = "recreational-offline"
 	var/last_program
 
 	///the default program loaded by this holodeck when spawned and when deactivated
-	var/offline_program = "offline"
+	var/offline_program = "recreational-offline"
 
 	///stores all of the unrestricted holodeck map templates that this computer has access to
 	var/list/program_cache

--- a/code/modules/holodeck/holodeck_map_templates.dm
+++ b/code/modules/holodeck/holodeck_map_templates.dm
@@ -15,7 +15,7 @@
 
 /datum/map_template/holodeck/recreation/offline
 	name = "Holodeck - Offline"
-	template_id = "offline"
+	template_id = "recreational-offline"
 	mappath = "_maps/holodeck/offline.dmm"
 
 /datum/map_template/holodeck/recreation/emptycourt
@@ -176,7 +176,7 @@
 
 /datum/map_template/holodeck/prison/offline
 	name = "Workshop - Offline"
-	template_id = "offline"
+	template_id = "workshop-offline"
 	mappath = "_maps/holodeck/workshop/offline.dmm"
 
 /datum/map_template/holodeck/prison/donut

--- a/code/modules/security/workshop.dm
+++ b/code/modules/security/workshop.dm
@@ -76,7 +76,7 @@
 /obj/machinery/computer/holodeck/prison/proc/temporary_down()
 	if(!offline)
 		say("Emergency shutdown engaged. Restarting in 2 minutes...")
-		offline_program = "offline"
+		offline_program = "workshop-offline"
 		emergency_shutdown()
 		offline = TRUE
 		offline_program = pick("donut", "plush")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Assigns the correct offline template IDs to the holodeck computers.
Fixes bad duplicate template ids for both the workshop and recreational holodecks, which caused the recreational holodeck to load the offline template of the workshop, causing problems.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug that broke recreational holodeck.
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/10511
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97298717/3fdc6ac2-bf4b-4148-83b9-8b0776fb29d4)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/97298717/e54399e0-b994-4b81-a4c7-6baad47b2c0a)

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: fixes recreational holodeck loading the wrong offline template.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
