### PR TITLE
Reverts crate's drag slowdown from 1.5 back to 0

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -21,7 +21,7 @@
 	close_sound = 'sound/machines/crate_close.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 50
-	drag_slowdown = 1.5
+	drag_slowdown = 0
 	imacrate = TRUE
 	var/crate_climb_time = 20
 	var/azimuth_angle_2 = 180 //in this context the azimuth angle for over 90 degree


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Reverts a undocumented change on https://github.com/BeeStation/BeeStation-Hornet/pull/10136 which increased the crate's drag_slowdown from 0 to 1.5. Meaning that there is no more slowdown from pulling the crates.

Only crates you'd usually find in maintenance or cargo have been changed, lockers or closets still have the slowdown intact.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Whenever the slowdown addition was intended or not, the change was not documented.

The slowdown is also so slow that it mainly affects cargo technicians who are most if not always the ones dragging crates around for deliveries or dragging them from maintenance back to the supply shuttle for the extra credits. I do not believe this will affect balance in any way like before.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/3f1c2cb2-c1bd-4d78-919d-69b0b4759aa9

</details>

## Changelog
:cl: Hardly
tweak: Reverted the crate's drag slowdown back to 0.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
