### PR TITLE
Fixes sanity getting stuck at insane and breaking the UI

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -188,6 +188,8 @@
 			setSanity(sanity+sanity_modifier*delta_time*mood+0.6)
 		if(SANITY_INSANE-1 to SANITY_CRAZY)
 			setSanity(sanity+sanity_modifier*delta_time*mood+0.9)
+		if (-INFINITY to SANITY_INSANE) //prevents it from going below 0. This caused issues.
+			setSanity(0)
 	HandleNutrition(owner)
 
 /datum/component/mood/proc/setSanity(amount, minimum=SANITY_INSANE, maximum=SANITY_GREAT)


### PR DESCRIPTION
## About The Pull Request
Adds a clamp to the sanity value for players, making it so they can't go below 0. Zero is still very much insane, but prevents the sanity value from falling outside of the bounds the game looks for, which causes it to get stuck at that point. While you could also just expand the range of values the game looks for, that could cause unintended behavior when multiplying two large negative numbers. I think this is best.

## Why It's Good For The Game

Fixes a slightly UI breaking and very annoying bug.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
Still don't know how to screenshot this. People aren't going insane immediately, so win?
</details>

## Changelog
:cl:
fix: Made it so that you can't become so insane that the entire sanity system breaks.
/:cl:

