### PR TITLE
Temporary fix for imperfect mutation toxin (Better!)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -612,10 +612,14 @@
 	race = /datum/species/oozeling
 	taste_description = "grandma's gelatin"
 
-/datum/reagent/medicine/mine_salve/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
-	M.reagents.add_reagent(/datum/reagent/toxin/genetic_instability, 10)
+/datum/reagent/mutationtoxin/jelly/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	M.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
 
 /datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/human/H)
+	if(H.reagents.has_reagent(/datum/reagent/genetic_instability))
+		H.reagents.del_reagent(type)
+		to_chat(H, "<span class='warning'>Your body is too unstable from a recent mutation, the imperfect mutation has no effect!</span>")
+		return FALSE
 	if(isoozeling(H))
 		to_chat(H, "<span class='warning'>Your body shifts and morphs, turning you into another subspecies!</span>")
 		var/species_type
@@ -638,6 +642,14 @@
 		to_chat(H, "<span class='warning'>You've become \a [initial(species_type.name)]!</span>")
 		return TRUE
 	return ..()
+
+//PLACEHOLDER TO STOP EXPLOIT, DO NOT MERGE THIS PR IT WILL BE FIXED PROPERLY
+
+/datum/reagent/genetic_instability
+	name = "Genetic Instability"
+	description = "Cannot slime transform while this is present"
+	chem_flags = CHEMICAL_NOT_SYNTH | CHEMICAL_RNG_FUN
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 
 /datum/reagent/mutationtoxin/golem
 	name = "Golem Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -630,7 +630,7 @@
 			species_type = pick(subtypesof(/datum/species/oozeling))
 		H.set_species(species_type)
 		H.reagents.del_reagent(type)
-		M.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
+		H.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
 		return TRUE
 
 	if(current_cycle >= cycles_to_turn) //overwrite since we want subtypes of jelly
@@ -638,7 +638,7 @@
 		H.set_species(species_type)
 		H.reagents.del_reagent(type)
 		to_chat(H, "<span class='warning'>You've become \a [initial(species_type.name)]!</span>")
-		M.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
+		H.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
 		return TRUE
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -612,9 +612,6 @@
 	race = /datum/species/oozeling
 	taste_description = "grandma's gelatin"
 
-/datum/reagent/mutationtoxin/jelly/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
-	M.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
-
 /datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/human/H)
 	if(H.reagents.has_reagent(/datum/reagent/genetic_instability))
 		H.reagents.del_reagent(type)
@@ -633,6 +630,7 @@
 			species_type = pick(subtypesof(/datum/species/oozeling))
 		H.set_species(species_type)
 		H.reagents.del_reagent(type)
+		M.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
 		return TRUE
 
 	if(current_cycle >= cycles_to_turn) //overwrite since we want subtypes of jelly
@@ -640,6 +638,7 @@
 		H.set_species(species_type)
 		H.reagents.del_reagent(type)
 		to_chat(H, "<span class='warning'>You've become \a [initial(species_type.name)]!</span>")
+		M.reagents.add_reagent(/datum/reagent/genetic_instability, 10)
 		return TRUE
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -612,13 +612,25 @@
 	race = /datum/species/oozeling
 	taste_description = "grandma's gelatin"
 
+/datum/reagent/medicine/mine_salve/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	M.reagents.add_reagent(/datum/reagent/toxin/genetic_instability, 10)
+
 /datum/reagent/mutationtoxin/jelly/on_mob_life(mob/living/carbon/human/H)
 	if(isoozeling(H))
 		to_chat(H, "<span class='warning'>Your body shifts and morphs, turning you into another subspecies!</span>")
-		var/species_type = pick(subtypesof(/datum/species/oozeling))
+		var/species_type
+		if(isstargazer(H))
+			species_type = /datum/species/oozeling/slime
+		else if(isslimeperson(H))
+			species_type = /datum/species/oozeling/luminescent
+		else if(isluminescent(H))
+			species_type = /datum/species/oozeling/stargazer
+		else //it is not already a subtype, so pick randomly
+			species_type = pick(subtypesof(/datum/species/oozeling))
 		H.set_species(species_type)
 		H.reagents.del_reagent(type)
 		return TRUE
+
 	if(current_cycle >= cycles_to_turn) //overwrite since we want subtypes of jelly
 		var/datum/species/species_type = pick(subtypesof(race))
 		H.set_species(species_type)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -969,3 +969,16 @@
 	M.silent = max(M.silent, 3)
 	M.confused = max(M.confused, 3)
 	..()
+
+/datum/reagent/toxin/genetic_instability
+	name = "Genetic Instability"
+	description = "A buildup of toxins resulting from rapid mutations"
+	chem_flags = CHEMICAL_NOT_SYNTH | CHEMICAL_RNG_FUN
+	toxpwr = 0
+	overdose_threshold = 30
+	metabolization_rate = 0.1
+
+/datum/reagent/toxin/geneetic_instability/overdose_process(mob/living/M)
+	holder.add_reagent(/datum/reagent/toxin/mutagen, 3)
+	holder.remove_reagent(/datum/reagent/toxin/genetic_instability, 2)
+

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -969,4 +969,3 @@
 	M.silent = max(M.silent, 3)
 	M.confused = max(M.confused, 3)
 	..()
-

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -970,15 +970,3 @@
 	M.confused = max(M.confused, 3)
 	..()
 
-/datum/reagent/toxin/genetic_instability
-	name = "Genetic Instability"
-	description = "A buildup of toxins resulting from rapid mutations"
-	chem_flags = CHEMICAL_NOT_SYNTH | CHEMICAL_RNG_FUN
-	toxpwr = 0
-	overdose_threshold = 30
-	metabolization_rate = 0.1
-
-/datum/reagent/toxin/geneetic_instability/overdose_process(mob/living/M)
-	holder.add_reagent(/datum/reagent/toxin/mutagen, 3)
-	holder.remove_reagent(/datum/reagent/toxin/genetic_instability, 2)
-


### PR DESCRIPTION
## About The Pull Request

* Imperfect mutation toxin now has a cooldown to prevent spamming
* Imperfect mutation toxin now rotates through species instead of always giving a random one - it only gives a random one if you aren't already one of the subspecies it turns you into

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Prevents spammy full heal exploit

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/9547572/1a73a563-a199-4e2f-9dda-eb414737d786)


## Changelog
:cl:
tweak: Imperfect mutation toxin now cycles through subspecies after you already have one instead of always being random. 
tweak: Imperfect mutation toxin now gives "genetic instability" which does nothing but prevents further Imperfect mutation toxin from working until it has been metabolized or removed. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
