### PR TITLE
Fixed Phobia related faint-looping for real this time

### DIFF
--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -159,6 +159,7 @@
 				fear_state = PHOBIA_STATE_TERROR
 				owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE)
 				owner.visible_message("<span class ='danger'>[owner] collapses into a fetal position and cowers in fear!</span>", "<span class ='userdanger'>I'm done for...</span>")
+				owner.Paralyze(80)
 				owner.Jitter(8)
 				stress++
 				if(prob(stress * 5))

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -18,12 +18,15 @@
 	var/fear_state = PHOBIA_STATE_CALM
 	var/stress_check = 0
 	var/last_scare = 0
+	var/faint_length = 0
+	var/cooldown_length = 0 //Grace period between faints caused by high fearscore
 	var/list/trigger_words
 	//instead of cycling every atom, only cycle the relevant types
 	var/list/trigger_mobs
 	var/list/trigger_objs //also checked in mob equipment
 	var/list/trigger_turfs
 	var/list/trigger_species
+	COOLDOWN_DECLARE(timer)
 
 /datum/brain_trauma/mild/phobia/New(new_phobia_type)
 	if(new_phobia_type)
@@ -32,6 +35,8 @@
 	if(!phobia_type)
 		phobia_type = pick_weight(SStraumas.phobia_types)
 
+	faint_length=300
+	cooldown_length=faint_length*2  //Has to be at least faint_length, else it practically doesnt do anything
 	gain_text = "<span class='warning'>You start finding [phobia_type] very unnerving...</span>"
 	lose_text = "<span class='notice'>You no longer feel afraid of [phobia_type].</span>"
 	scan_desc += " of [phobia_type]"
@@ -40,6 +45,7 @@
 	trigger_objs = SStraumas.phobia_objs[phobia_type]
 	trigger_turfs = SStraumas.phobia_turfs[phobia_type]
 	trigger_species = SStraumas.phobia_species[phobia_type]
+	fear_state = PHOBIA_STATE_CALM
 	..()
 
 
@@ -108,7 +114,7 @@
 			if(fear_state >= PHOBIA_STATE_UNEASY)
 				fear_state = PHOBIA_STATE_EDGY
 				owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE)
-				to_chat(owner, "<span class ='notice'>you manage to calm down a little.</span>")
+				to_chat(owner, "<span class ='notice'>You manage to calm down a little.</span>")
 			if(fear_state == PHOBIA_STATE_CALM)
 				fear_state = PHOBIA_STATE_EDGY
 				if(prob(stress * 5))
@@ -153,7 +159,6 @@
 				fear_state = PHOBIA_STATE_TERROR
 				owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE)
 				owner.visible_message("<span class ='danger'>[owner] collapses into a fetal position and cowers in fear!</span>", "<span class ='userdanger'>I'm done for...</span>")
-				owner.Paralyze(80)
 				owner.Jitter(8)
 				stress++
 				if(prob(stress * 5))
@@ -162,13 +167,19 @@
 			if(fear_state <= PHOBIA_STATE_TERROR)
 				fear_state = PHOBIA_STATE_FAINT
 				owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE) //in the case that we get so scared by enough bullshit nearby we skip the last stage
-				fearscore = 9
-				owner.visible_message("<span class ='danger'>[owner] faints in fear!</span>", "<span class ='userdanger'>It's too much! You faint!</span>")
-				owner.Sleeping(300)
-				if(prob(stress * 3))
-					owner.set_heartattack(TRUE)
-					to_chat(owner, "<span class='userdanger'>Your heart stops!</span>")
-				stress++
+				if(!timer || COOLDOWN_FINISHED(src, timer))
+					COOLDOWN_START(src, timer, cooldown_length)
+					owner.visible_message("<span class ='danger'>[owner] faints in fear!</span>", "<span class ='userdanger'>It's too much! You faint!</span>")
+					owner.Sleeping(faint_length)
+					fear_state = PHOBIA_STATE_EDGY
+					fearscore = 9
+					stress++
+					if(prob(stress))
+						owner.set_heartattack(TRUE)
+						to_chat(owner, "<span class='userdanger'>Your heart stops!</span>")
+				if(timer && !COOLDOWN_FINISHED(src, timer))
+					owner.visible_message("<span class ='danger'>[owner] looks ghostly pale, trembling uncontrollably!</span>", "<span class ='userdanger'>This is HELL! OUT!! NOW!!!</span>")
+					owner.Jitter(10)
 
 
 
@@ -202,7 +213,7 @@
 	if(owner.stat >= UNCONSCIOUS)
 		return
 	if(fear_state >= PHOBIA_STATE_EDGY)
-		stress_check = world.time + 3000
+		stress_check = world.time + 3000  //Stress begins to fall after 5 minutes only
 		last_scare = world.time + 100
 	if(reason)
 		if(isliving(reason))
@@ -245,10 +256,13 @@
 			owner.Jitter(3)
 		if(PHOBIA_STATE_FAINT)
 			if(!owner.stat)
-				if(fearscore>=36)  //Checks for fearscore so you wont be instantly fainting right after waking up from a faint and seeing the reason again
-					owner.Sleeping(300)
-					fear_state = PHOBIA_STATE_FIGHTORFLIGHT
+				if(!timer || (timer && COOLDOWN_FINISHED(src, timer)))  //If fainting hasnt happened yet, the cooldown timer never havve been created, so we check for that too
+					COOLDOWN_START(src, timer, cooldown_length)
+					owner.visible_message("<span class ='danger'>[owner] faints in fear!</span>", "<span class ='userdanger'>It's too much! You faint!</span>")
+					owner.Sleeping(faint_length)
+					fear_state = PHOBIA_STATE_EDGY
 					fearscore = 9
+					stress++
 
 
 /datum/brain_trauma/mild/phobia/on_lose()

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -178,7 +178,7 @@
 					if(prob(stress))
 						owner.set_heartattack(TRUE)
 						to_chat(owner, "<span class='userdanger'>Your heart stops!</span>")
-				if(timer && !COOLDOWN_FINISHED(src, timer))
+				else
 					owner.visible_message("<span class ='danger'>[owner] looks ghostly pale, trembling uncontrollably!</span>", "<span class ='userdanger'>This is HELL! OUT!! NOW!!!</span>")
 					owner.Jitter(10)
 

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -181,6 +181,7 @@
 				else
 					owner.visible_message("<span class ='danger'>[owner] looks ghostly pale, trembling uncontrollably!</span>", "<span class ='userdanger'>This is HELL! OUT!! NOW!!!</span>")
 					owner.Jitter(10)
+					stress++
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Made a cooldown for fainting caused by high fearscores for phobias. Currently this cooldown is twice the amount of the faint length (which I also made a variable than having it randomly given in the code, will use this later for implementing shorter cooldown between faints for higher stress levels in the future)
Since the cooldown starts with the fainting, it has to be at least as long as the faint's length itself else it doesnt do anything.
This cooldown can be tweaked at phobia.dm's 39th line

Also added new flavor text for when a faint is on cooldown, but you'd normally faint because of high fearscore.

Also made fainting more forgiving by decreasing the chance of a heartattack caused by high stress by 5 times. Basically the amount of times you actually faint/would faint but on cooldown * 3 amounts to the percentage chance of having one now. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I tried to fix this before (#8438), but I didnt yet know cooldowns existed and I wasnt experienced enough to code one myself. This fix is made to fix that last fix I did.

It sucks being stuck in a fainting loop being unable to do anything until you get a heartattack and die.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://www.youtube.com/watch?v=s6XuKWwrNmw

</details>

## Changelog
:cl:
tweak: decreased the chance to have a heartattack caused by high stress levels from phobias by 5 times
fix: fixed falling into a fainting loop caused by phobias for real now
add: new flavor text when your fear level is high enough to faint, but you fainted recently already (This means you are about to faint if you dont run)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
