### PR TITLE
Fixes Incorrect IPC trait Description

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2790,7 +2790,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "bolt",
 			SPECIES_PERK_NAME = "Shockingly Tasty",
-			SPECIES_PERK_DESC = "[plural_form] can feed on electricity from APCs, powercells, and lights; and do not otherwise need to eat.",
+			SPECIES_PERK_DESC = "[plural_form] can feed on electricity from APCs and powercells; and do not otherwise need to eat.",
 		))
 
 	return to_add

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2790,7 +2790,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "bolt",
 			SPECIES_PERK_NAME = "Shockingly Tasty",
-			SPECIES_PERK_DESC = "Ethereals can feed on electricity from APCs, powercells, and lights; and do not otherwise need to eat.",
+			SPECIES_PERK_DESC = "[plural_form] can feed on electricity from APCs, powercells, and lights; and do not otherwise need to eat.",
 		))
 
 	return to_add

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2850,3 +2850,4 @@ GLOBAL_LIST_EMPTY(features_by_species)
 //generic action proc for keybind stuff
 /datum/species/proc/primary_species_action()
 	return
+


### PR DESCRIPTION
## About The Pull Request
It says "Etheral" while you are looking at an IPC.

## Why It's Good For The Game
Minor oversight.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
Before

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/bafad870-9270-4dc7-8643-181e6a9a5405)

After

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/ebda7ae0-a0a0-4045-bd67-591d2b281f4a)

Does not mess with the Etheral description.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/df3efb71-afc9-4dc1-adff-b096df92438f)

</details>

## Changelog
:cl:
fix: Fixes power hungry trait description.
/:cl: