### PR TITLE
Fixes some initializations being counted as bad inits and a few actual bad inits

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -316,6 +316,7 @@
 	icon_state = "random_layer1"
 
 /atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, view)
+	. = ..()
 	src.add_atom_colour(SSparallax.assign_random_parallax_colour(), ADMIN_COLOUR_PRIORITY)
 
 /atom/movable/screen/parallax_layer/random/asteroids

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -166,7 +166,7 @@ SUBSYSTEM_DEF(atoms)
 				A.LateInitialize()
 		if(INITIALIZE_HINT_QDEL)
 			qdel(A)
-			qdeleted = TRUE
+			return TRUE //Don't need to check anything else since we know it's deleted already
 		else
 			BadInitializeCalls[the_type] |= BAD_INIT_NO_HINT
 

--- a/code/game/objects/items/bedsheets.dm
+++ b/code/game/objects/items/bedsheets.dm
@@ -296,7 +296,7 @@
 	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 
 /obj/item/bedsheet/double/Initialize()
-	..()
+	. = ..()
 	desc += " This one is double."
 
 /obj/item/bedsheet/double/blue

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -13,7 +13,7 @@
 	..()
 
 /obj/structure/closet/secure_closet/freezer/Initialize(mapload)
-	..()
+	. = ..()
 	recursive_organ_check(src)
 
 /obj/structure/closet/secure_closet/freezer/open(mob/living/user)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -189,7 +189,7 @@
 	return ..()
 
 /obj/structure/closet/crate/freezer/Initialize(mapload)
-	..()
+	. = ..()
 	recursive_organ_check(src)
 
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -192,8 +192,6 @@
 	. = ..()
 	recursive_organ_check(src)
 
-
-
 /obj/structure/closet/crate/freezer/blood
 	name = "blood freezer"
 	desc = "A freezer containing packs of blood."

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -316,7 +316,7 @@
 	initialized_device = 1
 
 /obj/structure/grille/prison/Initialize()
-	..()
+	. = ..()
 	if(!initialized_device)
 		setup_device()
 

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -77,7 +77,7 @@
 	var/heavy_burn_msg = "peeling away"
 
 /obj/item/bodypart/Initialize(mapload)
-	..()
+	. = ..()
 	name = "[limb_id] [parse_zone(body_zone)]"
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")

--- a/code/modules/xenoarchaeology/xenoartifact.dm
+++ b/code/modules/xenoarchaeology/xenoartifact.dm
@@ -426,7 +426,7 @@
 	if(prob(1))
 		material = pick(XENOA_PLASMA, XENOA_URANIUM, XENOA_BANANIUM)
 	difficulty = material
-	..()
+	. = ..()
 
 /datum/component/xenoartifact_pricing ///Pricing component for shipping solution. Consider swapping to cargo after change.
 	///Buying and selling related, based on guess qaulity
@@ -436,7 +436,7 @@
 
 /datum/component/xenoartifact_pricing/Initialize(...)
 	RegisterSignal(parent, XENOA_CHANGE_PRICE, PROC_REF(update_price))
-	..()
+	. = ..()
 
 /datum/component/xenoartifact_pricing/Destroy(force, silent)
 	UnregisterSignal(parent, XENOA_CHANGE_PRICE)
@@ -449,7 +449,7 @@
  ///Objective version for exploration
 /obj/item/xenoartifact/objective/Initialize(mapload, difficulty)
 	traits += new /datum/xenoartifact_trait/special/objective
-	..()
+	. = ..()
 
 /obj/item/xenoartifact/objective/ComponentInitialize()
 	AddComponent(/datum/component/gps, "[scramble_message_replace_chars("#########", 100)]", TRUE)


### PR DESCRIPTION
## About The Pull Request

The atom init code was counting atoms with INITIALIZE_HINT_QDEL as bad inits because they didn't have their init flags set (because they were just being deleted instead) so I just made it return.
On top of this there were a few things which used ..() instead of . = ..() to initialize.


## Why It's Good For The Game

Reduces the number of 'bad' inits from 181 to 0

## Testing Photographs and Procedure
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/43698041/74813ae9-cb48-4b39-bab3-e86ef1f15144)

<details>
<summary>Details</summary>
I did test this
</details>

## Changelog
:cl:
fix: Fixed some atoms initializing improperly
/:cl: