### PR TITLE
Ballistic guns chamber during Initialize again

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -75,8 +75,7 @@
 		magazine = new mag_type(src)
 	if (!caliber)
 		caliber = magazine.caliber
-	if (bolt_type == BOLT_TYPE_NO_BOLT)
-		chamber_round()
+	chamber_round()
 	update_icon()
 
 /obj/item/gun/ballistic/fire_sounds()

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -83,10 +83,6 @@
 
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/enchanted/arcane_barrage
 
-/obj/item/gun/ballistic/rifle/boltaction/enchanted/Initialize(mapload)
-	. = ..()
-	chamber_round()
-
 /obj/item/gun/ballistic/rifle/boltaction/enchanted/dropped()
 	guns_left = 0
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As it says on the tin, makes it so all guns under the ballistic subtype will automatically chamber a round if they spawn with a loaded magazine, bringing it back to how it functioned before #10020 . This partially reverts the fix from #10441 so they do not chamber a round twice, and empty themselves.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Requested change

Closes #10590

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

The arcane barrage is used at the start to show that they function even with the partial revert of the later fix. Guns that start without ammo and oddballs such as bows were also verified to function separately. All firearms were fired immediately after spawning from the Game Panel.

https://github.com/BeeStation/BeeStation-Hornet/assets/97719613/42b332e0-44a7-47fc-8d56-5fd587819d5d

</details>

## Changelog
:cl: Impish_Delights
tweak: Due to numerous complaints from Syndicate Agents and NT Sec alike, all ballistic firearms are now pre-chambered right off the shelf. Happy hunting!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
