### PR TITLE
Fixes race condition in shuttle loading

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -58,8 +58,6 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/obj/docking_port/mobile/preview_shuttle
 
-	var/datum/turf_reservation/preview_reservation
-
 	var/shuttles_loaded = FALSE
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
@@ -557,8 +555,6 @@ SUBSYSTEM_DEF(shuttle)
 
 	preview_template = SSshuttle.preview_template
 
-	preview_reservation = SSshuttle.preview_reservation
-
 /datum/controller/subsystem/shuttle/proc/is_in_shuttle_bounds(atom/A)
 	var/area/current = get_area(A)
 	if(istype(current, /area/shuttle) && !istype(current, /area/shuttle/transit))
@@ -698,22 +694,21 @@ SUBSYSTEM_DEF(shuttle)
 	preview_template = null
 	existing_shuttle = null
 	selected = null
-	QDEL_NULL(preview_reservation)
 
 /datum/controller/subsystem/shuttle/proc/load_template(datum/map_template/shuttle/S, datum/variable_ref/shuttle_reference)
 	. = FALSE
 	// load shuttle template, centred at shuttle import landmark,
-	preview_reservation = SSmapping.RequestBlockReservation(S.width, S.height, SSmapping.transit.z_value, /datum/turf_reservation/transit)
+	var/datum/turf_reservation/preview_reservation = SSmapping.RequestBlockReservation(S.width, S.height, SSmapping.transit.z_value, /datum/turf_reservation/transit)
 	if(!preview_reservation)
 		CRASH("failed to reserve an area for shuttle template loading")
 	var/turf/BL = TURF_FROM_COORDS_LIST(preview_reservation.bottom_left_coords)
 	var/datum/async_map_generator/shuttle_loader = S.load(BL, FALSE, TRUE, TRUE, FALSE)
-	shuttle_loader.on_completion(CALLBACK(src, PROC_REF(template_loaded), S, BL, shuttle_reference))
+	shuttle_loader.on_completion(CALLBACK(src, PROC_REF(template_loaded), S, BL, shuttle_reference, preview_reservation))
 	return shuttle_loader
 
 /// Template loaded completed.
 /// Parameters preceeded by _ are discarded and not used.
-/datum/controller/subsystem/shuttle/proc/template_loaded(datum/map_template/shuttle/S, turf/BL, datum/variable_ref/shuttle_reference)
+/datum/controller/subsystem/shuttle/proc/template_loaded(datum/map_template/shuttle/S, turf/BL, datum/variable_ref/shuttle_reference, datum/turf_reservation/preview_reservation)
 	var/affected = S.get_affected_turfs(BL, centered=FALSE)
 
 	var/found = 0
@@ -742,6 +737,8 @@ SUBSYSTEM_DEF(shuttle)
 		return
 	//Everything fine
 	S.post_load(shuttle_reference.value)
+	// Clear the preview reservation
+	qdel(preview_reservation)
 	return TRUE
 
 /datum/controller/subsystem/shuttle/proc/unload_preview()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The shuttle subsystem maintains a variable called preview_reservation, which holds a turf reservation for the preview shuttle. Every time a shuttle is loaded, this reservation is cleared.
This works perfectly fine, until you realise that this variable is used for all shuttles and not just the shuttle preview. This means that if a shuttle starts loading, the turf reservation will overwrite the old one, and if a shuttle that started loading before completes loading, the reservation will be cleared which can cause a whole host of issues.

I believe this to be the cause of the spurious unit test failures, however I cannot validate this 100%.

## Why It's Good For The Game

Fixes a core issue with shuttle loading.
I am hoping that this fixes the unit test failures.

## Testing Photographs and Procedure

- [x] I have confirmed that shuttle loading still works and that turf reservations are cleared.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/01d41464-939a-4db8-9194-25b4555f6992)


## Changelog
:cl:
fix: Fixes race condition in shuttle loading which caused some issues in certain cases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
