### PR TITLE
Fix mime PDA input not showing icons

### DIFF
--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -187,7 +187,10 @@
 	name = "emoji"
 
 /datum/asset/spritesheet_batched/emoji/create_spritesheets()
-	insert_all_icons("", 'icons/emoji.dmi')
+	for (var/icon_state_name in icon_states('icons/emoji.dmi'))
+		var/datum/universal_icon/u_icon = uni_icon('icons/emoji.dmi', icon_state_name, SOUTH)
+		u_icon.scale(48, 48)
+		insert_icon("[icon_state_name]", u_icon)
 
 /datum/asset/simple/lobby
 	assets = list(


### PR DESCRIPTION
## About The Pull Request

This was broken by a porting mistake in #10404, never got noticed because mime players don't talk :)

## Why It's Good For The Game

Mimes being able to use PDAs is good.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/10366817/ec31595a-fa02-4af5-b4c4-8a56533ae14d)

</details>

## Changelog
:cl:
fix: Mimes can type on PDAs again, as icons will now appear properly in their input.
/:cl:
