### PR TITLE
Adds Squish emote for slimes

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -22,6 +22,16 @@
 	key_third_person = "vibrates"
 	message = "vibrates!"
 
+/datum/emote/slime/squish
+	key = "squish"
+	key_third_person = "squishes"
+	message = "squishes"
+	emote_type = EMOTE_AUDIBLE
+	sound_volume = 25
+
+/datum/emote/slime/squish/get_sound(mob/living/user)
+	return 'sound/effects/blobattack.ogg'
+
 /datum/emote/slime/mood
 	key = "moodnone"
 	var/mood = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin, player-controlled slimes can now go *squish to make the same sound effect as the slime plushie
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
seemed reasonable that slimes can make the same sound the plushie of their namesake would make
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/64666f7e-400d-43d1-99e4-139935e90755



</details>

## Changelog
:cl:
add: *squish emote, only done by player-controlled slimes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
