### PR TITLE
Stops oozelings and IPCs dying due to handshakes with an elder god.

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -439,8 +439,7 @@
 	SEND_SIGNAL(sac_target, COMSIG_ADD_MOOD_EVENT, "shadow_realm_survived_sadness", /datum/mood_event/shadow_realm_live_sad)
 
 	// Could use a little pick-me-up...
-	sac_target.reagents?.add_reagent(/datum/reagent/medicine/atropine, 8)
-	sac_target.reagents?.add_reagent(/datum/reagent/medicine/epinephrine, 8)
+	sac_target.reagents?.add_reagent(/datum/reagent/eldritchkiss, 12) //this used to kill toxinlovers, hence the snowflake reagent
 
 /**
  * This proc is called from [proc/return_target] if the target dies in the shadow realm.

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2278,7 +2278,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Eldritch Kiss"
 	description = "The lingering touch of eldritch hands pulses through your veins."
 	chem_flags = CHEMICAL_NOT_SYNTH
-	process_flags = ORGANIC | SYNTHETIC
+	process_flags = ORGANIC | SYNTHETIC //i think this is how this works
+	self_consuming = TRUE //not having a liver will not deny the fairness of the elder gods
 
 /datum/reagent/medicine/eldritchkiss/on_mob_life(mob/living/carbon/M)
 	if(M.health <= 20)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2278,6 +2278,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Eldritch Kiss"
 	description = "The lingering touch of eldritch hands pulses through your veins."
 	chem_flags = CHEMICAL_NOT_SYNTH
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/reagent/medicine/eldritchkiss/on_mob_life(mob/living/carbon/M)
 	if(M.health <= 20)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2273,3 +2273,17 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	name = "Grasp of the Mansus"
 	description = "The Hand of the Mansus is at your neck."
 	metabolization_rate = 1 * REM
+
+/datum/reagent/eldritchkiss
+	name = "Eldritch Kiss"
+	description = "The lingering touch of eldritch hands pulses through your veins."
+	chem_flags = CHEMICAL_NOT_SYNTH
+
+/datum/reagent/medicine/eldritchkiss/on_mob_life(mob/living/carbon/M)
+	if(M.health <= 20)
+		M.adjustToxLoss(-4*REM, 0, TRUE) //this makes it heal toxinlovers, i think
+		M.adjustBruteLoss(-4*REM, 0)
+		M.adjustFireLoss(-4*REM, 0)
+		M.adjustOxyLoss(-5*REM, 0)
+		. = 1
+	M.losebreath = 0


### PR DESCRIPTION
## About The Pull Request
Adds a new chemical that is functionally identical to atrophine except safe for oozelings, and replaces the atrophine and epinepherine in the heretic minigame with it.

## Why It's Good For The Game
Fixes  #9177. Winning the heretic minigame shouldn't kill you

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
Testing? What testing? (I'll get to it, I'm trying to figure it out right now)

</details>

## Changelog
:cl:
add: Eldritch kiss reagent that's only given in heretic minigame - it won't kill oozelings by toxin healing. Identical to Atropine.
fix: Escaping from a handshake with an elder god no longer causes oozelings toxin damage.
/:cl:

