### PR TITLE
Make eldritch_amulet fire proof & lave proof

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_necks.dm
+++ b/code/modules/antagonists/heretic/items/heretic_necks.dm
@@ -15,6 +15,7 @@
 	icon = 'icons/obj/heretic.dmi'
 	icon_state = "eye_medalion"
 	w_class = WEIGHT_CLASS_SMALL
+	resistance_flags = FIRE_PROOF
 	/// Clothing trait only applied to heretics.
 	var/heretic_only_trait = TRAIT_THERMAL_VISION
 

--- a/code/modules/antagonists/heretic/items/heretic_necks.dm
+++ b/code/modules/antagonists/heretic/items/heretic_necks.dm
@@ -15,7 +15,7 @@
 	icon = 'icons/obj/heretic.dmi'
 	icon_state = "eye_medalion"
 	w_class = WEIGHT_CLASS_SMALL
-	resistance_flags = FIRE_PROOF
+	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	/// Clothing trait only applied to heretics.
 	var/heretic_only_trait = TRAIT_THERMAL_VISION
 


### PR DESCRIPTION
## About The Pull Request

Because heretic_focus is too, and this warm eldritch medallion is a sub-tree of Ash (which is on fire, yo)


## Why It's Good For The Game

So that Ash heretics wont burn down their focus in a battle of fire and wits

PS. Yes it happened to me 1 hour ago, I am not proud of it.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Warm Eldritch Medallion is now fire proof & lava proof
/:cl:
