### PR TITLE
Minor Spell Correction: Eletronic -> Ele c tronic

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -144,7 +144,7 @@
 	toggle_bolt(usr)
 	add_hiddenprint(usr)
 
-/obj/machinery/door/airlock/AIAltClick(mob/living/silicon/ai/user) // Eletrifies doors.
+/obj/machinery/door/airlock/AIAltClick(mob/living/silicon/ai/user) // Electrifies doors.
 	if(obj_flags & EMAGGED)
 		return
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -147,7 +147,7 @@
 	AltClick(user)
 	return
 
-/obj/machinery/door/airlock/BorgAltClick(mob/living/silicon/robot/user) // Eletrifies doors. Forwards to AI code.
+/obj/machinery/door/airlock/BorgAltClick(mob/living/silicon/robot/user) // Electrifies doors. Forwards to AI code.
 	if(get_dist(src,user) <= user.interaction_range)
 		AIAltClick(user)
 	else

--- a/code/modules/paperwork/paper_reader.dm
+++ b/code/modules/paperwork/paper_reader.dm
@@ -1,5 +1,5 @@
 /obj/item/paper_reader
-	name = "eletronic paper reader"
+	name = "electronic paper reader"
 	gender = NEUTER
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper_reader"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -542,7 +542,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/paper_reader
-	name = "Eletronic Paper Reader"
+	name = "Electronic Paper Reader"
 	desc = "A device to read papers for blind people."
 	id = "epaperread"
 	build_type = PROTOLATHE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a wayward C to the spelling of Electronic wherever it is used in game (4 places)

## Why It's Good For The Game

It bugs me when I open a Head of Staff locker.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Electronic is now spelled correctly.
/:cl:
