### PR TITLE
Bumps rust-g to 3.1.3 and fixes subtract blending in IconForge

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,7 +11,7 @@ export BYOND_MINOR=1589
 export RUST_VERSION=1.70
 
 #rust_g git tag
-export RUST_G_VERSION=3.1.2
+export RUST_G_VERSION=3.1.3
 
 #node version
 export NODE_VERSION=18


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bumps rust-g to fix a bug with iconforge https://github.com/BeeStation/rust-g/pull/14 causing some assets to blend incorrectly


## Why It's Good For The Game

Fixes
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26130695/fcbb4aa0-f280-4dc0-be3f-14109b2707d7)


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26130695/71b04139-e8c7-4bf5-ba2a-138388a5fc25)


</details>

## Changelog
:cl:
fix: Fixes subtract blending in IconForge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
