### PR TITLE
Makes emote punctuation standardised

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -621,7 +621,7 @@
 /datum/emote/living/must_breathe/cough
 	key = "cough"
 	key_third_person = "coughs"
-	message = "coughs!"
+	message = "coughs"
 
 /datum/emote/living/must_breathe/cough/can_run_emote(mob/user, status_check = TRUE, intentional)
 	return ..() && !HAS_TRAIT(user, TRAIT_SOOTHED_THROAT)
@@ -635,7 +635,7 @@
 /datum/emote/living/must_breathe/gasp
 	key = "gasp"
 	key_third_person = "gasps"
-	message = "gasps!"
+	message = "gasps"
 
 /datum/emote/living/must_breathe/gasp/get_sound(mob/living/user)
 	if(!ishuman(user))
@@ -646,12 +646,12 @@
 /datum/emote/living/must_breathe/huff
 	key = "huff"
 	key_third_person = "huffs"
-	message ="lets out a huff!"
+	message ="lets out a huff"
 
 /datum/emote/living/must_breathe/sigh
 	key = "sigh"
 	key_third_person = "sighs"
-	message = "sighs!"
+	message = "sighs"
 	emote_type = EMOTE_AUDIBLE|EMOTE_ANIMATED
 	emote_length = 3 SECONDS
 	overlay_y_offset = -1
@@ -666,7 +666,7 @@
 /datum/emote/living/must_breathe/sneeze
 	key = "sneeze"
 	key_third_person = "sneezes"
-	message = "sneezes!"
+	message = "sneezes"
 
 /datum/emote/living/must_breathe/sneeze/get_sound(mob/living/user)
 	if(!ishuman(user))
@@ -677,7 +677,7 @@
 /datum/emote/living/must_breathe/sniff
 	key = "sniff"
 	key_third_person = "sniffs"
-	message = "sniffs."
+	message = "sniffs"
 
 /datum/emote/living/must_breathe/sniff/get_sound(mob/living/user)
 	if(!ishuman(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes every emote end with a full stop
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
some emotes ended with an exclamation mark even if they didn't make much sense to do, like *sigh
*sniff also had a full stop that would have been added eitherway
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/563140ba-22ec-48b8-868d-6d036a080209)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/99eec05e-8ead-4211-87ce-a8dd7d6e6f26)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/085ac21f-549b-4707-bbe2-ec850212bfb6)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/05a5c67b-7de4-4f90-9f59-9813adf99027)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/c17ca536-ff57-4f8a-b95e-773e85f54ac7)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/1dd182e5-98df-4ebd-bf5e-313aa8578dbe)




</details>

## Changelog
:cl:
tweak: standardised the punctuation of emotes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
