### PR TITLE
Gives pepperclouds another charge

### DIFF
--- a/code/game/objects/items/peppercloud.dm
+++ b/code/game/objects/items/peppercloud.dm
@@ -7,8 +7,8 @@
 	item_state = "pepperspray"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	volume = 50
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 50)
+	volume = 75
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 75)
 
 	item_flags = NOBLUDGEON | ISWEAPON
 	reagent_flags = OPENCONTAINER
@@ -45,7 +45,7 @@
 			return
 
 		playsound(src.loc, 'sound/effects/spray.ogg', 50, 1, -6)
-		var/trans = target.reagents.trans_to(src, 50, transfered_by = user) //transfer 50u , using the spray's transfer amount would take too long to refill
+		var/trans = target.reagents.trans_to(src, 75, transfered_by = user) //transfer 75u , using the spray's transfer amount would take too long to refill
 		to_chat(user, "<span class='notice'>You fill \the [src] with [trans] units of the contents of \the [target].</span>")
 		return
 
@@ -89,13 +89,13 @@
 	if (reagents_removed)
 		reagents.handle_reactions()
 	// Check that we have enough pepperspray remaining
-	if (reagents.get_reagent_amount(/datum/reagent/consumable/condensedcapsaicin) < 15)
+	if (reagents.get_reagent_amount(/datum/reagent/consumable/condensedcapsaicin) < 25)
 		to_chat(user, "<span class='warning'>[src] doesn't contain enough capsaicin to deploy, refill it!<span>")
 		return
 	cooldown_time = world.time + activation_cooldown
-	var/datum/reagents/R = new/datum/reagents(15)
+	var/datum/reagents/R = new/datum/reagents(25)
 	R.my_atom = src
-	reagents.trans_to(R, 15)
+	reagents.trans_to(R, 25)
 	var/datum/effect_system/smoke_spread/chem/smoke = new
 	smoke.set_up(R, 1, center, silent = TRUE, circle = FALSE)
 	playsound(src, 'sound/weapons/grenadelaunch.ogg', 70, FALSE, -2)

--- a/code/game/objects/items/peppercloud.dm
+++ b/code/game/objects/items/peppercloud.dm
@@ -89,13 +89,13 @@
 	if (reagents_removed)
 		reagents.handle_reactions()
 	// Check that we have enough pepperspray remaining
-	if (reagents.get_reagent_amount(/datum/reagent/consumable/condensedcapsaicin) < 25)
+	if (reagents.get_reagent_amount(/datum/reagent/consumable/condensedcapsaicin) < 15)
 		to_chat(user, "<span class='warning'>[src] doesn't contain enough capsaicin to deploy, refill it!<span>")
 		return
 	cooldown_time = world.time + activation_cooldown
-	var/datum/reagents/R = new/datum/reagents(25)
+	var/datum/reagents/R = new/datum/reagents(15)
 	R.my_atom = src
-	reagents.trans_to(R, 25)
+	reagents.trans_to(R, 15)
 	var/datum/effect_system/smoke_spread/chem/smoke = new
 	smoke.set_up(R, 1, center, silent = TRUE, circle = FALSE)
 	playsound(src, 'sound/weapons/grenadelaunch.ogg', 70, FALSE, -2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pepperclouds now have 3 charges instead of 2.

## Why It's Good For The Game

Makes them slightly less annoying to reload, as they don't need to be reloaded as often.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/36961cd7-aa79-4257-90b5-b41cf47d36bd)

3x activation.

## Changelog
:cl:
balance: Pepperclouds now have 3 uses before needing to be refilled instead of 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
