### PR TITLE
Fixes Add Component/Element option in View Variables

### DIFF
--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -80,10 +80,10 @@
 		lst.Insert(1, result)
 		if(result in componentsubtypes)
 			datumname = "component"
-			target._AddComponent(arglist(lst))
+			target._AddComponent(lst)
 		else
 			datumname = "element"
-			target._AddElement(arglist(lst))
+			target._AddElement(lst)
 		log_admin("[key_name(usr)] has added [result] [datumname] to [target].")
 		message_admins("<span class='notice'>[key_name_admin(usr)] has added [result] [datumname] to [target].</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

View Variable's Add Component/Element seemed to have ran into runtimes or simply not do anything relevant to its purpose when used
since the _AddComponent it uses takes a list and not an argument tuple, removed a redundant arglist (converts lists into arg tuples) and this seems to have led to expected effect of the command
AddComponent macro that is probably more recommended takes in an arg tuple and wraps it in a list before passing it to _AddComponent - despite trying this approach instead, it did not seem to work, and I'm more content with skipping useless overhead anyway

## Why It's Good For The Game

Allows admins to use the Add Component/Element tool in View Variables for various purposes including fun adminbuses

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/27755442/7e341a40-140b-409d-87ab-51ec7cc9fd6e)

</details>

## Changelog
:cl: Aramix
fix: Admins can now use View Variable's Add Component/Element again (adminbus potential)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
