### PR TITLE
Medbot patches

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -232,6 +232,7 @@ GLOBAL_VAR(medibot_unique_id_gen)
 			efficiency = 1+(0.075*tech_boosters) //increase efficiency by 7.5% for every surgery researched
 			if(old_eff < efficiency)
 				speak("Surgical research data found! Efficiency increased by [round(efficiency/old_eff*100)]%!")
+				window_name = "Automatic Medical Unit v[efficiency]"
 	update_controls()
 	return
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -152,13 +152,13 @@ GLOBAL_VAR(medibot_unique_id_gen)
 	dat += "<TT><B>Medical Unit Controls v1.1</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</A><BR>"
 	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<BR>"
-	dat += "Beaker: "
-	if(reagent_glass)
-		dat += "<A href='?src=[REF(src)];eject=1'>Loaded \[[reagent_glass.reagents.total_volume]/[reagent_glass.reagents.maximum_volume]\]</a>"
-	else
-		dat += "None Loaded"
 	dat += "<br>Behaviour controls are [locked ? "locked" : "unlocked"]<hr>"
 	if(!locked || issilicon(user) || IsAdminGhost(user))
+		dat += "Beaker: "
+		if(reagent_glass)
+			dat += "<A href='?src=[REF(src)];eject=1'>Loaded \[[reagent_glass.name]: [reagent_glass.reagents.total_volume]/[reagent_glass.reagents.maximum_volume]\]</a><br>"
+		else
+			dat += "None Loaded<br>"
 		dat += "<TT>Healing Threshold: "
 		dat += "<a href='?src=[REF(src)];adj_threshold=-10'>--</a> "
 		dat += "<a href='?src=[REF(src)];adj_threshold=-5'>-</a> "
@@ -662,6 +662,20 @@ GLOBAL_VAR(medibot_unique_id_gen)
 
 /obj/machinery/bot_core/medbot
 	req_one_access = list(ACCESS_MEDICAL, ACCESS_ROBOTICS)
+
+/mob/living/simple_animal/bot/medbot/attackby(obj/item/I, mob/user, params)
+	..()
+	if(istype(I, /obj/item/pen)&&!locked)
+		rename_bot()
+		return
+
+/mob/living/simple_animal/bot/medbot/proc/rename_bot()
+	var/t = sanitize_name(stripped_input(usr, "Enter new robot name", name, name,MAX_NAME_LEN))
+	if(!t)
+		return
+	if(!in_range(src, usr) && loc != usr)
+		return
+	name = t
 
 #undef MEDBOT_PANIC_NONE
 #undef MEDBOT_PANIC_LOW

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -114,7 +114,7 @@
 /obj/item/computer_hardware/hard_drive/role/chemistry
 	name = "\improper ChemWhiz disk"
 	icon_state = "cart-chem"
-	disk_flags = DISK_CHEM
+	disk_flags = DISK_CHEM | DISK_ROBOS
 
 /obj/item/computer_hardware/hard_drive/role/brig_physician
 	name = "\improper R.O.B.U.S.T. MED-U disk"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
after doing some ingame playing, I've decided to make some changes from my previous medbot pr
could be the first of many

1. Beaker removal is only available on unlocked medbots, for some reason I've seen a lot of people remove the beaker from the medbot and then just leave the medbot, this should help with the issue
2.  Medbot now tells you the name of whatever is inserted in it, to help with knowing what it does
3.  Using a pen on a medbot lets you change its name, for on the fly-naming, to help you label a medbot if you change its function, or if robotics doesn't name it for you
4.  Chemists now start with the robot controller app on their pda, to help with medbot manegement
5. The window name at the top of the medbot UI now tells you the efficiency
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
mostly explained above, this is mostly QOL to prevent confusion and general ease of use for the medbots
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/296159e8-9170-4778-8bbb-c5078c837a6d



https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/d169ce8c-c355-4840-85d0-356d559d1180




</details>

## Changelog
:cl:
add: You can now name a constructed medbot using a pen on it
add: Chemist PDA job disks now also contain robot management
add: Medbot UI now tells you the name of the beaker/chembag that is inserted in it
qol: medbot efficiency can now be seen the medbots version number at the top of its UI
tweak: Medbots need to be unlocked to have their beaker/chembag removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
