### PR TITLE
Fixes telekinesis mutation throwing runtime when a holder touches an airlock

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -147,7 +147,8 @@
 
 /// Helper method for bumpopen() and try_to_activate_door(). Don't override.
 /obj/machinery/door/proc/activate_door_base(mob/user, can_close_door)
-	add_fingerprint(user)
+	if(user)
+		add_fingerprint(user)
 	if(operating)
 		return
 	// Cutting WIRE_IDSCAN disables normal entry
@@ -178,9 +179,12 @@
 	// But if we *have* cut the wire, this eventually falls through to attack_hand(), which calls try_to_activate_door(),
 	// which will fail because the door won't work if the wire is cut! Catch-22.
 	// Basically, TK won't work unless the door is all-access.
-	if(!id_scan_hacked() && !allowed())
+
+	if(user.stat || !tkMaxRangeCheck(user, src))
 		return
-	..()
+	new /obj/effect/temp_visual/telekinesis(get_turf(src))
+	add_hiddenprint(user)
+	activate_door_base(null, TRUE)
 
 /// Handles door activation via clicks, through attackby().
 /obj/machinery/door/proc/try_to_activate_door(obj/item/I, mob/user)

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -2,6 +2,8 @@
 ///returns TRUE if this mob has sufficient access to use this object.
 ///Note that this will return FALSE when passed null, unless the door doesn't require any access.
 /obj/proc/allowed(mob/accessor)
+	if(!accessor) // early return for null check. This exists because attack_tk() sends null accessor
+		return src.check_access(null)
 	if(SEND_SIGNAL(src, COMSIG_OBJ_ALLOWED, accessor) & COMPONENT_OBJ_ALLOW)
 		return TRUE
 	//check if it doesn't require any access at all


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes telekinesis mutation throwing runtime when a holder touches an airlock
It throws a runtime

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/33dd6080-4308-4c32-bc69-5ad1ca832d72)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/3e688ffe-1e70-4d4a-a612-029023af9b9f)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/27a72a8e-482c-4401-9027-0d3ae2d76b3f)


## Changelog
:cl:
fix: Fixed telekinesis mutation throwing runtime when a holder touches an airlock.
code: Telekinesis effect will be shown on an airlock whenever it's telekinetically interacted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
