### PR TITLE
Gives tot clowns the bananium esword and shield in the uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2178,7 +2178,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		by bouncing them back at the ones who fired them. It can also be thrown to bounce off of people, slipping them, \
 		and returning to you even if you miss. WARNING: DO NOT ATTEMPT TO STAND ON SHIELD WHILE DEPLOYED, EVEN IF WEARING ANTI-SLIP SHOES."
 	item = /obj/item/shield/energy/bananium
-	cost = 16
+	cost = 15
 	surplus = 0
 	restricted_roles = list(JOB_NAME_CLOWN)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2187,7 +2187,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An energy sword that deals no damage, but will slip anyone it contacts, be it by melee attack, thrown \
 	impact, or just stepping on it. Beware friendly fire, as even anti-slip shoes will not protect against it."
 	item = /obj/item/melee/transforming/energy/sword/bananium
-	cost = 3
+	cost = 5
 	surplus = 0
 	restricted_roles = list(JOB_NAME_CLOWN)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2172,6 +2172,25 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/shoes/clown_shoes/taeclowndo
 	restricted_roles = list(JOB_NAME_CLOWN)
 
+/datum/uplink_item/role_restricted/bananashield
+	name = "Bananium Energy Shield"
+	desc = "A clown's most powerful defensive weapon, this personal shield provides near immunity to ranged energy attacks \
+		by bouncing them back at the ones who fired them. It can also be thrown to bounce off of people, slipping them, \
+		and returning to you even if you miss. WARNING: DO NOT ATTEMPT TO STAND ON SHIELD WHILE DEPLOYED, EVEN IF WEARING ANTI-SLIP SHOES."
+	item = /obj/item/shield/energy/bananium
+	cost = 16
+	surplus = 0
+	restricted_roles = list(JOB_NAME_CLOWN)
+
+/datum/uplink_item/role_restricted/clownsword
+	name = "Bananium Energy Sword"
+	desc = "An energy sword that deals no damage, but will slip anyone it contacts, be it by melee attack, thrown \
+	impact, or just stepping on it. Beware friendly fire, as even anti-slip shoes will not protect against it."
+	item = /obj/item/melee/transforming/energy/sword/bananium
+	cost = 3
+	surplus = 0
+	restricted_roles = list(JOB_NAME_CLOWN)
+
 /datum/uplink_item/role_restricted/superior_honkrender
 	name = "Superior Honkrender"
 	desc = "An ancient artifact recovered from an ancient cave. Opens the way to the Dark Carnival"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds to the traitor uplkin the bananium esword and shield

## Why It's Good For The Game

It's a FUN and mostly harmless item that can't whipe off an entire security team, it's just annoying as shit, which should be the focus of a tot clown anyways

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/38511463-3d2b-4f99-ab53-ea5639eec856)
![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/6e3c77ef-cad2-480c-80dc-67d8585c8c6f)


</details>

## Changelog
:cl: ClownMoff
add: adds the bananium e-sword (3TC) and bananium shield (16 TC) to the uplink, restricted for clowns
/:cl:

