### PR TITLE
Replace "Red Dead Redemption Two" and "Yanye Kest" from clown random name gen.

### DIFF
--- a/strings/names/clown.txt
+++ b/strings/names/clown.txt
@@ -82,7 +82,7 @@ Pogo
 Polite Pablo
 Razzle Dazzle
 Red April
-Red Dead Redemption Two
+Bonkers
 Redshirt McBeat
 Rinso The Soapy
 Roboflop
@@ -116,7 +116,7 @@ Unimaginable Nut
 Valid Vincent
 Weather Report
 Widderwise
-Yanye Kest
+John Nanotrasen
 Yesterdays Beef
 Yobbo
 Ziggy Yoyo


### PR DESCRIPTION
Replace "Red Dead Redemption Two" and "Yanye Kest" with "Bonkers" and "John Nanotrasen"

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Red Dead Redemption 2 and Yanye Kest is removed from clowns random name generator.

## Why It's Good For The Game

RP and shit I guess.

</details>

## Changelog
:cl:
config: Replace "Red Dead Redemption Two" and "Yanye Kest" with "Bonkers" and "John Nanotrasen"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
