### PR TITLE
Fixes moths not being able to eat clothes

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -48,6 +48,9 @@
 #define WOUND "wound"
 */
 
+/// Involves being eaten
+#define CONSUME "consume"
+
 //bitflag damage defines used for suicide_act
 #define BRUTELOSS (1<<0)
 #define FIRELOSS (1<<1)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -48,9 +48,6 @@
 #define WOUND "wound"
 */
 
-/// Involves being eaten
-#define CONSUME "consume"
-
 //bitflag damage defines used for suicide_act
 #define BRUTELOSS (1<<0)
 #define FIRELOSS (1<<1)

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -18,6 +18,7 @@
   var/acid
   var/magic
   var/stamina
+  var/consume
 
 /datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0)
   src.melee = melee
@@ -31,6 +32,7 @@
   src.acid = acid
   src.magic = magic
   src.stamina = stamina
+  src.consume = melee
   tag = ARMORID
 
 /datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0)

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -1,73 +1,76 @@
-#define ARMORID "armor-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]-[magic]-[stamina]"
+#define ARMORID "armor-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]-[magic]-[stamina]-[consume]"
 
-/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0)
-  . = locate(ARMORID)
-  if (!.)
-    . = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, stamina)
+/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0, consume = 0)
+	. = locate(ARMORID)
+	if (!.)
+		. = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, stamina, consume)
 
 /datum/armor
-  datum_flags = DF_USE_TAG
-  var/melee
-  var/bullet
-  var/laser
-  var/energy
-  var/bomb
-  var/bio
-  var/rad
-  var/fire
-  var/acid
-  var/magic
-  var/stamina
+	datum_flags = DF_USE_TAG
+	var/melee
+	var/bullet
+	var/laser
+	var/energy
+	var/bomb
+	var/bio
+	var/rad
+	var/fire
+	var/acid
+	var/magic
+	var/stamina
+	var/consume
 
-/datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0)
-  src.melee = melee
-  src.bullet = bullet
-  src.laser = laser
-  src.energy = energy
-  src.bomb = bomb
-  src.bio = bio
-  src.rad = rad
-  src.fire = fire
-  src.acid = acid
-  src.magic = magic
-  src.stamina = stamina
-  tag = ARMORID
+/datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0, consume = 0)
+	src.melee = melee
+	src.bullet = bullet
+	src.laser = laser
+	src.energy = energy
+	src.bomb = bomb
+	src.bio = bio
+	src.rad = rad
+	src.fire = fire
+	src.acid = acid
+	src.magic = magic
+	src.stamina = stamina
+	src.consume = consume
+	tag = ARMORID
 
-/datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0)
-  return getArmor(src.melee+melee, src.bullet+bullet, src.laser+laser, src.energy+energy, src.bomb+bomb, src.bio+bio, src.rad+rad, src.fire+fire, src.acid+acid, src.magic+magic, src.stamina+stamina)
+/datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0, consume = 0)
+	return getArmor(src.melee+melee, src.bullet+bullet, src.laser+laser, src.energy+energy, src.bomb+bomb, src.bio+bio, src.rad+rad, src.fire+fire, src.acid+acid, src.magic+magic, src.stamina+stamina, src.consume+consume)
 
 /datum/armor/proc/modifyAllRatings(modifier = 0)
-  return getArmor(melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier, stamina+modifier)
+	return getArmor(melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier, stamina+modifier, consume+modifier)
 
-/datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic)
-  return getArmor((isnull(melee) ? src.melee : melee),\
-                  (isnull(bullet) ? src.bullet : bullet),\
-                  (isnull(laser) ? src.laser : laser),\
-                  (isnull(energy) ? src.energy : energy),\
-                  (isnull(bomb) ? src.bomb : bomb),\
-                  (isnull(bio) ? src.bio : bio),\
-                  (isnull(rad) ? src.rad : rad),\
-                  (isnull(fire) ? src.fire : fire),\
-                  (isnull(acid) ? src.acid : acid),\
-				  (isnull(magic) ? src.magic : magic),\
-				  (isnull(stamina) ? src.stamina : stamina))
+/datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, consume)
+	return getArmor((isnull(melee) ? src.melee : melee),\
+					(isnull(bullet) ? src.bullet : bullet),\
+					(isnull(laser) ? src.laser : laser),\
+					(isnull(energy) ? src.energy : energy),\
+					(isnull(bomb) ? src.bomb : bomb),\
+					(isnull(bio) ? src.bio : bio),\
+					(isnull(rad) ? src.rad : rad),\
+					(isnull(fire) ? src.fire : fire),\
+					(isnull(acid) ? src.acid : acid),\
+					(isnull(magic) ? src.magic : magic),\
+					(isnull(stamina) ? src.stamina : stamina),\
+					(isnull(consume) ? src.consume : consume))
 
 /datum/armor/proc/getRating(rating)
-  return vars[rating]
+	return vars[rating]
 
 /datum/armor/proc/getList()
-  return list(MELEE = melee, BULLET = bullet, LASER = laser, ENERGY = energy, BOMB = bomb, BIO = bio, RAD = rad, FIRE = fire, ACID = acid, MAGIC = magic, STAMINA = stamina)
+	return list(MELEE = melee, BULLET = bullet, LASER = laser, ENERGY = energy, BOMB = bomb, BIO = bio, RAD = rad, FIRE = fire, ACID = acid, MAGIC = magic, STAMINA = stamina, CONSUME = consume)
 
 /datum/armor/proc/attachArmor(datum/armor/AA)
-  return getArmor(melee+AA.melee, bullet+AA.bullet, laser+AA.laser, energy+AA.energy, bomb+AA.bomb, bio+AA.bio, rad+AA.rad, fire+AA.fire, acid+AA.acid, magic+AA.magic, stamina+AA.stamina)
+	return getArmor(melee+AA.melee, bullet+AA.bullet, laser+AA.laser, energy+AA.energy, bomb+AA.bomb, bio+AA.bio, rad+AA.rad, fire+AA.fire, acid+AA.acid, magic+AA.magic, stamina+AA.stamina, consume+AA.consume)
 
 /datum/armor/proc/detachArmor(datum/armor/AA)
-  return getArmor(melee-AA.melee, bullet-AA.bullet, laser-AA.laser, energy-AA.energy, bomb-AA.bomb, bio-AA.bio, rad-AA.rad, fire-AA.fire, acid-AA.acid, magic-AA.magic, stamina-AA.stamina)
+	return getArmor(melee-AA.melee, bullet-AA.bullet, laser-AA.laser, energy-AA.energy, bomb-AA.bomb, bio-AA.bio, rad-AA.rad, fire-AA.fire, acid-AA.acid, magic-AA.magic, stamina-AA.stamina, consume+AA.consume)
 
 /datum/armor/vv_edit_var(var_name, var_value)
-  if (var_name == NAMEOF(src, tag))
-    return FALSE
-  . = ..()
-  tag = ARMORID // update tag in case armor values were edited
+	if (var_name == NAMEOF(src, tag))
+		return FALSE
+	. = ..()
+	tag = ARMORID // update tag in case armor values were edited
 
 #undef ARMORID

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -18,7 +18,6 @@
   var/acid
   var/magic
   var/stamina
-  var/consume
 
 /datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0)
   src.melee = melee
@@ -32,7 +31,6 @@
   src.acid = acid
   src.magic = magic
   src.stamina = stamina
-  src.consume = melee
   tag = ARMORID
 
 /datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, stamina = 0)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -104,7 +104,7 @@
 		bite_consumption = bite_consumption,\
 		microwaved_type = microwaved_type,\
 		junkiness = junkiness,\
-		after_eat = CALLBACK(src, .proc/after_eat))
+		after_eat = CALLBACK(src, PROC_REF(after_eat)))
 
 /obj/item/food/clothing/proc/after_eat(mob/eater)
 	var/obj/item/clothing/resolved_clothing = clothing.resolve()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -495,7 +495,7 @@ BLIND     // can't see anything
 		new /obj/effect/decal/cleanable/shreds(current_position, name)
 		if(isliving(loc))
 			var/mob/living/possessing_mob = loc
-			possessing_mob.visible_message("<span class='danger'>[src] is consumed until naught but shreds remains!</span>", "span_boldwarning[src] falls apart into little bits!</span>")
+			possessing_mob.visible_message("<span class='danger'>[src] is consumed until naught but shreds remains!</span>", "<span class='boldwarning'>[src] falls apart into little bits!</span>")
 		deconstruct(FALSE)
 	else
 		..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -109,7 +109,7 @@
 /obj/item/food/clothing/proc/after_eat(mob/eater)
 	var/obj/item/clothing/resolved_clothing = clothing.resolve()
 	if (resolved_clothing)
-		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE)
+		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE, damage_flag = CONSUME)
 	else
 		qdel(src)
 
@@ -483,13 +483,19 @@ BLIND     // can't see anything
 			return 1
 	return 0
 
-
 /obj/item/clothing/obj_destruction(damage_flag)
 	if(damage_flag == BOMB || damage_flag == MELEE)
 		var/turf/T = get_turf(src)
 		spawn(1) //so the shred survives potential turf change from the explosion.
 			var/obj/effect/decal/cleanable/shreds/Shreds = new(T)
 			Shreds.desc = "The sad remains of what used to be [name]."
+		deconstruct(FALSE)
+	if(damage_flag == CONSUME) //This allows for moths to fully consume clothing, rather than damaging it like other sources like brute
+		var/turf/current_position = get_turf(src)
+		new /obj/effect/decal/cleanable/shreds(current_position, name)
+		if(isliving(loc))
+			var/mob/living/possessing_mob = loc
+			possessing_mob.visible_message("<span class='danger'>[src] is consumed until naught but shreds remains!</span>", "span_boldwarning[src] falls apart into little bits!</span>")
 		deconstruct(FALSE)
 	else
 		..()

--- a/code/modules/unit_tests/food_edibility_check.dm
+++ b/code/modules/unit_tests/food_edibility_check.dm
@@ -8,8 +8,8 @@
 		/obj/item/food/grown/mushroom,
 		/obj/item/food/donkpocket/random,
 		/obj/item/food/deepfryholder,
-		//obj/item/food/clothing,
-		//obj/item/food/meat/slab/human/mutant,
+		/obj/item/food/clothing,
+		/obj/item/food/meat/slab/human/mutant,
 		/obj/item/food/grown/shell)
 
 	var/list/food_paths = subtypesof(/obj/item/food) - not_food


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/55356
- https://github.com/tgstation/tgstation/pull/61082

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #10696 

Bugged logic post-oldfood removal made the edible component freak out when consuming a non-food food item like clothes.

Its fixed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I broke it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/4a318bff-87a0-4807-9fb6-72930f5e150d

Fixed the span thing at the end in 51852f4

</details>

## Changelog
:cl: rkz, Mothblocks, ArcaneDefence
fix: moths can eat clothes again (perhaps to the dismay of a few)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
