### PR TITLE
Reverts the removal of `get_recipes()`, fixes basemat recipes

### DIFF
--- a/code/controllers/subsystem/materials.dm
+++ b/code/controllers/subsystem/materials.dm
@@ -33,7 +33,12 @@ SUBSYSTEM_DEF(materials)
 		// Adds the dupe recipes into multiple material recipes
 		var/list/global_mat_recipes = ref.get_material_recipes()
 		if(global_mat_recipes)
-			global_mat_recipes += SSmaterials.rigid_stack_recipes.Copy()
+			if(ref.categories[MAT_CATEGORY_BASE_RECIPES])
+				global_mat_recipes += SSmaterials.rigid_stack_recipes.Copy()
+			/* put more material recipes here. example:
+			if(ref.categories[MAT_CATEGORY_SOME_NEW_RECIPES])
+				global_mat_recipes += SSmaterials.SOME_NEW_RECIPES.Copy()
+			*/
 
 /datum/controller/subsystem/materials/proc/GetMaterialRef(datum/material/fakemat)
 	if(!materials)

--- a/code/controllers/subsystem/materials.dm
+++ b/code/controllers/subsystem/materials.dm
@@ -30,6 +30,11 @@ SUBSYSTEM_DEF(materials)
 		for(var/c in ref.categories)
 			materials_by_category[c] += list(ref)
 
+		// Adds the dupe recipes into multiple material recipes
+		var/list/global_mat_recipes = ref.get_material_recipes()
+		if(global_mat_recipes)
+			global_mat_recipes += SSmaterials.rigid_stack_recipes.Copy()
+
 /datum/controller/subsystem/materials/proc/GetMaterialRef(datum/material/fakemat)
 	if(!materials)
 		InitializeMaterials()

--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -18,7 +18,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 	///Materials "Traits". its a map of key = category | Value = Bool. Used to define what it can be used for
 	var/list/categories = list()
 	///The type of sheet this material creates. This should be replaced as soon as possible by greyscale sheets
-	var/sheet_type
+	var/obj/item/stack/sheet_type
 	///This is a modifier for force, and resembles the strength of the material
 	var/strength_modifier = 1
 	///This is a modifier for integrity, and resembles the strength of the material
@@ -129,3 +129,16 @@ Simple datum which is instanced once per type and is used for every object of sa
 		if(type != initial(path.material_skin))
 			continue
 		return path
+
+
+/// Returns GLOB.recipes of a material to modify the recipes.
+/// This will be only called once from SSMaterials.
+/datum/material/proc/get_material_recipes()
+	if(!initial(sheet_type.material_type) || !categories[MAT_CATEGORY_BASE_RECIPES])
+		return
+	var/obj/item/stack/dummy_stack = new sheet_type(null) // we make a fake object here
+	if(!dummy_stack)
+		return
+	. = dummy_stack.get_recipes() // because we need to get the global list.
+	// NOTE: returning a GLOB.recipes from each subtype can be a way, but that should override all procs. This is simple.
+	qdel(dummy_stack)

--- a/code/game/objects/items/stacks/ores/ore_type.dm
+++ b/code/game/objects/items/stacks/ores/ore_type.dm
@@ -47,9 +47,8 @@ STACKSIZE_MACRO(/obj/item/stack/ore/iron)
 	refined_type = /obj/item/stack/sheet/glass
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/stack/ore/glass/get_main_recipes()
-	. = ..()
-	. += GLOB.sand_recipes
+/obj/item/stack/ore/glass/get_recipes()
+	return GLOB.sand_recipes
 
 /obj/item/stack/ore/glass/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(..() || !ishuman(hit_atom))

--- a/code/game/objects/items/stacks/rods/rods.dm
+++ b/code/game/objects/items/stacks/rods/rods.dm
@@ -33,9 +33,8 @@
 	update_icon()
 	AddElement(/datum/element/openspace_item_click_handler)
 
-/obj/item/stack/rods/get_main_recipes()
-	. = ..()
-	. += GLOB.rod_recipes
+/obj/item/stack/rods/get_recipes()
+	return GLOB.rod_recipes
 
 /obj/item/stack/rods/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
 	if(proximity_flag)

--- a/code/game/objects/items/stacks/sheets/mineral/exotics.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/exotics.dm
@@ -20,9 +20,8 @@ Exotic mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/bananium
 	material_type = /datum/material/bananium
 
-/obj/item/stack/sheet/mineral/bananium/get_main_recipes()
-	. = ..()
-	. += GLOB.bananium_recipes
+/obj/item/stack/sheet/mineral/bananium/get_recipes()
+	return GLOB.bananium_recipes
 
 
 /* Adamantine */
@@ -33,12 +32,12 @@ Exotic mineral Sheets
 	item_state = "sheet-adamantine"
 	singular_name = "adamantine sheet"
 	mats_per_unit = list(/datum/material/adamantine=MINERAL_MATERIAL_AMOUNT)
-	merge_type = /obj/item/stack/sheet/mineral/adamantine
 	grind_results = list(/datum/reagent/liquidadamantine = 10)
+	merge_type = /obj/item/stack/sheet/mineral/adamantine
+	material_type = /datum/material/adamantine
 
-/obj/item/stack/sheet/mineral/adamantine/get_main_recipes()
-	. = ..()
-	. += GLOB.adamantine_recipes
+/obj/item/stack/sheet/mineral/adamantine/get_recipes()
+	return GLOB.adamantine_recipes
 
 /* Alien Alloy */
 
@@ -51,6 +50,5 @@ Exotic mineral Sheets
 	sheettype = "abductor"
 	merge_type = /obj/item/stack/sheet/mineral/abductor
 
-/obj/item/stack/sheet/mineral/abductor/get_main_recipes()
-	. = ..()
-	. += GLOB.abductor_recipes
+/obj/item/stack/sheet/mineral/abductor/get_recipes()
+	return GLOB.abductor_recipes

--- a/code/game/objects/items/stacks/sheets/mineral/glass.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/glass.dm
@@ -32,9 +32,8 @@
 	user.visible_message("<span class='suicide'>[user] begins to slice [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return BRUTELOSS
 
-/obj/item/stack/sheet/glass/get_main_recipes()
-	. = ..()
-	. += GLOB.glass_recipes
+/obj/item/stack/sheet/glass/get_recipes()
+	return GLOB.glass_recipes
 
 /obj/item/stack/sheet/glass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
@@ -103,9 +102,8 @@
 	source.add_charge(amount * cost)
 	glasource.add_charge(amount * glacost)
 
-/obj/item/stack/sheet/rglass/get_main_recipes()
-	. = ..()
-	. += GLOB.reinforced_glass_recipes
+/obj/item/stack/sheet/rglass/get_recipes()
+	return GLOB.reinforced_glass_recipes
 
 /* Plasma glass */
 
@@ -123,9 +121,8 @@
 	material_flags = NONE
 	tableVariant = /obj/structure/table/glass/plasma
 
-/obj/item/stack/sheet/plasmaglass/get_main_recipes()
-	. = ..()
-	. += GLOB.pglass_recipes
+/obj/item/stack/sheet/plasmaglass/get_recipes()
+	return GLOB.pglass_recipes
 
 /obj/item/stack/sheet/plasmaglass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
@@ -162,9 +159,8 @@
 	point_value = 23
 	matter_amount = 8
 
-/obj/item/stack/sheet/plasmarglass/get_main_recipes()
-	. = ..()
-	. += GLOB.prglass_recipes
+/obj/item/stack/sheet/plasmarglass/get_recipes()
+	return GLOB.prglass_recipes
 
 /* Titanium glass */
 
@@ -179,9 +175,8 @@
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/titaniumglass
 
-/obj/item/stack/sheet/titaniumglass/get_main_recipes()
-	. = ..()
-	. += GLOB.titaniumglass_recipes
+/obj/item/stack/sheet/titaniumglass/get_recipes()
+	return GLOB.titaniumglass_recipes
 
 /* Plastitanium glass */
 
@@ -197,9 +192,8 @@
 	material_flags = NONE
 	merge_type = /obj/item/stack/sheet/plastitaniumglass
 
-/obj/item/stack/sheet/plastitaniumglass/get_main_recipes()
-	. = ..()
-	. += GLOB.plastitaniumglass_recipes
+/obj/item/stack/sheet/plastitaniumglass/get_recipes()
+	return GLOB.plastitaniumglass_recipes
 
 /*SHARDS FROM HERE ONWARD, NOT A STACK, MOVE IT AS THE PROPHECY FORETOLD*/
 /obj/item/shard

--- a/code/game/objects/items/stacks/sheets/mineral/materials.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/materials.dm
@@ -29,9 +29,8 @@ Mineral Sheets
 	sheettype = "sandstone"
 	merge_type = /obj/item/stack/sheet/mineral/sandstone
 
-/obj/item/stack/sheet/mineral/sandstone/get_main_recipes()
-	. = ..()
-	. += GLOB.sandstone_recipes
+/obj/item/stack/sheet/mineral/sandstone/get_recipes()
+	return GLOB.sandstone_recipes
 
 /* Diamond */
 
@@ -47,9 +46,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/diamond
 	material_type = /datum/material/diamond
 
-/obj/item/stack/sheet/mineral/diamond/get_main_recipes()
-	. = ..()
-	. += GLOB.diamond_recipes
+/obj/item/stack/sheet/mineral/diamond/get_recipes()
+	return GLOB.diamond_recipes
 
 /* Uranium */
 
@@ -65,9 +63,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/uranium
 	material_type = /datum/material/uranium
 
-/obj/item/stack/sheet/mineral/uranium/get_main_recipes()
-	. = ..()
-	. += GLOB.uranium_recipes
+/obj/item/stack/sheet/mineral/uranium/get_recipes()
+	return GLOB.uranium_recipes
 
 /* Plasma */
 
@@ -89,9 +86,8 @@ Mineral Sheets
 	user.visible_message("<span class='suicide'>[user] begins licking \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return TOXLOSS//dont you kids know that stuff is toxic?
 
-/obj/item/stack/sheet/mineral/plasma/get_main_recipes()
-	. = ..()
-	. += GLOB.plasma_recipes
+/obj/item/stack/sheet/mineral/plasma/get_recipes()
+	return GLOB.plasma_recipes
 
 /obj/item/stack/sheet/mineral/plasma/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(W.is_hot() > 300)//If the temperature of the object is over 300, then ignite
@@ -122,9 +118,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/gold
 	material_type = /datum/material/gold
 
-/obj/item/stack/sheet/mineral/gold/get_main_recipes()
-	. = ..()
-	. += GLOB.gold_recipes
+/obj/item/stack/sheet/mineral/gold/get_recipes()
+	return GLOB.gold_recipes
 
 /* Silver */
 
@@ -141,9 +136,8 @@ Mineral Sheets
 	material_type = /datum/material/silver
 	tableVariant = /obj/structure/table/optable
 
-/obj/item/stack/sheet/mineral/silver/get_main_recipes()
-	. = ..()
-	. += GLOB.silver_recipes
+/obj/item/stack/sheet/mineral/silver/get_recipes()
+	return GLOB.silver_recipes
 
 /* Copper */
 
@@ -157,11 +151,11 @@ Mineral Sheets
 	grind_results = list(/datum/reagent/copper = 20)
 	point_value = 3
 	merge_type = /obj/item/stack/sheet/mineral/copper
+	material_type = /datum/material/copper
 
 
-/obj/item/stack/sheet/mineral/copper/get_main_recipes()
-	. = ..()
-	. += GLOB.copper_recipes
+/obj/item/stack/sheet/mineral/copper/get_recipes()
+	return GLOB.copper_recipes
 
 /* Titanium */
 
@@ -181,9 +175,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/titanium
 	material_type = /datum/material/titanium
 
-/obj/item/stack/sheet/mineral/titanium/get_main_recipes()
-	. = ..()
-	. += GLOB.titanium_recipes
+/obj/item/stack/sheet/mineral/titanium/get_recipes()
+	return GLOB.titanium_recipes
 
 /* Plastitanium */
 
@@ -203,9 +196,8 @@ Mineral Sheets
 	merge_type = /obj/item/stack/sheet/mineral/plastitanium
 	material_flags = NONE
 
-/obj/item/stack/sheet/mineral/plastitanium/get_main_recipes()
-	. = ..()
-	. += GLOB.plastitanium_recipes
+/obj/item/stack/sheet/mineral/plastitanium/get_recipes()
+	return GLOB.plastitanium_recipes
 
 /* Coal */
 

--- a/code/game/objects/items/stacks/sheets/mineral/metals.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/metals.dm
@@ -41,9 +41,8 @@ Metals Sheets
 	new /obj/item/stack/sheet/runed_metal(loc, amount)
 	qdel(src)
 
-/obj/item/stack/sheet/iron/get_main_recipes()
-	. = ..()
-	. += GLOB.metal_recipes
+/obj/item/stack/sheet/iron/get_recipes()
+	return GLOB.metal_recipes
 
 /obj/item/stack/sheet/iron/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins whacking [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -69,9 +68,8 @@ Metals Sheets
 	matter_amount = 12
 	material_flags = NONE
 
-/obj/item/stack/sheet/plasteel/get_main_recipes()
-	. = ..()
-	. += GLOB.plasteel_recipes
+/obj/item/stack/sheet/plasteel/get_recipes()
+	return GLOB.plasteel_recipes
 
 /* Runed Metal */
 
@@ -101,9 +99,8 @@ Metals Sheets
 		return FALSE
 	return ..()
 
-/obj/item/stack/sheet/runed_metal/get_main_recipes()
-	. = ..()
-	. += GLOB.runed_metal_recipes
+/obj/item/stack/sheet/runed_metal/get_recipes()
+	return GLOB.runed_metal_recipes
 
 /* Brass - the cult one */
 
@@ -132,9 +129,8 @@ Metals Sheets
 	else
 		return ..()
 
-/obj/item/stack/sheet/brass/get_main_recipes()
-	. = ..()
-	. += GLOB.brass_recipes
+/obj/item/stack/sheet/brass/get_recipes()
+	return GLOB.brass_recipes
 
 /obj/item/stack/sheet/brass/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()
@@ -165,9 +161,8 @@ Metals Sheets
 	else
 		return ..()
 
-/obj/item/stack/sheet/bronze/get_main_recipes()
-	. = ..()
-	. += GLOB.bronze_recipes
+/obj/item/stack/sheet/bronze/get_recipes()
+	return GLOB.bronze_recipes
 
 /obj/item/stack/sheet/bronze/Initialize(mapload, new_amount, merge = TRUE)
 	. = ..()

--- a/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
+++ b/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
@@ -21,9 +21,8 @@ Miscellaneous material sheets
 	grind_results = list(/datum/reagent/consumable/honey = 20)
 	merge_type = /obj/item/stack/sheet/wax
 
-/obj/item/stack/sheet/wax/get_main_recipes()
-	. = ..()
-	. += GLOB.wax_recipes
+/obj/item/stack/sheet/wax/get_recipes()
+	return GLOB.wax_recipes
 
 /* Sandbags */
 
@@ -40,9 +39,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	new/datum/stack_recipe("sandbags", /obj/structure/barricade/sandbags, 1, one_per_turf = TRUE, on_floor = TRUE, time = 2.5 SECONDS), \
 	))
 
-/obj/item/stack/sheet/sandbags/get_main_recipes()
-	. = ..()
-	. += GLOB.sandbag_recipes
+/obj/item/stack/sheet/sandbags/get_recipes()
+	return GLOB.sandbag_recipes
 
 /obj/item/emptysandbag
 	name = "empty sandbag"
@@ -76,9 +74,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	grind_results = list(/datum/reagent/consumable/ice = 20)
 	merge_type = /obj/item/stack/sheet/snow
 
-/obj/item/stack/sheet/snow/get_main_recipes()
-	. = ..()
-	. += GLOB.snow_recipes
+/obj/item/stack/sheet/snow/get_recipes()
+	return GLOB.snow_recipes
 
 /* Plastic */
 
@@ -91,10 +88,10 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	custom_materials = list(/datum/material/plastic=MINERAL_MATERIAL_AMOUNT)
 	throwforce = 7
 	merge_type = /obj/item/stack/sheet/plastic
+	material_type = /datum/material/plastic
 
-/obj/item/stack/sheet/plastic/get_main_recipes()
-	. = ..()
-	. += GLOB.plastic_recipes
+/obj/item/stack/sheet/plastic/get_recipes()
+	return GLOB.plastic_recipes
 
 /* Cardboard */
 
@@ -110,9 +107,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	throwforce = 0
 	merge_type = /obj/item/stack/sheet/cardboard
 
-/obj/item/stack/sheet/cardboard/get_main_recipes()
-	. = ..()
-	. += GLOB.cardboard_recipes
+/obj/item/stack/sheet/cardboard/get_recipes()
+	return GLOB.cardboard_recipes
 
 
 /obj/item/stack/sheet/cardboard/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/stacks/sheets/organic/cloths.dm
+++ b/code/game/objects/items/stacks/sheets/organic/cloths.dm
@@ -37,9 +37,8 @@ Various Cloths
 	pull_effort = 50
 	loom_result = /obj/item/stack/sheet/silk
 
-/obj/item/stack/sheet/cotton/cloth/get_main_recipes()
-	. = ..()
-	. += GLOB.cloth_recipes
+/obj/item/stack/sheet/cotton/cloth/get_recipes()
+	return GLOB.cloth_recipes
 
 /* Durathread cloth */
 
@@ -66,9 +65,8 @@ Various Cloths
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'
 
-/obj/item/stack/sheet/cotton/cloth/durathread/get_main_recipes()
-	. = ..()
-	. += GLOB.durathread_recipes
+/obj/item/stack/sheet/cotton/cloth/durathread/get_recipes()
+	return GLOB.durathread_recipes
 
 /* Silk */
 
@@ -84,6 +82,5 @@ Various Cloths
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'
 
-/obj/item/stack/sheet/silk/get_main_recipes()
-	. = ..()
-	. += GLOB.silk_recipes
+/obj/item/stack/sheet/silk/get_recipes()
+	return GLOB.silk_recipes

--- a/code/game/objects/items/stacks/sheets/organic/hides.dm
+++ b/code/game/objects/items/stacks/sheets/organic/hides.dm
@@ -24,9 +24,8 @@
 	singular_name = "human skin piece"
 	novariants = FALSE
 
-/obj/item/stack/sheet/animalhide/human/get_main_recipes()
-	. = ..()
-	. += GLOB.human_recipes
+/obj/item/stack/sheet/animalhide/human/get_recipes()
+	return GLOB.human_recipes
 
 /* Corgi hide */
 
@@ -37,9 +36,8 @@
 	icon_state = "sheet-corgi"
 	item_state = "sheet-corgi"
 
-/obj/item/stack/sheet/animalhide/corgi/get_main_recipes()
-	. = ..()
-	. += GLOB.corgi_recipes
+/obj/item/stack/sheet/animalhide/corgi/get_recipes()
+	return GLOB.corgi_recipes
 
 /* Mothroach hide */
 
@@ -59,9 +57,8 @@
 	icon_state = "sheet-gondola"
 	item_state = "sheet-gondola"
 
-/obj/item/stack/sheet/animalhide/gondola/get_main_recipes()
-	. = ..()
-	. += GLOB.gondola_recipes
+/obj/item/stack/sheet/animalhide/gondola/get_recipes()
+	return GLOB.gondola_recipes
 
 /* Cot hide */
 
@@ -81,9 +78,8 @@
 	icon_state = "sheet-monkey"
 	icon_state = "sheet-monkey"
 
-/obj/item/stack/sheet/animalhide/monkey/get_main_recipes()
-	. = ..()
-	. += GLOB.monkey_recipes
+/obj/item/stack/sheet/animalhide/monkey/get_recipes()
+	return GLOB.monkey_recipes
 
 /* Lizard hide */
 
@@ -103,9 +99,8 @@
 	icon_state = "sheet-xeno"
 	item_state = "sheet-xeno"
 
-/obj/item/stack/sheet/animalhide/xeno/get_main_recipes()
-	. = ..()
-	. += GLOB.xeno_recipes
+/obj/item/stack/sheet/animalhide/xeno/get_recipes()
+	return GLOB.xeno_recipes
 
 /* Ashdrake hide */
 

--- a/code/game/objects/items/stacks/sheets/organic/leather.dm
+++ b/code/game/objects/items/stacks/sheets/organic/leather.dm
@@ -8,9 +8,8 @@
 	item_state = "sheet-leather"
 	icon = 'icons/obj/stacks/organic.dmi'
 
-/obj/item/stack/sheet/leather/Initialize/get_main_recipes()
-	. = ..()
-	. += GLOB.leather_recipes
+/obj/item/stack/sheet/leather/Initialize/get_recipes()
+	return GLOB.leather_recipes
 
 /obj/item/stack/sheet/leather/hairlesshide
 	name = "hairless hide"

--- a/code/game/objects/items/stacks/sheets/organic/miscellaneous_organics.dm
+++ b/code/game/objects/items/stacks/sheets/organic/miscellaneous_organics.dm
@@ -52,7 +52,6 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 	new/datum/stack_recipe("sinew restraints", /obj/item/restraints/handcuffs/cable/sinew, 1), \
 ))
 
-/obj/item/stack/sheet/sinew/get_main_recipes()
-	. = ..()
-	. += GLOB.sinew_recipes
+/obj/item/stack/sheet/sinew/get_recipes()
+	return GLOB.sinew_recipes
 

--- a/code/game/objects/items/stacks/sheets/organic/wood.dm
+++ b/code/game/objects/items/stacks/sheets/organic/wood.dm
@@ -22,9 +22,8 @@ Woods Sheets
 	merge_type = /obj/item/stack/sheet/wood
 	grind_results = list(/datum/reagent/carbon = 20)
 
-/obj/item/stack/sheet/wood/get_main_recipes()
-	. = ..()
-	. += GLOB.wood_recipes
+/obj/item/stack/sheet/wood/get_recipes()
+	return GLOB.wood_recipes
 
 /* Bamboo */
 
@@ -42,14 +41,13 @@ Woods Sheets
 	merge_type = /obj/item/stack/sheet/bamboo
 	grind_results = list("carbon" = 5)
 
-/obj/item/stack/sheet/bamboo/get_main_recipes()
-	. = ..()
-	. += GLOB.bamboo_recipes
+/obj/item/stack/sheet/bamboo/get_recipes()
+	return GLOB.bamboo_recipes
 
 /obj/item/stack/sheet/bamboo/Topic(href, href_list)
 	. = ..()
 	if(href_list["make"])
-		var/list/recipes_list = get_main_recipes()
+		var/list/recipes_list = get_recipes()
 		var/datum/stack_recipe/R = recipes_list[text2num(href_list["make"])]
 		if(R.result_type == /obj/structure/punji_sticks)
 			var/turf/T = get_turf(src)
@@ -68,6 +66,5 @@ Woods Sheets
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/paperframes
 
-/obj/item/stack/sheet/paperframes/get_main_recipes()
-	. = ..()
-	. += GLOB.paperframe_recipes
+/obj/item/stack/sheet/paperframes/get_recipes()
+	return GLOB.paperframe_recipes

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -517,9 +517,8 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 		user.visible_message("<span class='suicide'>[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return OXYLOSS
 
-/obj/item/stack/cable_coil/get_main_recipes()
-	. = ..()
-	. += GLOB.cable_coil_recipes
+/obj/item/stack/cable_coil/get_recipes()
+	return GLOB.cable_coil_recipes
 
 /obj/item/stack/cable_coil/Initialize(mapload, new_amount = null, param_color = null)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR has:
* Reverts the removal of intended function for `get_recipes()` proc that's removed by #10135
The proc was introduced in #9385 but it appears it's accidentally removed.
* Fixes material recipes don't show basemat recipes
* Some materials didn't have material_type variable

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bonks @Tsar-Salat 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/a5691133-686e-40d1-b80e-ac598abfec6a)

## Changelog
:cl:
code: Revived 'get_recipes()' proc
code: Base materials now correctly show a dupe version of a craftable object. Currently only a chair is available, and only certain materials like Iron, Plasma sheet, Bananium sheet, etc have this.
fix: fixed some materials are not matched to each other
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
