### PR TITLE
`dview()` optimisation part 1: Sight define clean up

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -1,14 +1,12 @@
-#define SEE_INVISIBLE_MINIMUM 5
+#define INVISIBILITY_SYSTEM_ALL_TURFS 5
 
-#define INVISIBILITY_LIGHTING 20
+/// SUPER IMPORTANT NOTE:
+/// * DO NOT EVER USE `invisibility = 0`. Everything must be INVISIBILITY_DEFAULT at default
+#define INVISIBILITY_DEFAULT  30
 
-#define SEE_INVISIBLE_LIVING 25
-
-//#define SEE_INVISIBLE_LEVEL_ONE 35 //currently unused
-//#define INVISIBILITY_LEVEL_ONE 35 //currently unused
-
-//#define SEE_INVISIBLE_LEVEL_TWO 45 //currently unused
-//#define INVISIBILITY_LEVEL_TWO 45 //currently unused
+#define SEE_INVISIBLE_NOLIGHT 35 // We don't want to see lights!
+#define INVISIBILITY_LIGHTING 40
+#define SEE_INVISIBLE_EVERYONE_DEFAULT 45 // We see lights!
 
 #define INVISIBILITY_SPIRIT 60   // invisibility level for ghostly & spiritual mobs(Revenant, floor cluwne, etc) + ghost observers
 #define SEE_INVISIBLE_SPIRIT 60  // You can see ghostly & spiritual presences
@@ -32,4 +30,3 @@
 #define VISOR_VISIONFLAGS	(1<<2) //all following flags only matter for glasses
 #define VISOR_DARKNESSVIEW	(1<<3)
 #define VISOR_INVISVIEW		(1<<4)
-

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -247,7 +247,7 @@
  * * source is obviously the source attom from where we start looking
  * * invis_flags is for if we want to include invisible mobs or even ghosts etc the default value 0 means only visible mobs are included SEE_INVISIBLE_SPIRIT would also include ghosts.
  */
-/proc/get_hearers_in_view(view_radius, atom/source, invis_flags = 0)
+/proc/get_hearers_in_view(view_radius, atom/source, invis_flags = SEE_INVISIBLE_NOLIGHT)
 	var/turf/center_turf = get_turf(source)
 	. = list()
 	if(!center_turf)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -591,7 +591,7 @@ GLOBAL_LIST_EMPTY(species_list)
 GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 ///Version of view() which ignores darkness, because BYOND doesn't have it (I actually suggested it but it was tagged redundant, BUT HEARERS IS A T- /rant).
-/proc/dview(range = world.view, center, invis_flags = 0)
+/proc/dview(range = world.view, center, invis_flags = INVISIBILITY_DEFAULT)
 	if(!center)
 		return
 
@@ -604,7 +604,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 /mob/dview
 	name = "INTERNAL DVIEW MOB"
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	density = FALSE
 	see_in_dark = 1e6
 	move_resist = INFINITY

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -256,7 +256,7 @@
 
 	CHECK_TICK
 
-	set_observer_default_invisibility(0, "<span class='warning'>The round is over! You are now visible to the living.</span>")
+	set_observer_default_invisibility(INVISIBILITY_DEFAULT, "<span class='warning'>The round is over! You are now visible to the living.</span>")
 	//These need update to actually reflect the real antagonists
 	//Print a list of antagonists to the server log
 	var/list/total_antagonists = list()

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -43,7 +43,7 @@
 	screen_loc = ui_devilsouldisplay
 
 /atom/movable/screen/devil/soul_counter/proc/update_counter(souls = 0)
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#FF0000'>[souls]</font></div>")
 	switch(souls)
 		if(0,null)

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -334,7 +334,7 @@
 /atom/movable/screen/parallax_layer/planet/update_status(mob/M)
 	var/turf/T = get_turf(M)
 	if(is_station_level(T.z))
-		invisibility = 0
+		invisibility = INVISIBILITY_DEFAULT
 	else
 		invisibility = INVISIBILITY_ABSTRACT
 

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -63,7 +63,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	sight = NONE
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	see_invisible = SEE_INVISIBLE_LIVING
+	see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT
 	invisibility = INVISIBILITY_MAXIMUM
 	can_hear_init = TRUE // Enable hearing sensitive trait
 	initial_language_holder = /datum/language_holder/empty // language will be changed from init()

--- a/code/datums/elements/undertile.dm
+++ b/code/datums/elements/undertile.dm
@@ -43,7 +43,7 @@
 		stack_trace("([src]): Atom [source] was given an undertile element, but has become dense! This can lead to invisible walls!")
 		return //Returning to actually prevent this from happening
 
-	source.invisibility = covered ? invisibility_level : 0
+	source.invisibility = covered ? invisibility_level : INVISIBILITY_DEFAULT
 
 	var/turf/T = get_turf(source)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -10,6 +10,8 @@
 	plane = GAME_PLANE
 	appearance_flags = TILE_BOUND
 
+	invisibility = INVISIBILITY_DEFAULT
+
 	/// pass_flags that we are. If any of this matches a pass_flag on a moving thing, by default, we let them through.
 	var/pass_flags_self = NONE
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -493,7 +493,7 @@
 		user.overlay_fullscreen("remote_view", /atom/movable/screen/fullscreen/impaired, 2)
 
 /obj/machinery/camera/update_remote_sight(mob/living/user)
-	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
+	user.see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT //can't see ghosts through cameras
 	if(isXRay())
 		user.sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		user.see_in_dark = max(user.see_in_dark, 8)

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -71,7 +71,7 @@
 	// Motion cameras outside of an "ai monitored" area will use this to detect stuff.
 	if (!area_motion)
 		//Target must be living and visible enough to the camera
-		if(isliving(AM) && AM.invisibility <= SEE_INVISIBLE_LIVING && AM.alpha >= MOTION_SENSOR_MINIMUM_ALPHA)
+		if(isliving(AM) && AM.invisibility <= SEE_INVISIBLE_EVERYONE_DEFAULT && AM.alpha >= MOTION_SENSOR_MINIMUM_ALPHA)
 			newTarget(AM)
 
 /obj/machinery/camera/motion/thunderdome

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -229,7 +229,7 @@
 	var/image/user_image = null
 
 /mob/camera/ai_eye/remote/update_remote_sight(mob/living/user)
-	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
+	user.see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT //can't see ghosts through cameras
 	user.sight = SEE_TURFS | SEE_BLACKNESS
 	user.see_in_dark = 2
 	return TRUE

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -186,7 +186,7 @@
 
 /obj/machinery/jukebox/disco/proc/dance_setup()
 	var/turf/cen = get_turf(src)
-	FOR_DVIEW(var/turf/t, 3, get_turf(src),INVISIBILITY_LIGHTING)
+	FOR_DVIEW(var/turf/t, 3, get_turf(src), INVISIBILITY_LIGHTING)
 		if(t.x == cen.x && t.y > cen.y)
 			var/obj/item/flashlight/spotlight/L = new /obj/item/flashlight/spotlight(t)
 			L.light_color = LIGHT_COLOR_RED

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -318,7 +318,7 @@
 			set_anchored(FALSE)
 			to_chat(user, "<span class='notice'>You unsecure the exterior bolts on the turret.</span>")
 			power_change()
-			invisibility = 0
+			invisibility = INVISIBILITY_DEFAULT
 			qdel(cover) //deletes the cover, and the turret instance itself becomes its own cover.
 
 	else if(I.GetID())
@@ -391,7 +391,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/porta_turret)
 	. = ..()
 	if(.)
 		power_change()
-		invisibility = 0
+		invisibility = INVISIBILITY_DEFAULT
 		spark_system.start() //creates some sparks because they look cool
 		qdel(cover) //deletes the cover - no need on keeping it there!
 
@@ -423,7 +423,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/porta_turret)
 	for(var/turf_z as() in valid_turfs)
 		var/turf/T = valid_turfs[turf_z]
 		for(var/mob/A as() in hearers(scan_range, T))
-			if(A.invisibility > SEE_INVISIBLE_LIVING)
+			if(A.invisibility > SEE_INVISIBLE_EVERYONE_DEFAULT)
 				continue
 
 			if(check_anomalies)//if it's set to check for simple animals
@@ -501,7 +501,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/porta_turret)
 		return
 	if(machine_stat & BROKEN)
 		return
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	raising = 1
 	if(cover)
 		flick("popup", cover)
@@ -526,7 +526,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/porta_turret)
 	if(cover)
 		cover.icon_state = "turretCover"
 	raised = 0
-	invisibility = 2
+	invisibility = INVISIBILITY_DEFAULT
 	update_icon()
 
 /obj/machinery/porta_turret/proc/assess_perp(mob/living/carbon/human/perp)

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -15,7 +15,7 @@
 /obj/machinery/porta_turret_cover/Destroy()
 	if(parent_turret)
 		parent_turret.cover = null
-		parent_turret.invisibility = 0
+		parent_turret.invisibility = INVISIBILITY_DEFAULT
 		parent_turret = null
 	return ..()
 
@@ -46,7 +46,7 @@
 		if(!parent_turret.anchored)
 			parent_turret.set_anchored(TRUE)
 			to_chat(user, "<span class='notice'>You secure the exterior bolts on the turret.</span>")
-			parent_turret.invisibility = 0
+			parent_turret.invisibility = INVISIBILITY_DEFAULT
 			parent_turret.update_appearance()
 		else
 			parent_turret.set_anchored(FALSE)

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -193,7 +193,7 @@ the shield is disabled by means other than the action button (like running out o
 	set_light_on(chassis.defense_mode)
 
 	if(chassis.defense_mode)
-		invisibility = 0
+		invisibility = INVISIBILITY_DEFAULT
 		flick("shield_raise", src)
 		playsound(src, 'sound/mecha/mech_shield_raise.ogg', 50, FALSE)
 		icon_state = "shield"

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -161,7 +161,7 @@
 		return round(time_left)
 
 /obj/effect/countdown/arena
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	name = "arena countdown"
 
 /obj/effect/countdown/arena/get_value()

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -44,7 +44,7 @@
 			break
 
 		//we ignore the puff itself and stuff below the floor
-		if(turf_atom == src || turf_atom.invisibility)
+		if(turf_atom == src || turf_atom.invisibility > SEE_INVISIBLE_EVERYONE_DEFAULT)
 			continue
 
 		if(!stream)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -285,7 +285,7 @@
 				O.laws = M.laws
 				M.laws.associate(O)
 
-			O.invisibility = 0
+			O.invisibility = INVISIBILITY_DEFAULT
 			//Transfer debug settings to new mob
 			O.custom_name = created_name
 			O.locked = panel_locked

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -206,7 +206,7 @@
 		to_chat(user, "<span class='notice'>You hit the floor with the bible.</span>")
 		if(user?.mind?.holy_role)
 			for(var/obj/effect/rune/R in orange(2,user))
-				R.invisibility = 0
+				R.invisibility = INVISIBILITY_DEFAULT
 	if(user?.mind?.holy_role)
 		if(A.reagents && A.reagents.has_reagent(/datum/reagent/water)) // blesses all the water in the holder
 			to_chat(user, "<span class='notice'>You bless [A].</span>")

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -65,6 +65,7 @@
 	icon_state = ""
 	layer = FLY_LAYER
 	bullet_bounce_sound = null
+	invisibility = INVISIBILITY_DEFAULT
 
 INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -441,7 +441,7 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 	I.add_overlay(src)
 	for(var/V in contents)
 		var/atom/A = V
-		if(A.invisibility)
+		if(A.invisibility > SEE_INVISIBLE_EVERYONE_DEFAULT)
 			continue
 		I.add_overlay(A)
 		if(limit)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -4,6 +4,8 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 	icon = 'icons/turf/floors.dmi'
 	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE // Important for interaction with and visualization of openspace.
 
+	invisibility = INVISIBILITY_SYSTEM_ALL_TURFS
+
 	/// If there's a tile over a basic floor that can be ripped out
 	var/overfloor_placed = FALSE
 	/// How accessible underfloor pieces such as wires, pipes, etc are on this turf. Can be HIDDEN, VISIBLE, or INTERACTABLE.

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			A.icon = 'icons/mob/blob.dmi'
 			A.icon_state = "blob_shield"
 			A.layer = BELOW_MOB_LAYER
-			A.invisibility = 0
+			A.invisibility = INVISIBILITY_DEFAULT
 			A.blend_mode = 0
 	var/datum/antagonist/blob/B = mind.has_antag_datum(/datum/antagonist/blob)
 	if(B)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -25,7 +25,7 @@
 
 	user.hud_used.lingstingdisplay.icon = icon_icon
 	user.hud_used.lingstingdisplay.icon_state = button_icon_state
-	user.hud_used.lingstingdisplay.invisibility = 0
+	user.hud_used.lingstingdisplay.invisibility = INVISIBILITY_DEFAULT
 
 /datum/action/changeling/sting/proc/unset_sting(mob/user)
 	to_chat(user, "<span class='warning'>We retract our sting, we can't sting anyone for now.</span>")

--- a/code/modules/antagonists/clock_cult/scriptures/interdiction_lens.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/interdiction_lens.dm
@@ -67,7 +67,7 @@
 	for(var/mob/living/L in viewers(INTERDICTION_LENS_RANGE, src))
 		if(!is_servant_of_ratvar(L) && use_power(5))
 			L.apply_status_effect(STATUS_EFFECT_INTERDICTION)
-	for(var/obj/mecha/M in dview(INTERDICTION_LENS_RANGE, src, SEE_INVISIBLE_MINIMUM))
+	for(var/obj/mecha/M in dview(INTERDICTION_LENS_RANGE, src, SEE_INVISIBLE_NOLIGHT))
 		if(use_power(5))
 			M.emp_act(EMP_HEAVY)
 			M.take_damage(400 * delta_time)

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -8,7 +8,7 @@
 	debris = list(/obj/item/stack/sheet/runed_metal = 1)
 
 /obj/structure/destructible/cult/Initialize(mapload)
-	. = ..()	
+	. = ..()
 	generate_psychic_mask()
 
 /obj/structure/destructible/cult/proc/conceal() //for spells that hide cult presence
@@ -23,7 +23,7 @@
 
 /obj/structure/destructible/cult/proc/reveal() //for spells that reveal cult presence
 	set_density(initial(density))
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	visible_message("<span class='danger'>[src] suddenly appears!</span>")
 	alpha = initial(alpha)
 	light_range = initial(light_range)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -121,7 +121,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	alpha = 100 //To help ghosts distinguish hidden runes
 
 /obj/effect/rune/proc/reveal() //for talisman of revealing/hiding
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	visible_message("<span class='danger'>[src] suddenly appears!</span>")
 	alpha = initial(alpha)
 
@@ -342,7 +342,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	if(sacrificial.mind && !sacrificial.suiciding)
 		stone.invisibility = INVISIBILITY_MAXIMUM //so it's not picked up during transfer_soul()
 		stone.transfer_soul("FORCE", sacrificial, usr)
-		stone.invisibility = 0
+		stone.invisibility = INVISIBILITY_DEFAULT
 
 	if(sacrificial)
 		if(iscyborg(sacrificial))

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -192,7 +192,7 @@
 	soon_to_be_ghoul.become_husk()
 	soon_to_be_ghoul.faction |= FACTION_HERETIC
 	soon_to_be_ghoul.apply_status_effect(/datum/status_effect/ghoul)
-	soon_to_be_ghoul.invisibility = 0
+	soon_to_be_ghoul.invisibility = INVISIBILITY_DEFAULT
 
 	var/datum/antagonist/heretic_monster/heretic_monster = soon_to_be_ghoul.mind.add_antag_datum(/datum/antagonist/heretic_monster)
 	heretic_monster.set_owner(user.mind)

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -77,7 +77,7 @@
 	for(var/atom/close_atom as anything in range(1, src))
 		if(!ismovable(close_atom))
 			continue
-		if(close_atom.invisibility)
+		if(close_atom.invisibility > INVISIBILITY_OBSERVER || close_atom.invisibility == INVISIBILITY_LIGHTING)
 			continue
 		if(close_atom == user)
 			continue

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -261,7 +261,7 @@
 	to_chat(src, "<span class='revendanger'>NO! No... it's too late, you can feel your essence [pick("breaking apart", "drifting away")]...</span>")
 	notransform = TRUE
 	revealed = TRUE
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	playsound(src, 'sound/effects/screech.ogg', 100, 1)
 	visible_message("<span class='warning'>[src] lets out a waning screech as violet mist swirls around its dissolving body!</span>")
 	icon_state = "revenant_draining"
@@ -294,7 +294,7 @@
 	else //Revenant isn't revealed, whether by force or their own will, so this means they are currently invisible
 		revealed = TRUE
 		incorporeal_move = FALSE
-		invisibility = 0
+		invisibility = INVISIBILITY_DEFAULT
 	update_spooky_icon()
 	orbiting?.end_orbit(src)
 	return TRUE
@@ -305,7 +305,7 @@
 	if(time <= 0)
 		return
 	revealed = TRUE
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	incorporeal_move = FALSE
 	if(!unreveal_time)
 		to_chat(src, "<span class='revendanger'>You have been revealed!</span>")

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -849,7 +849,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	unlock_sound = 'sound/items/rped.ogg'
 
 /datum/AI_Module/large/upgrade_cameras/upgrade(mob/living/silicon/ai/AI)
-	AI.see_override = SEE_INVISIBLE_MINIMUM //Night-vision, without which X-ray would be very limited in power.
+	AI.see_override = SEE_INVISIBLE_NOLIGHT //Night-vision, without which X-ray would be very limited in power.
 	AI.update_sight()
 
 	var/upgraded_cameras = 0

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -114,7 +114,7 @@
 			beams += I
 			I.master = src
 			I.setDir(_dir)
-			I.invisibility = visible? 0 : INVISIBILITY_ABSTRACT
+			I.invisibility = visible? INVISIBILITY_DEFAULT : INVISIBILITY_ABSTRACT
 			T = _T
 			_T = get_step(_T, _dir)
 			CHECK_TICK

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -688,7 +688,7 @@
 	icon_state = "at_shield1"
 	layer = ABOVE_MOB_LAYER
 	alpha = 255
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 
 /obj/effect/ctf/ammo/Initialize(mapload)
 	..()

--- a/code/modules/awaymissions/super_secret_room.dm
+++ b/code/modules/awaymissions/super_secret_room.dm
@@ -27,7 +27,7 @@
 		if(0)
 			SpeakPeace(list("Welcome to the error handling room.","Something's goofed up bad to send you here.","You should probably tell an admin what you were doing, or make a bug report."))
 			for(var/obj/structure/signpost/salvation/S in orange(7))
-				S.invisibility = 0
+				S.invisibility = INVISIBILITY_DEFAULT
 				var/datum/effect_system/smoke_spread/smoke = new
 				smoke.set_up(1, S.loc)
 				smoke.start()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -11,7 +11,7 @@
 	custom_materials = list(/datum/material/glass = 250)
 	var/vision_flags = 0
 	var/darkness_view = 2//Base human is 2
-	var/invis_view = SEE_INVISIBLE_LIVING	//admin only for now
+	var/invis_view = 45	//admin only for now
 	var/invis_override = 0 //Override to allow glasses to set higher than normal see_invis
 	var/lighting_alpha
 	var/list/icon/current = list() //the current hud icons

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -11,7 +11,7 @@
 	custom_materials = list(/datum/material/glass = 250)
 	var/vision_flags = 0
 	var/darkness_view = 2//Base human is 2
-	var/invis_view = 45	//admin only for now
+	var/invis_view = SEE_INVISIBLE_EVERYONE_DEFAULT	//admin only for now
 	var/invis_override = 0 //Override to allow glasses to set higher than normal see_invis
 	var/lighting_alpha
 	var/list/icon/current = list() //the current hud icons

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -16,7 +16,7 @@
 	vision_flags = NONE
 	darkness_view = 2
 	lighting_alpha = null
-	invis_view = 45
+	invis_view = SEE_INVISIBLE_EVERYONE_DEFAULT
 
 	var/list/modes = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
 	var/mode = MODE_NONE

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -16,7 +16,7 @@
 	vision_flags = NONE
 	darkness_view = 2
 	lighting_alpha = null
-	invis_view = SEE_INVISIBLE_LIVING
+	invis_view = 45
 
 	var/list/modes = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
 	var/mode = MODE_NONE

--- a/code/modules/events/wizard/ghost.dm
+++ b/code/modules/events/wizard/ghost.dm
@@ -7,7 +7,7 @@
 
 /datum/round_event/wizard/ghost/start()
 	var/msg = "<span class='warning'>You suddenly feel extremely obvious...</span>"
-	set_observer_default_invisibility(0, msg)
+	set_observer_default_invisibility(INVISIBILITY_DEFAULT, msg)
 
 
 //--//

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -19,7 +19,7 @@
 		if(istype(I, /obj/item/storage))
 			var/obj/item/storage/S = I
 			var/datum/component/storage/STR = S.GetComponent(/datum/component/storage)
-			if(prob(upgrade_scroll_chance) && S.contents.len < STR.max_items && !S.invisibility)
+			if(prob(upgrade_scroll_chance) && S.contents.len < STR.max_items && S.invisibility <= SEE_INVISIBLE_EVERYONE_DEFAULT)
 				var/obj/item/upgradescroll/scroll = new(get_turf(S))
 				SEND_SIGNAL(S, COMSIG_TRY_STORAGE_INSERT, scroll, null, TRUE, TRUE)
 				upgrade_scroll_chance = max(0,upgrade_scroll_chance-100)

--- a/code/modules/fields/peaceborg_dampener.dm
+++ b/code/modules/fields/peaceborg_dampener.dm
@@ -52,7 +52,7 @@
 	var/image/I = get_edgeturf_overlay(get_edgeturf_direction(T))
 	var/obj/effect/abstract/proximity_checker/advanced/F = edge_turfs[T]
 	F.appearance = I.appearance
-	F.invisibility = 0
+	F.invisibility = INVISIBILITY_DEFAULT
 	F.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	F.layer = 5
 

--- a/code/modules/mining/aux_base_camera.dm
+++ b/code/modules/mining/aux_base_camera.dm
@@ -121,7 +121,7 @@
 		turret_action.Grant(user)
 		actions += turret_action
 
-	eyeobj.invisibility = 0 //When the eye is in use, make it visible to players so they know when someone is building.
+	eyeobj.invisibility = INVISIBILITY_DEFAULT //When the eye is in use, make it visible to players so they know when someone is building.
 
 /obj/machinery/computer/camera_advanced/base_construction/remove_eye_control(mob/living/user)
 	..()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -877,7 +877,7 @@
 			continue
 		var/mob/dead/observer/G = i
 		ghost_counter++
-		G.invisibility = 0
+		G.invisibility = INVISIBILITY_DEFAULT
 		current_spirits |= G
 
 	for(var/mob/dead/observer/G in spirits - current_spirits)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -4,7 +4,7 @@
 /obj/effect/light_emitter
 	name = "Light emitter"
 	anchored = TRUE
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	var/set_luminosity = 8
 	var/set_cap = 0
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -593,7 +593,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		ghost_others = client.prefs.read_player_preference(/datum/preference/choiced/ghost_others) //A quick update just in case this setting was changed right before calling the proc
 
 	if (!ghostvision)
-		see_invisible = SEE_INVISIBLE_LIVING
+		see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT
 	else
 		see_invisible = SEE_INVISIBLE_OBSERVER
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -899,7 +899,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/examine(mob/user)
 	. = ..()
-	if(!invisibility)
+	if(!invisibility <= SEE_INVISIBLE_EVERYONE_DEFAULT)
 		. += "It seems extremely obvious."
 
 /mob/dead/observer/proc/set_invisibility(value)

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -5,7 +5,7 @@
 	var/canmove = 1
 	density = FALSE
 	anchored = TRUE
-	invisibility = 60
+	invisibility = INVISIBILITY_SPIRIT
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/effect/dummy/phased_mob/slaughter/relaymove(mob/user, direction)

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -4,7 +4,7 @@
 	var/emp_damage = 0//Handles a type of MMI damage
 	var/datum/dna/stored/stored_dna // dna var for brain. Used to store dna, brain dna is not considered like actual dna, brain.has_dna() returns FALSE.
 	stat = DEAD //we start dead by default
-	see_invisible = SEE_INVISIBLE_LIVING
+	see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT
 	possible_a_intents = list(INTENT_HELP, INTENT_HARM) //for mechas
 	speech_span = SPAN_ROBOT
 

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -1,6 +1,6 @@
 
 /mob/living/brain/Life()
-	set invisibility = 0
+	set invisibility = INVISIBILITY_DEFAULT
 	if (notransform)
 		return
 	if(!loc)

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,7 +1,7 @@
 
 
 /mob/living/carbon/alien/larva/Life()
-	set invisibility = 0
+	set invisibility = INVISIBILITY_DEFAULT
 	if (notransform)
 		return
 	if(..() && !IS_IN_STASIS(src)) //not dead and not in stasis

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -114,7 +114,7 @@
 	if(new_xeno)
 		new_xeno.mobility_flags = MOBILITY_FLAGS_DEFAULT
 		new_xeno.notransform = 0
-		new_xeno.invisibility = 0
+		new_xeno.invisibility = INVISIBILITY_DEFAULT
 
 	var/mob/living/carbon/host = owner
 	if(kill_on_success)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -19,7 +19,7 @@
 #define THERMAL_PROTECTION_HAND_RIGHT	0.025
 
 /mob/living/carbon/human/Life()
-	set invisibility = 0
+	set invisibility = INVISIBILITY_DEFAULT
 	if (notransform)
 		return
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/Life()
-	set invisibility = 0
+	set invisibility = INVISIBILITY_DEFAULT
 
 	if(notransform)
 		return
@@ -55,7 +55,7 @@
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling)
 			changeling.regenerate()
-			hud_used.lingchemdisplay.invisibility = 0
+			hud_used.lingchemdisplay.invisibility = INVISIBILITY_DEFAULT
 			hud_used.lingchemdisplay.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(changeling.chem_charges)]</font></div>")
 		else
 			hud_used.lingchemdisplay.invisibility = INVISIBILITY_ABSTRACT

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -3,7 +3,7 @@
 
 /mob/living/proc/Life(delta_time, times_fired)
 	set waitfor = FALSE
-	set invisibility = 0
+	set invisibility = INVISIBILITY_DEFAULT
 
 	SEND_SIGNAL(src, COMSIG_LIVING_LIFE, delta_time, times_fired)
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,5 +1,5 @@
 /mob/living
-	see_invisible = SEE_INVISIBLE_LIVING
+	see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT
 	sight = 0
 	see_in_dark = 2
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD,NANITE_HUD,DIAG_NANITE_FULL_HUD)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/Life()
-	set invisibility = 0
+	set invisibility = INVISIBILITY_DEFAULT
 	if (src.notransform)
 		return
 	..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1006,12 +1006,12 @@
 
 	if(sight_mode & BORGXRAY)
 		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		see_invisible = SEE_INVISIBLE_LIVING
+		see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT
 		see_in_dark = 8
 
 	if(sight_mode & BORGTHERM)
 		sight |= SEE_MOBS
-		see_invisible = min(see_invisible, SEE_INVISIBLE_LIVING)
+		see_invisible = min(see_invisible, SEE_INVISIBLE_EVERYONE_DEFAULT)
 		see_in_dark = 8
 
 	if(see_override)

--- a/code/modules/mob/living/simple_animal/hostile/floor_cluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floor_cluwne.dm
@@ -205,7 +205,7 @@ GLOBAL_VAR_INIT(floor_cluwnes, 0)
 
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/Appear()//handled in a separate proc so floor cluwne doesn't appear before the animation finishes
-	invisibility = FALSE
+	invisibility = INVISIBILITY_DEFAULT
 	density = TRUE
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/Reset_View(screens, colour, mob/living/carbon/human/H)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -133,7 +133,7 @@
 	if(!search_objects)
 		var/static/target_list = typecacheof(list(/obj/machinery/porta_turret, /obj/mecha)) //mobs are handled via ismob(A)
 		. = list()
-		for(var/atom/A as() in dview(vision_range, get_turf(target_from), SEE_INVISIBLE_MINIMUM))
+		for(var/atom/A as() in dview(vision_range, get_turf(target_from), SEE_INVISIBLE_NOLIGHT))
 			if((ismob(A) && A != src) || target_list[A.type])
 				. += A
 	else

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -7,7 +7,7 @@
 	var/attack_cooldown_time = 20 //How long, in deciseconds, the cooldown of attacks is
 
 /mob/living/simple_animal/slime/Life()
-	set invisibility = 0
+	set invisibility = INVISIBILITY_DEFAULT
 	if(notransform)
 		return
 	alpha = 255

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -17,6 +17,7 @@
 	throwforce = 10
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	pass_flags_self = PASSMOB
+	see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT
 
 	var/lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	var/datum/mind/mind

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -525,7 +525,7 @@
 
 	R.job = JOB_NAME_CYBORG
 	R.gender = gender
-	R.invisibility = 0
+	R.invisibility = INVISIBILITY_DEFAULT
 
 	if(client)
 		R.updatename(client)

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -110,7 +110,7 @@
 	plane = ZMIMIC_MAX_PLANE
 	blend_mode = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	invisibility = 0
+	invisibility = INVISIBILITY_DEFAULT
 	if (islist(color))
 		// We're using a color matrix, so just darken the colors across the board.
 		var/list/c_list = color

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -202,7 +202,7 @@
 				blueprints = TRUE
 	for(var/mob/mob in mobs)
 		// No describing invisible stuff (except ghosts)!
-		if(mob.alpha <= 50 || !((mob.invisibility < SEE_INVISIBLE_LIVING) || (see_ghosts && can_camera_see_atom(mob))))
+		if(mob.alpha <= 50 || !((mob.invisibility < SEE_INVISIBLE_EVERYONE_DEFAULT) || (see_ghosts && can_camera_see_atom(mob))))
 			continue
 		mobs_spotted[mob] = mob.stat
 		if(mob.mind)

--- a/code/modules/photography/camera/camera_image_capturing.dm
+++ b/code/modules/photography/camera/camera_image_capturing.dm
@@ -35,7 +35,7 @@
 				images += new /image/photo(newT, T.loc)
 			for(var/i in T.contents)
 				var/atom/A = i
-				if(!A.invisibility || (see_ghosts && can_camera_see_atom(A)))
+				if(A.invisibility <= SEE_INVISIBLE_EVERYONE_DEFAULT || (see_ghosts && can_camera_see_atom(A)))
 					images += new /image/photo(newT, A)
 		skip_normal = TRUE
 		wipe_images = TRUE
@@ -46,7 +46,7 @@
 			var/turf/T = i
 			images += new /image/photo(T.loc, T)
 			for(var/atom/movable/A in T)
-				if(A.invisibility)
+				if(A.invisibility > SEE_INVISIBLE_EVERYONE_DEFAULT)
 					if(!(see_ghosts && can_camera_see_atom(A)))
 						continue
 				images += new /image/photo(A.loc, A)

--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -93,7 +93,7 @@
 	plane = POINT_PLANE
 	duration = POINT_TIME
 
-/obj/effect/temp_visual/point/Initialize(mapload, set_invis = 0)
+/obj/effect/temp_visual/point/Initialize(mapload, set_invis = INVISIBILITY_DEFAULT)
 	. = ..()
 	var/atom/old_loc = loc
 	abstract_move(get_turf(src))

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -197,7 +197,7 @@
 			new_mob = new robot(M.loc)
 			if(issilicon(new_mob))
 				new_mob.gender = M.gender
-				new_mob.invisibility = 0
+				new_mob.invisibility = INVISIBILITY_DEFAULT
 				new_mob.job = JOB_NAME_CYBORG
 				var/mob/living/silicon/robot/Robot = new_mob
 				Robot.lawupdate = FALSE

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator_console.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator_console.dm
@@ -37,7 +37,7 @@
 
 /obj/machinery/computer/camera_advanced/shuttle_creator/GrantActions(mob/living/user)
 	..(user)
-	eyeobj.invisibility = SEE_INVISIBLE_LIVING
+	eyeobj.invisibility = SEE_INVISIBLE_EVERYONE_DEFAULT
 	if(area_action)
 		area_action.target = src
 		area_action.Grant(user)

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -90,7 +90,7 @@
 	var/movespeed = 2
 	density = FALSE
 	anchored = TRUE
-	invisibility = 60
+	invisibility = INVISIBILITY_SPIRIT
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/effect/dummy/phased_mob/spell_jaunt/Destroy()

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -42,7 +42,7 @@
 	var/mob/living/jaunter
 	density = FALSE
 	anchored = TRUE
-	invisibility = 60
+	invisibility = INVISIBILITY_SPIRIT
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/effect/dummy/phased_mob/shadow/relaymove(mob/user, direction)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -26,7 +26,7 @@
 	var/eye_icon_state = "eyes"
 	var/old_eye_color = "fff"
 	var/flash_protect = 0
-	var/see_invisible = SEE_INVISIBLE_LIVING
+	var/see_invisible = SEE_INVISIBLE_EVERYONE_DEFAULT
 	var/lighting_alpha
 	var/no_glasses
 	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect

--- a/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
+++ b/code/modules/xenoarchaeology/traits/xenoartifact_minors.dm
@@ -198,7 +198,7 @@
 	flavour_text = "Return to your master..."
 	use_cooldown = TRUE
 	banType = ROLE_SENTIENT_XENOARTIFACT
-	invisibility = 101
+	invisibility = INVISIBILITY_ABSTRACT
 	var/obj/item/xenoartifact/artifact
 
 /obj/effect/mob_spawn/sentient_artifact/Initialize(mapload, var/obj/item/xenoartifact/Z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* `dview()` optimisation part 1: Sight define clean up

I figured `dview()` can be much cleaner with invisibility
but for that, EVERYTHING must be `invisibility = 30` and our precious dview mob should have `see_invisible = 0`

But for now, I will clean up the defines first.
Invisibility from everything will be 30 now, and everyone will have `see_invisible = 35` so that the game will not be still changed
After this PR is merged, I will bring up part 2.

### Part 2: dview change
Not included, but sneak peek
```dm
/proc/dview(range = world.view, center, see_invisible_power = 0, sight_flags = NONE)
	if(!center)
		return

	GLOB.dview_mob.loc = center
	GLOB.dview_mob.see_invisible = see_invisible_power 
	GLOB.dview_mob.sight= sight_flags 

	. = view(range, GLOB.dview_mob)
	GLOB.dview_mob.loc = null
```
Did you notice? dview mob will have zero sight power.
turfs now do have 5 invisibility in this PR. This means you can simply get a list with turfs that you can see without filtering the list if see_invisible_power is given with 10.
If see_invisible_power = 0 and sight_flags = SEE_MOBS, you will get a list of mobs nearby you. You can quickly calculate if that mob is on a turf that you searched if it's necessary. OR just use the found mob list with SEE_MOBS flag that we can make mobs hear each other through a single wall or a single mech between them!


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Preparation for a better performance in the cursed engine

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/22d7a440-453c-4940-a7f5-d9062b288fe0)

works well. This is when my see_invisible is 10. If I do that to 0, I will see nothing
This IS NOT how `SEE_TURFS` flag works. I see only turfs that I can see.

## Changelog
:cl:
code: improved sight defines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
