### PR TITLE
Newfood customfood

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -618,6 +618,7 @@
 #include "code\datums\components\construction.dm"
 #include "code\datums\components\conveyor_movement.dm"
 #include "code\datums\components\creamed.dm"
+#include "code\datums\components\customizable_reagent_holder.dm"
 #include "code\datums\components\cult_ritual_item.dm"
 #include "code\datums\components\deadchat_control.dm"
 #include "code\datums\components\dejavu.dm"

--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -43,19 +43,14 @@
 #define CALTROP_BYPASS_SHOES 1
 #define CALTROP_IGNORE_WALKERS 2
 
-// Update flags for [/atom/proc/update_appearance]
-/// Update the atom's name
-#define UPDATE_NAME (1<<0)
-/// Update the atom's desc
-#define UPDATE_DESC (1<<1)
-/// Update the atom's icon state
-#define UPDATE_ICON_STATE (1<<2)
-/// Update the atom's overlays
-#define UPDATE_OVERLAYS (1<<3)
-/// Update the atom's greyscaling
-#define UPDATE_GREYSCALE (1<<4)
-/// Update the atom's smoothing. (More accurately, queue it for an update)
-#define UPDATE_SMOOTHING (1<<5)
-/// Update the atom's icon
-#define UPDATE_ICON (UPDATE_ICON_STATE|UPDATE_OVERLAYS)
-//Redirection component init flags
+//Ingredient type in datum/component/customizable_reagent_holder
+#define CUSTOM_INGREDIENT_TYPE_EDIBLE 1
+#define CUSTOM_INGREDIENT_TYPE_DRYABLE 2
+
+//Icon overlay type in datum/component/customizable_reagent_holder
+#define CUSTOM_INGREDIENT_ICON_NOCHANGE 0
+#define CUSTOM_INGREDIENT_ICON_FILL 1
+#define CUSTOM_INGREDIENT_ICON_SCATTER 2
+#define CUSTOM_INGREDIENT_ICON_STACK 3
+#define CUSTOM_INGREDIENT_ICON_LINE 4
+#define CUSTOM_INGREDIENT_ICON_STACKPLUSTOP 5

--- a/code/__DEFINES/dcs/signals/signals_atom.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom.dm
@@ -123,6 +123,8 @@
 	#define COMPONENT_BLOCK_REACH 1
 ///for when an atom has been created through processing (atom/original_atom, list/chosen_processing_option)
 #define COMSIG_ATOM_CREATEDBY_PROCESSING "atom_createdby_processing"
+///when an atom is processed (mob/living/user, obj/item/I, list/atom/results)
+#define COMSIG_ATOM_PROCESSED "atom_processed"
 ///! called when teleporting into a protected turf: (channel, turf/origin)
 #define COMSIG_ATOM_INTERCEPT_TELEPORT "intercept_teleport"
 	#define COMPONENT_BLOCK_TELEPORT 1

--- a/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_item/signals_food.dm
@@ -7,6 +7,12 @@
 #define COMSIG_FOOD_CROSSED "food_crossed"
 /// From base of Component/edible/On_Consume: (mob/living/eater, mob/living/feeder)
 #define COMSIG_FOOD_CONSUMED "food_consumed"
+///called when an atom with /datum/component/customizable_reagent_holder is customized (obj/item/I)
+#define COMSIG_ATOM_CUSTOMIZED "atom_customized"
+/// called when an item is used as an ingredient: (atom/customized)
+#define COMSIG_ITEM_USED_AS_INGREDIENT "item_used_as_ingredient"
+/// called when an edible ingredient is added: (datum/component/edible/ingredient)
+#define COMSIG_FOOD_INGREDIENT_ADDED "edible_ingredient_added"
 
 // Deep frying foods
 /// From obj/item/food/deepfryholder/Initialize

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -40,6 +40,22 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define UNPAINTABLE_1 				(1<<17)
 #define HTML_USE_INITAL_ICON_1		(1<<18) 			//! Should we use the initial icon for display? Mostly used by overlay only objects
 
+// Update flags for [/atom/proc/update_appearance]
+/// Update the atom's name
+#define UPDATE_NAME (1<<0)
+/// Update the atom's desc
+#define UPDATE_DESC (1<<1)
+/// Update the atom's icon state
+#define UPDATE_ICON_STATE (1<<2)
+/// Update the atom's overlays
+#define UPDATE_OVERLAYS (1<<3)
+/// Update the atom's greyscaling
+#define UPDATE_GREYSCALE (1<<4)
+/// Update the atom's smoothing. (More accurately, queue it for an update)
+#define UPDATE_SMOOTHING (1<<5)
+/// Update the atom's icon
+#define UPDATE_ICON (UPDATE_ICON_STATE|UPDATE_OVERLAYS)
+
 /// If the thing can reflect light (lasers/energy)
 #define RICOCHET_SHINY			(1<<0)
 /// If the thing can reflect matter (bullets/bomb shrapnel)

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -333,10 +333,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_DRYABLE "trait_dryable"
 ///Trait for dried items
 #define TRAIT_DRIED "trait_dried"
-/// Trait for customizable reagent holder
-//#define TRAIT_CUSTOMIZABLE_REAGENT_HOLDER "customizable_reagent_holder"
-/// Trait for allowing an item that isn't food into the customizable reagent holder
-//#define TRAIT_ODD_CUSTOMIZABLE_FOOD_INGREDIENT "odd_customizable_food_ingredient"
+// Trait for customizable reagent holder
+#define TRAIT_CUSTOMIZABLE_REAGENT_HOLDER "customizable_reagent_holder"
+// Trait for allowing an item that isn't food into the customizable reagent holder
+#define TRAIT_ODD_CUSTOMIZABLE_FOOD_INGREDIENT "odd_customizable_food_ingredient"
 
 ///Trait applied to turfs when an atmos holosign is placed on them. It will stop firedoors from closing.
 #define TRAIT_FIREDOOR_STOP "firedoor_stop"

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -1,0 +1,246 @@
+/**
+ * # Custom Atom Component
+ *
+ * When added to an atom, item ingredients can be put into that.
+ * The sprite is updated and reagents are transfered.
+ *
+ * If the component is added to something that is processed, creating new objects (being cut, for example),
+ * the replacement type needs to also have the component. The ingredients will be copied over. Reagents are not
+ * copied over since other components already take care of that.
+ */
+/datum/component/customizable_reagent_holder
+	can_transfer = TRUE
+	///List of item ingredients.
+	var/list/obj/item/ingredients
+	///Type path of replacement atom.
+	var/replacement
+	///Type of fill, can be [CUSTOM_INGREDIENT_ICON_NOCHANGE] for example.
+	var/fill_type
+	///Number of max ingredients.
+	var/max_ingredients
+	///Overlay used for certain fill types, always shows up on top.
+	var/mutable_appearance/top_overlay
+	///Type of ingredients to accept, [CUSTOM_INGREDIENT_TYPE_EDIBLE] for example.
+	var/ingredient_type
+
+
+/datum/component/customizable_reagent_holder/Initialize(
+		atom/replacement,
+		fill_type,
+		ingredient_type = CUSTOM_INGREDIENT_TYPE_EDIBLE,
+		max_ingredients = INFINITY,
+		list/obj/item/initial_ingredients = null)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	var/atom/atom_parent = parent
+	if (!atom_parent.reagents)
+		return COMPONENT_INCOMPATIBLE
+
+	src.replacement = replacement
+	src.fill_type = fill_type
+	src.max_ingredients = max_ingredients
+	src.ingredient_type = ingredient_type
+
+	if (initial_ingredients)
+		for (var/_ingredient in initial_ingredients)
+			var/obj/item/ingredient = _ingredient
+			add_ingredient(ingredient)
+			handle_fill(ingredient)
+
+
+/datum/component/customizable_reagent_holder/Destroy(force, silent)
+	QDEL_NULL(top_overlay)
+	return ..()
+
+
+/datum/component/customizable_reagent_holder/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/customizable_attack)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+	RegisterSignal(parent, COMSIG_ATOM_PROCESSED, .proc/on_processed)
+	ADD_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, src)
+
+
+/datum/component/customizable_reagent_holder/UnregisterFromParent()
+	. = ..()
+	UnregisterSignal(parent, list(
+		COMSIG_PARENT_ATTACKBY,
+		COMSIG_PARENT_EXAMINE,
+		COMSIG_ATOM_PROCESSED,
+	))
+	REMOVE_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, src)
+
+
+/datum/component/customizable_reagent_holder/PostTransfer()
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	var/atom/atom_parent = parent
+	if (!atom_parent.reagents)
+		return COMPONENT_INCOMPATIBLE
+
+///Handles when the customizable food is examined.
+/datum/component/customizable_reagent_holder/proc/on_examine(atom/A, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	var/atom/atom_parent = parent
+	var/ingredients_listed = ""
+	if (LAZYLEN(ingredients))
+		for (var/i in 1 to ingredients.len)
+			var/obj/item/ingredient = ingredients[i]
+			var/ending = ", "
+			switch(length(ingredients))
+				if (2)
+					if (i == 1)
+						ending = " and "
+				if (3 to INFINITY)
+					if (i == ingredients.len - 1)
+						ending = ", and "
+			ingredients_listed += "\a [ingredient.name][ending]"
+	examine_list += "It contains [LAZYLEN(ingredients) ? "[ingredients_listed]" : " no ingredients, "]making a [custom_adjective()]-sized [initial(atom_parent.name)]."
+
+
+///Handles when the customizable food is attacked by something.
+/datum/component/customizable_reagent_holder/proc/customizable_attack(datum/source, obj/ingredient, mob/attacker, silent = FALSE, force = FALSE)
+	SIGNAL_HANDLER
+
+	var/valid_ingredient = TRUE
+
+	switch (ingredient_type)
+		if (CUSTOM_INGREDIENT_TYPE_EDIBLE)
+			valid_ingredient = IS_EDIBLE(ingredient)
+
+	// only accept valid ingredients
+	if (!valid_ingredient || HAS_TRAIT(ingredient, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER))
+		to_chat(attacker, "<span class='warning'>[ingredient] doesn't belong on [parent]!</span>")
+		return
+
+	if (LAZYLEN(ingredients) >= max_ingredients)
+		to_chat(attacker, "<span class='warning'>[parent] is too full for any more ingredients!</span>")
+		return COMPONENT_NO_AFTERATTACK
+
+	var/atom/atom_parent = parent
+	if(!attacker.transferItemToLoc(ingredient, atom_parent))
+		return
+	if (replacement)
+		var/atom/replacement_parent = new replacement(atom_parent.loc)
+		ingredient.forceMove(replacement_parent)
+		replacement = null
+		RemoveComponent()
+		replacement_parent.TakeComponent(src)
+		qdel(atom_parent)
+	handle_reagents(ingredient)
+	add_ingredient(ingredient)
+	handle_fill(ingredient)
+
+
+///Handles the icon update for a new ingredient.
+/datum/component/customizable_reagent_holder/proc/handle_fill(obj/item/ingredient)
+	if (fill_type == CUSTOM_INGREDIENT_ICON_NOCHANGE)
+		//don't bother doing the icon procs
+		return
+	var/atom/atom_parent = parent
+	var/mutable_appearance/filling = mutable_appearance(atom_parent.icon, "[initial(atom_parent.icon_state)]_filling")
+	// get average color
+	var/icon/icon = new(ingredient.icon, ingredient.icon_state)
+	icon.Scale(1, 1)
+	var/fillcol = copytext(icon.GetPixel(1, 1), 1, 8) // remove opacity
+	filling.color = fillcol
+
+	switch(fill_type)
+		if(CUSTOM_INGREDIENT_ICON_SCATTER)
+			filling.pixel_x = rand(-1,1)
+			filling.pixel_y = rand(-1,1)
+		if(CUSTOM_INGREDIENT_ICON_STACK)
+			filling.pixel_x = rand(-1,1)
+			filling.pixel_y = 2 * LAZYLEN(ingredients) - 1
+		if(CUSTOM_INGREDIENT_ICON_STACKPLUSTOP)
+			filling.pixel_x = rand(-1,1)
+			filling.pixel_y = 2 * LAZYLEN(ingredients) - 1
+			if (top_overlay) // delete old top if exists
+				atom_parent.cut_overlay(top_overlay)
+			top_overlay = mutable_appearance(atom_parent.icon, "[atom_parent.icon_state]_top")
+			top_overlay.pixel_y = 2 * LAZYLEN(ingredients) + 3
+			atom_parent.add_overlay(filling)
+			atom_parent.add_overlay(top_overlay)
+			return
+		if(CUSTOM_INGREDIENT_ICON_FILL)
+			if (top_overlay)
+				filling.color = mix_color(filling.color)
+				atom_parent.cut_overlay(top_overlay)
+			top_overlay = filling
+		if(CUSTOM_INGREDIENT_ICON_LINE)
+			filling.pixel_x = filling.pixel_y = rand(-8,3)
+	atom_parent.add_overlay(filling)
+
+
+///Takes the reagents from an ingredient.
+/datum/component/customizable_reagent_holder/proc/handle_reagents(obj/item/ingredient)
+	var/atom/atom_parent = parent
+	if (atom_parent.reagents && ingredient.reagents)
+		ingredient.reagents.trans_to(atom_parent, ingredient.reagents.total_volume)
+	return
+
+
+///Adds a new ingredient and updates the parent's name.
+/datum/component/customizable_reagent_holder/proc/add_ingredient(obj/item/ingredient)
+	var/atom/atom_parent = parent
+	LAZYADD(ingredients, ingredient)
+	atom_parent.name = "[custom_adjective()] [custom_type()] [initial(atom_parent.name)]"
+	SEND_SIGNAL(atom_parent, COMSIG_ATOM_CUSTOMIZED, ingredient)
+	SEND_SIGNAL(ingredient, COMSIG_ITEM_USED_AS_INGREDIENT, atom_parent)
+
+
+///Gives an adjective to describe the size of the custom food.
+/datum/component/customizable_reagent_holder/proc/custom_adjective()
+	switch(LAZYLEN(ingredients))
+		if (0 to 2)
+			return "small"
+		if (3 to 5)
+			return "standard"
+		if (6 to 8)
+			return "big"
+		if (8 to 11)
+			return "ridiculous"
+		if (12 to INFINITY)
+			return "monstrous"
+
+
+///Gives the type of custom food (based on what the first ingredient was).
+/datum/component/customizable_reagent_holder/proc/custom_type()
+	var/custom_type = "empty"
+	if (LAZYLEN(ingredients))
+		var/obj/item/first_ingredient = ingredients[1]
+		if (istype(first_ingredient, /obj/item/food/meat))
+			var/obj/item/food/meat/meat = first_ingredient
+			if (meat.subjectname)
+				custom_type = meat.subjectname
+			else if (meat.subjectjob)
+				custom_type = meat.subjectjob
+		if (custom_type == "empty" && first_ingredient.name)
+			custom_type = first_ingredient.name
+	return custom_type
+
+
+///Returns the color of the input mixed with the top_overlay's color.
+/datum/component/customizable_reagent_holder/proc/mix_color(color)
+	if(LAZYLEN(ingredients) == 1 || !top_overlay)
+		return color
+	else
+		var/list/rgbcolor = list(0,0,0,0)
+		var/customcolor = GetColors(color)
+		var/ingcolor =  GetColors(top_overlay.color)
+		rgbcolor[1] = (customcolor[1]+ingcolor[1])/2
+		rgbcolor[2] = (customcolor[2]+ingcolor[2])/2
+		rgbcolor[3] = (customcolor[3]+ingcolor[3])/2
+		rgbcolor[4] = (customcolor[4]+ingcolor[4])/2
+		return rgb(rgbcolor[1], rgbcolor[2], rgbcolor[3], rgbcolor[4])
+
+
+///Copies over the parent's ingredients to the processing results (such as slices when the parent is cut).
+/datum/component/customizable_reagent_holder/proc/on_processed(datum/source, mob/living/user, obj/item/ingredient, list/atom/results)
+	SIGNAL_HANDLER
+
+	// Reagents are not transferred since that should be handled elsewhere.
+	for (var/r in results)
+		var/atom/result = r
+		result.AddComponent(/datum/component/customizable_reagent_holder, null, fill_type, ingredient_type = ingredient_type, max_ingredients = max_ingredients, initial_ingredients = ingredients)

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -55,9 +55,9 @@
 
 /datum/component/customizable_reagent_holder/RegisterWithParent()
 	. = ..()
-	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/customizable_attack)
-	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
-	RegisterSignal(parent, COMSIG_ATOM_PROCESSED, .proc/on_processed)
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(customizable_attack))
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE,  PROC_REF(on_examine))
+	RegisterSignal(parent, COMSIG_ATOM_PROCESSED,  PROC_REF(on_processed))
 	ADD_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, src)
 
 

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -70,7 +70,6 @@
 	))
 	REMOVE_TRAIT(parent, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER, src)
 
-
 /datum/component/customizable_reagent_holder/PostTransfer()
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -127,6 +126,7 @@
 		replacement = null
 		RemoveComponent()
 		replacement_parent.TakeComponent(src)
+		handle_reagents(atom_parent)
 		qdel(atom_parent)
 	handle_reagents(ingredient)
 	add_ingredient(ingredient)
@@ -177,6 +177,7 @@
 /datum/component/customizable_reagent_holder/proc/handle_reagents(obj/item/ingredient)
 	var/atom/atom_parent = parent
 	if (atom_parent.reagents && ingredient.reagents)
+		atom_parent.reagents.maximum_volume += ingredient.reagents.maximum_volume // If we don't do this custom food starts voiding reagents past a certain point.
 		ingredient.reagents.trans_to(atom_parent, ingredient.reagents.total_volume)
 	return
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -196,7 +196,7 @@ Behavior that's still missing from this component that original food items had t
 	this_food.create_reagents(volume)
 	original_atom.reagents.copy_to(this_food, original_atom.reagents.total_volume, 1 / chosen_processing_option[TOOL_PROCESSING_AMOUNT])
 
-	if(original_atom.name != initial(original_atom.nam`e))
+	if(original_atom.name != initial(original_atom.name))
 		this_food.name = "slice of [original_atom.name]"
 	if(original_atom.desc != initial(original_atom.desc))
 		this_food.desc = "[original_atom.desc]"

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -207,19 +207,8 @@ Behavior that's still missing from this component that original food items had t
 
 	this_food.reagents.multiply_reagents(CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
 
-	for(var/obj/item/crafted_part in this_food.contents)
+	for(var/obj/item/food/crafted_part in parts_list)
 		crafted_part.reagents?.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume, CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER)
-
-	var/list/objects_to_delete = this_food.contents.Copy()
-
-	// Remove all non recipe objects from the contents
-	for(var/content_object in this_food.contents)
-		for(var/recipe_object in recipe.parts)
-			if(istype(content_object, recipe_object))
-				objects_to_delete -= content_object
-				break
-
-	QDEL_LIST(objects_to_delete)
 
 	SSblackbox.record_feedback("tally", "food_made", 1, type)
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -6,7 +6,6 @@ These items take a specific time to eat, and can do most of the things our origi
 Behavior that's still missing from this component that original food items had that should either be put into seperate components or somewhere else:
 	Components:
 	Drying component (jerky etc)
-	Customizable component (custom pizzas etc)
 	Processable component (Slicing and cooking behavior essentialy, making it go from item A to B when conditions are met.)
 	Microwavability component
 	Frying component
@@ -78,12 +77,14 @@ Behavior that's still missing from this component that original food items had t
 	RegisterSignal(parent, COMSIG_ATOM_CHECKPARTS, PROC_REF(on_craft))
 	RegisterSignal(parent, COMSIG_ATOM_CREATEDBY_PROCESSING, PROC_REF(on_processed))
 	RegisterSignal(parent, COMSIG_ITEM_MICROWAVE_COOKED, PROC_REF(on_microwave_cooked))
+	RegisterSignal(parent, COMSIG_FOOD_INGREDIENT_ADDED, PROC_REF(edible_ingredient_added))
 	RegisterSignal(parent, COMSIG_EDIBLE_ON_COMPOST, PROC_REF(compost))
 
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(use_from_hand))
 		RegisterSignal(parent, COMSIG_ITEM_FRIED, PROC_REF(on_fried))
 		RegisterSignal(parent, COMSIG_ITEM_MICROWAVE_ACT, PROC_REF(on_microwaved))
+		RegisterSignal(parent, COMSIG_ITEM_USED_AS_INGREDIENT,  PROC_REF(used_to_customize))
 
 		var/obj/item/item = parent
 		if (!item.grind_results)
@@ -492,3 +493,20 @@ Behavior that's still missing from this component that original food items had t
 		var/satisfaction_text = pick("burps from enjoyment.", "yaps for more!", "woofs twice.", "looks at the area where \the [parent] was.")
 		L.manual_emote(satisfaction_text)
 		qdel(parent)
+
+///Response to being used to customize something
+/datum/component/edible/proc/used_to_customize(datum/source, atom/customized)
+	SIGNAL_HANDLER
+
+	SEND_SIGNAL(customized, COMSIG_FOOD_INGREDIENT_ADDED, src)
+
+///Response to an edible ingredient being added to parent.
+/datum/component/edible/proc/edible_ingredient_added(datum/source, datum/component/edible/ingredient)
+	SIGNAL_HANDLER
+
+	var/datum/component/edible/E = ingredient
+	if (LAZYLEN(E.tastes))
+		tastes = tastes.Copy()
+		for (var/t in E.tastes)
+			tastes[t] += E.tastes[t]
+	foodtypes |= E.foodtypes

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -173,9 +173,10 @@ Behavior that's still missing from this component that original food items had t
 
 	return TryToEat(M, user)
 
-/datum/component/edible/proc/on_fried(fry_object)
+/datum/component/edible/proc/on_fried(datum/source, atom/fry_object)
 	SIGNAL_HANDLER
 	var/atom/our_atom = parent
+	fry_object.reagents.maximum_volume = our_atom.reagents.maximum_volume
 	our_atom.reagents.trans_to(fry_object, our_atom.reagents.total_volume)
 	qdel(our_atom)
 	return COMSIG_FRYING_HANDLED
@@ -188,13 +189,14 @@ Behavior that's still missing from this component that original food items had t
 		return
 
 	var/atom/this_food = parent
-	var/reagents_for_slice = chosen_processing_option[TOOL_PROCESSING_AMOUNT]
 
-	this_food.create_reagents(volume) //Make sure we have a reagent container
+	//Make sure we have a reagent container large enough to fit the original atom's reagents.
+	volume = max(volume, ROUND_UP(original_atom.reagents.maximum_volume / chosen_processing_option[TOOL_PROCESSING_AMOUNT]))
 
-	original_atom.reagents.trans_to(this_food, reagents_for_slice)
+	this_food.create_reagents(volume)
+	original_atom.reagents.copy_to(this_food, original_atom.reagents.total_volume, 1 / chosen_processing_option[TOOL_PROCESSING_AMOUNT])
 
-	if(original_atom.name != initial(original_atom.name))
+	if(original_atom.name != initial(original_atom.nam`e))
 		this_food.name = "slice of [original_atom.name]"
 	if(original_atom.desc != initial(original_atom.desc))
 		this_food.desc = "[original_atom.desc]"
@@ -206,9 +208,16 @@ Behavior that's still missing from this component that original food items had t
 	var/atom/this_food = parent
 
 	this_food.reagents.multiply_reagents(CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
+	this_food.reagents.maximum_volume *= CRAFTED_FOOD_BASE_REAGENT_MODIFIER
 
 	for(var/obj/item/food/crafted_part in parts_list)
-		crafted_part.reagents?.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume, CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER)
+		if(!crafted_part.reagents)
+			continue
+
+		this_food.reagents.maximum_volume += crafted_part.reagents.maximum_volume * CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER
+		crafted_part.reagents.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume, CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER)
+
+	this_food.reagents.maximum_volume = ROUND_UP(this_food.reagents.maximum_volume) // Just because I like whole numbers for this.
 
 	SSblackbox.record_feedback("tally", "food_made", 1, type)
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -205,7 +205,7 @@ Behavior that's still missing from this component that original food items had t
 
 	var/atom/this_food = parent
 
-	this_food.reagents.clear_reagents()
+	this_food.reagents.multiply_reagents(CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
 
 	for(var/obj/item/crafted_part in this_food.contents)
 		crafted_part.reagents?.trans_to(this_food.reagents, crafted_part.reagents.maximum_volume, CRAFTED_FOOD_INGREDIENT_REAGENT_MODIFIER)
@@ -220,13 +220,6 @@ Behavior that's still missing from this component that original food items had t
 				break
 
 	QDEL_LIST(objects_to_delete)
-
-	for(var/r_id in initial_reagents)
-		var/amount = initial_reagents[r_id] * CRAFTED_FOOD_BASE_REAGENT_MODIFIER
-		if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
-			this_food.reagents.add_reagent(r_id, amount, tastes)
-		else
-			this_food.reagents.add_reagent(r_id, amount)
 
 	SSblackbox.record_feedback("tally", "food_made", 1, type)
 
@@ -258,16 +251,9 @@ Behavior that's still missing from this component that original food items had t
 
 	var/atom/this_food = parent
 
-	this_food.reagents.clear_reagents()
+	this_food.reagents.multiply_reagents(cooking_efficiency * CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
 
 	source_item.reagents?.trans_to(this_food, source_item.reagents.total_volume)
-
-	for(var/r_id in initial_reagents)
-		var/amount = initial_reagents[r_id] * cooking_efficiency * CRAFTED_FOOD_BASE_REAGENT_MODIFIER
-		if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
-			this_food.reagents.add_reagent(r_id, amount, tastes)
-		else
-			this_food.reagents.add_reagent(r_id, amount)
 
 ///Makes sure the thing hasn't been destroyed or fully eaten to prevent eating phantom edibles
 /datum/component/edible/proc/IsFoodGone(atom/owner, mob/living/feeder)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1444,7 +1444,7 @@
 	to_chat(user, "<span class='notice'>You start working on [src]</span>")
 	if(process_item.use_tool(src, user, processing_time, volume=50))
 		var/atom/atom_to_create = chosen_option[TOOL_PROCESSING_RESULT]
-		//var/list/atom/created_atoms = list() //Customfood
+		var/list/atom/created_atoms = list()
 		var/amount_to_create = chosen_option[TOOL_PROCESSING_AMOUNT]
 		for(var/i = 1 to amount_to_create)
 			var/atom/created_atom = new atom_to_create(drop_location())
@@ -1454,8 +1454,9 @@
 				created_atom.pixel_x += rand(-8,8)
 				created_atom.pixel_y += rand(-8,8)
 			created_atom.OnCreatedFromProcessing(user, process_item, chosen_option, src)
-		to_chat(user, "<span class='notice'>You manage to create [chosen_option[TOOL_PROCESSING_AMOUNT]] [initial(atom_to_create.gender) == PLURAL ? "[initial(atom_to_create.name)]" : "[initial(atom_to_create.name)][plural_s(initial(atom_to_create.name))]"] from [src].</span>")
-		//SEND_SIGNAL(src, COMSIG_ATOM_PROCESSED, user, process_item, created_atoms) //Custom food
+			to_chat(user, "<span class='notice'>You manage to create [chosen_option[TOOL_PROCESSING_AMOUNT]] [initial(atom_to_create.gender) == PLURAL ? "[initial(atom_to_create.name)]" : "[initial(atom_to_create.name)][plural_s(initial(atom_to_create.name))]"] from [src].</span>")
+			created_atoms.Add(created_atom)
+		SEND_SIGNAL(src, COMSIG_ATOM_PROCESSED, user, process_item, created_atoms)
 		UsedforProcessing(user, process_item, chosen_option)
 		return
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -429,6 +429,7 @@
   * Otherwise it simply forceMoves the atom into this atom
   */
 /atom/proc/CheckParts(list/parts_list, datum/crafting_recipe/R)
+	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, current_recipe)
 	if(parts_list)
 		for(var/A in parts_list)
 			if(istype(A, /datum/reagent))
@@ -445,7 +446,6 @@
 					M.forceMove(src)
 				SEND_SIGNAL(M, COMSIG_ATOM_USED_IN_CRAFT, src)
 		parts_list.Cut()
-	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
 
 ///Take air from the passed in gas mixture datum
 /atom/proc/assume_air(datum/gas_mixture/giver)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -429,23 +429,25 @@
   * Otherwise it simply forceMoves the atom into this atom
   */
 /atom/proc/CheckParts(list/parts_list, datum/crafting_recipe/R)
-	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, current_recipe)
-	if(parts_list)
-		for(var/A in parts_list)
-			if(istype(A, /datum/reagent))
-				if(!reagents)
-					reagents = new()
-				reagents.reagent_list.Add(A)
-				reagents.conditional_update()
-			else if(ismovable(A))
-				var/atom/movable/M = A
-				if(isliving(M.loc))
-					var/mob/living/L = M.loc
-					L.transferItemToLoc(M, src)
-				else
-					M.forceMove(src)
-				SEND_SIGNAL(M, COMSIG_ATOM_USED_IN_CRAFT, src)
-		parts_list.Cut()
+	SEND_SIGNAL(src, COMSIG_ATOM_CHECKPARTS, parts_list, R)
+	if(!parts_list)
+		return
+
+	for(var/A in parts_list)
+		if(istype(A, /datum/reagent))
+			if(!reagents)
+				reagents = new()
+			reagents.reagent_list.Add(A)
+			reagents.conditional_update()
+		else if(ismovable(A))
+			var/atom/movable/M = A
+			if(isliving(M.loc))
+				var/mob/living/L = M.loc
+				L.transferItemToLoc(M, src)
+			else
+				M.forceMove(src)
+			SEND_SIGNAL(M, COMSIG_ATOM_USED_IN_CRAFT, src)
+	parts_list.Cut()
 
 ///Take air from the passed in gas mixture datum
 /atom/proc/assume_air(datum/gas_mixture/giver)

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -47,6 +47,10 @@
 	w_class = WEIGHT_CLASS_SMALL
 	slice_type = /obj/item/food/breadslice/plain
 
+/obj/item/food/bread/plain/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/food/bread/empty, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 8)
+
 /obj/item/food/breadslice/plain
 	name = "bread slice"
 	desc = "A slice of home."
@@ -55,6 +59,10 @@
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 2
 	)
+
+/obj/item/food/breadslice/plain/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/customizable_reagent_holder, null, CUSTOM_INGREDIENT_ICON_STACK)
 
 /*
  * REAL MOLDY FOOD. We just cant support it right now. Start porting after newfood is complete
@@ -246,6 +254,23 @@
 		/datum/reagent/consumable/nutriment/vitamin = 2
 	)
 	foodtypes = GRAIN | FRUIT
+
+/obj/item/food/bread/empty
+	name = "bread"
+	icon_state = "tofubread"
+	desc = "It's bread, customized to your wildest dreams."
+	slice_type = /obj/item/food/breadslice/empty
+
+// What you get from cutting a custom bread. Different from custom sliced bread.
+/obj/item/food/breadslice/empty
+	name = "bread slice"
+	icon_state = "tofubreadslice"
+	foodtypes = GRAIN
+	desc = "It's a slice of bread, customized to your wildest dreams."
+
+/obj/item/food/breadslice/empty/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/customizable_reagent_holder, null, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 8)
 
 /obj/item/food/baguette
 	name = "baguette"

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -562,8 +562,6 @@
 	foodtypes = GRAIN | MEAT | DAIRY | TOXIC | GROSS | FRUIT
 	w_class = WEIGHT_CLASS_NORMAL // The crazy hamburger in the video was bigger than joker's hand therefore i think this weight class is adequate.
 
-/* When custom food is supported again
-
 // empty burger you can customize
 /obj/item/food/burger/empty
 	name = "burger"
@@ -571,5 +569,3 @@
 	icon_state = "custburg"
 	tastes = list("bun")
 	foodtypes = GRAIN
-
-*/

--- a/code/game/objects/items/food/dough.dm
+++ b/code/game/objects/items/food/dough.dm
@@ -49,11 +49,9 @@
 	tastes = list("bread" = 1)
 	foodtypes = GRAIN
 
-/*
 /obj/item/food/pizzabread/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/food/pizza/margherita, CUSTOM_INGREDIENT_ICON_SCATTER, max_ingredients = 12)
-*/
 
 /obj/item/food/doughslice
 	name = "dough slice"
@@ -81,11 +79,9 @@
 	tastes = list("bun" = 1) // the bun tastes of bun.
 	foodtypes = GRAIN
 
-/*
 /obj/item/food/bun/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/food/burger/empty, CUSTOM_INGREDIENT_ICON_STACKPLUSTOP)
-*/
 
 /obj/item/food/cakebatter
 	name = "cake batter"

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -62,11 +62,9 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 	foodtypes = GRAIN | VEGETABLES | DAIRY
 
-/* Customfood
 /obj/item/food/pizzaslice/margherita/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/customizable_reagent_holder, null, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 12)
-*/
 
 /obj/item/food/pizza/meat
 	name = "meatpizza"

--- a/code/game/objects/items/food/salad.dm
+++ b/code/game/objects/items/food/salad.dm
@@ -155,7 +155,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_price = PAYCHECK_EASY * 0.6
 
-/*
 /obj/item/reagent_containers/glass/bowl/Initialize()
 	. = ..()
 	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/food/salad/empty, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 6)
@@ -167,4 +166,3 @@
 	tastes = list()
 	icon_state = "bowl"
 	desc = "A delicious customized salad."
-*/

--- a/code/game/objects/items/food/spaghetti.dm
+++ b/code/game/objects/items/food/spaghetti.dm
@@ -29,6 +29,10 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 1)
 	microwaved_type = null
 
+/obj/item/food/spaghetti/boiledspaghetti/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/customizable_reagent_holder, null, CUSTOM_INGREDIENT_ICON_SCATTER, max_ingredients = 6)
+
 /obj/item/food/spaghetti/pastatomato
 	name = "spaghetti"
 	desc = "Spaghetti and crushed tomatoes. Just like your abusive father used to make!"

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -270,6 +270,22 @@
 	src.handle_reactions()
 	return amount
 
+///Multiplies the reagents inside this holder by a specific amount
+/datum/reagents/proc/multiply_reagents(multiplier=1)
+	var/list/cached_reagents = reagent_list
+	if(!total_volume)
+		return
+	var/change = (multiplier - 1) //Get the % change
+	for(var/reagent in cached_reagents)
+		var/datum/reagent/T = reagent
+		if(change > 0)
+			add_reagent(T.type, T.volume * change)
+		else
+			remove_reagent(T.type, abs(T.volume * change)) //absolute value to prevent a double negative situation (removing -50% would be adding 50%)
+
+	update_total()
+	handle_reactions()
+
 /datum/reagents/proc/trans_id_to(obj/target, reagent, amount=1, preserve_data=1)//Not sure why this proc didn't exist before. It does now! /N
 	var/list/cached_reagents = reagent_list
 	if (!target)


### PR DESCRIPTION
Ports:
- https://github.com/tgstation/tgstation/pull/55150
- https://github.com/tgstation/tgstation/pull/55207
- https://github.com/tgstation/tgstation/pull/57258
- https://github.com/tgstation/tgstation/pull/63265


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the customizable reagent holder element. Applies it to food, making customfood possible again.

This PR contains support for:
- Custom bread
- Custom Burgers
- Custom pizza
- Custom salad
- custom spaghetti
- custom toast

Additional linked port prs are to ensure reagent conservation of mass

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more 'why isnt customfood working' in mhelps :3



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/421f0967-42d7-4ae8-852d-987d0ae16631

hope you like tomato, kiddo

</details>

## Changelog
:cl: rkz, Jacklecroy, MrMelbert, TemporalOroboros
add: customizable_reagent_holder element
add: customized pizza, bread, salad, and burgers. Put toppings on your margherita pizza, bowls, buns, and bread to make them customized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
