### PR TITLE
adds intentional check to emotes with effects

### DIFF
--- a/code/datums/components/aiming.dm
+++ b/code/datums/components/aiming.dm
@@ -334,7 +334,7 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 
 /datum/component/aiming/proc/aim_react_act(choice)
 	if(choice == SURRENDER)
-		target.emote(SURRENDER)
+		target.emote(SURRENDER,intentional = TRUE)
 	QDEL_NULL(choice_menu_target)
 
 // Shows a crosshair effect when aiming at a target

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -73,7 +73,7 @@
 
 /datum/emote/living/collapse/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	if(. && isliving(user))
+	if(. && isliving(user) && intentional)
 		var/mob/living/L = user
 		L.Unconscious(40)
 
@@ -121,7 +121,7 @@
 
 /datum/emote/living/faint/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	if(. && isliving(user))
+	if(. && isliving(user) && intentional)
 		var/mob/living/L = user
 		L.SetSleeping(200)
 
@@ -243,7 +243,7 @@
 
 /datum/emote/living/point/run_emote(mob/user, params, type_override, intentional)
 	message_param = initial(message_param) // reset
-	if(ishuman(user))
+	if(ishuman(user) && intentional)
 		var/mob/living/carbon/human/H = user
 		if(H.get_num_arms() == 0)
 			if(H.get_num_legs() != 0)
@@ -338,7 +338,7 @@
 
 /datum/emote/living/surrender/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	if(. && isliving(user))
+	if(. && isliving(user) && intentional)
 		var/mob/living/L = user
 		L.Paralyze(200)
 
@@ -471,12 +471,13 @@
 
 /datum/emote/living/circle/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	var/obj/item/circlegame/N = new(user)
-	if(user.put_in_hands(N))
-		to_chat(user, "<span class='notice'>You make a circle with your hand.</span>")
-	else
-		qdel(N)
-		to_chat(user, "<span class='warning'>You don't have any free hands to make a circle with.</span>")
+	if(intentional)
+		var/obj/item/circlegame/N = new(user)
+		if(user.put_in_hands(N))
+			to_chat(user, "<span class='notice'>You make a circle with your hand.</span>")
+		else
+			qdel(N)
+			to_chat(user, "<span class='warning'>You don't have any free hands to make a circle with.</span>")
 
 /datum/emote/living/slap
 	key = "slap"
@@ -487,11 +488,12 @@
 	. = ..()
 	if(!.)
 		return
-	var/obj/item/slapper/N = new(user)
-	if(user.put_in_hands(N))
-		to_chat(user, "<span class='notice'>You ready your slapping hand.</span>")
-	else
-		to_chat(user, "<span class='warning'>You're incapable of slapping in your current state.</span>")
+	if(intentional)
+		var/obj/item/slapper/N = new(user)
+		if(user.put_in_hands(N))
+			to_chat(user, "<span class='notice'>You ready your slapping hand.</span>")
+		else
+			to_chat(user, "<span class='warning'>You're incapable of slapping in your current state.</span>")
 
 /datum/emote/living/raisehand
 	key = "highfive"
@@ -499,14 +501,15 @@
 	message = "raises their hand"
 	restraint_check = TRUE
 
-/datum/emote/living/raisehand/run_emote(mob/user, params)
+/datum/emote/living/raisehand/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	var/obj/item/highfive/N = new(user)
-	if(user.put_in_hands(N))
-		to_chat(user, "<span class='notice'>You raise your hand for a high-five.</span>")
-	else
-		qdel(N)
-		to_chat(user, "<span class='warning'>You don't have any free hands to high-five with.</span>")
+	if(intentional)
+		var/obj/item/highfive/N = new(user)
+		if(user.put_in_hands(N))
+			to_chat(user, "<span class='notice'>You raise your hand for a high-five.</span>")
+		else
+			qdel(N)
+			to_chat(user, "<span class='warning'>You don't have any free hands to high-five with.</span>")
 
 /datum/emote/living/fingergun
 	key = "fingergun"
@@ -514,14 +517,15 @@
 	message = "forms their fingers into the shape of a crude gun"
 	restraint_check = TRUE
 
-/datum/emote/living/fingergun/run_emote(mob/user, params)
+/datum/emote/living/fingergun/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	var/obj/item/gun/ballistic/revolver/mime/N = new(user)
-	if(user.put_in_hands(N))
-		to_chat(user, "<span class='notice'>You form your fingers into a gun.</span>")
-	else
-		qdel(N)
-		to_chat(user, "<span class='warning'>You don't have any free hands to make fingerguns with.</span>")
+	if(intentional)
+		var/obj/item/gun/ballistic/revolver/mime/N = new(user)
+		if(user.put_in_hands(N))
+			to_chat(user, "<span class='notice'>You form your fingers into a gun.</span>")
+		else
+			qdel(N)
+			to_chat(user, "<span class='warning'>You don't have any free hands to make fingerguns with.</span>")
 
 /datum/emote/living/click
 	key = "click"

--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -134,10 +134,6 @@
 	trigger_cost = 3
 	trigger_cooldown = 20
 	rogue_types = list(/datum/nanite_program/brain_misfire, /datum/nanite_program/brain_decay)
-	var/static/list/blacklist = list(
-		"*surrender",
-		"*collapse"
-	)
 
 /datum/nanite_program/comm/speech/register_extra_settings()
 	. = ..()
@@ -155,8 +151,6 @@
 	if(!comm_message)
 		var/datum/nanite_extra_setting/sentence = extra_settings[NES_SENTENCE]
 		sent_message = sentence.get_value()
-	if(sent_message in blacklist)
-		return
 	to_chat(host_mob, "<span class='warning'>You feel compelled to speak...</span>")
 	host_mob.say(sent_message, forced = "nanite speech")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
as the title says, also removes the (now unnecessary) blacklist on forced speech and makes the surrendering option on "Holds Up!" be considered intentional, for obvious reasons
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
forced speech should only cause speech, not emotes that can affect the player. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/c7bb8f54-9a80-4bbb-b2f0-4800f3f678d5



</details>

## Changelog
:cl:
tweak: forced speech can no longer force the emotes: faint, collapse, point, surrender, circle, slap, highfive and fingergun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
