### PR TITLE
Roundstart cyborgs are no longer RRed if deconstructed or gibbed

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -129,27 +129,25 @@
 
 
 /obj/item/mmi/proc/transfer_identity(mob/living/L) //Same deal as the regular brain proc. Used for human-->robot people.
-	if(!brainmob)
-		brainmob = new(src)
-	brainmob.name = L.real_name
-	brainmob.real_name = L.real_name
-	if(L.has_dna())
-		var/mob/living/carbon/C = L
-		if(!brainmob.stored_dna)
-			brainmob.stored_dna = new /datum/dna/stored(brainmob)
-		C.dna.copy_dna(brainmob.stored_dna)
-	brainmob.container = src
 
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		var/obj/item/organ/brain/newbrain = H.getorgan(/obj/item/organ/brain)
-		newbrain.forceMove(src)
-		brain = newbrain
-	else if(!brain)
+	//both of these need to be created so we can't keep either
+	if(brain)
+		QDEL_NULL(brain)
+	if(brainmob)
+		QDEL_NULL(brainmob)
+
+	var/obj/item/organ/BR = L.getorgan(/obj/item/organ/brain)
+	if(BR)
+		brain = new BR.type (src)
+	else
 		brain = new(src)
-		brain.name = "[L.real_name]'s brain"
 	brain.organ_flags |= ORGAN_FROZEN
 
+	brain.transfer_identity(L)
+	brainmob = brain.brainmob
+	brainmob.container = src
+
+	brain.name = "[L.real_name]'s brain"
 	name = "[initial(name)]: [brainmob.real_name]"
 	update_icon()
 	return

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -129,30 +129,25 @@
 
 
 /obj/item/mmi/proc/transfer_identity(mob/living/L) //Same deal as the regular brain proc. Used for human-->robot people.
+	if(!brainmob)
+		brainmob = new(src)
+	brainmob.name = L.real_name
+	brainmob.real_name = L.real_name
+	if(L.has_dna())
+		var/mob/living/carbon/C = L
+		if(!brainmob.stored_dna)
+			brainmob.stored_dna = new /datum/dna/stored(brainmob)
+		C.dna.copy_dna(brainmob.stored_dna)
+	brainmob.container = src
+
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		var/obj/item/organ/brain/newbrain = H.getorgan(/obj/item/organ/brain)
-		if(newbrain)
-			. = TRUE
-			newbrain.Remove(H, TRUE) //this calls newbrain.transfer_identity()
-			newbrain.forceMove(src)
-			if(brain)
-				qdel(brain)
-			if(brainmob)
-				qdel(brainmob)
-			brain = newbrain
-
-	if(!brain)
+		newbrain.forceMove(src)
+		brain = newbrain
+	else if(!brain)
 		brain = new(src)
-
-	if(!brain.brainmob)
-		if(brainmob)
-			qdel(brainmob) //hopefully this isn't incredibly short sighted and ignorant and breaks everything
-		brain.transfer_identity(L)
-
-	brainmob = brain.brainmob
-	brainmob.container = src
-	brain.name = "[brainmob.real_name]'s brain"
+		brain.name = "[L.real_name]'s brain"
 	brain.organ_flags |= ORGAN_FROZEN
 
 	name = "[initial(name)]: [brainmob.real_name]"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -67,7 +67,11 @@
 		BT.owner = null
 
 	if((!gc_destroyed || (owner && !owner.gc_destroyed)) && !no_id_transfer)
-		transfer_identity(C)
+		if(C.mind)
+			transfer_identity(C)
+			if(C.mind.current)
+				C.mind.transfer_to(brainmob)
+		to_chat(brainmob, "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>")
 	C.update_hair()
 
 /obj/item/organ/brain/setOrganDamage(d)
@@ -79,8 +83,6 @@
 /obj/item/organ/brain/proc/transfer_identity(mob/living/L)
 	name = "[L.name]'s brain"
 	if(brainmob || decoy_override)
-		return
-	if (!L.mind)
 		return
 	brainmob = new(src)
 	brainmob.name = L.real_name
@@ -97,9 +99,6 @@
 		var/obj/item/organ/zombie_infection/ZI = L.getorganslot(ORGAN_SLOT_ZOMBIE)
 		if(ZI)
 			brainmob.set_species(ZI.old_species)	//For if the brain is cloned
-	if(L.mind?.current)
-		L.mind.transfer_to(brainmob)
-	to_chat(brainmob, "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>")
 
 /obj/item/organ/brain/attackby(obj/item/O, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
## About The Pull Request

fixes #10583 

* refactored the MMI's transfer_identity() 
* behaviours not relevant to obj/item/organ/brain's transfer_identity() proc (like the message you get when turning into a brain) were moved to Remove()

## Why It's Good For The Game

Getting round removed in such a silly way is bad

Also, transfer_identity() had some behaviours that weren't relevant to the proc, so I moved them into Remove() which is the only other proc that calls the brain's transfer_identity() proc. Execution should still be practically identical while allowing use of transfer_identity() freely in other places (like right here)

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Here's the monkey thing

https://github.com/BeeStation/BeeStation-Hornet/assets/39193182/0bb9efac-b3a6-47cc-af22-5a4e9df3d8c9

Here's showing that you stay in your MMI after getting gibbed

https://github.com/BeeStation/BeeStation-Hornet/assets/39193182/04cf39c0-054b-425a-a41b-45e45ad12053


</details>

## Changelog
:cl: tonty
fix: roundstart/polymorphed cyborgs are now more spiritually grounded to their MMIs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
