### PR TITLE
Really tiny ocean water visual fix for echo

### DIFF
--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -166,7 +166,6 @@
 	icon_state = "water"
 	baseturfs = /turf/open/floor/plating/beach/water
 	slowdown = 3
-	var/obj/effect/water_overlay = null
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = 'sound/effects/splash.ogg'
 	footstep = FOOTSTEP_WATER
@@ -175,18 +174,6 @@
 	heavyfootstep = FOOTSTEP_WATER
 
 // pool.dm copy paste
-
-/turf/open/floor/plating/beach/water/Initialize(mapload)
-	. = ..()
-	water_overlay = new /obj/effect/overlay/poolwater(get_turf(src))
-
-/turf/open/floor/plating/beach/water/proc/set_colour(colour)
-	water_overlay.color = colour
-
-/turf/open/floor/plating/beach/water/end/ChangeTurf(path, list/new_baseturfs, flags)
-	if(water_overlay)
-		qdel(water_overlay)
-	. = ..()
 
 /turf/open/CanPass(atom/movable/mover, turf/target)
 	var/datum/component/swimming/S = mover.GetComponent(/datum/component/swimming) //If you're swimming around, you don't really want to stop swimming just like that do you?
@@ -298,6 +285,7 @@
 /turf/open/floor/plating/beach/deep_water
 	desc = "Deep water. What if there's sharks?"
 	icon_state = "water_deep"
+	name = "deep water"
 	density = 1 //no swimming
 
 /turf/open/floor/plating/beach/coastline_t


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the pool overlay from the ocean water to make it seamless.
Also changes the name of the deep water from "beach" to "deep water"

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It looks better. See the images section.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

With this:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/153900881/d08eb0d4-0488-48a3-a98a-b13bae45b8d0)

Without this:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/153900881/b2a31daf-1407-44ed-aac3-1cf7f09cdfd3)

</details>

## Changelog
:cl:
tweak: no pool overlay on ocean water
fix: deep water is now called deep water
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
