### PR TITLE
Fixes conflicting holodeck program IDs

### DIFF
--- a/code/modules/holodeck/holodeck_map_templates.dm
+++ b/code/modules/holodeck/holodeck_map_templates.dm
@@ -202,139 +202,139 @@
 
 /datum/map_template/holodeck/small/emptycourt
 	name = "Holodeck - Empty Court"
-	template_id = "emptycourt"
+	template_id = "emptycourt-small"
 	mappath = "_maps/holodeck/small/emptycourt.dmm"
 
 /datum/map_template/holodeck/small/dodgeball
 	name = "Holodeck - Dodgeball Court"
-	template_id = "dodgeball"
+	template_id = "dodgeball-small"
 	mappath = "_maps/holodeck/small/dodgeball.dmm"
 
 /datum/map_template/holodeck/small/basketball
 	name = "Holodeck - Basketball Court"
-	template_id = "basketball"
+	template_id = "basketball-small"
 	mappath = "_maps/holodeck/small/basketball.dmm"
 
 /datum/map_template/holodeck/small/thunderdome
 	name = "Holodeck - Thunderdome Arena"
-	template_id = "thunderdome"
+	template_id = "thunderdome-small"
 	mappath = "_maps/holodeck/small/thunderdome.dmm"
 
 /datum/map_template/holodeck/small/beach
 	name = "Holodeck - Beach"
-	template_id = "beach"
+	template_id = "beach-small"
 	mappath = "_maps/holodeck/small/beach.dmm"
 
 /datum/map_template/holodeck/small/lounge
 	name = "Holodeck - Lounge"
-	template_id = "lounge"
+	template_id = "lounge-small"
 	mappath = "_maps/holodeck/small/lounge.dmm"
 
 /datum/map_template/holodeck/small/petpark
 	name = "Holodeck - Pet Park"
-	template_id = "petpark"
+	template_id = "petpark-small"
 	mappath = "_maps/holodeck/small/petpark.dmm"
 
 /datum/map_template/holodeck/small/firingrange
 	name = "Holodeck - Firing Range"
-	template_id = "firingrange"
+	template_id = "firingrange-small"
 	mappath = "_maps/holodeck/small/firingrange.dmm"
 
 /datum/map_template/holodeck/small/anime_school
 	name = "Holodeck - Anime School"
-	template_id = "animeschool"
+	template_id = "animeschool-small"
 	mappath = "_maps/holodeck/small/animeschool.dmm"
 
 /datum/map_template/holodeck/small/chapelcourt
 	name = "Holodeck - Chapel Courtroom"
-	template_id = "chapelcourt"
+	template_id = "chapelcourt-small"
 	mappath = "_maps/holodeck/small/chapelcourt.dmm"
 
 /datum/map_template/holodeck/small/spacechess
 	name = "Holodeck - Space Chess"
-	template_id = "spacechess"
+	template_id = "spacechess-small"
 	mappath = "_maps/holodeck/small/spacechess.dmm"
 
 /datum/map_template/holodeck/small/spacecheckers
 	name = "Holodeck - Space Checkers"
-	template_id = "spacecheckers"
+	template_id = "spacecheckers-small"
 	mappath = "_maps/holodeck/small/spacecheckers.dmm"
 
 /datum/map_template/holodeck/small/kobayashi
 	name = "Holodeck - Kobayashi Maru"
-	template_id = "kobayashi"
+	template_id = "kobayashi-small"
 	mappath = "_maps/holodeck/small/kobayashi.dmm"
 
 /datum/map_template/holodeck/small/winterwonderland
 	name = "Holodeck - Winter Wonderland"
-	template_id = "winterwonderland"
+	template_id = "winterwonderland-small"
 	mappath = "_maps/holodeck/small/winterwonderland.dmm"
 
 /datum/map_template/holodeck/small/photobooth
 	name = "Holodeck - Photobooth"
-	template_id = "photobooth"
+	template_id = "photobooth-small"
 	mappath = "_maps/holodeck/small/photobooth.dmm"
 
 /datum/map_template/holodeck/small/skatepark
 	name = "Holodeck - Skatepark"
-	template_id = "skatepark"
+	template_id = "skatepark-small"
 	mappath = "_maps/holodeck/small/skatepark.dmm"
 
 /datum/map_template/holodeck/small/teahouse
 	name = "Holodeck - Japanese Tea House"
-	template_id = "teahouse"
+	template_id = "teahouse-small"
 	mappath = "_maps/holodeck/small/teahouse.dmm"
 
 /datum/map_template/holodeck/small/kitchen
 	name = "Holodeck - Kitchen"
-	template_id = "kitchen"
+	template_id = "kitchen-small"
 	mappath = "_maps/holodeck/small/kitchen.dmm"
 
 /datum/map_template/holodeck/small/meeting
 	name = "Holodeck - Meeting"
-	template_id = "meeting"
+	template_id = "meeting-small"
 	mappath = "_maps/holodeck/small/meeting.dmm"
 
 //bad evil no good programs
 
 /datum/map_template/holodeck/small/medicalsim
 	name = "Holodeck - Emergency Medical"
-	template_id = "medicalsim"
+	template_id = "medicalsim-small"
 	mappath = "_maps/holodeck/small/medicalsim.dmm"
 	restricted = TRUE
 
 /datum/map_template/holodeck/small/thunderdome1218
 	name = "Holodeck - 1218 AD"
-	template_id = "thunderdome1218"
+	template_id = "thunderdome1218-small"
 	mappath = "_maps/holodeck/small/thunderdome1218.dmm"
 	restricted = TRUE
 
 /datum/map_template/holodeck/small/burntest
 	name = "Holodeck - Atmospheric Burn Test"
-	template_id = "burntest"
+	template_id = "burntest-small"
 	mappath = "_maps/holodeck/small/burntest.dmm"
 	restricted = TRUE
 
 /datum/map_template/holodeck/small/wildlifesim
 	name = "Holodeck - Wildlife Simulation"
-	template_id = "wildlifesim"
+	template_id = "wildlifesim-small"
 	mappath = "_maps/holodeck/small/wildlifesim.dmm"
 	restricted = TRUE
 
 /datum/map_template/holodeck/small/holdoutbunker
 	name = "Holodeck - Holdout Bunker"
-	template_id = "holdoutbunker"
+	template_id = "holdoutbunker-small"
 	mappath = "_maps/holodeck/small/holdoutbunker.dmm"
 	restricted = TRUE
 
 /datum/map_template/holodeck/small/anthophillia
 	name = "Holodeck - Anthophillia"
-	template_id = "anthophillia"
+	template_id = "anthophillia-small"
 	mappath = "_maps/holodeck/small/anthophillia.dmm"
 	restricted = TRUE
 
 /datum/map_template/holodeck/small/refuelingstation
 	name = "Holodeck - Refueling Station"
-	template_id = "refuelingstation"
+	template_id = "refuelingstation-small"
 	mappath = "_maps/holodeck/small/refuelingstation.dmm"
 	restricted = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue where the smaller holodeck programs overwrote the larger ones in the associative list of holodeck programs due to using the exact same program ID
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/512ffe5a-299f-49c2-b981-6c610a615b69)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a bugfix, making 100% holo per deck instead of only 54%.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Small holodecks work
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/873be577-60a1-4537-a34c-0ff567a9283b)

Large holodecks work
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/13a9786a-f553-47b7-937e-3c95fff888c5)

</details>

## Changelog
:cl:
fix: Fixed conflicting holodeck program IDs which resulted in small holodecks overriding the normal sized ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
