### PR TITLE
Pulling tails gives a negative moodlet, felinids are startled and get negative moodlets when wet

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -223,9 +223,26 @@
 	timeout = 4 MINUTES
 
 /datum/mood_event/tailpull
-	description = "<span class='warning'>OUCH! Stop pulling my tail! It hurts!\n"
+	description = "<span class='warning'>OUCH! Someone pulled my tail!\n"
 	mood_change = -2
 	timeout = 2 MINUTES
+
+/datum/mood_event/watersprayed
+	description = "<span class='warning'>I hate being sprayed with water!</span>\n"
+	mood_change = -1
+	timeout = 30 SECONDS
+
+/datum/mood_event/watersplashed
+	//splash gets a larger debuff
+	description = "<span class='boldwarning'>I hate being splashed with water!</span>\n"
+	mood_change = -2
+	timeout = 30 SECONDS
+
+/datum/mood_event/hate_shower
+	description = "<span class='boldwarning'>I <i>HATE</i> showers!</span>\n"
+	mood_change = -2
+	timeout = 5 MINUTES //End of NSV code
+
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse
 	description = "<span class='boldwarning'>I recently saw my own corpse...</span>"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -273,3 +273,8 @@
 
 /datum/mood_event/saw_holopara_death/add_effects(name)
 	description = "<span class='warning'>Oh god, [name] just painfully turned to dust... What an horrifying sight...</span>"
+
+/datum/mood_event/tailpull
+	description = "<span class='warning'>OUCH! Stop pulling my tail! It hurts! </span>"
+	mood_change = -2
+	timeout = 2 MINUTES

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -222,6 +222,10 @@
 	mood_change = -25
 	timeout = 4 MINUTES
 
+/datum/mood_event/tailpull
+	description = "<span class='warning'>OUCH! Stop pulling my tail! It hurts!\n"
+	mood_change = -2
+	timeout = 2 MINUTES
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse
 	description = "<span class='boldwarning'>I recently saw my own corpse...</span>"
@@ -274,7 +278,3 @@
 /datum/mood_event/saw_holopara_death/add_effects(name)
 	description = "<span class='warning'>Oh god, [name] just painfully turned to dust... What an horrifying sight...</span>"
 
-/datum/mood_event/tailpull
-	description = "<span class='warning'>OUCH! Stop pulling my tail! It hurts! </span>"
-	mood_change = -2
-	timeout = 2 MINUTES

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -241,7 +241,7 @@
 /datum/mood_event/hate_shower
 	description = "<span class='boldwarning'>I <i>HATE</i> showers!</span>\n"
 	mood_change = -2
-	timeout = 5 MINUTES //End of NSV code
+	timeout = 5 MINUTES
 
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -135,7 +135,10 @@
 /obj/machinery/shower/proc/wash_atom(atom/A)
 	A.wash(CLEAN_RAD | CLEAN_TYPE_WEAK) // Clean radiation non-instantly
 	A.wash(CLEAN_WASH)
-	SEND_SIGNAL(A, COMSIG_ADD_MOOD_EVENT, "shower", /datum/mood_event/nice_shower)
+	if (iscatperson(A)) //NSV felinids hate showers (all this really does is turn the +3 from neat into a +1, and doesn't give the +4 from a nice shower)
+		SEND_SIGNAL(A, COMSIG_ADD_MOOD_EVENT, "shower", /datum/mood_event/hate_shower)
+	else
+		SEND_SIGNAL(A, COMSIG_ADD_MOOD_EVENT, "shower", /datum/mood_event/nice_shower)
 	reagents.reaction(A, TOUCH, reaction_volume)
 
 	if(isliving(A))

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -135,7 +135,7 @@
 /obj/machinery/shower/proc/wash_atom(atom/A)
 	A.wash(CLEAN_RAD | CLEAN_TYPE_WEAK) // Clean radiation non-instantly
 	A.wash(CLEAN_WASH)
-	if (iscatperson(A)) //NSV felinids hate showers (all this really does is turn the +3 from neat into a +1, and doesn't give the +4 from a nice shower)
+	if (iscatperson(A)) //Felinids hate showers (all this really does is turn the +3 from neat into a +1, and doesn't give the +4 from a nice shower)
 		SEND_SIGNAL(A, COMSIG_ADD_MOOD_EVENT, "shower", /datum/mood_event/hate_shower)
 	else
 		SEND_SIGNAL(A, COMSIG_ADD_MOOD_EVENT, "shower", /datum/mood_event/nice_shower)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -314,14 +314,14 @@
 
 	if(ismob(AM))
 		var/mob/M = AM
-
 		log_combat(src, M, "grabbed", addition="passive grab")
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER))) //Everything in this if statement handles chat messages for grabbing
 			var/mob/living/L = M
 			if (L.getorgan(/obj/item/organ/tail) && (is_zone_selected(BODY_ZONE_PRECISE_GROIN, precise_only = TRUE) || is_group_selected(BODY_GROUP_LEGS))) //Does the target have a tail?
 				M.visible_message("<span class ='warning'>[src] grabs [L] by [L.p_their()] tail!</span>",\
-								"<span class='warning'> [src] grabs you by the tail!</span>", null, null, src) //Message sent to area, Message sent to grabbee
+					"<span class='warning'> [src] grabs you by the tail! Ow!</span>",null, null, src) //Message sent to area, Message sent to grabee
 				to_chat(src, "<span class='notice'>You grab [L] by [L.p_their()] tail!</span>")  //Message sent to grabber
+				SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "tailpull", /datum/mood_event/tailpull)  //People dont enjoy their tail being pulled
 			else
 				M.visible_message("<span class='warning'>[src] grabs [M] [(is_zone_selected(BODY_ZONE_L_ARM) || is_zone_selected(BODY_ZONE_R_ARM))? "by their hands":"passively"]!</span>", \
 								"<span class='warning'>[src] grabs you [(is_zone_selected(BODY_ZONE_L_ARM) || is_zone_selected(BODY_ZONE_R_ARM))? "by your hands":"passively"]!</span>", null, null, src) //Message sent to area, Message sent to grabbee

--- a/code/modules/pool/components/swimming.dm
+++ b/code/modules/pool/components/swimming.dm
@@ -11,6 +11,7 @@
 	var/bob_height_min = 2
 	var/bob_height_max = 5
 	var/bob_tick = 0
+	var/positive_moodlet = TRUE
 
 /datum/component/swimming/Initialize()
 	. = ..()
@@ -31,9 +32,10 @@
 
 	lengths ++
 	if(lengths > lengths_for_bonus)
-		var/mob/living/L = parent
-		SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "exercise", /datum/mood_event/exercise)
-		L.apply_status_effect(STATUS_EFFECT_EXERCISED) //Swimming is really good excercise!
+		if(positive_moodlet)
+			var/mob/living/L = parent
+			SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "exercise", /datum/mood_event/exercise)
+			L.apply_status_effect(STATUS_EFFECT_EXERCISED) //Swimming is really good excercise!
 		lengths = 0
 
 //Damn edge cases

--- a/code/modules/pool/components/swimming_felinid.dm
+++ b/code/modules/pool/components/swimming_felinid.dm
@@ -1,7 +1,17 @@
+/datum/component/swimming/felinid //felinids don't like swimming
+	positive_moodlet = FALSE
+
 /datum/component/swimming/felinid/enter_pool()
 	var/mob/living/L = parent
 	L.emote("scream")
 	to_chat(parent, "<span class='userdanger'>You get covered in water and start panicking!</span>")
+	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "was_stuck_in_pool")
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "stuck_in_pool", /datum/mood_event/stuck_in_pool)
+
+/datum/component/swimming/felinid/exit_pool()
+	var/mob/living/L = parent
+	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "stuck_in_pool")
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "was_stuck_in_pool", /datum/mood_event/was_stuck_in_pool)
 
 /datum/component/swimming/felinid/process()
 	..()

--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -123,6 +123,8 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 		do_sparks(zap, TRUE, user)
 		to_chat(user, "<span class='userdanger'>WARNING: WATER DAMAGE DETECTED!</span>")
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "robotpool", /datum/mood_event/robotpool)
+	if(iscatperson(user)) //felinids should not get positive moodlets for swimming. Negative moodlets are in swimming_felinid.dm
+		return
 	else
 		if(!check_clothes(user))
 			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "pool", /datum/mood_event/poolparty)

--- a/code/modules/pool/pool_moodlets.dm
+++ b/code/modules/pool/pool_moodlets.dm
@@ -12,3 +12,13 @@
 	description = "<span class='warning'>Eugh! my clothes are soaking wet from that swim.</span>"
 	mood_change = -4
 	timeout = 4 MINUTES
+
+/datum/mood_event/stuck_in_pool
+	description = "<span class='boldwarning'>I'M STUCK IN THE POOL!</span>\n"
+	mood_change = -5 //felinids really hate water
+
+/datum/mood_event/was_stuck_in_pool
+	description = "<span class='warning'>I was stuck in the pool, I never thought I'd get out.</span>\n"
+	mood_change = -2 //felinids really hate water
+	timeout = 4 MINUTES
+

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -231,6 +231,14 @@
 		M.blood_volume = max(M.blood_volume - 30 * (1 - touch_mod), 0)
 		if(touch_mod < 0.9)
 			to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
+	var/mob/living/carbon/human/H = M //Felinids can be sprayed by water
+	if(istype(H) && iscatperson(H) && (method == TOUCH || method == VAPOR))
+		if(M.fire_stacks < 0) //if we're on fire, don't apply the negative mood
+			M.Immobilize(1) //startles the felinid
+			if (method == TOUCH)
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "watersplashed", /datum/mood_event/watersplashed)
+			if (method == VAPOR)
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))
 		M.ExtinguishMob()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -235,6 +235,7 @@
 	if(istype(H) && iscatperson(H) && (method == TOUCH || method == VAPOR))
 		if(M.fire_stacks < 0) //if we're on fire, don't apply the negative mood
 			M.Immobilize(1) //startles the felinid
+			M.emote("scream")
 			if (method == TOUCH)
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "watersplashed", /datum/mood_event/watersplashed)
 			if (method == VAPOR)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/BeeStation/NSV13/pull/1830 with some slight changes.
Tail pulling will apply a negative moodlet, and felinids will get negative moodlets when wet be it from being splashed, the pool, or showering.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes felinids slightly more cat-like. Felinids are also described as disliking water in the character preferences, this reinforces that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://youtu.be/tZieO2H6w5I

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: PatienceStPim, red031000
add: felinids get a negative moodlet when wet, and are startled when sprayed or splashed
del:  felinids will no longer get postive moodlets from "swimming"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
