### PR TITLE
Fixes cult halo doesn't disappear on a deconverted

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -288,7 +288,7 @@
 /datum/team/cult/proc/ascend(cultist)
 	if(ishuman(cultist))
 		var/mob/living/carbon/human/H = cultist
-		if(length(H.overlays_standing[HALO_LAYER])) // It appears you have this already. Applying this again will break the overlay
+		if(H.overlays_standing[HALO_LAYER]) // It appears you have this already. Applying this again will break the overlay
 			return
 		new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
 		var/istate = pick("halo1","halo2","halo3","halo4","halo5","halo6")

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -125,6 +125,16 @@
 		if(cult_team.cult_ascendent)
 			cult_team.ascend(current)
 
+/datum/antagonist/cult/master/apply_innate_effects(mob/living/mob_override)
+	. = ..()
+	var/mob/living/current = owner.current
+	if(!cult_team.reckoning_complete)
+		reckoning.Grant(current)
+	bloodmark.Grant(current)
+	throwing.Grant(current)
+	current.update_action_buttons_icon()
+	current.apply_status_effect(/datum/status_effect/cult_master)
+
 /datum/antagonist/cult/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/current = owner.current
@@ -144,6 +154,17 @@
 		if (H.remove_overlay(HALO_LAYER))
 			REMOVE_LUM_SOURCE(H, LUM_SOURCE_HOLY)
 		H.update_body()
+
+/datum/antagonist/cult/master/remove_innate_effects(mob/living/mob_override)
+	. = ..()
+	var/mob/living/current = owner.current
+	if(mob_override)
+		current = mob_override
+	reckoning.Remove(current)
+	bloodmark.Remove(current)
+	throwing.Remove(current)
+	current.update_action_buttons_icon()
+	current.remove_status_effect(/datum/status_effect/cult_master)
 
 /datum/antagonist/cult/on_removal()
 	SSticker.mode.cult -= owner
@@ -210,42 +231,6 @@
 	targets, such as a location or a noncultist, to direct the cult to them, and, finally, you are capable of summoning the entire living cult to your location <b><i>once</i></b>.")
 	to_chat(owner.current, "Use these abilities to direct the cult to victory at any cost.")
 
-/datum/antagonist/cult/master/apply_innate_effects(mob/living/mob_override)
-	. = ..()
-	var/mob/living/current = owner.current
-	if(mob_override)
-		current = mob_override
-	if(!cult_team.reckoning_complete)
-		reckoning.Grant(current)
-	bloodmark.Grant(current)
-	throwing.Grant(current)
-	current.update_action_buttons_icon()
-	current.apply_status_effect(/datum/status_effect/cult_master)
-	if(cult_team.cult_risen)
-		cult_team.rise(current)
-		if(cult_team.cult_ascendent)
-			cult_team.ascend(current)
-
-/datum/antagonist/cult/master/remove_innate_effects(mob/living/mob_override)
-	. = ..()
-	var/mob/living/current = owner.current
-	if(mob_override)
-		current = mob_override
-	reckoning.Remove(current)
-	bloodmark.Remove(current)
-	throwing.Remove(current)
-	current.update_action_buttons_icon()
-	current.remove_status_effect(/datum/status_effect/cult_master)
-
-	if(ishuman(current))
-		var/mob/living/carbon/human/H = current
-		H.eye_color = initial(H.eye_color)
-		H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-		REMOVE_TRAIT(H, CULT_EYES, null)
-		if (H.remove_overlay(HALO_LAYER))
-			REMOVE_LUM_SOURCE(H, LUM_SOURCE_HOLY)
-		H.update_body()
-
 /datum/team/cult
 	name = "Bloodcult"
 
@@ -303,6 +288,8 @@
 /datum/team/cult/proc/ascend(cultist)
 	if(ishuman(cultist))
 		var/mob/living/carbon/human/H = cultist
+		if(length(H.overlays_standing[HALO_LAYER])) // It appears you have this already. Applying this again will break the overlay
+			return
 		new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
 		var/istate = pick("halo1","halo2","halo3","halo4","halo5","halo6")
 		var/mutable_appearance/new_halo_overlay = mutable_appearance('icons/effects/32x64.dmi', istate, CALCULATE_MOB_OVERLAY_LAYER(HALO_LAYER))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes cult halo doesn't disappear on a deconverted

* closes https://github.com/BeeStation/BeeStation-Hornet/issues/7640

This happens when you apply 2 overlays to a person then remove only single one.
There are 6 cult halo variations and these are picked upon `ascend()`
If your character is somehow ascended twice, deconversion will only remove a single halo that you actually have two.


in the future, we'd likely need to make a failsafe add_overlay() thing when it shouldn't supposedly add more overlays

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/1d1c9dd9-dd95-4988-af88-0d1d915a7b73)

I tried `ascend()` twice and it doesn't give me an additional halo

## Changelog
:cl:
fix: Deconverted cultist's halo is now properly removed
code: slightly moved cultist code to make it easily readible and quick to find additional refs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
