### PR TITLE
Ban severity hotfix

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -336,7 +336,7 @@
 			else
 				selected_roles += role
 		if ("submit_ban")
-			parse_ban(key, key_enabled, ip_enabled, ip, cid_enabled, cid, use_last_connection, applies_to_admins, duration_type, duration, time_units, 1, reason, 1, ban_type, selected_roles, suppressed, force_cryo_after)
+			parse_ban(key, key_enabled, ip_enabled, ip, cid_enabled, cid, use_last_connection, applies_to_admins, duration_type, duration, time_units, "high", reason, 1, ban_type, selected_roles, suppressed, force_cryo_after)
 		else
 			if (action in group_list)
 				if (action in selected_groups)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes severity of 1 when creating TGUI ban panel bans

## Why It's Good For The Game

Unintended behaviour

## Testing procedure
Verified that the "severity" passed in is the same as received by the href in the legacy banning panel when high was selected.

## Changelog
:cl:
admin: severity in TGUI ban panel bans forced to "high", fixes severity of "1"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
