### PR TITLE
Medbots can now be more easily re-coloured, cargo medbots now spawn filled, cargo now has a bica-kelo-antox chembag crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -104,8 +104,8 @@
 	max_supply = 1
 	contains = list(/mob/living/simple_animal/bot/floorbot,
 					/mob/living/simple_animal/bot/floorbot,
-					/mob/living/simple_animal/bot/medbot,
-					/mob/living/simple_animal/bot/medbot,
+					/mob/living/simple_animal/bot/medbot/filled,
+					/mob/living/simple_animal/bot/medbot/filled,
 					/obj/item/tank/internals/air,
 					/obj/item/tank/internals/air,
 					/obj/item/tank/internals/air,
@@ -124,8 +124,8 @@
 	desc = "For when the shit hits the fan and medical can't keep up. Comes with a 7x5 Medical capsule and 2 Medibots for emergencies."
 	cost = 1100
 	max_supply = 1
-	contains = list(/mob/living/simple_animal/bot/medbot,
-					/mob/living/simple_animal/bot/medbot,
+	contains = list(/mob/living/simple_animal/bot/medbot/filled,
+					/mob/living/simple_animal/bot/medbot/filled,
 					/obj/item/survivalcapsule/medical)
 	crate_name = "emergency medical crate"
 	crate_type = /obj/structure/closet/crate/medical
@@ -1888,6 +1888,16 @@
 	contains = list(/obj/machinery/computer/pandemic)
 	crate_name = "P.A.N.D.E.M.I.C. Replacement Crate"
 	dangerous = TRUE
+
+/datum/supply_pack/medical/chem_bags
+	name = "Chembag Refill Crate"
+	desc = "Contains 3 bags, containing Bicaridine, Kelotane and Anti-toxin for when the chemist is too busy making methamphetamines."
+	cost = 1000
+	max_supply = 3
+	contains = list(/obj/item/reagent_containers/chem_bag/bicaridine,
+					/obj/item/reagent_containers/chem_bag/kelotane,
+					/obj/item/reagent_containers/chem_bag/antitoxin)
+	crate_name = "Chembag Refill Crate"
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -78,6 +78,12 @@ GLOBAL_VAR(medibot_unique_id_gen)
 	heal_threshold = 0
 	declare_crit = 0
 
+/mob/living/simple_animal/bot/medbot/filled
+	skin = MEDBOT_SKIN_ADVANCED
+	heal_threshold = 30
+	declare_crit = TRUE
+	reagent_glass = new /obj/item/reagent_containers/glass/beaker/large/kelobic
+
 /mob/living/simple_animal/bot/medbot/update_icon()
 	cut_overlays()
 	if(skin)
@@ -668,10 +674,14 @@ GLOBAL_VAR(medibot_unique_id_gen)
 	req_one_access = list(ACCESS_MEDICAL, ACCESS_ROBOTICS)
 
 /mob/living/simple_animal/bot/medbot/attackby(obj/item/I, mob/user, params)
-	..()
 	if(istype(I, /obj/item/pen)&&!locked)
 		rename_bot()
 		return
+	if(istype(I,/obj/item/storage/firstaid)&&!locked)
+		var/obj/item/storage/firstaid/B = I
+		skin=B.skin_type
+		update_icon()
+	..()
 
 /mob/living/simple_animal/bot/medbot/proc/rename_bot()
 	var/t = sanitize_name(stripped_input(usr, "Enter new robot name", name, name,MAX_NAME_LEN))

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -104,6 +104,14 @@ GLOBAL_VAR(medibot_unique_id_gen)
 	else
 		icon_state = "medibot1"
 
+/mob/living/simple_animal/bot/medbot/proc/rename_bot()
+	var/t = sanitize_name(stripped_input(usr, "Enter new robot name", name, name,MAX_NAME_LEN))
+	if(!t)
+		return
+	if(!in_range(src, usr) && loc != usr)
+		return
+	name = t
+
 /mob/living/simple_animal/bot/medbot/Initialize(mapload, new_skin)
 	. = ..()
 	skin = new_skin
@@ -264,6 +272,14 @@ GLOBAL_VAR(medibot_unique_id_gen)
 		show_controls(user)
 		update_icon()
 
+	if(istype(W, /obj/item/pen)&&!locked)
+		rename_bot()
+		return
+	if(istype(W,/obj/item/storage/firstaid)&&!locked)
+		var/obj/item/storage/firstaid/B = W
+		skin=B.skin_type
+		update_icon()
+
 	else
 		var/current_health = health
 		..()
@@ -366,6 +382,8 @@ GLOBAL_VAR(medibot_unique_id_gen)
 
 /mob/living/simple_animal/bot/medbot/examine(mob/user)
 	. = ..()
+	if(in_range(user, src))
+		. += "<span class='notice'>Use a pen to change its name, or a first aid kit to change its colour.</span>"
 	if(tipped_status == MEDBOT_PANIC_NONE)
 		return
 
@@ -672,25 +690,6 @@ GLOBAL_VAR(medibot_unique_id_gen)
 
 /obj/machinery/bot_core/medbot
 	req_one_access = list(ACCESS_MEDICAL, ACCESS_ROBOTICS)
-
-/mob/living/simple_animal/bot/medbot/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/pen)&&!locked)
-		rename_bot()
-		return
-	if(istype(I,/obj/item/storage/firstaid)&&!locked)
-		var/obj/item/storage/firstaid/B = I
-		skin=B.skin_type
-		update_icon()
-	..()
-
-/mob/living/simple_animal/bot/medbot/proc/rename_bot()
-	var/t = sanitize_name(stripped_input(usr, "Enter new robot name", name, name,MAX_NAME_LEN))
-	if(!t)
-		return
-	if(!in_range(src, usr) && loc != usr)
-		return
-	name = t
-
 #undef MEDBOT_PANIC_NONE
 #undef MEDBOT_PANIC_LOW
 #undef MEDBOT_PANIC_MED

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -275,16 +275,35 @@ GLOBAL_VAR(medibot_unique_id_gen)
 	if(istype(W, /obj/item/pen)&&!locked)
 		rename_bot()
 		return
-	if(istype(W,/obj/item/storage/firstaid)&&!locked)
-		var/obj/item/storage/firstaid/B = W
-		skin=B.skin_type
-		update_icon()
+	if(istype(W,/obj/item/toy/crayon/spraycan))
+		playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
+		reskin(user)
 
 	else
 		var/current_health = health
 		..()
 		if(health < current_health) //if medbot took some damage
 			step_to(src, (get_step_away(src,user)))
+
+/mob/living/simple_animal/bot/medbot/proc/reskin(mob/M)
+	var/skinlist = list(
+		MEDBOT_SKIN_DEFAULT = image(icon = 'icons/mob/aibots.dmi', icon_state = "firstaid_arm"),
+		MEDBOT_SKIN_BRUTE= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_brute"),
+		MEDBOT_SKIN_BURN= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_burn"),
+		MEDBOT_SKIN_TOXIN= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_tox"),
+		MEDBOT_SKIN_OXY= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_oxy"),
+		MEDBOT_SKIN_SURGERY= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_surgery"),
+		MEDBOT_SKIN_ADVANCED= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_advanced"),
+		MEDBOT_SKIN_RADIATION= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_rad")
+	)
+	if(emagged)
+		skinlist +=list(MEDBOT_SKIN_SYNDI= image(icon = 'icons/mob/aibots.dmi', icon_state = "kit_skin_syndi"),
+			MEDBOT_SKIN_BEZERK= image(icon = 'icons/mob/aibots.dmi', icon_state = "medskin_bezerk")
+			)
+	var/choice = show_radial_menu(M, src, skinlist, radius = 42, require_near = TRUE)
+	if(choice && !M.incapacitated() && in_range(M,src))
+		skin = choice
+		update_icon()
 
 /mob/living/simple_animal/bot/medbot/on_emag(atom/target, mob/user)
 	..()
@@ -383,7 +402,7 @@ GLOBAL_VAR(medibot_unique_id_gen)
 /mob/living/simple_animal/bot/medbot/examine(mob/user)
 	. = ..()
 	if(in_range(user, src))
-		. += "<span class='notice'>Use a pen to change its name, or a first aid kit to change its colour.</span>"
+		. += "<span class='notice'>Use a spraycan to change its colour, or a pen to change its name if unlocked.</span>"
 	if(tipped_status == MEDBOT_PANIC_NONE)
 		return
 

--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -38,3 +38,15 @@
 /obj/item/reagent_containers/chem_bag/epi
 	name = "epinephrine reserve bag"
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 200)
+
+/obj/item/reagent_containers/chem_bag/bicaridine
+	name = "bicaridine reserve bag"
+	list_reagents=  list(/datum/reagent/medicine/bicaridine = 100)
+
+/obj/item/reagent_containers/chem_bag/kelotane
+	name = "kelotane reserve bag"
+	list_reagents=  list(/datum/reagent/medicine/kelotane = 100)
+
+/obj/item/reagent_containers/chem_bag/antitoxin
+	name = "anti-toxin reserve bag"
+	list_reagents=  list(/datum/reagent/medicine/antitoxin = 100)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -221,6 +221,10 @@
 	name = "epinephrine reserve tank"
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 50)
 
+/obj/item/reagent_containers/glass/beaker/large/kelobic
+	name = "kelotane-bicaridine reserve tank"
+	list_reagents = list(/datum/reagent/medicine/kelotane = 50, /datum/reagent/medicine/bicaridine = 50)
+
 /obj/item/reagent_containers/glass/beaker/synthflesh
 	list_reagents = list(/datum/reagent/medicine/synthflesh = 50)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
as title says,
-  you can spray a medbot with a spraycan to repaint it using regular spraycan paint
- adds a new subtype of medbot that spawns with a 50u/50u kelo/bic beaker, only found in cargo crates
- adds the chembag cargo crate which has 1 kelotane bag, 1 bicaridine bag and 1 anti-toxin bag for the cost of 1000 credits
- examining a medbot now also tells you how to change its name/colour

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/504aa885-4d0f-42c3-9af5-700b8032235f



https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/7ccc9b59-2847-4561-b5ce-470be01f8516





</details>

## Changelog
:cl:
add: Chembag crate to cargo, it has 1 chembag for each basic healing chemical
add: cargo medbots now spawn with a bicaridine kelotone mix
add: using a spraycan on a medbot will re-colour it
add: examining a medbot now tells you about re-naming and re-colouring
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
