### PR TITLE
Makes the Stethoscope printable at the Medical lathe

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -264,6 +264,16 @@
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/stethoscope
+	name = "Stethoscope"
+	desc = "A medical tool used for listening to the body. Makes you look competent"
+	id = "stethoscope"
+	build_path = /obj/item/clothing/neck/stethoscope
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /////////////////////////////////////////
 //////////Cybernetic Implants////////////
 /////////////////////////////////////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -155,6 +155,7 @@
 		"screwdriver",
 		"shovel",
 		"spade",
+		"stethoscope",
 		"surgical_drapes",
 		"surgicaldrill",
 		"syringe",


### PR DESCRIPTION
## About The Pull Request

Adds stethoscopes to the starting tools techweb node and makes it printable at the medical lathe for a reasonable amount of iron and glass.

## Why It's Good For The Game
Because we were about to massively nerf medical diagnostics with very little recompense, and I don't think anyone realized they weren't printable yet. This makes bioscanners work slightly better, and even if they don't end up getting merged it's still an improvement.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/66409077/a98b7f7f-150c-4837-9760-d93800536178)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/66409077/403bd1fa-0a17-41d6-be26-490a6295696e)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/66409077/1b518e36-2506-4579-bf6c-36073e9c1fb4)
it works, okay

</details>

## Changelog
:cl: RDS88
add: You can now print stethoscopes at the medical lathe.
/:cl:

