### PR TITLE
RadStation Fixes and Minor changes

### DIFF
--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -10806,20 +10806,28 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "dwF" = (
-/obj/structure/table/reinforced,
-/obj/item/nanite_remote{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/item/nanite_remote{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
+/obj/effect/turf_decal/box,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/guideline/guideline_edge_alt/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
+/obj/effect/turf_decal/guideline/guideline_edge_alt/purple,
+/obj/effect/turf_decal/guideline/guideline_tri/purple{
 	dir = 4
+	},
+/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
+	dir = 9
+	},
+/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/guideline/guideline_tri/purple,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
@@ -16558,9 +16566,6 @@
 /area/security/checkpoint/engineering)
 "ffm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
@@ -33248,16 +33253,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/shuttledock)
-"kru" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "krA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42622,25 +42617,29 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "nlW" = (
-/obj/effect/turf_decal/box,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/guideline/guideline_edge_alt/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/guideline/guideline_edge_alt/purple{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/guideline/guideline_tri/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/guideline/guideline_tri/purple{
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/item/nanite_scanner{
+	pixel_x = -1;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
-	dir = 8
+/obj/item/nanite_scanner{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
@@ -43087,18 +43086,11 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "nrU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "nrZ" = (
@@ -44268,23 +44260,16 @@
 /turf/open/floor/engine,
 /area/security/nuke_storage)
 "nHQ" = (
-/obj/structure/table/reinforced,
-/obj/item/nanite_scanner{
-	pixel_x = 4;
-	pixel_y = -4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/item/nanite_scanner{
-	pixel_x = -1;
-	pixel_y = 6
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
@@ -50350,16 +50335,30 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_y = 34
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/nanite_remote{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/nanite_remote{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "pGu" = (
@@ -56750,22 +56749,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig/dock)
-"rGV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "rHt" = (
 /obj/item/chair/wood{
 	dir = 8
@@ -57874,6 +57857,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sbe" = (
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "scb" = (
 /turf/closed/wall/r_wall,
 /area/storage/tech)
@@ -63828,21 +63818,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "tRX" = (
-/obj/machinery/newscaster{
-	pixel_y = 34
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 22
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "tSg" = (
@@ -66013,14 +66000,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uBu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /obj/structure/chair/office/light{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/plasteel/dark,
@@ -106886,8 +106867,8 @@ kmS
 jhX
 nAP
 sSc
-tuP
-bHp
+dYv
+lMu
 tYV
 iEd
 boR
@@ -107139,12 +107120,12 @@ cOA
 eXl
 sSc
 tRX
-kru
+sxf
 uBu
 nrU
-fsB
-sZU
-gYb
+jCC
+tuP
+bHp
 aIj
 iEd
 pSR
@@ -107399,9 +107380,9 @@ pGt
 nlW
 dwF
 nHQ
-jCC
-jWc
-wEi
+fsB
+sZU
+gYb
 okC
 iEd
 tQl
@@ -107653,12 +107634,12 @@ mZq
 oFg
 sSc
 lxd
-sxf
+sbe
 wAA
 ffm
 jCC
-dYv
-rGV
+jWc
+wEi
 ycl
 iEd
 dRq

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -4338,7 +4338,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "buc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4843,9 +4843,9 @@
 "bDT" = (
 /obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "bEc" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -10807,19 +10807,21 @@
 /area/medical/sleeper)
 "dwF" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
-/obj/item/nanite_scanner{
+/obj/item/nanite_remote{
 	pixel_x = 4;
-	pixel_y = -4
+	pixel_y = 9
 	},
-/obj/item/nanite_scanner{
-	pixel_x = -1;
-	pixel_y = 6
+/obj/item/nanite_remote{
+	pixel_x = -2;
+	pixel_y = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "dwN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13753,20 +13755,6 @@
 "eqb" = (
 /turf/closed/wall,
 /area/library)
-"eqi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/nanite)
 "eqr" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
@@ -14549,7 +14537,7 @@
 /obj/structure/lattice/catwalk/over,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
-	req_access_txt = "7;29"
+	req_one_access_txt = "7;29"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16320,6 +16308,13 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/central)
+"fbP" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "7;29;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "fbQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16562,17 +16557,12 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ffm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "ffs" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17434,12 +17424,22 @@
 /area/vacant_room/office)
 "fsB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/guideline/guideline_tri/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/machinery/door/airlock/research/glass{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "fsF" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -22944,6 +22944,21 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"gYb" = (
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "gYh" = (
 /obj/machinery/light{
 	dir = 2
@@ -27002,6 +27017,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"iqZ" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine/vacuum,
+/area/engine/atmospherics_engine)
 "ira" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -28801,6 +28820,13 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"iYZ" = (
+/obj/machinery/button{
+	id_tag = "atmosshutters";
+	pixel_y = -32
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "iZa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29412,8 +29438,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jhX" = (
-/obj/machinery/nanite_chamber,
-/turf/open/floor/plasteel,
+/obj/machinery/computer/nanite_chamber_control{
+	dir = 4
+	},
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "jia" = (
 /obj/effect/decal/cleanable/oil,
@@ -33000,7 +33031,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "knx" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -33221,6 +33255,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/shuttledock)
+"kru" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "krA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36332,18 +36376,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig/dock)
-"lqi" = (
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/white,
-/area/science/nanite)
 "lqk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -36734,13 +36766,11 @@
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/guideline/guideline_tri/purple,
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "lxi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38868,8 +38898,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/button{
-	id_tag = "atmosshutters";
-	pixel_y = -32
+	pixel_y = -32;
+	id = "atmosshutters"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -42599,11 +42629,27 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "nlW" = (
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/box,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/guideline/guideline_edge_alt/purple{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/guideline/guideline_edge_alt/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/guideline/guideline_tri/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/guideline/guideline_tri/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
+	dir = 5
+	},
+/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "nlY" = (
 /obj/structure/chair{
@@ -43050,15 +43096,17 @@
 "nrU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "nrZ" = (
 /obj/effect/decal/cleanable/oil,
@@ -43621,10 +43669,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nAP" = (
-/obj/machinery/computer/nanite_chamber_control{
-	dir = 4
+/obj/machinery/nanite_chamber,
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "nAR" = (
 /obj/machinery/door/firedoor,
@@ -44227,19 +44276,24 @@
 /area/security/nuke_storage)
 "nHQ" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
-/obj/item/nanite_remote{
+/obj/item/nanite_scanner{
 	pixel_x = 4;
-	pixel_y = 9
+	pixel_y = -4
 	},
-/obj/item/nanite_remote{
-	pixel_x = -2;
-	pixel_y = 1
+/obj/item/nanite_scanner{
+	pixel_x = -1;
+	pixel_y = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "nIi" = (
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
@@ -48038,12 +48092,10 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
 "oVx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "oVz" = (
@@ -50091,7 +50143,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "pEe" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -50308,13 +50360,14 @@
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "pGu" = (
 /obj/structure/railing{
@@ -55640,7 +55693,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "rqj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -55768,14 +55821,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rrY" = (
-/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "rsh" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -56723,8 +56768,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -58778,6 +58823,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"srP" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/button{
+	id_tag = "atmosshutters";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "srZ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table/reinforced,
@@ -59038,6 +59094,10 @@
 /area/security/main{
 	name = "Security Viewing Hall"
 	})
+"sxf" = (
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "sxn" = (
 /obj/machinery/atmospherics/miner/station/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -59331,12 +59391,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "sDa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "sDs" = (
@@ -60258,24 +60316,6 @@
 /area/security/main{
 	name = "Security Break Room"
 	})
-"sRe" = (
-/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
-	dir = 10
-	},
-/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/guideline/guideline_edge_alt/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/guideline/guideline_tri/purple,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
 "sRf" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -60810,19 +60850,15 @@
 /area/crew_quarters/kitchen)
 "sZU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/guideline/guideline_edge_alt/purple,
-/obj/effect/turf_decal/guideline/guideline_tri/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "sZW" = (
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -62150,8 +62186,8 @@
 "trS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research/glass{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
+	name = "Nanites Lab";
+	req_access_txt = "7"
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -62286,6 +62322,21 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/cryo)
+"tuP" = (
+/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/guideline/guideline_edge_alt/purple,
+/obj/effect/turf_decal/guideline/guideline_tri/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/guideline/guideline_half_edge/purple{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
+/area/science/research)
 "tuQ" = (
 /obj/machinery/computer/cargo/request{
 	dir = 4
@@ -63799,16 +63850,18 @@
 	pixel_y = 34
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/guideline/guideline_tri/purple{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "tSg" = (
 /obj/effect/turf_decal/tile/black/fourcorners,
@@ -63967,7 +64020,7 @@
 "tVd" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
-	req_access_txt = "7;29"
+	req_one_access_txt = "7;29"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -65331,7 +65384,10 @@
 /obj/item/radio/intercom{
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/guideline/guideline_edge/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "uql" = (
 /obj/effect/decal/cleanable/oil,
@@ -65975,12 +66031,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uBu" = (
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/chair/office/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "uBD" = (
 /obj/machinery/door/airlock/research{
@@ -72162,15 +72223,11 @@
 /turf/open/floor/plasteel/tech,
 /area/engine/atmos)
 "wAA" = (
-/obj/effect/turf_decal/guideline/guideline_edge/purple{
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "wAF" = (
 /turf/closed/wall,
@@ -72356,6 +72413,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"wEi" = (
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "wEm" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 4
@@ -99884,8 +99957,8 @@ vJE
 vJE
 vYg
 snk
-hDf
 snk
+hDf
 vJE
 vJE
 vJE
@@ -100141,8 +100214,8 @@ vJE
 gPy
 qAN
 oAF
-wfZ
 oLB
+wfZ
 sSo
 vJE
 mQP
@@ -100157,7 +100230,7 @@ cCS
 jMi
 hsr
 dOz
-tVd
+fbP
 cCS
 cCS
 cCS
@@ -106830,8 +106903,8 @@ upN
 kmS
 jhX
 nAP
-jCC
-dYv
+sSc
+tuP
 bHp
 tYV
 iEd
@@ -107084,12 +107157,12 @@ cOA
 eXl
 sSc
 tRX
-uBu
+kru
 uBu
 nrU
 fsB
 sZU
-eAx
+gYb
 aIj
 iEd
 pSR
@@ -107344,9 +107417,9 @@ pGt
 nlW
 dwF
 nHQ
-lqi
-rrY
-voJ
+jCC
+jWc
+wEi
 okC
 iEd
 tQl
@@ -107598,11 +107671,11 @@ mZq
 oFg
 sSc
 lxd
-wAA
+sxf
 wAA
 ffm
-eqi
-sRe
+jCC
+dYv
 rGV
 ycl
 iEd
@@ -107858,7 +107931,7 @@ rqd
 btZ
 pDO
 bDT
-jCC
+sSc
 dYv
 lMu
 tPQ
@@ -119192,8 +119265,8 @@ xtQ
 tDc
 mLj
 lBr
-tfX
-iRY
+srP
+iYZ
 nQm
 hlX
 vVO
@@ -119449,7 +119522,7 @@ xtQ
 uPm
 mLj
 lBr
-tfX
+srP
 iRY
 kxQ
 pGp
@@ -119706,7 +119779,7 @@ xtQ
 rIt
 mLj
 lBr
-tfX
+srP
 iRY
 lKh
 lKh
@@ -120985,7 +121058,7 @@ gLb
 jKk
 ccE
 jWx
-oKF
+iqZ
 fsL
 egp
 eNg

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -28820,13 +28820,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"iYZ" = (
-/obj/machinery/button{
-	id_tag = "atmosshutters";
-	pixel_y = -32
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "iZa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -38898,7 +38891,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/button{
-	pixel_y = -32;
+	pixel_y = -25;
 	id = "atmosshutters"
 	},
 /turf/open/floor/plasteel/dark,
@@ -58823,17 +58816,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"srP" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/machinery/button{
-	id_tag = "atmosshutters";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "srZ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table/reinforced,
@@ -119265,8 +119247,8 @@ xtQ
 tDc
 mLj
 lBr
-srP
-iYZ
+tfX
+iRY
 nQm
 hlX
 vVO
@@ -119522,7 +119504,7 @@ xtQ
 uPm
 mLj
 lBr
-srP
+tfX
 iRY
 kxQ
 pGp
@@ -119779,7 +119761,7 @@ xtQ
 rIt
 mLj
 lBr
-srP
+tfX
 iRY
 lKh
 lKh


### PR DESCRIPTION
## About The Pull Request
Minor issues and other nitpicks with some of the design around Rad Station.

## Why It's Good For The Game
They are annoying, bugs and overall mildly detrimental to the game. Someone in Science shouldn't be able to destroy one windoor, enter Nanite room and blow everyone up within 2 minutes assuming Nanites and adequate research is available.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

I am unable to test myself, I will ask someone to test it for me.

</details>

## Changelog
:cl:
fix: [RadStation] Atmospherics turbine aux vent is now properly linked to the correct button.
fix: [RadStation] Atmospherics secure storage shutters is now properly linked to the correct button.
tweak: [RadStation] Turned the Nanite corner into its own room.
tweak: [RadStation] Relocated the aux base door to be centered.
fix: [RadStation] Incorrect access requirement on maintenance doors around Science.
/:cl: