### PR TITLE
Adds looking

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -496,6 +496,12 @@
 			if(!M.client)
 				continue
 
+			if(isitem(A))
+				var/obj/item/I = A
+				if((I.item_flags & IN_STORAGE) && get(I, /mob/living) == src)
+					to_chat(M, "<span class='srt subtle'>\The [usr] looks inside [usr.p_their()] [I.loc.name]")
+					break
+
 			if(M in can_see_target)
 				to_chat(M, "<span class='srt_info subtle'>\The [usr] looks at \the [A]</span>")
 			else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -521,7 +521,7 @@
 				loc_str = "at [p_their()] [I.name]."
 				examining_worn_item = TRUE
 
-	var/can_see_str = "(<span class='srt_info subtle'>\The [src] looks at [examined_thing].")
+	var/can_see_str = ("(<span class='srt_info subtle'>\The [src] looks at [examined_thing].")
 	if(examining_worn_item)
 		can_see_str = span_subtle("\The [src] looks [loc_str]")
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -489,6 +489,16 @@
 	if(is_blind(src) && !blind_examine_check(A))
 		return
 
+	if(!isobserver(usr) && !(usr == A))
+		var/list/can_see_target = viewers(usr)
+		for(var/mob/M as anything in viewers(4, usr))
+			if(!M.client)
+				continue
+			if(M in can_see_target)
+				to_chat(M, "<span class='subtle'>\The [usr] looks at \the [A]</span>")
+			else
+				to_chat(M, "<span class='subtle'>\The [usr] intently looks at something...</span>")
+
 	face_atom(A)
 	var/list/result = A.examine(src)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -486,10 +486,11 @@
 		// shift-click catcher may issue examinate() calls for out-of-sight turfs
 		return
 
-	if(is_blind(src) && !blind_examine_check(A))
+	var/isblind = is_blind(src)
+	if(isblind && !blind_examine_check(A))
 		return
 
-	if(!isobserver(usr) && !(usr == A) && !is_blind(src))
+	if(!isobserver(usr) && !(usr == A) && !isblind)
 		var/list/can_see_target = viewers(usr)
 		for(var/mob/M as anything in viewers(4, usr))
 			if(!M.client)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -495,10 +495,11 @@
 		for(var/mob/M as anything in viewers(4, usr))
 			if(!M.client)
 				continue
+
 			if(M in can_see_target)
-				to_chat(M, "<span class='subtle'>\The [usr] looks at \the [A]</span>")
+				to_chat(M, "<span class='srt_info subtle'>\The [usr] looks at \the [A]</span>")
 			else
-				to_chat(M, "<span class='subtle'>\The [usr] intently looks at something...</span>")
+				to_chat(M, "<span class='srt_info subtle'>\The [usr] intently looks at something...</span>")
 
 	face_atom(A)
 	var/list/result = A.examine(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -498,9 +498,12 @@
 
 			if(isitem(A))
 				var/obj/item/I = A
-				if((I.item_flags & IN_STORAGE) && get(I, /mob/living) == src)
-					to_chat(M, "<span class='srt subtle'>\The [usr] looks inside [usr.p_their()] [I.loc.name]")
-					break
+				if((I.item_flags & IN_STORAGE))
+					if(get(I, /mob/living) == src)
+						to_chat(M, "<span class='srt subtle'>\The [usr] looks inside [usr.p_their()] [I.loc.name]")
+					else
+						to_chat(M, "<span class='srt subtle'>\The [usr] looks inside \the [I.loc.name]")
+					continue
 
 			if(M in can_see_target)
 				to_chat(M, "<span class='srt_info subtle'>\The [usr] looks at \the [A]</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -489,7 +489,7 @@
 	if(is_blind(src) && !blind_examine_check(A))
 		return
 
-	if(!isobserver(usr) && !(usr == A))
+	if(!isobserver(usr) && !(usr == A) && !is_blind(src))
 		var/list/can_see_target = viewers(usr)
 		for(var/mob/M as anything in viewers(4, usr))
 			if(!M.client)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -521,7 +521,7 @@
 				loc_str = "at [p_their()] [I.name]."
 				examining_worn_item = TRUE
 
-	var/can_see_str = "(<span class='srt_info subtle'>\The [src] looks at [examined].")
+	var/can_see_str = "(<span class='srt_info subtle'>\The [src] looks at [examined_thing].")
 	if(examining_worn_item)
 		can_see_str = span_subtle("\The [src] looks [loc_str]")
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -490,31 +490,44 @@
 	if(isblind && !blind_examine_check(A))
 		return
 
-	if(!isobserver(usr) && !(usr == A) && !isblind)
-		var/list/can_see_target = viewers(usr)
-		for(var/mob/M as anything in viewers(4, usr))
-			if(!M.client)
-				continue
 
-			if(isitem(A))
-				var/obj/item/I = A
-				if((I.item_flags & IN_STORAGE))
-					if(get(I, /mob/living) == src)
-						to_chat(M, "<span class='srt subtle'>\The [usr] looks inside [usr.p_their()] [I.loc.name]")
-					else
-						to_chat(M, "<span class='srt subtle'>\The [usr] looks inside \the [I.loc.name]")
-					continue
 
-			if(M in can_see_target)
-				to_chat(M, "<span class='srt_info subtle'>\The [usr] looks at \the [A]</span>")
-			else
-				to_chat(M, "<span class='srt_info subtle'>\The [usr] intently looks at something...</span>")
+	if(!isblind && !A == src)
+		broadcast_examine(A)
 
 	face_atom(A)
 	var/list/result = A.examine(src)
 
 	to_chat(src, EXAMINE_BLOCK(jointext(result, "\n")))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, A)
+
+/mob/proc/broadcast_examine(atom/examined_thing)
+	var/mob/living/carbon/U = usr
+
+	if(U.IsStun() || U.IsParalyzed() || U.is_mouth_covered(mask_only = 1))
+		return
+
+	var/list/can_see_target = viewers(usr)
+	for(var/mob/M as anything in viewers(4, usr))
+		if(!M.client)
+			continue
+
+		if(isitem(examined_thing))
+			var/obj/item/I = examined_thing
+			if((I.item_flags & IN_STORAGE))
+				if(get(I, /mob/living) == src)
+					to_chat(M, "<span class='srt subtle'>\The [usr] looks inside [usr.p_their()] [I.loc.name]")
+				else
+					to_chat(M, "<span class='srt subtle'>\The [usr] looks inside \the [I.loc.name]")
+				continue
+
+		if(M in can_see_target)
+			to_chat(M, "<span class='srt_info subtle'>\The [usr] looks at \the [examined_thing]</span>")
+		else
+			to_chat(M, "<span class='srt_info subtle'>\The [usr] intently looks at something...</span>")
+
+/mob/dead/broadcast_examine(atom/examined_thing)
+	return
 
 /mob/proc/blind_examine_check(atom/examined_thing)
 	return TRUE

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -78,6 +78,7 @@ h1.alert, h2.alert		{color: #000000;}
 .greenannounce			{color: #00ff00;	font-weight: bold;}
 .rose					{color: #ff5050;}
 .info					{color: #0000CC;}
+.subtle					{color: ##4343ca;	font-weight: italic; font-size: 0.75;}
 .notice					{color: #000099;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .usernotice				{color: #000099;	font-weight: bold; font-size: 3;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -78,7 +78,7 @@ h1.alert, h2.alert		{color: #000000;}
 .greenannounce			{color: #00ff00;	font-weight: bold;}
 .rose					{color: #ff5050;}
 .info					{color: #0000CC;}
-.subtle					{color: ##4343ca;	font-weight: italic; font-size: 0.75;}
+.subtle					{color: #4343CA;	font-style: italic; font-size: 0.75;}
 .notice					{color: #000099;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .usernotice				{color: #000099;	font-weight: bold; font-size: 3;}

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -66,7 +66,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_INFO,
     name: 'Info',
     description: 'Non-urgent messages from the game and items',
-    selector: '.srt_info, .notice:not(.pm), .adminnotice, .info, .subtle',
+    selector: '.srt_info, .notice:not(.pm), .adminnotice, .info',
   },
   {
     type: MESSAGE_TYPE_WARNING,

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -66,7 +66,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_INFO,
     name: 'Info',
     description: 'Non-urgent messages from the game and items',
-    selector: '.srt_info, .notice:not(.pm), .adminnotice, .info',
+    selector: '.srt_info, .notice:not(.pm), .adminnotice, .info, .subtle',
   },
   {
     type: MESSAGE_TYPE_WARNING,

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1134,6 +1134,12 @@ em {
   padding: 0.5em 0.75em;
 }
 
+.subtle {
+  color: #4343ca;
+  font-size: 75%;
+  font-style: italic;
+}
+
 //Job Colours
 //Make sure you add to replacementNodes in renderer.js
 // ----------

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1139,6 +1139,12 @@ h2.alert {
   padding: 0.5em 0.75em;
 }
 
+.subtle {
+  color: #000099;
+  font-size: 75%;
+  font-style: italic;
+}
+
 //Job Colours
 //Make sure you add to replacementNodes in renderer.js
 // ----------


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a looking feature similar to Bay's in which examining will give near players a message nearby that you have looked at something.

Ported from
https://github.com/DaedalusDock/daedalusdock/pull/27
some of https://github.com/DaedalusDock/daedalusdock/pull/891
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
It makes people feel a bit more alive and more obvious whenever they are examining something while allowing for more RP situations.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
The best theme

![dreamseeker_PpFikbE8h6](https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/c447f762-69ea-4244-915d-f8d912f5cd73)

The boring theme

![dreamseeker_xY9Am8w3Ez](https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/88fa24bd-19e6-4834-a4f6-fd6f2f31fea7)

The soulful theme

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/15871981-865c-4871-80a7-44b6118c5f83)

Storage checking

![dreamseeker_JMRF72QYId](https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/197ab9ad-4a13-4ff7-9f5b-035468c2812c)




</details>

## Changelog
:cl: Kapu1178, ported by Hardly.
add: Nearby players can see when someone examines something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
