### PR TITLE
Gives Radstation's maintenance bar closet the correct carpets

### DIFF
--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -71999,7 +71999,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/tile/wood,
-/obj/item/stack/tile/carpet/black/fifty,
+/obj/item/stack/tile/carpet/royalblack/fifty,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "wyV" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Changes the stack of black carpet on the maintenance bar in radstation so it's royal black instead, matching with the bar's floor.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Fixes a small oversight, considering that the content in the closet is meant to match with the maintenance bar with the purpose of repairing the damaged bar.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![StrongDMM_rRAVz9TGHL](https://github.com/BeeStation/BeeStation-Hornet/assets/66234359/538d734e-1e61-4d3d-89e6-30b27a036bca)

</details>

## Changelog
:cl: Hardly
fix: Adds the proper carpets for Radstation's maintenance bar closet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
