### PR TITLE
Fixes weather's bad image rendering code

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -155,7 +155,7 @@
 		if(STARTUP_STAGE)
 			if(cached_weather_sprite_start)
 				new_overlay = cached_weather_sprite_start
-				previous_overlay = TRUE
+				previous_overlay = TRUE // temporary value. see below.
 		if(MAIN_STAGE)
 			if(cached_weather_sprite_start)
 				previous_overlay = cached_weather_sprite_start
@@ -169,7 +169,7 @@
 		if(END_STAGE)
 			if(cached_weather_sprite_end)
 				previous_overlay = cached_weather_sprite_end
-				new_overlay = TRUE
+				new_overlay = TRUE // temporary value. see below.
 
 	// we won't iterate all areas unnecesarily
 	if(!previous_overlay && !new_overlay)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -44,9 +44,23 @@
 	/// This causes the weather to only end if forced to
 	var/perpetual = FALSE
 
+	// cached sprites to go on area overlays.
+	var/mutable_appearance/cached_weather_sprite_start
+	var/mutable_appearance/cached_weather_sprite_process
+	var/mutable_appearance/cached_weather_sprite_end
+
 /datum/weather/New(z_levels)
 	..()
 	impacted_z_levels = z_levels
+	generate_cached_weather_sprites()
+
+/datum/weather/proc/generate_cached_weather_sprites()
+	if(telegraph_overlay)
+		cached_weather_sprite_start = mutable_appearance('icons/effects/weather_effects.dmi', telegraph_overlay, overlay_layer, overlay_plane, color = weather_color)
+	if(weather_overlay)
+		cached_weather_sprite_process = mutable_appearance('icons/effects/weather_effects.dmi', weather_overlay, overlay_layer, overlay_plane, color = weather_color)
+	if(end_overlay)
+		cached_weather_sprite_end = mutable_appearance('icons/effects/weather_effects.dmi', end_overlay, overlay_layer, overlay_plane, color = weather_color)
 
 /datum/weather/proc/telegraph()
 	if(stage == STARTUP_STAGE)
@@ -135,23 +149,40 @@
 	return
 
 /datum/weather/proc/update_areas()
-	for(var/V in impacted_areas)
-		var/area/N = V
-		N.layer = overlay_layer
-		N.plane = overlay_plane
-		N.icon = 'icons/effects/weather_effects.dmi'
-		N.color = weather_color
-		switch(stage)
-			if(STARTUP_STAGE)
-				N.icon_state = telegraph_overlay
-			if(MAIN_STAGE)
-				N.icon_state = weather_overlay
-			if(WIND_DOWN_STAGE)
-				N.icon_state = end_overlay
-			if(END_STAGE)
-				N.color = null
-				N.icon_state = ""
-				N.icon = 'icons/turf/areas.dmi'
-				N.layer = initial(N.layer)
-				N.plane = initial(N.plane)
-				N.set_opacity(FALSE)
+	var/previous_overlay
+	var/new_overlay
+	switch(stage)
+		if(STARTUP_STAGE)
+			if(cached_weather_sprite_start)
+				new_overlay = cached_weather_sprite_start
+				previous_overlay = TRUE
+		if(MAIN_STAGE)
+			if(cached_weather_sprite_start)
+				previous_overlay = cached_weather_sprite_start
+			if(cached_weather_sprite_process)
+				new_overlay = cached_weather_sprite_process
+		if(WIND_DOWN_STAGE)
+			if(cached_weather_sprite_process)
+				previous_overlay = cached_weather_sprite_process
+			if(cached_weather_sprite_end)
+				new_overlay = cached_weather_sprite_end
+		if(END_STAGE)
+			if(cached_weather_sprite_end)
+				previous_overlay = cached_weather_sprite_end
+				new_overlay = TRUE
+
+	// we won't iterate all areas unnecesarily
+	if(!previous_overlay && !new_overlay)
+		return
+
+	// removing TRUE value because we don't want typecheck every iteration from for loop
+	if(previous_overlay == TRUE)
+		previous_overlay = null
+	if(new_overlay == TRUE)
+		new_overlay = null
+
+	for(var/area/each_area as anything in impacted_areas)
+		if(previous_overlay)
+			each_area.cut_overlay(previous_overlay)
+		if(new_overlay)
+			each_area.add_overlay(new_overlay)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* closes https://github.com/BeeStation/BeeStation-Hornet/issues/9171

hopefully fixes it.
I am not sure why that happens, but I think the code is slow because it directly changes dmi and icon state, and even the code tries to change even if there's no necessary to update.

# NOTE
* Follow up fix: https://github.com/BeeStation/BeeStation-Hornet/pull/10904

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/635eadaf-feb9-44a7-9c6c-09a69d729f6a)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d3e27f0b-4ffe-4590-b567-8dae19bd7c00)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/bf9661f8-a8c2-410f-88a6-25938022eb13)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d94f2616-1b19-44e7-9311-398bd36dd4fe)


</details>

## Changelog
:cl:
code: slightly improved weather datum. This may fix a bug that weathers (radiation storm*) are rendered incorrectly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
