### PR TITLE
Fixes plumbing grinder can grind maint pills (floorpills)

### DIFF
--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -42,6 +42,10 @@
 		return
 	if(!isitem(AM))
 		return
+	if(istype(AM, /obj/item/reagent_containers))
+		var/obj/item/reagent_containers/reag_container = AM
+		if(reag_container.prevent_grinding) // don't grind floorpill
+			return
 	var/obj/item/I = AM
 	if(I.juice_results || I.grind_results)
 		if(I.juice_results)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* fixes https://github.com/BeeStation/BeeStation-Hornet/issues/10747

It is not supposed to be possible to grind floorpills.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/d6f0f79e-c10f-4fae-ad3c-31861e369c19)

plants, or standard pills are grindable.

## Changelog
:cl:
fix: plumbing grinder no longer grinds ungrindable pills (i.e. floorpills)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
