### PR TITLE
Fixes Revenant ingame info inaccuracies + minor rev fixes + prevent rev spawning on holytile

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -424,4 +424,6 @@ Turf and target are separate in case you want to teleport some distance from a t
 		found_tile = get_turf(pick_n_take(copied_turf_list))
 	while(found_tile.is_holy() && length(copied_turf_list))
 
+	if(found_tile.is_holy()) // we found no valid tile at all
+		return
 	return found_tile

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -413,3 +413,15 @@ Turf and target are separate in case you want to teleport some distance from a t
 	if(pressure <= 20 || pressure >= 550)
 		return FALSE
 	return TRUE
+
+/// returns a turf that isn't holy from the list
+/proc/get_non_holy_tile_from_list(list/turf_list)
+	if(!length(turf_list))
+		CRASH("No turf list has been given")
+	var/list/copied_turf_list = turf_list.Copy()
+	var/turf/found_tile
+	do
+		found_tile = get_turf(pick_n_take(copied_turf_list))
+	while(found_tile.is_holy() && length(copied_turf_list))
+
+	return found_tile

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -421,8 +421,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 	var/list/copied_turf_list = turf_list.Copy()
 	var/turf/found_tile
 	do
-		found_tile = get_turf(pick_n_take(copied_turf_list))
-	while(found_tile.is_holy() && length(copied_turf_list))
+		found_tile = get_turf(pick_n_take(copied_turf_list)) // uses 'pick_an_take()' proc, so an item will be drawn from the list for each iteration. also, uses 'get_turf()` just in case.
+	while(found_tile && found_tile.is_holy() && length(copied_turf_list))
 
 	if(found_tile.is_holy()) // we found no valid tile at all
 		return

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -602,7 +602,11 @@
 	return TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/generate_ruleset_body(mob/applicant)
-	var/mob/living/simple_animal/revenant/revenant = new(pick(spawn_locs))
+	var/turf/spawnable_turf = get_non_holy_tile_from_list(spawn_locs)
+	if(!spawnable_turf)
+		message_admins("Failed to find a proper spawn location because there are a lot of blessed tiles. We'll spawn it anyway.")
+		spawnable_turf = pick(spawn_locs)
+	var/mob/living/simple_animal/revenant/revenant = new(spawnable_turf)
 	revenant.key = applicant.key
 	message_admins("[ADMIN_LOOKUPFLW(revenant)] has been made into a revenant by the midround ruleset.")
 	log_game("[key_name(revenant)] was spawned as a revenant by the midround ruleset.")

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -537,18 +537,6 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		return TRUE
 	return FALSE
 
-/// returns a turf that isn't holy from the list
-/proc/get_non_holy_tile_from_list(list/turf_list)
-	if(!length(turf_list))
-		CRASH("No turf list has been given")
-	var/list/copied_turf_list = turf_list.Copy()
-	var/turf/found_tile
-	do
-		found_tile = get_turf(pick_n_take(copied_turf_list))
-	while(found_tile.is_holy() && length(copied_turf_list))
-
-	return found_tile
-
 ///Add our relevant floor texture, if we can / need
 /turf/proc/add_turf_texture(list/textures, force)
 	if(!length(textures) || length(contents) && (locate(/obj/effect/decal/cleanable/dirt) in contents || locate(/obj/effect/decal/cleanable/dirt) in vis_contents))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -537,6 +537,18 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 		return TRUE
 	return FALSE
 
+/// returns a turf that isn't holy from the list
+/proc/get_non_holy_tile_from_list(list/turf_list)
+	if(!length(turf_list))
+		CRASH("No turf list has been given")
+	var/list/copied_turf_list = turf_list.Copy()
+	var/turf/found_tile
+	do
+		found_tile = get_turf(pick_n_take(copied_turf_list))
+	while(found_tile.is_holy() && length(copied_turf_list))
+
+	return found_tile
+
 ///Add our relevant floor texture, if we can / need
 /turf/proc/add_turf_texture(list/textures, force)
 	if(!length(textures) || length(contents) && (locate(/obj/effect/decal/cleanable/dirt) in contents || locate(/obj/effect/decal/cleanable/dirt) in vis_contents))

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -155,7 +155,7 @@
 
 /mob/living/simple_animal/revenant/get_stat_tab_status()
 	var/list/tab_data = ..()
-	tab_data["Current essence (health)"] = GENERATE_STAT_TEXT("[essence]E (Max: [essence_regen_cap]E)")
+	tab_data["Current essence (health)"] = GENERATE_STAT_TEXT("[essence]E (Regeneration Cap: [essence_regen_cap]E)")
 	tab_data["Stolen essence"] = GENERATE_STAT_TEXT("[essence_accumulated]E")
 	tab_data["Unused stolen essence"] = GENERATE_STAT_TEXT("[essence_excess]E")
 	tab_data["Stolen perfect souls"] = GENERATE_STAT_TEXT("[perfectsouls]")

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -19,6 +19,7 @@
 	invisibility = INVISIBILITY_SPIRIT
 	health = INFINITY //Revenants don't use health, they use essence instead
 	maxHealth = INFINITY
+	do_not_show_health_on_stat_panel = TRUE // showing their health info is confusing
 	plane = GHOST_PLANE
 	healable = FALSE
 	spacewalk = TRUE
@@ -154,7 +155,7 @@
 
 /mob/living/simple_animal/revenant/get_stat_tab_status()
 	var/list/tab_data = ..()
-	tab_data["Current essence"] = GENERATE_STAT_TEXT("[essence]/[essence_regen_cap]E")
+	tab_data["Current essence (health)"] = GENERATE_STAT_TEXT("[essence]E (Max: [essence_regen_cap]E)")
 	tab_data["Stolen essence"] = GENERATE_STAT_TEXT("[essence_accumulated]E")
 	tab_data["Unused stolen essence"] = GENERATE_STAT_TEXT("[essence_excess]E")
 	tab_data["Stolen perfect souls"] = GENERATE_STAT_TEXT("[perfectsouls]")

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -171,7 +171,7 @@
 
 /obj/effect/proc_holder/spell/self/rev_teleport/cast(mob/living/simple_animal/revenant/user = usr)
 	if(!isrevenant(user))
-		to_chat(user, "<span class='revenwarning'>You are not revenent.</span>")
+		to_chat(user, "<span class='revenwarning'>You are not revenant.</span>")
 		return
 	if(is_station_level(user.z))
 		to_chat(user, "<span class='revenwarning'>Recalling yourself to the station is only available when you're not in the station.</span>")

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -278,7 +278,7 @@
 	name = "Report this to a coder"
 	var/reveal = 80 //How long it reveals the revenant in deciseconds
 	var/stun = 20 //How long it stuns the revenant in deciseconds
-	var/unlocked = FALSE //revenant needs to pay essence to learn their ability
+	var/locked = TRUE //revenant needs to pay essence to learn their ability
 	var/unlock_amount = 100 //How much essence it costs to unlock
 	var/cast_amount = 50 //How much essence it costs to use
 
@@ -287,7 +287,7 @@
 	update_button_info()
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/proc/update_button_info()
-	if(unlocked)
+	if(!locked)
 		action.name = "[initial(name)][cast_amount ? " ([cast_amount]E to cast)" : ""]"
 	else
 		action.name = "[initial(name)][unlock_amount ? " ([unlock_amount]SE to learn)" : ""]"
@@ -300,7 +300,7 @@
 		return TRUE
 	if(user.inhibited)
 		return FALSE
-	if(!unlocked)
+	if(locked)
 		if(user.essence_excess <= unlock_amount)
 			return FALSE
 	if(user.essence <= cast_amount)
@@ -310,21 +310,21 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/proc/attempt_cast(mob/living/simple_animal/revenant/user = usr)
 	// If you're not a revenant, it works anyway.
 	if(!isrevenant(user))
-		if(!unlocked)
-			unlocked = TRUE
+		if(locked)
+			locked = FALSE
 			panel = "Revenant Abilities"
 			action.name = "[initial(name)]"
 		action.UpdateButtonIcon()
 		return TRUE
 
 	// actual revenant check
-	if(!unlocked)
+	if(locked)
 		if (!user.unlock(unlock_amount))
 			charge_counter = charge_max
 			return FALSE
 		to_chat(user, "<span class='revennotice'>You have unlocked [initial(name)]!</span>")
 		panel = "Revenant Abilities"
-		unlocked = TRUE
+		locked = FALSE
 		charge_counter = charge_max
 		update_button_info()
 		return FALSE

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -171,6 +171,7 @@
 
 /obj/effect/proc_holder/spell/self/rev_teleport/cast(mob/living/simple_animal/revenant/user = usr)
 	if(!isrevenant(user))
+		to_chat(user, "<span class='revenwarning'>You are not revenent.</span>")
 		return
 	if(is_station_level(user.z))
 		to_chat(user, "<span class='revenwarning'>Recalling yourself to the station is only available when you're not in the station.</span>")
@@ -209,6 +210,7 @@
 			return
 		if(M.anti_magic_check(magic_check, holy_check)) //hear no evil
 			to_chat(user, "<span class='[boldnotice]'>Something is blocking your power into their mind!</span>")
+			return
 
 
 		var/msg = stripped_input(usr, "What do you wish to tell [M]?", null, "")
@@ -276,25 +278,29 @@
 	name = "Report this to a coder"
 	var/reveal = 80 //How long it reveals the revenant in deciseconds
 	var/stun = 20 //How long it stuns the revenant in deciseconds
-	var/locked = TRUE //If it's locked and needs to be unlocked before use
+	var/unlocked = FALSE //revenant needs to pay essence to learn their ability
 	var/unlock_amount = 100 //How much essence it costs to unlock
 	var/cast_amount = 50 //How much essence it costs to use
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/Initialize(mapload)
 	. = ..()
-	if(locked)
-		name = "[initial(name)] ([unlock_amount]SE)"
+	update_button_info()
+
+/obj/effect/proc_holder/spell/aoe_turf/revenant/proc/update_button_info()
+	if(unlocked)
+		action.name = "[initial(name)][cast_amount ? " ([cast_amount]E to cast)" : ""]"
 	else
-		name = "[initial(name)] ([cast_amount]E)"
+		action.name = "[initial(name)][unlock_amount ? " ([unlock_amount]SE to learn)" : ""]"
+	action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/can_cast(mob/living/simple_animal/revenant/user = usr)
 	if(charge_counter < charge_max)
 		return FALSE
-	if(!istype(user)) //Badmins, no. Badmins, don't do it.
+	if(!isrevenant(user)) // If you're not a revenant, it works anyway.
 		return TRUE
 	if(user.inhibited)
 		return FALSE
-	if(locked)
+	if(!unlocked)
 		if(user.essence_excess <= unlock_amount)
 			return FALSE
 	if(user.essence <= cast_amount)
@@ -302,26 +308,29 @@
 	return TRUE
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/proc/attempt_cast(mob/living/simple_animal/revenant/user = usr)
-	if(!istype(user)) //If you're not a revenant, it works. Please, please, please don't give this to a non-revenant.
-		name = "[initial(name)]"
-		if(locked)
+	// If you're not a revenant, it works anyway.
+	if(!isrevenant(user))
+		if(!unlocked)
+			unlocked = TRUE
 			panel = "Revenant Abilities"
-			locked = FALSE
+			action.name = "[initial(name)]"
+		action.UpdateButtonIcon()
 		return TRUE
-	if(locked)
+
+	// actual revenant check
+	if(!unlocked)
 		if (!user.unlock(unlock_amount))
 			charge_counter = charge_max
 			return FALSE
-		name = "[initial(name)] ([cast_amount]E)"
 		to_chat(user, "<span class='revennotice'>You have unlocked [initial(name)]!</span>")
 		panel = "Revenant Abilities"
-		locked = FALSE
+		unlocked = TRUE
 		charge_counter = charge_max
+		update_button_info()
 		return FALSE
 	if(!user.castcheck(-cast_amount))
 		charge_counter = charge_max
 		return FALSE
-	name = "[initial(name)] ([cast_amount]E)"
 	user.reveal(reveal)
 	user.stun(stun)
 	if(action)

--- a/code/modules/antagonists/revenant/revenant_spawn_event.dm
+++ b/code/modules/antagonists/revenant/revenant_spawn_event.dm
@@ -52,7 +52,11 @@
 	if(!spawn_locs.len) //If we can't find THAT, then just give up and cry
 		return MAP_ERROR
 
-	var/mob/living/simple_animal/revenant/revvie = new(pick(spawn_locs))
+	var/turf/spawnable_turf = get_non_holy_tile_from_list(spawn_locs)
+	if(!spawnable_turf)
+		message_admins("Failed to find a proper spawn location because there are a lot of blessed tiles. We'll spawn it anyway.")
+		spawnable_turf = pick(spawn_locs)
+	var/mob/living/simple_animal/revenant/revvie = new(spawnable_turf)
 	revvie.key = selected.key
 	message_admins("[ADMIN_LOOKUPFLW(revvie)] has been made into a revenant by an event.")
 	log_game("[key_name(revvie)] was spawned as a revenant by an event.")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -95,6 +95,9 @@
 
 	var/special_process = FALSE
 
+	///set it TRUE if "health" is not relable to this simple mob.
+	var/do_not_show_health_on_stat_panel
+
 	//Discovery
 	var/discovery_points = 200
 
@@ -339,6 +342,9 @@
 	add_movespeed_modifier(MOVESPEED_ID_SIMPLEMOB_VARSPEED, TRUE, 100, multiplicative_slowdown = speed, override = TRUE)
 
 /mob/living/simple_animal/get_stat_tab_status()
+	if(do_not_show_health_on_stat_panel)
+		return ..()
+
 	var/list/tab_data = ..()
 	tab_data["Health"] = GENERATE_STAT_TEXT("[round((health / maxHealth) * 100)]%")
 	return tab_data


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* fixes https://github.com/BeeStation/BeeStation-Hornet/issues/10626

Fixes Revenant ingame info inaccuracies
* Health will not be displayed in their stat panel
* Revenant spells will tell the req to unlock
* Some minor fixes
* Prevent rev spawning on a holy tile

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
improves player experience

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/a3e0e8e3-eb9d-41b1-ad1d-7f79a8aa96bb)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/0c7220cc-c303-4344-892e-d661c62c06c6)

forgot to capture rev holy tile one, but it works too

## Changelog
:cl:
fix: Stat panel will no longer say Revenant health
fix: Revenant spell buttons will now tell you the req to unlock or essence value to cast
fix: Revenant will be immediately rejected if their telepathy isn't working
fix: Some Revenant spells are now castable by non-revenants, for admeme
fix: Revenant won't spawn on a holytile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
