### PR TITLE
Prescription variants of existing glasses

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -358,7 +358,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/monocle = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptionjamjar
@@ -367,7 +367,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/regular/jamjar = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptionhipster
@@ -376,7 +376,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/regular/hipster = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptioncircle
@@ -385,7 +385,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/regular/circle = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptionsun
@@ -394,7 +394,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/sunglasses = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptioncold
@@ -403,7 +403,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/cold = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptionheat
@@ -412,7 +412,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/heat = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptionorange
@@ -421,7 +421,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/orange = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR
 
 /datum/crafting_recipe/prescriptionred
@@ -430,5 +430,5 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER)
 	reqs = list(/obj/item/clothing/glasses/red = 1,
-				/obj/item/clothing/glasses/regular/ = 1,
+				/obj/item/clothing/glasses/regular/ = 1)
 	category = CAT_EYEWEAR

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -351,3 +351,84 @@
 	reqs = list(/obj/item/food/grown/flower/lily = 3,
 				/obj/item/stack/cable_coil = 3)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/prescriptionmonocle
+	name = "prescription monocle"
+	result = /obj/item/clothing/glasses/monocle/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/monocle = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptionjamjar
+	name = "prescription jamjar glasses"
+	result = /obj/item/clothing/glasses/regular/jamjar/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/regular/jamjar = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptionhipster
+	name = "prescription hipster glasses"
+	result = /obj/item/clothing/glasses/regular/hipster/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/regular/hipster = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptioncircle
+	name = "prescription circle glasses"
+	result = /obj/item/clothing/glasses/regular/circle/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/regular/circle = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptionsun
+	name = "prescription sunglasses"
+	result = /obj/item/clothing/glasses/sunglasses/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/sunglasses = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptioncold
+	name = "prescription cold goggles"
+	result = /obj/item/clothing/glasses/cold/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/cold = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptionheat
+	name = "prescription heat goggles"
+	result = /obj/item/clothing/glasses/heat/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/heat = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptionorange
+	name = "prescription orange glasses"
+	result = /obj/item/clothing/glasses/orange/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/orange = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR
+
+/datum/crafting_recipe/prescriptionred
+	name = "prescription red glasses"
+	result = /obj/item/clothing/glasses/red/prescription
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/red = 1,
+				/obj/item/clothing/glasses/regular/ = 1,
+	category = CAT_EYEWEAR

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -196,6 +196,13 @@
 	icon_state = "monocle"
 	item_state = "headset" // lol
 
+/obj/item/clothing/glasses/monocle/prescription
+	name = "prescription monocle"
+	desc = "Such a dapper eyepiece! It has been fitted with a prescription grade lens"
+	icon_state = "monocle"
+	item_state = "headset"
+	vision_correction = 1
+
 /obj/item/clothing/glasses/material
 	name = "optical material scanner"
 	desc = "Very confusing glasses."
@@ -237,17 +244,38 @@
 	icon_state = "jamjar_glasses"
 	item_state = "jamjar_glasses"
 
+/obj/item/clothing/glasses/regular/jamjar/prescription
+	name = "prescription jamjar glasses"
+	desc = "Also known as Virginity Protectors. These have been fitted with prescription grade lenses."
+	icon_state = "jamjar_glasses"
+	item_state = "jamjar_glasses"
+	vision_correction = 1
+
 /obj/item/clothing/glasses/regular/hipster
-	name = "prescription glasses"
+	name = "hipster glasses"
 	desc = "Made by Uncool. Co."
 	icon_state = "hipster_glasses"
 	item_state = "hipster_glasses"
+
+/obj/item/clothing/glasses/regular/hipster/prescription
+	name = "prescription hipster glasses"
+	desc = "Made by Uncool. Co. These have been fitted with prescription grade lenses."
+	icon_state = "hipster_glasses"
+	item_state = "hipster_glasses"
+	vision_correction = 1
 
 /obj/item/clothing/glasses/regular/circle
 	name = "circle glasses"
 	desc = "Why would you wear something so controversial yet so brave?"
 	icon_state = "circle_glasses"
 	item_state = "circle_glasses"
+
+/obj/item/clothing/glasses/regular/circle/prescription
+	name = "prescription circle glasses"
+	desc = "Why would you wear something so controversial yet so brave? These have been fitted with prescription grade lenses."
+	icon_state = "circle_glasses"
+	item_state = "circle_glasses"
+	vision_correction = 1
 
 //Here lies green glasses, so ugly they died. RIP
 
@@ -258,6 +286,17 @@
 	item_state = "sunglasses"
 	darkness_view = 1
 	tint = 1
+	glass_colour_type = /datum/client_colour/glass_colour/gray
+	dog_fashion = /datum/dog_fashion/head
+
+/obj/item/clothing/glasses/sunglasses/prescription
+	name = "prescription sunglasses"
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover, these have been fitted with prescription grade lenses. They do not provide flash protection."
+	icon_state = "sun"
+	item_state = "sunglasses"
+	darkness_view = 1
+	tint = 1
+	vision_correction = 1
 	glass_colour_type = /datum/client_colour/glass_colour/gray
 	dog_fashion = /datum/dog_fashion/head
 
@@ -494,11 +533,25 @@
 	icon_state = "cold"
 	item_state = "cold"
 
+/obj/item/clothing/glasses/cold/prescription
+	name = "prescription cold goggles"
+	desc = "A pair of goggles meant for low temperatures. These have been fitted with prescription grade lenses."
+	icon_state = "cold"
+	item_state = "cold"
+	vision_correction = 1
+
 /obj/item/clothing/glasses/heat
 	name = "heat goggles"
 	desc = "A pair of goggles meant for high temperatures."
 	icon_state = "heat"
 	item_state = "heat"
+
+/obj/item/clothing/glasses/heat/prescription
+	name = "prescription heat goggles"
+	desc = "A pair of goggles meant for high temperatures. These have been fitted with prescription grade lenses."
+	icon_state = "heat"
+	item_state = "heat"
+	vision_correction = 1
 
 /obj/item/clothing/glasses/orange
 	name = "orange glasses"
@@ -507,9 +560,24 @@
 	item_state = "orangeglasses"
 	glass_colour_type = /datum/client_colour/glass_colour/lightorange
 
+/obj/item/clothing/glasses/orange/prescription
+	name = "prescription orange glasses"
+	desc = "A sweet pair of orange shades. These have been fitted with prescription grade lenses."
+	icon_state = "orangeglasses"
+	item_state = "orangeglasses"
+	vision_correction = 1
+	glass_colour_type = /datum/client_colour/glass_colour/lightorange
+
 /obj/item/clothing/glasses/red
 	name = "red glasses"
 	desc = "Hey, you're looking good, senpai!"
+	icon_state = "redglasses"
+	item_state = "redglasses"
+	glass_colour_type = /datum/client_colour/glass_colour/red
+
+/obj/item/clothing/glasses/red/prescription
+	name = "prescription red glasses"
+	desc = "Hey, you're looking good, senpai! These have been fitted with prescription grade lenses."
 	icon_state = "redglasses"
 	item_state = "redglasses"
 	glass_colour_type = /datum/client_colour/glass_colour/red

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -580,6 +580,7 @@
 	desc = "Hey, you're looking good, senpai! These have been fitted with prescription grade lenses."
 	icon_state = "redglasses"
 	item_state = "redglasses"
+	vision_correction = 1
 	glass_colour_type = /datum/client_colour/glass_colour/red
 
 /obj/item/clothing/glasses/godeye


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds prescription variants of existing cosmetic glasses, also corrects the name of the hipster glasses in game

TO ADD:
- Having the near sighted trait will automatically give you the prescription variant of any glasses you have equipped in the loadout
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More options for glasses for near sighted users is good 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://youtu.be/ZA151j1PQRM

</details>

## Changelog
:cl: Geatish
add: Added prescription variants of existing cosmetic glasses
add: Added crafting recipes for all the new prescription glasses
spellcheck: fixed hipster glasses being called prescription glasses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->