### PR TITLE
Added maze dimension to list of areas shelters cannot be deployed in

### DIFF
--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -10,7 +10,7 @@
 	. = ..()
 	blacklisted_turfs = typecacheof(/turf/closed)
 	whitelisted_turfs = list()
-	banned_areas = typecacheof(/area/shuttle)
+	banned_areas = typecacheof(list(/area/shuttle, /area/tear_in_reality))
 	banned_objects = list()
 
 /datum/map_template/shelter/proc/check_deploy(turf/deploy_location)
@@ -72,7 +72,7 @@
 /datum/map_template/shelter/charlie/New()
 	. = ..()
 	whitelisted_turfs = typecacheof(/turf/closed/mineral)
-	banned_objects = typecacheof(/obj/structure/stone_tile) 
+	banned_objects = typecacheof(/obj/structure/stone_tile)
 
 /datum/map_template/shelter/delta
 	name = "Shelter Delta"
@@ -100,13 +100,13 @@
 	description = "A small, spaceworthy shelter with most of the \
 	amenities of a standard bluespace shelter."
 	mappath = "_maps/templates/shelter_6.dmm"
-	
+
 /datum/map_template/shelter/golf
 	name = "Capsule Barricade"
 	shelter_id = "capsule_barricade"
 	description = "A 3x3 glass barricade, perfect for security and laserguns."
 	mappath = "_maps/templates/capsule_barricade.dmm"
-	
+
 /datum/map_template/shelter/foxtrot
 	name = "Security Checkpoint"
 	shelter_id = "capsule_checkpoint"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The change prevents shelters (mining survival capsules, shelters and luxury bars, security checkpoint/barrier) from being deployed at all in the maze dimension, as compared to only shuttles.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

This is good for the game because shelter deployment mechanism overrides restrictions (such as teleportation) in an area, and we don't want that for something that is CentCom z-level.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Proof that shelter doesn't work in binary maze

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/27755442/70c23503-8979-46e4-9b42-5a9f280e5560)

Proof that shelter still works where it's intended to

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/27755442/b18ff800-eed4-4c2e-aa45-7bfd980850c5)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/27755442/80c00a31-b274-4585-858e-33e0c61884bc)

</details>

## Changelog
:cl: Aramix
tweak: shelters cannot be deployed in maze dimension anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
