### PR TITLE
sensitive/apathetic only effect bad moodlets

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -90,9 +90,15 @@
 	shown_mood = 0
 	for(var/i in mood_events)
 		var/datum/mood_event/event = mood_events[i]
-		mood += event.mood_change
+		var/mob/living/owner = parent
+		var/mood_change = event.mood_change
+		if(owner.has_quirk(/datum/quirk/hypersensitive) && (mood_change<0))
+			mood_change*=1.5
+		if(owner.has_quirk(/datum/quirk/apathetic) && (mood_change<0))
+			mood_change*=0.5
+		mood += mood_change
 		if(!event.hidden)
-			shown_mood += event.mood_change
+			shown_mood += mood_change
 		mood *= mood_modifier
 		shown_mood *= mood_modifier
 

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -297,21 +297,11 @@
 
 /datum/quirk/hypersensitive
 	name = "Hypersensitive"
-	desc = "For better or worse, everything seems to affect your mood more than it should."
+	desc = "Bad things affect your mood more than they should."
 	icon = "flushed"
 	value = -1
 	gain_text = "<span class='danger'>You seem to make a big deal out of everything.</span>"
 	lose_text = "<span class='notice'>You don't seem to make a big deal out of everything anymore.</span>"
-
-/datum/quirk/hypersensitive/add()
-	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
-	if(mood)
-		mood.mood_modifier += 0.5
-
-/datum/quirk/hypersensitive/remove()
-	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
-	if(mood)
-		mood.mood_modifier -= 0.5
 
 /datum/quirk/light_drinker
 	name = "Light Drinker"

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -12,20 +12,10 @@
 
 /datum/quirk/apathetic
 	name = "Apathetic"
-	desc = "You just don't care as much as other people. That's nice to have in a place like this, I guess."
+	desc = "You are used to the awful things that happen here, bad events affect your mood less."
 	icon = "meh"
 	value = 1
 	mood_quirk = TRUE
-
-/datum/quirk/apathetic/add()
-	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
-	if(mood)
-		mood.mood_modifier -= 0.2
-
-/datum/quirk/apathetic/remove()
-	var/datum/component/mood/mood = quirk_target.GetComponent(/datum/component/mood)
-	if(mood)
-		mood.mood_modifier += 0.2
 
 /datum/quirk/drunkhealing
 	name = "Drunken Resilience"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
as title says, the hypersensitive and apathetic quirks will now only affect negative traits
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
hypersensitive is honestly just a positive trait, with how much easier it is get good moodlets compared to negative moodlets
and apathetic had the opposite issue, positive moodlets would just affect you less making it harder to manage mood
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I highlited the wrong variable, you should be looking at the variable `mood=-3`
you can tell it works because (-10/2) + 2 = -3, otherwise it would've been -7

https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/c89e50d5-38b0-401a-a715-acad47f4afa3




</details>

## Changelog
:cl:
tweak: Hypersensitive and Apathetic quirks now only affect negative moodlets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
