### PR TITLE
Fixes leather recipes; A stack of "Initialize"?

### DIFF
--- a/code/game/objects/items/stacks/sheets/organic/leather.dm
+++ b/code/game/objects/items/stacks/sheets/organic/leather.dm
@@ -8,7 +8,7 @@
 	item_state = "sheet-leather"
 	icon = 'icons/obj/stacks/organic.dmi'
 
-/obj/item/stack/sheet/leather/Initialize/get_recipes()
+/obj/item/stack/sheet/leather/get_recipes()
 	return GLOB.leather_recipes
 
 /obj/item/stack/sheet/leather/hairlesshide


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue caused in #10135 which ended up causing leather to have no recipes.
Instead the recipes were all on an accidentally created subtype who's name you can easily tell by the PR title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## ~~Why It's Good For The Game~~ Fixes are good for the game.
Plus I'm not sure we'll find a use for this newfound stack of "Initialize" leather anytime soon

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/e27cfdc6-5d82-4d55-829e-b7303d1d4085)

</details>

## Changelog
:cl:
fix: Crafting things with stacks leather is now possible again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
