### PR TITLE
Some poster fixes: hard delete boogaloo

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -160,7 +160,7 @@
 			to_chat(user, "<span class='notice'>You place the poster!</span>")
 			return
 
-	if(D.loc != src) //Would do QDELETED, but it's also possible the poster gets taken down by dismantling the wall
+	if(D.loc == src) //Would do QDELETED, but it's also possible the poster gets taken down by dismantling the wall
 		to_chat(user, "<span class='notice'>The poster falls down!</span>")
 		D.roll_and_drop(temp_loc)
 

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -160,7 +160,7 @@
 			to_chat(user, "<span class='notice'>You place the poster!</span>")
 			return
 
-	if(!QDELETED(D))
+	if(D.loc != src) //Would do QDELETED, but it's also possible the poster gets taken down by dismantling the wall
 		to_chat(user, "<span class='notice'>The poster falls down!</span>")
 		D.roll_and_drop(temp_loc)
 
@@ -171,6 +171,9 @@
 	icon_state = "poster_ripped"
 	name = "ripped poster"
 	desc = "You can't make out anything from the poster's original print. It's ruined."
+
+/obj/structure/sign/poster/ripped/roll_and_drop()
+	return null //We shouldn't be an item
 
 /obj/structure/sign/poster/random
 	name = "random poster" // could even be ripped

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -173,7 +173,7 @@
 	desc = "You can't make out anything from the poster's original print. It's ruined."
 
 /obj/structure/sign/poster/ripped/roll_and_drop()
-	return null //We shouldn't be an item
+	qdel(src) //We shouldn't be an item
 
 /obj/structure/sign/poster/random
 	name = "random poster" // could even be ripped

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -153,15 +153,16 @@
 	playsound(D.loc, 'sound/items/poster_being_created.ogg', 100, 1)
 
 	if(do_after(user, PLACE_SPEED, target=src))
-		if(!D || QDELETED(D))
+		if(QDELETED(D))
 			return
 
 		if(iswallturf(src) && user && user.loc == temp_loc)	//Let's check if everything is still there
 			to_chat(user, "<span class='notice'>You place the poster!</span>")
 			return
 
-	to_chat(user, "<span class='notice'>The poster falls down!</span>")
-	D.roll_and_drop(temp_loc)
+	if(!QDELETED(D))
+		to_chat(user, "<span class='notice'>The poster falls down!</span>")
+		D.roll_and_drop(temp_loc)
 
 // Various possible posters follow
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

(Thanks to Ragantis on the beecord for finding this)
When ripping a poster, it deletes the original. When walking away, it ends up moving it back inside of the poster item, and onto the floor.

Posters apparently didn't check for qdeletion when you cancel the placement; which normally does this forcemove action; thus resulting in the poster from moving back from nullspace into the game, though with invisibility; when you attempt to place the poster again you end up with an unclickable blockage that won't let you place another poster there. On top of that it hard deletes because of this.

Additional fixes:
- if a wall was dismantled while a ripped poster was still on it, it ends up dropping a "hypothetical poster". Let's be honest, it shouldn't exist.
- if a wall was dismantled while you were putting up a poster, it ends up creating two poster items sharing the same poster; or what I dub as a "Quantum Poster"

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Hard deletes cause lag, lag is bad, removing lag is good, good is this bugfix.

Also something that says "coders please fix" should probably be fixed.

"Quantum Poster"s also may not be intended either.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/e8ecee63-a3aa-42e6-b6a8-dd4515eb54a9

</details>

## Changelog
:cl:
fix: Posters no longer drop on the floor if you end up canceling placement after ripping it.
fix: Ripped posters can no longer drop from the wall.
fix: Walls being dismantled while a poster is being put up no longer creates two poster items sharing the same poster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
