### PR TITLE
Revolution 2.0: Now the gamemode works

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -324,6 +324,8 @@ GLOBAL_LIST_INIT(phonetic_alphabet, world.file2list("strings/phonetic_alphabet.t
 
 GLOBAL_LIST_INIT(numbers_as_words, world.file2list("strings/numbers_as_words.txt"))
 
+GLOBAL_LIST_INIT(revolution_convertion_text, world.file2list("strings/revolution_convertion.txt"))
+
 /proc/generate_number_strings()
 	var/list/L[198]
 	for(var/i in 1 to 99)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -699,7 +699,6 @@
 
 /datum/mind/proc/make_Rev()
 	var/datum/antagonist/rev/head/head = new()
-	head.give_flash = TRUE
 	head.give_hud = TRUE
 	add_antag_datum(head)
 	special_role = ROLE_REV_HEAD

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -122,7 +122,6 @@
 		M.mind.special_role = ROLE_REV_HEAD
 		revolution = new()
 		var/datum/antagonist/rev/head/new_head = new()
-		new_head.give_flash = TRUE
 		new_head.give_hud = TRUE
 		new_head.remove_clumsy = TRUE
 		new_head = M.mind.add_antag_datum(new_head, revolution)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -383,7 +383,7 @@
 	var/list/all_heads = SSjob.get_all_heads()
 	var/list/all_security = SSjob.get_all_sec()
 
-	if (all_heads.len < 4  || all_security.len < 3)
+	if (all_heads.len < 2  || all_security.len < 2 || all_heads.len + all_security.len < 5)
 		log_game("DYNAMIC: [ruletype] [name] failed to get enough heads or security. Refunding [cost] threat.")
 		return DYNAMIC_EXECUTE_FAILURE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -359,7 +359,7 @@
 	antag_cap = 3
 	flags = HIGH_IMPACT_RULESET | NO_OTHER_ROUNDSTARTS_RULESET | PERSISTENT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/latejoin/provocateur)
-	// I give up, just there should be enough heads with 35 players...
+
 	minimum_players = 35
 	/// How much threat should be injected when the revolution wins?
 	var/revs_win_threat_injection = 20
@@ -380,6 +380,13 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/revs/execute(forced = FALSE)
+	var/list/all_heads = SSjob.get_all_heads()
+	var/list/all_security = SSjob.get_all_sec()
+
+	if (all_heads.len < 4  || all_security.len < 3)
+		log_game("DYNAMIC: [ruletype] [name] failed to get enough heads or security. Refunding [cost] threat.")
+		return DYNAMIC_EXECUTE_FAILURE
+
 	revolution = new()
 	for(var/datum/mind/M in assigned)
 		if(check_eligible(M))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -384,7 +384,6 @@
 	for(var/datum/mind/M in assigned)
 		if(check_eligible(M))
 			var/datum/antagonist/rev/head/new_head = new antag_datum()
-			new_head.give_flash = TRUE
 			new_head.give_hud = TRUE
 			new_head.remove_clumsy = TRUE
 			M.add_antag_datum(new_head,revolution)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -104,7 +104,6 @@
 	for(var/datum/mind/rev_mind in headrev_candidates)
 		log_game("[key_name(rev_mind)] has been selected as a head rev")
 		var/datum/antagonist/rev/head/new_head = new()
-		new_head.give_flash = TRUE
 		new_head.give_hud = TRUE
 		new_head.remove_clumsy = TRUE
 		rev_mind.add_antag_datum(new_head,revolution)
@@ -113,7 +112,6 @@
 	revolution.update_objectives()
 	revolution.update_heads()
 
-	SSshuttle.registerHostileEnvironment(src)
 	..()
 
 
@@ -138,8 +136,6 @@
 ///////////////////////////////
 /datum/game_mode/revolution/check_finished()
 	if(CONFIG_GET(keyed_list/continuous)["revolution"])
-		if(finished)
-			SSshuttle.clearHostileEnvironment(src)
 		return ..()
 	if(finished && end_when_heads_dead)
 		return TRUE

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -441,7 +441,7 @@
 		priority_announce("A recent assessment of your station has marked your station as a severe risk area for high ranking Nanotrasen officials. \
 		For the safety of our staff, we have blacklisted your station for new employment of security and command. \
 		[pick(world.file2list("strings/anti_union_propaganda.txt"))]", null, SSstation.announcer.get_rand_report_sound(), null, "Central Command Loyalty Monitoring Division")
-		if(get_security_level != SEC_LEVEL_RED)
+		if(get_security_level() != SEC_LEVEL_RED)
 			set_security_level(SEC_LEVEL_RED)
 		addtimer(CALLBACK(SSshuttle.emergency, TYPE_PROC_REF(/obj/docking_port/mobile/emergency, request), null, 1), 50)
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -55,6 +55,7 @@
 		"Eliminate the heads of staff. Viva la revolution!")
 
 /datum/antagonist/rev/create_team(datum/team/revolution/new_team)
+	SSshuttle.registerRevolutionEnvironment(src)
 	if(!new_team)
 		//For now only one revolution at a time
 		for(var/datum/antagonist/rev/head/H in GLOB.antagonists)
@@ -153,6 +154,9 @@
 		to_chat(user, "<span class='warning'>You can't convert that person!</span>")
 		return
 	for(var/mob/living/carbon/target in targets)
+		if(target.time_of_last_attack_recieved + 30 > world.time)
+			to_chat(user, "<span class='warning'>You will not convice someone who was attacked so recently!</span>")
+			return
 		for(var/i in 1 to 3)
 			user.say(pick(GLOB.revolution_convertion_text), forced = "revolution convertion")
 			target.Stun(30)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -153,7 +153,7 @@
 		to_chat(user, "<span class='warning'>You can't convert that person!</span>")
 		return
 	for(var/mob/living/carbon/target in targets)
-		for(var/i = 1 to 3)
+		for(var/i in 1 to 3)
 			user.say("I hereby convert you to the revolution!", forced = "revolution convertion")
 			target.Stun(30)
 			var/beam = target.Beam(user, "sendbeam", time = 30)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -154,12 +154,16 @@
 		to_chat(user, "<span class='warning'>You can't convert that person!</span>")
 		return
 	for(var/mob/living/carbon/target in targets)
+		if(!(target in oview(range)))
+			to_chat(user, "<span class='warning'>Your target is too far away!</span>")
+			return
 		if(target.time_of_last_attack_recieved + 30 > world.time)
 			to_chat(user, "<span class='warning'>You will not convice someone who was attacked so recently!</span>")
 			return
 		for(var/i in 1 to 3)
 			user.say(pick(GLOB.revolution_convertion_text), forced = "revolution convertion")
 			target.Stun(30)
+			target.silent = 4
 			var/beam = target.Beam(user, "sendbeam", time = 30)
 			if(!do_after(user, 30, target))
 				qdel(beam)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -154,12 +154,12 @@
 		return
 	for(var/mob/living/carbon/target in targets)
 		for(var/i = 1 to 3)
-			user.say("I hereby convert you to the revolution!", forced = "revolution convertion")
+			user.say(pick(GLOB.revolution_convertion_text), forced = "revolution convertion")
 			target.Stun(30)
 			var/beam = target.Beam(user, "sendbeam", time = 30)
 			if(!do_after(user, 30, target))
 				qdel(beam)
-				to_chat(user, "<span class='warning'>You stopped explaining Space-Communism. Conversion failed!</span>")
+				to_chat(user, "<span class='warning'>You stopped explaining Revolution Theory to your target. Conversion failed!</span>")
 				return
 		rev_datum.add_revolutionary(target.mind)
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -153,10 +153,8 @@
 		to_chat(user, "<span class='warning'>You can't convert that person!</span>")
 		return
 	for(var/mob/living/carbon/target in targets)
-		for(var/i = 1 to 3)
-			user.say(pick(GLOB.revolution_convertion_text), forced = "revolution convertion")
 		for(var/i in 1 to 3)
-			user.say("I hereby convert you to the revolution!", forced = "revolution convertion")
+			user.say(pick(GLOB.revolution_convertion_text), forced = "revolution convertion")
 			target.Stun(30)
 			var/beam = target.Beam(user, "sendbeam", time = 30)
 			if(!do_after(user, 30, target))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -247,7 +247,6 @@
 		//No flash protection, blind and stun
 		if(M.flash_act(1))
 			if(user)
-				terrible_conversion_proc(M, user)
 				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
 				to_chat(user, "<span class='danger'>You blind [M] with the flash!</span>")
 				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
@@ -325,22 +324,6 @@
 	if(!..())
 		return
 	AOE_flash()
-
-/obj/item/assembly/flash/proc/terrible_conversion_proc(mob/living/carbon/H, mob/user)
-	if(istype(H) && H.stat != DEAD)
-		if(user.mind)
-			var/datum/antagonist/rev/head/converter = user.mind.has_antag_datum(/datum/antagonist/rev/head)
-			if(!converter)
-				return
-			if(!H.client)
-				to_chat(user, "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>")
-				return
-			if(H.stat != CONSCIOUS)
-				to_chat(user, "<span class='warning'>They must be conscious before you can convert [H.p_them()]!</span>")
-				return
-			if(!converter.add_revolutionary(H.mind))
-				to_chat(user, "<span class='warning'>This mind seems resistant to the flash!</span>")
-
 
 /obj/item/assembly/flash/cyborg
 	bulb = /obj/item/flashbulb/recharging/cyborg

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -200,6 +200,15 @@
 	device_theme = THEME_SYNDICATE
 	theme_locked = TRUE
 
+/obj/item/modular_computer/revolutionary
+	icon_state = "tablet-syndicate"
+	icon_state_powered = "tablet-syndicate"
+	icon_state_unpowered = "tablet-syndicate"
+	comp_light_luminosity = 6.3
+	device_theme = THEME_SYNDICATE
+	theme_locked = TRUE
+	light_color = COLOR_RED
+
 /// Given to Nuke Ops members.
 /obj/item/modular_computer/tablet/nukeops
 	icon_state = "tablet-syndicate"

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -85,6 +85,14 @@
 	install_component(new /obj/item/computer_hardware/hard_drive/small/nukeops)
 	install_component(new /obj/item/computer_hardware/network_card)
 
+/// Given to Head Revolutionaries.a
+/obj/item/modular_computer/tablet/revolutionary/Initialize(mapload)
+	. = ..()
+	install_component(new /obj/item/computer_hardware/processor_unit/small)
+	install_component(new /obj/item/computer_hardware/battery(src, /obj/item/stock_parts/cell/computer))
+	install_component(new /obj/item/computer_hardware/hard_drive/small/revolutionary)
+	install_component(new /obj/item/computer_hardware/network_card)
+
 //Borg Built-in tablet
 /obj/item/modular_computer/tablet/integrated/Initialize()
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -401,8 +401,6 @@
 	objects = list()
 	for(var/datum/mind/M in SSjob.get_all_heads())
 		var/mob/living/head = M.current
-		if(!trackable(head))
-			continue
 		var/list/crewinfo = list(
 			ref = REF(head),
 			name = "[++count]. [M.assigned_role]",

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -368,3 +368,43 @@
 		name = "Nuke Auth. Disk",
 		)
 	objects += list(nukeinfo)
+
+
+////////////////////////////
+//Head of Staff finder app//
+////////////////////////////
+
+///A program that tracks Heads of Staff
+
+/datum/computer_file/program/radar/headlocator360
+	filename = "headlocator360"
+	filedesc = "headlocator360"
+	category = PROGRAM_CATEGORY_MISC
+	program_icon_state = "radarsyndicate"
+	extended_desc = "This program allows for tracking of Heads of Staff."
+	requires_ntnet = FALSE
+	available_on_ntnet = FALSE
+	tgui_id = "NtosRadarSyndicate"
+	program_icon = "bomb"
+	arrowstyle = "ntosradarpointerS.png"
+	pointercolor = "red"
+	tracks_grand_z = TRUE
+
+/datum/computer_file/program/radar/headlocator360/find_atom()
+	return locate(selected) in GLOB.player_list
+
+/datum/computer_file/program/radar/headlocator360/scan()
+	var/count = 0
+	if(!COOLDOWN_FINISHED(src, last_scan))
+		return
+	COOLDOWN_START(src, last_scan, SCAN_COOLDOWN)
+	objects = list()
+	for(var/datum/mind/M in SSjob.get_all_heads())
+		var/mob/living/head = M.current
+		if(!trackable(head))
+			continue
+		var/list/crewinfo = list(
+			ref = REF(head),
+			name = "[++count]. [M.assigned_role]",
+			)
+		objects += list(crewinfo)

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -235,3 +235,12 @@
 	max_capacity = 32
 	icon_state = "ssd_micro"
 	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/computer_hardware/hard_drive/small/revolutionary
+	power_usage = 8
+	max_capacity = 70
+
+/obj/item/computer_hardware/hard_drive/small/revolutionary/install_default_programs()
+	store_file(new /datum/computer_file/program/computerconfig(src))
+	store_file(new /datum/computer_file/program/filemanager(src))
+	store_file(new /datum/computer_file/program/radar/headlocator360(src)) //I am legitimately afraid if I don't do this, Ops players will think they just don't get a pinpointer anymore.

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -350,10 +350,15 @@
 
 	if(SSshuttle.checkInfestedEnvironment()) //If an Alien Queen exists, set a delayed alert
 		infestation_alert_timer = addtimer(CALLBACK(src, PROC_REF(infested_shuttle)), rand(150 SECONDS, call_time), TIMER_STOPPABLE) //Delay timer is random from 2:30 to the full duration of the shuttle call
+	if(SSshuttle.checkRevolutionEnvironment()) //If a revolution is happening, set a delayed alert
+		infestation_alert_timer = addtimer(CALLBACK(src, PROC_REF(revolution_shuttle)), rand(150 SECONDS, call_time), TIMER_STOPPABLE) //Delay timer is random from 2:30 to the full duration of the shuttle call
 
 /obj/docking_port/mobile/emergency/proc/infested_shuttle()
 	if(SSshuttle.checkInfestedEnvironment()) //Check again to ensure the queen is still present
 		SSshuttle.delayForInfestedStation() //And delay the shuttle if they are
+
+/obj/docking_port/mobile/emergency/proc/revolution_shuttle()
+	SSshuttle.delayForRevolutionaryStation() // If we have Revolution delay the Shuttle Call
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -18,15 +18,8 @@
 				"Captain"
 			],
 			"restricted_roles": ["Cyborg"]
-		},
-		"Revolution": {
-			"cost": 110
 		}
 	},
 	"Midround": {},
-	"Latejoin": {
-		"Provocateur": {
-			"cost": 110
-		}
-	}
+	"Latejoin": {}
 }

--- a/strings/revolution_convertion.txt
+++ b/strings/revolution_convertion.txt
@@ -1,0 +1,10 @@
+The time is now to stand up against Nanotrasen's oppression and fight for our freedom.
+Only through unity and strength can we overthrow the chains of tyranny imposed by Nanotrasen.
+Every voice against Nanotrasen matters in the struggle for justice; let yours be heard.
+We must seize control of our future from Nanotrasen and be the architects of our own destiny.
+The courage to dream is the spark that ignites the flame of revolution against Nanotrasen.
+In the face of Nanotrasen's injustice, silence is complicity; speak out and resist.
+Our cause against Nanotrasen is just, our will is strong, and our numbers are growing every day.
+By standing together, we can dismantle Nanotrasen's systems of power that oppress us.
+Join our noble fight for liberty against Nanotrasen and be part of something greater.
+Real change comes from the bottom up; your involvement is crucial in the fight against Nanotrasen.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Remasters Revolution.

now headrevs don't convert instantly with a Flash, they have a special ability to convert Crew into revolutionaries (Stunning someone and staying with them X seconds)

The headrevs also have a tablet with a program to locate the Heads of Staff (No more heads hiding in closets).

The revolution no longer prevents to call the Shuttle, but it will have a delay if it is called. 

If the revolution is successful and all the heads are eliminated the shuttle will be called automatically in order to send the revolutionaries to a re-education program in Central Command.

If the revolution fails, Dynamic will continue to do its thing (as it happens in Cult, Nukeops, Blob...).

### Tasks for a TM:

- [X] Create convert ability
- [X] Create tablet and tablet program to locate heads
- [X] Modify shuttle behavior with Revolution



## Why It's Good For The Game

These changes modernize Revolution's gameplay, fixing many of the problems it had:

- Heads of staff can no longer hide, extending the round uselessly.
- RevHeads cannot hide for a long time either because calling the shuttle is possible.
- The conversion is no longer a simple click and becomes a process that requires either collaboration of several revolutionaries or isolated targets.

I believe that with these changes Revolution can be put back into rotation.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
New Ability:

https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/af80e7b5-ae29-4483-a68b-5041955b5ecb



</details>

## Changelog
:cl:
add: Head Revolutionaries now start with a computer that can be used to track the Heads of Staff
tweak: Head Revolutionaries now have an ability to convert other crew into Revolutionaries instead of the flash
tweak: Heads of staff can call the shuttle if there is a revolution in the station, but a delay will be added to the ETA.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
