### PR TITLE
 [PORT] Allows admins to skip some paper sanitization 

### DIFF
--- a/code/modules/admin/admin_fax_panel.dm
+++ b/code/modules/admin/admin_fax_panel.dm
@@ -124,7 +124,7 @@
 					break
 
 			fax_paper.name = "paper — [default_paper_name]"
-			fax_paper.add_raw_text(params["rawText"])
+			fax_paper.add_raw_text(params["rawText"], advanced_html = TRUE)
 
 			if(stamp)
 				fax_paper.add_stamp(stamp_class, params["stampX"], params["stampY"], params["stampAngle"], stamp)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -160,14 +160,16 @@
  * * text - The text to append to the paper.
  * * font - The font to use.
  * * color - The font color to use.
- * * bold - Whether this text should be rendered completely bold.
+ * * bold - Whether this text should be rendered completely bold
+ * * advanced_html - Boolean that is true when the writer has R_FUN permission, which sanitizes less HTML (such as images) from the new paper_input.
  */
-/obj/item/paper/proc/add_raw_text(text, font, color, bold)
+/obj/item/paper/proc/add_raw_text(text, font, color, bold, advanced_html)
 	var/new_input_datum = new /datum/paper_input(
 		text,
 		font,
 		color,
 		bold,
+		advanced_html,
 	)
 
 	input_field_count += get_input_field_count(text)
@@ -567,7 +569,7 @@
 			// Safe to assume there are writing implement details as user.can_write(...) fails with an invalid writing implement.
 			var/writing_implement_data = holding.get_writing_implement_details()
 
-			add_raw_text(paper_input, writing_implement_data["font"], writing_implement_data["color"], writing_implement_data["use_bold"])
+			add_raw_text(paper_input, writing_implement_data["font"], writing_implement_data["color"], writing_implement_data["use_bold"], check_rights_for(user?.client, R_FUN))
 
 			log_paper("[key_name(user)] wrote to [name]: \"[paper_input]\"")
 			to_chat(user, "You have added to your paper masterpiece!");
@@ -651,15 +653,18 @@
 	var/colour = ""
 	/// Whether to render the font bold or not.
 	var/bold = FALSE
+	/// Whether the creator has R_FUN permission, which allows for less sanitised HTML.
+	var/advanced_html = FALSE
 
-/datum/paper_input/New(_raw_text, _font, _colour, _bold)
+/datum/paper_input/New(_raw_text, _font, _colour, _bold, _advanced_html)
 	raw_text = _raw_text
 	font = _font
 	colour = _colour
 	bold = _bold
+	advanced_html = _advanced_html
 
 /datum/paper_input/proc/make_copy()
-	return new /datum/paper_input(raw_text, font, colour, bold);
+	return new /datum/paper_input(raw_text, font, colour, bold, advanced_html);
 
 /datum/paper_input/proc/to_list()
 	return list(
@@ -667,6 +672,7 @@
 		font = font,
 		color = colour,
 		bold = bold,
+		advanced_html = advanced_html,
 	)
 
 /// A single instance of a saved stamp on paper.

--- a/tgui/packages/tgui/interfaces/AntagInfoBrainwashed.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBrainwashed.tsx
@@ -62,7 +62,7 @@ const ObjectivePrintout = (_props, context) => {
                 <span
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{
-                    __html: sanitizeText(objective.explanation), // brainwashing objectives are sanitized anyways
+                    __html: sanitizeText(objective.explanation, false), // brainwashing objectives are sanitized anyways
                   }}
                 />
               </Stack.Item>

--- a/tgui/packages/tgui/interfaces/AntagInfoHoloparasite.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoHoloparasite.tsx
@@ -184,7 +184,7 @@ const ObjectiveInfo = (_props, context) => {
             <span
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{
-                __html: sanitizeText(objective.explanation),
+                __html: sanitizeText(objective.explanation, false),
               }}
             />
           </Stack.Item>

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -29,6 +29,7 @@ type PaperContext = {
   default_pen_font: string;
   default_pen_color: string;
   signature_font: string;
+  sanitize_test: boolean;
 
   // ui_data
   held_item_details?: WritingImplement;
@@ -39,6 +40,7 @@ type PaperInput = {
   font?: string;
   color?: string;
   bold?: boolean;
+  advanced_html?: boolean;
 };
 
 type StampInput = {
@@ -554,6 +556,7 @@ export class PreviewView extends Component<PreviewViewProps> {
       const fontColor = value.color || default_pen_color;
       const fontFace = value.font || default_pen_font;
       const fontBold = value.bold || false;
+      const advancedHtml = value.advanced_html || false;
 
       let processingOutput = this.formatAndProcessRawText(
         rawText,
@@ -562,7 +565,8 @@ export class PreviewView extends Component<PreviewViewProps> {
         paper_color,
         fontBold,
         fieldCount,
-        readOnly
+        readOnly,
+        advancedHtml
       );
 
       output += processingOutput.text;
@@ -679,16 +683,18 @@ export class PreviewView extends Component<PreviewViewProps> {
     paperColor: string,
     bold: boolean,
     fieldCounter: number = 0,
-    forceReadonlyFields: boolean = false
+    forceReadonlyFields: boolean = false,
+    advanced_html: boolean = false
   ): FieldCreationReturn => {
     // First lets make sure it ends in a new line
+    const { data } = useBackend<PaperContext>(this.context);
     rawText += rawText[rawText.length] === '\n' ? '\n' : '\n\n';
 
     // Second, parse the text using markup
     const parsedText = this.runMarkedDefault(rawText);
 
     // Third, we sanitize the text of html
-    const sanitizedText = sanitizeText(parsedText);
+    const sanitizedText = sanitizeText(parsedText, advanced_html);
 
     // Fourth we replace the [__] with fields
     const fieldedText = this.createFields(sanitizedText, font, 12, color, paperColor, forceReadonlyFields, fieldCounter);

--- a/tgui/packages/tgui/interfaces/common/ObjectiveSection.tsx
+++ b/tgui/packages/tgui/interfaces/common/ObjectiveSection.tsx
@@ -27,7 +27,7 @@ export const ObjectivesSection = (props: Props, _context) => {
                 <span
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{
-                    __html: sanitizeText(objective.explanation),
+                    __html: sanitizeText(objective.explanation, false),
                   }}
                 />
               </Stack.Item>

--- a/tgui/packages/tgui/sanitize.js
+++ b/tgui/packages/tgui/sanitize.js
@@ -45,21 +45,30 @@ const defTag = [
   'ul',
 ];
 
+// Advanced HTML tags we can trust admins (but no players) with
+
+const advTag = ['img'];
+
 let defAttr = ['class', 'style'];
 
 /**
  * Feed it a string and it should spit out a sanitized version.
  *
  * @param {string} input
+ * @param {boolean} advHtml
  * @param {array} tags
  * @param {array} forbidAttr
+ * @param {array} advTags
  */
-export const sanitizeText = (input, tags = defTag, forbidAttr = defAttr) => {
+export const sanitizeText = (input, advHtml, tags = defTag, forbidAttr = defAttr, advTags = advTag) => {
   // This is VERY important to think first if you NEED
   // the tag you put in here.  We are pushing all this
   // though dangerouslySetInnerHTML and even though
   // the default DOMPurify kills javascript, it dosn't
   // kill href links or such
+  if (advHtml) {
+    tags = tags.concat(advTags);
+  }
   return DOMPurify.sanitize(input, {
     ALLOWED_TAGS: tags,
     FORBID_ATTR: forbidAttr,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/72553
Allowing admins with the R_FUN perm to create less sanitized papers (currently they only have access to the img tag)

## Why It's Good For The Game
Now admins can create fancy texts to send in faxes, creating cool bus opportunities!
For example:

![211176186-c33d611d-8ac3-4683-bef8-10016e34eaf4](https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/0bbe3b2a-d284-4c12-82e1-7b25705b738a)


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/269388f8-bd55-496d-8155-81223fb156d8)

</details>

## Changelog
:cl: Zonespace27, Miliviu
admins: Admins with the appropriate permissions can now use HTML image tags in paper and faxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
