### PR TITLE
Cryogenic freezer no longer accepts mobs that were never controlled by a player

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -355,12 +355,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		return
 
 	if(!target.mind)
-		if(iscarbon(target))
-			var/mob/living/carbon/targetCarbon = target
-			if(!targetCarbon.last_mind)
-				to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
-				return
-		else
 			to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
 			return
 	if(occupant)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -354,6 +354,9 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	if(!istype(target) || user.incapacitated() || !target.Adjacent(user) || !Adjacent(user) || !ismob(target) || (!ishuman(user) && !iscyborg(user)) || !istype(user.loc, /turf) || target.buckled)
 		return
 
+	if(!target.key)
+		to_chat(user, "<span class='notice'>[target] is not a player controled mob.</span>")
+		return
 	if(occupant)
 		to_chat(user, "<span class='boldnotice'>The cryo pod is already occupied!</span>")
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -355,8 +355,8 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		return
 
 	if(!target.mind)
-			to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
-			return
+		to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
+		return
 	if(occupant)
 		to_chat(user, "<span class='boldnotice'>The cryo pod is already occupied!</span>")
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -354,9 +354,15 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	if(!istype(target) || user.incapacitated() || !target.Adjacent(user) || !Adjacent(user) || !ismob(target) || (!ishuman(user) && !iscyborg(user)) || !istype(user.loc, /turf) || target.buckled)
 		return
 
-	if(!target.key)
-		to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
-		return
+	if(!target.mind)
+		if(iscarbon(target))
+			var/mob/living/carbon/targetCarbon = target
+			if(!targetCarbon.last_mind)
+				to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
+				return
+		else
+			to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
+			return
 	if(occupant)
 		to_chat(user, "<span class='boldnotice'>The cryo pod is already occupied!</span>")
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -355,7 +355,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		return
 
 	if(!target.key)
-		to_chat(user, "<span class='notice'>[target] is not a player controled mob.</span>")
+		to_chat(user, "<span class='notice'>[target] is not a player controlled mob.</span>")
 		return
 	if(occupant)
 		to_chat(user, "<span class='boldnotice'>The cryo pod is already occupied!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #10824

Now you can't put a mob without a key inside a cryo-chamber

## Why It's Good For The Game

Stop players from getting the Cryo-chambers full of mobs...

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/62a691d4-90f1-4219-8c94-06852dc5f399



</details>

## Changelog
:cl: Miliviu
tweak: cryogenic freezer no longer accepts mobs that were never controlled by a player
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
