### PR TITLE
Fixes "Random Arcades" being a useless machine that doesn't do anything in all Station Maps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -58439,7 +58439,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "uBy" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -34139,7 +34139,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "kVR" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/west{
@@ -68320,7 +68320,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "vXY" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -36559,7 +36559,7 @@
 /turf/open/floor/iron,
 /area/engine/storage_shared)
 "eNB" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/prison,

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -5972,7 +5972,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 1
 	},
 /obj/structure/railing,

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -55672,7 +55672,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -66549,7 +66549,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal{
 	dir = 1
 	},
@@ -72211,7 +72211,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "suV" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
@@ -75171,7 +75171,7 @@
 /turf/open/floor/iron/sepia,
 /area/engine/engineering)
 "thX" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -77646,7 +77646,7 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "tPH" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -51709,7 +51709,7 @@
 /turf/open/floor/iron/dark,
 /area/security/main)
 "kAD" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1;
@@ -74737,7 +74737,7 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/hor)
 "stT" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -44196,7 +44196,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "kZa" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -44478,7 +44478,7 @@
 /turf/open/floor/iron,
 /area/storage/tools)
 "lge" = (
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/randomarcade,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -44569,7 +44569,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "nQr" = (
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -68011,7 +68011,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/machinery/computer/arcade{
+/obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/carpet,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes "Random Arcades" being a useless machine that doesn't do anything in all Station Maps
fixes #10805

## Why It's Good For The Game

It's quite obvious...

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/cd52fc83-5981-43d1-a8d6-2e67b75f74a2)

</details>

## Changelog
:cl:
fix: Multiple Random Arcades now work and spawn a random arcade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
