### PR TITLE
Fixes lockers not glowing

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -121,6 +121,7 @@
 
 	//Overlay is similar enough for both that we can use the same mask for both
 	. += emissive_appearance(icon, icon_locked, src.layer)
+	ADD_LUM_SOURCE(src, LUM_SOURCE_MANAGED_OVERLAY)
 	. += locked ? icon_locked : icon_unlocked
 
 /obj/structure/closet/update_appearance(updates=ALL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lockers now glow in the dark again.
closes #10777 

## Why It's Good For The Game

Lockers should glow!

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/9f623ed5-ee3c-49e1-99b3-56a0a73a7ee5)

</details>

## Changelog
:cl: Ratón
fix: lockers now glow in the dark
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
