### PR TITLE
Removes the only sleep on deconstruct()

### DIFF
--- a/code/modules/antagonists/clock_cult/clockwork_massive.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_massive.dm
@@ -69,24 +69,30 @@ GLOBAL_LIST_INIT(clockwork_portals, list())
 		to_chat(world, pick(phase_messages))
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/deconstruct(disassembled = TRUE)
-	if(!(flags_1 & NODECONSTRUCT_1))
-		if(!disassembled)
-			resistance_flags |= INDESTRUCTIBLE
-			visible_message("<span class='userdanger'>[src] begins to pulse uncontrollably... you might want to run!</span>")
-			sound_to_playing_players(volume = 50, channel = CHANNEL_JUSTICAR_ARK, S = sound('sound/effects/clockcult_gateway_disrupted.ogg'))
-			for(var/mob/M in GLOB.player_list)
-				var/turf/T = get_turf(M)
-				if((T && T.get_virtual_z_level() == get_virtual_z_level()) || is_servant_of_ratvar(M))
-					M.playsound_local(M, 'sound/machines/clockcult/ark_deathrattle.ogg', 100, FALSE, pressure_affected = FALSE)
-			sleep(27)
-			explosion(src, 1, 3, 8, 8)
-			sound_to_playing_players('sound/effects/explosion_distant.ogg', volume = 50)
-			for(var/obj/effect/portal/wormhole/clockcult/CC in GLOB.all_wormholes)
-				qdel(CC)
-			SSshuttle.clearHostileEnvironment(src)
-			set_security_level(SEC_LEVEL_RED)
-			sleep(300)
-			SSticker.force_ending = TRUE
+	if((flags_1 & NODECONSTRUCT_1))
+		return
+	if(disassembled)
+		return
+	resistance_flags |= INDESTRUCTIBLE
+	visible_message("<span class='userdanger'>[src] begins to pulse uncontrollably... you might want to run!</span>")
+	sound_to_playing_players(volume = 50, channel = CHANNEL_JUSTICAR_ARK, S = sound('sound/effects/clockcult_gateway_disrupted.ogg'))
+	for(var/mob/M in GLOB.player_list)
+		var/turf/T = get_turf(M)
+		if((T && T.get_virtual_z_level() == get_virtual_z_level()) || is_servant_of_ratvar(M))
+			M.playsound_local(M, 'sound/machines/clockcult/ark_deathrattle.ogg', 100, FALSE, pressure_affected = FALSE)
+	addtimer(CALLBACK(src, PROC_REF(last_call)), 27)
+
+/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/last_call()
+	explosion(src, 1, 3, 8, 8)
+	sound_to_playing_players('sound/effects/explosion_distant.ogg', volume = 50)
+	for(var/obj/effect/portal/wormhole/clockcult/CC in GLOB.all_wormholes)
+		qdel(CC)
+	SSshuttle.clearHostileEnvironment(src)
+	set_security_level(SEC_LEVEL_RED)
+	addtimer(CALLBACK(src, PROC_REF(clockies_win)), 300)
+
+/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/clockies_win()
+	SSticker.force_ending = TRUE
 	qdel(src)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clockwork ark had some shitcode lying around that prevented using signals on deconstruct()

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can use signals with deconstruct()

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: rkz, Dakae
code: removed sleeper in deconstruct()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
