### PR TITLE
Fixes heretics making walking husks if they sacrifice a husk

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -766,7 +766,7 @@
 			else
 				set_stat(CONSCIOUS)
 			if(!is_blind())
-				var/datum/component/blind_sense/B = GetComponent(/datum/component/blind_sense)	
+				var/datum/component/blind_sense/B = GetComponent(/datum/component/blind_sense)
 				B?.RemoveComponent()
 		update_mobility()
 	update_damage_hud()
@@ -801,6 +801,9 @@
 	if(!getorganslot(ORGAN_SLOT_LIVER))
 		return FALSE
 
+	// We don't want walking husks god no
+	if(HAS_TRAIT(TRAIT_HUSK))
+		cure_husk()
 	return ..()
 
 /mob/living/carbon/fully_heal(admin_revive = FALSE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -802,8 +802,8 @@
 		return FALSE
 
 	// We don't want walking husks god no
-	if(HAS_TRAIT(TRAIT_HUSK))
-		cure_husk()
+	if(HAS_TRAIT(src, TRAIT_HUSK))
+		src.cure_husk()
 	return ..()
 
 /mob/living/carbon/fully_heal(admin_revive = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. Modified the underlying "healing" proc to heal husks given it otherwise creates walking husks!
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/10788

## Why It's Good For The Game

Man-made horrors should be relegated to intended behaviour

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/c1c82bbd-cfae-41d6-98b5-fcc6b5ebdba7



</details>

## Changelog
:cl: Ratón
fix: Heretics can no longer create walking husks by sacrificing a husked target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
