### PR TITLE
Fixes 'view tags' being in Admin.Game category

### DIFF
--- a/code/modules/admin/tag.dm
+++ b/code/modules/admin/tag.dm
@@ -52,7 +52,7 @@
 
 /// Display all of the tagged datums
 /datum/admins/proc/display_tags()
-	set category = "Admin.Game"
+	set category = "Admin"
 	set name = "View Tags"
 
 	if (!istype(src, /datum/admins))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes 'view tags' being in Admin.Game category
* caused by https://github.com/BeeStation/BeeStation-Hornet/pull/10758

This is caused because we don't have subcategory verb system.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

It's just simple text edit

## Changelog
:cl:
fix: view tags verb is now in Admin category instead of Admin.Game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
