### PR TITLE
New system - Preload Injection (that supports {} values), helpful for dmm

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -268,7 +268,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("neutral","Syndicate")
+	preload_datum = /datum/preload_injection/faction/add_syndicate
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
@@ -1606,7 +1606,7 @@
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("neutral","Syndicate")
+	preload_datum = /datum/preload_injection/faction/add_syndicate
 	},
 /turf/open/floor/iron/white/side{
 	dir = 9
@@ -1623,7 +1623,7 @@
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "hr" = (
 /mob/living/carbon/monkey{
-	faction = list("neutral","Syndicate")
+	preload_datum = /datum/preload_injection/faction/add_syndicate
 	},
 /turf/open/floor/iron/white/side{
 	dir = 5
@@ -1712,7 +1712,7 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "hE" = (
 /mob/living/carbon/monkey{
-	faction = list("neutral","Syndicate")
+	preload_datum = /datum/preload_injection/faction/add_syndicate
 	},
 /turf/open/floor/iron/white/side{
 	dir = 10
@@ -1729,7 +1729,7 @@
 "hG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("neutral","Syndicate")
+	preload_datum = /datum/preload_injection/faction/add_syndicate
 	},
 /turf/open/floor/iron/white/side{
 	dir = 6
@@ -5221,7 +5221,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/monkey{
-	faction = list("neutral","Syndicate")
+	preload_datum = /datum/preload_injection/faction/add_syndicate
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,

--- a/beestation.dme
+++ b/beestation.dme
@@ -530,6 +530,7 @@
 #include "code\datums\numbered_display.dm"
 #include "code\datums\outfit.dm"
 #include "code\datums\position_point_vector.dm"
+#include "code\datums\preload_injection.dm"
 #include "code\datums\profiling.dm"
 #include "code\datums\progressbar.dm"
 #include "code\datums\radiation_wave.dm"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -78,10 +78,10 @@
 /// Define for the heretic faction applied to heretics and heretic mobs.
 #define FACTION_HERETIC "heretics"
 
-#define FACTION_SYNDICATE "Syndicate"
-#define FACTION_BLOB "Blob"
-#define FACTION_ALIEN "Xenomorph"
-#define FACTION_WIZARD "Wizard"
+#define FACTION_SYNDICATE "syndicate" // should be lowercase because of dmm preload. We'll capitalise it someday
+#define FACTION_BLOB "blob"
+#define FACTION_ALIEN "xenomorph"
+#define FACTION_WIZARD "wizard"
 
 // Heretic path defines.
 #define HERETIC_PATH_START "Heretic Start Path"

--- a/code/datums/preload_injection.dm
+++ b/code/datums/preload_injection.dm
@@ -10,7 +10,7 @@ GLOBAL_DATUM_INIT(preload_handler, /datum/preload_injection/master, new)
 	var/static/list/cached_injectors = list()
 
 /datum/preload_injection/master/apply(atom/target, actual_injector = null)
-	var/datum/preload_injection/real_injector = actual_injector || target.preload_data
+	var/datum/preload_injection/real_injector = actual_injector || target.preload_datum
 	if(cached_injectors[real_injector])
 		real_injector = cached_injectors[real_injector]
 	else

--- a/code/datums/preload_injection.dm
+++ b/code/datums/preload_injection.dm
@@ -1,0 +1,43 @@
+/datum/preload_injection // basetype
+/datum/preload_injection/proc/apply(atom/target)
+	CRASH("preload_injection called parent apply(), but it's not a thing.")
+
+//----------------------------------------------------------------------
+// for init time save
+// Instead of running the given value to atom, we'll run GLOB.preload_handler with injector path
+GLOBAL_DATUM_INIT(preload_handler, /datum/preload_injection/master, new)
+/datum/preload_injection/master
+	var/static/list/cached_injectors = list()
+
+/datum/preload_injection/master/apply(atom/target, actual_injector = null)
+	var/datum/preload_injection/real_injector = actual_injector || target.preload_data
+	if(cached_injectors[real_injector])
+		real_injector = cached_injectors[real_injector]
+	else
+		real_injector = new real_injector
+		cached_injectors[real_injector.type] = real_injector
+	real_injector.apply(target)
+//----------------------------------------------------------------------
+// in case when you want to apply multiple injectors
+/datum/preload_injection/multiple
+	var/list/multiple_injectors
+
+/datum/preload_injection/multiple/apply(atom/target)
+	for(var/each_injector in multiple_injectors)
+		GLOB.preload_handler.apply(target, each_injector)
+//----------------------------------------------------------------------
+// faction application
+/datum/preload_injection/faction
+	var/list/faction_to_add
+	var/list/faction_to_force
+
+/datum/preload_injection/faction/apply(mob/target)
+	if(length(faction_to_force))
+		target.faction = faction_to_force.Copy()
+	if(length(faction_to_add))
+		target.faction |= faction_to_add
+
+/datum/preload_injection/faction/add_syndicate
+	faction_to_add = list(FACTION_SYNDICATE)
+/datum/preload_injection/faction/force_syndicate
+	faction_to_force = list(FACTION_SYNDICATE)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -148,6 +148,10 @@
 	/// DO NOT EDIT THIS, USE ADD_LUM_SOURCE INSTEAD
 	var/_emissive_count = 0
 
+	/// preload definitions{} in dmm dislikes define macros. preload_injection tricks it.
+	/// any object with preload values will follow macro defines through this preload_injection
+	var/datum/preload_injection/preload_datum
+
 /**
   * Called when an atom is created in byond (built in engine proc)
   *
@@ -162,6 +166,12 @@
 	//atom creation method that preloads variables at creation
 	if(GLOB.use_preloader && src.type == GLOB._preloader_path)//in case the instanciated atom is creating other atoms in New()
 		world.preloader_load(src)
+
+	if(preload_datum)
+		if(GLOB.preload_handler)
+			GLOB.preload_handler.apply(src)
+		else
+			stack_trace("GLOB.preload_handler doesn't exist, but we need it. Is that deleted somehow?")
 
 	if(datum_flags & DF_USE_TAG)
 		GenerateTag()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
New system - Preload Injection (that supports {} values), helpful for dmm
preload data `{faction = list("syndicate")}` in dmm has been a bit annoying, and that's why faction macro defines were not a thing.
It was previously introduced as `dmm_handler` in my old job refactor PR, and I renamed this `Preload Injection` because it can support outside of dmm preload:
### DMM
```dm
/mob/living/carbon/monkey{
	preload_datum = /datum/preload_injection/faction/add_syndicate
	},
```
### Code
```dm
/proc/does_something()
	var/new/mob = new /mob{preload_data = /datum/preload_injection/very_special_creation}
	// This mob will specifically have preload injection datum to run
```
Note that this is applied before initialization, so should be used carefully.

## Note
I didn't intentionally touched all faction macros and dmm because it bloats the contents to review, but the essential part is reviewing this new injection system, not other wrong usages were corrected.
So, this PR only included a few cases how this can be used. This PR will be helpful to correct dmm files to have macro defines later (especially factions)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
dmm not using macro is awful

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/4820587b-ac04-4b3f-adfe-de7087514a96)

add_faction type. This one additionally gets syndicate



![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/b696dd54-a2fd-47b4-85fc-a81045008672)

force_faction type. This one only has syndicate faction.


## Changelog
:cl:
code: "Preload Injection" datum system to support dmm preload{something = "val change"} stuff
fix: Syndicate lavabase monkeys now have monkey faction, and it uses preload injection to get syndicate faction (to prevent turret misfires)
fix: made faction macro defines lowercased because it's not yet fully ready for capitalisation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
