### PR TITLE
LOOC will tell admins if the LOOC was sent by someone in their vision range

### DIFF
--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -73,7 +73,11 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 	for(var/client/client in GLOB.admins)
 		if(!client.prefs.read_player_preference(/datum/preference/toggle/chat_ooc))
 			continue
-		var/prefix = "[(client in targets) ? "" : "(R)"]LOOC"
+		var/prefix
+		if(in_view[get_turf(client.mob)])
+			prefix = "[(client in targets) ? "" : "(R)"]LOOC (NEARBY)"
+		else
+			prefix = "[(client in targets) ? "" : "(R)"]LOOC"
 		to_chat(client, "<span class='looc'><span class='prefix'>[prefix]:</span> <EM>[ADMIN_LOOKUPFLW(mob)]:</EM> <span class='message'>[msg]</span></span>", avoid_highlighting = (client == src))
 
 /proc/log_looc(text)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

LOOC will tell admins if the LOOC was sent by someone in their vision range showing (Nearby) in the prefix
closes #10592

Right now the nearby also appears if you sent the message, should I change that?

## Why It's Good For The Game

2 reasons why:

Less confusion when you are an admin
The corgi asked for this


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I have testing evidence but I had to join with my guest account to test this so my CID is visible, I'll attach screenshots

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/45698448/631b6d01-c46e-47a7-bd60-45b5c4871203)


</details>

## Changelog
:cl:
admin: LOOC will now tell you if you were near the sender
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
