### PR TITLE
Ghost orbiting a zmimic will make you orbit the original atom.

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -9,11 +9,11 @@
 
 	// Things you might plausibly want to follow
 	if(ismovable(A))
-+       // It's a mimic! Fetch associated (real) atom
-+       if(istype(A, /atom/movable/openspace/mimic))
-+               var/atom/movable/openspace/mimic/M = A
-+               check_orbitable(M.associated_atom)
-+               return
+		// It's a mimic! Fetch associated (real) atom
+		if(istype(A, /atom/movable/openspace/mimic))
+			var/atom/movable/openspace/mimic/M = A
+			check_orbitable(M.associated_atom)
+			return
 		check_orbitable(A)
 
 	// Otherwise jump

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -9,11 +9,6 @@
 
 	// Things you might plausibly want to follow
 	if(ismovable(A))
-		// It's a mimic! Fetch associated (real) atom
-		if(istype(A, /atom/movable/openspace/mimic))
-			var/atom/movable/openspace/mimic/M = A
-			check_orbitable(M.associated_atom)
-			return
 		check_orbitable(A)
 
 	// Otherwise jump

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -9,6 +9,11 @@
 
 	// Things you might plausibly want to follow
 	if(ismovable(A))
++       // It's a mimic! Fetch associated (real) atom
++       if(istype(A, /atom/movable/openspace/mimic))
++               var/atom/movable/openspace/mimic/M = A
++               check_orbitable(M.associated_atom)
++               return
 		check_orbitable(A)
 
 	// Otherwise jump

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1906,3 +1906,6 @@
 		luminosity = max(max(base_luminosity, affecting_dynamic_lumi), 1)
 	else
 		luminosity = max(base_luminosity, affecting_dynamic_lumi)
+
+/atom/movable/proc/get_orbitable()
+	. = src

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1908,4 +1908,4 @@
 		luminosity = max(base_luminosity, affecting_dynamic_lumi)
 
 /atom/movable/proc/get_orbitable()
-	. = src
+	return src

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -452,7 +452,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 
 // This is the ghost's follow verb with an argument
-/mob/dead/observer/check_orbitable(atom/movable/target)
+/mob/dead/observer/check_orbitable(atom/movable/target_original)
+	var/atom/movable/target = target_original.get_orbitable()
 	if (!istype(target))
 		return
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -202,6 +202,10 @@
 	if (!destruction_timer)
 		destruction_timer = QDEL_IN(src, 10 SECONDS)
 
+// Get actual source atom when orbiting
+/atom/movable/openspace/mimic/get_orbitable()
+	. = associated_atom
+
 // -- TURF PROXY --
 // This thing holds the mimic appearance for non-OVERWRITE turfs.
 /atom/movable/openspace/turf_proxy

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -204,7 +204,7 @@
 
 // Get actual source atom when orbiting
 /atom/movable/openspace/mimic/get_orbitable()
-	. = associated_atom
+	return associated_atom
 
 // -- TURF PROXY --
 // This thing holds the mimic appearance for non-OVERWRITE turfs.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin.
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/10731

## Why It's Good For The Game

Bug bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/28ddc02f-c423-4114-a426-827f10ba3a94



</details>

## Changelog
:cl:
fix: orbiting a zmimic as a ghost will make you orbit the original atom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
