### PR TITLE
Stores BCIs in the contents of the chamber instead of in nullspace

### DIFF
--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -347,7 +347,7 @@
 	if (isnull(bci_to_implant))
 		. += "<span class='notice'>There is no BCI inserted.</span>"
 	else
-		. += "<span class='notice'>Alt-click to remove [bci_to_implant_resolved].</span>"
+		. += "<span class='notice'>Alt-click to remove [bci_to_implant].</span>"
 
 /obj/machinery/bci_implanter/proc/set_busy(status, working_icon)
 	busy = status

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -326,7 +326,7 @@
 	var/busy_icon_state
 	var/locked = FALSE
 
-	var/datum/weakref/bci_to_implant
+	var/obj/item/organ/internal/cyberimp/bci/bci_to_implant
 
 	COOLDOWN_DECLARE(message_cooldown)
 
@@ -335,19 +335,16 @@
 	occupant_typecache = typecacheof(/mob/living/carbon)
 
 /obj/machinery/bci_implanter/on_deconstruction()
-	var/obj/item/organ/cyberimp/bci/bci_to_implant_resolved = bci_to_implant?.resolve()
-	bci_to_implant_resolved?.forceMove(drop_location())
-	bci_to_implant = null
+	drop_stored_bci()
 
 /obj/machinery/bci_implanter/Destroy()
-	QDEL_NULL(bci_to_implant)
+	qdel(bci_to_implant)
 	return ..()
 
 /obj/machinery/bci_implanter/examine(mob/user)
 	. = ..()
 
-	var/obj/item/organ/cyberimp/bci/bci_to_implant_resolved = bci_to_implant?.resolve()
-	if (isnull(bci_to_implant_resolved))
+	if (isnull(bci_to_implant))
 		. += "<span class='notice'>There is no BCI inserted.</span>"
 	else
 		. += "<span class='notice'>Alt-click to remove [bci_to_implant_resolved].</span>"
@@ -394,11 +391,10 @@
 		balloon_alert(user, "it's locked!")
 		return ..()
 
-	var/obj/item/organ/cyberimp/bci/bci_to_implant_resolved = bci_to_implant?.resolve()
-	if (isnull(bci_to_implant_resolved))
+	if (isnull(bci_to_implant))
 		balloon_alert(user, "no bci inserted!")
 	else
-		user.put_in_hands(bci_to_implant_resolved)
+		user.put_in_hands(bci_to_implant)
 		balloon_alert(user, "ejected bci")
 
 	bci_to_implant = null
@@ -423,10 +419,10 @@
 			balloon_alert(user, "bci has no circuit!")
 			return
 
-		var/obj/item/organ/cyberimp/bci/previous_bci_to_implant = bci_to_implant?.resolve()
+		var/obj/item/organ/internal/cyberimp/bci/previous_bci_to_implant = bci_to_implant
 
-		bci_to_implant = WEAKREF(weapon)
-		weapon.moveToNullspace()
+		user.transferItemToLoc(weapon, src)
+		bci_to_implant = weapon
 
 		if (isnull(previous_bci_to_implant))
 			balloon_alert(user, "inserted bci")
@@ -465,22 +461,20 @@
 	playsound(loc, 'sound/machines/ping.ogg', 30, FALSE)
 
 	var/obj/item/organ/cyberimp/bci/bci_organ = carbon_occupant.getorgan(/obj/item/organ/cyberimp/bci)
-	var/obj/item/organ/cyberimp/bci/bci_to_implant_resolved = bci_to_implant?.resolve()
 
 	if (bci_organ)
 		bci_organ.Remove(carbon_occupant)
 
-		if (isnull(bci_to_implant_resolved))
+		if (isnull(bci_to_implant))
 			say("Occupant's previous brain-computer interface has been transferred to internal storage unit.")
-			bci_organ.moveToNullspace()
-			bci_to_implant = WEAKREF(bci_organ)
+			carbon_occupant.transferItemToLoc(bci_organ, src)
+			bci_to_implant = bci_organ
 		else
 			say("Occupant's previous brain-computer interface has been ejected.")
 			bci_organ.forceMove(drop_location())
-	else if (!isnull(bci_to_implant_resolved))
-		say("Occupant has been injected with [bci_to_implant_resolved].")
-		bci_to_implant_resolved.Insert(carbon_occupant)
-		bci_to_implant = null
+	else if (!isnull(bci_to_implant))
+		say("Occupant has been injected with [bci_to_implant].")
+		bci_to_implant.Insert(carbon_occupant)
 
 /obj/machinery/bci_implanter/open_machine()
 	if(state_open)
@@ -498,8 +492,8 @@
 
 	var/mob/living/carbon/carbon_occupant = occupant
 	if (istype(occupant))
-		var/obj/item/organ/cyberimp/bci/existing_bci_organ = carbon_occupant.getorgan(/obj/item/organ/cyberimp/bci)
-		if (isnull(existing_bci_organ) && isnull(bci_to_implant?.resolve()))
+		var/obj/item/organ/internal/cyberimp/bci/bci_organ = carbon_occupant.getorgan(/obj/item/organ/internal/cyberimp/bci)
+		if (isnull(bci_organ) && isnull(bci_to_implant))
 			say("No brain-computer interface inserted, and occupant does not have one. Insert a BCI to implant one.")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 			return FALSE
@@ -533,6 +527,21 @@
 		return
 
 	open_machine()
+
+/obj/machinery/bci_implanter/proc/drop_stored_bci()
+	if (isnull(bci_to_implant))
+		return
+	bci_to_implant.forceMove(drop_location())
+
+/obj/machinery/bci_implanter/dump_inventory_contents(list/subset)
+	// Prevents opening the machine dropping the BCI.
+	// "dump_contents()" still drops the BCI.
+	return ..(contents - bci_to_implant)
+
+/obj/machinery/bci_implanter/Exited(atom/movable/gone, direction)
+	if (gone == bci_to_implant)
+		bci_to_implant = null
+	return ..()
 
 /obj/item/circuitboard/machine/bci_implanter
 	name = "Brain-Computer Interface Manipulation Chamber (Machine Board)"

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -326,7 +326,7 @@
 	var/busy_icon_state
 	var/locked = FALSE
 
-	var/obj/item/organ/internal/cyberimp/bci/bci_to_implant
+	var/obj/item/organ/cyberimp/bci/bci_to_implant
 
 	COOLDOWN_DECLARE(message_cooldown)
 
@@ -419,7 +419,7 @@
 			balloon_alert(user, "bci has no circuit!")
 			return
 
-		var/obj/item/organ/internal/cyberimp/bci/previous_bci_to_implant = bci_to_implant
+		var/obj/item/organ/cyberimp/bci/previous_bci_to_implant = bci_to_implant
 
 		user.transferItemToLoc(weapon, src)
 		bci_to_implant = weapon
@@ -492,7 +492,7 @@
 
 	var/mob/living/carbon/carbon_occupant = occupant
 	if (istype(occupant))
-		var/obj/item/organ/internal/cyberimp/bci/bci_organ = carbon_occupant.getorgan(/obj/item/organ/internal/cyberimp/bci)
+		var/obj/item/organ/cyberimp/bci/bci_organ = carbon_occupant.getorgan(/obj/item/organ/cyberimp/bci)
 		if (isnull(bci_organ) && isnull(bci_to_implant))
 			say("No brain-computer interface inserted, and occupant does not have one. Insert a BCI to implant one.")
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/10748
Ports https://github.com/tgstation/tgstation/pull/70350

## Why It's Good For The Game

Bug bad!!!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



https://github.com/BeeStation/BeeStation-Hornet/assets/61665800/9e1de495-a222-4d4f-9655-8d1aa20c013a




</details>

## Changelog
:cl: Ratón
fix: MMIs no longer get sent to the gem room when they get put into a BCI implanter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
