### PR TITLE
Rerun tests if unit test flaky (among other things)

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -1,0 +1,23 @@
+# Creates an entry in html/changelogs automatically, to eventually be compiled by compile_changelogs
+name: Auto Changelog
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - master
+permissions:
+  contents: write
+jobs:
+  auto_labeler:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Run auto labeler
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
+          await processAutoChangelog({ github, context })

--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -9,13 +9,13 @@ on:
 permissions:
   contents: write
 jobs:
-  auto_labeler:
+  auto_changelog:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Run auto labeler
+    - name: Run auto changelog
       uses: actions/github-script@v6
       with:
         script: |

--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -21,3 +21,4 @@ jobs:
         script: |
           const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
           await processAutoChangelog({ github, context })
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   run_linters:
     runs-on: ubuntu-20.04
+    name: Run Linters
     steps:
       - uses: actions/checkout@v3
       - name: Python setup
@@ -51,8 +52,15 @@ jobs:
           tools/build/build --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
-          ~/dreamchecker
+          ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
+      - name: Annotate Lints
+        uses: yogstation13/DreamAnnotate@v1
+        if: success() || failure()
+        with:
+          outputFile: output-annotations.txt
+
   compile_all_maps:
+    name: Compile Maps
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -71,6 +79,7 @@ jobs:
           python3 tools/ci/template_dm_generator.py
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
   run_all_tests:
+    name: Integration Tests
     runs-on: ubuntu-20.04
     services:
       mariadb:
@@ -118,7 +127,9 @@ jobs:
         run: |
           source $HOME/BYOND/byond/bin/byondsetup
           bash tools/ci/run_server.sh
+
   test_windows:
+    name: Windows Build
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rerun_flaky_tests.yml
+++ b/.github/workflows/rerun_flaky_tests.yml
@@ -1,0 +1,31 @@
+name: Rerun/Report Flaky Tests
+on:
+  workflow_run:
+    workflows: [CI Suite]
+    types:
+    - completed
+jobs:
+  rerun_flaky_tests:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Rerun flaky tests
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { rerunFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
+          await rerunFlakyTests({ github, context })
+  report_flaky_tests:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.run_attempt == 2 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Report flaky tests
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { reportFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
+          await reportFlakyTests({ github, context })

--- a/tools/pull_request_hooks/autoChangelog.js
+++ b/tools/pull_request_hooks/autoChangelog.js
@@ -1,0 +1,42 @@
+import { parseChangelog } from "./changelogParser.js";
+
+const safeYml = (string) =>
+	string.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+
+export function changelogToYml(changelog, login) {
+	const author = changelog.author || login;
+	const ymlLines = [];
+
+	ymlLines.push(`author: "${safeYml(author)}"`);
+	ymlLines.push(`delete-after: True`);
+	ymlLines.push(`changes:`);
+
+	for (const change of changelog.changes) {
+		ymlLines.push(
+			`  - ${change.type.changelogKey}: "${safeYml(change.description)}"`
+		);
+	}
+
+	return ymlLines.join("\n");
+}
+
+export async function processAutoChangelog({ github, context }) {
+	const changelog = parseChangelog(context.payload.pull_request.body);
+	if (!changelog || changelog.changes.length === 0) {
+		console.log("no changelog found");
+		return;
+	}
+
+	const yml = changelogToYml(
+		changelog,
+		context.payload.pull_request.user.login
+	);
+
+	github.rest.repos.createOrUpdateFileContents({
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		path: `html/changelogs/AutoChangeLog-pr-${context.payload.pull_request.number}.yml`,
+		message: `Automatic changelog for PR #${context.payload.pull_request.number} [ci skip]`,
+		content: Buffer.from(yml).toString("base64"),
+	});
+}

--- a/tools/pull_request_hooks/autoChangelog.test.js
+++ b/tools/pull_request_hooks/autoChangelog.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { changelogToYml } from "./autoChangelog.js";
+import { parseChangelog } from "./changelogParser.js";
+
+assert.equal(
+	changelogToYml(
+		parseChangelog(`
+			My cool PR!
+			:cl: DenverCoder9
+			add: Adds new stuff
+			add: Adds more stuff
+			/:cl:
+		`)
+	),
+
+	`author: "DenverCoder9"
+delete-after: True
+changes:
+  - rscadd: "Adds new stuff"
+  - rscadd: "Adds more stuff"`
+);

--- a/tools/pull_request_hooks/changelogConfig.js
+++ b/tools/pull_request_hooks/changelogConfig.js
@@ -1,0 +1,129 @@
+/**
+ * A map of changelog phrases to meta-information.
+ *
+ * The first entry in the list is used in the changelog YML file as the key when
+ * used, but other than that all entries are equivalent.
+ *
+ * placeholders - The default messages, if the changelog has this then we pretend it
+ * doesn't exist.
+ */
+export const CHANGELOG_ENTRIES = [
+	[
+		["rscadd", "add", "adds"],
+		{
+			placeholders: [
+				"Added new mechanics or gameplay changes",
+				"Added more things",
+			],
+		},
+	],
+
+	[
+		["bugfix", "fix", "fixes"],
+		{
+			placeholders: ["fixed a few things"],
+		},
+	],
+
+	[
+		["rscdel", "del", "dels"],
+		{
+			placeholders: ["Removed old things"],
+		},
+	],
+
+	/* We dont have it
+	[
+		["qol"],
+		{
+			placeholders: ["made something easier to use"],
+		},
+	],
+	*/
+
+	[
+		["soundadd"],
+		{
+			placeholders: ["added a new sound thingy"],
+		},
+	],
+
+	[
+		["sounddel"],
+		{
+			placeholders: ["removed an old sound thingy"],
+		},
+	],
+
+	[
+		["imageadd"],
+		{
+			placeholders: ["added some icons and images"],
+		},
+	],
+
+	[
+		["imagedel"],
+		{
+			placeholders: ["deleted some icons and images"],
+		},
+	],
+
+	[
+		["spellcheck", "typo"],
+		{
+			placeholders: ["fixed a few typos"],
+		},
+	],
+
+	[
+		["balance"],
+		{
+			placeholders: ["rebalanced something"],
+		},
+	],
+
+	[
+		["code_imp", "code"],
+		{
+			placeholders: ["changed some code"],
+		},
+	],
+
+	[
+		["refactor"],
+		{
+			placeholders: ["refactored some code"],
+		},
+	],
+
+	[
+		["config"],
+		{
+			placeholders: ["changed some config setting"],
+		},
+	],
+
+	[
+		["admin"],
+		{
+			placeholders: ["messed with admin stuff"],
+		},
+	],
+
+	[
+		["server"],
+		{
+			placeholders: ["something server ops should know"],
+		},
+	],
+];
+
+// Valid changelog openers
+export const CHANGELOG_OPEN_TAGS = [":cl:", "??"];
+
+// Valid changelog closers
+export const CHANGELOG_CLOSE_TAGS = ["/:cl:", "/ :cl:", ":/cl:", "/??", "/ ??"];
+
+// Placeholder value for an author
+export const CHANGELOG_AUTHOR_PLACEHOLDER_NAME = "optional name here";

--- a/tools/pull_request_hooks/changelogParser.js
+++ b/tools/pull_request_hooks/changelogParser.js
@@ -1,0 +1,80 @@
+import * as changelogConfig from "./changelogConfig.js";
+
+const REGEX_CHANGELOG_LINE = /^(\w+): (.+)$/;
+
+const CHANGELOG_KEYS_TO_ENTRY = {};
+for (const [types, entry] of changelogConfig.CHANGELOG_ENTRIES) {
+	const entryWithChangelogKey = {
+		...entry,
+		changelogKey: types[0],
+	};
+
+	for (const type of types) {
+		CHANGELOG_KEYS_TO_ENTRY[type] = entryWithChangelogKey;
+	}
+}
+
+function parseChangelogBody(lines, openTag) {
+	const [changelogOpening] = lines.splice(0, 1);
+
+	const author =
+		changelogOpening.substring(openTag.length).trim() || undefined;
+
+	const changelog = {
+		author,
+		changes: [],
+	};
+
+	for (const line of lines) {
+		if (line.trim().length === 0) {
+			continue;
+		}
+
+		for (const closeTag of changelogConfig.CHANGELOG_CLOSE_TAGS) {
+			if (line.startsWith(closeTag)) {
+				return changelog;
+			}
+		}
+
+		const match = line.match(REGEX_CHANGELOG_LINE);
+		if (match) {
+			const [_, type, description] = match;
+
+			const entry = CHANGELOG_KEYS_TO_ENTRY[type];
+
+			if (entry.placeholders.includes(description)) {
+				continue;
+			}
+
+			if (entry) {
+				changelog.changes.push({
+					type: entry,
+					description,
+				});
+			}
+		} else {
+			const lastChange = changelog.changes[changelog.changes.length - 1];
+			if (lastChange) {
+				lastChange.description += `\n${line}`;
+			}
+		}
+	}
+
+	return changelog;
+}
+
+export function parseChangelog(text) {
+	const lines = text.split("\n").map((line) => line.trim());
+
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+
+		for (const openTag of changelogConfig.CHANGELOG_OPEN_TAGS) {
+			if (line.startsWith(openTag)) {
+				return parseChangelogBody(lines.slice(index), openTag);
+			}
+		}
+	}
+
+	return undefined;
+}

--- a/tools/pull_request_hooks/changelogParser.test.js
+++ b/tools/pull_request_hooks/changelogParser.test.js
@@ -1,0 +1,72 @@
+import { strict as assert } from "node:assert";
+import { parseChangelog } from "./changelogParser.js";
+
+// Basic test
+const basicChangelog = parseChangelog(`
+	My cool PR!
+	:cl: DenverCoder9
+	add: Adds new stuff
+	/:cl:
+`);
+
+assert.equal(basicChangelog.author, "DenverCoder9");
+assert.equal(basicChangelog.changes.length, 1);
+assert.equal(basicChangelog.changes[0].type.changelogKey, "rscadd");
+assert.equal(basicChangelog.changes[0].description, "Adds new stuff");
+
+// Multi-line test
+const multiLineChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	add: Adds new stuff
+	to the game
+	/:cl:
+`);
+
+assert.equal(multiLineChangelog.author, undefined);
+assert.equal(multiLineChangelog.changes.length, 1);
+assert.equal(multiLineChangelog.changes[0].type.changelogKey, "rscadd");
+assert.equal(
+	multiLineChangelog.changes[0].description,
+	"Adds new stuff\nto the game"
+);
+
+// Placeholders
+const placeholderChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	add: Added new mechanics or gameplay changes
+	/:cl:
+`);
+
+assert.equal(placeholderChangelog.changes.length, 0);
+
+// No changelog
+const noChangelog = parseChangelog(`
+	My cool PR!
+`);
+
+assert.equal(noChangelog, undefined);
+
+// No /:cl:
+
+const noCloseChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	add: Adds new stuff
+`);
+
+assert.equal(noCloseChangelog.changes.length, 1);
+assert.equal(noCloseChangelog.changes[0].type.changelogKey, "rscadd");
+assert.equal(noCloseChangelog.changes[0].description, "Adds new stuff");
+
+// :cl: with arbitrary text
+
+const arbitraryTextChangelog = parseChangelog(`
+	My cool PR!
+	:cl:
+	Adds new stuff
+	/:cl:
+`);
+
+assert.equal(arbitraryTextChangelog.changes.length, 0);

--- a/tools/pull_request_hooks/package.json
+++ b/tools/pull_request_hooks/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "module"
+}

--- a/tools/pull_request_hooks/rerunFlakyTests.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.js
@@ -1,0 +1,274 @@
+const LABEL = "🤖 Flaky Test Report";
+const TITLE_BOT_HEADER = "title: ";
+
+// Only check jobs that start with these.
+// Helps make sure we don't restart something like screenshot tests or linters, which are not known to be flaky.
+const CONSIDERED_JOBS = [
+	"Integration Tests",
+];
+
+async function getFailedJobsForRun(github, context, workflowRunId, runAttempt) {
+  const {
+    data: { jobs },
+  } = await github.rest.actions.listJobsForWorkflowRunAttempt({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id: workflowRunId,
+    attempt_number: runAttempt,
+  });
+
+  return jobs
+    .filter((job) => job.conclusion === "failure")
+    .filter((job) =>
+      CONSIDERED_JOBS.some((title) => job.name.startsWith(title))
+    );
+}
+
+export async function rerunFlakyTests({ github, context }) {
+  const failingJobs = await getFailedJobsForRun(
+    github,
+    context,
+    context.payload.workflow_run.id,
+    context.payload.workflow_run.run_attempt
+  );
+
+  if (failingJobs.length > 1) {
+    console.log("Multiple jobs failing. PROBABLY not flaky, not rerunning.");
+    return;
+  }
+
+  if (failingJobs.length === 0) {
+    throw new Error(
+      "rerunFlakyTests should not have run on a run with no failing jobs"
+    );
+  }
+
+  github.rest.actions.reRunWorkflowFailedJobs({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id: context.payload.workflow_run.id,
+  });
+}
+
+// Tries its best to extract a useful error title and message for the given log
+export function extractDetails(log) {
+  // Strip off timestamp
+  const lines = log.split(/^[0-9.:T\-]*?Z /gm);
+
+  const failureRegex = /^\t?FAILURE #(?<number>[0-9]+): (?<headline>.+)/;
+  const groupRegex = /^##\[group\](?<group>.+)/;
+
+  const failures = [];
+  let lastGroup = "root";
+  let loggingFailure;
+
+  const newFailure = (failureMatch) => {
+    const { headline } = failureMatch.groups;
+
+    loggingFailure = {
+      headline,
+      group: lastGroup.replace("/datum/unit_test/", ""),
+      details: [],
+    };
+  };
+
+  for (const line of lines) {
+    const groupMatch = line.match(groupRegex);
+    if (groupMatch) {
+      lastGroup = groupMatch.groups.group.trim();
+      continue;
+    }
+
+    const failureMatch = line.match(failureRegex);
+
+    if (loggingFailure === undefined) {
+      if (!failureMatch) {
+        continue;
+      }
+
+      newFailure(failureMatch);
+    } else if (failureMatch || line.startsWith("##")) {
+      failures.push(loggingFailure);
+      loggingFailure = undefined;
+
+      if (failureMatch) {
+        newFailure(failureMatch);
+      }
+    } else {
+      loggingFailure.details.push(line.trim());
+    }
+  }
+
+  // We had no logged failures, there's not really anything we can do here
+  if (failures.length === 0) {
+    return {
+      title: "Flaky test failure with no obvious source",
+      failures,
+    };
+  }
+
+  // We *could* create multiple failures for multiple groups.
+  // This would be important if we had multiple flaky tests at the same time.
+  // I'm choosing not to because it complicates this logic a bit, has the ability to go terribly wrong,
+  // and also because there's something funny to me about that increasing the urgency of fixing
+  // flaky tests. If it becomes a serious issue though, I would not mind this being fixed.
+  const uniqueGroups = new Set(failures.map((failure) => failure.group));
+
+  if (uniqueGroups.size > 1) {
+    return {
+      title: `Multiple flaky test failures in ${Array.from(uniqueGroups)
+        .sort()
+        .join(", ")}`,
+      failures,
+    };
+  }
+
+  const failGroup = failures[0].group;
+
+  if (failures.length > 1) {
+    return {
+      title: `Multiple errors in flaky test ${failGroup}`,
+      failures,
+    };
+  }
+
+  const failure = failures[0];
+
+  // Common patterns where we can always get a detailed title
+  const runtimeMatch = failure.headline.match(/Runtime in .+?: (?<error>.+)/);
+  if (runtimeMatch) {
+    return {
+      title: `Flaky test ${failGroup}: ${runtimeMatch.groups.error.trim()}`,
+      failures,
+    };
+  }
+
+  // Try to normalize the title and remove anything that might be variable
+  const normalizedError = failure.headline.replace(/\s*at .+?:[0-9]+.*/g, ""); // "<message> at code.dm:123"
+
+  return {
+    title: `Flaky test ${failGroup}: ${normalizedError}`,
+    failures,
+  };
+}
+
+async function getExistingIssueId(graphql, context, title) {
+  // Hope you never have more than 100 of these open!
+  const {
+    repository: {
+      issues: { nodes: openFlakyTestIssues },
+    },
+  } = await graphql(
+    `
+      query ($owner: String!, $repo: String!, $label: String!) {
+        repository(owner: $owner, name: $repo) {
+          issues(
+            labels: [$label]
+            first: 100
+            orderBy: { field: CREATED_AT, direction: DESC }
+            states: [OPEN]
+          ) {
+            nodes {
+              number
+              title
+              body
+            }
+          }
+        }
+      }
+    `,
+    {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      label: LABEL,
+    }
+  );
+
+  const exactTitle = openFlakyTestIssues.find((issue) => issue.title === title);
+  if (exactTitle !== undefined) {
+    return exactTitle.number;
+  }
+
+  const foundInBody = openFlakyTestIssues.find((issue) =>
+    issue.body.contains(`<!-- ${TITLE_BOT_HEADER}${exactTitle} -->`)
+  );
+  if (foundInBody !== undefined) {
+    return foundInBody.number;
+  }
+
+  return undefined;
+}
+
+function createBody({ title, failures }, runUrl) {
+  return `
+	<!-- This issue can be renamed, but do not change the next comment! -->
+	<!-- title: ${title} -->
+	Flaky tests were detected in [this test run](${runUrl}). This means that there was a failure that was cleared when the tests were simply restarted.
+
+	Failures:
+	\`\`\`
+	${failures
+    .map(
+      (failure) =>
+        `${failure.group}: ${failure.headline}\n\t${failure.details.join("\n")}`
+    )
+    .join("\n")}
+	\`\`\`
+	`.replace(/^\s*/gm, "");
+}
+
+export async function reportFlakyTests({ github, context }) {
+  const failedJobsFromLastRun = await getFailedJobsForRun(
+    github,
+    context,
+    context.payload.workflow_run.id,
+    context.payload.workflow_run.run_attempt - 1
+  );
+
+  // This could one day be relaxed if we face serious enough flaky test problems, so we're going to loop anyway
+  if (failedJobsFromLastRun.length !== 1) {
+    console.log(
+      "Multiple jobs failing after retry, assuming maintainer rerun."
+    );
+
+    return;
+  }
+
+  for (const job of failedJobsFromLastRun) {
+    const { data: log } =
+      await github.rest.actions.downloadJobLogsForWorkflowRun({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        job_id: job.id,
+      });
+
+    const details = extractDetails(log);
+
+    const existingIssueId = await getExistingIssueId(
+      github.graphql,
+      context,
+      details.title
+    );
+
+    if (existingIssueId !== undefined) {
+      // Maybe in the future, if it's helpful, update the existing issue with new links
+      console.log(`Existing issue found: #${existingIssueId}`);
+      return;
+    }
+
+    await github.rest.issues.create({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      title: details.title,
+      labels: [LABEL],
+      body: createBody(
+        details,
+        `https://github.com/${context.repo.owner}/${
+          context.repo.repo
+        }/actions/runs/${context.payload.workflow_run.id}/attempts/${
+          context.payload.workflow_run.run_attempt - 1
+        }`
+      ),
+    });
+  }
+}

--- a/tools/pull_request_hooks/rerunFlakyTests.test.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.test.js
@@ -1,0 +1,39 @@
+import { strict as assert } from "node:assert";
+import fs from "node:fs";
+import { extractDetails } from "./rerunFlakyTests.js";
+
+function extractDetailsFromPayload(filename) {
+  return extractDetails(
+    fs.readFileSync(`tests/flakyTestPayloads/${filename}.txt`, {
+      encoding: "utf8",
+    })
+  );
+}
+
+const chatClient = extractDetailsFromPayload("chat_client");
+assert.equal(
+  chatClient.title,
+  "Flaky test create_and_destroy: /datum/computer_file/program/chatclient hard deleted 1 times out of a total del count of 13"
+);
+assert.equal(chatClient.failures.length, 1);
+
+const monkeyBusiness = extractDetailsFromPayload("monkey_business");
+assert.equal(
+  monkeyBusiness.title,
+  "Flaky test monkey_business: Cannot execute null.resolve()."
+);
+assert.equal(monkeyBusiness.failures.length, 1);
+
+const shapeshift = extractDetailsFromPayload("shapeshift");
+assert.equal(
+  shapeshift.title,
+  "Multiple errors in flaky test shapeshift_spell"
+);
+assert.equal(shapeshift.failures.length, 16);
+
+const multipleFailures = extractDetailsFromPayload("multiple_failures");
+assert.equal(
+  multipleFailures.title,
+  "Multiple flaky test failures in more_shapeshift_spell, shapeshift_spell"
+);
+assert.equal(multipleFailures.failures.length, 2);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports:
- https://github.com/tgstation/tgstation/pull/54735
- https://github.com/tgstation/tgstation/pull/54821
- https://github.com/tgstation/tgstation/pull/70652
- https://github.com/tgstation/tgstation/pull/70833
- https://github.com/tgstation/tgstation/pull/70835
- https://github.com/tgstation/tgstation/pull/71519

Separates autochangelog generation to its own workflow, Reruns flaky tests if they occur in tests, Annotate Lints

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ive been trying to get someone to port this for quite a while. No one has taken to it, however, so I will be doing it.

Its good because some stupid test failing for an ungodly reason shouldnt be on the contributor/maint to deal with, it should just fix itself.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: rkz, Mothblocks, actioninja, Cyberboss
server: separates autochangelog into its own workflow
server: flaky tests rerun themselves automatically if they fail
server: The linter now annotates itself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
