### PR TITLE
Fixes a bug where attaching a wig to a pet causes the wig to be qdel'd after placing the pet down

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -34,7 +34,7 @@
 /obj/item/clothing/head/attackby(obj/item/W, mob/user, params)
 	. = ..()
 	if(istype(W, /obj/item/clothing/head/wig))
-		if(flags_inv && HIDEHAIR)
+		if(flags_inv & HIDEHAIR)
 			to_chat(user, "<span class='notice'>You can't attach a wig to [src]!</span>")
 			return
 		if(attached_wig)
@@ -88,7 +88,7 @@
 	. = ..()
 	if(attached_wig)
 		. += "<span class='notice'>There's \a [attached_wig.name] attached, which can be removed through the context menu.</span>"
-	else if(!(flags_inv && HIDEHAIR))
+	else if(!(flags_inv & HIDEHAIR))
 		. += "<span class='notice'>A wig can be attached to the [src].</span>"
 
 ///Special throw_impact for hats to frisbee hats at people to place them on their heads/attempt to de-hat them.

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -34,7 +34,7 @@
 /obj/item/clothing/head/attackby(obj/item/W, mob/user, params)
 	. = ..()
 	if(istype(W, /obj/item/clothing/head/wig))
-		if(flags_inv && HIDEHAIR)
+		if(flags_inv & HIDEHAIR)
 			to_chat(user, "<span class='notice'>You can't attach a wig to [src]!</span>")
 			return
 		if(attached_wig)

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -34,7 +34,7 @@
 /obj/item/clothing/head/attackby(obj/item/W, mob/user, params)
 	. = ..()
 	if(istype(W, /obj/item/clothing/head/wig))
-		if(flags_inv & HIDEHAIR)
+		if(flags_inv && HIDEHAIR)
 			to_chat(user, "<span class='notice'>You can't attach a wig to [src]!</span>")
 			return
 		if(attached_wig)

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -70,6 +70,9 @@
 		to_chat(L, "<span class='warning'>[held_mob] wriggles free!</span>")
 		L.dropItemToGround(src)
 
+	if(attached_wig)
+		unattach_wig()
+
 	held_mob.forceMove(get_turf(held_mob))
 	held_mob.reset_perspective()
 	held_mob.setDir(SOUTH)

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -7,7 +7,6 @@
 	icon_state = ""
 	slot_flags = NONE
 	clothing_flags = NOTCONSUMABLE
-	flags_inv = HIDEHAIR
 	var/mob/living/held_mob
 	var/can_head = TRUE
 	///We are currently releasing the mob held in holder

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -7,6 +7,7 @@
 	icon_state = ""
 	slot_flags = NONE
 	clothing_flags = NOTCONSUMABLE
+	flags_inv = HIDEHAIR
 	var/mob/living/held_mob
 	var/can_head = TRUE
 	///We are currently releasing the mob held in holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Title says it all.


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
random qdels are bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/7ac032cd-880f-4396-9e45-1fec98feadab


</details>

## Changelog
:cl: XeonMations
fix: Fixed wigs attached to animals being sent to the shadow realm after a pet is released from a person's grasp
fix: Fixed wigs bitflag checking uses && instead of single &
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
