### PR TITLE
Update CODEOWNERS to use a mapping team for maps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # Mapping
 
-/_maps @beestation-mapping
+/_maps @BeeStation/beestation-mapping
 
 # crossedfall
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,10 @@
 # In the event that multiple org members are to be informed of changes
 # to the same file or dir, add them to the end under Multiple Owners
 
+# Mapping
+
+/_maps @beestation-mapping
+
 # crossedfall
 
 .dockerignore @crossedfall
@@ -25,10 +29,6 @@ Dockerfile @crossedfall
 /code/game/machinery/shuttle @powerfulbacon
 /code/modules/shuttle/super_cruise @powerfulbacon
 /code/modules/shuttle/shuttle_creation @powerfulbacon
-
-# pestoverde322
-
-/_maps @pestoverde322
 
 # itsmeow
 


### PR DESCRIPTION
## About The Pull Request

Updates code-owners so that it works by using a team instead of an individual person.

## Why It's Good For The Game

More flexability and the use of teams allows for setting up specific rules per-group (mappers can only merge mapping changes, as an example).

## Testing Photographs and Procedure

N/A

## Changelog

N/A
