### PR TITLE
VV editor can now see /appearance types

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1821,6 +1821,7 @@
 #include "code\modules\admin\verbs\SDQL2\SDQL_2_wrappers.dm"
 #include "code\modules\admin\view_variables\admin_delete.dm"
 #include "code\modules\admin\view_variables\color_matrix_editor.dm"
+#include "code\modules\admin\view_variables\debug_variable_appearance.dm"
 #include "code\modules\admin\view_variables\debug_variables.dm"
 #include "code\modules\admin\view_variables\filterrific.dm"
 #include "code\modules\admin\view_variables\get_variables.dm"

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -14,7 +14,14 @@
 #define isimage(thing) (istype(thing, /image))
 
 GLOBAL_VAR_INIT(magic_appearance_detecting_image, new /image) // appearances are awful to detect safely, but this seems to be the best way ~ninjanomnom
-#define isappearance(thing) (!ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing))
+/proc/isappearance(image/thing)
+	if(!ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing))
+		try
+			if(thing.vars) // if you can not access "vars", this means /appearance.
+				return FALSE
+		catch
+			return TRUE
+	return FALSE
 
 // The filters list has the same ref type id as a filter, but isnt one and also isnt a list, so we have to check if the thing has Cut() instead
 GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -14,14 +14,7 @@
 #define isimage(thing) (istype(thing, /image))
 
 GLOBAL_VAR_INIT(magic_appearance_detecting_image, new /image) // appearances are awful to detect safely, but this seems to be the best way ~ninjanomnom
-/proc/isappearance(image/thing)
-	if(!ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing))
-		try
-			if(thing.vars) // if you can not access "vars", this means /appearance.
-				return FALSE
-		catch
-			return TRUE
-	return FALSE
+#define isappearance(thing) (!isimage(thing) && !ispath(thing) && istype(GLOB.magic_appearance_detecting_image, thing))
 
 // The filters list has the same ref type id as a filter, but isnt one and also isnt a list, so we have to check if the thing has Cut() instead
 GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -54,6 +54,7 @@
 
 //Helpers for vv_get_dropdown()
 #define VV_DROPDOWN_OPTION(href_key, name) . += "<option value='?_src_=vars;[HrefToken()];[href_key]=TRUE;target=[REF(src)]'>[name]</option>"
+#define VV_DROPDOWN_OPTION_APPEARANCE(thing, href_key, name) . += "<option value='?_src_=vars;[HrefToken()];[href_key]=TRUE;target=[REF(thing)]'>[name]</option>"
 
 // VV HREF KEYS
 #define VV_HK_TARGET "target"

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -54,6 +54,7 @@
 
 //Helpers for vv_get_dropdown()
 #define VV_DROPDOWN_OPTION(href_key, name) . += "<option value='?_src_=vars;[HrefToken()];[href_key]=TRUE;target=[REF(src)]'>[name]</option>"
+//Same with VV_DROPDOWN_OPTION, but global proc doesn't have src
 #define VV_DROPDOWN_OPTION_APPEARANCE(thing, href_key, name) . += "<option value='?_src_=vars;[HrefToken()];[href_key]=TRUE;target=[REF(thing)]'>[name]</option>"
 
 // VV HREF KEYS

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -52,5 +52,10 @@
 	if(("name" in vars) && !isatom(src))
 		. += "<b>[vars["name"]]</b><br>"
 
+/image/vv_get_header()
+	. = list()
+	if(("name" in vars) && !isatom(src))
+		. += "<b>[vars["name"]]</b><br>"
+
 /datum/proc/on_reagent_change(changetype)
 	return

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -52,10 +52,5 @@
 	if(("name" in vars) && !isatom(src))
 		. += "<b>[vars["name"]]</b><br>"
 
-/image/vv_get_header()
-	. = list()
-	if(("name" in vars) && !isatom(src))
-		. += "<b>[vars["name"]]</b><br>"
-
 /datum/proc/on_reagent_change(changetype)
 	return

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -32,8 +32,6 @@
 	ADD_UNUSED_VAR(unused_var_names, dummy_image, stat_tabs)
 	ADD_UNUSED_VAR(unused_var_names, dummy_image, cooldowns)
 	ADD_UNUSED_VAR(unused_var_names, dummy_image, datum_flags)
-	ADD_UNUSED_VAR(unused_var_names, dummy_image, visibility)
-	ADD_UNUSED_VAR(unused_var_names, dummy_image, tgui_shared_states)
 	ADD_UNUSED_VAR(unused_var_names, dummy_image, tgui_shared_states)
 
 	for(var/each in dummy_image.vars) // try to inherit var list from /image
@@ -64,87 +62,87 @@
 
 		// appearance vars in DM document
 		if(NAMEOF(appearance, alpha))
-			return rappearance.alpha
+			return appearance.alpha
 		if(NAMEOF(appearance, appearance_flags))
-			return rappearance.appearance_flags
+			return appearance.appearance_flags
 		if(NAMEOF(appearance, blend_mode))
-			return rappearance.blend_mode
+			return appearance.blend_mode
 		if(NAMEOF(appearance, color))
-			return rappearance.color
+			return appearance.color
 		if(NAMEOF(appearance, desc))
-			return rappearance.desc
+			return appearance.desc
 		if(NAMEOF(appearance, gender))
-			return rappearance.gender
+			return appearance.gender
 		if(NAMEOF(appearance, icon))
-			return rappearance.icon
+			return appearance.icon
 		if(NAMEOF(appearance, icon_state))
-			return rappearance.icon_state
+			return appearance.icon_state
 		if(NAMEOF(appearance, invisibility))
-			return rappearance.invisibility
+			return appearance.invisibility
 		if(NAMEOF(appearance, infra_luminosity))
-			return rappearance.infra_luminosity
+			return appearance.infra_luminosity
 		if(NAMEOF(appearance, filters))
-			return rappearance.filters
+			return appearance.filters
 		if(NAMEOF(appearance, layer))
-			return rappearance.layer
+			return appearance.layer
 		if(NAMEOF(appearance, luminosity))
-			return rappearance.luminosity
+			return appearance.luminosity
 		if(NAMEOF(appearance, maptext))
-			return rappearance.maptext
+			return appearance.maptext
 		if(NAMEOF(appearance, maptext_width))
-			return rappearance.maptext_width
+			return appearance.maptext_width
 		if(NAMEOF(appearance, maptext_height))
-			return rappearance.maptext_height
+			return appearance.maptext_height
 		if(NAMEOF(appearance, maptext_x))
-			return rappearance.maptext_x
+			return appearance.maptext_x
 		if(NAMEOF(appearance, maptext_y))
-			return rappearance.maptext_y
+			return appearance.maptext_y
 		if(NAMEOF(appearance, mouse_over_pointer))
-			return rappearance.mouse_over_pointer
+			return appearance.mouse_over_pointer
 		if(NAMEOF(appearance, mouse_drag_pointer))
-			return rappearance.mouse_drag_pointer
+			return appearance.mouse_drag_pointer
 		if(NAMEOF(appearance, mouse_drop_pointer))
-			return rappearance.mouse_drop_pointer
+			return appearance.mouse_drop_pointer
 		if("mouse_drop_zone") // OpenDream didn't implement this yet.
 			return appearance:mouse_drop_zone
 		if(NAMEOF(appearance, mouse_opacity))
-			return rappearance.mouse_opacity
+			return appearance.mouse_opacity
 		if(NAMEOF(appearance, name))
-			return rappearance.name
+			return appearance.name
 		if(NAMEOF(appearance, opacity))
-			return rappearance.opacity
+			return appearance.opacity
 		if(NAMEOF(appearance, overlays))
-			return rappearance.overlays
+			return appearance.overlays
 		if("override") // only /image has this
 			var/image/image_appearance = appearance
 			return image_appearance.override
 		if(NAMEOF(appearance, pixel_x))
-			return rappearance.pixel_x
+			return appearance.pixel_x
 		if(NAMEOF(appearance, pixel_y))
-			return rappearance.pixel_y
+			return appearance.pixel_y
 		if(NAMEOF(appearance, pixel_w))
-			return rappearance.pixel_w
+			return appearance.pixel_w
 		if(NAMEOF(appearance, pixel_z))
-			return rappearance.pixel_z
+			return appearance.pixel_z
 		if(NAMEOF(appearance, plane))
-			return rappearance.plane
+			return appearance.plane
 		if(NAMEOF(appearance, render_source))
-			return rappearance.render_source
+			return appearance.render_source
 		if(NAMEOF(appearance, render_target))
-			return rappearance.render_target
+			return appearance.render_target
 		if(NAMEOF(appearance, suffix))
-			return rappearance.suffix
+			return appearance.suffix
 		if(NAMEOF(appearance, text))
-			return rappearance.text
+			return appearance.text
 		if(NAMEOF(appearance, transform))
-			return rappearance.transform
+			return appearance.transform
 		if(NAMEOF(appearance, underlays))
-			return rappearance.underlays
+			return appearance.underlays
 
 		if(NAMEOF(appearance, parent_type))
-			return rappearance.parent_type
+			return appearance.parent_type
 		if(NAMEOF(appearance, type))
-			return "/appearance (as [rappearance.type])" // don't fool people
+			return "/appearance (as [appearance.type])" // don't fool people
 
 		// These are not documented ones but trackable values. Maybe we'd want these.
 		if(NAMEOF(appearance, animate_movement))
@@ -169,15 +167,15 @@
 
 		// we wouldn't need these, but let's these trackable anyway...
 		if(NAMEOF(appearance, density))
-			return rappearance.density
+			return appearance.density
 		if(NAMEOF(appearance, screen_loc))
-			return rappearance.screen_loc
+			return appearance.screen_loc
 		if(NAMEOF(appearance, sorted_verbs))
-			return rappearance.sorted_verbs
+			return appearance.sorted_verbs
 		if(NAMEOF(appearance, tag))
-			return rappearance.tag
+			return appearance.tag
 		if(NAMEOF(appearance, cached_ref))
-			return rappearance.cached_ref
+			return appearance.cached_ref
 	return RESULT_VARIABLE_NOT_FOUND
 
 /// Shows a header name on top when you investigate an appearance

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -199,11 +199,7 @@
 		. += thing.icon_state ? "\"[thing.icon_state]\"" : "(icon_state = null)"
 
 /image/vv_get_header()
-	. = list()
-	var/icon_name = "<b>[length(icon) ? icon || "null" : "(icon exists, but name is null)"]</b><br/>"
-	. += replacetext(icon_name, "icons/obj", "") // shortens the name. We know the path already.
-	if(icon)
-		. += icon_state ? "\"[icon_state]\"" : "(icon_state = null)"
+	return vv_get_header_appearance(src)
 
 /// Makes a format name for shortened vv name.
 /proc/get_appearance_vv_summary_name(image/thing)
@@ -212,15 +208,6 @@
 		icon_file_name = length(icon_file_name) ? icon_file_name[length(icon_file_name)] : "(null??)" // thing.icon exists but it's null????
 	if(thing.icon_state)
 		return "[icon_file_name]:[thing.icon_state]"
-	else
-		return "[icon_file_name]"
-
-/image/proc/get_image_vv_summary_name()
-	var/icon_file_name = icon ? splittext("[icon]", "/") : "null"
-	if(islist(icon_file_name))
-		icon_file_name = length(icon_file_name) ? icon_file_name[length(icon_file_name)] : "(null??)"
-	if(icon_state)
-		return "[icon_file_name]:[icon_state]"
 	else
 		return "[icon_file_name]"
 

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -32,7 +32,7 @@
 	del(dummy_image)
 	dummy_image = null
 
-/// appearance type needs a manual change because it doesn't have "vars" variable internally.
+/// appearance type needs a manual var referencing because it doesn't have "vars" variable internally.
 /// There's no way doing this in a fancier way.
 /proc/debug_variable_appearance(var_name, image/appearance)
 	try // somehow /appearance has "vars" variable.
@@ -130,7 +130,7 @@
 			if("type")
 				value = appearance.type
 
-			// These are not undocumented ones but maybe it's trackable values
+			// These are not documented ones but trackable values. Maybe we'd want these.
 			if("animate_movement")
 				value = atom_appearance.animate_movement
 			if("dir")
@@ -159,7 +159,7 @@
 			if("z")
 				value = atom_appearance.z
 
-			// we wouldn't need these, but let's trackable anyway...
+			// we wouldn't need these, but let's these trackable anyway...
 			if("cooldowns")
 				value = atom_appearance.cooldowns
 			if("gc_destroyed")

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -34,11 +34,6 @@
 /// appearance type needs a manual var referencing because it doesn't have "vars" variable internally.
 /// There's no way doing this in a fancier way.
 /proc/debug_variable_appearance(var_name, image/appearance)
-	try // somehow /appearance has "vars" variable.
-		return debug_variable(var_name, appearance.vars[var_name], 0, appearance, sanitize = TRUE, display_flags = NONE)
-	catch
-		pass()
-
 	var/atom/movable/atom_appearance = appearance
 	var/value
 	try

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -1,0 +1,200 @@
+/proc/build_appearance_var_list()
+	. = list()
+	var/list/unused_var_names = list(
+		"vars", // /appearnace doesn't have internal "vars" variable. Even if it has, we have no reason to see it
+		"appearance", // it only does self-reference
+		"x","y","z", // these are always 0
+
+		// we have no reason to show those, right?
+		"active_timers",
+		"comp_lookup",
+		"signal_procs",
+		"status_traits",
+		"stat_tabs",
+		"cooldowns",
+		"datum_flags",
+		"gender",
+		"visibility",
+		"verbs",
+		)
+	var/image/dummy_image = image(null, null)
+	for(var/each in dummy_image.vars)
+		if(each in unused_var_names)
+			continue
+		. += each
+	del(dummy_image)
+	dummy_image = null
+
+/// appearance type needs a manual change because it doesn't have "vars" variable internally.
+/// There's no way doing this in a fancier way.
+/proc/debug_variable_appearance(var_name, image/appearance)
+	try // somehow /appearance has vars variable.
+		return "<li style='backgroundColor:white'>(STATIC) [var_name] = [_debug_variable_value(var_name, appearance.vars[var_name], 0, appearance)]</li>"
+	catch
+		pass()
+
+	var/atom/movable/atom_appearance = appearance
+	var/value
+	try
+		switch(var_name) // Welcome to this curse
+			// real vars that appearance uses
+			if("parent_type")
+				value = appearance.parent_type
+			if("type")
+				value = appearance.type
+
+			// appearance vars in DM document
+			if("alpha")
+				value = appearance.alpha
+			if("appearance_flags")
+				value = appearance.appearance_flags
+			if("blend_mode")
+				value = appearance.blend_mode
+			if("color")
+				value = appearance.color
+			if("desc")
+				value = appearance.desc
+			if("gender")
+				value = appearance.gender
+			if("icon")
+				value = appearance.icon
+			if("icon_state")
+				value = appearance.icon_state
+			if("invisibility")
+				value = appearance.invisibility
+			if("infra_luminosity")
+				value = atom_appearance.infra_luminosity
+			if("filters")
+				value = appearance.filters
+			if("layer")
+				value = appearance.layer
+			if("luminosity")
+				value = appearance.luminosity
+			if("maptext")
+				value = appearance.maptext
+			if("maptext_width")
+				value = appearance.maptext_width
+			if("maptext_height")
+				value = appearance.maptext_height
+			if("maptext_x")
+				value = appearance.maptext_x
+			if("maptext_y")
+				value = appearance.maptext_y
+			if("mouse_over_pointer")
+				value = appearance.mouse_over_pointer
+			if("mouse_drag_pointer")
+				value = appearance.mouse_drag_pointer
+			if("mouse_drop_pointer")
+				value = appearance.mouse_drop_pointer
+			if("mouse_drop_zone")
+				value = appearance.mouse_drop_zone
+			if("mouse_opacity")
+				value = appearance.mouse_opacity
+			if("name")
+				value = appearance.name
+			if("opacity")
+				value = appearance.opacity
+			if("overlays")
+				value = appearance.overlays
+			if("override")
+				value = appearance.override
+			if("pixel_x")
+				value = appearance.pixel_x
+			if("pixel_y")
+				value = appearance.pixel_y
+			if("pixel_w")
+				value = appearance.pixel_w
+			if("pixel_z")
+				value = appearance.pixel_z
+			if("plane")
+				value = appearance.plane
+			if("render_source")
+				value = appearance.render_source
+			if("render_target")
+				value = appearance.render_target
+			if("suffix")
+				value = appearance.suffix
+			if("text")
+				value = appearance.text
+			if("transform")
+				value = appearance.transform
+			if("underlays")
+				value = appearance.underlays
+
+
+			// These are not undocumented ones but maybe it's trackable values
+			if("animate_movement")
+				value = atom_appearance.animate_movement
+			if("cooldowns")
+				value = atom_appearance.cooldowns
+			if("datum_components")
+				value = atom_appearance.datum_components
+			if("datum_flags")
+				value = atom_appearance.datum_flags
+			if("density")
+				value = atom_appearance.density
+
+			if("dir")
+				value = atom_appearance.dir
+
+			if("gc_destroyed")
+				value = atom_appearance.gc_destroyed
+			if("glide_size")
+				value = atom_appearance.glide_size
+
+			if("pixel_step_size")
+				value = "" //atom_appearance.pixel_step_size
+				// DM compiler complains this
+
+			// we wouldn't need these, but let's trackable anyway...
+			if("screen_loc")
+				value = atom_appearance.screen_loc
+			if("sorted_verbs")
+				value = atom_appearance.sorted_verbs
+			if("tag")
+				value = atom_appearance.tag
+			if("tgui_shared_states")
+				value = atom_appearance.tgui_shared_states
+			if("verbs")
+				value = atom_appearance.verbs
+			if("weak_reference")
+				value = atom_appearance.weak_reference
+			if("cached_ref")
+				value = appearance.cached_ref
+
+			/// These variables are only available in some conditions.
+			if("contents")
+				value = atom_appearance.contents
+			if("vis_contents")
+				value = atom_appearance.vis_contents
+			if("loc")
+				value = atom_appearance.loc
+			if("locs")
+				value = atom_appearance.locs
+			if("x")
+				value = atom_appearance.x
+			if("y")
+				value = atom_appearance.y
+			if("z")
+				value = atom_appearance.z
+
+			else
+				return "<li style='backgroundColor:white'>(STATIC) [var_name] <font color='blue'>(Undefined var name in switch)</font></li>"
+	catch
+		return "<li style='backgroundColor:white'>(STATIC) <font color='blue'>[var_name] = (untrackable)</font></li>"
+	return "<li style='backgroundColor:white'>(STATIC) [var_name] = [_debug_variable_value(var_name, value, 0, appearance, sanitize = TRUE, display_flags = NONE)]</li>"
+
+/proc/vv_get_header_appearance(image/thing)
+	. = list()
+	. += "<b>[length(thing.icon) ? thing.icon || "null" : "(icon exists, but name is null)"]</b><br/>"
+	if(thing.icon)
+		. += thing.icon_state ? "\"[thing.icon_state]\"" : "(icon_state = null)"
+
+/proc/get_appearance_vv_summary_name(image/thing)
+	var/icon_file_name = thing.icon ? splittext("[thing.icon]", "/") : "null"
+	if(islist(icon_file_name))
+		icon_file_name = length(icon_file_name) ? icon_file_name[length(icon_file_name)] : "(null??)" // thing.icon exists but it's null????
+	if(thing.icon_state)
+		return "[icon_file_name]:[thing.icon_state]"
+	else
+		return "[icon_file_name]"

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -74,7 +74,7 @@
 /// manually locate a variable through string value.
 /// appearance type needs a manual var referencing because it doesn't have "vars" variable internally.
 /// There's no way doing this in a fancier way.
-/proc/locate_appearance_variable(var_name, image/appearance/appearance) // it isn't /movable. It had to be at it to use NAMEOF macro
+/proc/locate_appearance_variable(var_name, image/appearance/appearance) // WARN: /image/appearance is a mocking type, not real one
 	switch(var_name) // Welcome to this curse
 		// appearance doesn't have "vars" variable.
 		// This means you need to target a variable manually through this way.

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -193,7 +193,7 @@
 /// Shows a header name on top when you investigate an appearance
 /proc/vv_get_header_appearance(image/thing)
 	. = list()
-	var/icon_name = "<b>[length(thing.icon) ? thing.icon || "null" : "(icon exists, but name is null)"]</b><br/>"
+	var/icon_name = "<b>[thing.icon || "null"]</b><br/>"
 	. += replacetext(icon_name, "icons/obj", "") // shortens the name. We know the path already.
 	if(thing.icon)
 		. += thing.icon_state ? "\"[thing.icon_state]\"" : "(icon_state = null)"
@@ -205,7 +205,7 @@
 /proc/get_appearance_vv_summary_name(image/thing)
 	var/icon_file_name = thing.icon ? splittext("[thing.icon]", "/") : "null"
 	if(islist(icon_file_name))
-		icon_file_name = length(icon_file_name) ? icon_file_name[length(icon_file_name)] : "(null??)" // thing.icon exists but it's null????
+		icon_file_name = length(icon_file_name) ? icon_file_name[length(icon_file_name)] : "null"
 	if(thing.icon_state)
 		return "[icon_file_name]:[thing.icon_state]"
 	else

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -36,7 +36,7 @@
 /// There's no way doing this in a fancier way.
 /proc/debug_variable_appearance(var_name, image/appearance)
 	try // somehow /appearance has "vars" variable.
-		return "<li style='backgroundColor:white'>(STATIC) [var_name] = [_debug_variable_value(var_name, appearance.vars[var_name], 0, appearance)]</li>"
+		return debug_variable(var_name, appearance.vars[var_name], 0, appearance, sanitize = TRUE, display_flags = NONE)
 	catch
 		pass()
 
@@ -208,3 +208,16 @@
 		return "[icon_file_name]:[thing.icon_state]"
 	else
 		return "[icon_file_name]"
+
+/proc/vv_get_dropdown_appearance(image/thing)
+	. = list()
+	try
+		if(thing.vars)
+			VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "---")
+			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_MARK, "Mark Object")
+			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_TAG, "Tag Datum")
+			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_DELETE, "Delete")
+			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_EXPOSE, "Show VV To Player")
+	catch
+		VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "---")
+		VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "VV option not allowed")

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -9,7 +9,6 @@
 /proc/build_appearance_var_list()
 	. = list("vis_flags") // manual listing
 	var/list/unused_var_names = list(
-		"vars", // /appearnace doesn't have internal "vars" variable. Even if it has, we have no reason to see it
 		"appearance", // it only does self-reference
 		"x","y","z", // these are always 0
 
@@ -199,6 +198,13 @@
 	if(thing.icon)
 		. += thing.icon_state ? "\"[thing.icon_state]\"" : "(icon_state = null)"
 
+/image/vv_get_header()
+	. = list()
+	var/icon_name = "<b>[length(icon) ? icon || "null" : "(icon exists, but name is null)"]</b><br/>"
+	. += replacetext(icon_name, "icons/obj", "") // shortens the name. We know the path already.
+	if(icon)
+		. += icon_state ? "\"[icon_state]\"" : "(icon_state = null)"
+
 /// Makes a format name for shortened vv name.
 /proc/get_appearance_vv_summary_name(image/thing)
 	var/icon_file_name = thing.icon ? splittext("[thing.icon]", "/") : "null"
@@ -209,15 +215,16 @@
 	else
 		return "[icon_file_name]"
 
+/image/proc/get_image_vv_summary_name()
+	var/icon_file_name = icon ? splittext("[icon]", "/") : "null"
+	if(islist(icon_file_name))
+		icon_file_name = length(icon_file_name) ? icon_file_name[length(icon_file_name)] : "(null??)"
+	if(icon_state)
+		return "[icon_file_name]:[icon_state]"
+	else
+		return "[icon_file_name]"
+
 /proc/vv_get_dropdown_appearance(image/thing)
 	. = list()
-	try
-		if(thing.vars)
-			VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "---")
-			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_MARK, "Mark Object")
-			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_TAG, "Tag Datum")
-			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_DELETE, "Delete")
-			VV_DROPDOWN_OPTION_APPEARANCE(thing, VV_HK_EXPOSE, "Show VV To Player")
-	catch
-		VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "---")
-		VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "VV option not allowed")
+	VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "---")
+	VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "VV option not allowed")

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -38,7 +38,7 @@
 
 /// appearance type needs a manual var referencing because it doesn't have "vars" variable internally.
 /// There's no way doing this in a fancier way.
-/proc/debug_variable_appearance(var_name, atom/movable/appearance) // movable can handle various variables than /image, and /appearance has more variables than /image.
+/proc/debug_variable_appearance(var_name, appearance)
 	var/value
 	try
 		switch(var_name) // Welcome to this curse
@@ -47,120 +47,119 @@
 
 			// appearance vars in DM document
 			if("alpha")
-				value = appearance.alpha
+				value = appearance:alpha
 			if("appearance_flags")
-				value = appearance.appearance_flags
+				value = appearance:appearance_flags
 			if("blend_mode")
-				value = appearance.blend_mode
+				value = appearance:blend_mode
 			if("color")
-				value = appearance.color
+				value = appearance:color
 			if("desc")
-				value = appearance.desc
+				value = appearance:desc
 			if("gender")
-				value = appearance.gender
+				value = appearance:gender
 			if("icon")
-				value = appearance.icon
+				value = appearance:icon
 			if("icon_state")
-				value = appearance.icon_state
+				value = appearance:icon_state
 			if("invisibility")
-				value = appearance.invisibility
+				value = appearance:invisibility
 			if("infra_luminosity")
-				value = appearance.infra_luminosity
+				value = appearance:infra_luminosity
 			if("filters")
-				value = appearance.filters
+				value = appearance:filters
 			if("layer")
-				value = appearance.layer
+				value = appearance:layer
 			if("luminosity")
-				value = appearance.luminosity
+				value = appearance:luminosity
 			if("maptext")
-				value = appearance.maptext
+				value = appearance:maptext
 			if("maptext_width")
-				value = appearance.maptext_width
+				value = appearance:maptext_width
 			if("maptext_height")
-				value = appearance.maptext_height
+				value = appearance:maptext_height
 			if("maptext_x")
-				value = appearance.maptext_x
+				value = appearance:maptext_x
 			if("maptext_y")
-				value = appearance.maptext_y
+				value = appearance:maptext_y
 			if("mouse_over_pointer")
-				value = appearance.mouse_over_pointer
+				value = appearance:mouse_over_pointer
 			if("mouse_drag_pointer")
-				value = appearance.mouse_drag_pointer
+				value = appearance:mouse_drag_pointer
 			if("mouse_drop_pointer")
-				value = appearance.mouse_drop_pointer
+				value = appearance:mouse_drop_pointer
 			if("mouse_drop_zone")
-				value = appearance.mouse_drop_zone
+				value = appearance:mouse_drop_zone
 			if("mouse_opacity")
-				value = appearance.mouse_opacity
+				value = appearance:mouse_opacity
 			if("name")
-				value = appearance.name
+				value = appearance:name
 			if("opacity")
-				value = appearance.opacity
+				value = appearance:opacity
 			if("overlays")
-				value = appearance.overlays
+				value = appearance:overlays
 			if("override")
-				var/image/image_appearance = appearance
-				value = image_appearance.override
+				value = appearance:override
 			if("pixel_x")
-				value = appearance.pixel_x
+				value = appearance:pixel_x
 			if("pixel_y")
-				value = appearance.pixel_y
+				value = appearance:pixel_y
 			if("pixel_w")
-				value = appearance.pixel_w
+				value = appearance:pixel_w
 			if("pixel_z")
-				value = appearance.pixel_z
+				value = appearance:pixel_z
 			if("plane")
-				value = appearance.plane
+				value = appearance:plane
 			if("render_source")
-				value = appearance.render_source
+				value = appearance:render_source
 			if("render_target")
-				value = appearance.render_target
+				value = appearance:render_target
 			if("suffix")
-				value = appearance.suffix
+				value = appearance:suffix
 			if("text")
-				value = appearance.text
+				value = appearance:text
 			if("transform")
-				value = appearance.transform
+				value = appearance:transform
 			if("underlays")
-				value = appearance.underlays
+				value = appearance:underlays
 
 			if("parent_type")
-				value = appearance.parent_type
+				value = appearance:parent_type
 			if("type")
-				value = "/appearance (as [appearance.type])" // don't fool people
+				value = "/appearance (as [appearance:type])" // don't fool people
 
 			// These are not documented ones but trackable values. Maybe we'd want these.
 			if("animate_movement")
-				value = appearance.animate_movement
+				value = appearance:animate_movement
 			if("dir")
-				value = appearance.dir
+				value = appearance:dir
 			if("glide_size")
-				value = appearance.glide_size
+				value = appearance:glide_size
 			if("pixel_step_size")
-				value = "" //appearance.pixel_step_size
+				value = "" //appearance:pixel_step_size
 				// DM compiler complains this
 
 			// I am not sure if these will be ever detected, but I made a connection just in case.
 			if("contents")
-				value = appearance.contents
+				value = appearance:contents
 			if("vis_contents")
-				value = appearance.vis_contents
+				value = appearance:vis_contents
 			if("vis_flags") // DM document says /appearance has this, but it throws error
-				value = appearance.vis_flags
+				value = appearance:vis_flags
 			if("loc")
-				value = appearance.loc
+				value = appearance:loc
 
 			// we wouldn't need these, but let's these trackable anyway...
 			if("density")
-				value = appearance.density
+				value = appearance:density
 			if("screen_loc")
-				value = appearance.screen_loc
+				value = appearance:screen_loc
 			if("sorted_verbs")
-				value = appearance.sorted_verbs
+				value = appearance:sorted_verbs
 			if("tag")
-				value = appearance.tag
+				value = appearance:tag
 			if("cached_ref")
-				value = appearance.cached_ref
+				value = appearance:cached_ref
 
 			else
 				return "<li style='backgroundColor:white'>(READ ONLY) [var_name] <font color='blue'>(Undefined var name in switch)</font></li>"

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -19,6 +19,10 @@
 	var/mouse_drop_zone
 #endif
 
+/image/appearance/New(loc, ...)
+	. = ..()
+	CRASH("something tried to use '/image/appearance', but this isn't actual type we use. Do not fucking do this.")
+
 /// Makes a var list of /appearance type actually uses. This will be only called once.
 /proc/build_virtual_appearance_vars()
 	var/list/used_variables = list("vis_flags") // manual listing.
@@ -46,13 +50,15 @@
 	ADD_UNUSED_VAR(unused_var_names, nameof_reference, datum_flags)
 	ADD_UNUSED_VAR(unused_var_names, nameof_reference, tgui_shared_states)
 
-	var/image/dummy_image = image(null, null)
+	var/image/dummy_image = image(null, null) // actual type we'll copy variable names
 	for(var/each in dummy_image.vars) // try to inherit var list from /image
 		if(each in unused_var_names)
 			continue
-		. += each
+		used_variables += each
 	del(dummy_image)
 	dummy_image = null
+
+	return used_variables
 
 /// debug_variable() proc but made for /appearance type specifically
 /proc/debug_variable_appearance(var_name, appearance)
@@ -126,7 +132,7 @@
 			return appearance.opacity
 		if(NAMEOF(appearance, overlays))
 			return appearance.overlays
-		if("override") // only /image has this
+		if("override") // only /image has this. mocking type can't steal byond internal var name
 			var/image/image_appearance = appearance
 			return image_appearance.override
 		if(NAMEOF(appearance, pixel_x))

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -1,5 +1,5 @@
 /proc/build_appearance_var_list()
-	. = list()
+	. = list("vis_flags") // manual listing
 	var/list/unused_var_names = list(
 		"vars", // /appearnace doesn't have internal "vars" variable. Even if it has, we have no reason to see it
 		"appearance", // it only does self-reference
@@ -13,7 +13,6 @@
 		"stat_tabs",
 		"cooldowns",
 		"datum_flags",
-		"gender",
 		"visibility",
 		"verbs",
 		)
@@ -37,12 +36,6 @@
 	var/value
 	try
 		switch(var_name) // Welcome to this curse
-			// real vars that appearance uses
-			if("parent_type")
-				value = appearance.parent_type
-			if("type")
-				value = appearance.type
-
 			// appearance vars in DM document
 			if("alpha")
 				value = appearance.alpha
@@ -121,32 +114,51 @@
 			if("underlays")
 				value = appearance.underlays
 
+			if("parent_type")
+				value = appearance.parent_type
+			if("type")
+				value = appearance.type
 
 			// These are not undocumented ones but maybe it's trackable values
 			if("animate_movement")
 				value = atom_appearance.animate_movement
+			if("dir")
+				value = atom_appearance.dir
+			if("glide_size")
+				value = atom_appearance.glide_size
+			if("pixel_step_size")
+				value = "" //atom_appearance.pixel_step_size
+				// DM compiler complains this
+
+			// These variables are only available in some conditions.
+			if("contents")
+				value = atom_appearance.contents
+			if("vis_contents")
+				value = atom_appearance.vis_contents
+			if("vis_flags")
+				value = atom_appearance.vis_flags
+			if("loc")
+				value = atom_appearance.loc
+			if("locs")
+				value = atom_appearance.locs
+			if("x")
+				value = atom_appearance.x
+			if("y")
+				value = atom_appearance.y
+			if("z")
+				value = atom_appearance.z
+
+			// we wouldn't need these, but let's trackable anyway...
 			if("cooldowns")
 				value = atom_appearance.cooldowns
+			if("gc_destroyed")
+				value = atom_appearance.gc_destroyed
 			if("datum_components")
 				value = atom_appearance.datum_components
 			if("datum_flags")
 				value = atom_appearance.datum_flags
 			if("density")
 				value = atom_appearance.density
-
-			if("dir")
-				value = atom_appearance.dir
-
-			if("gc_destroyed")
-				value = atom_appearance.gc_destroyed
-			if("glide_size")
-				value = atom_appearance.glide_size
-
-			if("pixel_step_size")
-				value = "" //atom_appearance.pixel_step_size
-				// DM compiler complains this
-
-			// we wouldn't need these, but let's trackable anyway...
 			if("screen_loc")
 				value = atom_appearance.screen_loc
 			if("sorted_verbs")
@@ -162,22 +174,6 @@
 			if("cached_ref")
 				value = appearance.cached_ref
 
-			/// These variables are only available in some conditions.
-			if("contents")
-				value = atom_appearance.contents
-			if("vis_contents")
-				value = atom_appearance.vis_contents
-			if("loc")
-				value = atom_appearance.loc
-			if("locs")
-				value = atom_appearance.locs
-			if("x")
-				value = atom_appearance.x
-			if("y")
-				value = atom_appearance.y
-			if("z")
-				value = atom_appearance.z
-
 			else
 				return "<li style='backgroundColor:white'>(STATIC) [var_name] <font color='blue'>(Undefined var name in switch)</font></li>"
 	catch
@@ -186,7 +182,8 @@
 
 /proc/vv_get_header_appearance(image/thing)
 	. = list()
-	. += "<b>[length(thing.icon) ? thing.icon || "null" : "(icon exists, but name is null)"]</b><br/>"
+	var/icon_name = "<b>[length(thing.icon) ? thing.icon || "null" : "(icon exists, but name is null)"]</b><br/>"
+	. += replacetext(icon_name, "icons/obj", "") // shortens the name. We know the path already.
 	if(thing.icon)
 		. += thing.icon_state ? "\"[thing.icon_state]\"" : "(icon_state = null)"
 

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -186,10 +186,10 @@
 				value = appearance.cached_ref
 
 			else
-				return "<li style='backgroundColor:white'>(STATIC) [var_name] <font color='blue'>(Undefined var name in switch)</font></li>"
+				return "<li style='backgroundColor:white'>(READ ONLY) [var_name] <font color='blue'>(Undefined var name in switch)</font></li>"
 	catch
-		return "<li style='backgroundColor:white'>(STATIC) <font color='blue'>[var_name] = (untrackable)</font></li>"
-	return "<li style='backgroundColor:white'>(STATIC) [var_name] = [_debug_variable_value(var_name, value, 0, appearance, sanitize = TRUE, display_flags = NONE)]</li>"
+		return "<li style='backgroundColor:white'>(READ ONLY) <font color='blue'>[var_name] = (untrackable)</font></li>"
+	return "<li style='backgroundColor:white'>(READ ONLY) [var_name] = [_debug_variable_value(var_name, value, 0, appearance, sanitize = TRUE, display_flags = NONE)]</li>"
 
 /// Shows a header name on top when you investigate an appearance
 /proc/vv_get_header_appearance(image/thing)

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -1,3 +1,11 @@
+/* 	< OH MY GOD. Can't you just make "/image/proc/foo()" instead of making these? >
+ * 		/appearance is a hardcoded byond type, and it is very internal type.
+ *		Its type is actually /image, but it isn't truly /image. We defined it as "/appearance"
+ * 		new procs to /image will only work to actual /image references, but...
+ * 		/appearance references are not capable of executing procs, because these are not real /image
+ * 		This is why these global procs exist. Welcome to the curse.
+ */
+/// Makes a var list of /appearance type actually uses. This will be only called once.
 /proc/build_appearance_var_list()
 	. = list("vis_flags") // manual listing
 	var/list/unused_var_names = list(
@@ -27,7 +35,7 @@
 /// appearance type needs a manual change because it doesn't have "vars" variable internally.
 /// There's no way doing this in a fancier way.
 /proc/debug_variable_appearance(var_name, image/appearance)
-	try // somehow /appearance has vars variable.
+	try // somehow /appearance has "vars" variable.
 		return "<li style='backgroundColor:white'>(STATIC) [var_name] = [_debug_variable_value(var_name, appearance.vars[var_name], 0, appearance)]</li>"
 	catch
 		pass()
@@ -36,6 +44,9 @@
 	var/value
 	try
 		switch(var_name) // Welcome to this curse
+			// appearance doesn't have "vars" variable.
+			// This means you need to target a variable manually through this way.
+
 			// appearance vars in DM document
 			if("alpha")
 				value = appearance.alpha
@@ -180,6 +191,7 @@
 		return "<li style='backgroundColor:white'>(STATIC) <font color='blue'>[var_name] = (untrackable)</font></li>"
 	return "<li style='backgroundColor:white'>(STATIC) [var_name] = [_debug_variable_value(var_name, value, 0, appearance, sanitize = TRUE, display_flags = NONE)]</li>"
 
+/// Shows a header name on top when you investigate an appearance
 /proc/vv_get_header_appearance(image/thing)
 	. = list()
 	var/icon_name = "<b>[length(thing.icon) ? thing.icon || "null" : "(icon exists, but name is null)"]</b><br/>"
@@ -187,6 +199,7 @@
 	if(thing.icon)
 		. += thing.icon_state ? "\"[thing.icon_state]\"" : "(icon_state = null)"
 
+/// Makes a format name for shortened vv name.
 /proc/get_appearance_vv_summary_name(image/thing)
 	var/icon_file_name = thing.icon ? splittext("[thing.icon]", "/") : "null"
 	if(islist(icon_file_name))

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -38,8 +38,7 @@
 
 /// appearance type needs a manual var referencing because it doesn't have "vars" variable internally.
 /// There's no way doing this in a fancier way.
-/proc/debug_variable_appearance(var_name, image/appearance)
-	var/atom/movable/atom_appearance = appearance
+/proc/debug_variable_appearance(var_name, atom/movable/appearance) // movable can handle various variables than /image, and /appearance has more variables than /image.
 	var/value
 	try
 		switch(var_name) // Welcome to this curse
@@ -66,7 +65,7 @@
 			if("invisibility")
 				value = appearance.invisibility
 			if("infra_luminosity")
-				value = atom_appearance.infra_luminosity
+				value = appearance.infra_luminosity
 			if("filters")
 				value = appearance.filters
 			if("layer")
@@ -100,7 +99,8 @@
 			if("overlays")
 				value = appearance.overlays
 			if("override")
-				value = appearance.override
+				var/image/image_appearance = appearance
+				value = image_appearance.override
 			if("pixel_x")
 				value = appearance.pixel_x
 			if("pixel_y")
@@ -131,34 +131,34 @@
 
 			// These are not documented ones but trackable values. Maybe we'd want these.
 			if("animate_movement")
-				value = atom_appearance.animate_movement
+				value = appearance.animate_movement
 			if("dir")
-				value = atom_appearance.dir
+				value = appearance.dir
 			if("glide_size")
-				value = atom_appearance.glide_size
+				value = appearance.glide_size
 			if("pixel_step_size")
-				value = "" //atom_appearance.pixel_step_size
+				value = "" //appearance.pixel_step_size
 				// DM compiler complains this
 
 			// I am not sure if these will be ever detected, but I made a connection just in case.
 			if("contents")
-				value = atom_appearance.contents
+				value = appearance.contents
 			if("vis_contents")
-				value = atom_appearance.vis_contents
+				value = appearance.vis_contents
 			if("vis_flags") // DM document says /appearance has this, but it throws error
-				value = atom_appearance.vis_flags
+				value = appearance.vis_flags
 			if("loc")
-				value = atom_appearance.loc
+				value = appearance.loc
 
 			// we wouldn't need these, but let's these trackable anyway...
 			if("density")
-				value = atom_appearance.density
+				value = appearance.density
 			if("screen_loc")
-				value = atom_appearance.screen_loc
+				value = appearance.screen_loc
 			if("sorted_verbs")
-				value = atom_appearance.sorted_verbs
+				value = appearance.sorted_verbs
 			if("tag")
-				value = atom_appearance.tag
+				value = appearance.tag
 			if("cached_ref")
 				value = appearance.cached_ref
 

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -6,25 +6,30 @@
  * 		This is why these global procs exist. Welcome to the curse.
  */
 /// Makes a var list of /appearance type actually uses. This will be only called once.
-/proc/build_appearance_var_list()
+/proc/build_virtual_appearance_vars()
 	. = list("vis_flags") // manual listing
 	var/list/unused_var_names = list(
 		"appearance", // it only does self-reference
 		"x","y","z", // these are always 0
+        "weak_reference", // it's not a good idea to make a weak_ref on this, and this won't have it
+        "vars", // inherited from /image, but /appearance hasn't this
 
 		// we have no reason to show those, right?
 		"active_timers",
 		"comp_lookup",
+		"datum_components",
 		"signal_procs",
 		"status_traits",
+		"gc_destroyed",
 		"stat_tabs",
 		"cooldowns",
 		"datum_flags",
 		"visibility",
 		"verbs",
+		"tgui_shared_states"
 		)
 	var/image/dummy_image = image(null, null)
-	for(var/each in dummy_image.vars)
+	for(var/each in dummy_image.vars) // try to inherit var list from /image
 		if(each in unused_var_names)
 			continue
 		. += each
@@ -122,7 +127,7 @@
 			if("parent_type")
 				value = appearance.parent_type
 			if("type")
-				value = appearance.type
+				value = "/appearance (as [appearance.type])" // don't fool people
 
 			// These are not documented ones but trackable values. Maybe we'd want these.
 			if("animate_movement")
@@ -135,33 +140,17 @@
 				value = "" //atom_appearance.pixel_step_size
 				// DM compiler complains this
 
-			// These variables are only available in some conditions.
+			// I am not sure if these will be ever detected, but I made a connection just in case.
 			if("contents")
 				value = atom_appearance.contents
 			if("vis_contents")
 				value = atom_appearance.vis_contents
-			if("vis_flags")
+			if("vis_flags") // DM document says /appearance has this, but it throws error
 				value = atom_appearance.vis_flags
 			if("loc")
 				value = atom_appearance.loc
-			if("locs")
-				value = atom_appearance.locs
-			if("x")
-				value = atom_appearance.x
-			if("y")
-				value = atom_appearance.y
-			if("z")
-				value = atom_appearance.z
 
 			// we wouldn't need these, but let's these trackable anyway...
-			if("cooldowns")
-				value = atom_appearance.cooldowns
-			if("gc_destroyed")
-				value = atom_appearance.gc_destroyed
-			if("datum_components")
-				value = atom_appearance.datum_components
-			if("datum_flags")
-				value = atom_appearance.datum_flags
 			if("density")
 				value = atom_appearance.density
 			if("screen_loc")
@@ -170,12 +159,6 @@
 				value = atom_appearance.sorted_verbs
 			if("tag")
 				value = atom_appearance.tag
-			if("tgui_shared_states")
-				value = atom_appearance.tgui_shared_states
-			if("verbs")
-				value = atom_appearance.verbs
-			if("weak_reference")
-				value = atom_appearance.weak_reference
 			if("cached_ref")
 				value = appearance.cached_ref
 
@@ -193,7 +176,7 @@
 	if(thing.icon)
 		. += thing.icon_state ? "\"[thing.icon_state]\"" : "(icon_state = null)"
 
-/image/vv_get_header()
+/image/vv_get_header() // it should redirect to global proc version because /appearance can't call a proc, unless we want dupe code here
 	return vv_get_header_appearance(src)
 
 /// Makes a format name for shortened vv name.
@@ -208,5 +191,7 @@
 
 /proc/vv_get_dropdown_appearance(image/thing)
 	. = list()
+    // unless you have a good reason to add a vv option for /appearance,
+    // /appearance type shouldn't alloow any vv option. Even "Mark Datum" is a questionable behaviour here.
 	VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "---")
 	VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "VV option not allowed")

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -5,30 +5,37 @@
  * 		/appearance references are not capable of executing procs, because these are not real /image
  * 		This is why these global procs exist. Welcome to the curse.
  */
+#define ADD_UNUSED_VAR(varlist, thing, varname) if(NAMEOF(##thing, ##varname)) ##varlist += #varname
+#define RESULT_VARIABLE_NOT_FOUND "_switch_result_variable_not_found"
+
 /// Makes a var list of /appearance type actually uses. This will be only called once.
 /proc/build_virtual_appearance_vars()
-	. = list("vis_flags") // manual listing
-	var/list/unused_var_names = list(
-		"appearance", // it only does self-reference
-		"x","y","z", // these are always 0
-        "weak_reference", // it's not a good idea to make a weak_ref on this, and this won't have it
-        "vars", // inherited from /image, but /appearance hasn't this
+	var/list/used_variables = list("vis_flags") // manual listing.
+	. = used_variables
+	var/list/unused_var_names = list()
 
-		// we have no reason to show those, right?
-		"active_timers",
-		"comp_lookup",
-		"datum_components",
-		"signal_procs",
-		"status_traits",
-		"gc_destroyed",
-		"stat_tabs",
-		"cooldowns",
-		"datum_flags",
-		"visibility",
-		"verbs",
-		"tgui_shared_states"
-		)
 	var/image/dummy_image = image(null, null)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, appearance) // it only does self-reference
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, x) // xyz are always 0
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, y)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, z)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, weak_reference) // it's not a good idea to make a weak_ref on this, and this won't have it
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, vars) // inherited from /image, but /appearance hasn't this
+
+	// we have no reason to show these, right?
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, active_timers)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, comp_lookup)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, datum_components)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, signal_procs)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, status_traits)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, gc_destroyed)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, stat_tabs)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, cooldowns)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, datum_flags)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, visibility)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, tgui_shared_states)
+	ADD_UNUSED_VAR(unused_var_names, dummy_image, tgui_shared_states)
+
 	for(var/each in dummy_image.vars) // try to inherit var list from /image
 		if(each in unused_var_names)
 			continue
@@ -36,136 +43,142 @@
 	del(dummy_image)
 	dummy_image = null
 
-/// appearance type needs a manual var referencing because it doesn't have "vars" variable internally.
-/// There's no way doing this in a fancier way.
+/// debug_variable() proc but made for /appearance type specifically
 /proc/debug_variable_appearance(var_name, appearance)
 	var/value
 	try
-		switch(var_name) // Welcome to this curse
-			// appearance doesn't have "vars" variable.
-			// This means you need to target a variable manually through this way.
-
-			// appearance vars in DM document
-			if("alpha")
-				value = appearance:alpha
-			if("appearance_flags")
-				value = appearance:appearance_flags
-			if("blend_mode")
-				value = appearance:blend_mode
-			if("color")
-				value = appearance:color
-			if("desc")
-				value = appearance:desc
-			if("gender")
-				value = appearance:gender
-			if("icon")
-				value = appearance:icon
-			if("icon_state")
-				value = appearance:icon_state
-			if("invisibility")
-				value = appearance:invisibility
-			if("infra_luminosity")
-				value = appearance:infra_luminosity
-			if("filters")
-				value = appearance:filters
-			if("layer")
-				value = appearance:layer
-			if("luminosity")
-				value = appearance:luminosity
-			if("maptext")
-				value = appearance:maptext
-			if("maptext_width")
-				value = appearance:maptext_width
-			if("maptext_height")
-				value = appearance:maptext_height
-			if("maptext_x")
-				value = appearance:maptext_x
-			if("maptext_y")
-				value = appearance:maptext_y
-			if("mouse_over_pointer")
-				value = appearance:mouse_over_pointer
-			if("mouse_drag_pointer")
-				value = appearance:mouse_drag_pointer
-			if("mouse_drop_pointer")
-				value = appearance:mouse_drop_pointer
-			if("mouse_drop_zone")
-				value = appearance:mouse_drop_zone
-			if("mouse_opacity")
-				value = appearance:mouse_opacity
-			if("name")
-				value = appearance:name
-			if("opacity")
-				value = appearance:opacity
-			if("overlays")
-				value = appearance:overlays
-			if("override")
-				value = appearance:override
-			if("pixel_x")
-				value = appearance:pixel_x
-			if("pixel_y")
-				value = appearance:pixel_y
-			if("pixel_w")
-				value = appearance:pixel_w
-			if("pixel_z")
-				value = appearance:pixel_z
-			if("plane")
-				value = appearance:plane
-			if("render_source")
-				value = appearance:render_source
-			if("render_target")
-				value = appearance:render_target
-			if("suffix")
-				value = appearance:suffix
-			if("text")
-				value = appearance:text
-			if("transform")
-				value = appearance:transform
-			if("underlays")
-				value = appearance:underlays
-
-			if("parent_type")
-				value = appearance:parent_type
-			if("type")
-				value = "/appearance (as [appearance:type])" // don't fool people
-
-			// These are not documented ones but trackable values. Maybe we'd want these.
-			if("animate_movement")
-				value = appearance:animate_movement
-			if("dir")
-				value = appearance:dir
-			if("glide_size")
-				value = appearance:glide_size
-			if("pixel_step_size")
-				value = "" //appearance:pixel_step_size
-				// DM compiler complains this
-
-			// I am not sure if these will be ever detected, but I made a connection just in case.
-			if("contents")
-				value = appearance:contents
-			if("vis_contents")
-				value = appearance:vis_contents
-			if("vis_flags") // DM document says /appearance has this, but it throws error
-				value = appearance:vis_flags
-			if("loc")
-				value = appearance:loc
-
-			// we wouldn't need these, but let's these trackable anyway...
-			if("density")
-				value = appearance:density
-			if("screen_loc")
-				value = appearance:screen_loc
-			if("sorted_verbs")
-				value = appearance:sorted_verbs
-			if("tag")
-				value = appearance:tag
-			if("cached_ref")
-				value = appearance:cached_ref
-
-			else
-				return "<li style='backgroundColor:white'>(READ ONLY) [var_name] <font color='blue'>(Undefined var name in switch)</font></li>"
+		value = locate_appearance_variable(var_name, appearance)
 	catch
 		return "<li style='backgroundColor:white'>(READ ONLY) <font color='blue'>[var_name] = (untrackable)</font></li>"
+	if(value == RESULT_VARIABLE_NOT_FOUND)
+		return "<li style='backgroundColor:white'>(READ ONLY) [var_name] <font color='blue'>(Undefined var name in switch)</font></li>"
 	return "<li style='backgroundColor:white'>(READ ONLY) [var_name] = [_debug_variable_value(var_name, value, 0, appearance, sanitize = TRUE, display_flags = NONE)]</li>"
+
+/// manually locate a variable through string value.
+/// appearance type needs a manual var referencing because it doesn't have "vars" variable internally.
+/// There's no way doing this in a fancier way.
+/proc/locate_appearance_variable(var_name, atom/movable/appearance) // it isn't /movable. It had to be at it to use NAMEOF macro
+	switch(var_name) // Welcome to this curse
+		// appearance doesn't have "vars" variable.
+		// This means you need to target a variable manually through this way.
+
+		// appearance vars in DM document
+		if(NAMEOF(appearance, alpha))
+			return rappearance.alpha
+		if(NAMEOF(appearance, appearance_flags))
+			return rappearance.appearance_flags
+		if(NAMEOF(appearance, blend_mode))
+			return rappearance.blend_mode
+		if(NAMEOF(appearance, color))
+			return rappearance.color
+		if(NAMEOF(appearance, desc))
+			return rappearance.desc
+		if(NAMEOF(appearance, gender))
+			return rappearance.gender
+		if(NAMEOF(appearance, icon))
+			return rappearance.icon
+		if(NAMEOF(appearance, icon_state))
+			return rappearance.icon_state
+		if(NAMEOF(appearance, invisibility))
+			return rappearance.invisibility
+		if(NAMEOF(appearance, infra_luminosity))
+			return rappearance.infra_luminosity
+		if(NAMEOF(appearance, filters))
+			return rappearance.filters
+		if(NAMEOF(appearance, layer))
+			return rappearance.layer
+		if(NAMEOF(appearance, luminosity))
+			return rappearance.luminosity
+		if(NAMEOF(appearance, maptext))
+			return rappearance.maptext
+		if(NAMEOF(appearance, maptext_width))
+			return rappearance.maptext_width
+		if(NAMEOF(appearance, maptext_height))
+			return rappearance.maptext_height
+		if(NAMEOF(appearance, maptext_x))
+			return rappearance.maptext_x
+		if(NAMEOF(appearance, maptext_y))
+			return rappearance.maptext_y
+		if(NAMEOF(appearance, mouse_over_pointer))
+			return rappearance.mouse_over_pointer
+		if(NAMEOF(appearance, mouse_drag_pointer))
+			return rappearance.mouse_drag_pointer
+		if(NAMEOF(appearance, mouse_drop_pointer))
+			return rappearance.mouse_drop_pointer
+		if("mouse_drop_zone") // OpenDream didn't implement this yet.
+			return appearance:mouse_drop_zone
+		if(NAMEOF(appearance, mouse_opacity))
+			return rappearance.mouse_opacity
+		if(NAMEOF(appearance, name))
+			return rappearance.name
+		if(NAMEOF(appearance, opacity))
+			return rappearance.opacity
+		if(NAMEOF(appearance, overlays))
+			return rappearance.overlays
+		if("override") // only /image has this
+			var/image/image_appearance = appearance
+			return image_appearance.override
+		if(NAMEOF(appearance, pixel_x))
+			return rappearance.pixel_x
+		if(NAMEOF(appearance, pixel_y))
+			return rappearance.pixel_y
+		if(NAMEOF(appearance, pixel_w))
+			return rappearance.pixel_w
+		if(NAMEOF(appearance, pixel_z))
+			return rappearance.pixel_z
+		if(NAMEOF(appearance, plane))
+			return rappearance.plane
+		if(NAMEOF(appearance, render_source))
+			return rappearance.render_source
+		if(NAMEOF(appearance, render_target))
+			return rappearance.render_target
+		if(NAMEOF(appearance, suffix))
+			return rappearance.suffix
+		if(NAMEOF(appearance, text))
+			return rappearance.text
+		if(NAMEOF(appearance, transform))
+			return rappearance.transform
+		if(NAMEOF(appearance, underlays))
+			return rappearance.underlays
+
+		if(NAMEOF(appearance, parent_type))
+			return rappearance.parent_type
+		if(NAMEOF(appearance, type))
+			return "/appearance (as [rappearance.type])" // don't fool people
+
+		// These are not documented ones but trackable values. Maybe we'd want these.
+		if(NAMEOF(appearance, animate_movement))
+			return appearance.animate_movement
+		if(NAMEOF(appearance, dir))
+			return appearance.dir
+		if(NAMEOF(appearance, glide_size))
+			return appearance.glide_size
+		if("pixel_step_size")
+			return "" //atom_appearance.pixel_step_size
+			// DM compiler complains this
+
+		// I am not sure if these will be ever detected, but I made a connection just in case.
+		if(NAMEOF(appearance, contents)) // It's not a thing, but I don't believe how DM will change /appearance in future.
+			return appearance.contents
+		if(NAMEOF(appearance, loc)) // same reason above
+			return appearance.loc
+		if(NAMEOF(appearance, vis_contents)) // same reason above
+			return appearance.vis_contents
+		if(NAMEOF(appearance, vis_flags)) // DM document says /appearance has this, but it throws error
+			return appearance.vis_flags
+
+		// we wouldn't need these, but let's these trackable anyway...
+		if(NAMEOF(appearance, density))
+			return rappearance.density
+		if(NAMEOF(appearance, screen_loc))
+			return rappearance.screen_loc
+		if(NAMEOF(appearance, sorted_verbs))
+			return rappearance.sorted_verbs
+		if(NAMEOF(appearance, tag))
+			return rappearance.tag
+		if(NAMEOF(appearance, cached_ref))
+			return rappearance.cached_ref
+	return RESULT_VARIABLE_NOT_FOUND
 
 /// Shows a header name on top when you investigate an appearance
 /proc/vv_get_header_appearance(image/thing)
@@ -190,7 +203,11 @@
 
 /proc/vv_get_dropdown_appearance(image/thing)
 	. = list()
-    // unless you have a good reason to add a vv option for /appearance,
-    // /appearance type shouldn't alloow any vv option. Even "Mark Datum" is a questionable behaviour here.
+	// unless you have a good reason to add a vv option for /appearance,
+	// /appearance type shouldn't allow any vv option. Even "Mark Datum" is a questionable behaviour here.
 	VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "---")
 	VV_DROPDOWN_OPTION_APPEARANCE(thing, "", "VV option not allowed")
+	return .
+
+#undef ADD_UNUSED_VAR
+#undef RESULT_VARIABLE_NOT_FOUND

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -52,6 +52,10 @@
 	if(isappearance(value)) // Reminder: Do not replace this into /image/debug_variable_value() proc. /appearance can't do that.
 		return "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>/appearance (<span class='value'>[get_appearance_vv_summary_name(value)]</span>) [REF(value)]</a>"
 
+	if(isimage(value))
+		var/image/image = value
+		return "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>[image.type] (<span class='value'>[get_appearance_vv_summary_name(image)]</span>) [REF(value)]</a>"
+
 	if(isfilter(value))
 		var/datum/filter_value = value
 		return "/filter (<span class='value'>[filter_value.type] [REF(filter_value)]</span>)"

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -49,9 +49,8 @@
 		return "/icon (<span class='value'>[value]</span>)"
 		#endif
 
-	if(isappearance(value))
-		var/icon_name = get_appearance_vv_summary_name(value)
-		return "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)];use_locate=1'>/appearance (<span class='value'>[icon_name]</span>) [REF(value)]</a>"
+	if(isappearance(value)) // Reminder: Do not replace this into /image/debug_variable_value() proc. /appearance can't do that.
+		return "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)]'>/appearance (<span class='value'>[get_appearance_vv_summary_name(value)]</span>) [REF(value)]</a>"
 
 	if(isfilter(value))
 		var/datum/filter_value = value

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -50,8 +50,8 @@
 		#endif
 
 	if(isappearance(value))
-		var/image/actually_an_appearance = value
-		return "/appearance (<span class='value'>[actually_an_appearance.icon]</span>)"
+		var/icon_name = get_appearance_vv_summary_name(value)
+		return "<a href='?_src_=vars;[HrefToken()];Vars=[REF(value)];use_locate=1'>/appearance (<span class='value'>[icon_name]</span>) [REF(value)]</a>"
 
 	if(isfilter(value))
 		var/datum/filter_value = value

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -85,15 +85,14 @@
 		dropdownoptions = thing.vv_get_dropdown()
 
 	var/list/names = list()
-	if(!islist)
-		if(isappearance)
-			var/static/list/appearnace_vars
-			if(!appearnace_vars)
-				appearnace_vars = build_appearance_var_list()
-			names = appearnace_vars.Copy()
-		else
-			for(var/varname in thing.vars)
-				names += varname
+	if(isappearance)
+		var/static/list/appearnace_vars
+		if(!appearnace_vars)
+			appearnace_vars = build_appearance_var_list()
+		names = appearnace_vars.Copy()
+	else if(!islist)
+		for(var/varname in thing.vars)
+			names += varname
 
 	sleep(1 TICKS)
 

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -1,3 +1,6 @@
+#define ICON_STATE_CHECKED 1 /// this dmi is checked. We don't check this one anymore.
+#define ICON_STATE_NULL 2 /// this dmi has null-named icon_state, allowing it to show a sprite on vv editor.
+
 /client/proc/debug_variables(datum/thing in world)
 	set category = "Debug"
 	set name = "View Variables"
@@ -32,12 +35,26 @@
 		if(!sprite)
 			no_icon = TRUE
 
-	else if(isimage(thing) || isappearance(thing))
-		var/image/image_object = thing
+	else if(isimage(thing) || isappearance)
 		// icon_state=null shows first image even if dmi has no icon_state for null name.
-		// Unless dmi has a single icon_state as null name, let's skip null-name because it's confusing
-		if(image_object.icon_state || length(icon_states(image_object.icon)) == 1)
-			sprite = icon(image_object.icon, image_object.icon_state)
+		// This list remembers which dmi has null icon_state, to determine if icon_state=null should display a sprite
+		// (NOTE: icon_state="" is correct, but saying null is obvious)
+		var/static/list/dmi_nullstate_checklist = list()
+		var/image/image_object = thing
+		var/icon_filename_text = "[image_object.icon]" // "icon(null)" type can exist. textifying filters it.
+		if(icon_filename_text)
+			if(image_object.icon_state)
+				sprite = icon(image_object.icon, image_object.icon_state)
+
+			else // it means: icon_state=""
+				if(!dmi_nullstate_checklist[icon_filename_text])
+					dmi_nullstate_checklist[icon_filename_text] = ICON_STATE_CHECKED
+					if("" in icon_states(image_object.icon))
+						// this dmi has nullstate. We'll allow "icon_state=null" to show image.
+						dmi_nullstate_checklist[icon_filename_text] = ICON_STATE_NULL
+
+				if(dmi_nullstate_checklist[icon_filename_text] == ICON_STATE_NULL)
+					sprite = icon(image_object.icon, image_object.icon_state)
 
 	var/sprite_text
 	if(sprite)
@@ -89,9 +106,7 @@
 
 	var/list/names = list()
 	if(isappearance)
-		var/static/list/virtual_appearance_vars
-		if(!virtual_appearance_vars)
-			virtual_appearance_vars = build_virtual_appearance_vars()
+		var/static/list/virtual_appearance_vars = build_virtual_appearance_vars()
 		names = virtual_appearance_vars.Copy()
 	else if(!islist)
 		for(var/varname in thing.vars)
@@ -296,3 +311,6 @@ datumrefresh=[refid];[HrefToken()]'>Refresh</a>
 
 /client/proc/vv_update_display(datum/thing, span, content)
 	src << output("[span]:[content]", "variables[REF(thing)].browser:replace_span")
+
+#undef ICON_STATE_CHECKED
+#undef ICON_STATE_NULL

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -87,10 +87,10 @@
 
 	var/list/names = list()
 	if(isappearance)
-		var/static/list/appearnace_vars
-		if(!appearnace_vars)
-			appearnace_vars = build_appearance_var_list()
-		names = appearnace_vars.Copy()
+		var/static/list/appearance_vars
+		if(!appearance_vars)
+			appearance_vars = build_appearance_var_list()
+		names = appearance_vars.Copy()
 	else if(!islist)
 		for(var/varname in thing.vars)
 			names += varname

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -34,7 +34,9 @@
 
 	else if(isimage(thing) || isappearance(thing))
 		var/image/image_object = thing
-		if(image_object.icon_state) // icon_state=null shows first image. Let's skip null name for general cases, because it's confusing.
+		// icon_state=null shows first image even if dmi has no icon_state for null name.
+		// Unless dmi has a single icon_state as null name, let's skip null-name because it's confusing
+		if(image_object.icon_state || length(icon_states(image_object.icon)) == 1)
 			sprite = icon(image_object.icon, image_object.icon_state)
 
 	var/sprite_text
@@ -87,10 +89,10 @@
 
 	var/list/names = list()
 	if(isappearance)
-		var/static/list/appearance_vars
-		if(!appearance_vars)
-			appearance_vars = build_appearance_var_list()
-		names = appearance_vars.Copy()
+		var/static/list/virtual_appearance_vars
+		if(!virtual_appearance_vars)
+			virtual_appearance_vars = build_virtual_appearance_vars()
+		names = virtual_appearance_vars.Copy()
 	else if(!islist)
 		for(var/varname in thing.vars)
 			names += varname

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -34,7 +34,8 @@
 
 	else if(isimage(thing) || isappearance(thing))
 		var/image/image_object = thing
-		sprite = icon(image_object.icon, image_object.icon_state)
+		if(image_object.icon_state) // icon_state=null shows first image. Let's skip null name for general cases, because it's confusing.
+			sprite = icon(image_object.icon, image_object.icon_state)
 
 	var/sprite_text
 	if(sprite)
@@ -80,7 +81,7 @@
 			var/link = dropdownoptions[name]
 			dropdownoptions[i] = "<option value[link? "='[link]'":""]>[name]</option>"
 	else if(isappearance)
-		dropdownoptions = list("VV unavailable")
+		dropdownoptions = vv_get_dropdown_appearance(thing)
 	else
 		dropdownoptions = thing.vv_get_dropdown()
 

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -7,6 +7,8 @@
 	//We'll spawn everything here
 	var/turf/spawn_at = run_loc_floor_bottom_left
 	var/list/ignore = list(
+		//this is somehow a subtype of /atom/movable, because of its purpose...
+		/image/appearance
 		//Never meant to be created, errors out the ass for mobcode reasons
 		/mob/living/carbon,
 		//Nother template type, doesn't like being created with no seed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* TG discussion here: https://github.com/tgstation/tgstation/pull/82670

VV editor can now see /appearance types
These ones are kinda blackboxed, and we have no idea what these are in general.
I made it investigatable, but because of the nature of /appearance, the code is super janky, but it's inevitable curse.

I left an important comment inside:

### Comment
 	< OH MY GOD. Can't you just make "/image/proc/foo()" instead of making these? >
 		/appearance is a hardcoded byond type, and it is very internal type.
		Its type is actually /image, but it isn't truly /image. We defined it as "/appearance"
 		new procs to /image will only work to actual /image references, but...
 		/appearance references are not capable of executing procs, because these are not real /image
 		This is why these global procs exist. Welcome to the curse.



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Debugging tool is good for us

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/f0c48ddf-fc2e-455f-8d4c-ad491e7c3b00)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/614948d5-7d56-4e9c-b9b1-316e80fe62bf)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/ac13c6b6-199d-43aa-a6d8-62b2038b4d93)

--------------

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/c348022e-57a0-472f-a41a-24eb4c94189e)

I can see things are duplicated inside.

------------

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/14190b1f-a530-428f-9de9-564ff9818b00)

~some /appearance types are editable in specific situations (usually client only images like atom_hud)~
Actually it was /image and vv editor bug thought it's appearance. This pr fixed that too

## Changelog
:cl:
code: /appearance type references are now investigatable in vv editor. 
fix: Fixed /image ref was identified as /appearance in vv editor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
