### PR TITLE
Adds a fake type for emissive_appearance and emissive_blocker

### DIFF
--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -12,8 +12,12 @@
 		plane = FLOAT_PLANE
 
 // Helper similar to image()
-/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE, color)
-	var/mutable_appearance/MA = new()
+/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE, color, fake_typepath)
+	var/mutable_appearance/MA
+	if(!fake_typepath)
+		MA = new()
+	else
+		MA = new fake_typepath()
 	MA.icon = icon
 	MA.icon_state = icon_state
 	MA.layer = layer
@@ -24,13 +28,17 @@
 		MA.color = color
 	return MA
 
+// pretend them to be another type. These are helpful in vv editor
+/emissive_appearance/parent_type = /mutable_appearance
+/emissive_blocker/parent_type = /mutable_appearance
+
 /// Produces a mutable appearance glued to the [EMISSIVE_PLANE] dyed to be the [EMISSIVE_COLOR].
 /// Setting the layer is highly important
 /proc/emissive_appearance(icon, icon_state = "", layer = FLOAT_LAYER, alpha = 255, appearance_flags = NONE)
 	// We actually increase the layer ever so slightly so that emissives overpower blockers.
 	// We do this because emissives and blockers can be applied to the same item and in that case
 	// we do not want the item to block its own emissive overlay.
-	var/mutable_appearance/appearance = mutable_appearance(icon, icon_state, layer + 0.01, EMISSIVE_PLANE, alpha, appearance_flags | EMISSIVE_APPEARANCE_FLAGS)
+	var/mutable_appearance/appearance = mutable_appearance(icon, icon_state, layer + 0.01, EMISSIVE_PLANE, alpha, appearance_flags | EMISSIVE_APPEARANCE_FLAGS, fake_typepath = /emissive_appearance)
 	var/list/found = GLOB.emissive_color[alpha+1]
 	if (!found)
 		found = GLOB.emissive_color[alpha+1] = list(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,alpha/255, 1,1,1,0)
@@ -40,6 +48,6 @@
 /// Produces a mutable appearance glued to the [EMISSIVE_PLANE], but instead of more opaque being white, more opaque is black.
 /// Setting the layer is highly important
 /proc/emissive_blocker(icon, icon_state = "", layer = FLOAT_LAYER, alpha = 255, appearance_flags = NONE)
-	var/mutable_appearance/appearance = mutable_appearance(icon, icon_state, layer, EMISSIVE_PLANE, alpha, appearance_flags | EMISSIVE_APPEARANCE_FLAGS)
+	var/mutable_appearance/appearance = mutable_appearance(icon, icon_state, layer, EMISSIVE_PLANE, alpha, appearance_flags | EMISSIVE_APPEARANCE_FLAGS, fake_typepath = /emissive_blocker)
 	appearance.color = GLOB.em_blocker_matrix
 	return appearance


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a fake type for emissive_appearance and emissive_blocker
These are classified in /alternative_appearance in vv editor, and that makes us difficult to identify which one is which.
This PR makes a fake typepath as `/emissive_appearance` and `/emissive_blocker` that has parent_type as `alternative_appearance`, but it shows their own type path in vv editor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Debuging QoL
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/cf3af24a-c1f2-4eed-9713-437d0bf58f5c)
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/42978a91-fb1f-47eb-8059-fc271e05b46d)

emissive_appearance

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/739815a8-8e1b-4ffa-990b-fc86c82ee392)

emissive_blocker (without my appearance pr verbose)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/7189e7b5-c14f-46bb-8e9a-86bb42e6e88d)


## Changelog
:cl:
code: added a fake typepath for /emissive_appearance and /emissive_blocker for vv debuging QoL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
