### PR TITLE
Proper luminosity usage

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -171,16 +171,16 @@ GLOBAL_DATUM_INIT(starlight_overlay, /image, create_starlight_overlay())
 
 /// Add a luminosity source to a target
 #define ADD_LUM_SOURCE(target, em_source) \
-target._emissive_count |= em_source;\
-if (target._emissive_count == em_source)\
+UNLINT(target._emissive_count |= em_source);\
+if (UNLINT(target._emissive_count == em_source))\
 {\
 	target.update_luminosity();\
 }
 
 /// Remove a luminosity source to a target
 #define REMOVE_LUM_SOURCE(target, em_source) \
-target._emissive_count &= ~(em_source);\
-if (target._emissive_count == 0)\
+UNLINT(target._emissive_count &= ~(em_source));\
+if (UNLINT(target._emissive_count == 0))\
 {\
 	target.update_luminosity();\
 }

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(dynamic_lighting == DYNAMIC_LIGHTING_IFSTARLIGHT)
 		dynamic_lighting = CONFIG_GET(flag/starlight) ? DYNAMIC_LIGHTING_ENABLED : DYNAMIC_LIGHTING_DISABLED
 	if(dynamic_lighting == DYNAMIC_LIGHTING_DISABLED)
-		base_luminosity = 1
+		set_base_luminosity(src, 1)
 
 	. = ..()
 
@@ -246,7 +246,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	update_lighting_overlay()
 	//Areas with a lighting overlay should be fully visible, and the tiles adjacent to them should also
 	//be luminous
-	luminosity = 1
+	set_base_luminosity(src, 1)
 	//Add the lighting overlay
 	add_overlay(lighting_overlay)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1909,8 +1909,11 @@
 	else
 		UNLINT(luminosity = max(base_luminosity, affecting_dynamic_lumi))
 
-#define set_base_luminosity(target, new_value) UNLINT(target.base_luminosity = new_value);\
-	target.update_luminosity();
+#define set_base_luminosity(target, new_value)\
+if (UNLINT(target.base_luminosity != new_value)) {\
+	UNLINT(target.base_luminosity = new_value);\
+	target.update_luminosity();\
+}
 
 /atom/movable/proc/get_orbitable()
 	return src

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -143,10 +143,12 @@
 	///LazyList of all balloon alerts currently on this atom
 	var/list/balloon_alerts
 
-	/// How much luminosity should we have by default?
-	var/base_luminosity = 0
+	/// What is our default level of luminosity, if you want inherent luminosity
+	/// withing an atom's type, set luminosity instead and we will manage it for you.
+	/// Always use set_base_luminosity instead of directly modifying this
+	VAR_PRIVATE/base_luminosity = 0
 	/// DO NOT EDIT THIS, USE ADD_LUM_SOURCE INSTEAD
-	var/_emissive_count = 0
+	VAR_PRIVATE/_emissive_count = 0
 
 /**
   * Called when an atom is created in byond (built in engine proc)
@@ -1902,10 +1904,13 @@
 	if (isnull(base_luminosity))
 		base_luminosity = initial(luminosity)
 
-	if (_emissive_count)
-		luminosity = max(max(base_luminosity, affecting_dynamic_lumi), 1)
+	if (UNLINT(_emissive_count))
+		UNLINT(luminosity = max(max(base_luminosity, affecting_dynamic_lumi), 1))
 	else
-		luminosity = max(base_luminosity, affecting_dynamic_lumi)
+		UNLINT(luminosity = max(base_luminosity, affecting_dynamic_lumi))
+
+#define set_base_luminosity(target, new_value) UNLINT(target.base_luminosity = new_value);\
+	target.update_luminosity();
 
 /atom/movable/proc/get_orbitable()
 	return src

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -124,13 +124,6 @@
 	ADD_LUM_SOURCE(src, LUM_SOURCE_MANAGED_OVERLAY)
 	. += locked ? icon_locked : icon_unlocked
 
-/obj/structure/closet/update_appearance(updates=ALL)
-	. = ..()
-	if((opened || broken || !secure) || !imacrate)
-		luminosity = 0
-		return
-	luminosity = 1
-
 /obj/structure/closet/proc/animate_door(var/closing = FALSE)
 	if(!door_anim_time)
 		return

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -39,7 +39,6 @@
 			stack_trace("A lighting object was qdeleted with a different loc then it is suppose to have ([COORD(oldturf)] -> [COORD(newturf)])")
 		if (isturf(myturf))
 			myturf.lighting_object = null
-			set_base_luminosity(myturf, initial(myturf.luminosity))
 			myturf.underlays -= additive_underlay
 		myturf = null
 
@@ -147,7 +146,9 @@
 	else
 		myturf.underlays -= additive_underlay
 
-	set_base_luminosity(src, set_luminosity)
+	// Use luminosity directly because we are the lighting object
+	// and not the turf
+	luminosity = set_luminosity
 
 	if (myturf.above)
 		if(myturf.above.shadower)

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -23,7 +23,6 @@
 	if (myturf.lighting_object)
 		qdel(myturf.lighting_object, force = TRUE)
 	myturf.lighting_object = src
-	myturf.luminosity = 0
 
 	additive_underlay = mutable_appearance(LIGHTING_ICON, "light", FLOAT_LAYER, LIGHTING_PLANE_ADDITIVE, 255, RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM)
 	additive_underlay.blend_mode = BLEND_ADD
@@ -40,7 +39,7 @@
 			stack_trace("A lighting object was qdeleted with a different loc then it is suppose to have ([COORD(oldturf)] -> [COORD(newturf)])")
 		if (isturf(myturf))
 			myturf.lighting_object = null
-			myturf.luminosity = initial(myturf.luminosity)
+			set_base_luminosity(myturf, initial(myturf.luminosity))
 			myturf.underlays -= additive_underlay
 		myturf = null
 
@@ -148,7 +147,7 @@
 	else
 		myturf.underlays -= additive_underlay
 
-	luminosity = set_luminosity
+	set_base_luminosity(src, set_luminosity)
 
 	if (myturf.above)
 		if(myturf.above.shadower)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes some usage of luminosity that was still on the old system.
~~Since this is being used in the extremly hot lighting object update function, I have inlined the proc and made it so that it doesn't update the luminosity count at all if it doesn't need to.~~ nvm that was a non-issue and has been reverted. (Lighting updates luminosity on its own lighting object and not the turf)

## Why It's Good For The Game

We have a proper system for updating and managing luminosity counts, remove the uses of it that would break it.
Also, I am linting aganist anyone incorrectly using base_luminosity or lum count directly, rather than just saying "please dont use this >_<"

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2a1b189c-aeee-467e-bf86-ebb09b6000f2)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/38412265-9f60-4f65-ba81-73776fede538)

Still works fine when broke.

Map looks normal.

## Changelog
:cl:
fix: Updates some uses of luminosity internall for lockers and turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
