### PR TITLE
Updates the hub entry

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -421,6 +421,7 @@
 #include "code\controllers\subsystem\fail2topic.dm"
 #include "code\controllers\subsystem\fire_burning.dm"
 #include "code\controllers\subsystem\garbage.dm"
+#include "code\controllers\subsystem\hub.dm"
 #include "code\controllers\subsystem\icon_smooth.dm"
 #include "code\controllers\subsystem\idlenpcpool.dm"
 #include "code\controllers\subsystem\input.dm"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -23,6 +23,8 @@
 
 /datum/config_entry/string/servername	// server name (the name of the game window)
 
+/datum/config_entry/string/servertag	// Server tagline for displaying on the hub
+
 /datum/config_entry/string/serversqlname	// short form server name used for the DB
 
 /datum/config_entry/string/stationname	// station name (the name of the station in-game)
@@ -242,6 +244,9 @@
 
 /datum/config_entry/string/discordurl
 	config_entry_value = "https://discord.gg/zUe34rs"
+
+/datum/config_entry/string/websiteurl
+	config_entry_value = "http://beestation13.com"
 
 /datum/config_entry/string/roundstatsurl
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -245,9 +245,6 @@
 /datum/config_entry/string/discordurl
 	config_entry_value = "https://discord.gg/zUe34rs"
 
-/datum/config_entry/string/websiteurl
-	config_entry_value = "http://beestation13.com"
-
 /datum/config_entry/string/roundstatsurl
 
 /datum/config_entry/string/gamelogurl

--- a/code/controllers/subsystem/hub.dm
+++ b/code/controllers/subsystem/hub.dm
@@ -1,0 +1,7 @@
+SUBSYSTEM_DEF(hub)
+	name = "Hub Entry"
+	flags = SS_NO_INIT
+	wait = 1 MINUTES
+
+/datum/controller/subsystem/hub/fire(resumed)
+	world.update_status()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -360,13 +360,13 @@ GLOBAL_VAR(restart_counter)
 
 	var/server_name = CONFIG_GET(string/servername)
 	if (server_name)
-		s += "<a href='[world.url]'><b>[server_name] - [station_name]</b></a><br>"
+		s += "<a href='[world.url]'><b>[server_name] - [station_name()]</b></a><br>"
 	else
 		s += "<a href='[world.url]'><b>[station_name()]</b></a><br>";
 
 	var/server_tag = CONFIG_GET(string/servertag)
-	if (servertag)
-		s += "[servertag]<br>"
+	if (server_tag)
+		s += "[server_tag]<br><br>"
 
 	var/players = GLOB.clients.len
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -380,7 +380,7 @@ GLOBAL_VAR(restart_counter)
 	s += "Time: <b>[gameTimestamp("hh:mm")]</b><br>"
 	s += "Alert: <b>[capitalize(get_security_level())]</b><br>"
 	s += "Players: <b>[players][popcaptext]</b><br>"
-	s += "Map: <b>[SSmapping.config?.map_name ?? "Loading..."]</b><br>"
+	s += "Map: <b>[SSmapping.config?.map_name || "Loading..."]</b><br>"
 
 	var/list/urls = list()
 	var/discordurl = CONFIG_GET(string/discordurl)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -380,7 +380,7 @@ GLOBAL_VAR(restart_counter)
 	s += "Time: <b>[gameTimestamp("hh:mm")]</b><br>"
 	s += "Alert: <b>[capitalize(get_security_level())]</b><br>"
 	s += "Players: <b>[players][popcaptext]</b><br>"
-	s += "Map: <b>[SSmapping.config.map_name]</b><br>"
+	s += "Map: <b>[SSmapping.config?.map_name ?? "Loading..."]</b><br>"
 
 	var/list/urls = list()
 	var/discordurl = CONFIG_GET(string/discordurl)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -356,24 +356,17 @@ GLOBAL_VAR(restart_counter)
 	..()
 
 /world/proc/update_status()
-
-	var/list/features = list()
-
-	if (!GLOB.enter_allowed)
-		features += "closed"
-
 	var/s = ""
-	var/hostedby
-	if(config)
-		var/server_name = CONFIG_GET(string/servername)
-		if (server_name)
-			s += "<b>[server_name]</b> &#8212; "
 
-		hostedby = CONFIG_GET(string/hostedby)
+	var/server_name = CONFIG_GET(string/servername)
+	if (server_name)
+		s += "<a href='[world.url]'><b>[server_name] - [station_name]</b></a><br>"
+	else
+		s += "<a href='[world.url]'><b>[station_name()]</b></a><br>";
 
-	s += "<b>[station_name()]</b>";
-	var/discordurl = CONFIG_GET(string/discordurl)
-	s += " (<a href='[discordurl]'>Discord</a>|<a href='http://beestation13.com'>Website</a>)"
+	var/server_tag = CONFIG_GET(string/servertag)
+	if (servertag)
+		s += "[servertag]<br>"
 
 	var/players = GLOB.clients.len
 
@@ -384,15 +377,23 @@ GLOBAL_VAR(restart_counter)
 
 	game_state = (CONFIG_GET(number/extreme_popcap) && players >= CONFIG_GET(number/extreme_popcap)) //tells the hub if we are full
 
-	if (!host && hostedby)
-		features += "hosted by <b>[hostedby]</b>"
+	s += "Time: <b>[gameTimestamp("hh:mm")]</b><br>"
+	s += "Alert: <b>[capitalize(get_security_level())]</b><br>"
+	s += "Players: <b>[players][popcaptext]</b><br>"
+	s += "Map: <b>[SSmapping.config.map_name]</b><br>"
 
-	if(length(features))
-		s += ": [jointext(features, ", ")]"
-
-	s += "<br>Time: <b>[gameTimestamp("hh:mm")]</b>"
-	s += "<br>Alert: <b>[capitalize(get_security_level())]</b>"
-	s += "<br>Players: <b>[players][popcaptext]</b>"
+	var/list/urls = list()
+	var/discordurl = CONFIG_GET(string/discordurl)
+	if (discordurl)
+		urls += "<a href='[discordurl]'>Discord</a>"
+	var/wikiurl = CONFIG_GET(string/wikiurl)
+	if (wikiurl)
+		urls += "<a href='[wikiurl]'>Wiki</A>"
+	var/websiteurl = CONFIG_GET(string/websiteurl)
+	if (websiteurl)
+		urls += "<a href='[websiteurl]'>Website</A>"
+	if (length(urls))
+		s += jointext(urls, " | ")
 
 	status = s
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -370,7 +370,7 @@ GLOBAL_VAR(restart_counter)
 		popcaptext = "/[popcap]"
 
 	// Determine our character usage
-	var/character_usage = 85	// Base character usage
+	var/character_usage = 86	// Base character usage
 	// Discord URL is needed
 	if (discordurl)
 		character_usage += length(discordurl)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -363,6 +363,11 @@ GLOBAL_VAR(restart_counter)
 	var/server_name = CONFIG_GET(string/servername)
 	var/server_tag = CONFIG_GET(string/servertag)
 	var/station_name = station_name()
+	var/players = GLOB.clients.len
+	var/popcaptext = ""
+	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
+	if (popcap)
+		popcaptext = "/[popcap]"
 
 	// Determine our character usage
 	var/character_usage = 85	// Base character usage
@@ -415,13 +420,6 @@ GLOBAL_VAR(restart_counter)
 
 	if (server_tag)
 		s += "[server_tag]<p>"
-
-	var/players = GLOB.clients.len
-
-	var/popcaptext = ""
-	var/popcap = max(CONFIG_GET(number/extreme_popcap), CONFIG_GET(number/hard_popcap), CONFIG_GET(number/soft_popcap))
-	if (popcap)
-		popcaptext = "/[popcap]"
 
 	s += "Time: <b>[gameTimestamp("hh:mm:ss")]</b><br>"
 	s += "Players: <b>[players][popcaptext]</b><br>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -438,7 +438,6 @@
 		to_chat(world, "<B>New players may now enter the game.</B>")
 	log_admin("[key_name(usr)] toggled new player game entering.")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] toggled new player game entering.</span>")
-	world.update_status()
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Entering", "[GLOB.enter_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleAI()
@@ -452,7 +451,6 @@
 	else
 		to_chat(world, "<B>The AI job is chooseable now.</B>")
 	log_admin("[key_name(usr)] toggled AI allowed.")
-	world.update_status()
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle AI", "[!alai ? "Disabled" : "Enabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleaban()
@@ -467,7 +465,6 @@
 		to_chat(world, "<B>You may no longer respawn :(</B>")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] toggled respawn to [!new_nores ? "On" : "Off"].</span>")
 	log_admin("[key_name(usr)] toggled respawn to [!new_nores ? "On" : "Off"].")
-	world.update_status()
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Respawn", "[!new_nores ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/delay()

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -206,7 +206,6 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	//BR finished? Let people play as borgs/golems again
 	ENABLE_BITFIELD(GLOB.ghost_role_flags, (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS))
 
-	world.update_status()
 	GLOB.battle_royale = null
 
 //Trigger random events and shit, update the world border
@@ -275,7 +274,6 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	//Don't let anyone join as posibrains/golems etc
 	DISABLE_BITFIELD(GLOB.ghost_role_flags, (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS))
 
-	world.update_status()
 	if(SSticker.current_state < GAME_STATE_PREGAME)
 		to_chat(world, "<span class=boldannounce>Battle Royale: Waiting for server to be ready...</span>")
 		SSticker.start_immediately = FALSE

--- a/config/config.txt
+++ b/config/config.txt
@@ -290,9 +290,6 @@ DONATEURL https://www.patreon.com/user?u=10639001
 ## Discord Invite
 DISCORDURL https://discord.gg/ss13
 
-## Website URL
-WEBSITEURL http://beestation13.com
-
 ## Round specific stats address
 ## Link to round specific parsed logs; IE statbus. It is appended with the RoundID automatically by ticker/Reboot()
 ## This will take priority over the game logs address during reboot.

--- a/config/config.txt
+++ b/config/config.txt
@@ -288,7 +288,7 @@ GITHUBURL https://www.github.com/beestation/beestation-hornet
 DONATEURL https://www.patreon.com/user?u=10639001
 
 ## Discord Invite
-DISCORDURL https://discord.gg/zUe34rs
+DISCORDURL https://discord.gg/ss13
 
 ## Website URL
 WEBSITEURL http://beestation13.com

--- a/config/config.txt
+++ b/config/config.txt
@@ -33,7 +33,7 @@ $include policies.txt
 #@SERVERNAME beestation
 
 ## Server Tagline: The tag that will appear on the HUB
-#@SERVERTAG A new-player friendly, classic space station 13 roleplaying experience!
+#@SERVERTAG Join us for a new-player friendly, classic space station 13 roleplaying experience!
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 #@SERVERSQLNAME ss13newbs

--- a/config/config.txt
+++ b/config/config.txt
@@ -33,7 +33,7 @@ $include policies.txt
 #@SERVERNAME beestation
 
 ## Server Tagline: The tag that will appear on the HUB
-#@SERVERTAG Join us for a new-player friendly, classic space station 13 roleplaying experience!
+@SERVERTAG Join us for a new-player friendly, classic space station 13 roleplaying experience!
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 #@SERVERSQLNAME ss13newbs

--- a/config/config.txt
+++ b/config/config.txt
@@ -32,6 +32,9 @@ $include policies.txt
 ## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'beestation' with the name of your choice.
 #@SERVERNAME beestation
 
+## Server Tagline: The tag that will appear on the HUB
+#@SERVERTAG A new-player friendly, classic space station 13 roleplaying experience!
+
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 #@SERVERSQLNAME ss13newbs
 
@@ -286,6 +289,9 @@ DONATEURL https://www.patreon.com/user?u=10639001
 
 ## Discord Invite
 DISCORDURL https://discord.gg/zUe34rs
+
+## Website URL
+WEBSITEURL http://beestation13.com
 
 ## Round specific stats address
 ## Link to round specific parsed logs; IE statbus. It is appended with the RoundID automatically by ticker/Reboot()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Our hub entry is currently very boring, this makes it a little bit more unique from all the others.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/02ce8b66-a675-4f41-8f01-332f3930bc04)

We don't even have any fancy blue text:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f8920e52-7ac8-4d54-8de2-111caeed5f7e)

With the changes, it will look something like this:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/1fad6260-fde3-4d32-bafa-8e06b8075903)

Removed a few things in it that wouldn't matter for a hub entry, or weren't used. Even though it didn't show up anymore, crossedfall's clout probably won't be the thing getting new players to join, so I removed the hosted by section.

I decided to use the discord link in the name (I just wanted it to be a link so it looks cool and blue), since the discord link is the shortest link we have.
I am using //discord.gg/ss13 instead of https://discord.gg/ss13 since that works and is shorter.

## Why It's Good For The Game

Bring back the new player friendly tagline on the hub, it is everywhere else except the 1 place that new players would be looking. Every SS13 server needs new players to keep it running, and hopefully this should make our hub advertisement a little bit more appealing since we do not stand out right now.

Also adds a subsystem to manage hub entry updating since it would only update when clients joined the game before.

## Testing Photographs and Procedure

<details>

### During Load

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/018e7cb2-dcb1-4a17-86a1-08380c21a30c)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/a3e3d64b-4672-44c6-88fd-f585637ac64d)

### Post Launch

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e968a45d-ecd9-450f-ab4b-cd0ff7fe48f9)


![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/12e980ca-67cc-41aa-b526-d48093b58079)

### Handling too many characters

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/04b21fe5-3aea-45b1-b318-59590c4be630)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/e0849853-a3db-49c7-8bf0-9e0eeb1ed481)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5b5a4add-468e-4652-97e8-ad6716bab5a2)

(I forgot to count a character, so I removed it)

</details>

## Changelog
:cl:
tweak: Modifies the hub entry to make it a little more interesting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
