### PR TITLE
Improves client.eye system + advanced camera now accepts observing of mobs

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -148,6 +148,9 @@
 	/// DO NOT EDIT THIS, USE ADD_LUM_SOURCE INSTEAD
 	var/_emissive_count = 0
 
+	/// list of clients that using this atom as their eye. SHOULD BE USED CAREFULLY
+	var/list/eye_users
+
 /**
   * Called when an atom is created in byond (built in engine proc)
   *
@@ -269,6 +272,7 @@
   * Top level of the destroy chain for most atoms
   *
   * Cleans up the following:
+  * * Removes clients who use this, and resets their eye
   * * Removes alternate apperances from huds that see them
   * * qdels the reagent holder from atoms if it exists
   * * clears the orbiters list
@@ -276,6 +280,14 @@
   * * clears the light object
   */
 /atom/Destroy()
+	for(var/client/each_client as anything in eye_users)
+		eye_users -= each_client
+		if(isnull(each_client.mob))
+			stack_trace("CRITICAL: Failed to recover a client's eye as their mob.")
+			continue
+		each_client.mob.reset_perspective()
+	eye_users = null
+
 	if(alternate_appearances)
 		for(var/current_alternate_appearance in alternate_appearances)
 			var/datum/atom_hud/alternate_appearance/selected_alternate_appearance = alternate_appearances[current_alternate_appearance]
@@ -1082,7 +1094,6 @@
   */
 /atom/proc/update_remote_sight(mob/living/user)
 	return
-
 
 /**
   * Hook for running code when a dir change occurs

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -24,6 +24,12 @@
 	var/reveal_camera_mob = FALSE
 	var/camera_mob_icon = 'icons/mob/cameramob.dmi'
 	var/camera_mob_icon_state = "marker"
+	/// I hate making this variable separately, but mob/camera/ai_eye is too complex
+	/// This takes an image to show camera_eye sprite to clients who are observers
+	var/image/camera_sprite_for_observers
+
+	/// list of mobs who are watching camera, not using it directly.
+	var/list/camera_observers = list()
 
 /obj/machinery/computer/camera_advanced/Initialize(mapload)
 	. = ..()
@@ -104,6 +110,7 @@
 		actions += move_down_action
 
 /obj/machinery/proc/remove_eye_control(mob/living/user)
+	SIGNAL_HANDLER
 	CRASH("[type] does not implement ai eye handling")
 
 /obj/machinery/computer/camera_advanced/remove_eye_control(mob/living/user)
@@ -122,6 +129,9 @@
 			user.client.images -= eyeobj.user_image
 		user.client.view_size.unsupress()
 
+	shoo_all_observers()
+	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+
 	ConcealCameraMob()
 	eyeobj.eye_user = null
 	user.remote_control = null
@@ -134,11 +144,13 @@
 		user.unset_machine()
 
 /obj/machinery/computer/camera_advanced/Destroy()
+	if(current_user)
+		remove_eye_control(current_user)
+		current_user = null
 	ConcealCameraMob()
 	if(eyeobj)
 		QDEL_NULL(eyeobj)
 	QDEL_LIST(actions)
-	current_user = null
 	return ..()
 
 /obj/machinery/computer/camera_advanced/on_unset_machine(mob/M)
@@ -160,7 +172,7 @@
 	if(!is_operational) //you cant use broken machine you chumbis
 		return
 	if(current_user)
-		to_chat(user, "The console is already in use!")
+		start_observe(user)
 		return
 	var/mob/living/L = user
 
@@ -198,6 +210,36 @@
 		give_eye_control(L)
 		eyeobj.setLoc(eyeobj.loc)
 
+/obj/machinery/computer/camera_advanced/proc/start_observe(mob/user)
+	if(!user.client || !eyeobj)
+		return
+
+	if(!camera_sprite_for_observers && eyeobj.visible_icon)
+		camera_sprite_for_observers = image(eyeobj.icon, eyeobj, eyeobj.icon_state, FLY_LAYER)
+
+	if(user in camera_observers)
+		stop_observe(user)
+		return
+
+	camera_observers += user
+	if(eyeobj.visible_icon && user.client)
+		user.client.images += camera_sprite_for_observers
+	RegisterSignals(user, list(COMSIG_MOB_LOGOUT, COMSIG_MOVABLE_MOVED), PROC_REF(stop_observe))
+	user.reset_perspective(eyeobj)
+
+/obj/machinery/computer/camera_advanced/proc/stop_observe(mob/user)
+	SIGNAL_HANDLER
+
+	camera_observers -= user
+	if(user.client && camera_sprite_for_observers)
+		user.client.images -= camera_sprite_for_observers
+	UnregisterSignal(user, list(COMSIG_MOB_LOGOUT, COMSIG_MOVABLE_MOVED))
+	user.reset_perspective()
+
+/obj/machinery/computer/camera_advanced/proc/shoo_all_observers()
+	for(var/each_mob in camera_observers)
+		stop_observe(each_mob)
+
 /obj/machinery/computer/camera_advanced/attack_robot(mob/user)
 	return attack_hand(user)
 
@@ -215,6 +257,8 @@
 	eyeobj.setLoc(eyeobj.loc)
 	if(should_supress_view_changes )
 		user.client.view_size.supress()
+
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(remove_eye_control))
 
 /mob/camera/ai_eye/remote
 	name = "Inactive Camera Eye"

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -222,19 +222,24 @@
 		return
 
 	camera_observers += user
-	if(eyeobj.visible_icon && user.client)
-		user.client.images += camera_sprite_for_observers
+	if(user.client)
+		if(eyeobj.visible_icon)
+			user.client.images += camera_sprite_for_observers
+		user.reset_perspective(eyeobj)
+		if(should_supress_view_changes)
+			user.client.view_size.supress()
 	RegisterSignals(user, list(COMSIG_MOB_LOGOUT, COMSIG_MOVABLE_MOVED), PROC_REF(stop_observe))
-	user.reset_perspective(eyeobj)
 
 /obj/machinery/computer/camera_advanced/proc/stop_observe(mob/user)
 	SIGNAL_HANDLER
 
 	camera_observers -= user
-	if(user.client && camera_sprite_for_observers)
-		user.client.images -= camera_sprite_for_observers
+	if(user.client)
+		if(camera_sprite_for_observers)
+			user.client.images -= camera_sprite_for_observers
+		user.reset_perspective()
+		user.client.view_size.unsupress()
 	UnregisterSignal(user, list(COMSIG_MOB_LOGOUT, COMSIG_MOVABLE_MOVED))
-	user.reset_perspective()
 
 /obj/machinery/computer/camera_advanced/proc/shoo_all_observers()
 	for(var/each_mob in camera_observers)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -312,7 +312,7 @@
 				if(pipenetdiff.len)
 					user.update_pipe_vision(target_move)
 				user.forceMove(target_move)
-				user.client.eye = target_move  //Byond only updates the eye every tick, This smooths out the movement
+				user.client.set_eye(target_move)  //Byond only updates the eye every tick, This smooths out the movement
 				if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
 					user.last_played_vent = world.time
 					playsound(src, 'sound/machines/ventcrawl.ogg', 50, 1, -3)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -127,3 +127,6 @@
 
 	/// Whether or not this client has standard hotkeys enabled
 	var/hotkeys = TRUE
+
+	/// client/eye is immediately changed, and it makes a lot of errors to track eye change
+	var/datum/weakref/eye_weakref

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -581,6 +581,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 			send2tgs("Server", "[cheesy_message] (No admins online)")
 
+	if(isatom(eye)) // admeme vv failproof. eye must be atom
+		var/atom/eye_thing = eye
+		LAZYREMOVE(eye_thing.eye_users, src)
 	GLOB.requests.client_logout(src)
 	GLOB.directory -= ckey
 	GLOB.clients -= src
@@ -965,6 +968,24 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
 
 	..()
+
+/// Sets client eye to 1st param.
+/// * WARN: Do not change old_eye. Check client/var/eye_weakref
+/client/proc/set_eye(atom/new_eye, atom/old_eye = src.eye)
+	if(new_eye == old_eye)
+		return
+
+	if(isatom(old_eye)) // admeme vv failproof. /datum can't be their eyes
+		LAZYREMOVE(old_eye.eye_users, src)
+
+	eye = new_eye
+	eye_weakref = WEAKREF(eye)
+
+	if(isatom(new_eye))
+		LAZYADD(new_eye.eye_users, src)
+
+	// SEND_SIGNAL(src, COMSIG_CLIENT_SET_EYE, old_eye, new_eye) // use this when you want a thing from TG
+
 
 /client/proc/add_verbs_from_config()
 	if (interviewee)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -842,7 +842,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				remove_verb(/mob/dead/observer/verb/boo)
 				remove_verb(/mob/dead/observer/verb/possess)
 
-/mob/dead/observer/reset_perspective(atom/A)
+/mob/dead/observer/reset_perspective(atom/new_eye)
 	if(client)
 		if(ismob(client.eye) && (client.eye != src))
 			var/mob/target = client.eye
@@ -873,7 +873,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/mob/mob_eye = creatures[eye_name]
 	//Istype so we filter out points of interest that are not mobs
 	if(client && mob_eye && istype(mob_eye))
-		client.eye = mob_eye
+		client.set_eye(mob_eye)
 		if(mob_eye.hud_used)
 			client.screen = list()
 			LAZYINITLIST(mob_eye.observers)

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -167,7 +167,7 @@
 	if(!B)
 		return
 	forceMove(B.loc)
-	src.client.eye = src
+	src.client.set_eye(src)
 	src.visible_message("<span class='warning'><B>[src] rises out of the pool of blood!</B></span>")
 	exit_blood_effect(B)
 	if(iscarbon(src))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1439,15 +1439,16 @@
 		result += static_virus
 	return result
 
-/mob/living/reset_perspective(atom/A)
-	if(..())
-		update_sight()
-		if(client.eye && client.eye != src)
-			var/atom/AT = client.eye
-			AT.get_remote_view_fullscreens(src)
-		else
-			clear_fullscreen("remote_view", 0)
-		update_pipe_vision()
+/mob/living/reset_perspective(atom/new_eye)
+	if(!..())
+		return
+	update_sight()
+	if(client.eye && client.eye != src)
+		var/atom/AT = client.eye
+		AT.get_remote_view_fullscreens(src)
+	else
+		clear_fullscreen("remote_view", 0)
+	update_pipe_vision()
 
 /mob/living/update_mouse_pointer()
 	..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -912,33 +912,36 @@
 	malf_picker = new /datum/module_picker
 
 
-/mob/living/silicon/ai/reset_perspective(atom/A)
+/mob/living/silicon/ai/reset_perspective(atom/new_eye)
+	SHOULD_CALL_PARENT(FALSE) // AI needs to work as their own...
 	if(camera_light_on)
 		light_cameras()
-	if(client)
-		if(ismovable(A))
-			if(A != GLOB.ai_camera_room_landmark)
-				end_multicam()
-			client.perspective = EYE_PERSPECTIVE
-			client.eye = A
-		else
+	if(!client)
+		return
+
+	if(ismovable(new_eye))
+		if(new_eye != GLOB.ai_camera_room_landmark)
 			end_multicam()
-			if(isturf(loc))
-				if(eyeobj)
-					client.eye = eyeobj
-					client.perspective = EYE_PERSPECTIVE
-				else
-					client.eye = client.mob
-					client.perspective = MOB_PERSPECTIVE
-			else
+		client.perspective = EYE_PERSPECTIVE
+		client.set_eye(new_eye)
+	else
+		end_multicam()
+		if(isturf(loc))
+			if(eyeobj)
+				client.set_eye(eyeobj)
 				client.perspective = EYE_PERSPECTIVE
-				client.eye = loc
-		update_sight()
-		if(client.eye != src)
-			var/atom/AT = client.eye
-			AT.get_remote_view_fullscreens(src)
+			else
+				client.set_eye(client.mob)
+				client.perspective = MOB_PERSPECTIVE
 		else
-			clear_fullscreen("remote_view", 0)
+			client.perspective = EYE_PERSPECTIVE
+			client.set_eye(loc)
+	update_sight()
+	if(client.eye != src)
+		var/atom/AT = client.eye
+		AT.get_remote_view_fullscreens(src)
+	else
+		clear_fullscreen("remote_view", 0)
 
 /mob/living/silicon/ai/revive(full_heal = 0, admin_revive = 0)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -87,7 +87,7 @@
 		if(use_static)
 			ai.camera_visibility(src)
 		if(ai.client && !ai.multicam_on)
-			ai.client.eye = src
+			ai.client.set_eye(src)
 		update_ai_detect_hud()
 		//Holopad
 		if(istype(ai.current_holopad, /obj/machinery/holopad))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -220,9 +220,9 @@
 	notes_assets.send(client)
 	client.perspective = EYE_PERSPECTIVE
 	if(holoform)
-		client.eye = src
+		client.set_eye(src)
 	else
-		client.eye = card
+		client.set_eye(card)
 
 /mob/living/silicon/pai/get_stat_tab_status()
 	var/list/tab_data = ..()

--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -32,7 +32,7 @@
 	card.forceMove(src)
 	if(client)
 		client.perspective = EYE_PERSPECTIVE
-		client.eye = src
+		client.set_eye(src)
 	set_light_on(FALSE)
 	icon_state = "[chassis]"
 	held_state = "[chassis]"
@@ -59,7 +59,7 @@
 		MH.release()
 	if(client)
 		client.perspective = EYE_PERSPECTIVE
-		client.eye = card
+		client.set_eye(card)
 	var/turf/T = drop_location()
 	card.forceMove(T)
 	forceMove(card)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -2,6 +2,7 @@
   * Run when a client is put in this mob or reconnets to byond and their client was on this mob
   *
   * Things it does:
+  * * call set_eye() to manually manage atom/list/eye_users
   * * Adds player to player_list
   * * sets lastKnownIP
   * * sets computer_id
@@ -23,6 +24,9 @@
   * * attaches the ash listener element so clients can hear weather
   */
 /mob/Login()
+	// set_eye() is important here, because your eye doesn't know if you're using them as your eye
+	// FALSE when weakref doesn't exist, to prevent using their current eye
+	client.set_eye(client.eye, client.eye_weakref?.resolve() || FALSE)
 	add_to_player_list()
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -438,41 +438,44 @@
 			return B
 
 /**
-  * Reset the attached clients perspective (viewpoint)
-  *
-  * reset_perspective() set eye to common default : mob on turf, loc otherwise
-  * reset_perspective(thing) set the eye to the thing (if it's equal to current default reset to mob perspective)
-  */
-/mob/proc/reset_perspective(atom/A)
-	if(client)
-		if(A)
-			if(ismovable(A))
-				//Set the the thing unless it's us
-				if(A != src)
-					client.perspective = EYE_PERSPECTIVE
-					client.eye = A
-				else
-					client.eye = client.mob
-					client.perspective = MOB_PERSPECTIVE
-			else if(isturf(A))
-				//Set to the turf unless it's our current turf
-				if(A != loc)
-					client.perspective = EYE_PERSPECTIVE
-					client.eye = A
-				else
-					client.eye = client.mob
-					client.perspective = MOB_PERSPECTIVE
-			else
-				//Do nothing
-		else
-			//Reset to common defaults: mob if on turf, otherwise current loc
-			if(isturf(loc))
-				client.eye = client.mob
-				client.perspective = MOB_PERSPECTIVE
-			else
+ * Reset the attached clients perspective (viewpoint)
+ *
+ * reset_perspective(null) set eye to common default : mob on turf, loc otherwise
+ * reset_perspective(thing) set the eye to the thing (if it's equal to current default reset to mob perspective)
+ */
+/mob/proc/reset_perspective(atom/new_eye)
+	SHOULD_CALL_PARENT(TRUE)
+	if(!client)
+		return
+
+	if(new_eye)
+		if(ismovable(new_eye))
+			//Set the the thing unless it's us
+			if(new_eye != src)
 				client.perspective = EYE_PERSPECTIVE
-				client.eye = loc
-		return TRUE
+				client.set_eye(new_eye)
+			else
+				client.set_eye(client.mob)
+				client.perspective = MOB_PERSPECTIVE
+		else if(isturf(new_eye))
+			//Set to the turf unless it's our current turf
+			if(new_eye != loc)
+				client.perspective = EYE_PERSPECTIVE
+				client.set_eye(new_eye)
+			else
+				client.set_eye(client.mob)
+				client.perspective = MOB_PERSPECTIVE
+		else
+			//Do nothing
+	else
+		//Reset to common defaults: mob if on turf, otherwise current loc
+		if(isturf(loc))
+			client.set_eye(client.mob)
+			client.perspective = MOB_PERSPECTIVE
+		else
+			client.perspective = EYE_PERSPECTIVE
+			client.set_eye(loc)
+	return TRUE
 
 /**
   * Examine a mob

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -158,7 +158,7 @@
 		return FALSE
 	fakefire()
 	forceMove(drop_location())
-	client.eye = src
+	client.set_eye(src)
 	visible_message("<span class='warning'><B>[src] appears in a fiery blaze!</B></span>")
 	playsound(get_turf(src), 'sound/magic/exit_blood.ogg', 100, 1, -1)
 	addtimer(CALLBACK(src, PROC_REF(fakefireextinguish)), 15, TIMER_UNIQUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Two improvements in this PR
* Improves client.eye system
  * This correctly tracks how a client's eye is changed from what to what.
  * new variable `/atom/var/list/eye_users`
  * new variable `/client/var/datum/weakref/eye_weakref`
  * Very minor referencing https://github.com/tgstation/tgstation/pull/69115
* advanced camera now accepts observing of mobs
  * Only `camera_advanced.dm`. Exclude to review this if you

These actually can go separately, but this is specifically merged to track new atom variable `list/eye_users` in general system


* client/list/images is too excessive if you don't care z level of images, thus the PR (#10897) has made client images are only visible to you when you're at the same z.
But, meanwhile, this doesn't respect your current eye. If you see things through a camera, atom_hud system still thinks you're at that z level, but your respected z should be changed to your current eye, because atom_hud should be supposed to show images on the z of where your eye is currently at.
If I tell a case, abductors will not be capable of abductee marks through their camera. That's the issue in the new atom_hud port PR.

So, this is basic implementation for a new signal, like `COMSIG_CLIENT_EYE_CHANGED` to handle atom_hud's client images to show correct on z level
but also, it is a required system for
* https://github.com/BeeStation/BeeStation-Hornet/pull/10789

## Why do you need to have `eye_weakref`?
because DM immediately change your eye on `mob/login()`, and you lose which eye you had previously, even if your eye should be persistent.

## So, where do you use `eye_users`?

If a thing is removed, and if it's a client's eye, we need to remove things from that client.

Example)
* Camera eye is made
* This camera eye is special, and you can see ghosts from this
* If a camera eye is no longer allowed to see ghost...
  * Step 1: `SSclient_vision.revoke_vision_key_from_mob("ghost", camera_mob)`
  * Step 2: Access `camera_mob.eye_users`
  * Step 3: Remove those ghost images from `eye_users`

## How can you use `SEND_SIGNAL(EYE_Z_CHANGE)` from `set_eye()`?
If `EYE_Z_CHANGE` is sent, we need to access both client image systems: `atom_hud` and `SSclient_vision`
Both will handle which z objects should be removed from your client images, and which z objects should be newly added to you, based on your new client eye.

For example...
```DM
for(var/client/each_cli as anything in eye_users)
    SEND_SIGNAL(each_cli , COMSIG_CLIENT_EYE_Z_CHANGED, src, old_z, new_z)
```
because `COMSIG_MOVABLE_Z_CHANGED` is not capable of managing this

## I think resolving weakref on `mob/login()` seems to be unnecessary.

It is necessary. **just because it needs to remove your client from your old eye.**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improving basic systems to progress further

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/87972842/8a319442-81fa-4f60-96b8-14a4075c285e)

I've tested a lot locally. I figured it's working well.

https://youtu.be/k1axM8RbQXs

How new camera works

</details>

## Changelog
:cl:
code: minor port of set_eye() and reset_perspective() proc from TG, #PR 69115 (LemonInTheDark)
code: improved basic game system to track client's currently used eye
tweak: advanced camera is now visible by anyone even if it's currently used by someone. (This doesn't support the shuttle docking system, because it uses different one.)
fix: minor fix that advanced camera was still usable even if you're locker'ed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
