### PR TITLE
Fixes the AI malfunction "Upgrade Camera Network" power looking horrible for the AI

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -849,7 +849,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	unlock_sound = 'sound/items/rped.ogg'
 
 /datum/AI_Module/large/upgrade_cameras/upgrade(mob/living/silicon/ai/AI)
-	AI.see_override = SEE_INVISIBLE_MINIMUM //Night-vision, without which X-ray would be very limited in power.
+	AI.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE //Night-vision, without which X-ray would be very limited in power.
 	AI.update_sight()
 
 	var/upgraded_cameras = 0


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, AI with the combat upgrades can use the "Upgrade Camera Network" to make all of their cameras X-ray. Since this wouldn't be useful for looking in maints, the AI also gets nightvision.
<details>
<summary>This is what it looks like before this PR:</summary>

![dreamseeker_0XaZdesb71](https://github.com/BeeStation/BeeStation-Hornet/assets/105242196/f1fab160-d029-4807-9973-0194d7d70aca)
</details>
So I updated it to use the "lighting_alpha", that a lot of other features use.
If needed I can change the "lighting_alpha" variable to an even brighter one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Fix good, now it doesn't look wierd :)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_Ev81jO8mau](https://github.com/BeeStation/BeeStation-Hornet/assets/105242196/7c60eba0-152c-4b94-af19-cd605ed4b103)

</details>

## Changelog
:cl:
fix: fixed the AI malfunction "Upgrade Camera Network" power looking horrible for the AI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
