### PR TITLE
adds ability to remove candidacy after submitting for pAIs

### DIFF
--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -71,6 +71,7 @@ SUBSYSTEM_DEF(pai)
 	data["comments"] = candidate.comments
 	data["description"] = candidate.description
 	data["name"] = candidate.name
+	data["ready"] = check_ready(candidate)
 	var/datum/pai_candidate/default_candidate = new
 	default_candidate.load(user)
 	data["default_name"] = default_candidate.name
@@ -115,6 +116,11 @@ SUBSYSTEM_DEF(pai)
 			candidate.description = params["candidate"]["description"]
 			candidate.name = params["candidate"]["name"]
 			candidate.save(usr)
+		if("delete")
+			if(!candidate.ready)
+				return FALSE
+			candidate.ready = FALSE
+			to_chat(usr, "<span class='notice'>Your candidacy has been deleted. You can no longer be selected as a pAI personality.</span>")
 	return TRUE
 
 

--- a/tgui/packages/tgui/interfaces/PaiSubmit.tsx
+++ b/tgui/packages/tgui/interfaces/PaiSubmit.tsx
@@ -12,6 +12,7 @@ type Data = {
   comments: string;
   description: string;
   name: string;
+  ready: boolean;
   default_name: string;
   default_description: string;
   default_comments: string;
@@ -138,6 +139,15 @@ const ButtonsDisplay = (props, context) => {
               })
             }>
             SUBMIT
+          </Button>
+        </Stack.Item>
+        <Stack.Item>
+          <Button
+            disabled={!data.ready}
+            color="bad"
+            onClick={() => act('delete')}
+            tooltip="Removes you from the candidate pool">
+            Delete
           </Button>
         </Stack.Item>
       </Stack>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a button to pAI candidacy menu that allows you to change the decision. button only works if you submitted candidacy
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People that marked themself as ready can now change the decision
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
When you first open

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/a49ed153-8db8-4d60-b3b6-e43426c63fbd)

When you submit

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/7891863a-e5f6-48e9-8e3a-d5376e350c9d)

When you delete the candidacy
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/40302913/d4998d78-e197-4669-926e-8b8f2acfe9ad)



</details>

## Changelog
:cl:
add: Added ability to unmark yourself as ready for pAIs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
