### PR TITLE
rkz bugfix pack: food, deathgasp, wiki

### DIFF
--- a/code/__HELPERS/type_processing.dm
+++ b/code/__HELPERS/type_processing.dm
@@ -11,7 +11,7 @@
 			/obj/item/bodypart = "BODYPART",
 			/obj/item/book/manual = "MANUAL",
 			/obj/item/reagent_containers/food/drinks = "DRINK", //longest paths comes first
-			/obj/item/reagent_containers/food = "FOOD",
+			/obj/item/food = "FOOD",
 			/obj/item/reagent_containers = "REAGENT_CONTAINERS",
 			/obj/machinery/atmospherics = "ATMOS_MECH",
 			/obj/machinery/portable_atmospherics = "PORT_ATMOS",

--- a/code/datums/ai/dog/dog_behaviors.dm
+++ b/code/datums/ai/dog/dog_behaviors.dm
@@ -11,7 +11,7 @@
 	var/obj/item/fetch_thing = controller.blackboard[BB_FETCH_TARGET]
 
 	//either we can't pick it up, or we'd rather eat it, so stop trying.
-	if(fetch_thing.anchored || !isturf(fetch_thing.loc) || istype(fetch_thing, /obj/item/reagent_containers/food) || !living_pawn.CanReach(fetch_thing))
+	if(fetch_thing.anchored || !isturf(fetch_thing.loc) || istype(fetch_thing, /obj/item/food) || !living_pawn.CanReach(fetch_thing))
 		finish_action(controller, FALSE)
 		return
 
@@ -108,7 +108,7 @@
 /datum/ai_behavior/eat_snack/perform(delta_time, datum/ai_controller/controller)
 	. = ..()
 	var/obj/item/snack = controller.current_movement_target
-	if(!istype(snack) || !istype(snack, /obj/item/reagent_containers/food) || !(isturf(snack.loc) || ishuman(snack.loc)))
+	if(!istype(snack) || !istype(snack, /obj/item/food) || !(isturf(snack.loc) || ishuman(snack.loc)))
 		finish_action(controller, FALSE)
 
 	var/mob/living/living_pawn = controller.pawn

--- a/code/datums/ai/dog/dog_subtrees.dm
+++ b/code/datums/ai/dog/dog_subtrees.dm
@@ -19,7 +19,7 @@
 		var/atom/movable/interact_target = controller.blackboard[BB_FETCH_TARGET]
 		if(in_range(living_pawn, interact_target) && (isturf(interact_target.loc)))
 			controller.current_movement_target = interact_target
-			if(istype(interact_target, /obj/item/reagent_containers/food))
+			if(istype(interact_target, /obj/item/food))
 				controller.queue_behavior(/datum/ai_behavior/eat_snack)
 			else if(isitem(interact_target))
 				controller.queue_behavior(/datum/ai_behavior/simple_equip)

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -151,7 +151,7 @@ have ways of interacting with a specific mob and control it.
 	return top_force_item
 
 /datum/ai_controller/monkey/proc/IsEdible(obj/item/thing)
-	if(istype(thing, /obj/item/reagent_containers/food))
+	if(istype(thing, /obj/item/food))
 		return TRUE
 	if(istype(thing, /obj/item/reagent_containers/food/drinks/drinkingglass))
 		var/obj/item/reagent_containers/food/drinks/drinkingglass/glass = thing

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -11,10 +11,14 @@
 	var/mob/living/carbon/attached
 	var/mode = IV_INJECTING
 	var/obj/item/reagent_containers/beaker
-	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
-									/obj/item/reagent_containers/chem_bag,
-									/obj/item/reagent_containers/food,
-									/obj/item/reagent_containers/glass))
+	var/static/list/drip_containers = typecacheof(list(
+		/obj/item/reagent_containers/blood,
+		/obj/item/reagent_containers/chem_bag,
+		/obj/item/reagent_containers/food/drinks,
+		/obj/item/food, //Fuck it. You want to stab an IV into that 100u blood tomato? Be my guest.
+		/obj/item/reagent_containers/glass
+		)
+	)
 	var/can_convert = TRUE // If it can be made into an anesthetic machine or not
 
 /obj/machinery/iv_drip/Initialize(mapload)

--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -251,9 +251,11 @@
 /obj/item/book/manual/wiki/attack_self(mob/user)
 	var/wikiurl = CONFIG_GET(string/wikiurl)
 	if(!wikiurl)
+		user.balloon_alert(user, "what!? these pages are blank!")
 		return
-	if(alert(user, "This will open the wiki page in your browser. Are you sure?", null, "Yes", "No") != "Yes")
+	if(tgui_alert(user, "This will open the wiki page in your browser. Are you sure?", list("Yes", "No")) != "Yes")
 		return
+
 	DIRECT_OUTPUT(user, link("[wikiurl]/[page_link]"))
 
 /obj/item/book/manual/wiki/chemistry
@@ -330,7 +332,7 @@
 	icon_state = "barbook"
 	author = "Sir John Rose"
 	title = "Barman Recipes: Mixing Drinks and Changing Lives"
-	page_link = "Guide_to_food_and_drinks"
+	page_link = "Guide_to_Drinks"
 
 /obj/item/book/manual/wiki/robotics_cyborgs
 	name = "Robotics for Dummies"
@@ -366,7 +368,7 @@
 	icon_state ="cooked_book"
 	author = "the Kanamitan Empire"
 	title = "To Serve Man"
-	page_link = "Guide_to_food_and_drinks"
+	page_link = "Guide_to_Food"
 
 /obj/item/book/manual/wiki/tcomms
 	name = "Subspace Telecommunications And You"

--- a/code/modules/crew_objectives/civilian_objectives.dm
+++ b/code/modules/crew_objectives/civilian_objectives.dm
@@ -30,7 +30,7 @@
 
 /datum/objective/crew/foodhoard
 	var/datum/crafting_recipe/food/targetfood
-	var/obj/item/reagent_containers/food/foodpath
+	var/obj/item/food/foodpath
 	explanation_text = "Personally deliver at least (Something broke, yell on GitHub) to CentCom."
 	jobs = JOB_NAME_COOK
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -94,7 +94,7 @@
 	message_monkey = "lets out a faint chimper as it collapses and stops moving"
 	message_ipc = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off"
 	message_simple =  "stops moving"
-	stat_allowed = UNCONSCIOUS
+	stat_allowed = HARD_CRIT
 
 /datum/emote/living/deathgasp/run_emote(mob/user, params, type_override, intentional)
 	var/mob/living/simple_animal/S = user

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -72,19 +72,19 @@
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/attacked_by(obj/item/O, mob/user)
 	. = ..()
-	if(istype(O, /obj/item/reagent_containers/food))
+	if(istype(O, /obj/item/food))
 		feed(O)
 
-/mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/feed(obj/item/reagent_containers/food/tasty)
+/mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/feed(obj/item/food/tasty)
 	if (stat == DEAD) // plapatin I swear to god
 		return
 	if (contents.len > GOOSE_SATIATED)
 		visible_message("<span class='notice'>[src] looks too full to eat \the [tasty]!</span>")
 		return
-	if (tasty.foodtype & GROSS)
+	if (tasty.foodtypes & GROSS)
 		visible_message("<span class='notice'>[src] hungrily gobbles up \the [tasty]!</span>")
 		tasty.forceMove(src)
-		playsound(src,'sound/items/eatfood.ogg', 70, 1)
+		playsound(src,'sound/items/eatfood.ogg', 70, TRUE)
 		vomitCoefficient += 3
 		vomitTimeBonus += 2
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a few bugs I introduced, but aren't really on the radar yet.

1. Removes a bunch of stuff referencing or checking for oldfood. Inherited an old check that lets you use food as IV drips. (It was possible in oldfood, lmk if you want me to remove it)
2. Fixes deathgasping not being allowed to fire during the correct mob stat state
3. Fixes wiki manual links to food and drink guides. (I split them into two to update for newfood a few weeks ago)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix issues I introduced

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/8a028a35-b6bd-4b7c-a571-8f59605adf29)


</details>

## Changelog
:cl: rkz
fix: bad food references
fix: deathgasping should work more consistently
fix: wiki manuals for chef and bartender should function now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
