### PR TITLE
Added vision correction to the normal glasses

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -534,6 +534,7 @@
 	clothing_flags = SCAN_REAGENTS | SCAN_BOOZEPOWER
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	vision_correction = 1  // why should the eye of a god have bad vision? 
 
 /obj/item/clothing/glasses/godeye/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -195,6 +195,7 @@
 	desc = "Such a dapper eyepiece!"
 	icon_state = "monocle"
 	item_state = "headset" // lol
+	vision_correction = 1
 
 /obj/item/clothing/glasses/material
 	name = "optical material scanner"
@@ -236,18 +237,21 @@
 	desc = "Also known as Virginity Protectors."
 	icon_state = "jamjar_glasses"
 	item_state = "jamjar_glasses"
+	vision_correction = 1
 
 /obj/item/clothing/glasses/regular/hipster
-	name = "prescription glasses"
+	name = "hipster glasses"
 	desc = "Made by Uncool. Co."
 	icon_state = "hipster_glasses"
 	item_state = "hipster_glasses"
+	vision_correction = 1
 
 /obj/item/clothing/glasses/regular/circle
 	name = "circle glasses"
 	desc = "Why would you wear something so controversial yet so brave?"
 	icon_state = "circle_glasses"
 	item_state = "circle_glasses"
+	vision_correction = 1
 
 /obj/item/clothing/glasses/sunglasses/circle_sunglasses
 	name = "circle sunglasses"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the godeye, monocle, hipster, jamjar and round glasses correct vision. Also corrects the in-game name for the hipster glasses

## Why It's Good For The Game

Short sighted people will now be able to use different glasses than just the standard ones, giving more customization for your character

## Testing Photographs and Procedure


<details>


https://github.com/BeeStation/BeeStation-Hornet/assets/130587823/222a6eab-4086-4c1d-868b-379d8e45b2b2


</details>

## Changelog
:cl: Geatish
tweak: Made the godeye, monocle, hipster, jamjar and round glasses correct vision for short sightedness
spellcheck: The hipster glasses are now actually called hipster glasses instead of prescription glasses 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
