### PR TITLE
Fixes 515 compilation issue

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2057,7 +2057,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	// Apply some burn damage to the body
 	if(humi.coretemperature < bodytemp_cold_damage_limit && !HAS_TRAIT(humi, TRAIT_RESISTCOLD))
 		switch(humi.coretemperature)
-			if(201 to bodytemp_cold_damage_limit)
+			if(201 to INFINITY)
 				humi.apply_damage(COLD_DAMAGE_LEVEL_1 * coldmod * humi.physiology.cold_mod, BURN)
 			if(120 to 200)
 				humi.apply_damage(COLD_DAMAGE_LEVEL_2 * coldmod * humi.physiology.cold_mod, BURN)


### PR DESCRIPTION


## Testing Photographs and Procedure

Code is mathematically identical, since any case that was greater than the cold limit is already filtered out, meaning that we can just find any value greater than 201.

I tested it by compiling the code in 515.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/fd649f2c-f104-4f52-9046-b6dcbf2bdcdf)

## Changelog
:cl:
fix: Fixes 515 compilation issue regarding species cold temperature
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
