### PR TITLE
Adds the alarm app to the atmos, engi and CE job disks 

### DIFF
--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -30,9 +30,11 @@
 	if(disk_flags & DISK_POWER)
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
+		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
+		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)
@@ -61,9 +63,6 @@
 	if(disk_flags & DISK_ROBOS)
 		var/datum/computer_file/program/robocontrol/robo = new(src)
 		progs_to_store += robo
-
-	if(disk_flags & DISK_ALARM)
-		progs_to_store += new var/datum/computer_file/program/alarm_monitor(src)
 
 	if(disk_flags & DISK_CARGO)
 		progs_to_store += new /datum/computer_file/program/bounty(src)
@@ -102,12 +101,12 @@
 	name = "\improper Power-ON disk"
 	desc = "Engineers ignoring station power-draw since 2400."
 	icon_state = "cart-engie"
-	disk_flags = DISK_POWER | DISK_ALARM
+	disk_flags = DISK_POWER
 
 /obj/item/computer_hardware/hard_drive/role/atmos
 	name = "\improper BreatheDeep disk"
 	icon_state = "cart-atmos"
-	disk_flags = DISK_ATMOS | DISK_ROBOS | DISK_ALARM
+	disk_flags = DISK_ATMOS | DISK_ROBOS
 
 /obj/item/computer_hardware/hard_drive/role/medical
 	name = "\improper Med-U disk"
@@ -174,7 +173,7 @@
 	name = "space parts DELUXE disk"
 	icon_state = "cart-qm"
 	desc = "Perfect for the Quartermaster on the go!"
-	disk_flags = DISK_CARGO | DISK_SILO_LOG | DISK_ROBOS | DISK_BUDGET 
+	disk_flags = DISK_CARGO | DISK_SILO_LOG | DISK_ROBOS | DISK_BUDGET
 
 /obj/item/computer_hardware/hard_drive/role/cargo_technician
 	name = "space parts disk"
@@ -200,7 +199,7 @@
 /obj/item/computer_hardware/hard_drive/role/ce
 	name = "\improper Power-On DELUXE disk"
 	icon_state = "cart-ce"
-	disk_flags = DISK_POWER | DISK_ATMOS | DISK_MANIFEST | DISK_STATUS | DISK_ROBOS | DISK_BUDGET | DISK_ALARM
+	disk_flags = DISK_POWER | DISK_ATMOS | DISK_MANIFEST | DISK_STATUS | DISK_ROBOS | DISK_BUDGET
 
 /obj/item/computer_hardware/hard_drive/role/cmo
 	name = "\improper Med-U DELUXE disk"

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -62,6 +62,9 @@
 		var/datum/computer_file/program/robocontrol/robo = new(src)
 		progs_to_store += robo
 
+	if(disk_flags & DISK_ALARM)
+		progs_to_store += new var/datum/computer_file/program/alarm_monitor(src)
+
 	if(disk_flags & DISK_CARGO)
 		progs_to_store += new /datum/computer_file/program/bounty(src)
 
@@ -86,9 +89,6 @@
 	if(disk_flags & DISK_HOP)
 		progs_to_store += new /datum/computer_file/program/card_mod(src)
 		progs_to_store += new /datum/computer_file/program/job_management(src)
-
-	if(disk_flags & DISK_ALARM)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
 
 	for (var/datum/computer_file/program/prog in progs_to_store)
 		prog.usage_flags = PROGRAM_ALL

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -31,10 +31,12 @@
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
+			var/datum/station_alert/alert_control
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
+			var/datum/station_alert/alert_control
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -30,11 +30,11 @@
 	if(disk_flags & DISK_POWER)
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor/New()(src)
+		progs_to_store += new /datum/computer_file/program/alarm_monitor/New(src)
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor/New()(src)
+		progs_to_store += new /datum/computer_file/program/alarm_monitor/New(src)
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -30,15 +30,11 @@
 	if(disk_flags & DISK_POWER)
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-			var/datum/station_alert/alert_control
-			return ..()
+		progs_to_store += new /datum/computer_file/program/alarm_monitor/New()(src)
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-			var/datum/station_alert/alert_control
-			return ..()
+		progs_to_store += new /datum/computer_file/program/alarm_monitor/New()(src)
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -30,11 +30,15 @@
 	if(disk_flags & DISK_POWER)
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor/New(src)
+		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
+		var/list/allowed_areas = GLOB.the_station_areas
+		return ..()
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
-		progs_to_store += new /datum/computer_file/program/alarm_monitor/New(src)
+		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
+		var/list/allowed_areas = GLOB.the_station_areas
+		return ..()
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -87,6 +87,9 @@
 		progs_to_store += new /datum/computer_file/program/card_mod(src)
 		progs_to_store += new /datum/computer_file/program/job_management(src)
 
+	if(disk_flags & DISK_ALARM)
+		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
+
 	for (var/datum/computer_file/program/prog in progs_to_store)
 		prog.usage_flags = PROGRAM_ALL
 		prog.required_access = list()
@@ -99,12 +102,12 @@
 	name = "\improper Power-ON disk"
 	desc = "Engineers ignoring station power-draw since 2400."
 	icon_state = "cart-engie"
-	disk_flags = DISK_POWER | DISK_STATUS
+	disk_flags = DISK_POWER | DISK_ALARM
 
 /obj/item/computer_hardware/hard_drive/role/atmos
 	name = "\improper BreatheDeep disk"
 	icon_state = "cart-atmos"
-	disk_flags = DISK_ATMOS | DISK_ROBOS | DISK_STATUS
+	disk_flags = DISK_ATMOS | DISK_ROBOS | DISK_ALARM
 
 /obj/item/computer_hardware/hard_drive/role/medical
 	name = "\improper Med-U disk"
@@ -171,7 +174,7 @@
 	name = "space parts DELUXE disk"
 	icon_state = "cart-qm"
 	desc = "Perfect for the Quartermaster on the go!"
-	disk_flags = DISK_CARGO | DISK_SILO_LOG | DISK_ROBOS | DISK_BUDGET
+	disk_flags = DISK_CARGO | DISK_SILO_LOG | DISK_ROBOS | DISK_BUDGET 
 
 /obj/item/computer_hardware/hard_drive/role/cargo_technician
 	name = "space parts disk"
@@ -197,7 +200,7 @@
 /obj/item/computer_hardware/hard_drive/role/ce
 	name = "\improper Power-On DELUXE disk"
 	icon_state = "cart-ce"
-	disk_flags = DISK_POWER | DISK_ATMOS | DISK_MANIFEST | DISK_STATUS | DISK_ROBOS | DISK_BUDGET
+	disk_flags = DISK_POWER | DISK_ATMOS | DISK_MANIFEST | DISK_STATUS | DISK_ROBOS | DISK_BUDGET | DISK_ALARM
 
 /obj/item/computer_hardware/hard_drive/role/cmo
 	name = "\improper Med-U DELUXE disk"

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -31,14 +31,10 @@
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-		var/list/allowed_areas = GLOB.the_station_areas
-		return ..()
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-		var/list/allowed_areas = GLOB.the_station_areas
-		return ..()
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -31,14 +31,14 @@
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-		var/datum/station_alert/alert_control
-		return ..()
+			var/datum/station_alert/alert_control
+			return ..()
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-		var/datum/station_alert/alert_control
-		return ..()
+			var/datum/station_alert/alert_control
+			return ..()
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -31,12 +31,14 @@
 		progs_to_store += new /datum/computer_file/program/power_monitor(src)
 		progs_to_store += new /datum/computer_file/program/supermatter_monitor(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-			var/datum/station_alert/alert_control
+		var/datum/station_alert/alert_control
+		return ..()
 
 	if(disk_flags & DISK_ATMOS)
 		progs_to_store += new /datum/computer_file/program/atmosscan(src)
 		progs_to_store += new /datum/computer_file/program/alarm_monitor(src)
-			var/datum/station_alert/alert_control
+		var/datum/station_alert/alert_control
+		return ..()
 
 	if(disk_flags & DISK_SEC)
 		progs_to_store += new /datum/computer_file/program/records/security(src)

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -99,12 +99,12 @@
 	name = "\improper Power-ON disk"
 	desc = "Engineers ignoring station power-draw since 2400."
 	icon_state = "cart-engie"
-	disk_flags = DISK_POWER
+	disk_flags = DISK_POWER | DISK_STATUS
 
 /obj/item/computer_hardware/hard_drive/role/atmos
 	name = "\improper BreatheDeep disk"
 	icon_state = "cart-atmos"
-	disk_flags = DISK_ATMOS | DISK_ROBOS
+	disk_flags = DISK_ATMOS | DISK_ROBOS | DISK_STATUS
 
 /obj/item/computer_hardware/hard_drive/role/medical
 	name = "\improper Med-U disk"


### PR DESCRIPTION
added the alarm app to engi and atmos job disks

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the alarm app to the atmos, engi and CE job disks 
## Why It's Good For The Game

The people whos job it is to keep the station running benefit from knowing when there is an alarm going off on the station 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Geatish
tweak: Added the alarm app on the atmos, engineer and CE job disks 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
