### PR TITLE
fixes slimepotion attack_chain violators, makes stack_traces TESTING only.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -15,10 +15,14 @@
 	if(target.attackby(src,user, params))
 		return TRUE
 	if(QDELETED(src))
+		#ifdef TESTING
 		stack_trace("An item got deleted while performing an item attack and did not stop melee_attack_chain.")
+		#endif
 		return TRUE
 	if(QDELETED(target))
+		#ifdef TESTING
 		stack_trace("The target of an item attack got deleted and melee_attack_chain was not stopped.")
+		#endif
 		return TRUE
 	return afterattack(target, user, TRUE, params)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -914,8 +914,6 @@
 
 /obj/item/slimepotion/speed/pre_attack(obj/thingy, mob/user)
 	. = ..()
-	if(!.)
-		return
 	if(isitem(thingy))
 		var/obj/item/item = thingy
 		if(item.anchored)
@@ -959,8 +957,6 @@
 
 /obj/item/slimepotion/fireproof/pre_attack(obj/item/clothing/clothing, mob/user)
 	. = ..()
-	if(!.)
-		return
 	if(!uses)
 		qdel(src)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #10946 

ez bugfix so slimepotions respect attack chain and actually, yknow, work.

Assuming the old if statement was some bandaid that got disrupted when attack chain was cleaned up recently.

moved melee attack chain stack_trace under TESTING def. They are wayyy too finicky and get sent everytime an item inhand is deleted. Its a fine usage, but its polluting live logs and all usable data has been logged and collected.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

the two borked slimepotions dont early return every time you use them (rendering them unusable)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/7272d740-9335-4f06-8888-d3ab322a8d0a



</details>

## Changelog
:cl:
fix: fixed speed and fireproofing slimepotions not applying
server: moved melee attack chain stack_trace under TESTING def.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
