### PR TITLE
Extend Lobby Time

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -45,7 +45,7 @@ STATIONNAME Space Station 13
 #HUB
 
 ## Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
-LOBBY_COUNTDOWN 180
+LOBBY_COUNTDOWN 450
 
 ## Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.
 ROUND_END_COUNTDOWN 90

--- a/config/config.txt
+++ b/config/config.txt
@@ -45,7 +45,7 @@ STATIONNAME Space Station 13
 #HUB
 
 ## Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
-LOBBY_COUNTDOWN 450
+LOBBY_COUNTDOWN 300
 
 ## Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.
 ROUND_END_COUNTDOWN 90


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lobby time to <s>450</s> 300 seconds.
## Why It's Good For The Game

If you crash you can rejoin in time to ready up and dont miss round start.
Small breaks between rounds are good for You, go get some water and drink it.
Did I mention more time for admins to play music to chill to?
Feedback thread for this PR to measure playerbase approval:
https://forums.beestation13.com/t/extend-time-to-start-the-round-by-a-factor-of-3/25738

## Testing Photographs and Procedure

bruh
</details>

## Changelog
:cl:
tweak: changed LOBBY_COUNTDOWN from 180 to 300 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
