### PR TITLE
romerol zombification overrides quirk/surgery pacifism

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -8,6 +8,11 @@
 	var/datum/species/old_species = /datum/species/human
 	var/living_transformation_time = 30
 	var/converts_living = FALSE
+	/*
+	* If pacifist upon receiving the infection, we remove it, but store it in this var
+	* When the organ is removed, this var is checked, and if true we give pacifism back.
+	*/
+	var/we_had_pacifist_prior_trauma = FALSE
 
 	var/revive_time_min = 60 SECONDS
 	var/revive_time_max = 100 SECONDS
@@ -27,6 +32,13 @@
 /obj/item/organ/zombie_infection/Insert(var/mob/living/carbon/M, special = 0, pref_load = FALSE)
 	. = ..()
 	START_PROCESSING(SSobj, src)
+	//trauma-induced pacifism check
+	if(HAS_TRAIT_FROM(M, TRAIT_PACIFISM, TRAUMA_TRAIT))
+		REMOVE_TRAIT(M, TRAIT_PACIFISM, TRAUMA_TRAIT)
+		we_had_pacifist_prior_trauma = TRUE
+	//quirk pacifism check
+	if(M.has_quirk(/datum/quirk/nonviolent))
+		REMOVE_TRAIT(M, TRAIT_PACIFISM, ROUNDSTART_TRAIT)
 
 /obj/item/organ/zombie_infection/Remove(mob/living/carbon/M, special = 0, pref_load = FALSE)
 	. = ..()
@@ -35,6 +47,11 @@
 		M.set_species(old_species)
 	if(timer_id)
 		deltimer(timer_id)
+
+	if(we_had_pacifist_prior_trauma == TRUE)
+		ADD_TRAIT(M, TRAIT_PACIFISM, TRAUMA_TRAIT)
+	if(M.has_quirk(/datum/quirk/nonviolent))
+		ADD_TRAIT(M, TRAIT_PACIFISM, ROUNDSTART_TRAIT)
 
 /obj/item/organ/zombie_infection/on_find(mob/living/finder)
 	to_chat(finder, "<span class='warning'>Inside the head is a disgusting black \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #10289 

Title. Getting the zombie_infection tumor organ (either via getting bit or romerol injection) removes quirk and surgery pacifism.

When the organ is removed and the mob deconverted from a zombie, the pacifism is added back.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Talked to other staff, agreed that a conversion antag that can spread itself only through attacks shouldnt have to worry about pacification quirks or if they got hit by the cat doctor. The zombie tumor will override any ethics or minor brain modification that inhibits intentionally hurting others.

Some more temporary pacifiers like pax or slime extracts may still apply pacifism, that is intentional on my part. 50u of pax into the bloodstream slowing down a zombie makes more sense than "I have my ethics!"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: permanent pacified users with either the Pacifist quirk or pacified brain surgery will now be able to attack others if they are infected by Romerol zombies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
