### PR TITLE
Fixes incorrect message being shown on brain mob and heads

### DIFF
--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -232,7 +232,7 @@ SUBSYSTEM_DEF(zclear)
 				var/nullspaced_mob_names = ""
 				var/valid = FALSE
 				for(var/mob/M as() in nullspaced_mobs)
-					if(M.key || M.get_ghost(FALSE, TRUE))
+					if(M.key || !M.soul_departed())
 						nullspaced_mob_names += " - [M.name]\n"
 						valid = TRUE
 				if(valid)

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -104,3 +104,6 @@
 	if(istype(loc, /obj/item/organ/brain))
 		var/obj/item/organ/brain/B = loc
 		. = B.traumas
+
+/mob/living/brain/soul_departed()
+	return !key && !get_ghost(FALSE, TRUE)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -135,7 +135,7 @@
 	if(suicided)
 		. += "<span class='info'>It's started turning slightly grey. They must not have been able to handle the stress of it all.</span>"
 	else if(brainmob)
-		if(brainmob.get_ghost(FALSE, TRUE))
+		if(!brainmob.soul_departed())
 			if(brain_death || brainmob.health <= HEALTH_THRESHOLD_DEAD)
 				. += "<span class='info'>It's lifeless and severely damaged.</span>"
 			else if(organ_flags & ORGAN_FAILING)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -391,5 +391,8 @@
 	if(dat.len)
 		return dat.Join()
 
-/mob/living/proc/soul_departed()
+/mob/proc/soul_departed()
+	return !key && !get_ghost(FALSE, TRUE)
+
+/mob/living/soul_departed()
 	return getorgan(/obj/item/organ/brain) && !key && !get_ghost(FALSE, TRUE)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -74,7 +74,7 @@
 		else if(brain.brain_death || brainmob?.health <= HEALTH_THRESHOLD_DEAD)
 			. += "<span class='info'>It seems to be leaking some kind of... clear fluid? The brain inside must be in pretty bad shape... There is no coming back from that.</span>"
 		else if(brainmob)
-			if(brainmob.get_ghost(FALSE, TRUE))
+			if(!brainmob.soul_departed())
 				. += "<span class='info'>Its muscles are still twitching slightly... It still seems to have a bit of life left to it.</span>"
 			else
 				. += "<span class='info'>It seems seems particularly lifeless. Perhaps there'll be a chance for them later.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you were a brain and had a ghost, it would show the brain as being revivable. If you entered your body, then it would show your brain as being unable to be revived. This issue was present in both brains, heads, and weirldy, z-clear.

## Why It's Good For The Game

People don't bother reviving brains or heads if there is no spark of life, so we better make damn sure that its correct.

## Testing Photographs and Procedure

While in brain:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/fe63003b-7af3-4048-87a0-5c249d657822)

While in ghost:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/12d7e563-944b-4f9d-80c8-093cb91560f5)

While in another body:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/fb3bb5a2-59ef-4cf8-94a2-f4045ef8169c)

## Changelog
:cl:
fix: Fixes incorrect message on brains and heads.
fix: Fixes z-clear not announcing brains that have someone inside their brain instead of ghosted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
