### PR TITLE
Miner hotfix

### DIFF
--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -26,6 +26,7 @@
 	desc = "All that remains of a hivelord. It can be used to heal completely, but it will rapidly decay into uselessness."
 	icon_state = "roro core 2"
 	item_flags = NOBLUDGEON
+	organ_flags = null
 	slot = "hivecore"
 	force = 0
 	actions_types = list(/datum/action/item_action/organ_action/use)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -207,7 +207,7 @@
 	var/temp_icon_to_use = initial(icon_state)
 	if(modifystate)
 		var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-		temp_icon_to_use += "[shot.select_name]"
+		temp_icon_to_use += "[initial(shot.select_name)]"
 
 	temp_icon_to_use += "[ratio]"
 	if(!skip_inhand)

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -32,6 +32,7 @@
 /obj/item/gun/energy/e_gun/mini/add_seclight_point()
 	// The mini energy gun's light comes attached but is unremovable.
 	AddComponent(/datum/component/seclite_attachable, \
+		starting_light = new /obj/item/flashlight/seclite(src), \
 		is_light_removable = FALSE, \
 		light_overlay_icon = 'icons/obj/guns/flashlights.dmi', \
 		light_overlay = "mini-light", \

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -22,7 +22,7 @@
 
 	var/recharge_timerid
 
-/obj/item/gun/energy/recharge/kinetic_accelerator/add_seclight_point()
+/obj/item/gun/energy/kinetic_accelerator/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
 		light_overlay_icon = 'icons/obj/guns/flashlights.dmi', \
 		light_overlay = "flight", \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I gave miners a bad day.

This pr includes two very small fixes, but annoying for miners to deal with currently
1. The attack chain refactor somehow made regenerative cores (like the legion core) inherit organs, its parents, behavior. (I blame shitcode) This meant that using the item would end up chewing and eating the legion core. Harm intent bypassed this. I have resolved this by ensuring regenerative cores have their organ_flags set to `NULL` instead of inheriting the flag `edible`. Now, any intent or z will apply it as expected.

2. I mistyped the typepath for PKA's, so it was not possible to attach seclites to them. It has been rectified.

3. 414 error prevented mini e_guns seclite from working properly. Its been rectified.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

hotfix

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Im kind of tired after my final, so I didnt realize I hit z. But yes, afterwards I did test applying via help intent. It worked.

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/4f28eda6-bc98-4364-b6ad-36763770a3e9



</details>

## Changelog
:cl:
fix: pka seclite attachment
fix: legion cores are not eaten like demonic potatoes, you may apply them normally again and expect the usual healing
fix: fixes the flashlight on mini e_guns like the PTSD 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
