### PR TITLE
Fixes hub entry data collection

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -399,24 +399,24 @@ GLOBAL_VAR(restart_counter)
 		// Station name is going to be truncated with ...
 		if (discordurl)
 			if (server_name)
-				s += "<a href='[discordurl]'><b>[server_name] &#8212; [copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
+				s += "<a href='[discordurl]'><b>[server_name]</b> - <b>[copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
 			else
 				s += "<a href='[discordurl]'><b>[copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
 		else
 			if (server_name)
-				s += "<b>[server_name] &#8212; [copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
+				s += "<b>[server_name]</b> - <b>[copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
 			else
 				s += "<b>[copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
 	else
 		// Station name can be displayed in full
 		if (discordurl)
 			if (server_name)
-				s += "<a href='[discordurl]'><b>[server_name] &#8212; [station_name]</b></a><br>"
+				s += "<a href='[discordurl]'><b>[server_name]</b> - <b>[station_name]</b></a><br>"
 			else
 				s += "<a href='[discordurl]'><b>[station_name]</b></a><br>"
 		else
 			if (server_name)
-				s += "<b>[server_name] &#8212; [station_name]</b><br>"
+				s += "<b>[server_name]</b> - <b>[station_name]</b><br>"
 			else
 				s += "<b>[station_name]</b><br>"
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -372,7 +372,7 @@ GLOBAL_VAR(restart_counter)
 		popcaptext = "/[popcap]"
 
 	// Determine our character usage
-	var/character_usage = 90	// Base character usage
+	var/character_usage = 92	// Base character usage
 	// Discord URL is needed
 	if (discordurl)
 		character_usage += length(discordurl)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -399,24 +399,24 @@ GLOBAL_VAR(restart_counter)
 		// Station name is going to be truncated with ...
 		if (discordurl)
 			if (server_name)
-				s += "<a href='[discordurl]'><b>[server_name]&#8212;[copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
+				s += "<a href='[discordurl]'><b>[server_name] &#8212; [copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
 			else
 				s += "<a href='[discordurl]'><b>[copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
 		else
 			if (server_name)
-				s += "<b>[server_name]&#8212;[copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
+				s += "<b>[server_name] &#8212; [copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
 			else
 				s += "<b>[copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
 	else
 		// Station name can be displayed in full
 		if (discordurl)
 			if (server_name)
-				s += "<a href='[discordurl]'><b>[server_name]&#8212;[station_name]</b></a><br>"
+				s += "<a href='[discordurl]'><b>[server_name] &#8212; [station_name]</b></a><br>"
 			else
 				s += "<a href='[discordurl]'><b>[station_name]</b></a><br>"
 		else
 			if (server_name)
-				s += "<b>[server_name]&#8212;[station_name]</b><br>"
+				s += "<b>[server_name] &#8212; [station_name]</b><br>"
 			else
 				s += "<b>[station_name]</b><br>"
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -372,7 +372,7 @@ GLOBAL_VAR(restart_counter)
 		popcaptext = "/[popcap]"
 
 	// Determine our character usage
-	var/character_usage = 86	// Base character usage
+	var/character_usage = 90	// Base character usage
 	// Discord URL is needed
 	if (discordurl)
 		character_usage += length(discordurl)
@@ -399,24 +399,24 @@ GLOBAL_VAR(restart_counter)
 		// Station name is going to be truncated with ...
 		if (discordurl)
 			if (server_name)
-				s += "<a href='[discordurl]'><b>[server_name] - [copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
+				s += "<a href='[discordurl]'><b>[server_name]&#8212;[copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
 			else
 				s += "<a href='[discordurl]'><b>[copytext(station_name, 1, station_name_limit - 3)]...</b></a><br>"
 		else
 			if (server_name)
-				s += "<b>[server_name] - [copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
+				s += "<b>[server_name]&#8212;[copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
 			else
 				s += "<b>[copytext(station_name, 1, station_name_limit - 3)]...</b><br>"
 	else
 		// Station name can be displayed in full
 		if (discordurl)
 			if (server_name)
-				s += "<a href='[discordurl]'><b>[server_name] - [station_name]</b></a><br>"
+				s += "<a href='[discordurl]'><b>[server_name]&#8212;[station_name]</b></a><br>"
 			else
 				s += "<a href='[discordurl]'><b>[station_name]</b></a><br>"
 		else
 			if (server_name)
-				s += "<b>[server_name] - [station_name]</b><br>"
+				s += "<b>[server_name]&#8212;[station_name]</b><br>"
 			else
 				s += "<b>[station_name]</b><br>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the hub to use the special `&#8212;` character instead of the `-` character. This means data collection will be handled more gracefully.

@Crossedfall will need to take a look at this to ensure that the <a href... tags have no effect.

This is what it will look like instead:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/91222f2a-23db-4a58-8085-9a4bf87f8bc6)

Closes #10912

## Changelog
:cl:
fix: Fixes the hub entry not using the correct character to divide the station name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
