### PR TITLE
Makes hacking easier

### DIFF
--- a/code/__DEFINES/airlock.dm
+++ b/code/__DEFINES/airlock.dm
@@ -9,8 +9,8 @@
 #define AIRLOCK_WIRE_SECURITY_NONE 0	// Airlocks that are super easy to hack and have mostly labelled wires. No risk.
 #define AIRLOCK_WIRE_SECURITY_SIMPLE 1	// Airlock with less labelled wires, takes longer to hack but not shock risk.
 #define AIRLOCK_WIRE_SECURITY_PROTECTED 2	// Airlock has no labelled wires and has a single shock wire that is labelled
-#define AIRLOCK_WIRE_SECURITY_ADVANCED 3	// Airlock has 2 duds and 1 shock wire
-#define AIRLOCK_WIRE_SECURITY_ELITE 4	// Airlock has 2 duds and 2 shock wires
+#define AIRLOCK_WIRE_SECURITY_ADVANCED 3	// Airlock has 1 duds and 1 shock wire
+#define AIRLOCK_WIRE_SECURITY_ELITE 4	// Airlock has 1 duds and 2 shock wires
 #define AIRLOCK_WIRE_SECURITY_MAXIMUM 5	// Airlock has 2 duds, 2 shock wires and only a single power cable.
 
 #define AIRLOCK_CLOSED	1

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -23,24 +23,27 @@
 	if (security_level >= AIRLOCK_WIRE_SECURITY_ELITE)
 		wires |= WIRE_ZAP2
 	//Add dud wires
-	if (security_level >= AIRLOCK_WIRE_SECURITY_ADVANCED)
+	if (security_level >= AIRLOCK_WIRE_SECURITY_MAXIMUM)
 		add_duds(2)
-	else if (security_level >= AIRLOCK_WIRE_SECURITY_SIMPLE)
+	else if (security_level >= AIRLOCK_WIRE_SECURITY_ADVANCED)
 		add_duds(1)
 
 	//Add labelled wires
 	if (security_level <= AIRLOCK_WIRE_SECURITY_NONE)
-		//At security level 0, the following wires could be unknowns:
-		//POWER1, BACKUP1, IDSCAN, AI WIRE, LIGHT
+		labelled_wires[WIRE_POWER1] = TRUE
+		labelled_wires[WIRE_BACKUP1] = TRUE
+		labelled_wires[WIRE_LIGHT] = TRUE
 		labelled_wires[WIRE_OPEN] = TRUE
-		labelled_wires[WIRE_BOLTS] = TRUE
-		labelled_wires[WIRE_SHOCK] = TRUE
 	if (security_level <= AIRLOCK_WIRE_SECURITY_SIMPLE)
-		//At security level 1, there are duds and the open, bolt and shock wires are not revealed.
 		labelled_wires[WIRE_SAFETY] = TRUE
 		labelled_wires[WIRE_TIMING] = TRUE
-	if (security_level == AIRLOCK_WIRE_SECURITY_PROTECTED)
+		labelled_wires[WIRE_SHOCK] = TRUE
+		labelled_wires[WIRE_IDSCAN] = TRUE
+	if (security_level <= AIRLOCK_WIRE_SECURITY_PROTECTED)
 		labelled_wires[WIRE_ZAP1] = TRUE
+	if (security_level <= AIRLOCK_WIRE_SECURITY_ADVANCED)
+		labelled_wires[WIRE_BOLTS] = TRUE
+		labelled_wires[WIRE_AI] = TRUE
 	..()
 
 /datum/wires/airlock/interactable(mob/user)
@@ -127,8 +130,6 @@
 
 /datum/wires/airlock/on_cut(wire, mend)
 	var/obj/machinery/door/airlock/A = holder
-	if(isliving(usr) && A.hasPower())
-		A.shock(usr, 100) //Cutting wires directly on powered doors without protection is not advised.
 	switch(wire)
 		if(WIRE_POWER1, WIRE_POWER2) // Cut to loose power, repair all to gain power.
 			if(mend && !is_cut(WIRE_POWER1) && !is_cut(WIRE_POWER2))
@@ -163,6 +164,8 @@
 			else
 				if(A.secondsElectrified != MACHINE_ELECTRIFIED_PERMANENT)
 					A.set_electrified(MACHINE_ELECTRIFIED_PERMANENT, usr)
+			if(isliving(usr))
+				A.shock(usr, 50)
 		if(WIRE_SAFETY) // Cut to disable safeties, mend to re-enable.
 			A.safe = mend
 		if(WIRE_TIMING) // Cut to disable auto-close, mend to re-enable.

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -172,7 +172,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_job_reverse = TRUE
 	lighting_colour_tube = "#ffe5cb"
 	lighting_colour_bulb = "#ffdbb4"
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_NONE
 	lights_always_start_on = TRUE
 	color_correction = /datum/client_colour/area_color/cold_ish
 
@@ -743,7 +743,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#fff4d6"
 	lighting_colour_bulb = "#ffebc1"
 	sound_environment = SOUND_AREA_WOODFLOOR
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_NONE
 	color_correction = /datum/client_colour/area_color/warm_ish
 
 /area/crew_quarters/bar/mood_check(mob/living/carbon/subject)
@@ -802,7 +802,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#ffce99"
 	lighting_colour_bulb = "#ffdbb4"
 	lighting_brightness_tube = 8
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_NONE
 	color_correction = /datum/client_colour/area_color/warm_ish
 
 /area/library/lounge
@@ -823,7 +823,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	clockwork_warp_allowed = FALSE
 	clockwork_warp_fail = "The consecration here prevents you from warping in."
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 
 /area/chapel/main
 	name = "Chapel"
@@ -1348,7 +1348,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#ffe3cc"
 	lighting_colour_bulb = "#ffdbb8"
 	sound_environment = SOUND_AREA_STANDARD_STATION
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 	color_correction = /datum/client_colour/area_color/warm_yellow
 
 /area/quartermaster/get_turf_textures()
@@ -1376,16 +1376,18 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/cargo/lobby
 	name = "\improper Cargo Lobby"
 	icon_state = "cargo_lobby"
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 	color_correction = /datum/client_colour/area_color/warm_yellow
 
 /area/quartermaster/qm
 	name = "Quartermaster's Office"
 	icon_state = "quart_office"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/quartermaster/qm_bedroom
 	name = "Quartermaster's Bedroom"
 	icon_state = "quart_private"
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
 
 /area/quartermaster/miningdock
 	name = "Mining Dock"
@@ -1416,7 +1418,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_bonus = -1
 	mood_message = "<span class='warning'>It feels dirty in here!\n</span>"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_NONE
 
 /area/janitor/custodian
 	name = "Custodial Closet"
@@ -1427,7 +1429,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "hydro"
 	sound_environment = SOUND_AREA_STANDARD_STATION
 	area_flags = HIDDEN_STASH_LOCATION | VALID_TERRITORY | BLOBS_ALLOWED | UNIQUE_AREA
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_NONE
 	color_correction = /datum/client_colour/area_color/cold_ish
 
 /area/hydroponics/get_turf_textures()
@@ -1554,7 +1556,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Storage
 /area/storage
 	sound_environment = SOUND_AREA_STANDARD_STATION
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_PROTECTED
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
 	lights_always_start_on = TRUE
 	color_correction = /datum/client_colour/area_color/warm_yellow
 
@@ -1603,7 +1605,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "yellow"
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_STANDARD_STATION
-	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_SIMPLE
+	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_NONE
 
 /area/construction/mining/aux_base
 	name = "Auxiliary Base Construction"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the following changes:
- 2 dud wires now only appears on level 5 security airlocks.
- 1 dud wire only appear on level 3 security airlocks.
- The AI and bolts wire is labeled on level 3 or lower airlocks. (Engineering, Science)
- The zap wire is labelled on level 2 or lower airlocks (as it was before) (Law office, genetics, viro, QM's office)
- The safety, timing, shock, and ID scan wires are revealed on level 1 or lower airlocks. (Chapel, Medical, Storage)
- All wires are revealed on level 0 airlocks. (Maintenance, constructed doors, some public service areas)

The following areas are now level 0:
- Maintenance, Bar, Library, Janitor's closet, Hydroponics, Construction Area

## Why It's Good For The Game

People have complained about hacking and how difficult it is as an antagonist, and I get that. I don't want antagonists to have free AA to the entire station via hacking but at the same time a lot of doors have risk to them when they aren't really *that* secure.

The new requirements make most of the station easier to access by revealing more wires that are annoying when you cut them.

This also makes it so cutting wires is no longer a guaranteed shock, which allows you to cut them without insulated gloves. You can't cut the power lines, but this will let your fix the bolts or AI wire without getting shocked (although I guess you could always fix it by hitting the power wire first but i thought this was a bit harsh).

## Testing Photographs and Procedure

<details>
<summary>Holodeck</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5001e5f8-a8b2-4ca4-adf1-39b953766311)

</details>


<details>
<summary>Chapel</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/71c2b02c-5902-4549-b527-35ebaa6c0871)

</details>
<details>
<summary>Maintenance</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/bb5bf3d9-b5b8-40ce-97dd-579ec209a016)
</details>

<details>
<summary>Security</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/da1fa095-29bc-463f-b8d8-63c72cebb45d)

</details>

<details>
<summary>Science</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/6ad55d17-25fd-427b-9fbd-e552f5d90268)

</details>

## Changelog
:cl:
balance: Made hacking easier across the board by lowering the security areas of some areas and revealing more wires.
balance: Cutting wires on airlocks is no longer guaranteed to shock you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
