### PR TITLE
Increases weapon slowdown for heavier weapons

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -100,7 +100,7 @@
 			pin = new pin(src)
 
 	add_seclight_point()
-	
+
 	if(!canMouseDown) //Some things like beam rifles override this.
 		canMouseDown = automatic //Nsv13 / Bee change.
 	build_zooming()
@@ -113,7 +113,7 @@
 		spread_unwielded = weapon_weight * 10 + 10
 	if (has_weapon_slowdown)
 		if (!slowdown)
-			slowdown = 0.3 + weapon_weight * 0.1
+			slowdown = 0.1 + weapon_weight * 0.3
 		item_flags |= SLOWS_WHILE_IN_HAND
 	if(requires_wielding)
 		RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(wield))

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -17,6 +17,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
+	has_weapon_slowdown = FALSE
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With the recent gun changes, I intended for the slowdown on heavier weapons to function as a con for melee combat, making gun wielding users easier to hit, however the slowdown calculation was written poorly and provides almost no slowdown. A riot armoured shotgun wielder still moves at a pretty significant speed.

This changes the values:
- Small: 2.9 -> 2.9 (16%)
- Medium: 3.0 -> 3.2 (28%)
- Heavy: 3.1 -> 3.5 (40%)

This will not affect disablers, but will make energy guns and shotguns have slightly more slowdown, with shotguns and other heavy weapons like the sniper rifle being the most impacted.

Also I removed the weapon slowdown for the KA.

Obviously guns are still going to dominate in a 1v1 situation, however it should make it just a little bit harder to hold off the swarm if you don't keep a safe distance to your targets.

## Why It's Good For The Game

The previous slowdown values have almost no effect for heavier weapons, and shotgun users can still walk about as fast as a regular user. Lowering the unholster delay made guns more powerful while the slowdown did not make them any easier to fight against.

I don't expect there will be a dramatic change, its relatively minor and still pretty hard to spot. Perhaps in the future we can always tinker with adding in the slowdown when firing, so that you can run with guns but are slowed when shooting or something.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/252c08a9-1eda-4359-acc8-67be9740db29

## Changelog
:cl:
balance: Increases weapon slowdown for heavy weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
