### PR TITLE
Buffs hand-teleporter against teleportation wakes again

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -255,8 +255,8 @@
 	alpha = 0
 	duration = 11 SECONDS
 
-/obj/effect/temp_visual/portal_opening/Initialize(mapload)
+/obj/effect/temp_visual/portal_opening/Initialize(mapload, time)
 	. = ..()
 	transform = matrix() * 0
-	animate(src, time = 10 SECONDS, transform = matrix(), alpha = 255)
+	animate(src, time = time, transform = matrix(), alpha = 255)
 	animate(time = 0.5 SECONDS, transform = matrix() * 0, alpha = 0)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -256,7 +256,7 @@
 	duration = 11 SECONDS
 
 /obj/effect/temp_visual/portal_opening/Initialize(mapload, time)
+	duration = time
 	. = ..()
 	transform = matrix() * 0
 	animate(src, time = time, transform = matrix(), alpha = 255)
-	animate(time = 0.5 SECONDS, transform = matrix() * 0, alpha = 0)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -193,7 +193,7 @@
 		to_chat(user, "<span class='notice'>You begin teleporting to the target.</span>")
 		// Longer distances take more time to teleport, since they are more likely
 		// to be something like a base of operations and not just a quick jaunt away
-		var/time = max(1 SECONDS, target_turf.get_virtual_z_level() == current_location.get_virtual_z_level() ? min(distance, 10 SECONDS) : 10 SECONDS)
+		var/time = max(1 SECONDS, target_turf.get_virtual_z_level() == current_location.get_virtual_z_level() ? min(distance, 15 SECONDS) : 15 SECONDS)
 		var/obj/effect/temp_visual/portal_opening/target_effect = new(target_turf, time)
 		var/obj/effect/temp_visual/portal_opening/source_effect = new(get_turf(user), time)
 		if (!do_after(user, 10 SECONDS, user))

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -191,15 +191,16 @@
 		var/obj/effect/temp_visual/teleportation_wake/wake = teleport_target
 		var/turf/target_turf = get_teleport_turf(wake.destination, 2 + distance)
 		to_chat(user, "<span class='notice'>You begin teleporting to the target.</span>")
-		var/obj/effect/temp_visual/portal_opening/target_effect = new(target_turf)
-		var/obj/effect/temp_visual/portal_opening/source_effect = new(get_turf(user))
-		if (do_after(user, 10 SECONDS, user))
-			do_teleport(user, target_turf)
-		else
+		// Longer distances take more time to teleport, since they are more likely
+		// to be something like a base of operations and not just a quick jaunt away
+		var/time = max(1 SECONDS, target_turf.get_virtual_z_level() == current_location.get_virtual_z_level() ? min(distance, 10 SECONDS) : 10 SECONDS)
+		var/obj/effect/temp_visual/portal_opening/target_effect = new(target_turf, time)
+		var/obj/effect/temp_visual/portal_opening/source_effect = new(get_turf(user), time)
+		if (!do_after(user, 10 SECONDS, user))
 			animate(user, flags = ANIMATION_END_NOW)
 			qdel(target_effect)
 			qdel(source_effect)
-		return
+			return
 	var/area/A = get_area(teleport_target)
 	if(A.teleport_restriction)
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -185,18 +185,19 @@
 		user.show_message("<span class='notice'>\The [src] is recharging!</span>")
 		return
 	var/teleport_target = L[t1]
+	var/turf/target_turf = get_teleport_turf(get_turf(teleport_target))
 	// Non-turfs (Wakes) are handled differently
 	if (istype(teleport_target, /obj/effect/temp_visual/teleportation_wake))
 		var/distance = get_dist(teleport_target, user)
 		var/obj/effect/temp_visual/teleportation_wake/wake = teleport_target
-		var/turf/target_turf = get_teleport_turf(wake.destination, 2 + distance)
+		target_turf = get_teleport_turf(wake.destination, 2 + distance)
 		to_chat(user, "<span class='notice'>You begin teleporting to the target.</span>")
 		// Longer distances take more time to teleport, since they are more likely
 		// to be something like a base of operations and not just a quick jaunt away
-		var/time = max(1 SECONDS, target_turf.get_virtual_z_level() == current_location.get_virtual_z_level() ? min(distance, 15 SECONDS) : 15 SECONDS)
+		var/time = max(1 SECONDS, target_turf.get_virtual_z_level() == current_location.get_virtual_z_level() ? min(get_dist(target_turf, current_location) * 3, 15 SECONDS) : 15 SECONDS)
 		var/obj/effect/temp_visual/portal_opening/target_effect = new(target_turf, time)
-		var/obj/effect/temp_visual/portal_opening/source_effect = new(get_turf(user), time)
-		if (!do_after(user, 10 SECONDS, user))
+		var/obj/effect/temp_visual/portal_opening/source_effect = new(current_location, time)
+		if (!do_after(user, time, user))
 			animate(user, flags = ANIMATION_END_NOW)
 			qdel(target_effect)
 			qdel(source_effect)
@@ -210,7 +211,7 @@
 	if(!current_location || current_area.teleport_restriction || is_away_level(current_location.z) || is_centcom_level(current_location.z) || !isturf(user.loc))//If turf was not found or they're on z level 2 or >7 which does not currently exist. or if user is not located on a turf
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
 		return
-	var/list/obj/effect/portal/created = create_portal_pair(current_location, get_teleport_turf(get_turf(teleport_target)), src, 300, 1, null, atmos_link_override)
+	var/list/obj/effect/portal/created = create_portal_pair(current_location, target_turf, src, 300, 1, null, atmos_link_override)
 	if(!(LAZYLEN(created) == 2))
 		return
 

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -186,11 +186,13 @@
 		return
 	var/teleport_target = L[t1]
 	var/turf/target_turf = get_teleport_turf(get_turf(teleport_target))
+	var/move_source = TRUE
 	// Non-turfs (Wakes) are handled differently
 	if (istype(teleport_target, /obj/effect/temp_visual/teleportation_wake))
 		var/distance = get_dist(teleport_target, user)
 		var/obj/effect/temp_visual/teleportation_wake/wake = teleport_target
 		target_turf = get_teleport_turf(wake.destination, 2 + distance)
+		move_source = FALSE
 		to_chat(user, "<span class='notice'>You begin teleporting to the target.</span>")
 		// Longer distances take more time to teleport, since they are more likely
 		// to be something like a base of operations and not just a quick jaunt away
@@ -218,9 +220,12 @@
 	var/obj/effect/portal/c1 = created[1]
 	var/obj/effect/portal/c2 = created[2]
 
-	var/turf/check_turf = get_turf(get_step(user, user.dir))
-	if(!check_turf.is_blocked_turf(TRUE, src))
-		c1.forceMove(check_turf)
+	if (move_source)
+		var/turf/check_turf = get_turf(get_step(user, user.dir))
+		if(!check_turf.is_blocked_turf(TRUE, src))
+			c1.forceMove(check_turf)
+	else
+		c1.Bumped(user)
 	active_portal_pairs[created[1]] = created[2]
 
 	investigate_log("was used by [key_name(user)] at [AREACOORD(user)] to create a portal pair with destinations [AREACOORD(c1)] and [AREACOORD(c2)].", INVESTIGATE_PORTAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Following teleportation wakes now opens a portal again, rather than just teleporting 1 person. Teleporting a single person is useless since if you are following any amount of threat you will just follow it and die.

Changes the amount of time it takes to open a portal to
- 15 seconds across zs
- 15 seconds maximum
- 1 second minimum
- 3 seconds for every 10 units that the target location is away.

Note that wake teleportations will still teleport you instantly.

## Why It's Good For The Game

Makes the hand teleporter more powerful again, removing the ability to bring other people with you through the portals made it completely useless and removed all value of it. High risk, high reward.

I want to make it so that teleports that are far away take time and are easier to prepare for (on the other side), but short rank teleports like blinks are quicker to follow. Since teleports can be used for getting away and giving yourself some time to recover, this does need to be monitored carefully and may need more tweaking again.

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/658b648a-6f98-4ae6-835b-932a980e9425

## Changelog
:cl:
balance: Handheld teleports will open portals when following wakes again and scale their opening time with distance to the target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
