### PR TITLE
Makes tonfa usable (minor buff)

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -414,7 +414,7 @@
 			target.visible_message(desc["visiblestun"], desc["localstun"])
 
 		else if(user.is_zone_selected(BODY_ZONE_HEAD) || user.is_zone_selected(BODY_ZONE_PRECISE_EYES) || user.is_zone_selected(BODY_ZONE_PRECISE_MOUTH))
-			target.apply_damage(18, STAMINA, BODY_ZONE_HEAD, def_check) // 90 : 5 = 18 , 5 hits to KnockOut
+			target.apply_damage(stamina_damage*0.8, STAMINA, BODY_ZONE_HEAD, def_check) // 90 : 5 = 18 , 5 hits to KnockOut
 
 			if(target.staminaloss > 89 && !target.has_status_effect(STATUS_EFFECT_SLEEPING) && (!sleep_cooldowns[target] || COOLDOWN_FINISHED(src, sleep_cooldowns[target])))
 				T.force_say(user)
@@ -437,13 +437,13 @@
 			log_combat(user, target, "stunned", src)
 			target.visible_message(desc["visibleleg"], desc["localleg"])
 			if (Rl.get_staminaloss() < 26 && Ra.get_staminaloss() < 26 && La.get_staminaloss() < 26)
-				target.apply_damage(25, STAMINA, BODY_ZONE_L_LEG, def_check)
+				target.apply_damage(stamina_damage, STAMINA, BODY_ZONE_L_LEG, def_check)
 			else
-				target.apply_damage(10, STAMINA, BODY_ZONE_L_LEG, def_check)
+				target.apply_damage(stamina_damage*0.5, STAMINA, BODY_ZONE_L_LEG, def_check)
 			if (Ll.get_staminaloss() == 50)
-				target.apply_damage(10, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.5, STAMINA, BODY_ZONE_CHEST, def_check)
 			else
-				target.apply_damage(5, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.2, STAMINA, BODY_ZONE_CHEST, def_check)
 
 			if(Ll.get_staminaloss() == 50 && CHECK_BITFIELD(target.mobility_flags, MOBILITY_STAND) && (!trip_cooldowns[target] || COOLDOWN_FINISHED(src, trip_cooldowns[target])))
 				target.visible_message("<span class='emote'><b>[T]</b> [pick(list("falls down.","falls face first into the floor.","gets viciously tripped.","got clumsy."))]</span>")
@@ -458,13 +458,13 @@
 			log_combat(user, target, "stunned", src)
 			target.visible_message(desc["visibleleg"], desc["localleg"])
 			if (Ll.get_staminaloss() < 26 && Ra.get_staminaloss() < 26 && La.get_staminaloss() < 26)
-				target.apply_damage(25, STAMINA, BODY_ZONE_R_LEG, def_check)
+				target.apply_damage(stamina_damage, STAMINA, BODY_ZONE_R_LEG, def_check)
 			else
-				target.apply_damage(10, STAMINA, BODY_ZONE_R_LEG, def_check)
+				target.apply_damage(stamina_damage*0.5, STAMINA, BODY_ZONE_R_LEG, def_check)
 			if (Rl.get_staminaloss() == 50)
-				target.apply_damage(10, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.5, STAMINA, BODY_ZONE_CHEST, def_check)
 			else
-				target.apply_damage(5, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.2, STAMINA, BODY_ZONE_CHEST, def_check)
 
 			if(Rl.get_staminaloss() == 50 && CHECK_BITFIELD(target.mobility_flags, MOBILITY_STAND) && (!trip_cooldowns[target] || COOLDOWN_FINISHED(src, trip_cooldowns[target])))
 				target.visible_message("<span class='emote'><b>[T]</b> [pick(list("falls down.","falls face first into the floor.","gets viciously tripped.","got clumsy."))]</span>")
@@ -483,13 +483,13 @@
 				log_combat(user, target, "disarmed", src)
 				target.visible_message(desc["visibledisarm"], desc["localdisarm"])
 			if (Ra.get_staminaloss() < 26 && Ll.get_staminaloss() < 26 && Rl.get_staminaloss() < 26)
-				target.apply_damage(20, STAMINA, BODY_ZONE_L_ARM, def_check)
+				target.apply_damage(stamina_damage*0.8, STAMINA, BODY_ZONE_L_ARM, def_check)
 			else
-				target.apply_damage(5, STAMINA, BODY_ZONE_L_ARM, def_check)
+				target.apply_damage(stamina_damage*0.2, STAMINA, BODY_ZONE_L_ARM, def_check)
 			if (La.get_staminaloss() == 50)
-				target.apply_damage(10, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.5, STAMINA, BODY_ZONE_CHEST, def_check)
 			else
-				target.apply_damage(4, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.2, STAMINA, BODY_ZONE_CHEST, def_check)
 
 		else if(user.is_zone_selected(BODY_ZONE_R_ARM))
 			if(!Ra.get_staminaloss() == 50)
@@ -499,13 +499,13 @@
 				log_combat(user, target, "disarmed", src)
 				target.visible_message(desc["visibledisarm"], desc["localdisarm"])
 			if (La.get_staminaloss() < 26 && Ll.get_staminaloss() < 26 && Rl.get_staminaloss() < 26)
-				target.apply_damage(20, STAMINA, BODY_ZONE_R_ARM, def_check)
+				target.apply_damage(stamina_damage*0.8, STAMINA, BODY_ZONE_R_ARM, def_check)
 			else
-				target.apply_damage(5, STAMINA, BODY_ZONE_R_ARM, def_check)
+				target.apply_damage(stamina_damage*0.2, STAMINA, BODY_ZONE_R_ARM, def_check)
 			if (Ra.get_staminaloss() == 50)
-				target.apply_damage(10, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.5, STAMINA, BODY_ZONE_CHEST, def_check)
 			else
-				target.apply_damage(4, STAMINA, BODY_ZONE_CHEST, def_check)
+				target.apply_damage(stamina_damage*0.2, STAMINA, BODY_ZONE_CHEST, def_check)
 
 		add_fingerprint(user)
 

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -350,7 +350,7 @@
 	force = 8
 	throwforce = 7
 	cooldown = 0
-	stamina_damage = 25 // 4 hits to stamcrit
+	stamina_damage = 30 // 4 hits to stamcrit < that was a lie
 	stun_animation = TRUE
 	/// Per-mob sleep cooldowns.
 	/// [mob] = [world.time where the cooldown ends]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Using the tonfa is a nightmare. I understand it is intended to be used as a backup currently, but it doesn't do enough stamina damage to knock someone out usually requiring upwards of 6-7 hits.

Changing the value from **25** to **30** should make it actually be viable against unarmored targets instead of being a brig knockout joke. This is star far below the stun baton which deals 40 each hit.

Custom stamina damage to limbs and head is unchanged, due to my wish for it to be used for combos where you aim for chest then limbs for advantage instead of always aiming for head/limbs making you use it slower and depending on actual skill. 
(limb stam is about ~18 against 30 on chest)


_There is a bigger rework that I had in mind, but that will have to wait for a good coder. I also want everyone's thoughts on this and if you believe this will even make it viable._
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes alt batong decent again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->


</details>

## Changelog
:cl:
balance: balances tonfa by giving it the intended stun amount
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
