### PR TITLE
Adds cigars to the smoker trait option list

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -398,6 +398,7 @@ GLOBAL_LIST_INIT(smoker_cigarettes, list(
 	/obj/item/storage/fancy/cigarettes/cigpack_robust,
 	/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 	/obj/item/storage/fancy/cigarettes/cigpack_carp,
+	/obj/item/storage/fancy/cigarettes/dromedaryco
 	/obj/item/storage/fancy/cigarettes/cigars,
 	/obj/item/storage/fancy/cigarettes/cigars/cohiba,
 	/obj/item/storage/fancy/cigarettes/cigars/havana

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -397,7 +397,10 @@ GLOBAL_LIST_INIT(smoker_cigarettes, list(
 	/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 	/obj/item/storage/fancy/cigarettes/cigpack_robust,
 	/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
-	/obj/item/storage/fancy/cigarettes/cigpack_carp
+	/obj/item/storage/fancy/cigarettes/cigpack_carp,
+	/obj/item/storage/fancy/cigarettes/cigars,
+	/obj/item/storage/fancy/cigarettes/cigars/cohiba,
+	/obj/item/storage/fancy/cigarettes/cigars/havana
 ))
 
 GLOBAL_LIST_INIT(alcoholic_bottles, list(

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -398,7 +398,7 @@ GLOBAL_LIST_INIT(smoker_cigarettes, list(
 	/obj/item/storage/fancy/cigarettes/cigpack_robust,
 	/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 	/obj/item/storage/fancy/cigarettes/cigpack_carp,
-	/obj/item/storage/fancy/cigarettes/dromedaryco
+	/obj/item/storage/fancy/cigarettes/dromedaryco,
 	/obj/item/storage/fancy/cigarettes/cigars,
 	/obj/item/storage/fancy/cigarettes/cigars/cohiba,
 	/obj/item/storage/fancy/cigarettes/cigars/havana

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -600,7 +600,10 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
-		/obj/item/storage/fancy/cigarettes/cigpack_carp)
+		/obj/item/storage/fancy/cigarettes/cigpack_carp,
+		/obj/item/storage/fancy/cigarettes/cigars,
+		/obj/item/storage/fancy/cigarettes/cigars/havana,
+		/obj/item/storage/fancy/cigarettes/cigars/cohiba)
 	. = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -600,12 +600,7 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift,
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
-		/obj/item/storage/fancy/cigarettes/cigpack_carp,
-		/obj/item/storage/fancy/cigarettes/cigpack_syndicate //THIS IS ONLY FOR TESTING IF I FORGOT TO REMOVE THIS THEN SHAME ON ME AND REMOVE THIS ASAP!!
-		/obj/item/storage/fancy/cigarettes/dromedaryco,
-		/obj/item/storage/fancy/cigarettes/cigars,
-		/obj/item/storage/fancy/cigarettes/cigars/havana,
-		/obj/item/storage/fancy/cigarettes/cigars/cohiba)
+		/obj/item/storage/fancy/cigarettes/cigpack_carp) 
 	. = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -601,6 +601,7 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 		/obj/item/storage/fancy/cigarettes/cigpack_carp,
+		/obj/item/storage/fancy/cigarettes/cigpack_syndicate //THIS IS ONLY FOR TESTING IF I FORGOT TO REMOVE THIS THEN SHAME ON ME AND REMOVE THIS ASAP!!
 		/obj/item/storage/fancy/cigarettes/dromedaryco,
 		/obj/item/storage/fancy/cigarettes/cigars,
 		/obj/item/storage/fancy/cigarettes/cigars/havana,

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -593,15 +593,10 @@
 	process = TRUE
 
 /datum/quirk/junkie/smoker/on_spawn()
-	drug_container_type = read_choice_preference(/datum/preference/choiced/quirk/smoker_cigarettes)
-	if(!drug_container_type)
-		drug_container_type = pick(/obj/item/storage/fancy/cigarettes,
-		/obj/item/storage/fancy/cigarettes/cigpack_midori,
-		/obj/item/storage/fancy/cigarettes/cigpack_uplift,
-		/obj/item/storage/fancy/cigarettes/cigpack_robust,
-		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
-		/obj/item/storage/fancy/cigarettes/cigpack_carp) 
-	. = ..()
+    drug_container_type = read_choice_preference(/datum/preference/choiced/quirk/smoker_cigarettes)
+    if(!drug_container_type)
+        drug_container_type = pick(GLOB.smoker_cigarettes) 
+    . = ..()
 
 /datum/quirk/junkie/smoker/announce_drugs()
 	to_chat(quirk_target, "<span class='boldnotice'>There is a [initial(drug_container_type.name)] [where_drug], and a lighter [where_accessory]. Make sure you get your favorite brand when you run out.</span>")

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -601,6 +601,7 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 		/obj/item/storage/fancy/cigarettes/cigpack_carp,
+		/obj/item/storage/fancy/cigarettes/dromedaryco,
 		/obj/item/storage/fancy/cigarettes/cigars,
 		/obj/item/storage/fancy/cigarettes/cigars/havana,
 		/obj/item/storage/fancy/cigarettes/cigars/cohiba)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cigars and DromedaryCo cigarettes are now an option for the smoker trait
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Giving people a wider range of choice in how they get lung cancer is good 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/130587823/dd229ea6-234d-4ecb-ad40-1d5b8c7803a0)

The "hated brand type" mood debuff works with the cigars and dromedary cigs

</details>

## Changelog
:cl: Geatish
add: You can now choose cigars and DromedaryCo cigs in the smoker trait option
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
