### PR TITLE
Adds the ability to (de)construct the pool ladder

### DIFF
--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -165,6 +165,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 	desc = "Click this to get out of a pool quickly."
 	icon = 'icons/obj/pool.dmi'
 	icon_state = "ladder"
+	anchored = TRUE
 	pixel_y = 12
 
 GLOBAL_LIST_EMPTY(pool_filters)

--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -106,7 +106,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 		return
 	if(!W.tool_use_check(user,10))
 		return
-	if(!istype(get_step(src, NORTH), /turf/open/indestructible/sound/pool/)) //Ladders only face up, and no stacking!
+	if(!istype(get_step(src, NORTH), /turf/open/indestructible/sound/pool)) //Ladders only face up, and no stacking!
 		balloon_alert(user, "You start installing a pool ladder...")
 		if(do_after(user, 5 SECONDS, target=src))
 			W.use(10)

--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -9,7 +9,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 */
 
 /obj/effect/overlay/poolwater
-	name = "Pool water"
+	name = "pool water"
 	icon = 'icons/obj/pool.dmi'
 	icon_state = "water"
 	anchored = TRUE
@@ -17,7 +17,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /turf/open/indestructible/sound/pool
-	name = "Swimming pool"
+	name = "swimming pool"
 	desc = "A fun place where you go to swim! <b>Drag and drop yourself onto it to climb in...</b>"
 	icon = 'icons/obj/pool.dmi'
 	icon_state = "pool"
@@ -92,20 +92,26 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 		dropping.visible_message("<span class='notice'>[user] starts to lower [dropping] down into [src].</span>", \
 		 "<span class='notice'>You start to lower [dropping] down into [src].</span>")
 	else
-		to_chat(user, "<span class='notice'>You start climbing down into [src]...")
+		to_chat(user, "<span class='notice'>You start climbing down into [src]...</span>")
 	if(do_after(user, 4 SECONDS, target = dropping))
 		splash(dropping)
 
 /turf/open/indestructible/sound/pool/attackby(obj/item/W, mob/user, params)
-	. = ..()
-	if(istype(W, /obj/item/stack/rods) && user.loc == get_step(src, NORTH) && !istype(user.loc, /turf/open/indestructible/sound/pool/))
-		var/obj/item/stack/rods/R = W //^ Only build pool ladders from the shore (north, because the ladder can't rotate)
-		if(R.tool_use_check(user,10))
-			to_chat(user, "<span class ='notice'>You start installing a pool ladder.</span>")
-			if(do_after(user, 5 SECONDS, target=src))
-				R.use(10)
-				new /obj/structure/pool_ladder(src)
-				return TRUE
+	if(..())
+		return
+	if(!istype(W, /obj/item/stack/rods))
+		return
+	if(locate(/obj/structure/pool_ladder) in src)
+		balloon_alert(user, "You try to make a pool ladder, but there is aleady one here!")
+		return
+	if(!W.tool_use_check(user,10))
+		return
+	if(!istype(get_step(src, NORTH), /turf/open/indestructible/sound/pool/)) //Ladders only face up, and no stacking!
+		balloon_alert(user, "You start installing a pool ladder...")
+		if(do_after(user, 5 SECONDS, target=src))
+			W.use(10)
+			new /obj/structure/pool_ladder(src)
+			return TRUE
 
 /turf/open/indestructible/sound/pool/proc/splash(mob/user)
 	user.forceMove(src)
@@ -158,7 +164,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 		return TRUE
 
 /obj/effect/turf_decal/pool
-	name = "Pool siding"
+	name = "pool siding"
 	icon = 'icons/obj/pool.dmi'
 	icon_state = "poolborder"
 
@@ -171,15 +177,19 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 //Pool machinery
 
 /obj/structure/pool_ladder
-	name = "Pool ladder"
-	desc = "Click this to get out of a pool quickly."
+	name = "pool ladder"
+	desc = "A faster and safer way to leave the pool."
 	icon = 'icons/obj/pool.dmi'
 	icon_state = "ladder"
 	anchored = TRUE
 	pixel_y = 12
 
+/obj/structure/pool_ladder/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>There are <b>bolts</b> securing it to the side of the pool.</span>"
+
 /obj/structure/pool_ladder/wrench_act(mob/living/user, obj/item/I)
-	to_chat(user, "<span class='notice'>You start disassembling [src].</span>")
+	balloon_alert(user, "You start disassembling [src].")
 	if(I.use_tool(src, user, 5 SECONDS))
 		deconstruct()
 
@@ -212,7 +222,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 GLOBAL_LIST_EMPTY(pool_filters)
 
 /obj/machinery/pool_filter
-	name = "Pool filter"
+	name = "pool filter"
 	desc = "A device which can help you regulate conditions in a pool. Use a <b>wrench</b> to change its operating temperature, or hit it with a reagent container to load in new liquid to add to the pool."
 	icon = 'icons/obj/pool.dmi'
 	icon_state = "poolfilter"

--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -179,6 +179,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 	pixel_y = 12
 
 /obj/structure/pool_ladder/wrench_act(mob/living/user, obj/item/I)
+	to_chat(user, "<span class='notice'>You start disassembling [src].</span>")
 	if(I.use_tool(src, user, 5 SECONDS))
 		deconstruct()
 


### PR DESCRIPTION
## About The Pull Request
Originally made this to fix the ladder being unanchored, but figured adding (de)construction steps to it could be helpful too.
Deconstruction is done with a wrench.
Right now you can only build them from outside the pool when standing north of it (because ladders don't turn).
Also changed the pool part names to be lowercase, since they're not proper names, and the description of the pool ladder to be less OOC (mentioning clicking on it).

## Why It's Good For The Game
Ladders are more useful when secured, and when you can rebuild them!

## Testing Photographs and Procedure

https://github.com/BeeStation/BeeStation-Hornet/assets/43698041/7da7f608-af55-4b84-8e56-1adc36dad04f


## Changelog
:cl:
add: Made it possible to disassemble pool ladders with wrenches and possible to build them with rods.
fix: Fixed pool ladders being unanchored.
/:cl: