### PR TITLE
Brings tinfoil variant of envirosuit helmet inline with other envirosuit helmets

### DIFF
--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -60,7 +60,7 @@
 	icon_state = "tinfoil_envirohelm"
 	item_state = "tinfoil_envirohelm"
 	strip_delay = 150
-	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | EFFECT_HAT | SNUG_FIT
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | EFFECT_HAT | SNUG_FIT | HEADINTERNALS
 	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 50, ACID = 50, STAMINA = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	light_system = MOVABLE_LIGHT

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -60,7 +60,7 @@
 	icon_state = "tinfoil_envirohelm"
 	item_state = "tinfoil_envirohelm"
 	strip_delay = 150
-	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | EFFECT_HAT | SNUG_FIT | HEADINTERNALS
+	clothing_flags = STOPSPRESSUREDAMAGE | EFFECT_HAT | SNUG_FIT | HEADINTERNALS
 	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 50, ACID = 50, STAMINA = 50)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	light_system = MOVABLE_LIGHT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When envirosuit helmets were given internals functionality originally, these ones had seemingly been forgotten and remained with the requirement for a separate breath mask.

Also removing the `THICKMATERIAL` flag to bring them inline with other envirosuit helmets which no longer have that flag. (Allows for syringes and the such to reasonably be used on plasmamen)

I meant to include this in a related PR merged last night; but had forgotten about it until it was too late.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adding tinfoil shouldn't magically make you need a breath mask for the envirosuit helmet, or become thick enough to prevent syringes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/22382345/ace77f53-89d6-4e01-82c6-9e7856eadff4)

Yes this sprite is absolutely sovl.... No I don't know how to sprite well enough to fix it.

</details>

## Changelog
:cl:
fix: Tinfoil envirosuit helmets act as internals now and no longer block syringes, just like other envirosuit helmets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
