### PR TITLE
Fixes gun loading bug

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -68,14 +68,17 @@
 	if(!can_load(user))
 		return
 	if(istype(A, /obj/item/ammo_box))
+		if (length(user.progressbars))
+			return
 		var/obj/item/ammo_box/AM = A
-		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
-			//If the box you're loading from is empty, break.
-			if(!AM.stored_ammo)
-				break
+		while (length(AM.stored_ammo))
 			if(!multiload)
 				if(!do_after(user, 4, src, IGNORE_USER_LOC_CHANGE))
 					break
+			//If the box you're loading from is empty, break.
+			if (!length(AM.stored_ammo))
+				break
+			var/obj/item/ammo_casing/AC = AM.stored_ammo[1]
 			var/did_load = give_round(AC)
 			if(did_load)
 				AM.stored_ammo -= AC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #10998

## About The Pull Request

Loading a gun from an ammo bug multiple times at the same time causes the gun to stop working.

## Why It's Good For The Game

This bug will trip people up and cause them to unnecessarilly be killed.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/da9e897b-d88f-4e93-bf40-e6cd06859792)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/80d31807-4bc0-42e3-807b-424971a57206)


## Changelog
:cl:
fix: Fixes loading a gun from an ammo box multiple times resulting in the gun being unable to fire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
