### PR TITLE
Shadow Sect - New Rite, Final Darkness

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -173,6 +173,8 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 
 #define iscogscarab(A) (istype(A, /mob/living/simple_animal/drone/cogscarab))
 
+#define isfaithless(A) (istype(A, /mob/living/simple_animal/hostile/faithless))
+
 //Misc mobs
 #define isobserver(A) (istype(A, /mob/dead/observer))
 

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -34,3 +34,8 @@
 
 	footstep_type = FOOTSTEP_MOB_SHOE
 	hardattacks = TRUE
+
+/mob/living/simple_animal/hostile/faithless/faithful
+	name = "Faithsworn"
+	desc = "A creature made of pure faith from shadowpeople."
+	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -38,4 +38,6 @@
 /mob/living/simple_animal/hostile/faithless/faithful
 	name = "Faithsworn"
 	desc = "A creature made of pure faith from shadowpeople."
+	melee_damage = 20
 	gold_core_spawnable = NO_SPAWN
+	del_on_death = TRUE

--- a/code/modules/religion/sects/plant_sect.dm
+++ b/code/modules/religion/sects/plant_sect.dm
@@ -72,7 +72,7 @@
 				L.updatehealth()
 				if(L.blood_volume < BLOOD_VOLUME_NORMAL)
 					L.blood_volume += 1.0
-			CHECK_TICK
+
 	if(last_spread <= world.time)
 		var/list/validturfs = list()
 		var/list/natureturfs = list()

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -15,7 +15,8 @@
 		/datum/religion_rites/shadow_obelisk,
 		/datum/religion_rites/shadow_conversion,
 		/datum/religion_rites/shadow_blessing,
-		/datum/religion_rites/shadow_eyes)
+		/datum/religion_rites/shadow_eyes,
+		/datum/religion_rites/summon_faithful)
 	altar_icon_state = "convertaltar-dark"
 	var/light_reach = 1
 	var/light_power = 0
@@ -101,8 +102,6 @@
 	var/light_amount = T.get_lumcount()
 	var/favor_gained = max(1 - light_amount, 0) * delta_time
 	sect.adjust_favor(favor_gained, creator)
-
-
 
 /**** Shadow rites ****/ //Original code by DingoDongler
 
@@ -251,11 +250,10 @@
 	if(!rite_target)
 		return FALSE
 	ADD_TRAIT(rite_target, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
-	//glowing wings overlay
+	to_chat(rite_target, "<span class='userdanger'>You are grateful to have been converted to the dark by [user]. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
 	playsound(rite_target, 'sound/weapons/fwoosh.ogg', 75, 0)
 	rite_target.visible_message("<span class='notice'>[rite_target] has been blessed by the rite of [name]!</span>")
 	return TRUE
-
 
 /datum/religion_rites/shadow_eyes
 	name = "Grant Shadow Eyes"
@@ -301,3 +299,23 @@
 	organ.Insert(rite_target)
 	rite_target.visible_message("<span class='notice'>[organ] have been merged into [rite_target] by the rite of [name]!</span>")
 	return TRUE
+
+/datum/religion_rites/summon_faithful
+	name = "Summon the faithful"
+	desc = "Summons 2-6 Faithful, Creatures similar to the faithless, that will not attack any shadowpeople, but are hostile to others."
+	ritual_length = 30 SECONDS
+	ritual_invocations = list(
+		"Join us in this darkness ...",
+		"... Protect us from the light ...",
+		"... Destroy those who defy us ...")
+	invoke_msg = "... Let the darkness come and fight!!"
+	favor_cost = 20000
+
+/datum/religion_rites/summon_faithful/invoke_effect(mob/living/user, atom/religious_tool)
+	var/altar_turf = get_turf(religious_tool)
+	for(var/i in 2 to 6)
+		var/mob/living/simple_animal/hostile/faithless/faithful/faithful = new(altar_turf)
+		faithful.AddComponent(/datum/component/dark_favor, user)
+		faithful.set_light(1, 1, DARKNESS_INVERSE_COLOR)
+	playsound(altar_turf, 'sound/magic/fireball.ogg', 50, TRUE)
+	return ..()

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -70,18 +70,11 @@
 	var/last_spread = 0
 
 /obj/structure/destructible/religion/shadow_obelisk/Initialize(mapload)
-	var/datum/religion_sect/shadow_sect/sect = GLOB.religious_sect
 	. = ..()
-	if(!sect.faithful_used)
-		return
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/structure/destructible/religion/shadow_obelisk/LateInitialize()
-	var/datum/religion_sect/shadow_sect/sect = GLOB.religious_sect
 	. = ..()
-	if(!sect.faithful_used)
-		return
-	START_PROCESSING(SSobj, src)
 
 /obj/structure/destructible/religion/shadow_obelisk/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -89,63 +82,62 @@
 
 /obj/structure/destructible/religion/shadow_obelisk/process(delta_time)
 	var/datum/religion_sect/shadow_sect/sect = GLOB.religious_sect
-	if(sect.faithful_used)
-		if(last_heal <= world.time)
-			last_heal = world.time + heal_delay
-			for(var/mob/living/L in range(5, src))
-				if(L.health == L.maxHealth)
-					continue
-				if(!isshadow(L) && !L.mind?.holy_role && !isfaithless(L))
-					continue
-				new /obj/effect/temp_visual/heal(get_turf(src), "#29005f")
-				if(isshadow(L) || L.mind?.holy_role || isfaithless(L))
-					L.adjustBruteLoss(-2*delta_time, 0)
-					L.adjustToxLoss(-2*delta_time, 0)
-					L.adjustOxyLoss(-2*delta_time, 0)
-					L.adjustFireLoss(-2*delta_time, 0)
-					L.adjustCloneLoss(-2*delta_time, 0)
-					L.updatehealth()
-					if(L.blood_volume < BLOOD_VOLUME_NORMAL)
-						L.blood_volume += 1.0
-				CHECK_TICK
-		if(last_spread <= world.time)
-			var/list/validturfs = list()
-			var/list/shadowturfs = list()
-			for(var/T in circleviewturfs(src, 5))
-				if(istype(T, /turf/open/floor/black))
-					shadowturfs |= T
-					continue
-				var/static/list/blacklisted_pylon_turfs = typecacheof(list(
-					/turf/closed,
-					/turf/open/floor/black,
-					/turf/open/space,
-					/turf/open/lava,
-					/turf/open/chasm,
-					/turf/open/openspace,
-					/turf/open/floor/plating/beach,
-					/turf/open/indestructible,
-					/turf/open/floor/prison))
-				if(is_type_in_typecache(T, blacklisted_pylon_turfs))
-					continue
-				else
-					validturfs |= T
-
-			last_spread = world.time + spread_delay
-
-			var/turf/T = safepick(validturfs)
-			if(T)
-				if(istype(T, /turf/open/floor/plating))
-					T.PlaceOnTop(/turf/open/floor/black, flags = CHANGETURF_INHERIT_AIR)
-				else
-					T.ChangeTurf(/turf/open/floor/black, flags = CHANGETURF_INHERIT_AIR)
+	if(!sect.faithful_used)
+		return
+	if(last_heal <= world.time)
+		last_heal = world.time + heal_delay
+		for(var/mob/living/L in range(5, src))
+			if(L.health == L.maxHealth)
+				continue
+			if(!isshadow(L) && !L.mind?.holy_role && !isfaithless(L))
+				continue
+			new /obj/effect/temp_visual/heal(get_turf(src), "#29005f")
+			if(isshadow(L) || L.mind?.holy_role || isfaithless(L))
+				L.adjustBruteLoss(-2*delta_time, 0)
+				L.adjustToxLoss(-2*delta_time, 0)
+				L.adjustOxyLoss(-2*delta_time, 0)
+				L.adjustFireLoss(-2*delta_time, 0)
+				L.adjustCloneLoss(-2*delta_time, 0)
+				L.updatehealth()
+				if(L.blood_volume < BLOOD_VOLUME_NORMAL)
+					L.blood_volume += 1.0
+			CHECK_TICK
+	if(last_spread <= world.time)
+		var/list/validturfs = list()
+		var/list/shadowturfs = list()
+		for(var/T in circleviewturfs(src, 5))
+			if(istype(T, /turf/open/floor/black))
+				shadowturfs |= T
+				continue
+			var/static/list/blacklisted_obelisk_turfs = typecacheof(list(
+				/turf/closed,
+				/turf/open/floor/black,
+				/turf/open/space,
+				/turf/open/lava,
+				/turf/open/chasm,
+				/turf/open/openspace,
+				/turf/open/floor/plating/beach,
+				/turf/open/indestructible,
+				/turf/open/floor/prison))
+			if(is_type_in_typecache(T, blacklisted_obelisk_turfs))
+				continue
 			else
-				var/turf/open/floor/black/F = safepick(shadowturfs)
-				if(F)
-					new /obj/effect/temp_visual/religion/turf/floor(F)
-				else
-					// Are we in space or something? No black turfs or
-					// convertable turfs?
-					last_spread = world.time + spread_delay*2
+				validturfs |= T
+		last_spread = world.time + spread_delay
+		var/turf/T = safepick(validturfs)
+		if(T)
+			if(istype(T, /turf/open/floor/plating))
+				T.PlaceOnTop(/turf/open/floor/black, flags = CHANGETURF_INHERIT_AIR)
+			else
+				T.ChangeTurf(/turf/open/floor/black, flags = CHANGETURF_INHERIT_AIR)
+		else
+			var/turf/open/floor/black/F = safepick(shadowturfs)
+			if(F)
+				new /obj/effect/temp_visual/religion/turf/floor(F)
+			else
+				// Are we in space or something? No black turfs or
+				// convertable turfs?
+				last_spread = world.time + spread_delay*2
 
 /obj/structure/destructible/religion/shadow_obelisk/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/nullrod))
@@ -387,7 +379,7 @@
 
 /datum/religion_rites/final_darkness
 	name = "Final Darkness"
-	desc = "The endgame, Activates the shadow heal and (if you meet the requirements) summons numerous Faithsworn entities from every obelisk in existence. THIS IS ONE USE ONLY."
+	desc = "The endgame, Activates the obelisk heal and summons Faithsworn entities from every obelisk in existence. THIS IS ONE USE ONLY."
 	ritual_length = 60 SECONDS
 	ritual_invocations = list(
 		"Join us in this darkness ...",
@@ -396,28 +388,29 @@
 	invoke_msg = "... Let the darkness come and fight!!"
 	favor_cost = 50000
 
-
 /datum/religion_rites/final_darkness/invoke_effect(mob/living/user, atom/religious_tool)
 	var/datum/religion_sect/shadow_sect/sect = GLOB.religious_sect
 	if(sect.faithful_used)
 		to_chat(user,"<span class='warning'>This rite has already been used, your favor has been refuned.</span>")
 		GLOB.religious_sect?.adjust_favor(50000, user)
-		return..()
+		return ..()
 	sect.faithful_used = TRUE
+	var/altar_turf = get_turf(religious_tool)
+	var/obj/structure/destructible/religion/shadow_obelisk/lisk = new(altar_turf)
+	sect.obelisks += lisk
+	lisk.AddComponent(/datum/component/dark_favor, user)
+	lisk.set_light(sect.light_reach, sect.light_power, DARKNESS_INVERSE_COLOR)
+	playsound(altar_turf, 'sound/magic/fireball.ogg', 50, TRUE)
+	priority_announce("May our lord, [GLOB.deity], have mercy on your soul as darkness reigns apon you all.", "Faith Alert", SSstation.announcer.get_rand_alert_sound())
+	addtimer(CALLBACK(lisk, TYPE_PROC_REF(/obj/structure/destructible/religion/shadow_obelisk, final_darkness_activate)), 100)
+
+/obj/structure/destructible/religion/shadow_obelisk/proc/final_darkness_activate()
+	var/datum/religion_sect/shadow_sect/sect = GLOB.religious_sect
 	for(var/obj/structure/destructible/religion/shadow_obelisk/obs in sect.obelisks)
-		obs.LateInitialize()
-	if(user.mind.is_murderbone())
-		priority_announce("May our lord, [GLOB.deity], have mercy on your soul as darkness reigns apon you all.", "Faith Alert", SSstation.announcer.get_rand_alert_sound())
-		sleep(150)
-		for(var/obj/structure/destructible/religion/shadow_obelisk/obs in sect.obelisks)
-			var/obelisk_turf = get_turf(obs)
-			for(var/i in 1 to 3)
-				var/mob/living/simple_animal/hostile/faithless/faithful/faithful = new(obelisk_turf)
-				faithful.AddComponent(/datum/component/dark_favor, user)
-				faithful.set_light(2, -2, DARKNESS_INVERSE_COLOR)
-			playsound(obs, 'sound/hallucinations/wail.ogg', 50, TRUE)
-		return ..()
-	else
-		for(var/obj/structure/destructible/religion/shadow_obelisk/obs in sect.obelisks)
-			playsound(obs, 'sound/magic/fireball.ogg', 50, TRUE)
-		return ..()
+		START_PROCESSING(SSobj, obs)
+		var/obelisk_turf = get_turf(obs)
+		for(var/i in 1 to 3)
+			var/mob/living/simple_animal/hostile/faithless/faithful/faithful = new(obelisk_turf)
+			faithful.AddComponent(/datum/component/dark_favor, faithful)
+			faithful.set_light(2, -2, DARKNESS_INVERSE_COLOR)
+		playsound(obs, 'sound/hallucinations/wail.ogg', 50, TRUE)

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -55,7 +55,6 @@
 	else
 		to_chat(chap,  "<span class='userdanger'>You are not an antagonist, please do not spread darkness outside of the chapel without Command Staff approval.</span>")
 
-
 // Shadow sect construction
 /obj/structure/destructible/religion/shadow_obelisk
 	name = "Shadow Obelisk"
@@ -68,13 +67,6 @@
 	var/last_heal = 0
 	var/spread_delay = 45
 	var/last_spread = 0
-
-/obj/structure/destructible/religion/shadow_obelisk/Initialize(mapload)
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/structure/destructible/religion/shadow_obelisk/LateInitialize()
-	. = ..()
 
 /obj/structure/destructible/religion/shadow_obelisk/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -120,7 +120,8 @@
 					/turf/open/floor/black,
 					/turf/open/space,
 					/turf/open/lava,
-					/turf/open/chasm))
+					/turf/open/chasm,
+					/turf/open/openspace))
 				if(is_type_in_typecache(T, blacklisted_pylon_turfs))
 					continue
 				else

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -93,7 +93,7 @@
 				L.updatehealth()
 				if(L.blood_volume < BLOOD_VOLUME_NORMAL)
 					L.blood_volume += 1.0
-			CHECK_TICK
+
 	if(last_spread <= world.time)
 		var/list/validturfs = list()
 		var/list/shadowturfs = list()

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -403,6 +403,8 @@
 	for(var/obj/structure/destructible/religion/shadow_obelisk/obs in sect.obelisks)
 		obs.LateInitialize()
 	if(user.mind.is_murderbone())
+		priority_announce("May our lord, [GLOB.deity], have mercy on your soul as darkness reigns apon you all.", "Faith Alert", SSstation.announcer.get_rand_alert_sound())
+		sleep(150)
 		for(var/obj/structure/destructible/religion/shadow_obelisk/obs in sect.obelisks)
 			var/obelisk_turf = get_turf(obs)
 			for(var/i in 1 to 3)

--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -121,7 +121,10 @@
 					/turf/open/space,
 					/turf/open/lava,
 					/turf/open/chasm,
-					/turf/open/openspace))
+					/turf/open/openspace,
+					/turf/open/floor/plating/beach,
+					/turf/open/indestructible,
+					/turf/open/floor/prison))
 				if(is_type_in_typecache(T, blacklisted_pylon_turfs))
 					continue
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As an *almost* Antag only sect, Shadow feels very passive and station friendly, with the abilities to give people nightvision or converting them to shadow people...

Not much antag-wise going on here apart from making the station a bit dark, which could be done with some tools and time taking out the lights.

This PR adds a new rite to the sect, Final Darkness, which can summon 1-3 creatures that dont attack shadow-people, great for causing a chaos in the halls. It also activates a Shadow heal/spread from the obelisks, similar to the plant sect's nature pylons

Rite - Final Darkness 
- Summons 1-3 Faithsworn from every obelisk in existence (Creatures similar to the faithless, that will not attack any shadowpeople, but are hostile to others. ) (Announcement is made to crew 15 seconds before the summon happens)
- Activates the Obelisk's shadow healing.
- Costs 50,000 Favor
- One use only.

## Why It's Good For The Game

Adds something antag-worthy to an almost antag only sect, making it worth the TC spent, after a lot of work anyway...

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/17776299/032d6c43-005d-4b10-add5-51d9a5013a9a)

https://github.com/BeeStation/BeeStation-Hornet/assets/17776299/45ffef23-350e-4fdc-878e-719965d15fd0

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/17776299/4ee35562-ee6f-479a-8dd3-b7955d0872bd)

</details>

## Changelog
:cl:

add: Added Final Darkness rite to the Shadow-Sect
add: Faithsworn mob


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
