### PR TITLE
Singularity qdel fix 

### DIFF
--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -161,7 +161,7 @@
 	consume(source, user)
 
 // Will there be an impact? Who knows.  Will we see it? No.
-/datum/component/singularity/proc/consume_bullets(obj/projectile/projectile)
+/datum/component/singularity/proc/consume_bullets(datum/source, obj/projectile/projectile)
 	SIGNAL_HANDLER
 	qdel(projectile)
 

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -5,7 +5,7 @@
 #define CHANCE_TO_MOVE_TO_TARGET 60
 
 //What's the range for the singularity to see things to eat?
-#define SINGULARITY_SIGHT_SIZE 20
+#define SINGULARITY_SIGHT_SIZE 10
 
 /// Things that maybe move around and does stuff to things around them
 /// Used for the singularity (duh) and Nar'Sie
@@ -212,22 +212,16 @@
 /datum/component/singularity/proc/move(delta_time)
 	var/list/drifting_dir = GLOB.alldirs
 	drifting_dir -= last_failed_movement
-	var/singularity_sight_modifier
-	var/nearest_distance = SINGULARITY_SIGHT_SIZE + singularity_sight_modifier
+	var/neareest_distance = SINGULARITY_SIGHT_SIZE
 	var/closest_target
-	var/static/things_to_eat = typecacheof(list(/turf/closed/wall, /obj/structure, /mob/living))
-	var/static/things_to_not_eat = typecacheof(list(/obj/structure/grille/indestructable, /obj/structure/window/reinforced/fulltile/indestructable, /turf/closed/indestructible, /turf/open/indestructible))
-	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE + singularity_sight_modifier, parent)) //Find the nearest wall, floor, structure or mob
-		if((A.type in things_to_eat) && !(A.type in things_to_not_eat)) //can we eat it?
+	var/static/things_to_eat = typecacheof(list(/turf/open/floor, /turf/closed/wall, /obj/structure))
+	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE, parent)) //Find the furthest wall, floor or structure that we can eat, then go that direction
+		if(A.type in things_to_eat)
 			var/dist = get_dist(parent, A)
-			if(dist < nearest_distance)
+			if(dist < neareest_distance)
 				closest_target = A
-				nearest_distance = dist
-				singularity_sight_modifier = 0
-	var/dir = get_dir(parent, closest_target) //go that way
-	if ((dir == null) && (singularity_sight_modifier < 45)) //Increase the search radius if you find nothing, up to a maximum, ofcourse.
-		singularity_sight_modifier++
-		return
+				neareest_distance = dist
+	var/dir = get_dir(parent, closest_target)
 	if(dir in drifting_dir) //Can we go that direction?
 		final_dir = dir //If so, go that way.
 	else

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -5,7 +5,7 @@
 #define CHANCE_TO_MOVE_TO_TARGET 60
 
 //What's the range for the singularity to see things to eat?
-#define SINGULARITY_SIGHT_SIZE 10
+#define SINGULARITY_SIGHT_SIZE 20
 
 /// Things that maybe move around and does stuff to things around them
 /// Used for the singularity (duh) and Nar'Sie
@@ -212,16 +212,22 @@
 /datum/component/singularity/proc/move(delta_time)
 	var/list/drifting_dir = GLOB.alldirs
 	drifting_dir -= last_failed_movement
-	var/neareest_distance = SINGULARITY_SIGHT_SIZE
+	var/singularity_sight_modifier
+	var/nearest_distance = SINGULARITY_SIGHT_SIZE + singularity_sight_modifier
 	var/closest_target
-	var/static/things_to_eat = typecacheof(list(/turf/open/floor, /turf/closed/wall, /obj/structure))
-	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE, parent)) //Find the furthest wall, floor or structure that we can eat, then go that direction
-		if(A.type in things_to_eat)
+	var/static/things_to_eat = typecacheof(list(/turf/closed/wall, /obj/structure, /mob/living))
+	var/static/things_to_not_eat = typecacheof(list(/obj/structure/grille/indestructable, /obj/structure/window/reinforced/fulltile/indestructable, /turf/closed/indestructible, /turf/open/indestructible))
+	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE + singularity_sight_modifier, parent)) //Find the nearest wall, floor, structure or mob
+		if((A.type in things_to_eat) && !(A.type in things_to_not_eat)) //can we eat it?
 			var/dist = get_dist(parent, A)
-			if(dist < neareest_distance)
+			if(dist < nearest_distance)
 				closest_target = A
-				neareest_distance = dist
-	var/dir = get_dir(parent, closest_target)
+				nearest_distance = dist
+				singularity_sight_modifier = 0
+	var/dir = get_dir(parent, closest_target) //go that way
+	if ((dir == null) && (singularity_sight_modifier < 45)) //Increase the search radius if you find nothing, up to a maximum, ofcourse.
+		singularity_sight_modifier++
+		return
 	if(dir in drifting_dir) //Can we go that direction?
 		final_dir = dir //If so, go that way.
 	else

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -217,10 +217,10 @@
 	var/closest_target
 	var/static/things_to_eat = typecacheof(list(/turf/closed/wall, /obj/structure, /mob/living))
 	var/static/things_to_not_eat = typecacheof(list(/obj/structure/grille/indestructable, /obj/structure/window/reinforced/fulltile/indestructable, /turf/closed/indestructible, /turf/open/indestructible))
-	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE + singularity_sight_modifier, parent)) //Find the nearest wall, floor, structure or mob
+	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE + singularity_sight_modifier, parent)) //Find the nearest wall, strucutre or mob
 		if((A.type in things_to_eat) && !(A.type in things_to_not_eat)) //can we eat it?
-			var/dist = get_dist(parent, A)
-			if(dist < nearest_distance)
+			var/dist = get_dist(parent, A) //Get the distance to it.
+			if(dist < nearest_distance) //Is it closer than the previous iteration?
 				closest_target = A
 				nearest_distance = dist
 				singularity_sight_modifier = 0

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -217,10 +217,10 @@
 	var/closest_target
 	var/static/things_to_eat = typecacheof(list(/turf/closed/wall, /obj/structure, /mob/living))
 	var/static/things_to_not_eat = typecacheof(list(/obj/structure/grille/indestructable, /obj/structure/window/reinforced/fulltile/indestructable, /turf/closed/indestructible, /turf/open/indestructible))
-	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE + singularity_sight_modifier, parent)) //Find the nearest wall, strucutre or mob
+	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE + singularity_sight_modifier, parent)) //Find the nearest wall, floor, structure or mob
 		if((A.type in things_to_eat) && !(A.type in things_to_not_eat)) //can we eat it?
-			var/dist = get_dist(parent, A) //Get the distance to it.
-			if(dist < nearest_distance) //Is it closer than the previous iteration?
+			var/dist = get_dist(parent, A)
+			if(dist < nearest_distance)
 				closest_target = A
 				nearest_distance = dist
 				singularity_sight_modifier = 0

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -21,9 +21,6 @@
 	/// The chosen direction to drift in
 	var/drifting_dir
 
-	/// The final chosen direction to go.
-	var/final_dir
-
 	/// How many tiles out to pull in
 	var/grav_pull
 

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -4,9 +4,6 @@
 /// What's the chance that, when a singularity moves, it'll go to its target?
 #define CHANCE_TO_MOVE_TO_TARGET 60
 
-//What's the range for the singularity to see things to eat?
-#define SINGULARITY_SIGHT_SIZE 10
-
 /// Things that maybe move around and does stuff to things around them
 /// Used for the singularity (duh) and Nar'Sie
 /datum/component/singularity
@@ -21,7 +18,7 @@
 	/// Does this singularity move?
 	var/roaming
 
-	/// The chosen directions to drift in
+	/// The chosen direction to drift in
 	var/drifting_dir
 
 	/// The final chosen direction to go.
@@ -144,7 +141,7 @@
 	if(time_since_last_eat > 1) // Delta time is in seconds for "reasons"
 		time_since_last_eat = 0
 		if (roaming)
-			move(delta_time)
+			move()
 		eat()
 
 /datum/component/singularity/proc/block_blob()
@@ -209,26 +206,13 @@
 
 	turfs_to_eat--
 
-/datum/component/singularity/proc/move(delta_time)
-	var/list/drifting_dir = GLOB.alldirs
-	drifting_dir -= last_failed_movement
-	var/neareest_distance = SINGULARITY_SIGHT_SIZE
-	var/closest_target
-	var/static/things_to_eat = typecacheof(list(/turf/open/floor, /turf/closed/wall, /obj/structure))
-	for(var/atom/A as() in oview(SINGULARITY_SIGHT_SIZE, parent)) //Find the furthest wall, floor or structure that we can eat, then go that direction
-		if(A.type in things_to_eat)
-			var/dist = get_dist(parent, A)
-			if(dist < neareest_distance)
-				closest_target = A
-				neareest_distance = dist
-	var/dir = get_dir(parent, closest_target)
-	if(dir in drifting_dir) //Can we go that direction?
-		final_dir = dir //If so, go that way.
-	else
-		final_dir = pick(drifting_dir) //Else, pick a random other direction to go.
-	if(!QDELETED(target) && prob(CHANCE_TO_MOVE_TO_TARGET)) //Do we have a beacon to go to? If so, with chance, go there instead.
-		final_dir = get_dir(parent, target)
-	step(parent, final_dir)
+/datum/component/singularity/proc/move()
+	var/drifting_dir = pick(GLOB.alldirs - last_failed_movement)
+
+	if(!QDELETED(target) && prob(CHANCE_TO_MOVE_TO_TARGET))
+		drifting_dir = get_dir(parent, target)
+
+	step(parent, drifting_dir)
 
 /datum/component/singularity/proc/moved(datum/source, atom/new_location)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug where any projectile would qdel the singularity, instead of being qdel'd itself. 


## Why It's Good For The Game

Proper singularity behavior is good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/0c3c1e73-2f8b-4ea7-80b9-7ef05ca39454



</details>

## Changelog
:cl: XeonMations
fix: Fixed a bug where any projectile would delete the singularity instead of being deleted itself.
/:cl:

