### PR TITLE
Firedoor PDA

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -112,11 +112,6 @@
 	if(operating)
 		return
 
-	if(istype(C, /obj/item/modular_computer/tablet/pda))
-		var/attack_verb = pick("smushes","rubs","smashes","presses","taps")
-		visible_message("<span class='warning'>[user] [attack_verb] \the [C] against [src]\s card reader.</span>", "<span class='warning'>You [attack_verb] \the [C] against [src]\s card reader. It doesn't do anything.</span>", "You hear plastic click against metal.")
-		return
-
 	if(welded)
 		if(C.tool_behaviour == TOOL_WRENCH)
 			if(boltslocked)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -147,19 +147,19 @@
 	if(!density || welded)
 		return
 
-	if(isidcard(I))
-		if((check_safety(user) == TRUE) || check_access(I))
-			log_opening(I, user, check_safety(user))
+	var/obj/item/card/id/id_card = I.GetID()
+	if(istype(id_card))
+		if((check_safety(user) == TRUE) || check_access(id_card))
+			log_opening(id_card, user, check_safety(user))
 			playsound(src, 'sound/machines/beep.ogg', 50, 1)
 			open()
 			return
 		else
-			log_opening(I, user, -1)
+			log_opening(id_card, user, -1)
 			to_chat(user, "<span class='danger'>Access Denied, User not authorized to override alarms or pressure checks.</span>")
 			playsound(src, 'sound/machines/terminal_error.ogg', 50, 1)
 			return
 	to_chat("<span class='warning'>You try to pull the card reader. Nothing happens.</span>")
-	return
 
 /obj/machinery/door/firedoor/proc/log_opening(obj/item/card/id/I, mob/user, safe)
 	var/safestate = "UNK_STATE:"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using a PDA on a firedoor is now the same as using an ID on it. In fact, anything that can contain an ID and still work will function, just the same as how airlocks work.

## Why It's Good For The Game

This interaction is unintuitive, annoying and inconsistent from the rest of the door mechanics. To put it simply, its just bad design and unnecessarilly annoying towards new players without actually adding anything to the game.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8a32cb0e-c85d-4389-9449-991e6ed761e8)


## Changelog
:cl:
tweak: Removes the unintuitive and inconsistent interaction with PDA and firelock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
