### PR TITLE
Fixes soulstone construct conversion deleting the soulstone if cancelled

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -252,7 +252,7 @@
 			var/mob/living/simple_animal/shade/A = locate() in src
 			if(A)
 				var/construct_class = show_radial_menu(user, src, GLOB.construct_radial_images, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
-				if(!T || !T.loc)
+				if(!T || !T.loc || !construct_class)
 					return
 
 				make_new_construct_from_class(construct_class, theme, A, user, FALSE, T.loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #10896
Fixes #10895

## Why It's Good For The Game

Shards should not be deleted if you cancel their conversion into a construct.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/63f1146e-1981-4959-b671-e85ff3cde51a)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/d4d4d19b-0735-471b-9baa-5d1937e1d5b4)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2297c7ad-6b8d-4bb6-b8c4-38f89894f602)


## Changelog
:cl:
fix: Fixes shards being deleted if you cancel their conversion into a construct.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
