### PR TITLE
Fixes 0g inertia, shooting and lying abuse.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -500,13 +500,14 @@
 		// If target not able to use items, move and stand - or if they're just dead, pass over.
 		if(L.stat == DEAD)
 			return FALSE
+		// If things pass through the mob, then this will too unless they are lying down (lying down forces density to be false)
 		if(!L.density)
+			// If you are moving, then bullets will hit you even if you are lying.
+			// This is to counter abuse in space where you can be moving via inertia while lying #11020
+			if (!(L.mobility_flags & MOBILITY_STAND) && L.last_move_time + max(L.inertia_move_delay, CRAWLING_ADD_SLOWDOWN + CONFIG_GET(number/movedelay/run_delay)) > world.time)
+				return TRUE
 			return FALSE
 		if (L.mobility_flags & MOBILITY_STAND)// if you stand, it returns true and you get hit. If you arent standing(i.e. resting), it returns false and you dont get hit. Such stupid code.
-			return TRUE
-		// If you are moving, then bullets will hit you even if you are lying.
-		// This is to counter abuse in space where you can be moving via inertia while lying #11020
-		if (L.last_move_time < world.time + max(L.inertia_move_delay, CRAWLING_ADD_SLOWDOWN + CONFIG_GET(number/movedelay/run_delay)))
 			return TRUE
 		var/stunned = !CHECK_BITFIELD(L.mobility_flags, MOBILITY_USE | MOBILITY_STAND | MOBILITY_MOVE)
 		return !stunned || hit_stunned_targets

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -504,6 +504,10 @@
 			return FALSE
 		if (L.mobility_flags & MOBILITY_STAND)// if you stand, it returns true and you get hit. If you arent standing(i.e. resting), it returns false and you dont get hit. Such stupid code.
 			return TRUE
+		// If you are moving, then bullets will hit you even if you are lying.
+		// This is to counter abuse in space where you can be moving via inertia while lying #11020
+		if (L.last_move_time < world.time + max(L.inertia_move_delay, CRAWLING_ADD_SLOWDOWN + CONFIG_GET(number/movedelay/run_delay)))
+			return TRUE
 		var/stunned = !CHECK_BITFIELD(L.mobility_flags, MOBILITY_USE | MOBILITY_STAND | MOBILITY_MOVE)
 		return !stunned || hit_stunned_targets
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #11020
Fixes #11061

Makes it so that you will be hit by projectiles if you are moving.

Question: Should this apply to 0g environments only? Answer: No, this applies always since hitting crawling people is annoying if they are moving.

## Why It's Good For The Game

I love the fact that you can crawl to dodge bullets, however this is highly abusable in space due to the fact that you will inertia move when firing weapons. I consider the strategy of flying up to somewhere, resting and shooting to be able to fire at an attacker while being able to dodge bullets as you are moving and avoiding direct bullets abuse, and something that needs to be fixed.

## Testing Photographs and Procedure

No impact when not moving
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/feb08530-4c43-4a83-a1d9-9575abace1ef)

Impact when crawling or drifting
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/5394e307-ebe5-47bb-877b-f557817cf6ed)

(Tested with both 0g and crawling)

## Changelog
:cl:
fix: You will now be hit by projectiles when moving, preventing abuse of inertia mechanics, lying and guns in space.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
