### PR TITLE
Malf AI powers are cooler now

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 					else //Adding uses to an existing module
 						action.uses += initial(action.uses)
 						temp = "Additional use[action.uses > 1 ? "s" : ""] added to [action.name]!"
-						action.button.desc = "[initial(action.button.desc)] There are [action.uses] reactivations remaining."
+						action.desc = "[initial(action.button.desc)] There are [action.uses] reactivations remaining."
 						A.update_action_buttons()
 						A.log_message("purchased malf module [AM.module_name] (NEW USES: [action.uses]) (NEW PROCESSING: [processing_time - AM.cost])", LOG_GAME)
 			processing_time -= AM.cost

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -782,7 +782,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		else
 			apc.overload++
 	owner.log_message("activated malf module [name]", LOG_GAME)
-	desc = "[initial(desc)] There are [uses] reactivations remaining."
+	desc = "[initial(desc)] There are [uses - 1] reactivations remaining."
 	owner_AI.update_action_buttons()
 	to_chat(owner, "<span class='notice'>Overcurrent applied to the powernet.</span>")
 	owner.playsound_local(owner, "sparks", 50, 0)
@@ -948,7 +948,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	var/datum/round_event/event_announcement = new event_control.typepath()
 	event_announcement.kill()
 	event_announcement.announce(TRUE)
-	desc = "[initial(desc)] There are [uses] reactivations remaining."
+	desc = "[initial(desc)] There are [uses - 1] reactivations remaining."
 	owner_AI.update_action_buttons()
 	owner.log_message("activated malf module [name] (TYPE: [chosen_event])", LOG_GAME)
 	return TRUE

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 					else //Adding uses to an existing module
 						action.uses += initial(action.uses)
 						temp = "Additional use[action.uses > 1 ? "s" : ""] added to [action.name]!"
-						action.desc = "[initial(action.button.desc)] There are [action.uses] reactivations remaining."
+						action.desc = "[initial(action.desc)] There are [action.uses] reactivations remaining."
 						A.update_action_buttons()
 						A.log_message("purchased malf module [AM.module_name] (NEW USES: [action.uses]) (NEW PROCESSING: [processing_time - AM.cost])", LOG_GAME)
 			processing_time -= AM.cost

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -202,8 +202,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 					else //Adding uses to an existing module
 						action.uses += initial(action.uses)
 						temp = "Additional use[action.uses > 1 ? "s" : ""] added to [action.name]!"
-						action.desc = "[initial(action.desc)] There are [action.uses] reactivations remaining."
-						A.update_action_buttons()
+						action.update_desc()
 						A.log_message("purchased malf module [AM.module_name] (NEW USES: [action.uses]) (NEW PROCESSING: [processing_time - AM.cost])", LOG_GAME)
 			processing_time -= AM.cost
 
@@ -774,7 +773,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		else
 			apc.overload++
 	owner.log_message("activated malf module [name]", LOG_GAME)
-	owner_AI.update_action_buttons()
 	to_chat(owner, "<span class='notice'>Overcurrent applied to the powernet.</span>")
 	owner.playsound_local(owner, "sparks", 50, 0)
 
@@ -838,7 +836,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 			uses-- //Not adjust_uses() so it doesn't automatically delete or show a message
 	to_chat(owner, "<span class='notice'>Diagnostic complete! Cameras reactivated: <b>[fixed_cameras]</b>. Reactivations remaining: <b>[uses]</b>.</span>")
 	owner.playsound_local(owner, 'sound/items/wirecutter.ogg', 50, 0)
-	owner_AI.update_action_buttons()
 	if(uses)
 		owner.log_message("activated malf module [name] (NEW USES: [uses])", LOG_GAME)
 	else
@@ -897,7 +894,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		AI.eyeobj.set_relay_speech(TRUE)
 
 
-//Fake Alert: Overloads a random number of lights across the station. Three uses. //Actually one use, always has been, silly comment
+//Fake Alert: Overloads a random number of lights across the station. One use.
 /datum/AI_Module/small/fake_alert
 	module_name = "Fake Alert"
 	mod_pick_name = "fake_alert"
@@ -928,7 +925,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	var/datum/round_event/event_announcement = new event_control.typepath()
 	event_announcement.kill()
 	event_announcement.announce(TRUE)
-	owner_AI.update_action_buttons()
 	owner.log_message("activated malf module [name] (TYPE: [chosen_event])", LOG_GAME)
 	return TRUE
 

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -51,8 +51,13 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	if(cooldown_period)
 		owner_AI.malf_cooldown = world.time + cooldown_period
 
+/datum/action/innate/ai/proc/update_desc()
+		desc = "[initial(desc)] There are [uses] reactivations remaining."
+		button.desc = desc
+
 /datum/action/innate/ai/proc/adjust_uses(amt, silent)
 	uses += amt
+	update_desc()
 	if(!silent && uses)
 		to_chat(owner, "<span class='notice'>[name] now has <b>[uses]</b> use[uses > 1 ? "s" : ""] remaining.</span>")
 	if(!uses)
@@ -78,6 +83,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/action/innate/ai/ranged/adjust_uses(amt, silent)
 	uses += amt
+	update_desc()
 	if(!silent && uses)
 		to_chat(owner, "<span class='notice'>[name] now has <b>[uses]</b> use[uses > 1 ? "s" : ""] remaining.</span>")
 	if(!uses)
@@ -577,8 +583,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/action/innate/ai/ranged/overload_machine/New()
 	..()
-	desc = "[desc] There are [uses] reactivations remaining."
-	button.desc = desc
+	update_desc()
 
 /datum/action/innate/ai/ranged/overload_machine/proc/detonate_machine(obj/machinery/M)
 	if(M && !QDELETED(M))
@@ -609,8 +614,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		return
 	ranged_ability_user.playsound_local(ranged_ability_user, "sparks", 50, 0)
 	attached_action.adjust_uses(-1)
-	attached_action.desc = "[initial(desc)] There are [attached_action.uses] reactivations remaining."
-	attached_action.owner_AI.update_action_buttons()
 	target.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [target]!</span>")
 	caller.log_message("activated malf module [name]", LOG_GAME)
 	addtimer(CALLBACK(attached_action, TYPE_PROC_REF(/datum/action/innate/ai/ranged/overload_machine, detonate_machine), target), 50) //kaboom!
@@ -637,8 +640,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/action/innate/ai/ranged/override_machine/New()
 	..()
-	desc = "[desc] There are [uses] reactivations remaining."
-	button.desc = desc
+	update_desc()
 
 /datum/action/innate/ai/ranged/override_machine/proc/animate_machine(obj/machinery/M)
 	if(M && !QDELETED(M))
@@ -667,8 +669,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		return
 	ranged_ability_user.playsound_local(ranged_ability_user, 'sound/misc/interference.ogg', 50, 0)
 	attached_action.adjust_uses(-1)
-	attached_action.desc = "[initial(desc)] There are [attached_action.uses] reactivations remaining."
-	attached_action.owner_AI.update_action_buttons()
 	target.audible_message("<span class='userdanger'>You hear a loud electrical buzzing sound coming from [target]!</span>")
 	caller.log_message("activated malf module [name]", LOG_GAME)
 	addtimer(CALLBACK(attached_action, TYPE_PROC_REF(/datum/action/innate/ai/ranged/override_machine, animate_machine), target), 50) //kabeep!
@@ -772,8 +772,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/action/innate/ai/blackout/New()
 	..()
-	desc = "[desc] There are [uses] reactivations remaining."
-	button.desc = desc
+	update_desc()
 
 /datum/action/innate/ai/blackout/Activate()
 	for(var/obj/machinery/power/apc/apc in GLOB.apcs_list)
@@ -782,7 +781,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		else
 			apc.overload++
 	owner.log_message("activated malf module [name]", LOG_GAME)
-	desc = "[initial(desc)] There are [uses - 1] reactivations remaining."
 	owner_AI.update_action_buttons()
 	to_chat(owner, "<span class='notice'>Overcurrent applied to the powernet.</span>")
 	owner.playsound_local(owner, "sparks", 50, 0)
@@ -836,8 +834,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/action/innate/ai/reactivate_cameras/New()
 	..()
-	desc = "[desc] There are [uses] reactivations remaining."
-	button.desc = desc
+	update_desc()
 
 /datum/action/innate/ai/reactivate_cameras/Activate()
 	var/fixed_cameras = 0
@@ -852,7 +849,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 			uses-- //Not adjust_uses() so it doesn't automatically delete or show a message
 	to_chat(owner, "<span class='notice'>Diagnostic complete! Cameras reactivated: <b>[fixed_cameras]</b>. Reactivations remaining: <b>[uses]</b>.</span>")
 	owner.playsound_local(owner, 'sound/items/wirecutter.ogg', 50, 0)
-	desc = "[initial(desc)] There are [uses] reactivations remaining."
 	owner_AI.update_action_buttons()
 	if(uses)
 		owner.log_message("activated malf module [name] (NEW USES: [uses])", LOG_GAME)
@@ -930,9 +926,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/action/innate/ai/fake_alert/New()
 	..()
-	desc = "[desc] There are [uses] reactivations remaining."
-	button.desc = desc
-
+	update_desc()
 /datum/action/innate/ai/fake_alert/Activate()
 	var/list/events_to_chose = list()
 	for(var/datum/round_event_control/E in SSevents.control)
@@ -948,7 +942,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	var/datum/round_event/event_announcement = new event_control.typepath()
 	event_announcement.kill()
 	event_announcement.announce(TRUE)
-	desc = "[initial(desc)] There are [uses - 1] reactivations remaining."
 	owner_AI.update_action_buttons()
 	owner.log_message("activated malf module [name] (TYPE: [chosen_event])", LOG_GAME)
 	return TRUE

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -55,6 +55,11 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		desc = "[initial(desc)] There are [uses] reactivations remaining."
 		button.desc = desc
 
+/datum/action/innate/ai/New()
+	..()
+	if(initial(uses) > 1)
+		update_desc()
+
 /datum/action/innate/ai/proc/adjust_uses(amt, silent)
 	uses += amt
 	update_desc()
@@ -581,10 +586,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	uses = 2
 	linked_ability_type = /obj/effect/proc_holder/ranged_ai/overload_machine
 
-/datum/action/innate/ai/ranged/overload_machine/New()
-	..()
-	update_desc()
-
 /datum/action/innate/ai/ranged/overload_machine/proc/detonate_machine(obj/machinery/M)
 	if(M && !QDELETED(M))
 		var/turf/T = get_turf(M)
@@ -637,10 +638,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	button_icon_state = "override_machine"
 	uses = 4
 	linked_ability_type = /obj/effect/proc_holder/ranged_ai/override_machine
-
-/datum/action/innate/ai/ranged/override_machine/New()
-	..()
-	update_desc()
 
 /datum/action/innate/ai/ranged/override_machine/proc/animate_machine(obj/machinery/M)
 	if(M && !QDELETED(M))
@@ -770,10 +767,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	button_icon_state = "blackout"
 	uses = 3
 
-/datum/action/innate/ai/blackout/New()
-	..()
-	update_desc()
-
 /datum/action/innate/ai/blackout/Activate()
 	for(var/obj/machinery/power/apc/apc in GLOB.apcs_list)
 		if(prob(30 * apc.overload))
@@ -831,10 +824,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	uses = 20
 	auto_use_uses = FALSE
 	cooldown_period = 30
-
-/datum/action/innate/ai/reactivate_cameras/New()
-	..()
-	update_desc()
 
 /datum/action/innate/ai/reactivate_cameras/Activate()
 	var/fixed_cameras = 0
@@ -924,9 +913,6 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	button_icon_state = "fake_alert"
 	uses = 1
 
-/datum/action/innate/ai/fake_alert/New()
-	..()
-	update_desc()
 /datum/action/innate/ai/fake_alert/Activate()
 	var/list/events_to_chose = list()
 	for(var/datum/round_event_control/E in SSevents.control)

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -52,8 +52,8 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		owner_AI.malf_cooldown = world.time + cooldown_period
 
 /datum/action/innate/ai/proc/update_desc()
-		desc = "[initial(desc)] There are [uses] reactivations remaining."
-		button.desc = desc
+	desc = ("[initial(desc)] There [uses > 1 ? "are" : "is"] <b>[uses]</b> reactivation[uses > 1 ? "s" : ""] remaining.")
+	button.desc = desc
 
 /datum/action/innate/ai/New()
 	..()

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -175,6 +175,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 			// Cost check
 			if(AM.cost > processing_time)
 				temp = "You cannot afford this module."
+				to_chat(A, "<span class='notice'>You cannot afford this module.</span>")
 				break
 
 			var/datum/action/innate/ai/action = locate(AM.power_type) in A.actions


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Went ahead and fixed some things wrong with the Malf AI powers that irked me (that aren't the UI, that's a bit of a bigger task).

* Reactivate cameras Module: Removed one time purchase limitation, lowered the ammount of cameras fixed from 30 to 20, fixed a logging runtime (when using the last charge of the camera module), fixed the action description not updating the number of uses.
* This (previously non-working) feature of showing the uses left on a an action power was also given to the following powers (the other reusable ones): Overload Machine, Machine Override, Blackout and Fake Alert.
* For all 5 reusable actions I also made the unlock text and sound play when purchasing extra uses (previously had no feedback).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing cameras isn't an extremly powerful tool for it to be unique (note that it doesn't rebuild them, it only fixes cameras that are offline that could be fixed with wirecutters). Plus most of the time if the crew is already cutting all of your cameras, repairing them should be the least of your worries compared to the imminent raid on your sattelite. For balance reasons, so if the crew keeps doing it to keep you from doing other things, I lowered the ammount of cameras fixed per processing power (30 -> 20 cameras for 10 processing power).
Feedback is also nice when purchasing things since the UI doesn't even update automatically to show that you've had processing power removed, so it's now nice to have a way to immedietly check that your purchase went through when buying more uses of a power you already had unlocked.
Finally fixing runtimes and broken features is nice.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots (there's a few)</summary>
Started up my server as AI, spawned in a couple dozen broken cameras and made myself Malfunctioning.

The button to buy more of the cameras power is still there after a single purchase (no longer one time use):

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/105242196/baae8db7-2952-42e2-b355-8bffacb69805)

No runtime when using all charges (the runtime on the screenshot was from me breaking a camera while setting up the screenshots):

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/105242196/9e533ddb-d250-479e-a79d-36f5cf88c010)

Purchasing the same module twice in a row played the purchase sound effect and showed the text twice (to indicate the purchase was sucesfull twice), and hovering over the action button shows the updated number of lists correctly:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/105242196/13a2770c-18e7-497d-87e1-29ee820691db)

Another screenshot of the camera module after a partial use, showing the text in chat and the action button description correctly updating:

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/105242196/60fb643f-7e5f-4467-9fe9-fac6aa5cee89)

Finally gave myself a few malf_upgrade disks to be able to purchase 2 of all the changed upgrades and saw that the action description was working for all of them

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/105242196/b70f6d04-c5a0-439c-902a-ffaf21591bc9)

Also kept giving myself disks to be able to afford and use all other powers and used them just to double check everything else was unnafected (but I forgot to take a screenshot of this part, oopsie).

</details>

## Changelog
:cl:
balance: Removed one time limitation on Reactivate Cameras module for Malf AI but lowered the cameras fixed (30 -> 20)
fix: Action buttons for malf powers with multiple uses now correctly update
tweak: Purchasing more uses of a Malf Module now gives feedback in chat and with noise
fix: Removed a malf power logging runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
