### PR TITLE
Nature Sect Fix - Stops the orb from replacing open-space tiles and blocking off stairs

### DIFF
--- a/code/modules/religion/sects/plant_sect.dm
+++ b/code/modules/religion/sects/plant_sect.dm
@@ -86,7 +86,10 @@
 				/turf/open/space,
 				/turf/open/lava,
 				/turf/open/chasm,
-				/turf/open/openspace))
+				/turf/open/openspace,
+				/turf/open/floor/plating/beach,
+				/turf/open/indestructible,
+				/turf/open/floor/prison))
 			if(is_type_in_typecache(T, blacklisted_pylon_turfs))
 				continue
 			else

--- a/code/modules/religion/sects/plant_sect.dm
+++ b/code/modules/religion/sects/plant_sect.dm
@@ -85,7 +85,8 @@
 				/turf/open/floor/grass,
 				/turf/open/space,
 				/turf/open/lava,
-				/turf/open/chasm))
+				/turf/open/chasm,
+				/turf/open/openspace))
 			if(is_type_in_typecache(T, blacklisted_pylon_turfs))
 				continue
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue regarding open-space tiles getting replaced

## Why It's Good For The Game

Fix good yes

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

N/A

</details>

## Changelog
:cl:
fix: fixed openspace tiles being replaced by a nature orb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
