### PR TITLE
Revert the new Ripley step and turn sound

### DIFF
--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -26,9 +26,6 @@
 	var/list/cargo
 	/// How much things Ripley can carry in their Cargo Compartment
 	var/cargo_capacity = 15
-	/// Custom Ripley step and turning sounds (from TGMC)
-	stepsound = 'sound/mecha/powerloader_step.ogg'
-	turnsound = 'sound/mecha/powerloader_turn2.ogg'
 
 /obj/vehicle/sealed/mecha/working/ripley/Move()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR reverts the Ripley sounds implemented in #10979 to the classic mech sounds on @Wueue behalf.

NOTE: this does not remove the sounds, as they will be used to something else.

## Why It's Good For The Game

According to Wueue, the current sounds of the ripley is "Like a rolling boulder", and while i agree that the sounds might be out of date, the movement sound does not fit the bulky nature of the Ripley itself.

## Testing Photographs and Procedure
[N/A, it's a revert sounds PR]

## Changelog
:cl:
tweak: Reverted the Ripley sounds to the old one.
/:cl:
