### PR TITLE
Fix misadressed Ian and Bee suit headgear icon path

### DIFF
--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -63,8 +63,9 @@
 	desc = "Bkaw!"
 	icon_state = "chickenhead"
 	item_state = "chickensuit"
-	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = SNUG_FIT
+	body_parts_covered = HEAD
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/head/costume/griffin
 	name = "griffon head"
@@ -126,3 +127,100 @@
 	icon_state = "clockwork_helmet_old"
 	flags_inv = HIDEEARS|HIDEHAIR
 	armor = list(MELEE = 5,  BULLET = 0, LASER = -5, ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 20, ACID = 20, STAMINA = 30)
+
+/obj/item/clothing/head/hooded/flashsuit
+	name = "flash button"
+	desc = "You will learn to fear the flash."
+	icon = 'icons/obj/clothing/head/costume.dmi'
+	worn_icon = 'icons/mob/clothing/head/costume.dmi'
+	icon_state = "flashsuit"
+	body_parts_covered = HEAD
+	flags_inv = HIDEHAIR|HIDEEARS|HIDEFACIALHAIR|HIDEFACE|HIDEMASK|HIDESNOUT
+
+/obj/item/clothing/head/hooded/carp_hood
+	name = "carp hood"
+	desc = "A hood attached to a carp costume."
+	icon = 'icons/obj/clothing/head/costume.dmi'
+	worn_icon = 'icons/mob/clothing/head/costume.dmi'
+	icon_state = "carp_casual"
+	body_parts_covered = HEAD
+	cold_protection = HEAD
+	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	flags_inv = HIDEHAIR|HIDEEARS
+
+/obj/item/clothing/head/hooded/carp_hood/equipped(mob/living/carbon/human/user, slot)
+	..()
+	if (slot == ITEM_SLOT_HEAD)
+		user.faction |= "carp"
+
+/obj/item/clothing/head/hooded/carp_hood/dropped(mob/living/carbon/human/user)
+	..()
+	if (user.head == src)
+		user.faction -= "carp"
+
+/obj/item/clothing/head/hooded/carp_hood/spaceproof
+	name = "carp helmet"
+	desc = "Spaceworthy and it looks like a space carp's head, smells like one too."
+	icon_state = "carp_helm"
+	item_state = "syndicate"
+	armor = list(MELEE = 20,  BULLET = 10, LASER = 20, ENERGY = 20, BOMB = 30, BIO = 100, RAD = 75, FIRE = 60, ACID = 75, STAMINA = 40)
+	light_system = NO_LIGHT_SUPPORT
+	light_range = 0 //luminosity when on
+	actions_types = list()
+
+/obj/item/clothing/head/hooded/carp_hood/spaceproof/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, LOCKED_HELMET_TRAIT)
+
+/obj/item/clothing/head/hooded/carp_hood/spaceproof/old
+	name = "battered carp helmet"
+	desc = "It's covered in bite marks and scratches, yet seems to be still perfectly functional."
+	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 50, FIRE = 80, ACID = 70, STAMINA = 10)
+
+/obj/item/clothing/suit/hooded/carp_costume/spaceproof/old
+	name = "battered carp space suit"
+	desc = "It's covered in bite marks and scratches, yet seems to be still perfectly functional."
+	slowdown = 1
+	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 50, FIRE = 80, ACID = 70, STAMINA = 10)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
+	hoodtype = /obj/item/clothing/head/hooded/carp_hood/spaceproof/old
+
+/obj/item/clothing/head/hooded/ian_hood
+	name = "corgi hood"
+	desc = "A hood that looks just like a corgi's head, it won't guarantee dog biscuits."
+	icon = 'icons/obj/clothing/head/costume.dmi'
+	worn_icon = 'icons/mob/clothing/head/costume.dmi'
+	icon_state = "ian"
+	body_parts_covered = HEAD
+	//cold_protection = HEAD
+	//min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	flags_inv = HIDEHAIR|HIDEEARS
+
+/obj/item/clothing/head/hooded/bee_hood
+	name = "bee hood"
+	desc = "A hood attached to a bee costume."
+	icon = 'icons/obj/clothing/head/costume.dmi'
+	worn_icon = 'icons/mob/clothing/head/costume.dmi'
+	icon_state = "bee"
+	body_parts_covered = HEAD
+	clothing_flags = THICKMATERIAL | SNUG_FIT
+	flags_inv = HIDEHAIR|HIDEEARS
+	dynamic_hair_suffix = ""
+
+/obj/item/clothing/suit/hooded/bee_costume/syndie
+	name = "BLF costume"
+	armor = list(MELEE = 20,  BULLET = 20, LASER = 20, ENERGY = 40, BOMB = 0, BIO = 60, RAD = 0, FIRE = 0, ACID = 50, STAMINA = 40)
+	hoodtype = /obj/item/clothing/head/hooded/bee_hood/syndie
+
+/obj/item/clothing/head/hooded/bee_hood/syndie
+	armor = list(MELEE = 20,  BULLET = 20, LASER = 20, ENERGY = 40, BOMB = 0, BIO = 60, RAD = 0, FIRE = 0, ACID = 50, STAMINA = 40)
+
+/obj/item/clothing/head/hooded/human_head
+	name = "bloated human head"
+	desc = "A horribly bloated and mismatched human head."
+	icon = 'icons/obj/clothing/head/costume.dmi'
+	worn_icon = 'icons/mob/clothing/head/costume.dmi'
+	icon_state = "lingspacehelmet"
+	body_parts_covered = HEAD
+	flags_cover = HEADCOVERSEYES
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -12,15 +12,6 @@
 	body_parts_covered = CHEST|GROIN
 	hoodtype = /obj/item/clothing/head/hooded/flashsuit
 
-/obj/item/clothing/head/hooded/flashsuit
-	name = "flash button"
-	desc = "You will learn to fear the flash."
-	icon = 'icons/obj/clothing/head/costume.dmi'
-	worn_icon = 'icons/mob/clothing/head/costume.dmi'
-	icon_state = "flashsuit"
-	body_parts_covered = HEAD
-	flags_inv = HIDEHAIR|HIDEEARS|HIDEFACIALHAIR|HIDEFACE|HIDEMASK|HIDESNOUT
-
 /obj/item/clothing/suit/costume/pirate
 	name = "pirate coat"
 	desc = "Yarr."
@@ -35,7 +26,7 @@
 	icon_state = "hgpirate"
 	item_state = null
 
-/obj/item/clothing/suit/costume/cyborg_suit
+/obj/item/clothing/suit/costume/cyborg_suit //unavailable save for adminbus
 	name = "cyborg suit"
 	desc = "Suit for a cyborg costume."
 	icon_state = "death"
@@ -127,7 +118,6 @@
 	item_state = "chickensuit"
 	body_parts_covered = CHEST|ARMS|GROIN|LEGS|FEET
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
-
 
 /obj/item/clothing/suit/costume/monkeysuit
 	name = "monkey suit"
@@ -251,27 +241,6 @@
 	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/pneumatic_cannon/speargun)
 	hoodtype = /obj/item/clothing/head/hooded/carp_hood
 
-/obj/item/clothing/head/hooded/carp_hood
-	name = "carp hood"
-	desc = "A hood attached to a carp costume."
-	icon = 'icons/obj/clothing/head/costume.dmi'
-	worn_icon = 'icons/mob/clothing/head/costume.dmi'
-	icon_state = "carp_casual"
-	body_parts_covered = HEAD
-	cold_protection = HEAD
-	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	flags_inv = HIDEHAIR|HIDEEARS
-
-/obj/item/clothing/head/hooded/carp_hood/equipped(mob/living/carbon/human/user, slot)
-	..()
-	if (slot == ITEM_SLOT_HEAD)
-		user.faction |= "carp"
-
-/obj/item/clothing/head/hooded/carp_hood/dropped(mob/living/carbon/human/user)
-	..()
-	if (user.head == src)
-		user.faction -= "carp"
-
 //Carpsuit, bestsuit, lovesuit
 
 /obj/item/clothing/suit/hooded/carp_costume/spaceproof
@@ -298,33 +267,6 @@
 	hoodtype = /obj/item/clothing/head/hooded/carp_hood/spaceproof
 	resistance_flags = NONE
 
-/obj/item/clothing/head/hooded/carp_hood/spaceproof
-	name = "carp helmet"
-	desc = "Spaceworthy and it looks like a space carp's head, smells like one too."
-	icon_state = "carp_helm"
-	item_state = "syndicate"
-	armor = list(MELEE = 20,  BULLET = 10, LASER = 20, ENERGY = 20, BOMB = 30, BIO = 100, RAD = 75, FIRE = 60, ACID = 75, STAMINA = 40)
-	light_system = NO_LIGHT_SUPPORT
-	light_range = 0 //luminosity when on
-	actions_types = list()
-
-/obj/item/clothing/head/hooded/carp_hood/spaceproof/Initialize(mapload)
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, LOCKED_HELMET_TRAIT)
-
-/obj/item/clothing/head/hooded/carp_hood/spaceproof/old
-	name = "battered carp helmet"
-	desc = "It's covered in bite marks and scratches, yet seems to be still perfectly functional."
-	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 50, FIRE = 80, ACID = 70, STAMINA = 10)
-
-/obj/item/clothing/suit/hooded/carp_costume/spaceproof/old
-	name = "battered carp space suit"
-	desc = "It's covered in bite marks and scratches, yet seems to be still perfectly functional."
-	slowdown = 1
-	armor = list(MELEE = 0,  BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 50, FIRE = 80, ACID = 70, STAMINA = 10)
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
-	hoodtype = /obj/item/clothing/head/hooded/carp_hood/spaceproof/old
-
 /obj/item/clothing/suit/hooded/ian_costume	//It's Ian, rub his bell- oh god what happened to his inside parts?
 	name = "corgi costume"
 	desc = "A costume that looks like someone made a human-like corgi, it won't guarantee belly rubs."
@@ -339,17 +281,6 @@
 	hoodtype = /obj/item/clothing/head/hooded/ian_hood
 	dog_fashion = /datum/dog_fashion/back
 
-/obj/item/clothing/head/hooded/ian_hood
-	name = "corgi hood"
-	desc = "A hood that looks just like a corgi's head, it won't guarantee dog biscuits."
-	icon = 'icons/obj/clothing/suits/costume.dmi'
-	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	icon_state = "ian"
-	body_parts_covered = HEAD
-	//cold_protection = HEAD
-	//min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	flags_inv = HIDEHAIR|HIDEEARS
-
 /obj/item/clothing/suit/hooded/bee_costume // It's Hip!
 	name = "bee costume"
 	desc = "Bee the true Queen!"
@@ -360,25 +291,6 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	clothing_flags = THICKMATERIAL
 	hoodtype = /obj/item/clothing/head/hooded/bee_hood
-
-/obj/item/clothing/head/hooded/bee_hood
-	name = "bee hood"
-	desc = "A hood attached to a bee costume."
-	icon = 'icons/obj/clothing/suits/costume.dmi'
-	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	icon_state = "bee"
-	body_parts_covered = HEAD
-	clothing_flags = THICKMATERIAL | SNUG_FIT
-	flags_inv = HIDEHAIR|HIDEEARS
-	dynamic_hair_suffix = ""
-
-/obj/item/clothing/suit/hooded/bee_costume/syndie
-	name = "BLF costume"
-	armor = list(MELEE = 20,  BULLET = 20, LASER = 20, ENERGY = 40, BOMB = 0, BIO = 60, RAD = 0, FIRE = 0, ACID = 50, STAMINA = 40)
-	hoodtype = /obj/item/clothing/head/hooded/bee_hood/syndie
-
-/obj/item/clothing/head/hooded/bee_hood/syndie
-	armor = list(MELEE = 20,  BULLET = 20, LASER = 20, ENERGY = 40, BOMB = 0, BIO = 60, RAD = 0, FIRE = 0, ACID = 50, STAMINA = 40)
 
 /obj/item/clothing/suit/hooded/bloated_human	//OH MY GOD WHAT HAVE YOU DONE!?!?!?
 	name = "bloated human suit"
@@ -391,17 +303,6 @@
 	allowed = list()
 	actions_types = list(/datum/action/item_action/toggle_human_head)
 	hoodtype = /obj/item/clothing/head/hooded/human_head
-
-
-/obj/item/clothing/head/hooded/human_head
-	name = "bloated human head"
-	desc = "A horribly bloated and mismatched human head."
-	icon = 'icons/obj/clothing/head/costume.dmi'
-	worn_icon = 'icons/mob/clothing/head/costume.dmi'
-	icon_state = "lingspacehelmet"
-	body_parts_covered = HEAD
-	flags_cover = HEADCOVERSEYES
-	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/suit/costume/striped_sweater
 	name = "striped sweater"


### PR DESCRIPTION
## About The Pull Request

This Pr fixes the wrong adress on the ian and bee suit's headgear icons, and also move all the `/obj/item/clothing/head/costume/` from `code\modules\clothing\suits\costume.dm` to `\code\modules\clothing\head\costume.dm`.

## Why It's Good For The Game

Fixes regarding the immersion of your character pretending to be a dog or a bee good? I mean the bee one is also used for a traitor kit but still...

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Vide
os</summary>

![dreamseeker_mFpi7ecFF7](https://github.com/BeeStation/BeeStation-Hornet/assets/75247747/856d3f93-5d90-4794-bb28-6512fcda3151)

</details>

## Changelog
:cl:
fix: fixed the Iansuit's and Beesuit's head icon not rendering.
/:cl:

