### PR TITLE
Fixes durands taking no damage from projectiles

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_obj/signals_projectile.dm
+++ b/code/__DEFINES/dcs/signals/signals_obj/signals_projectile.dm
@@ -6,7 +6,7 @@
 #define COMSIG_PROJECTILE_SELF_ON_HIT "projectile_self_on_hit"			// from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
 #define COMSIG_PROJECTILE_ON_HIT "projectile_on_hit"			// from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
 #define COMSIG_PROJECTILE_BEFORE_FIRE "projectile_before_fire" 			// from base of /obj/projectile/proc/fire(): (obj/projectile, atom/original_target)
-#define COMSIG_PROJECTILE_PREHIT "com_proj_prehit"				// sent to targets during the process_hit proc of projectiles
+#define COMSIG_PROJECTILE_PREHIT "com_proj_prehit"				// sent to targets during the process_hit proc of projectiles (obj/projectile/source, list/arguments)
 #define COMSIG_PROJECTILE_RANGE_OUT "projectile_range_out"				// sent to targets during the process_hit proc of projectiles
 #define COMSIG_EMBED_TRY_FORCE "item_try_embed"					// sent when trying to force an embed (mainly for projectiles, only used in the embed element)
 	#define COMPONENT_EMBED_SUCCESS (1<<1)						// returned when the embed is successful

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -403,7 +403,7 @@
 		return process_hit(T, select_target(T, target, bumped), bumped, hit_something)	// try to hit something else
 	// at this point we are going to hit the thing
 	// in which case send signal to it
-	SEND_SIGNAL(target, COMSIG_PROJECTILE_PREHIT, args)
+	SEND_SIGNAL(target, COMSIG_PROJECTILE_PREHIT, src, args)
 	if(mode == PROJECTILE_PIERCE_HIT)
 		++pierces
 	hit_something = TRUE

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -68,8 +68,8 @@
 	SEND_SIGNAL(shield, COMSIG_MECHA_ACTION_TRIGGER, owner, signal_args)
 
 //Redirects projectiles to the shield if defense_check decides they should be blocked and returns true.
-/obj/vehicle/sealed/mecha/combat/durand/proc/prehit(obj/projectile/source, list/signal_args)
-	if(defense_check(source.loc) && shield)
+/obj/vehicle/sealed/mecha/combat/durand/proc/prehit(obj/vehicle/sealed/mecha/combat/durand/source, obj/projectile/projectile, list/signal_args)
+	if(defense_check(get_step(src, angle2dir(projectile.Angle + 180))) && shield)
 		signal_args[2] = shield
 
 
@@ -205,13 +205,11 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		invisibility = 0
 		flick("shield_raise", src)
 		playsound(src, 'sound/mecha/mech_shield_raise.ogg', 50, FALSE)
-		set_light(l_range = MINIMUM_USEFUL_LIGHT_RANGE	, l_power = 5, l_color = "#00FFFF")
 		icon_state = "shield"
 		RegisterSignal(chassis, COMSIG_ATOM_DIR_CHANGE, PROC_REF(resetdir))
 	else
 		flick("shield_drop", src)
 		playsound(src, 'sound/mecha/mech_shield_drop.ogg', 50, FALSE)
-		set_light(0)
 		icon_state = "shield_null"
 		invisibility = INVISIBILITY_MAXIMUM //no showing on right-click
 		UnregisterSignal(chassis, COMSIG_ATOM_DIR_CHANGE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #11038

Projectiles would be always blocked by durands, even from behind.
Fixes a runtime with improper use of lighting.

## Why It's Good For The Game

Durand shield should not protect from behind.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/8f39b77d-a401-441e-8505-9a289da22c1d)

Bullet from front blocked

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/86caf34f-79bd-42cb-8566-c60f8abe8b73)

Bullet from side damaged

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/407bedac-0c4a-4e2f-a57c-a3f72daa511a)

Tested from all angles

## Changelog
:cl:
fix: Durand shield will no longer block projectiles shot from behind.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
