### PR TITLE
Remove law change code extraction alert

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -26,7 +26,7 @@
 		if(!current)
 			to_chat(user, "<span class='warning'>You haven't selected anything to transmit laws to!</span>")
 			return
-		var/input = stripped_input(user, "Please enter the Upload code.", "Uplode Code Check")
+		var/input = stripped_input(user, "Please enter the Upload code.", "Upload Code Check")
 		if(!GLOB.upload_code)
 			GLOB.upload_code = random_code(4)
 		if(input != GLOB.upload_code)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -177,7 +177,7 @@
 			message_admins("[ADMIN_LOOKUPFLW(usr)] is extracting the upload key!")
 			extracting = TRUE
 			ui_update();
-			say("commencing extraction.")
+			say("Commencing extraction.")
 			src.timerid = addtimer(CALLBACK(src, PROC_REF(extraction),usr), 300, TIMER_STOPPABLE)
 
 

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -176,14 +176,9 @@
 
 			message_admins("[ADMIN_LOOKUPFLW(usr)] is extracting the upload key!")
 			extracting = TRUE
-			ui_update()
-			if(allowed(usr))
-				say("Credentials successfully verified, commencing extraction.")
-				src.timerid = addtimer(CALLBACK(src, PROC_REF(extraction),usr), 300, TIMER_STOPPABLE)
-			else
-				var/message = "ALERT: UNAUTHORIZED UPLOAD KEY EXTRACTION AT [get_area_name(loc, TRUE)]"
-				radio.talk_into(src, message, radio_channel)
-				src.timerid = addtimer(CALLBACK(src, PROC_REF(extraction),usr), 600, TIMER_STOPPABLE)
+			ui_update();
+			say("commencing extraction.")
+			src.timerid = addtimer(CALLBACK(src, PROC_REF(extraction),usr), 300, TIMER_STOPPABLE)
 
 
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the alert that occurs when the law change code is extracted without RD permissions.
also fixes minor spelling mistake

## Why It's Good For The Game

The last few months have seen a decrease in AI subversion to the point of it not even being tried anymore. The payoff does not appear to be worth the risk for almost all players. This change aims to reinvigorate this mechanic and see more use of secret code extraction and law upload without removing the checks on proximity etc.

PR made after the following thread on the forums:
https://forums.beestation13.com/t/ai-tired-of-being-round-removed-as-the-first-step-in-every-blood-cult-shift/

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/39484008/cb36326e-301f-4cac-b0be-e4efa5226762


</details>

## Changelog
:cl:
del: Removed law change code extraction alert when attempted by Non-RD staff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
