### PR TITLE
Legion core healing nerf + legion core fix

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -549,6 +549,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/regenerative_core
 	var/power = 1
 	var/alreadyinfected = FALSE
+	var/duration_amount = 1
 
 /datum/status_effect/regenerative_core/on_apply()
 	if(!HAS_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED))
@@ -559,6 +560,7 @@
 	ADD_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED, "legion_core_trait")
 	if(is_mining_level(owner.z))
 		power = 5
+		duration_amount = 2
 	owner.adjustBruteLoss(-20 * power)
 	owner.adjustFireLoss(-20 * power)
 	owner.cure_nearsighted()
@@ -572,7 +574,7 @@
 		var/mob/living/carbon/human/humi = owner
 		humi.coretemperature = humi.get_body_temp_normal()
 	owner.restoreEars()
-	duration = rand(150, 450) * 2
+	duration = rand(150, 450) * duration_amount
 	return TRUE
 
 /datum/status_effect/regenerative_core/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -572,7 +572,7 @@
 		var/mob/living/carbon/human/humi = owner
 		humi.coretemperature = humi.get_body_temp_normal()
 	owner.restoreEars()
-	duration = rand(150, 450) * power
+	duration = rand(150, 450) * 2
 	return TRUE
 
 /datum/status_effect/regenerative_core/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -548,8 +548,8 @@
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = /atom/movable/screen/alert/status_effect/regenerative_core
 	var/power = 1
+	var/duration_mod = 1
 	var/alreadyinfected = FALSE
-	var/duration_amount = 1
 
 /datum/status_effect/regenerative_core/on_apply()
 	if(!HAS_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED))
@@ -560,7 +560,7 @@
 	ADD_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED, "legion_core_trait")
 	if(is_mining_level(owner.z))
 		power = 5
-		duration_amount = 2
+		duration_mod = 2
 	owner.adjustBruteLoss(-20 * power)
 	owner.adjustFireLoss(-20 * power)
 	owner.cure_nearsighted()
@@ -574,7 +574,7 @@
 		var/mob/living/carbon/human/humi = owner
 		humi.coretemperature = humi.get_body_temp_normal()
 	owner.restoreEars()
-	duration = rand(150, 450) * duration_amount
+	duration = rand(150, 450) * duration_mod
 	return TRUE
 
 /datum/status_effect/regenerative_core/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -557,10 +557,10 @@
 		alreadyinfected = TRUE
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "legion_core_trait")
 	ADD_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED, "legion_core_trait")
-	if(owner.z == 5)
-		power = 2
-	owner.adjustBruteLoss(-50 * power)
-	owner.adjustFireLoss(-50 * power)
+	if(is_mining_level(owner.get_virtual_z_level))
+		power = 5
+	owner.adjustBruteLoss(-20 * power)
+	owner.adjustFireLoss(-20 * power)
 	owner.cure_nearsighted()
 	owner.ExtinguishMob()
 	owner.fire_stacks = 0

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -557,7 +557,7 @@
 		alreadyinfected = TRUE
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "legion_core_trait")
 	ADD_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED, "legion_core_trait")
-	if(is_mining_level(owner.get_virtual_z_level))
+	if(is_mining_level(owner.z))
 		power = 5
 	owner.adjustBruteLoss(-20 * power)
 	owner.adjustFireLoss(-20 * power)

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -15,7 +15,9 @@
 	if(C.preserved)
 		to_chat(user, "<span class='notice'>[M] is already stabilised.")
 		return
-
+	if(C.inert)
+		to_chat(user, "<span class='notice'>[M] is inert, it's not worth it to stabilize a nonfunctional one.")
+		return
 	C.preserved()
 	to_chat(user, "<span class='notice'>You inject [M] with the stabilizer. It will no longer go inert.</span>")
 	qdel(src)
@@ -42,8 +44,6 @@
 		go_inert()
 
 /obj/item/organ/regenerative_core/proc/preserved(implanted = 0)
-	if(inert)
-		return
 	preserved = TRUE
 	update_icon()
 	desc = "All that remains of a hivelord. It is preserved, allowing you to use it to heal completely without danger of decay."

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -44,7 +44,6 @@
 /obj/item/organ/regenerative_core/proc/preserved(implanted = 0)
 	if(inert)
 		return
-	inert = FALSE
 	preserved = TRUE
 	update_icon()
 	desc = "All that remains of a hivelord. It is preserved, allowing you to use it to heal completely without danger of decay."

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -42,6 +42,8 @@
 		go_inert()
 
 /obj/item/organ/regenerative_core/proc/preserved(implanted = 0)
+	if(inert)
+		return
 	inert = FALSE
 	preserved = TRUE
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Changes the legion core's healing buff down from 50 on station z level to 20 on station z level.

Also fixes being able to preserve inert legion cores.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Miners spamming out the basic equivelant of an aheal on station premises only to shrug it off by eating some mushrooms should not be okay to do. Also bugfix good.


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/d55ea541-14df-4fff-b8a9-2757265beafe


https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/cc163577-e9ed-4817-9ca2-633f7d80cc8e



</details>

## Changelog
:cl:XeonMations
balance: Changed legion core healing from 50 to 20 on station z level
balance: Made inert legion cores no longer able to be preserved and thus work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
