### PR TITLE
Removes Nanites Mindshield

### DIFF
--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -265,13 +265,6 @@
 	program_type = /datum/nanite_program/conductive
 	category = list("Augmentation Nanites")
 
-/datum/design/nanites/mindshield
-	name = "Mental Barrier"
-	desc = "The nanites form a protective membrane around the host's brain, shielding them from abnormal influences while they're active."
-	id = "mindshield_nanites"
-	program_type = /datum/nanite_program/mindshield
-	category = list("Augmentation Nanites")
-
 /datum/design/nanites/adrenaline
 	name = "Adrenaline Burst"
 	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
@@ -649,3 +642,11 @@
 	id = "unsafe_storage_nanites"
 	program_type = /datum/nanite_program/protocol/unsafe_storage
 	category = list("Protocols_Nanites")
+	
+////////////////////NANITE CLASSIFIED//////////////////////////////////////
+/datum/design/nanites/mindshield
+	name = "Mental Barrier"
+	desc = "The nanites form a protective membrane around the host's brain, shielding them from abnormal influences while they're active."
+	id = "mindshield_nanites"
+	program_type = /datum/nanite_program/mindshield
+	category = list("Classified_Nanites")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -2239,7 +2239,6 @@
 	design_ids = list(
 		"blinding_nanites",
 		"hallucination_nanites",
-		"mindshield_nanites",
 		"mute_nanites",
 		"pacifying_nanites",
 		"sleep_nanites",
@@ -2247,6 +2246,22 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000, TECHWEB_POINT_TYPE_NANITES = 1000)
 	export_price = 5000
+	
+/datum/techweb_node/nanite_cc
+	id = "nanite_cc"
+	tech_tier = 5
+	display_name = "Classified Nanites"
+	description = "Highly confidential nanite programs from CC. Report usage to your nearest administraitor."
+	prereq_ids = list(
+		"nanite_neural",
+		"neural_programming",
+	)
+	design_ids = list(
+		"mindshield_nanites",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000, TECHWEB_POINT_TYPE_NANITES = 1000)
+	export_price = 5000
+	hidden = TRUE
 
 /datum/techweb_node/nanite_harmonic
 	id = "nanite_harmonic"


### PR DESCRIPTION
## About The Pull Request
Moves the nanite mindshield to debug only.

Closes #11058.

## Why It's Good For The Game
Mindshield on nanites can makes a large portion of the station unconvertable, ruining the balance of conversion antags like blood cultists and revolutionaries.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
It is not visible by normal means.

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/dad1c8fd-8141-4887-b5a1-74a1f9133007)

When the debug disk is used, you can see it and research it.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/3354e553-c137-483a-95d2-9ca50ccbdd72)

It shows up in an otherwise hidden nanite program category.
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/5a7f6f72-cca2-4586-8218-33b746f4e9a3)
</details>

## Changelog
:cl:
balance: Made nanite mindshield unobtainable.
add: Classified Nanites category (mindshield).
/:cl:
