### PR TITLE
mark of rust no longer triggers grenades

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -971,13 +971,11 @@
 		for(var/organ_slot in organs_to_damage)
 			if(prob(75))
 				carbon_owner.adjustOrganLoss(organ_slot, 20)
-		var/list/item_blacklist = list(/obj/item/grenade)
+
 		// And roughly 75% of their items will take a smack, too
 		for(var/obj/item/thing in carbon_owner.get_all_gear())
-			if(!QDELETED(thing) && prob(75))
-				for(var/blacklisted in item_blacklist)
-					if(!istype(thing, blacklisted))
-						thing.take_damage(100)
+			if(!QDELETED(thing) && prob(75) && !istype(thing, /obj/item/grenade))
+				thing.take_damage(100)
 	return ..()
 
 /datum/status_effect/corrosion_curse

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -951,6 +951,12 @@
 
 /datum/status_effect/heretic_mark/rust
 	effect_icon_state = "emark3"
+	var/static/list/item_blacklist = list()
+
+/datum/status_effect/heretic_mark/rust/on_creation(mob/living/new_owner, ...)
+	. = ..()
+	if(!item_blacklist[owner])
+		item_blacklist[owner] = typecacheof(list(/obj/item/grenade))
 
 /datum/status_effect/heretic_mark/rust/on_effect()
 	if(!iscarbon(owner))
@@ -971,13 +977,10 @@
 		for(var/organ_slot in organs_to_damage)
 			if(prob(75))
 				carbon_owner.adjustOrganLoss(organ_slot, 20)
-		var/list/item_blacklist = list(/obj/item/grenade)
 		// And roughly 75% of their items will take a smack, too
 		for(var/obj/item/thing in carbon_owner.get_all_gear())
-			if(!QDELETED(thing) && prob(75))
-				for(var/blacklisted in item_blacklist)
-					if(!istype(thing, blacklisted))
-						thing.take_damage(100)
+			if(!QDELETED(thing) && prob(75) && !is_type_in_typecache(thing, item_blacklist[owner]))
+				thing.take_damage(100)
 	return ..()
 
 /datum/status_effect/corrosion_curse

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -951,12 +951,6 @@
 
 /datum/status_effect/heretic_mark/rust
 	effect_icon_state = "emark3"
-	var/static/list/item_blacklist = list()
-
-/datum/status_effect/heretic_mark/rust/on_creation(mob/living/new_owner, ...)
-	. = ..()
-	if(!item_blacklist[owner])
-		item_blacklist[owner] = typecacheof(list(/obj/item/grenade))
 
 /datum/status_effect/heretic_mark/rust/on_effect()
 	if(!iscarbon(owner))
@@ -977,10 +971,13 @@
 		for(var/organ_slot in organs_to_damage)
 			if(prob(75))
 				carbon_owner.adjustOrganLoss(organ_slot, 20)
+		var/list/item_blacklist = list(/obj/item/grenade)
 		// And roughly 75% of their items will take a smack, too
 		for(var/obj/item/thing in carbon_owner.get_all_gear())
-			if(!QDELETED(thing) && prob(75) && !is_type_in_typecache(thing, item_blacklist[owner]))
-				thing.take_damage(100)
+			if(!QDELETED(thing) && prob(75))
+				for(var/blacklisted in item_blacklist)
+					if(!istype(thing, blacklisted))
+						thing.take_damage(100)
 	return ..()
 
 /datum/status_effect/corrosion_curse

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -971,11 +971,13 @@
 		for(var/organ_slot in organs_to_damage)
 			if(prob(75))
 				carbon_owner.adjustOrganLoss(organ_slot, 20)
-
+		var/list/item_blacklist = list(/obj/item/grenade)
 		// And roughly 75% of their items will take a smack, too
 		for(var/obj/item/thing in carbon_owner.get_all_gear())
-			if(!QDELETED(thing) && prob(75) && !istype(thing, /obj/item/grenade))
-				thing.take_damage(100)
+			if(!QDELETED(thing) && prob(75))
+				for(var/blacklisted in item_blacklist)
+					if(!istype(thing, blacklisted))
+						thing.take_damage(100)
 	return ..()
 
 /datum/status_effect/corrosion_curse

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -974,7 +974,7 @@
 
 		// And roughly 75% of their items will take a smack, too
 		for(var/obj/item/thing in carbon_owner.get_all_gear())
-			if(!QDELETED(thing) && prob(75))
+			if(!QDELETED(thing) && prob(75) && !istype(thing, /obj/item/grenade))
 				thing.take_damage(100)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
as title says

fixes #11073 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
attacking someone shouldn't cause you to be stunned because of an item you cannot see and random chance
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/54711687/8746ee86-90aa-477e-9866-14eafc239173



</details>

## Changelog
:cl:
tweak: Rust Heretic's Mark of Rust can no longer damage grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
