### PR TITLE
Fixes action button use while buckled, standardises hand blocking trait

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -54,14 +54,16 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define IS_ONTOP_1 (1<<12)
 /// Should we use the initial icon for display? Mostly used by overlay only objects
 #define HTML_USE_INITAL_ICON_1 (1<<13)
+/// Prevents direct access for anything in the contents of this atom.
+#define NO_DIRECT_ACCESS_FROM_CONTENTS_1 (1<<14)
 
 //turf-only flags. These use flags_1 too.
 // These exist to cover /turf and /area at the same time
-#define NOJAUNT_1					(1<<14)
-#define UNUSED_RESERVATION_TURF_1	(1<<15)
-#define CAN_BE_DIRTY_1				(1<<16) 	//! If a turf can be made dirty at roundstart. This is also used in areas.
-#define NO_LAVA_GEN_1				(1<<17) 	//! Blocks lava rivers being generated on the turf
-#define NO_RUINS_1					(1<<18) //! Blocks ruins spawning on the turf
+#define NOJAUNT_1					(1<<15)
+#define UNUSED_RESERVATION_TURF_1	(1<<16)
+#define CAN_BE_DIRTY_1				(1<<17) 	//! If a turf can be made dirty at roundstart. This is also used in areas.
+#define NO_LAVA_GEN_1				(1<<18) 	//! Blocks lava rivers being generated on the turf
+#define NO_RUINS_1					(1<<19) //! Blocks ruins spawning on the turf
 
 // Update flags for [/atom/proc/update_appearance]
 /// Update the atom's name

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -98,7 +98,8 @@
 	var/alerttooltipstyle = ""
 	var/override_alerts = FALSE //If it is overriding other alerts of the same type
 	var/mob/owner //Alert owner
-
+	/// The thing that this alert is showing
+	var/obj/master
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	if(!QDELETED(src))

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -28,8 +28,6 @@
 	icon_state = "act_equip"
 
 /atom/movable/screen/human/equip/Click()
-	if(ismecha(usr.loc)) // stops inventory actions in a mech
-		return TRUE
 	var/mob/living/carbon/human/H = usr
 	H.quick_equip()
 

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -1,6 +1,10 @@
+// Checks to see if the mob is able to use their hands, or if they are blocked by cuffs or stuns
 #define AB_CHECK_HANDS_BLOCKED (1<<0)
-#define AB_CHECK_IMMOBILE (1<<1)
+// Checks to see if the mob is incapacitated by stuns or paralysis effects
+#define AB_CHECK_INCAPACITATED (1<<1)
+// Checks to see if the mob is standing
 #define AB_CHECK_LYING (1<<2)
+// Checks to see if the mob in concious
 #define AB_CHECK_CONSCIOUS (1<<3)
 
 /datum/action
@@ -108,7 +112,7 @@
 		return FALSE
 	if((check_flags & AB_CHECK_HANDS_BLOCKED) && HAS_TRAIT(owner, TRAIT_HANDS_BLOCKED))
 		return FALSE
-	if((check_flags & AB_CHECK_IMMOBILE) && HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
+	if((check_flags & AB_CHECK_INCAPACITATED) && HAS_TRAIT(owner, TRAIT_INCAPACITATED))
 		return FALSE
 	if((check_flags & AB_CHECK_LYING) && isliving(owner))
 		var/mob/living/action_user = owner
@@ -155,7 +159,7 @@
 
 //Presets for item actions
 /datum/action/item_action
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_LYING|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 	button_icon_state = null
 	// If you want to override the normal icon being the item
 	// then change this to an icon state
@@ -525,7 +529,7 @@
 /datum/action/item_action/agent_box
 	name = "Deploy Box"
 	desc = "Find inner peace, here, in the box."
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 	background_icon_state = "bg_agent"
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "deploy_box"

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -33,6 +33,8 @@
 	. = ..()
 	if(.)
 		return
+	if (HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_belt = H.get_item_by_slot(ITEM_SLOT_BELT)
@@ -77,6 +79,8 @@
 	. = ..()
 	if(.)
 		return
+	if (HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_back = H.get_item_by_slot(ITEM_SLOT_BACK)
@@ -117,6 +121,8 @@
 /datum/keybinding/human/quick_equip_suit_storage/down(client/user)
 	. = ..()
 	if(.)
+		return
+	if (HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -33,9 +33,9 @@
 	. = ..()
 	if(.)
 		return
-	if (HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return
 	var/mob/living/carbon/human/H = user.mob
+	if (HAS_TRAIT(H, TRAIT_HANDS_BLOCKED))
+		return
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_belt = H.get_item_by_slot(ITEM_SLOT_BELT)
 	if(!equipped_belt) // We also let you equip a belt like this
@@ -79,9 +79,9 @@
 	. = ..()
 	if(.)
 		return
-	if (HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return
 	var/mob/living/carbon/human/H = user.mob
+	if (HAS_TRAIT(H, TRAIT_HANDS_BLOCKED))
+		return
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_back = H.get_item_by_slot(ITEM_SLOT_BACK)
 	if(!equipped_back) // We also let you equip a backpack like this
@@ -122,9 +122,9 @@
 	. = ..()
 	if(.)
 		return
-	if (HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		return
 	var/mob/living/carbon/human/H = user.mob
+	if (HAS_TRAIT(H, TRAIT_HANDS_BLOCKED))
+		return
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/stored = H.get_item_by_slot(ITEM_SLOT_SUITSTORE)
 	if(!stored)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1769,7 +1769,7 @@
   */
 /atom/proc/setClosed()
 	return
-	
+
 /**
   * Used to attempt to charge an object with a payment component.
   *

--- a/code/game/objects/structures/popout_cake.dm
+++ b/code/game/objects/structures/popout_cake.dm
@@ -164,7 +164,7 @@
 /datum/action/item_action/pull_string
 	name = "String Tug"
 	desc = "Pull the string and pop out of the cake in a surprising fashion, with confetti and everything!"
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 	button_icon_state = "pull_string"
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	var/obj/structure/popout_cake/cake = null

--- a/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
@@ -238,7 +238,7 @@
 	icon_icon = 'icons/mob/actions/actions_clockcult.dmi'
 	background_icon_state = "bg_clock"
 	buttontooltipstyle = "brass"
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 
 /datum/action/innate/clockcult/quick_bind
 	name = "Quick Bind"

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -4,7 +4,7 @@
 	icon_icon = 'icons/mob/actions/actions_cult.dmi'
 	background_icon_state = "bg_demon"
 	buttontooltipstyle = "cult"
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 
 /datum/action/innate/cult/IsAvailable()
 	if(!iscultist(owner))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -457,6 +457,9 @@
 	set name = "quick-equip"
 	set hidden = 1
 
+	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
+		return TRUE
+
 	var/obj/item/I = get_active_held_item()
 	if (I)
 		I.equip_to_best_slot(src)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -83,7 +83,7 @@
 /datum/action/innate/cocoon
 	name = "Cocoon"
 	desc = "Restore your wings and antennae, and heal some damage. If your cocoon is broken externally you will take heavy damage!"
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 	button_icon_state = "wrap_0"
 	icon_icon = 'icons/mob/actions/actions_animal.dmi'
 

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -59,6 +59,8 @@
 	SIGNAL_HANDLER
 	mobility_flags &= ~(MOBILITY_USE | MOBILITY_PICKUP | MOBILITY_STORAGE)
 	drop_all_held_items()
+	if (active_storage)
+		active_storage.hide_from(src)
 
 ///Called when TRAIT_HANDS_BLOCKED is removed from the mob.
 /mob/living/proc/on_handsblocked_trait_loss(datum/source)

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -12,6 +12,9 @@
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_HANDS_BLOCKED), PROC_REF(on_handsblocked_trait_gain))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_HANDS_BLOCKED), PROC_REF(on_handsblocked_trait_loss))
 
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_INCAPACITATED), PROC_REF(on_incapacitated_trait_gain))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_INCAPACITATED), PROC_REF(on_incapacitated_trait_loss))
+
 	RegisterSignals(src, list(
 		SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION),
 		SIGNAL_REMOVETRAIT(TRAIT_CRITICAL_CONDITION),
@@ -61,11 +64,13 @@
 	drop_all_held_items()
 	if (active_storage)
 		active_storage.hide_from(src)
+	update_action_buttons_icon(TRUE)
 
 ///Called when TRAIT_HANDS_BLOCKED is removed from the mob.
 /mob/living/proc/on_handsblocked_trait_loss(datum/source)
 	SIGNAL_HANDLER
 	mobility_flags |= (MOBILITY_USE | MOBILITY_PICKUP | MOBILITY_STORAGE)
+	update_action_buttons_icon(TRUE)
 
 /// Called when traits that alter succumbing are added/removed.
 /// Will show or hide the succumb alert prompt.
@@ -75,3 +80,13 @@
 		throw_alert("succumb", /atom/movable/screen/alert/succumb)
 	else
 		clear_alert("succumb")
+
+///Called when TRAIT_INCAPACITATED is added to the mob.
+/mob/living/proc/on_incapacitated_trait_gain(datum/source)
+	SIGNAL_HANDLER
+	update_action_buttons_icon(TRUE)
+
+///Called when TRAIT_INCAPACITATED is removed from the mob.
+/mob/living/proc/on_incapacitated_trait_loss(datum/source)
+	SIGNAL_HANDLER
+	update_action_buttons_icon(TRUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1235,6 +1235,7 @@
 	else
 		mobility_flags |= MOBILITY_UI|MOBILITY_PULL
 
+	update_action_buttons_icon(TRUE)
 
 	if(stat == UNCONSCIOUS)
 		drop_all_held_items()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -135,6 +135,7 @@
 	. = ..()
 	if(!on)
 		mobility_flags |= MOBILITY_STAND //base bots removes all mobility flags when turned off, resulting in the bot becoming passable. we don't want this since it's a large device that should block things.
+		update_action_buttons_icon(TRUE)
 
 /mob/living/simple_animal/bot/mulebot/proc/set_id(new_id)
 	id = new_id

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -316,6 +316,10 @@
   * on the item in the slot if the users active hand is empty
   */
 /mob/proc/attack_ui(slot)
+	if(world.time <= usr.next_move)
+		return FALSE
+	if(HAS_TRAIT(usr, TRAIT_HANDS_BLOCKED))
+		return FALSE
 	var/obj/item/W = get_active_held_item()
 	if(istype(W))
 		//IF HELD TRY APPLY TO SLOT

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1255,6 +1255,7 @@
 	SEND_SIGNAL(src, COMSIG_MOB_STATCHANGE, new_stat)
 	. = stat
 	stat = new_stat
+	update_action_buttons_icon(TRUE)
 
 /mob/proc/set_active_storage(new_active_storage)
 	if(active_storage)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -419,7 +419,7 @@
 	auto.Grant(buckled_mob, src)
 
 /datum/action/innate/proto_emitter
-	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_INCAPACITATED | AB_CHECK_CONSCIOUS
 	///Stores the emitter the user is currently buckled on
 	var/obj/machinery/power/emitter/prototype/proto_emitter
 	///Stores the mob instance that is buckled to the emitter

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -669,7 +669,7 @@
 
 /datum/action/toggle_scope_zoom
 	name = "Toggle Scope"
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_LYING
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_LYING
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "sniper_zoom"
 	var/obj/item/gun/gun = null

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -355,7 +355,7 @@
 /datum/action/innate/nanite_button
 	name = "Button"
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
-	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 	button_icon_state = "power_green"
 	var/datum/nanite_program/dermal_button/program
 

--- a/code/modules/surgery/organs/wings.dm
+++ b/code/modules/surgery/organs/wings.dm
@@ -234,7 +234,7 @@
 
 /datum/action/innate/flight
 	name = "Toggle Flight"
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_IMMOBILE
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "flight"
 

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -1,5 +1,5 @@
 /obj/vehicle/sealed
-	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
+	flags_1 = PREVENT_CONTENTS_EXPLOSION_1 | NO_DIRECT_ACCESS_FROM_CONTENTS_1
 	var/enter_delay = 2 SECONDS
 	var/mouse_pointer
 
@@ -33,7 +33,6 @@
 /obj/vehicle/sealed/after_add_occupant(mob/M)
 	. = ..()
 	ADD_TRAIT(M, TRAIT_HANDS_BLOCKED, VEHICLE_TRAIT)
-
 
 /obj/vehicle/sealed/after_remove_occupant(mob/M)
 	. = ..()

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -92,13 +92,13 @@
 //ACTION DATUMS
 
 /datum/action/vehicle
-	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_INCAPACITATED | AB_CHECK_CONSCIOUS
 	icon_icon = 'icons/mob/actions/actions_vehicle.dmi'
 	button_icon_state = "vehicle_eject"
 	var/obj/vehicle/vehicle_target
 
 /datum/action/vehicle/sealed
-	check_flags = AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_INCAPACITATED | AB_CHECK_CONSCIOUS
 	var/obj/vehicle/sealed/vehicle_entered_target
 
 /datum/action/vehicle/sealed/climb_out


### PR DESCRIPTION
#fixes #11085

## About The Pull Request

Mobility refactor introduced an issue where immobilisation was made into a more broad definition of the inability to move. Some action buttons check for immobilisation, which makes no sense. Instead I changed this to incapacitation since almost all of them should be checking stuns.

This also standardises some inventory code and refactors it to be way more sensible. You are not meant to be able to use items while in mechs, so I have changed some of the hotkeys and UI actions to be consistent and sensible. This is included in this PR because that was also part of the mobility refactor.

- Refactors direct access because the original code is horrible and wasteful, unncessarilly creating lists when we are checking for a single item.
- Adds a new atom flag which allows you to disable direct access to the thing that you are inside of. This is used for mechs to stop passengers from repairing the mech/vehicle.
- Refactors the inventory UI to have less horrible code. Before it was absolutely abysmal, abusing types and skipping access. Standardises some of the common hotkey/verbs to perform the checking at the action level rather than at the UI level.
- Prevents you from using hotkeys to bypass hand checks.
- When you lose access to your hands, the inventory UI will now close preventing you from seeing in your backpack while in a mech or unconcious.
- Adds more action button updates so that when entering or leaving a mech, the button availablity will always update accordingly
- Changes it so that actions check for incapacitation instead of immobility.

## Why It's Good For The Game

Inconsistencies make no sense, a verb, a UI icon and a direct click should be treated the same if they are meant to do the same thing. When you sit down, you should be able to use your PDA.

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/2af3feda-1a47-4e3a-89b0-d60edef7d17e)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/1de240b4-f073-48d5-8a6c-77ad252201f6)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/0f0e85d5-0df7-4d1e-be14-ea1c4b0ed0fd)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/63391d11-80b9-416c-8479-1e2e4a924717)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/ecf10153-ec66-4c6b-8a01-3b0e56c4bada)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/17126da6-2137-4f7b-b820-a8d01c49bbe4)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/952631cf-cdfb-4eb2-a88c-2d89c6efe71a)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/98fad87b-5682-4984-86a5-e4c7039a1e15)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/42f26ab7-35c0-415f-a95a-e3878fba9da1)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/27f7ae6d-8803-48db-829c-9fd2a92e2f22)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/fbcc21fc-db3a-411a-be8a-e47f02979d8f)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/1ddb5178-73da-4bf2-9515-9c089a6e54e3)


## Changelog
:cl:
fix: Fixes being unable to use items while buckled.
fix: Fixes inconsistencies between when you can and can't use items, resulting in hotkeys bypassing some item use checks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
