### PR TITLE
Roundstart Arrivals Shuttle Spawn!

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -467,7 +467,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_BANANIUM_SHIPMENTS "station_trait_bananium_shipments"
 #define STATION_TRAIT_CARP_INFESTATION "station_trait_carp_infestation"
 #define STATION_TRAIT_PREMIUM_INTERNALS "station_trait_premium_internals"
-#define STATION_TRAIT_LATE_ARRIVALS "station_trait_late_arrivals"
 #define STATION_TRAIT_RANDOM_ARRIVALS "station_trait_random_arrivals"
 #define STATION_TRAIT_HANGOVER "station_trait_hangover"
 #define STATION_TRAIT_FILLED_MAINT "station_trait_filled_maint"

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -511,37 +511,15 @@ SUBSYSTEM_DEF(job)
 
 	living_mob.job = rank
 
-	//If we joined at roundstart we should be positioned at our workstation
+	//If we joined at roundstart we should be positioned at our workstation //Nah dude, watch me:
 	if(!joined_late)
-		var/spawning_handled = FALSE
-		var/obj/S = null
-		if(HAS_TRAIT(SSstation, STATION_TRAIT_LATE_ARRIVALS) && job.random_spawns_possible)
-			SendToLateJoin(living_mob)
-			spawning_handled = TRUE
-		else if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_ARRIVALS) && job.random_spawns_possible)
+		if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_ARRIVALS) && job.random_spawns_possible)
 			DropLandAtRandomHallwayPoint(living_mob)
-			spawning_handled = TRUE
 		else if(HAS_TRAIT(SSstation, STATION_TRAIT_HANGOVER) && job.random_spawns_possible)
 			SpawnLandAtRandom(living_mob, (typesof(/area/hallway) | typesof(/area/crew_quarters/bar) | typesof(/area/crew_quarters/dorms)))
-			spawning_handled = TRUE
-		else if(length(GLOB.jobspawn_overrides[rank]))
-			S = pick(GLOB.jobspawn_overrides[rank])
-		else
-			for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
-				if(sloc.name != rank)
-					S = sloc //so we can revert to spawning them on top of eachother if something goes wrong
-					continue
-				if(locate(/mob/living) in sloc.loc)
-					continue
-				S = sloc
-				sloc.used = TRUE
-				break
-		if(S)
-			S.JoinPlayerHere(living_mob, FALSE)
-		if(!S && !spawning_handled) //if there isn't a spawnpoint send them to latejoin, if there's no latejoin go yell at your mapper
-			log_world("Couldn't find a round start spawn point for [rank]")
-			SendToLateJoin(living_mob)
 
+		//send those fuckers to arrivals anyways.
+		SendToLateJoin(living_mob)
 
 	if(living_mob.mind)
 		living_mob.mind.assigned_role = rank

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -5,7 +5,7 @@ SUBSYSTEM_DEF(shuttle)
 	wait = 1 SECONDS
 	init_order = INIT_ORDER_SHUTTLE
 	flags = SS_KEEP_TIMING
-	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
+	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME
 
 	var/list/mobile = list()
 	var/list/stationary = list()

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -29,17 +29,6 @@
 	blacklist = list(/datum/station_trait/strong_supply_lines)
 	trait_to_give = STATION_TRAIT_DISTANT_SUPPLY_LINES
 
-/datum/station_trait/late_arrivals
-	name = "Late Arrivals"
-	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 2
-	show_in_report = TRUE
-	report_message = "Sorry for that, we didn't expect to fly into that vomiting goose while bringing you to your new station."
-	trait_to_give = STATION_TRAIT_LATE_ARRIVALS
-	blacklist = list(/datum/station_trait/random_spawns, /datum/station_trait/hangover)
-	possible_announcements = list("You are getting late, again. Get your stuff together or you are all fired.",
-								"Our calculations were off by a bit. Shuttle will be there in a few seconds.")
-
 /datum/station_trait/random_spawns
 	name = "Drive-by landing"
 	trait_type = STATION_TRAIT_NEGATIVE
@@ -47,7 +36,7 @@
 	show_in_report = TRUE
 	report_message = "Sorry for that, we missed your station by a few miles, so we just launched you towards your station in pods. Hope you don't mind!"
 	trait_to_give = STATION_TRAIT_RANDOM_ARRIVALS
-	blacklist = list(/datum/station_trait/late_arrivals, /datum/station_trait/hangover)
+	blacklist = list(/datum/station_trait/hangover)
 	possible_announcements = list("We overshot your station by a few miles. Prepare to be pod launched onto it.",
 								"We've missed your station, sorry for that. You will be launched onto it shortly.")
 
@@ -58,7 +47,7 @@
 	show_in_report = TRUE
 	report_message = "Ohh.... Man.... That mandatory office party from last shift... God that was awesome... I woke up in some random toilet 3 sectors away..."
 	trait_to_give = STATION_TRAIT_HANGOVER
-	blacklist = list(/datum/station_trait/late_arrivals, /datum/station_trait/random_spawns)
+	blacklist = list(/datum/station_trait/random_spawns)
 	possible_announcements = list("That was one hell of a night. Now, get back to work.",
 								"Party's over. Get back to work.")
 

--- a/code/game/gamemodes/objectives/_objective.dm
+++ b/code/game/gamemodes/objectives/_objective.dm
@@ -196,8 +196,6 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	if(possible_target.current.stat == DEAD)
 		return FALSE
 	var/target_area = get_area(possible_target.current)
-	if(!HAS_TRAIT(SSstation, STATION_TRAIT_LATE_ARRIVALS) && istype(target_area, /area/shuttle/arrival))
-		return FALSE
 	return TRUE
 
 /datum/objective/proc/find_target_by_role(role, role_type=FALSE,invert=FALSE)//Option sets either to check assigned role or special role. Default to assigned., invert inverts the check, eg: "Don't choose a Ling"

--- a/code/game/gamemodes/objectives/_objective.dm
+++ b/code/game/gamemodes/objectives/_objective.dm
@@ -195,7 +195,6 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 		return FALSE
 	if(possible_target.current.stat == DEAD)
 		return FALSE
-	var/target_area = get_area(possible_target.current)
 	return TRUE
 
 /datum/objective/proc/find_target_by_role(role, role_type=FALSE,invert=FALSE)//Option sets either to check assigned role or special role. Default to assigned., invert inverts the check, eg: "Don't choose a Ling"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes it so that people no longer spawn at their workplaces or spawners at roundstart, but instead always spawn with the arrivals shuttle.

Basically like that one station trait. I removed that by the way, since it's now the default.

**This would be much nicer if the following config entries were changed by the way:**
**ARRIVALS_SHUTTLE_REQUIRE_UNDOCKED / uncommented**
**ARRIVALS_SHUTTLE_DOCK_WINDOW / set to something longer, maybe 200 or so.**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I like the concept of everyone starting in the same space and being held there for a bit. NSV also frequently spawns people near each other, and the command team used to give the roundstart announcement right then and there using megaphones.

I think it adds a sort of camaraderie. Instant feedback with whom you'll be working today. It's very comfy I think.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/153900881/448c446e-11ae-406e-a174-6d39fb4d5fc7)

</details>

## Changelog
:cl:
tweak: Roundstart spawns now use the arrivals shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
