### PR TITLE
Makes you able to butt out cigarettes on people

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -297,19 +297,33 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		qdel(src)
 	. = ..()
 
-/obj/item/clothing/mask/cigarette/afterattack(mob/M, mob/user, proximity)
+/obj/item/clothing/mask/cigarette/afterattack(mob/living/M, mob/living/user, proximity)
 	if(!istype(M))
 		return ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return ..()
 	if(lit && user.a_intent == INTENT_HARM)
+		force = 4
+		var/target_zone = user.get_combat_bodyzone()
+		M.apply_damage(force, BURN, target_zone)
 		qdel(src)
 		var/cig_butt = new type_butt()
 		user.put_in_hands(cig_butt)
 		new /obj/effect/decal/cleanable/ash(M.loc)
-		playsound(user, 'sound/items/cig_snuff.ogg', 25, 1)
+		playsound(user, 'sound/surgery/cautery2.ogg', 25, 1)
 		return ..()
 	if(lit && user.a_intent != INTENT_HARM)
 		smoketime -= 120
-		return
+		if(prob(40))
+			src.extinguish()
+			if(src.smoketime <= 0)
+				qdel(src)
+				var/cig_butt = new type_butt()
+				user.put_in_hands(cig_butt)
+				playsound(user, 'sound/items/cig_snuff.ogg', 25, 1)
+				return ..()
+		else
+			return ..()
 	. = ..()
 
 /obj/item/clothing/mask/cigarette/attack(mob/living/carbon/M, mob/living/carbon/user)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -297,6 +297,18 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		qdel(src)
 	. = ..()
 
+/obj/item/clothing/mask/cigarette/afterattack(mob/living/carbon/M, mob/user, proximity)
+	if(!istype(M))
+		return ..()
+	if(lit && user.a_intent == INTENT_HARM)
+		qdel(src)
+		var/cig_butt = new type_butt()
+		user.put_in_hands(cig_butt)
+		new /obj/effect/decal/cleanable/ash(M.loc)
+		playsound(user, 'sound/items/cig_snuff.ogg', 25, 1)
+		return ..()
+	. = ..()
+
 /obj/item/clothing/mask/cigarette/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!istype(M))
 		return ..()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -297,7 +297,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		qdel(src)
 	. = ..()
 
-/obj/item/clothing/mask/cigarette/afterattack(mob/living/carbon/M, mob/user, proximity)
+/obj/item/clothing/mask/cigarette/afterattack(mob/M, mob/user, proximity)
 	if(!istype(M))
 		return ..()
 	if(lit && user.a_intent == INTENT_HARM)
@@ -307,6 +307,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		new /obj/effect/decal/cleanable/ash(M.loc)
 		playsound(user, 'sound/items/cig_snuff.ogg', 25, 1)
 		return ..()
+	if(lit && user.a_intent != INTENT_HARM)
+		smoketime -= 120
+		return
 	. = ..()
 
 /obj/item/clothing/mask/cigarette/attack(mob/living/carbon/M, mob/living/carbon/user)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -175,8 +175,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	else
 		return ..()
 
-/obj/item/clothing/mask/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
-	. = ..()
+/obj/item/clothing/mask/cigarette/proc/dip(obj/item/reagent_containers/glass/glass, mob/user, proximity)
 	if(!proximity || lit) //can't dip if cigarette is lit (it will heat the reagents in the glass instead)
 		return
 	if(istype(glass))	//you can dip cigarettes into beakers
@@ -190,6 +189,38 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			else
 				to_chat(user, "<span class='notice'>[src] is full.</span>")
 
+/obj/item/clothing/mask/cigarette/proc/butt(mob/living/M, mob/living/user, proximity)
+	if(!istype(M))
+		return
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
+	if(lit && user.a_intent == INTENT_HARM)
+		force = 4
+		var/target_zone = user.get_combat_bodyzone()
+		M.apply_damage(force, BURN, target_zone)
+		qdel(src)
+		var/cig_butt = new type_butt()
+		user.put_in_hands(cig_butt)
+		new /obj/effect/decal/cleanable/ash(M.loc)
+		playsound(user, 'sound/surgery/cautery2.ogg', 25, 1)
+		return
+	if(lit && user.a_intent != INTENT_HARM)
+		smoketime -= 120
+		if(prob(40))
+			src.extinguish()
+			if(src.smoketime <= 0)
+				qdel(src)
+				var/cig_butt = new type_butt()
+				user.put_in_hands(cig_butt)
+				playsound(user, 'sound/items/cig_snuff.ogg', 25, 1)
+
+/obj/item/clothing/mask/cigarette/afterattack(var/target, mob/living/user, proximity)
+	if (istype(target, /mob/living))
+		butt(target, user, proximity)
+		. = ..()
+	else
+		. = ..()
+		dip(target, user, proximity)
 
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)
 	if(lit)
@@ -295,35 +326,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		new /obj/effect/decal/cleanable/ash(user.loc)
 		playsound(src, 'sound/items/cig_snuff.ogg', 25, 1)
 		qdel(src)
-	. = ..()
-
-/obj/item/clothing/mask/cigarette/afterattack(mob/living/M, mob/living/user, proximity)
-	if(!istype(M))
-		return ..()
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		return ..()
-	if(lit && user.a_intent == INTENT_HARM)
-		force = 4
-		var/target_zone = user.get_combat_bodyzone()
-		M.apply_damage(force, BURN, target_zone)
-		qdel(src)
-		var/cig_butt = new type_butt()
-		user.put_in_hands(cig_butt)
-		new /obj/effect/decal/cleanable/ash(M.loc)
-		playsound(user, 'sound/surgery/cautery2.ogg', 25, 1)
-		return ..()
-	if(lit && user.a_intent != INTENT_HARM)
-		smoketime -= 120
-		if(prob(40))
-			src.extinguish()
-			if(src.smoketime <= 0)
-				qdel(src)
-				var/cig_butt = new type_butt()
-				user.put_in_hands(cig_butt)
-				playsound(user, 'sound/items/cig_snuff.ogg', 25, 1)
-				return ..()
-		else
-			return ..()
 	. = ..()
 
 /obj/item/clothing/mask/cigarette/attack(mob/living/carbon/M, mob/living/carbon/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

-You can now butt cigarettes on people by being on harm intent. 
-Attacking someone on non harm intent will reduce its time lit and has a chance to be put out. 

## Why It's Good For The Game

Adding more actions to cigarettes and cigars good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/130587823/55a837f0-2b73-4c93-9793-fef4dc3492f2


</details>

## Changelog
:cl: Geatish
tweak: you can now butt cigarettes on other people if you're on harm intent
tweak: cigarettes will have their smoke time reduced and have a chance to get extinguished if attacking on non harm intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
