### PR TITLE
Digitigrade Lizards will no longer experience Toe Stubbing

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -50,7 +50,7 @@
 	if(!istype(H))
 		return
 	var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-	if(!HAS_TRAIT(H, TRAIT_ALWAYS_STUBS) && (H.shoes || feetCover || !(H.mobility_flags & MOBILITY_STAND) || HAS_TRAIT(H, TRAIT_PIERCEIMMUNE) || H.m_intent == MOVE_INTENT_WALK))
+	if(!HAS_TRAIT(H, TRAIT_ALWAYS_STUBS) && (H.shoes || feetCover || !(H.mobility_flags & MOBILITY_STAND) || HAS_TRAIT(H, TRAIT_PIERCEIMMUNE) || H.m_intent == MOVE_INTENT_WALK || H.dna?.species.bodytype & BODYTYPE_DIGITIGRADE))
 		return
 	if(HAS_TRAIT(H, TRAIT_ALWAYS_STUBS) || ((world.time >= last_bump + 100) && prob(5)))
 		to_chat(H, "<span class='warning'>You stub your toe on the [name]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that having digitigrade legs protects you from shoeless toe stubs.
Closes #11082

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ever since the toe stub mechanic was added with #1940 , there was a somewhat interesting drawback to being shoeless for all species so as to incentivise wearing shoes (and because the concept is funny and rarely experienced)

However, since then, digitigrade lizards have been widely avoided by a lot of lizard players, a lot of them saying that their main problem was the random toe stub that plagues them

It's just not a fun mechanic for lizards. Something that detrimental should have a counter, something you can do to prevent it - Just like how you can avoid glass shards by watching your surroundings or make sure you don't die from suffocation as plasmaman by getting more tanks/refilling every so often.
But there is none, you are forced to permanently endure a completely RNG hardstun which you just can't counter/avoid bar from destroying every table on station. 
All it has done for digitigrade is get people who would be willing to deal with glass shards refuse to pick that trait, because who really wants to be dealing with toe stubs?
And it's a shame to make people convinced that they should just not pick the one thing that makes lizards significantly different from most other races.

Lore wise, this can be easily justified with the fact that digitigrade legs are essentially dino feet, they *don't* have little toes to stub like humans do (it's really their whole feet that'll be slamming in the table) and their feet are completely hardened up with scales. It makes sense for them to ignore toe stubs.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/BeeStation/BeeStation-Hornet/assets/24866230/f266fe2a-ea94-450b-a2d9-1aaf3010905f
(upped the probability of toe stub to 99 & lowered cooldown for demonstration, it's still the usual values)

</details>

## Changelog
:cl:
balance: Digitigrade Lizards will no longer get their toe stubbed on tables.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
