### PR TITLE
Removes the Security item spawner and captain spawner from random-maintenance

### DIFF
--- a/_maps/RandomRooms/5x4/rdm_captain_quarters.dmm
+++ b/_maps/RandomRooms/5x4/rdm_captain_quarters.dmm
@@ -53,7 +53,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/landmark/start/captain,
 /obj/machinery/light_switch{
 	pixel_x = 23
 	},
@@ -94,7 +93,11 @@
 	req_access = list(20);
 	name = "captain's locker"
 	},
-/obj/effect/spawner/lootdrop/ruinloot/security,
+/obj/item/clothing/head/collectable/captain,
+/obj/item/toy/figure/captain{
+	pixel_x = 4;
+	pixel_y = -7
+	},
 /turf/open/floor/carpet/blue,
 /area/template_noop)
 "G" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
in rdm_captain_quarters.dmm there are two things that stick out

a Captain spawner

and a security item spawner.
the security item spawner can contain:
![image](https://github.com/BeeStation/BeeStation-Hornet/assets/79304582/922028bd-c1b5-40c0-9909-ec37a7ca0775)

thats a little silly, isnt it.

this PR removes the captain spawner, and replaces the item spawner with a collectable captain hat, and a captain figurine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i dont think the captain should spawn in maintenance :p   
i dont think those items should spawn in maintenance
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
del: removes Captain spawner from rdm_captain_quarters.dmm
tweak: replaces item spawner in rdm_captain_quarters.dmm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
