### PR TITLE
Fixed holy aura not being removed correctly with holy water

### DIFF
--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -12,6 +12,19 @@
 	var/identifier
 
 /datum/component/anti_magic/Initialize(_source, _magic = FALSE, _holy = FALSE, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire, _allowed_slots)
+	// Random enough that it will never conflict, and avoids having a static variable
+	identifier = identifier_current++
+	source = _source
+	magic = _magic
+	holy = _holy
+	if(!isnull(_charges))
+		charges = _charges
+	blocks_self = _blocks_self
+	reaction = _reaction
+	expire = _expire
+	if(!isnull(_allowed_slots))
+		allowed_slots = _allowed_slots
+
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
@@ -25,19 +38,6 @@
 		mob_parent.update_alt_appearances()
 	else
 		return COMPONENT_INCOMPATIBLE
-
-	// Random enough that it will never conflict, and avoids having a static variable
-	identifier = identifier_current++
-	source = _source
-	magic = _magic
-	holy = _holy
-	if(!isnull(_charges))
-		charges = _charges
-	blocks_self = _blocks_self
-	reaction = _reaction
-	expire = _expire
-	if(!isnull(_allowed_slots))
-		allowed_slots = _allowed_slots
 
 /datum/component/anti_magic/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
@@ -63,6 +63,15 @@
 	REMOVE_TRAIT(user, TRAIT_SEE_ANTIMAGIC, identifier)
 	user.remove_alt_appearance("magic_protection_[identifier]")
 	user.update_alt_appearances()
+
+/datum/component/anti_magic/Destroy(force, silent)
+	if(ismob(parent)) //If the component is attached to an item, it should go through on_drop instead.
+		var/mob/user = parent
+		UnregisterSignal(user, COMSIG_MOB_RECEIVE_MAGIC)
+		REMOVE_TRAIT(user, TRAIT_SEE_ANTIMAGIC, identifier)
+		user.remove_alt_appearance("magic_protection_[identifier]")
+		user.update_alt_appearances()
+	. = ..()
 
 /datum/component/anti_magic/proc/protect(datum/source, mob/user, _magic, _holy, major, self, list/protection_sources)
 	SIGNAL_HANDLER

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -71,7 +71,7 @@
 		REMOVE_TRAIT(user, TRAIT_SEE_ANTIMAGIC, identifier)
 		user.remove_alt_appearance("magic_protection_[identifier]")
 		user.update_alt_appearances()
-	. = ..()
+	return ..()
 
 /datum/component/anti_magic/proc/protect(datum/source, mob/user, _magic, _holy, major, self, list/protection_sources)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Made qdel'ing an anti-magic component remove the aura too

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/11118


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

bugfix good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/d6717ab3-e8ec-4c95-9304-55cb4a53b03a



</details>

## Changelog
:cl:XeonMations
fix: Fixed holy aura not being removed after holy water is removed from the person's symptom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
