### PR TITLE
Made explosive flashbulbs spawn with a flash.

### DIFF
--- a/code/game/objects/items/devices/explosive_flashbulb.dm
+++ b/code/game/objects/items/devices/explosive_flashbulb.dm
@@ -1,3 +1,6 @@
+/obj/item/assembly/flash/bomb
+	bulb = /obj/item/flashbulb/bomb
+
 /obj/item/flashbulb/bomb
 	name = "suspicious flashbulb"
 	desc = "A powerful flashbulb that looks slightly off, with strange wires running out the back."

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -105,7 +105,7 @@
 
 /obj/item/assembly/flash/Initialize(mapload)
 	. = ..()
-	bulb = new bulb
+	bulb = new bulb(src)
 
 /obj/item/assembly/flash/examine(mob/user)
 	. = ..()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1393,9 +1393,9 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	purchasable_from = (UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/explosives/explosive_flashbulbs
-	name = "Explosive Flashbulb"
-	desc = "A flashbulb stuffed with explosives that when used by an oblivious security officers, will cause a violent explosion."
-	item = /obj/item/flashbulb/bomb
+	name = "Explosive Flash"
+	desc = "A flash with a bulb stuffed with explosives that when used by an oblivious security officers, will cause a violent explosion."
+	item = /obj/item/assembly/flash/bomb
 	cost = 1
 	surplus = 8
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/11117

Makes explosive flashbulbs rename to explosive flash and spawns a flash with an explosive flashbulb inside of it.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

getting your hands on an explosive bulb with no use bad. Also bacon requested it.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/BeeStation/BeeStation-Hornet/assets/62395746/cdfb18cb-4632-450f-aea6-139b77ee7395



</details>

## Changelog
:cl:XeonMations
balance: Made explosive flashbulbs spawn with a flash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
