### PR TITLE
Prevent drifting while not on a turf

### DIFF
--- a/code/datums/components/drift.dm
+++ b/code/datums/components/drift.dm
@@ -62,6 +62,10 @@
 /datum/component/drift/proc/before_move(datum/source)
 	SIGNAL_HANDLER
 	var/atom/movable/movable_parent = parent
+	// We cannot drift while not on a turf
+	if (!isturf(movable_parent.loc))
+		qdel(src)
+		return MOVELOOP_SKIP_STEP
 	movable_parent.inertia_moving = TRUE
 	old_dir = movable_parent.dir
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/9383

Holocredits will no longer drift out of your hand.

## Why It's Good For The Game

You can use this to make infinite money

## Testing Photographs and Procedure

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/f4f972bf-af72-4c2c-b36b-47a0fba3de5a)

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/26465327/83f3e17a-c5f3-4cf5-ad7c-dabc0f0df966)


## Changelog
:cl:
fix: Items will no longer drift out of your hand when picked up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
