### PR TITLE
Paperframe recipe needs less stuff / Paper bundle tweak

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -731,7 +731,7 @@
 	name = "Paper Frames"
 	result = /obj/item/stack/sheet/paperframes/five
 	time = 10
-	reqs = list(/obj/item/stack/sheet/wood = 5, /obj/item/paper = 20)
+	reqs = list(/obj/item/stack/sheet/wood = 1, /obj/item/paper = 5)
 	category = CAT_MISC
 
 /datum/crafting_recipe/naturalpaper

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -731,11 +731,11 @@
 	name = "Paper Frames"
 	result = /obj/item/stack/sheet/paperframes/five
 	time = 10
-	reqs = list(/obj/item/stack/sheet/wood = 1, /obj/item/paper = 5)
+	reqs = list(/obj/item/stack/sheet/wood = 2, /obj/item/paper = 10)
 	category = CAT_MISC
 
 /datum/crafting_recipe/naturalpaper
-	name = "Hand-Pressed Paper"
+	name = "Hand-Pressed Paper Bundle"
 	time = 30
 	reqs = list(/datum/reagent/water = 50, /obj/item/stack/sheet/wood = 1)
 	tools = list(/obj/item/hatchet)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -142,7 +142,7 @@
 
 /obj/item/paper_bin/bundlenatural
 	name = "natural paper bundle"
-	desc = "A bundle of paper created using traditional methods."
+	desc = "A bundle of paper created using traditional methods. <b>You can cut the cord on this with a sharp implement, freeing all 30 sheets at once.</b>"
 	icon_state = "paper_bundle"
 	papertype = /obj/item/paper/natural
 	resistance_flags = FLAMMABLE

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -142,10 +142,14 @@
 
 /obj/item/paper_bin/bundlenatural
 	name = "natural paper bundle"
-	desc = "A bundle of paper created using traditional methods. <b>You can cut the cord on this with a sharp implement, freeing all 30 sheets at once.</b>"
+	desc = "A bundle of paper created using traditional methods."
 	icon_state = "paper_bundle"
 	papertype = /obj/item/paper/natural
 	resistance_flags = FLAMMABLE
+
+/obj/item/paper_bin/bundlenatural/examine()
+	. = ..()
+	. += "<span class='notice'>You can cut the cord on this with a sharp implement, freeing all 30 sheets at once.</span>"
 
 /obj/item/paper_bin/bundlenatural/attack_hand(mob/user)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~Paper walls are very nice to look at and very fragile. AND THEY TAKE SO MUCH TIME TO MAKE IT'S UNBELIEVABLE.
You have to sit there and individually pull sheets of paper out of whatever you scrounged up or crafted.~~

~~A 5x5 room with 2 doors would take 50 paper frames. That means 200 sheets of paper. Now you have to sit there clicking and dropping paper 200 times, where do you get 200 paper from you ask?~~

~~At 30 paper a piece that's 7 paper bins or crafted natural paper stacks.~~

~~Good luck scrounging for those bins all around the station. Or waiting for the botanist to make wood(which you'll need anyways for the frames) If you wanna craft them instead you need 50 water and 1 wood per 30 paper by the way.~~

Ignore allat, we're changing it only a little bit now. 
Now the paper BUNDLE is called a bundle too, and has description text in bold noting that you can just cut the damn thing. Paper frames now need 2 wood, 10 paper instead cuz 20 really was a bit much.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because the alternative is terrible, and it's super weak, and it looks good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/153900881/3364b9a5-83e2-4ed9-b985-a133018581b0)

## Changelog
:cl:
tweak: paper frames now take 10 paper and 2 wood to craft
tweak: paper bundle is now also called that
add: add description text to paper bundle to show people you can just cut it open
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
