### PR TITLE
Puts clown and mimes in the service department on their job datums

### DIFF
--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -1,7 +1,7 @@
 /datum/job/clown
 	title = JOB_NAME_CLOWN
 	description = "Be the life and soul of the station. Entertain the crew with your hilarious jokes and silly antics, including slipping, pie-ing and honking around. Remember your job is to keep things funny for others, not just yourself."
-	department_for_prefs = DEPT_BITFLAG_CIV
+	department_for_prefs = DEPT_BITFLAG_SRV
 	department_head = list(JOB_NAME_HEADOFPERSONNEL)
 	supervisors = "the head of personnel"
 	faction = "Station"

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -1,7 +1,7 @@
 /datum/job/mime
 	title = JOB_NAME_MIME
 	description = "Be the Clown's mute counterpart and arch nemesis. Conduct pantomimes and performances, create interesting situations with your mime powers. Remember your job is to keep things funny for others, not just yourself."
-	department_for_prefs = DEPT_BITFLAG_CIV
+	department_for_prefs = DEPT_BITFLAG_SRV
 	department_head = list(JOB_NAME_HEADOFPERSONNEL)
 	supervisors = "the head of personnel"
 	faction = "Station"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mimes and clowns are listed as civilians in the variable "department_for_prefs" in their respective job datum. This is wrong, because they are both from service and fall under the Head of Personnel.

## Why It's Good For The Game

Cuz it was wrong and now its fixed :)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![imagen](https://github.com/BeeStation/BeeStation-Hornet/assets/148357670/3d959b9e-82e0-4658-b6eb-2e786d284f2b)


</details>

## Changelog
:cl: Varo
fix: Clown and mimes now appear in the correct department (service) in the job preferences menu
/:cl:
