### PR TITLE
Ports bad catwalk layering fix

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(minor_mapping)
 		var/turf/T = pick_n_take(turfs)
 		var/obj/item/storage/backpack/satchel/flat/F = new(T)
 
-		SEND_SIGNAL(F, COMSIG_OBJ_HIDE, T.underfloor_accessibility < UNDERFLOOR_VISIBLE)
+		SEND_SIGNAL(F, COMSIG_OBJ_HIDE, T.underfloor_accessibility)
 		amount--
 
 /proc/find_exposed_wires()

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -234,8 +234,10 @@
 		net.add_plumber(src, dir)
 		net.add_plumber(P, opposite_dir)
 
-/datum/component/plumbing/proc/hide(atom/movable/AM, should_hide)
+/datum/component/plumbing/proc/hide(atom/movable/AM, underfloor_accessibility)
 	SIGNAL_HANDLER
+
+	var/should_hide = !underfloor_accessibility
 
 	tile_covered = should_hide
 	AM.update_appearance()

--- a/code/datums/elements/undertile.dm
+++ b/code/datums/elements/undertile.dm
@@ -19,6 +19,7 @@
 
 /datum/element/undertile/Attach(datum/target, invisibility_trait, invisibility_level = INVISIBILITY_MAXIMUM, tile_overlay, use_alpha = TRUE, use_anchor = FALSE)
 	. = ..()
+
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
 
@@ -35,42 +36,55 @@
 	src.use_alpha = use_alpha
 	src.use_anchor = use_anchor
 
+
 ///called when a tile has been covered or uncovered
-/datum/element/undertile/proc/hide(atom/movable/source, covered)
+/datum/element/undertile/proc/hide(atom/movable/source, underfloor_accessibility)
 	SIGNAL_HANDLER
 
 	if(source.density)
 		stack_trace("([src]): Atom [source] was given an undertile element, but has become dense! This can lead to invisible walls!")
 		return //Returning to actually prevent this from happening
 
-	source.invisibility = covered ? invisibility_level : 0
+	source.invisibility = underfloor_accessibility < UNDERFLOOR_VISIBLE ? invisibility_level : 0
 
 	var/turf/T = get_turf(source)
 
-	if(covered)
-		if(invisibility_trait)
-			ADD_TRAIT(source, invisibility_trait, ELEMENT_TRAIT(type))
+	if(underfloor_accessibility < UNDERFLOOR_INTERACTABLE)
+		source.plane = FLOOR_PLANE // We do this so that turfs that allow you to see what's underneath them don't have to be on the game plane (which causes ambient occlusion weirdness)
+
 		if(tile_overlay)
 			T.add_overlay(tile_overlay)
-		if(use_alpha)
-			source.alpha = ALPHA_UNDERTILE
+
 		if(use_anchor)
 			source.set_anchored(TRUE)
 
+		if(underfloor_accessibility < UNDERFLOOR_VISIBLE)
+			if(use_alpha)
+				source.alpha = ALPHA_UNDERTILE
+
+			if(invisibility_trait)
+				ADD_TRAIT(source, invisibility_trait, ELEMENT_TRAIT(type))
+
 	else
+		source.plane = initial(source.plane)
+
 		if(invisibility_trait)
 			REMOVE_TRAIT(source, invisibility_trait, ELEMENT_TRAIT(type))
+
 		if(tile_overlay)
 			T.overlays -= tile_overlay
+
 		if(use_alpha)
-			source.alpha = 255
+			source.alpha = initial(source.alpha)
+
 		if(use_anchor)
 			source.set_anchored(FALSE)
 
-/datum/element/undertile/Detach(atom/movable/AM, visibility_trait, invisibility_level = INVISIBILITY_MAXIMUM)
+
+/datum/element/undertile/Detach(atom/movable/source, visibility_trait, invisibility_level = INVISIBILITY_MAXIMUM)
 	. = ..()
 
-	hide(AM, FALSE)
+	hide(source, UNDERFLOOR_INTERACTABLE)
 
 
 #undef ALPHA_UNDERTILE

--- a/code/game/objects/items/devices/pressureplates.dm
+++ b/code/game/objects/items/devices/pressureplates.dm
@@ -68,5 +68,7 @@
 	return ..()
 
 ///Called from COMSIG_OBJ_HIDE to toggle the active part, because yeah im not making a special exception on the element to support it
-/obj/item/pressure_plate/proc/ToggleActive(datum/source, covered)
-	active = covered
+/obj/item/pressure_plate/proc/ToggleActive(datum/source, underfloor_accessibility)
+	SIGNAL_HANDLER
+
+	active = underfloor_accessibility < UNDERFLOOR_VISIBLE

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -13,7 +13,6 @@
 	baseturfs = /turf/open/floor/plating
 	floor_tile = /obj/item/stack/tile/catwalk_tile
 	layer = CATWALK_LAYER
-	plane = GAME_PLANE
 	footstep = FOOTSTEP_CATWALK
 	barefootstep = FOOTSTEP_CATWALK
 	clawfootstep = FOOTSTEP_CATWALK
@@ -47,13 +46,13 @@
 	if(!covered)
 		underfloor_accessibility = UNDERFLOOR_INTERACTABLE
 		layer = TURF_LAYER
-		plane = FLOOR_PLANE
 		icon_state = "[catwalk_type]_below"
 	else
 		underfloor_accessibility = UNDERFLOOR_VISIBLE
 		layer = CATWALK_LAYER
-		plane = GAME_PLANE
 		icon_state = "[catwalk_type]_above"
+
+	levelupdate()
 	user.balloon_alert(user, "[!covered ? "Cover removed" : "Ccover added"]")
 	tool.play_tool_sound(src)
 	update_appearance()

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -14,9 +14,6 @@
 	floor_tile = /obj/item/stack/tile/catwalk_tile
 	layer = CATWALK_LAYER
 	footstep = FOOTSTEP_CATWALK
-	barefootstep = FOOTSTEP_CATWALK
-	clawfootstep = FOOTSTEP_CATWALK
-	heavyfootstep = FOOTSTEP_CATWALK
 	overfloor_placed = TRUE
 	underfloor_accessibility = UNDERFLOOR_VISIBLE
 	var/covered = TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -352,7 +352,7 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 /turf/proc/levelupdate()
 	for(var/obj/O in src)
 		if(O.flags_1 & INITIALIZED_1)
-			SEND_SIGNAL(O, COMSIG_OBJ_HIDE, underfloor_accessibility < UNDERFLOOR_VISIBLE)
+			SEND_SIGNAL(O, COMSIG_OBJ_HIDE, underfloor_accessibility)
 
 // override for space turfs, since they should never hide anything
 /turf/open/space/levelupdate()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -36,8 +36,9 @@
 /obj/machinery/atmospherics/components/proc/update_icon_nopipes()
 	return
 
-/obj/machinery/atmospherics/components/proc/hide_pipe(datum/source, covered)
-	showpipe = !covered
+/obj/machinery/atmospherics/components/proc/hide_pipe(datum/source, underfloor_accessibility)
+	SIGNAL_HANDLER
+	showpipe = !!underfloor_accessibility
 	update_icon()
 
 /obj/machinery/atmospherics/components/update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts catwalk layering to no longer cast ambient occlusion on 2.00 - 2.50 layer objects. Catwalk tiles now respect undertile element.

Fixes footstep sound runtime when walking over catwalks

Ports:
- https://github.com/tgstation/tgstation/pull/71555 (I stripped out plane cube garbage)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Catwalk tiles use layers to draw ontop of pipes, wires, decals and atmospheric objects. However, using this traditional method with no tweaks made it susceptible to ambient occlusion (the catwalk tile casted shadows on its surroundings like a wall)

Here is before

![Screenshot 2024-07-02 010940](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/02cdbb92-a692-4db8-9fb4-9a6e99b7be00)

Here is after

![Screenshot 2024-07-02 012528](https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/3f1faf1f-6448-4d3d-bd57-402c8c3b9f89)

Simple enough

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

No runtime

https://github.com/BeeStation/BeeStation-Hornet/assets/62388554/f514176a-6ae5-429c-a0ac-eff011d76dbc

Amient occlusion fix info provided above

</details>

## Changelog
:cl: rkz, GoldenAlpharex
refactor: refactored undertile element to support layers without casting ambient occlusion
fix: no more audio runtime when walking on catwalk tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
