### PR TITLE
Brig Medical Reduction V2 - Not Forgotten Edition

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -59884,6 +59884,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "vnK" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21697,10 +21697,6 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5;
 	pixel_y = -1
 	},
@@ -23594,10 +23590,6 @@
 	pixel_y = 2
 	},
 /obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/syringe,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -39780,9 +39772,6 @@
 	pixel_x = -28
 	},
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
 /obj/item/clothing/mask/balaclava,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5
@@ -59889,9 +59878,6 @@
 /obj/item/reagent_containers/syringe{
 	name = "steel point"
 	},
-/obj/item/reagent_containers/glass/bottle/charcoal,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -64556,7 +64542,6 @@
 /area/teleporter)
 "xvB" = (
 /obj/structure/table/optable,
-/obj/item/defibrillator/loaded,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/window/reinforced{

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -11083,8 +11083,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
-/obj/item/storage/backpack/duffelbag/sec/surgery,
-/obj/item/blood_filter,
 /turf/open/floor/iron/white,
 /area/security/brig/medbay)
 "dqj" = (
@@ -44144,7 +44142,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/wrench/medical,
-/obj/item/reagent_containers/glass/bottle/morphine,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/dark,
@@ -69017,7 +69014,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/defibrillator/loaded,
+/obj/effect/loot_jobscale/medical/first_aid_kit,
 /turf/open/floor/iron/dark,
 /area/security/brig/medbay)
 "whZ" = (

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -69015,6 +69015,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/loot_jobscale/medical/first_aid_kit,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron/dark,
 /area/security/brig/medbay)
 "whZ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -72440,6 +72440,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "qVr" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -38944,7 +38944,6 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
 /obj/item/healthanalyzer,
 /turf/open/floor/iron/white,
 /area/security/brig)
@@ -50768,9 +50767,6 @@
 	},
 /obj/item/reagent_containers/glass/bottle/facid{
 	pixel_x = 7
-	},
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -72437,11 +72433,6 @@
 	icon_state = "4-8"
 	},
 /obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5;
 	pixel_y = -1
@@ -72449,7 +72440,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "qVr" = (
@@ -92552,8 +92542,6 @@
 /area/maintenance/port/aft)
 "xDw" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/charcoal,
 /obj/item/reagent_containers/syringe,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -16136,10 +16136,6 @@
 	})
 "hKX" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_x = -1;
-	pixel_y = 7
-	},
 /obj/item/clothing/mask/surgical{
 	pixel_x = 3;
 	pixel_y = -8

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -92079,6 +92079,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron/white,
 /area/security/main)
 "xcT" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -944,9 +944,6 @@
 "amP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
 /obj/item/clothing/mask/balaclava,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5
@@ -39917,16 +39914,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -3;
 	pixel_y = 2
 	},
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
-/obj/item/defibrillator/loaded,
 /obj/item/reagent_containers/blood/OPlus,
 /turf/open/floor/iron/techmaint,
 /area/security/main)
@@ -40818,9 +40810,6 @@
 /obj/item/storage/box/bodybags,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
@@ -65433,10 +65422,6 @@
 	pixel_y = 2
 	},
 /obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/syringe,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera{
@@ -92089,9 +92074,6 @@
 /obj/item/reagent_containers/syringe{
 	name = "steel point"
 	},
-/obj/item/reagent_containers/glass/bottle/charcoal,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -78163,6 +78163,7 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron/showroomfloor,
 /area/security/main)
 "tzZ" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -34798,9 +34798,6 @@
 	dir = 1
 	},
 /obj/structure/table/optable,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
@@ -40809,7 +40806,6 @@
 /area/crew_quarters/fitness/recreation)
 "hbv" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -56670,10 +56666,6 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/healthanalyzer,
 /obj/item/storage/box/bodybags,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5;
 	pixel_y = -1
@@ -78171,9 +78163,6 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/main)
 "tzZ" = (
@@ -86956,7 +86945,6 @@
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/regular,
 /obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21987,6 +21987,7 @@
 	pixel_y = -4
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "cUm" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21979,10 +21979,6 @@
 /area/crew_quarters/bar)
 "cTU" = (
 /obj/structure/rack,
-/obj/item/storage/firstaid/regular,
-/obj/item/healthanalyzer{
-	pixel_y = -2
-	},
 /obj/machinery/camera{
 	c_tag = "Brig - Infirmary";
 	dir = 1
@@ -43575,8 +43571,6 @@
 "kTH" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/charcoal,
 /obj/item/reagent_containers/syringe,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -63149,9 +63143,6 @@
 	pixel_x = -28
 	},
 /obj/structure/table,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
 /obj/item/clothing/mask/balaclava,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -60217,6 +60217,7 @@
 	pixel_x = 5;
 	pixel_y = 12
 	},
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron,
 /area/security/brig/medbay)
 "sRq" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -19724,7 +19724,6 @@
 	name = "Prison Visitation"
 	})
 "gee" = (
-/obj/item/defibrillator/loaded,
 /obj/structure/closet/crate/freezer/blood,
 /obj/item/rollerbed,
 /obj/item/rollerbed{
@@ -48862,10 +48861,6 @@
 /area/science/xenobiology)
 "pmV" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = -5;
-	pixel_y = 10
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/iron/dark,
@@ -60222,15 +60217,6 @@
 	pixel_x = 5;
 	pixel_y = 12
 	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/item/storage/backpack/duffelbag/sec/surgery,
 /turf/open/floor/iron,
 /area/security/brig/medbay)
 "sRq" = (
@@ -66446,10 +66432,6 @@
 	pixel_y = -4
 	},
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 5
-	},
-/obj/item/blood_filter,
 /turf/open/floor/iron/dark,
 /area/security/brig/medbay)
 "uJI" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -115,7 +115,8 @@
 	new /obj/item/blood_filter(src)
 	new /obj/item/radio/headset/headset_medsec(src)
 	new	/obj/item/storage/firstaid/regular(src)
-	new /obj/item/storage/pill_bottle/charcoal
+	new /obj/item/storage/pill_bottle/charcoal(src)
+	new /obj/item/storage/pill_bottle/kelotane(src)
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/clothing/under/rank/brig_physician(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -115,10 +115,7 @@
 	new /obj/item/blood_filter(src)
 	new /obj/item/radio/headset/headset_medsec(src)
 	new	/obj/item/storage/firstaid/regular(src)
-	new	/obj/item/storage/firstaid/fire(src)
-	new	/obj/item/storage/firstaid/toxin(src)
-	new	/obj/item/storage/firstaid/o2(src)
-	new	/obj/item/storage/firstaid/brute(src)
+	new /obj/item/storage/pill_bottle/charcoal
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/clothing/under/rank/brig_physician(src)


### PR DESCRIPTION
## About The Pull Request

Forgot I made this, here it is again

It makes security not have more medical gear than medbay does. Seriously, the amount of kits the brig physician locker has, the amount of surgical duffel bags, defibrillators, and the odd loose first aid kit in security was a little ridiculous. 

What they now have is a first aid kit in the open, an additional first aid kit in the brig physician locker, surgical duffelbag in the brig physician locker, defibrillator in the locker, and a bottle of charcoal pills in the brig physician locker. One kit was left out in the open so that if a brig physician isn't present you aren't totally screwed.  Charcoal pills were added so you have coverage for all 3 damage types.

## Why It's Good For The Game

I think we can all agree the brig having more medical supplies than medical was a little ridiculous. Two defibrillators, three surgery duffelbags, and about five medkits are you kidding me? The medkit that's sitting out means its still possible to heal yourself in a pinch when there isn't a brig physician, but on high pop that kit will run dry really quick and will encourage people to interact with the brig physician for healing. It also gives the brig physician something to do with the chem lab they always build since right now they never actually need one.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2024-07-04 082949](https://github.com/BeeStation/BeeStation-Hornet/assets/117550914/41b11c2a-58c0-4a9b-a747-cd9c54ea9cac)

It compiles, here's what spawns in the locker
</details>

## Changelog
:cl:
balance: Reduced the med kit count in the brig, total of two first aid kits
del: Removed duplicate medical equipment in the brig, and specialty medkit spawns from the brig physician locker
tweak: Brig surgical duffelbags and defibrillators now spawn in the brig physician locker instead of on the ground
add: Extra gauze to brig infirmary and kelotane/charcoal bottles to the brig physician locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
