### PR TITLE
CentCom / CTF / Wizard's den is now dchat free for actual players

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -109,6 +109,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define XENOBIOLOGY_COMPATIBLE		(1<<9)
 /// Are hidden stashes allowed to spawn here?
 #define HIDDEN_STASH_LOCATION		(1<<10)
+/// People that are in an area with this flag will hear dead chat from ghosts. Kinda CentCom OOC feature.
+#define AREA_DEADCHAT_ALLOWED		(1<<11)
 
 /*
 	These defines are used specifically with the atom/pass_flags bitmask

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -412,6 +412,9 @@ GLOBAL_LIST_EMPTY(species_list)
 			override = TRUE
 		if(SSticker.current_state == GAME_STATE_FINISHED)
 			override = TRUE
+		var/area/mob_area = get_area(M)
+		if(mob_area.area_flags & AREA_DEADCHAT_ALLOWED)
+			override = TRUE
 		if(isnewplayer(M) && !override)
 			continue
 		if(M.stat != DEAD && !override)

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -12,7 +12,7 @@
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
 	teleport_restriction = TELEPORT_ALLOW_NONE
-	area_flags = VALID_TERRITORY | UNIQUE_AREA
+	area_flags = VALID_TERRITORY | UNIQUE_AREA | AREA_DEADCHAT_ALLOWED
 	flags_1 = NONE
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
 
@@ -84,6 +84,7 @@
 /area/tdome
 	name = "Thunderdome"
 	icon_state = "yellow"
+	area_flags = VALID_TERRITORY | BLOBS_ALLOWED | UNIQUE_AREA | AREA_DEADCHAT_ALLOWED
 	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
@@ -126,7 +127,7 @@
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
 	teleport_restriction = TELEPORT_ALLOW_NONE
-	area_flags = VALID_TERRITORY | UNIQUE_AREA
+	area_flags = VALID_TERRITORY | UNIQUE_AREA | AREA_DEADCHAT_ALLOWED
 	flags_1 = NONE
 	network_root_id = "MAGIC_NET"
 	airlock_hack_difficulty = AIRLOCK_WIRE_SECURITY_MAXIMUM
@@ -172,6 +173,7 @@
 /area/ctf
 	name = "Capture the Flag"
 	icon_state = "yellow"
+	area_flags = VALID_TERRITORY | BLOBS_ALLOWED | UNIQUE_AREA | AREA_DEADCHAT_ALLOWED
 	requires_power = FALSE
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 	has_gravity = STANDARD_GRAVITY

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -31,7 +31,8 @@
 	for (var/mob/M in GLOB.player_list)
 		if(isnewplayer(M))
 			continue
-		if (M.stat == DEAD || (M.client && M.client.holder && M.client.prefs.read_player_preference(/datum/preference/toggle/chat_dead))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
+		var/area/mob_area = get_area(M)
+		if (M.stat == DEAD || (mob_area.area_flags & AREA_DEADCHAT_ALLOWED) || (M.client && M.client.holder && M.client.prefs.read_player_preference(/datum/preference/toggle/chat_dead))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
 			to_chat(M, rendered)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
CentCom / CTF / Wizard's den is now dchat free for actual players. You can hear ghost chats as long as you're in those places.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These areas are quite often to be OOC-allowed, while non-admin players have a trouble to communicate with ghost people.
We know actual ERTs or CC officials are players that shouldn't interact with ghosts, but letting all people regardless they're an actual player or not communicate with ghosts would be much better to make them well-prepared for RP in a station they're going to.

For Wizards, 90% (estimate) players of wizards are a new player. They need to get ghosts' tips directly instead of costing ghost orb or an apprentice.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
to be posted

## Changelog
:cl:
add: living people in CentCom / CTF / Wizard's den can hear dchat. This is meant to communicate with ghosts when necessary. When you engage in an actual RP (when you're ERT or a CC official), please refrain communicating with them(Wizard is okay).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
