### PR TITLE
Empty Variable for Storage Items

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -22,7 +22,6 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_LARGE
 	var/skin_type = MEDBOT_SKIN_DEFAULT
-	var/empty = FALSE
 
 /obj/item/storage/firstaid/regular
 	icon_state = "firstaid"
@@ -33,8 +32,6 @@
 	return BRUTELOSS
 
 /obj/item/storage/firstaid/regular/PopulateContents()
-	if(empty)
-		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 2,
@@ -49,8 +46,6 @@
 	w_class = WEIGHT_CLASS_NORMAL //Intended to be used by ERTs or other uncommon roles
 
 /obj/item/storage/firstaid/compact/PopulateContents()
-	if(empty)
-		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 2,
@@ -126,8 +121,6 @@
 		))
 
 /obj/item/storage/firstaid/medical/PopulateContents()
-	if(empty)
-		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 2,
@@ -147,8 +140,6 @@
 	skin_type = null
 
 /obj/item/storage/firstaid/ancient/PopulateContents()
-	if(empty)
-		return
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 2,
 		/obj/item/stack/medical/bruise_pack = 3,
@@ -173,8 +164,6 @@
 	icon_state = pick("firstaid-burn","firstaid-burnalt")
 
 /obj/item/storage/firstaid/fire/PopulateContents()
-	if(empty)
-		return
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/silver_sulf = 4,
 		/obj/item/storage/pill_bottle/kelotane = 1,
@@ -222,8 +211,6 @@
 	return TOXLOSS
 
 /obj/item/storage/firstaid/radbgone/PopulateContents()
-	if(empty)
-		return
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/antirad_plus = 2,
 		/obj/item/reagent_containers/pill/antirad = 2,

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -4,13 +4,15 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/rummage_if_nodrop = TRUE
 	var/component_type = /datum/component/storage/concrete
+	var/empty = FALSE
 
 /obj/item/storage/get_dumping_location(obj/item/storage/source,mob/user)
 	return src
 
 /obj/item/storage/Initialize(mapload)
 	. = ..()
-	PopulateContents()
+	if(!empty)
+		PopulateContents()
 
 /obj/item/storage/ComponentInitialize()
 	AddComponent(component_type)


### PR DESCRIPTION
## About The Pull Request
Adds an empty variable to storage items to prevent items from being added to it.

## Why It's Good For The Game
It is mostly for the comfort of mappers in case they want to use a specific storage container without it including any items at all instead of having to make a subtype of whatever storage item they wishes to use.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/75c462ed-ea03-4093-84e4-2d60332646fa)

https://github.com/BeeStation/BeeStation-Hornet/assets/82539179/c94791a5-5e26-45ce-8740-0576678d8247

</details>

## Changelog
:cl:
code: Changed PopulateItems() to check if it should be empty or not.
tweak: Changed Medkits to not use their empty variable.
/:cl:
