### PR TITLE
freezing now cures advanced mutation toxin

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -157,9 +157,8 @@
 
 /datum/disease/transformation/slime
 	name = "Advanced Mutation Transformation"
-	cure_text = "frost oil"
-	cures = list(/datum/reagent/consumable/frostoil)
-	cure_chance = 80
+	cure_text = "Below Freezing Temperature"
+	cures = list()
 	agent = "Advanced Mutation Toxin"
 	desc = "This highly concentrated extract converts anything into more of itself."
 	danger = DISEASE_BIOHAZARD
@@ -173,6 +172,9 @@
 
 /datum/disease/transformation/slime/stage_act()
 	..()
+	var/mob/living/carbon/H = affected_mob
+	if(H.bodytemperature < T0C)
+		cure()
 	switch(stage)
 		if(1)
 			if(ishuman(affected_mob) && affected_mob.dna)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
as it says on the title, if you get the advanced mutation toxin disease, you now simply need to lower your body temperature to below 0C

frost oil no longer directly cures the disease
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Advanced mutation toxin is an incredibly powerful poison, being able to practically round remove anyone since the only way to cure it is either via xenobio (which probably made the toxin in the first place) or botany (which requires atleast 5-10 minutes to grow chilly peppers)

changing the requirement to be freezing temperatures makes curing easier, but still requiring some work
it can be cured via wrenching a shower and standing under it, going to cryo, walking into space or going somewhere cold which isn't normally a common place
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/d7f75022-868d-4b5b-9fe4-9d6e07b76977




</details>

## Changelog
:cl:
balance: Advanced Mutation Toxin is now cured via below freezing temperatures
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
