### PR TITLE
A handful of circuitry fixes and changes

### DIFF
--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -425,7 +425,7 @@
 	name = "Compact Remote Shell"
 	desc = "A handheld shell with one big button."
 	id = "compact_remote_shell"
-	build_path = /obj/item/compact_remote
+	build_path = /obj/item/shell/compact_remote
 	materials = list(/datum/material/glass = 2000, /datum/material/iron = 5000)
 	build_type = PROTOLATHE | COMPONENT_PRINTER
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_SHELLS)
@@ -434,7 +434,7 @@
 	name = "Controller Shell"
 	desc = "A handheld shell with several buttons."
 	id = "controller_shell"
-	build_path = /obj/item/controller
+	build_path = /obj/item/shell/controller
 	build_type = PROTOLATHE | COMPONENT_PRINTER
 	materials = list(/datum/material/glass = 2000, /datum/material/iron = 7000)
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_SHELLS)
@@ -443,7 +443,7 @@
 	name = "Scanner Shell"
 	desc = "A handheld scanner shell that can scan entities."
 	id = "scanner_shell"
-	build_path = /obj/item/wiremod_scanner
+	build_path = /obj/item/shell/wiremod_scanner
 	build_type = PROTOLATHE | COMPONENT_PRINTER
 	materials = list(/datum/material/glass = 4000, /datum/material/iron = 5000)
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_SHELLS)

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -6,7 +6,7 @@
 	circuit = /obj/item/circuitboard/machine/component_printer
 
 	remote_materials = TRUE
-	auto_link = TRUE
+	auto_link = FALSE
 	can_sync = TRUE
 
 	//Quick.
@@ -16,8 +16,7 @@
 
 	categories = WIREMODE_CATEGORIES
 
-/obj/machinery/component_printer/crowbar_act(mob/living/user, obj/item/tool)
-
+/obj/machinery/modular_fabricator/component_printer/crowbar_act(mob/living/user, obj/item/tool)
 	if(..())
 		return TRUE
 	return default_deconstruction_crowbar(tool)
@@ -27,6 +26,18 @@
 		return TRUE
 	return default_deconstruction_screwdriver(user, "fab-o", "fab-idle", tool)
 
+/obj/machinery/modular_fabricator/component_printer/AfterMaterialInsert(type_inserted, id_inserted, amount_inserted)
+	. = ..()
+	var/datum/material/M = id_inserted
+	add_overlay("fab-load-[M.name]")
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, cut_overlay), "fab-load-[M.name]"), 10)
+
+/obj/machinery/modular_fabricator/component_printer/set_default_sprite()
+	cut_overlay("fab-active")
+
+/obj/machinery/modular_fabricator/component_printer/set_working_sprite()
+	add_overlay("fab-active")
+
 /obj/item/circuitboard/machine/component_printer
 	name = "\improper Component Printer (Machine Board)"
 	icon_state = "science"
@@ -34,7 +45,7 @@
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/stock_parts/manipulator = 2,
-		/obj/item/reagent_containers/glass/beaker = 2,
+		/obj/item/reagent_containers/glass/beaker = 2, //this doesn't make any sense, yet i wasn't allowed to fix it.
 	)
 
 /// Module duplicator, allows you to save and recreate module components.

--- a/code/modules/wiremod/shell/compact_remote.dm
+++ b/code/modules/wiremod/shell/compact_remote.dm
@@ -5,10 +5,11 @@
  */
 /obj/item/compact_remote
 	name = "compact remote"
+	desc = "A smaller handheld device with one big button."
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "setup_small_simple"
 	item_state = "electronic"
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	//worn_icon_state = "electronic"		//remember to change it later lol
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -6,9 +6,11 @@
  */
 /obj/item/controller
 	name = "controller"
+	desc = "A handheld device with three buttons."
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "setup_small_calc"
 	item_state = "electronic"
+	w_class = WEIGHT_CLASS_SMALL
 	//worn_icon_state = "electronic"	//remember to change it
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
@@ -23,30 +25,32 @@
 
 /obj/item/circuit_component/controller
 	display_name = "Controller"
-	desc = "Used to receive inputs from the controller shell. Use the shell in hand to trigger the output signal. Alt-click for the alternate signal. Right click for the extra signal."
+	desc = "Used to receive inputs from the controller shell. Use the shell in hand to trigger the first signal. Alt-click for the second signal. CTRL-click for the thrid signal."
 
 	/// The three separate buttons that are called in attack_hand on the shell.
 	var/datum/port/output/signal
 	var/datum/port/output/alt
-	var/datum/port/output/right
+	var/datum/port/output/ctrl
 
 	/// The entity output
 	var/datum/port/output/entity
 
 /obj/item/circuit_component/controller/populate_ports()
 	entity = add_output_port("User", PORT_TYPE_ATOM)
-	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
-	alt = add_output_port("Alternate Signal", PORT_TYPE_SIGNAL)
-	right = add_output_port("Extra Signal", PORT_TYPE_SIGNAL)
+	signal = add_output_port("First Signal", PORT_TYPE_SIGNAL)
+	alt = add_output_port("Second Signal", PORT_TYPE_SIGNAL)
+	ctrl = add_output_port("Third Signal", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/controller/register_shell(atom/movable/shell)
 	RegisterSignal(shell, COMSIG_ITEM_ATTACK_SELF, PROC_REF(send_trigger))
 	RegisterSignal(shell, COMSIG_CLICK_ALT, PROC_REF(send_alternate_signal))
+	RegisterSignal(shell, COMSIG_CLICK_CTRL, PROC_REF(send_ctrl_signal))
 
 /obj/item/circuit_component/controller/unregister_shell(atom/movable/shell)
 	UnregisterSignal(shell, list(
 		COMSIG_ITEM_ATTACK_SELF,
 		COMSIG_CLICK_ALT,
+		COMSIG_CLICK_CTRL,
 	))
 
 /**
@@ -56,7 +60,7 @@
 	SIGNAL_HANDLER
 	if(!user.Adjacent(source))
 		return
-	source.balloon_alert(user, "Clicked the primary button.")
+	source.balloon_alert(user, "Clicked the first button.")
 	playsound(source, get_sfx("terminal_type"), 25, FALSE)
 	entity.set_output(user)
 	signal.set_output(COMPONENT_SIGNAL)
@@ -68,20 +72,20 @@
 	SIGNAL_HANDLER
 	if(!user.Adjacent(source))
 		return
-	source.balloon_alert(user, "Clicked the alternate button.")
+	source.balloon_alert(user, "Clicked the second button.")
 	playsound(source, get_sfx("terminal_type"), 25, FALSE)
 	entity.set_output(user)
 	alt.set_output(COMPONENT_SIGNAL)
 	return COMPONENT_INTERCEPT_ALT
 
 /**
- * Called when the shell item is right-clicked in active hand
+ * Called when the shell item is ctrl-clicked in active hand
  */
-/obj/item/circuit_component/controller/proc/send_right_signal(atom/source, mob/user)
+/obj/item/circuit_component/controller/proc/send_ctrl_signal(atom/source, mob/user)
 	SIGNAL_HANDLER
 	if(!user.Adjacent(source))
 		return
-	source.balloon_alert(user, "Clicked the extra button.")
+	source.balloon_alert(user, "Clicked the third button.")
 	playsound(source, get_sfx("terminal_type"), 25, FALSE)
 	entity.set_output(user)
-	right.set_output(COMPONENT_SIGNAL)
+	ctrl.set_output(COMPONENT_SIGNAL)

--- a/code/modules/wiremod/shell/drone.dm
+++ b/code/modules/wiremod/shell/drone.dm
@@ -6,7 +6,7 @@
 /mob/living/circuit_drone
 	name = "drone"
 	icon = 'icons/obj/wiremod.dmi'
-	icon_state = "setup_medium_med"
+	icon_state = "setup_drone_arms"		//RIP setup_medium_med, you were too cute for this world. Maybe some other day they'll find a use for you
 
 	light_system = MOVABLE_LIGHT
 

--- a/code/modules/wiremod/shell/scanner.dm
+++ b/code/modules/wiremod/shell/scanner.dm
@@ -5,9 +5,11 @@
  */
 /obj/item/wiremod_scanner
 	name = "scanner"
+	desc = "A handheld device that lets you scan people"
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "setup_small"
 	item_state = "electronic"
+	w_class = WEIGHT_CLASS_SMALL
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 
@@ -20,7 +22,7 @@
 	. = ..()
 	AddComponent(/datum/component/shell, list(
 		new /obj/item/circuit_component/wiremod_scanner()
-	), SHELL_CAPACITY_SMALL)
+	), SHELL_CAPACITY_MEDIUM)
 
 /obj/item/circuit_component/wiremod_scanner
 	display_name = "Scanner"

--- a/code/modules/wiremod/shell/shell_items.dm
+++ b/code/modules/wiremod/shell/shell_items.dm
@@ -47,7 +47,7 @@
 	name = "server assembly"
 	icon_state = "setup_stationary-open"
 	shell_to_spawn = /obj/structure/server
-	screw_delay = 8 SECONDS
+	screw_delay = 6 SECONDS
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/shell/server/ComponentInitialize()

--- a/code/modules/wiremod/shell/shell_items.dm
+++ b/code/modules/wiremod/shell/shell_items.dm
@@ -29,22 +29,30 @@
 	name = "bot assembly"
 	icon_state = "setup_medium_box-open"
 	shell_to_spawn = /obj/structure/bot
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/shell/money_bot
 	name = "money bot assembly"
 	icon_state = "setup_large-open"
 	shell_to_spawn = /obj/structure/money_bot
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/shell/drone
 	name = "drone assembly"
-	icon_state = "setup_medium_med-open"
+	icon_state = "setup_drone_arms-open"
 	shell_to_spawn = /mob/living/circuit_drone
+	w_class = WEIGHT_CLASS_NORMAL		// you should be able to fit these in your back pack
 
 /obj/item/shell/server
 	name = "server assembly"
 	icon_state = "setup_stationary-open"
 	shell_to_spawn = /obj/structure/server
-	screw_delay = 10 SECONDS
+	screw_delay = 8 SECONDS
+	w_class = WEIGHT_CLASS_BULKY
+
+/obj/item/shell/server/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
 
 /obj/item/shell/airlock
 	name = "circuit airlock assembly"
@@ -52,14 +60,39 @@
 	icon_state = "construction"
 	shell_to_spawn = /obj/machinery/door/airlock/shell
 	screw_delay = 10 SECONDS
+	w_class = WEIGHT_CLASS_GIGANTIC
+
+/obj/item/shell/airlock/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/two_handed, require_twohands=TRUE) // that you even are allowed to carry around an airlock frame is weird.
 
 /obj/item/shell/bci
 	name = "brain-computer interface assembly"
 	icon_state = "bci-open"
 	shell_to_spawn = /obj/item/organ/cyberimp/bci
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/shell/scanner_gate
 	name = "scanner gate assembly"
 	icon = 'icons/obj/machines/scangate.dmi'
 	icon_state = "scangate"
 	shell_to_spawn = /obj/structure/scanner_gate_shell
+	w_class = WEIGHT_CLASS_LARGE
+
+/obj/item/shell/controller
+	name = "controller assembly"
+	icon_state = "setup_small_calc-open"
+	shell_to_spawn = /obj/item/controller
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/shell/compact_remote
+	name = "compact remote assembly"
+	icon_state = "setup_small_simple-open"
+	shell_to_spawn = /obj/item/compact_remote
+	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/shell/wiremod_scanner
+	name = "scanner assembly"
+	icon_state = "setup_small-open"
+	shell_to_spawn = /obj/item/wiremod_scanner
+	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now press the third button on the controller by CTRL-clicking, instead of right clicking which wasnt possible. Also changed text to reflect these changes and clarify some things. 
Gave every shell, both normal and open, a weight. (Handheld items are small (expect compact remote and bci which are tiny), bots and drones are normal size, the scanner gate is large, server shell is bulky and requires two hands to hold, same with the airlock shell but it is gigantic instead.
Made the drone shell use the correct sprite (rip the medbot shell)
Fixed so the printed compact remote, controller and scanner spawn as open
Fixed so you can disassemble the component printer and fixed the printing animation
The component printer no longer auto links to the silo
the server shell only takes 6 seconds instead of 10 to screw together.

Got reminied of a ton of bugs and 90% completed fetures circuitry has, drafted so i could add them to this pr.

- [x] Fix component printers animations (note: the the inserting of mats into ANY lathe or machine is currently broken, so i am moving this issue over to someone else.)
- [x] Fix component printer not being able to be dismantled
- [x] Add unassembled shell for various different shells 
~~- [ ] Add some unused shells from `icon/obj/wiremod.dmi`~~ saving this for another pr since it would balloon off too much in just this one. 

## Why It's Good For The Game
Things working as they should is good
The handheld shells being a normal sized item doesn't make sense, it doesn't fit in your pocket and it makes the BCI preferable in basically every case. The compact remote shell being tiny is to reflect the changes made to the other shells. 
The server shell taking ages to screw together is honestly not that fun. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![controllers pr](https://github.com/user-attachments/assets/7b5a15a1-9700-4866-ab87-ca3851482836)

https://github.com/user-attachments/assets/6d15d914-ce82-4aba-9762-9b685c7022c6

![image](https://github.com/user-attachments/assets/a999af96-9962-4dbe-8dd7-c45d71e9aa53)

![image](https://github.com/user-attachments/assets/0ea854cd-a680-4e31-a1f6-b4955486ffdd)


</details>

## Changelog
:cl: Geatish
balance: Gave each shell a size, handheld shells are small (expect for the compact remote which is tiny) the rest are normal size or larger.
fix: You can now press the third button on the controller shell by CTRL-clicking.
fix: The component printer can now be deconstructed and its printing animation now works, it also no longer auto links to the silo.
fix: Printing the compact remote, controller and scanner now gives you the unscrewed variant.
fix: The drone shell now uses the correct sprite
balance: The server shell now takes only 6 seconds to screw together, rather than 10
/:cl: