### PR TITLE
Fix: Modular fabricators dumping ore silos onto the floor

### DIFF
--- a/code/game/machinery/fabricators/modular_fabricator.dm
+++ b/code/game/machinery/fabricators/modular_fabricator.dm
@@ -361,7 +361,7 @@
 	return T
 
 /obj/machinery/modular_fabricator/on_deconstruction()
-	var/datum/component/material_container/materials = get_material_container()
+	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.retrieve_all()
 
 /obj/machinery/modular_fabricator/proc/AfterMaterialInsert(item_inserted, id_inserted, amount_inserted)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes modular fabricators remotely dumping the contents of a connected ore silo onto the floor. This bug was introduced in #4210 when it reused code for getting remote material containers first, which would cause it to find the silo first and dump it instead.

This was previously brought up in #9269, but unfortunately that went stale and disappeared off the radar until brought up again by @Geatish rediscovering it.

## Why It's Good For The Game

99% sure this can be abused and isn't intended.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Deconstruction while linked:
![image](https://github.com/user-attachments/assets/550d0bde-86ed-414d-9f87-be8a30fc0d44)

Deconstruction while unlinked:
![image](https://github.com/user-attachments/assets/fa9818f1-8266-4813-8407-34d274161d75)

</details>

## Changelog
:cl:
fix: Modular Fabricators no longer dump the contents of a connected ore silo onto the ground
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
