### PR TITLE
Mimite Runtime Fixes, Mob Balancing, and more.

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(pai_list)
 GLOBAL_LIST_EMPTY(available_ai_shells)
 GLOBAL_LIST_INIT(simple_animals, list(list(),list(),list(),list())) // One for each AI_* status define
 GLOBAL_LIST_EMPTY(spidermobs)				//all sentient spider mobs
+GLOBAL_LIST_EMPTY(all_mimites)				//all mimites and their subtypes
 GLOBAL_LIST_EMPTY(bots_list)
 GLOBAL_LIST_EMPTY(ai_eyes)
 GLOBAL_LIST_EMPTY(suit_sensors_list) 		//all people with suit sensors on

--- a/code/modules/events/mimite_infestation.dm
+++ b/code/modules/events/mimite_infestation.dm
@@ -6,9 +6,9 @@
 
 
 /datum/round_event/mimite_infestation
-	announceWhen	= 400
+	announceWhen	= 200
 	// 50% chance of being incremented by one
-	var/spawncount = 2
+	var/spawncount = 3
 	fakeable = TRUE
 
 /datum/round_event/mimite_infestation/setup()
@@ -23,7 +23,7 @@
 			living_mimites = TRUE
 
 	if(living_mimites || fake)
-		priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", ANNOUNCER_ALIENS)
+		priority_announce("Anomlous lifesigns detected aboard [station_name()]. Please report any strange disturbances and Secure any exterior access, including ducting and ventilation.", "Lifesign Anomaly Alert", ANNOUNCER_ALIENS)
 
 /datum/round_event/mimite_infestation/start()
 	var/list/vents = list()
@@ -44,6 +44,7 @@
 		var/obj/vent = pick_n_take(vents)
 		var/mob/living/simple_animal/hostile/mimite/new_mimite = new(vent.loc)
 		spawncount--
+		announce_to_ghosts(new_mimite)
 		message_admins("[ADMIN_LOOKUPFLW(new_mimite)] has been spawned by an event.")
 		log_game("mimites where spawned by an event.")
 	return SUCCESSFUL_SPAWN

--- a/code/modules/events/mimite_infestation.dm
+++ b/code/modules/events/mimite_infestation.dm
@@ -1,6 +1,3 @@
-//Global List for mimite event
-GLOBAL_LIST_EMPTY(all_mimites)
-
 /datum/round_event_control/mimite_infestation
 	name = "Mimite Infestation"
 	typepath = /datum/round_event/mimite_infestation
@@ -16,7 +13,7 @@ GLOBAL_LIST_EMPTY(all_mimites)
 
 /datum/round_event/mimite_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 50)
-	endWhen = 6000 //60 min, if I'm correct?
+	endWhen = 3600 //60 min
 	if(prob(50))
 		spawncount++
 
@@ -46,6 +43,13 @@ GLOBAL_LIST_EMPTY(all_mimites)
 	while(spawncount > 0 && vents.len)
 		var/obj/vent = pick_n_take(vents)
 		var/mob/living/simple_animal/hostile/mimite/new_mimite = new(vent.loc)
+		switch(length(GLOB.player_list))
+			if(0 to 20)
+				new_mimite.remaining_replications = 3
+			if(20 to 40)
+				new_mimite.remaining_replications = 4
+			else
+				new_mimite.remaining_replications = 5
 		spawncount--
 		announce_to_ghosts(new_mimite)
 		message_admins("[ADMIN_LOOKUPFLW(new_mimite)] has been spawned by an event.")

--- a/code/modules/events/mimite_infestation.dm
+++ b/code/modules/events/mimite_infestation.dm
@@ -16,21 +16,15 @@ GLOBAL_LIST_EMPTY(all_mimites)
 
 /datum/round_event/mimite_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 50)
-	endWhen = 9000 //90 min, if I'm correct? after 90 min, CC finishes scanning and nukes all remaining Mimites
+	endWhen = 6000 //60 min, if I'm correct?
 	if(prob(50))
 		spawncount++
-
-/datum/round_event/mimite_infestation/tick()
-	if(LAZYLEN(GLOB.all_mimites) <= 0)
-		end()
-		endWhen = activeFor += 1
 
 /datum/round_event/mimite_infestation/announce(fake)
 	var/living_mimites = FALSE
 	for(var/mob/living/simple_animal/hostile/mimite/A)
 		if(A.stat != DEAD)
 			living_mimites = TRUE
-
 	if(living_mimites || fake)
 		priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", ANNOUNCER_ALIENS)
 
@@ -60,13 +54,8 @@ GLOBAL_LIST_EMPTY(all_mimites)
 
 
 /datum/round_event/mimite_infestation/end()
-	if(LAZYLEN(GLOB.all_mimites) >= 1)
-		priority_announce("After a full calibration, our sensors detected an outbreak of Mimites, Deploying countermeasures now.", "Lifesign Alert", SSstation.announcer.get_rand_alert_sound())
+	if(LAZYLEN(GLOB.all_mimites) >= 1) //If they're still around at the end of 60 min, turn of replication permanently
 		for(var/mob/living/simple_animal/hostile/mimite/M in GLOB.all_mimites)
-			new /obj/effect/temp_visual/target(M.loc)
-			sleep(9)
-			M.death()
-		if(LAZYLEN(GLOB.all_mimites) >= 1)
-			QDEL_LIST(GLOB.all_mimites)// just incase they somehow didnt die
+			M.eventongoing = FALSE
 	else
 		priority_announce("Sensors are no-longer detecting an outbreak of Mimites, well done crew!", "Lifesign Alert", SSstation.announcer.get_rand_alert_sound())

--- a/code/modules/events/mimite_infestation.dm
+++ b/code/modules/events/mimite_infestation.dm
@@ -1,3 +1,6 @@
+//Global List for mimite event
+GLOBAL_LIST_EMPTY(all_mimites)
+
 /datum/round_event_control/mimite_infestation
 	name = "Mimite Infestation"
 	typepath = /datum/round_event/mimite_infestation
@@ -6,15 +9,21 @@
 
 
 /datum/round_event/mimite_infestation
-	announceWhen	= 200
+	announceWhen = 200
 	// 50% chance of being incremented by one
 	var/spawncount = 3
 	fakeable = TRUE
 
 /datum/round_event/mimite_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 50)
+	endWhen = 9000 //90 min, if I'm correct? after 90 min, CC finishes scanning and nukes all remaining Mimites
 	if(prob(50))
 		spawncount++
+
+/datum/round_event/mimite_infestation/tick()
+	if(LAZYLEN(GLOB.all_mimites) <= 0)
+		end()
+		endWhen = activeFor += 1
 
 /datum/round_event/mimite_infestation/announce(fake)
 	var/living_mimites = FALSE
@@ -23,7 +32,7 @@
 			living_mimites = TRUE
 
 	if(living_mimites || fake)
-		priority_announce("Anomlous lifesigns detected aboard [station_name()]. Please report any strange disturbances and Secure any exterior access, including ducting and ventilation.", "Lifesign Anomaly Alert", ANNOUNCER_ALIENS)
+		priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", ANNOUNCER_ALIENS)
 
 /datum/round_event/mimite_infestation/start()
 	var/list/vents = list()
@@ -48,3 +57,16 @@
 		message_admins("[ADMIN_LOOKUPFLW(new_mimite)] has been spawned by an event.")
 		log_game("mimites where spawned by an event.")
 	return SUCCESSFUL_SPAWN
+
+
+/datum/round_event/mimite_infestation/end()
+	if(LAZYLEN(GLOB.all_mimites) >= 1)
+		priority_announce("After a full calibration, our sensors detected an outbreak of Mimites, Deploying countermeasures now.", "Lifesign Alert", SSstation.announcer.get_rand_alert_sound())
+		for(var/mob/living/simple_animal/hostile/mimite/M in GLOB.all_mimites)
+			new /obj/effect/temp_visual/target(M.loc)
+			sleep(9)
+			M.death()
+		if(LAZYLEN(GLOB.all_mimites) >= 1)
+			QDEL_LIST(GLOB.all_mimites)// just incase they somehow didnt die
+	else
+		priority_announce("Sensors are no-longer detecting an outbreak of Mimites, well done crew!", "Lifesign Alert", SSstation.announcer.get_rand_alert_sound())

--- a/code/modules/mob/living/simple_animal/hostile/mimite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimite.dm
@@ -70,6 +70,7 @@
 	var/mimite_stuck = 0	//If mimite_lastmove hasn't changed, this will increment until it reaches mimite_stuck_threshold
 	var/mimite_stuck_threshold = 10 //if this == mimite_stuck, it'll force the mimite to stop moving
 	var/attemptingventcrawl = FALSE
+	var/eventongoing = TRUE
 
 /mob/living/simple_animal/hostile/mimite/Initialize()
 	. = ..()
@@ -214,10 +215,9 @@
 	if(isturf(loc) && replicate)
 		if(LAZYLEN(GLOB.all_mimites) >= 30) //stop replicating if theres 30 or more
 			replicate = FALSE
-			mimite_growth = 0
-		else if(LAZYLEN(GLOB.all_mimites) <=10 && venthunt) //start replicating again if under a total of 10
+		else if(LAZYLEN(GLOB.all_mimites) <= 15 && eventongoing) //if event hasnt ended, and theres 15 or less, replicate
 			replicate = TRUE
-		if(replicate) //we still want growth and replication if over 10
+		if(replicate) //we still want growth and replication if over 15
 			mimite_growth += rand(1,6)
 		if(mimite_growth >= 350)
 			if(!grow_as)

--- a/code/modules/mob/living/simple_animal/hostile/mimite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimite.dm
@@ -185,8 +185,6 @@
 			if(LAZYLEN(things) >= 1)
 				var/atom/movable/T = pick(things)
 				assume(T)
-			else
-				assume(pick(/obj/item/clothing/gloves/color/yellow, /obj/item/clothing/mask/gas/sechailer, /obj/item/cigbutt, /obj/item/reagent_containers/food/drinks/beer/almost_empty, /obj/item/shard, /obj/item/pen, /obj/item/clothing/head/helmet/alt, /obj/item/restraints/handcuffs))
 
 /mob/living/simple_animal/hostile/mimite/can_track(mob/living/user)
 	if(morphed)

--- a/code/modules/mob/living/simple_animal/hostile/mimite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimite.dm
@@ -185,6 +185,8 @@
 			if(LAZYLEN(things) >= 1)
 				var/atom/movable/T = pick(things)
 				assume(T)
+			else
+				approachvent()
 
 /mob/living/simple_animal/hostile/mimite/can_track(mob/living/user)
 	if(morphed)

--- a/code/modules/mob/living/simple_animal/hostile/mimite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimite.dm
@@ -71,10 +71,10 @@
 	var/mimite_stuck_threshold = 10 //if this == mimite_stuck, it'll force the mimite to stop moving
 	var/attemptingventcrawl = FALSE
 
-
 /mob/living/simple_animal/hostile/mimite/Initialize()
 	. = ..()
 	AddElement(/datum/element/point_of_interest)
+	GLOB.all_mimites += src
 	var/image/I = image(icon = 'icons/mob/hud.dmi', icon_state = "hudcultist", layer = DATA_HUD_PLANE, loc = src)
 	I.alpha = 200
 	I.appearance_flags = RESET_ALPHA
@@ -212,7 +212,13 @@
 /mob/living/simple_animal/hostile/mimite/Life()
 	. = ..()
 	if(isturf(loc) && replicate)
-		mimite_growth += rand(1,6)
+		if(LAZYLEN(GLOB.all_mimites) >= 30) //stop replicating if theres 30 or more
+			replicate = FALSE
+			mimite_growth = 0
+		else if(LAZYLEN(GLOB.all_mimites) <=10 && venthunt) //start replicating again if under a total of 10
+			replicate = TRUE
+		if(replicate) //we still want growth and replication if over 10
+			mimite_growth += rand(1,6)
 		if(mimite_growth >= 350)
 			if(!grow_as)
 				grow_as = pick_weight(list(/mob/living/simple_animal/hostile/mimite = 60, /mob/living/simple_animal/hostile/mimite/ranged = 30, /mob/living/simple_animal/hostile/mimite/crate = 10))
@@ -300,6 +306,7 @@
 	return 0
 
 /mob/living/simple_animal/hostile/mimite/death(gibbed)
+	GLOB.all_mimites -= src
 	new /obj/effect/decal/cleanable/oil(get_turf(src))
 	..()
 

--- a/code/modules/mob/living/simple_animal/hostile/mimite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimite.dm
@@ -217,7 +217,7 @@
 		mimite_growth += rand(1,6)
 		if(mimite_growth >= 350 && remaining_replications)
 			if(!grow_as)
-				grow_as = pick_weight(list(/mob/living/simple_animal/hostile/mimite = 60, /mob/living/simple_animal/hostile/mimite/ranged = 30, /mob/living/simple_animal/hostile/mimite/crate = 10))
+				grow_as = pick_weight(list(/mob/living/simple_animal/hostile/mimite = 50, /mob/living/simple_animal/hostile/mimite/ranged = 45, /mob/living/simple_animal/hostile/mimite/crate = 5))
 			var/mob/living/simple_animal/hostile/mimite/S = new grow_as(src.loc)
 			remaining_replications--
 			S.remaining_replications = remaining_replications
@@ -321,7 +321,6 @@
 	melee_damage = 15
 	speed = 4
 	move_to_delay = 4
-	replicate = FALSE
 	venthunt = FALSE
 	morphed = TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/mimite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimite.dm
@@ -71,6 +71,7 @@
 	var/mimite_stuck_threshold = 10 //if this == mimite_stuck, it'll force the mimite to stop moving
 	var/attemptingventcrawl = FALSE
 	var/eventongoing = TRUE
+	var/remaining_replications = 4
 
 /mob/living/simple_animal/hostile/mimite/Initialize()
 	. = ..()
@@ -213,16 +214,13 @@
 /mob/living/simple_animal/hostile/mimite/Life()
 	. = ..()
 	if(isturf(loc) && replicate)
-		if(LAZYLEN(GLOB.all_mimites) >= 30) //stop replicating if theres 30 or more
-			replicate = FALSE
-		else if(LAZYLEN(GLOB.all_mimites) <= 15 && eventongoing) //if event hasnt ended, and theres 15 or less, replicate
-			replicate = TRUE
-		if(replicate) //we still want growth and replication if over 15
-			mimite_growth += rand(1,6)
-		if(mimite_growth >= 350)
+		mimite_growth += rand(1,6)
+		if(mimite_growth >= 350 && remaining_replications)
 			if(!grow_as)
 				grow_as = pick_weight(list(/mob/living/simple_animal/hostile/mimite = 60, /mob/living/simple_animal/hostile/mimite/ranged = 30, /mob/living/simple_animal/hostile/mimite/crate = 10))
 			var/mob/living/simple_animal/hostile/mimite/S = new grow_as(src.loc)
+			remaining_replications--
+			S.remaining_replications = remaining_replications
 			playsound(S.loc, 'sound/effects/meatslap.ogg', 60, TRUE)
 			mimite_growth = 0
 			approachvent()

--- a/code/modules/mob/living/simple_animal/hostile/mimite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimite.dm
@@ -1,4 +1,5 @@
-#define MIMITE_COOLDOWN 80
+#define MIMITE_COOLDOWN 60
+#define MIMITE_VENT_COOLDOWN 100
 
 /mob/living/simple_animal/hostile/mimite
 	name = "Mimite"
@@ -14,13 +15,12 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	deathmessage = "splatters into a pile of black gunk!"
 	del_on_death = TRUE
-
 	response_help = "touches"
 	response_disarm = "pushes"
 	response_harm = "hits"
 	speed = 3
-	maxHealth = 75
-	health = 75
+	maxHealth = 50
+	health = 50
 	gender = NEUTER
 	mob_biotypes = list(MOB_INORGANIC)
 	wander = FALSE
@@ -66,6 +66,11 @@
 	var/travelling_in_vent = 0
 	var/replicate = TRUE
 	var/venthunt = TRUE
+	var/mimite_lastmove = null //Updates/Stores position of the mimite while it's moving
+	var/mimite_stuck = 0	//If mimite_lastmove hasn't changed, this will increment until it reaches mimite_stuck_threshold
+	var/mimite_stuck_threshold = 10 //if this == mimite_stuck, it'll force the mimite to stop moving
+	var/attemptingventcrawl = FALSE
+
 
 /mob/living/simple_animal/hostile/mimite/Initialize()
 	. = ..()
@@ -76,9 +81,9 @@
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/mimites, "hudcultist", I)
 
 /mob/living/simple_animal/hostile/mimite/examine(mob/user)
-	if(morphed)
+	if(morphed && replicate && venthunt)
 		. = form.examine(user)
-		if(get_dist(user,src)<=2)
+		if(get_dist(user,src)<=4)
 			. += "<span class='warning'>It doesn't look quite right...</span>"
 	else
 		. = ..()
@@ -179,6 +184,8 @@
 			if(LAZYLEN(things) >= 1)
 				var/atom/movable/T = pick(things)
 				assume(T)
+			else
+				assume(pick(/obj/item/clothing/gloves/color/yellow, /obj/item/clothing/mask/gas/sechailer, /obj/item/cigbutt, /obj/item/reagent_containers/food/drinks/beer/almost_empty, /obj/item/shard, /obj/item/pen, /obj/item/clothing/head/helmet/alt, /obj/item/restraints/handcuffs))
 
 /mob/living/simple_animal/hostile/mimite/can_track(mob/living/user)
 	if(morphed)
@@ -194,7 +201,7 @@
 /mob/living/simple_animal/hostile/mimite/attack_hand(mob/living/carbon/human/M)
 	if(morphed)
 		M.Knockdown(40)
-		M.reagents.add_reagent(/datum/reagent/toxin/morphvenom/mimite, 10)
+		M.reagents.add_reagent(/datum/reagent/toxin/morphvenom/mimite, 5)
 		to_chat(M, "<span class='userdanger'>[src] bites you!</span>")
 		visible_message("<span class='danger'>[src] violently bites [M]!</span>",\
 				"<span class='userdanger'>You ambush [M]!</span>", null, COMBAT_MESSAGE_RANGE)
@@ -203,70 +210,94 @@
 		..()
 
 /mob/living/simple_animal/hostile/mimite/Life()
-	..()
-	if(QDELETED(entry_vent))
-		entry_vent = null
+	. = ..()
 	if(isturf(loc) && replicate)
-		mimite_growth += rand(0,2)
-		if(mimite_growth >= 250)
+		mimite_growth += rand(1,6)
+		if(mimite_growth >= 350)
 			if(!grow_as)
-				grow_as = pick(/mob/living/simple_animal/hostile/mimite, /mob/living/simple_animal/hostile/mimite/crate, /mob/living/simple_animal/hostile/mimite/ranged)
+				grow_as = pick_weight(list(/mob/living/simple_animal/hostile/mimite = 60, /mob/living/simple_animal/hostile/mimite/ranged = 30, /mob/living/simple_animal/hostile/mimite/crate = 10))
 			var/mob/living/simple_animal/hostile/mimite/S = new grow_as(src.loc)
-			playsound(S.loc, 'sound/effects/meatslap.ogg', 20, TRUE)
+			playsound(S.loc, 'sound/effects/meatslap.ogg', 60, TRUE)
 			mimite_growth = 0
+			approachvent()
 	if(AIStatus == AI_STATUS_OFF || client)
 		return
-	if(venthunt)
-		if(travelling_in_vent)
-			if(isturf(loc))
-				travelling_in_vent = 0
+	if(venthunt && !attemptingventcrawl && mimite_time <= world.time && prob(25))
+		approachvent()
+	if(attemptingventcrawl && entry_vent)
+		SSmove_manager.move_to(src, entry_vent, 1)
+		tryventcrawl()
+	if(isStuck())
+		SSmove_manager.stop_looping(src)
+
+/mob/living/simple_animal/hostile/mimite/proc/approachvent()
+	for(var/obj/machinery/atmospherics/components/unary/vent_pump/v in view(6,src))
+		if(!v.welded)
+			entry_vent = v
+			SSmove_manager.move_to(src, entry_vent, 1)
+			break
+	tryventcrawl()
+
+/mob/living/simple_animal/hostile/mimite/proc/tryventcrawl()
+	attemptingventcrawl = TRUE
+	mimite_time = world.time + MIMITE_VENT_COOLDOWN
+	if(QDELETED(entry_vent))
+		entry_vent = null
+	if(travelling_in_vent)
+		if(isturf(loc))
+			travelling_in_vent = 0
+			entry_vent = null
+			attemptingventcrawl = FALSE
+	else if(entry_vent)
+		if(get_dist(src, entry_vent) <= 3)
+			var/list/vents = list()
+			var/datum/pipeline/entry_vent_parent = entry_vent.parents[1]
+			for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in entry_vent_parent.other_atmosmch)
+				vents.Add(temp_vent)
+			if(!vents.len)
 				entry_vent = null
-		else if(entry_vent)
-			if(get_dist(src, entry_vent) <= 3)
-				var/list/vents = list()
-				var/datum/pipeline/entry_vent_parent = entry_vent.parents[1]
-				for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in entry_vent_parent.other_atmosmch)
-					vents.Add(temp_vent)
-				if(!vents.len)
+				attemptingventcrawl = FALSE
+				return
+			var/obj/machinery/atmospherics/components/unary/vent_pump/exit_vent = pick(vents)
+			var/travel_time = round(get_dist(loc, exit_vent.loc) * 2)
+			travelling_in_vent = 1
+			spawn(travel_time)
+				if(!exit_vent || exit_vent.welded)
+					forceMove(entry_vent)
 					entry_vent = null
+					attemptingventcrawl = FALSE
+					travelling_in_vent = 0
 					return
-				var/obj/machinery/atmospherics/components/unary/vent_pump/exit_vent = pick(vents)
-				if(prob(50))
+				else
 					visible_message("<B>[src] scrambles into the ventilation ducts!</B>", \
-									"<span class='italics'>You hear something scampering through the ventilation ducts.</span>")
+					"<span class='italics'>You hear something scampering through the ventilation ducts.</span>")
+					forceMove(exit_vent.loc)
+					entry_vent = null
+					attemptingventcrawl = FALSE
+					travelling_in_vent = 0
+					var/area/new_area = get_area(loc)
+					if(new_area)
+						new_area.Entered(src)
+					SSmove_manager.move_away(src, exit_vent, 4)
+	else
+		entry_vent = null
+		attemptingventcrawl = FALSE
+		travelling_in_vent = 0
+		return
 
-				spawn(rand(20,60))
-					forceMove(exit_vent)
-					var/travel_time = round(get_dist(loc, exit_vent.loc) / 2)
-					spawn(travel_time)
-
-						if(!exit_vent || exit_vent.welded)
-							forceMove(entry_vent)
-							entry_vent = null
-							return
-
-						if(prob(50))
-							audible_message("<span class='italics'>You hear something scampering through the ventilation ducts.</span>")
-						sleep(travel_time)
-
-						if(!exit_vent || exit_vent.welded)
-							forceMove(entry_vent)
-							entry_vent = null
-							return
-						forceMove(exit_vent.loc)
-						entry_vent = null
-						var/area/new_area = get_area(loc)
-						if(new_area)
-							new_area.Entered(src)
-						SSmove_manager.move_away(src, exit_vent, 4)
-		//=================
-		else if(prob(1))
-			//ventcrawl!
-			for(var/obj/machinery/atmospherics/components/unary/vent_pump/v in view(6,src))
-				if(!v.welded)
-					entry_vent = v
-					SSmove_manager.move_to(src, entry_vent, 1)
-					break
+/mob/living/simple_animal/hostile/mimite/proc/isStuck()
+	//Check to see if the mimite is stuck due to things like windows or doors or windowdoors
+	if(mimite_lastmove)
+		if(mimite_lastmove == src.loc)
+			if(mimite_stuck_threshold >= ++mimite_stuck)
+				mimite_stuck = 0
+				mimite_lastmove = null
+				return 1
+		else
+			mimite_lastmove = null
+	else
+		mimite_lastmove = src.loc
+	return 0
 
 /mob/living/simple_animal/hostile/mimite/death(gibbed)
 	new /obj/effect/decal/cleanable/oil(get_turf(src))
@@ -315,8 +346,8 @@
 	morphed = FALSE
 	vision_range = 9
 	aggro_vision_range = 9
-	M.Knockdown(60)
-	M.reagents.add_reagent(/datum/reagent/toxin/morphvenom/mimite, 15)
+	M.Knockdown(20)
+	M.reagents.add_reagent(/datum/reagent/toxin/morphvenom/mimite, 10)
 	to_chat(M, "<span class='userdanger'>[src] bites you!</span>")
 	visible_message("<span class='danger'>[src] violently bites [M]!</span>",\
 			"<span class='userdanger'>You ambush [M]!</span>", null, COMBAT_MESSAGE_RANGE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out there where a few missed runtimes, and some issues with venting and travelling across the station.
This fixes those, nerfs the mimites HP and on-click ambush, increases the time between replication, forces a vent on replication so they dont stack up, sets a few backup items to change into if nothing is nearby, and more.

Full list of changes-
Shorter Announce Time
Announce to ghosts
Increased original spawn from 2 to 3
Updated Annoucement message
HP down from 75 to 50
Increased range at which Examine shows something odd
Increased Replication time
Ambush venom amount nerfed
Grow_As is now weighted, so less ambush crates.
Two procs, ApproachVent and TryVentcrawl, to fix venting issues that came with the spiderling code.
Attempt to vent after replication to prevent mob buildup in one location.

Global list for all mimites
Endwhen-60 min
If no mimites exist anymore, announce it
If they exist at the 60 min mark, replication stops completely
Each mimite has a fixed replication cap, each time one replicates, its child inherits the new cap - 1



## Why It's Good For The Game

Fixes good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

(https://github.com/user-attachments/assets/25ae2b47-f482-49d7-864a-c02e145913bf)

</details>





## Changelog
:cl:
add: If all Mimites are dead, an announcement plays.
add: If the Mimite event hits 60 minutes and mimites still alive, they stop replicating entirely
tweak: tweaked replication rate of the Mimites, and added a replication limit
balance: Nerfed Mimite health and ambush venom. Remember that they can be scanned with Discovery Scanners and examine can reveal them.
fix: fixed a few runtimes regarding Mimites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
