### PR TITLE
Removes clumsiness from Clown Operatives 

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -47,12 +47,6 @@
 /datum/outfit/syndicate/clownop/no_crystals
 	tc = 0
 
-/datum/outfit/syndicate/clownop/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.dna.add_mutation(CLOWNMUT)
-
 /datum/outfit/syndicate/clownop/leader
 	name = "Clown Operative Leader - Basic"
 	id = /obj/item/card/id/syndicate/nuke_leader


### PR DESCRIPTION
## About The Pull Request
Removes clumsiness from clown operative leaders and operatives

## Why It's Good For The Game

Picture this. You are a clown op. You get adminbussed into this out of rotation gamemode. You spawn with a pistol. You use that pistol to attack someone. You shoot yourself because, for some reason, you are clumsy. You lose. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![imagen](https://github.com/user-attachments/assets/2ee2b082-dfb8-4a5b-a554-6619c0002bb5)

</details>

## Changelog
:cl: Clownmoff
fix: Removes clown ops clumsiness, which they shouldn't have
/:cl:
