### PR TITLE
Fixes z-mimic having destruction qdel timer when it shouldn't

### DIFF
--- a/code/__DEFINES/zmimic.dm
+++ b/code/__DEFINES/zmimic.dm
@@ -9,10 +9,10 @@
 
 /// Is this movable visible from a turf that is mimicking below? Note: this does not necessarily mean *directly* below.
 #define MOVABLE_IS_BELOW_ZTURF(M) (\
-	isturf(M:loc) && isturf(M:loc?:above) && ( \
-		TURF_IS_MIMICKING(M:loc?:above) \
-		|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M:loc?:above, z_flags, Z_MIMIC_BELOW))  \
-		|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M:loc?:above, z_flags, Z_MIMIC_BELOW))) \
+	isturf(M:loc) && isturf(M:loc:above) && ( \
+		TURF_IS_MIMICKING(M:loc:above) \
+		|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M, above?:z_flags, Z_MIMIC_BELOW))  \
+		|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M, above?:z_flags, Z_MIMIC_BELOW))) \
 )
 /// Is this movable located on a turf that is mimicking below? Note: this does not necessarily mean *directly* on.
 #define MOVABLE_IS_ON_ZTURF(M) (\

--- a/code/__DEFINES/zmimic.dm
+++ b/code/__DEFINES/zmimic.dm
@@ -9,15 +9,17 @@
 
 /// Is this movable visible from a turf that is mimicking below? Note: this does not necessarily mean *directly* below.
 #define MOVABLE_IS_BELOW_ZTURF(M) (\
-	isturf(loc) && (TURF_IS_MIMICKING(loc:above) \
-	|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M, above?:z_flags, Z_MIMIC_BELOW))  \
-	|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M, above?:z_flags, Z_MIMIC_BELOW))) \
+	isturf(M:loc) && isturf(M:loc?:above) && ( \
+		TURF_IS_MIMICKING(M:loc?:above) \
+		|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M:loc?:above, z_flags, Z_MIMIC_BELOW))  \
+		|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M:loc?:above, z_flags, Z_MIMIC_BELOW))) \
 )
 /// Is this movable located on a turf that is mimicking below? Note: this does not necessarily mean *directly* on.
 #define MOVABLE_IS_ON_ZTURF(M) (\
-	isturf(loc) && (TURF_IS_MIMICKING(loc:above) \
-	|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M, z_flags, Z_MIMIC_BELOW)) \
-	|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M, z_flags, Z_MIMIC_BELOW))) \
+	isturf(M:loc) && (\
+		TURF_IS_MIMICKING(M:loc) \
+		|| ((M:zmm_flags & ZMM_LOOKAHEAD) && ZM_INTERNAL_SCAN_LOOKAHEAD(M, z_flags, Z_MIMIC_BELOW)) \
+		|| ((M:zmm_flags & ZMM_LOOKBESIDE) && ZM_INTERNAL_SCAN_LOOKBESIDE(M, z_flags, Z_MIMIC_BELOW))) \
 )
 
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -16,10 +16,14 @@
 		return
 
 	if (MOVABLE_IS_BELOW_ZTURF(src))
+		if(bound_overlay.destruction_timer)
+			deltimer(bound_overlay.destruction_timer)
+			bound_overlay.destruction_timer = null
 		SSzcopy.queued_overlays += bound_overlay
 		bound_overlay.queued += 1
-	else if (bound_overlay && !bound_overlay.destruction_timer)
-		bound_overlay.destruction_timer = QDEL_IN(bound_overlay, 10 SECONDS)
+	else
+		if(!bound_overlay.destruction_timer)
+			bound_overlay.destruction_timer = QDEL_IN(bound_overlay, 10 SECONDS)
 
 // Grabs a list of every openspace mimic that's directly or indirectly copying this object. Returns an empty list if none found.
 /atom/movable/proc/get_associated_mimics()
@@ -194,13 +198,19 @@
 		if (destruction_timer)
 			deltimer(destruction_timer)
 			destruction_timer = null
-	else if (!destruction_timer)
-		destruction_timer = QDEL_IN(src, 10 SECONDS)
+	else
+		if (!destruction_timer)
+			destruction_timer = QDEL_IN(src, 10 SECONDS)
 
 // Called when the turf we're on is deleted/changed.
 /atom/movable/openspace/mimic/proc/owning_turf_changed()
-	if (!destruction_timer)
-		destruction_timer = QDEL_IN(src, 10 SECONDS)
+	if (MOVABLE_IS_BELOW_ZTURF(associated_atom))
+		if (destruction_timer)
+			deltimer(destruction_timer)
+			destruction_timer = null
+	else
+		if (!destruction_timer)
+			destruction_timer = QDEL_IN(src, 10 SECONDS)
 
 // Get actual source atom when orbiting
 /atom/movable/openspace/mimic/get_orbitable()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* fixes https://github.com/BeeStation/BeeStation-Hornet/issues/10883

Fixes z-mimic having destruction qdel timer when it shouldn't


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/d0a4f1f3-e79b-40dd-b70b-7b061b5949fd)

![image](https://github.com/user-attachments/assets/ebf7c6a4-0c84-43df-82a9-30c1943f5cca)

when it's moving, it no longer gets destruction time unnecesarily.


![image](https://github.com/user-attachments/assets/d4fa009d-ed05-4b3f-88b4-56df3d312978)
![image](https://github.com/user-attachments/assets/363b8da2-7a6c-42f3-b1f5-ccfa43611288)

![image](https://github.com/user-attachments/assets/fd0b591f-88a1-43e9-bf06-6a7778746cff)
![image](https://github.com/user-attachments/assets/a2b79938-f44a-4f44-aeee-fb08148722df)

works well


## Changelog
:cl:
fix: Fixed z-mimic having destruction qdel timer when it shouldn't
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
