### PR TITLE
small fix for cameras on explo shuttle

### DIFF
--- a/_maps/shuttles/exploration/exploration_shuttle.dmm
+++ b/_maps/shuttles/exploration/exploration_shuttle.dmm
@@ -167,9 +167,6 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "v" = (
-/obj/machinery/camera/preset{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -262,7 +259,7 @@
 /area/shuttle/exploration)
 "F" = (
 /obj/machinery/camera/preset{
-	dir = 8
+	dir = 6
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
theres two floating cameras on the explo shuttle. this makes it just have one, non-floating camera.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
we shouldnt have floating cameras
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/421bd59a-e0cd-4feb-8d8a-2d4e81e063f8)

</details>

## Changelog
:cl:
fix: fixed floating cameras on the exploration shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
