### PR TITLE
Prevents Free Range Intercoms from Accessing Syndicate and CentCom Radio Channels

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -62,7 +62,7 @@
 #define RADIO_KEY_UPLINK "d"
 #define RADIO_TOKEN_UPLINK ":d"
 
-#define MIN_FREE_FREQ 1201 // -------------------------------------------------
+#define MIN_FREE_FREQ 1339 // -------------------------------------------------
 // Frequencies are always odd numbers and range from 1201 to 1599.
 
 #define FREQ_SYNDICATE 1213  //!  Nuke op comms frequency, dark brown

--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -63,7 +63,7 @@
 #define RADIO_TOKEN_UPLINK ":d"
 
 #define MIN_FREE_FREQ 1339 // -------------------------------------------------
-// Frequencies are always odd numbers and range from 1201 to 1599.
+// Frequencies are always odd numbers and range from 1339 to 1599.
 
 #define FREQ_SYNDICATE 1213  //!  Nuke op comms frequency, dark brown
 #define FREQ_UPLINK 1214   //!  Dummy channel for headset uplink


### PR DESCRIPTION
## About The Pull Request
Fixes #11230.

Simply limits the minimum free range to 1339. It doesn't block any of the normal radio channels.

## Why It's Good For The Game
AIs asking CentCom directly for help with the Blob, Pirates and Xenos? Maybe, but no.

## Testing Photographs and Procedure

<summary>Screenshots&Videos</summary>

Blocks accessing restricted channels.
![image](https://github.com/user-attachments/assets/eddf37a1-fbea-4170-9ecb-be5c1d039728)

Doesn't block normal station channels.
![image](https://github.com/user-attachments/assets/ea58b25f-753e-45f0-a354-c8e5414361b8)

Nor does it block CentCom headset.
![image](https://github.com/user-attachments/assets/8cf3e4bd-9cd9-4f85-8bec-d4f15b0d018d)

</details>

## Changelog
:cl: Markus Larsson
fix: fixed AI having Syndicate and CentCom comms.
/:cl:
