### PR TITLE
Made electric vehicles no longer ignore EMPs

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -425,7 +425,11 @@
 	SIGNAL_HANDLER
 
 	emped = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
+	var/atom/movable/AM = parent
+	AM.add_emitter(/obj/emitter/fire_smoke, "smoke")
+	addtimer(CALLBACK(src, PROC_REF(reboot)), 300 / severity, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
 
 /datum/component/riding/proc/reboot()
 	emped = FALSE
+	var/atom/movable/AM = parent
+	AM.remove_emitter("smoke")

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -424,6 +424,8 @@
 /datum/component/riding/proc/on_emp_act(datum/source, severity)
 	SIGNAL_HANDLER
 
+	if(!empable)
+		return
 	emped = TRUE
 	var/atom/movable/AM = parent
 	AM.add_emitter(/obj/emitter/fire_smoke, "smoke")

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -31,6 +31,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, PROC_REF(vehicle_mob_buckle))
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, PROC_REF(vehicle_mob_unbuckle))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(vehicle_moved))
+	RegisterSignal(parent, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	//Calculate the move multiplier speed, to be proportional to mob speed
 	vehicle_move_multiplier = CONFIG_GET(number/movedelay/run_delay) / 1.5
 
@@ -419,3 +420,12 @@
 		var/mob/living/simple_animal/S = parent
 		S.toggle_ai(AI_ON)
 	..()
+
+/datum/component/riding/proc/on_emp_act(datum/source, severity)
+	SIGNAL_HANDLER
+
+	emped = TRUE
+	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
+
+/datum/component/riding/proc/reboot()
+	emped = FALSE

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -22,6 +22,8 @@
 	var/ride_check_ridden_restrained = FALSE
 
 	var/del_on_unbuckle_all = FALSE
+	var/emped = FALSE
+	var/empable = FALSE
 
 /datum/component/riding/Initialize()
 	if(!ismovable(parent))
@@ -171,6 +173,9 @@
 		return
 	last_vehicle_move = world.time
 
+	if(emped && empable)
+		to_chat(user, "<span class='notice'>\The [AM]'s controls aren't responding!</span>")
+		return
 	if(keycheck(user))
 		var/turf/next = get_step(AM, direction)
 		var/turf/current = get_turf(AM)

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -11,8 +11,10 @@
 
 /obj/vehicle/ridden/atv/Initialize(mapload)
 	. = ..()
+	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
+	D.empable = TRUE
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
@@ -101,4 +103,16 @@
 
 /obj/vehicle/ridden/atv/Destroy()
 	STOP_PROCESSING(SSobj,src)
+	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	return ..()
+
+/obj/vehicle/ridden/atv/proc/on_emp_act(datum/source, severity)
+	SIGNAL_HANDLER
+
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = TRUE
+	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
+
+/obj/vehicle/ridden/atv/proc/reboot()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = FALSE

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -11,7 +11,6 @@
 
 /obj/vehicle/ridden/atv/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
 	D.empable = TRUE
@@ -103,16 +102,4 @@
 
 /obj/vehicle/ridden/atv/Destroy()
 	STOP_PROCESSING(SSobj,src)
-	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	return ..()
-
-/obj/vehicle/ridden/atv/proc/on_emp_act(datum/source, severity)
-	SIGNAL_HANDLER
-
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
-
-/obj/vehicle/ridden/atv/proc/reboot()
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = FALSE

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -13,10 +13,6 @@
 	var/obj/item/stock_parts/cell/power_cell
 	var/low_power_alerted = FALSE
 
-/obj/vehicle/ridden/wheelchair/motorized/Initialize(mapload)
-	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
-
 /obj/vehicle/ridden/wheelchair/motorized/CheckParts(list/parts_list)
 	..()
 	refresh_parts()
@@ -36,7 +32,6 @@
 	return power_cell
 
 /obj/vehicle/ridden/wheelchair/motorized/obj_destruction(damage_flag)
-	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/A in contents)
 		A.forceMove(T)
@@ -177,14 +172,3 @@
 		else
 			visible_message("<span class='danger'>[src] crashes into [M], sending [H] flying!</span>")
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
-
-/obj/vehicle/ridden/wheelchair/motorized/proc/on_emp_act(datum/source, severity)
-	SIGNAL_HANDLER
-
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
-
-/obj/vehicle/ridden/wheelchair/motorized/proc/reboot()
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = FALSE

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -13,6 +13,10 @@
 	var/obj/item/stock_parts/cell/power_cell
 	var/low_power_alerted = FALSE
 
+/obj/vehicle/ridden/wheelchair/motorized/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
+
 /obj/vehicle/ridden/wheelchair/motorized/CheckParts(list/parts_list)
 	..()
 	refresh_parts()
@@ -25,12 +29,14 @@
 		power_efficiency = C.rating
 	var/datum/component/riding/D = GetComponent(/datum/component/riding)
 	D.vehicle_move_delay = round(1.5 * delay_multiplier) / speed
+	D.empable = TRUE
 
 
 /obj/vehicle/ridden/wheelchair/motorized/get_cell()
 	return power_cell
 
 /obj/vehicle/ridden/wheelchair/motorized/obj_destruction(damage_flag)
+	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/A in contents)
 		A.forceMove(T)
@@ -171,3 +177,14 @@
 		else
 			visible_message("<span class='danger'>[src] crashes into [M], sending [H] flying!</span>")
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
+
+/obj/vehicle/ridden/wheelchair/motorized/proc/on_emp_act(datum/source, severity)
+	SIGNAL_HANDLER
+
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = TRUE
+	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
+
+/obj/vehicle/ridden/wheelchair/motorized/proc/reboot()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = FALSE

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -11,7 +11,6 @@
 /obj/vehicle/ridden/janicart/Initialize(mapload)
 	. = ..()
 	update_icon()
-	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
 	D.empable = TRUE
@@ -21,7 +20,6 @@
 
 /obj/vehicle/ridden/janicart/Destroy()
 	GLOB.janitor_devices -= src
-	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	if(mybag)
 		qdel(mybag)
 		mybag = null
@@ -95,17 +93,6 @@
 	if(floorbuffer)
 		autoclean_toggle.toggle_target = null
 		QDEL_NULL(autoclean_toggle)
-
-/obj/vehicle/ridden/janicart/proc/on_emp_act(datum/source, severity)
-	SIGNAL_HANDLER
-
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
-
-/obj/vehicle/ridden/janicart/proc/reboot()
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = FALSE
 
 /obj/vehicle/ridden/janicart/upgraded
 	floorbuffer = TRUE

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -11,14 +11,17 @@
 /obj/vehicle/ridden/janicart/Initialize(mapload)
 	. = ..()
 	update_icon()
+	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 7), TEXT_EAST = list(-12, 7), TEXT_WEST = list( 12, 7)))
+	D.empable = TRUE
 	GLOB.janitor_devices += src
 	if(floorbuffer)
 		AddElement(/datum/element/cleaning)
 
 /obj/vehicle/ridden/janicart/Destroy()
 	GLOB.janitor_devices -= src
+	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	if(mybag)
 		qdel(mybag)
 		mybag = null
@@ -92,6 +95,17 @@
 	if(floorbuffer)
 		autoclean_toggle.toggle_target = null
 		QDEL_NULL(autoclean_toggle)
+
+/obj/vehicle/ridden/janicart/proc/on_emp_act(datum/source, severity)
+	SIGNAL_HANDLER
+
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = TRUE
+	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
+
+/obj/vehicle/ridden/janicart/proc/reboot()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = FALSE
 
 /obj/vehicle/ridden/janicart/upgraded
 	floorbuffer = TRUE

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -10,8 +10,10 @@
 
 /obj/vehicle/ridden/secway/Initialize(mapload)
 	. = ..()
+	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
+	D.empable = TRUE
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
 
 /obj/vehicle/ridden/secway/obj_break()
@@ -44,6 +46,7 @@
 
 /obj/vehicle/ridden/secway/Destroy()
 	STOP_PROCESSING(SSobj,src)
+	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	return ..()
 
 /obj/vehicle/ridden/secway/bullet_act(obj/projectile/P)
@@ -52,3 +55,14 @@
 			M.bullet_act(P)
 		return TRUE
 	return ..()
+
+/obj/vehicle/ridden/secway/proc/on_emp_act(datum/source, severity)
+	SIGNAL_HANDLER
+
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = TRUE
+	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
+
+/obj/vehicle/ridden/secway/proc/reboot()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.emped = FALSE

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -10,7 +10,6 @@
 
 /obj/vehicle/ridden/secway/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
 	D.empable = TRUE
@@ -46,7 +45,6 @@
 
 /obj/vehicle/ridden/secway/Destroy()
 	STOP_PROCESSING(SSobj,src)
-	UnregisterSignal(src, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	return ..()
 
 /obj/vehicle/ridden/secway/bullet_act(obj/projectile/P)
@@ -55,14 +53,3 @@
 			M.bullet_act(P)
 		return TRUE
 	return ..()
-
-/obj/vehicle/ridden/secway/proc/on_emp_act(datum/source, severity)
-	SIGNAL_HANDLER
-
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 300, TIMER_UNIQUE|TIMER_OVERRIDE) //if a new EMP happens, remove the old timer so it doesn't reactivate early
-
-/obj/vehicle/ridden/secway/proc/reboot()
-	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.emped = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Made electric vehicles, such as the secway, the janicart, the ATV and the electric wheelchair no longer ignore EMPs

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Electrical vehicles should not bypass EMPs, as EMPs are made to disrupt electrical connections. Also gives vehicles atleast one downside now.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Multiple vehicles no longer ignore EMPs:

https://github.com/user-attachments/assets/1c467a2a-27a3-4c9a-8a47-0b74c42e4435

Visual effect added:

https://github.com/user-attachments/assets/02b060c0-77f9-4241-be0f-32a92ee6d6b9



</details>

## Changelog
:cl: XeonMations
balance: Electric vehicles such as the janicart, secway, electric wheelchair and ATV now are affected by EMPs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
