### PR TITLE
clears boxstation /obj/machinery/camera/autoname aberrations

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7459,9 +7459,7 @@
 "bBf" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/black/fourcorners,
-/obj/machinery/camera/motion{
-	dir = 5
-	},
+/obj/machinery/camera/motion/directional/west,
 /turf/open/floor/iron/grid/steel,
 /area/ai_monitored/storage/eva)
 "bBi" = (
@@ -32214,15 +32212,13 @@
 /obj/effect/turf_decal/siding/dark_blue{
 	dir = 4
 	},
-/obj/machinery/camera/motion{
-	c_tag = "AI Upload Chamber - Port";
-	dir = 10;
-	network = list("aiupload")
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/camera/motion/directional/south{
+	network = list("aiupload")
+	},
 /turf/open/floor/iron/grid/steel,
 /area/ai_monitored/turret_protected/ai_upload)
 "jDW" = (
@@ -57689,11 +57685,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/camera/motion{
-	c_tag = "AI Upload Foyer";
-	dir = 6;
-	network = list("aiupload")
-	},
 /obj/item/kirbyplants/photosynthetic{
 	layer = 3.1
 	},
@@ -57704,6 +57695,9 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/motion/directional/east{
+	network = list("aiupload")
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "uyT" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16166,12 +16166,10 @@
 	pixel_y = 24;
 	req_access_txt = "47"
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "cJv" = (
@@ -16227,9 +16225,7 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "cKg" = (
@@ -17259,10 +17255,8 @@
 /obj/machinery/airalarm/directional/south{
 	pixel_y = -22
 	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "dgz" = (
@@ -19032,12 +19026,10 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "dTK" = (
@@ -26818,12 +26810,10 @@
 /turf/open/floor/carpet/green,
 /area/crew_quarters/dorms)
 "hqI" = (
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hqX" = (
@@ -28545,12 +28535,10 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
 "iau" = (
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/bridge)
 "iaG" = (
@@ -29300,10 +29288,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/autoname{
-	dir = 6;
-	network = list("ss13","engine")
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "ioR" = (
@@ -31159,9 +31144,7 @@
 /turf/open/floor/iron,
 /area/quartermaster/storage)
 "jfm" = (
-/obj/machinery/camera/autoname{
-	dir = 10
-	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jfw" = (
@@ -31555,15 +31538,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "joD" = (
@@ -33160,10 +33141,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 10;
-	network = list("ss13","engine")
-	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jYW" = (
@@ -33712,16 +33690,13 @@
 /mob/living/simple_animal/pet/dog/corgi/Ian,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/bed/dogbed/ian,
-/obj/machinery/camera/autoname{
-	c_tag = "Head of Personnel's Office";
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "kns" = (
@@ -36436,12 +36411,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/structure/sign/warning/deathsposal{
 	pixel_x = -32
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "lqJ" = (
@@ -37733,10 +37706,7 @@
 /area/tcommsat/computer)
 "lYs" = (
 /obj/structure/lattice,
-/obj/machinery/camera/autoname{
-	dir = 9;
-	network = list("minisat")
-	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/space,
 /area/space/nearstation)
 "lYu" = (
@@ -40364,13 +40334,10 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/camera/autoname{
-	c_tag = "Command Hallway #1";
-	dir = 5
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
 "nhM" = (
@@ -40702,12 +40669,10 @@
 "npd" = (
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "npw" = (
@@ -41324,12 +41289,10 @@
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/cmo)
 "nCY" = (
@@ -42932,9 +42895,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "okX" = (
@@ -43012,11 +42973,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/yellow,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing/chamber)
 "onS" = (
@@ -43466,10 +43425,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "oxC" = (
-/obj/machinery/camera/autoname{
-	dir = 6;
-	network = list("ss13, prison")
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
@@ -43477,6 +43432,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/techmaint,
 /area/security/prison/shielded)
 "oyM" = (
@@ -44024,15 +43980,12 @@
 /obj/effect/turf_decal/tile/red/anticorner_ramp/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 6;
-	network = list("ss13, prison")
-	},
 /obj/structure/sign/warning/radiation_shelter{
 	pixel_x = 1;
 	pixel_y = 33
 	},
 /obj/effect/landmark/prisonspawn,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/prison,
 /area/security/prison)
 "oLE" = (
@@ -44247,12 +44200,10 @@
 /turf/open/floor/catwalk_floor,
 /area/engine/engineering)
 "oRW" = (
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "oSi" = (
@@ -45463,12 +45414,10 @@
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 24
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/crew_quarters/fitness)
 "ptj" = (
@@ -50540,12 +50489,10 @@
 "rCg" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/bodybags,
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "rCK" = (
@@ -51500,10 +51447,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/bombcloset/security,
-/obj/machinery/camera/autoname{
-	dir = 9;
-	network = list("ss13, security")
-	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rVI" = (
@@ -53123,12 +53067,10 @@
 "sFY" = (
 /obj/machinery/iv_drip,
 /obj/structure/bed/roller,
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "sGk" = (
@@ -53303,10 +53245,8 @@
 /obj/structure/sign/departments/minsky/research/research{
 	pixel_x = 32
 	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
 /obj/effect/spawner/randomvend/cola,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/aft)
 "sJJ" = (
@@ -54585,9 +54525,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tjd" = (
@@ -55509,10 +55447,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 6;
-	network = list("ss13","engine")
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/engine/engineering)
 "tCh" = (
@@ -57892,10 +57827,7 @@
 	},
 /obj/item/storage/box/deputy,
 /obj/item/toy/figure/hos,
-/obj/machinery/camera/autoname{
-	dir = 6;
-	network = list("ss13","security")
-	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "uCp" = (
@@ -59797,12 +59729,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "vxH" = (
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/machinery/light_switch{
 	pixel_x = -28
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "vyv" = (
@@ -61115,10 +61045,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -32
 	},
-/obj/machinery/camera/autoname{
-	dir = 5;
-	network = list("ss13, prison")
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/prison,
 /area/security/prison)
 "wcx" = (
@@ -62028,9 +61955,7 @@
 	dir = 1
 	},
 /obj/machinery/telecomms/server/presets/exploration,
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/circuit/telecomms/server,
 /area/quartermaster/exploration_dock)
 "wvD" = (
@@ -64018,16 +63943,13 @@
 /area/crew_quarters/locker)
 "xsv" = (
 /obj/structure/table/wood,
-/obj/machinery/camera/autoname{
-	c_tag = "Captain's Office";
-	dir = 5
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/recharger{
 	pixel_y = 2
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "xsB" = (
@@ -65462,10 +65384,7 @@
 /area/crew_quarters/heads/hor)
 "xXh" = (
 /obj/structure/lattice,
-/obj/machinery/camera/autoname{
-	dir = 5;
-	network = list("minisat")
-	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/space,
 /area/space/nearstation)
 "xXr" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -29288,7 +29288,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","engine")
+	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "ioR" = (
@@ -33141,7 +33143,9 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("ss13","engine")
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jYW" = (
@@ -37706,7 +37710,9 @@
 /area/tcommsat/computer)
 "lYs" = (
 /obj/structure/lattice,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13", "minisat")
+	},
 /turf/open/space,
 /area/space/nearstation)
 "lYu" = (
@@ -43432,7 +43438,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13, prison")
+	},
 /turf/open/floor/iron/techmaint,
 /area/security/prison/shielded)
 "oyM" = (
@@ -43985,7 +43993,9 @@
 	pixel_y = 33
 	},
 /obj/effect/landmark/prisonspawn,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13, prison")
+	},
 /turf/open/floor/prison,
 /area/security/prison)
 "oLE" = (
@@ -51447,7 +51457,9 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/bombcloset/security,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("ss13","security")
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rVI" = (
@@ -55447,7 +55459,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","engine")
+	},
 /turf/open/floor/iron/dark,
 /area/engine/engineering)
 "tCh" = (
@@ -57827,7 +57841,9 @@
 	},
 /obj/item/storage/box/deputy,
 /obj/item/toy/figure/hos,
-/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","security")
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "uCp" = (
@@ -59875,7 +59891,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/south{
-	network = list("ss13, engine")
+	network = list("ss13, prison")
 	},
 /turf/open/floor/prison,
 /area/security/prison)
@@ -65384,7 +65400,9 @@
 /area/crew_quarters/heads/hor)
 "xXh" = (
 /obj/structure/lattice,
-/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("ss13", "minisat")
+	},
 /turf/open/space,
 /area/space/nearstation)
 "xXr" = (

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -5889,6 +5889,7 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/quartermaster/exploration_prep)
 "bFD" = (
@@ -31688,13 +31689,6 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/cmo)
-"kgN" = (
-/obj/effect/landmark/start/exploration,
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/quartermaster/exploration_prep)
 "kgX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -32699,6 +32693,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/quartermaster/storage)
 "kvO" = (
@@ -39808,7 +39803,6 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "mHx" = (
-/obj/machinery/camera/autoname/directional/west,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -30
 	},
@@ -74099,9 +74093,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xRL" = (
-/obj/machinery/camera/autoname{
-	dir = 10
-	},
 /obj/structure/table,
 /obj/item/dest_tagger,
 /obj/item/dest_tagger,
@@ -74110,6 +74101,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 32
 	},
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/quartermaster/sorting)
 "xRO" = (
@@ -98483,7 +98475,7 @@ eTb
 iot
 nIR
 bFs
-kgN
+rde
 qCw
 kWB
 iOB

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -44197,8 +44197,7 @@
 	req_access_txt = "16"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 5;
+/obj/machinery/camera/autoname/directional/east{
 	network = list("aiupload")
 	},
 /turf/open/floor/circuit,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Weirdly, all of the `/obj/machinery/camera/autoname` wallitems failed to convert to their directional subtypes in the dir pr, for boxstation.

This led to these remaining on station, and their dirs fucking up.



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These 30 or so cameras out of the so 600 wallitems I processed in the wallitems pr, is getting flak. Its a simple fix.

I want to move past this

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Doesn't apply.

</details>

## Changelog
:cl:
fix: fix boxstation autoname camera directionals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
