### PR TITLE
Makes humans indomitable. (Adds a single non-gameplay changing perk to humans)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -68,6 +68,12 @@
 		SPECIES_PERK_NAME = "Asimov Superiority",
 		SPECIES_PERK_DESC = "The AI and their cyborgs are often (but not always) subservient only \
 			to humans. As a human, silicons are required to both protect and obey you under the Asimov lawset.",
+	),
+	list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = "users",
+		SPECIES_PERK_NAME = "Indomitable Human Spirit",
+		SPECIES_PERK_DESC = "You're a human, you were born to inherit the stars!",
 	))
 
 	if(CONFIG_GET(flag/enforce_human_authority))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a single, non-gameplay changing perk to humans in the preferences menu.

This does not affect the actual species or anything of the sorts

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Humans were born to inherit the stars, might as well add in something that shows it.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/59937a47-a08f-44cf-a1f4-65a9071442ae)

</details>

## Changelog
:cl: XeonMations
add: Humans are now Indomitable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
