### PR TITLE
Removes Missplaced Skeleton Ghost Spawn

### DIFF
--- a/_maps/RandomRooms/10x10/rdm_dorms.dmm
+++ b/_maps/RandomRooms/10x10/rdm_dorms.dmm
@@ -48,11 +48,11 @@
 /turf/open/floor/carpet/purple,
 /area/template_noop)
 "ld" = (
-/obj/effect/mob_spawn/human/skeleton/alive,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/remains/human,
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "mB" = (

--- a/_maps/RandomRooms/10x10/sk_rdm170_laser_tag.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm170_laser_tag.dmm
@@ -53,9 +53,8 @@
 /turf/open/floor/iron/dark,
 /area/template_noop)
 "m" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/skeleton/alive,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/template_noop)
 "o" = (


### PR DESCRIPTION
## About The Pull Request
My mistake when I made the room.

## Why It's Good For The Game
Ghost spawns on station are bad.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

</details>

## Changelog
:cl:
fix: Removed the skeleton ghost spawn in dorm maintenance.
/:cl:
