### PR TITLE
Fixes time freezing once and for all

### DIFF
--- a/code/__DEFINES/explosions.dm
+++ b/code/__DEFINES/explosions.dm
@@ -26,9 +26,7 @@
 	target.ex_act(##args);
 
 // Explodable component deletion values
-/// Makes the explodable component queue to reset its exploding status when it detonates.
-#define EXPLODABLE_NO_DELETE 0
 /// Makes the explodable component delete itself when it detonates.
-#define EXPLODABLE_DELETE_SELF 1
+#define EXPLODABLE_DELETE_SELF 0
 /// Makes the explodable component delete its parent when it detonates.
-#define EXPLODABLE_DELETE_PARENT 2
+#define EXPLODABLE_DELETE_PARENT 1

--- a/code/controllers/subsystem/explosion.dm
+++ b/code/controllers/subsystem/explosion.dm
@@ -558,7 +558,9 @@ SUBSYSTEM_DEF(explosions)
 				new /obj/effect/hotspot(T) //Mostly for ambience!
 		cost_flameturf = MC_AVERAGE(cost_flameturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
-		if (low_turf.len || med_turf.len || high_turf.len)
+		// If a significant amount of turfs change, then we will run lighter for the rest of the tick
+		// because maptick is going to have an unexpected increase.
+		if (low_turf.len + med_turf.len + high_turf.len > 10)
 			Master.laggy_byond_map_update_incoming()
 
 	if(currentpart == SSEXPLOSIONS_MOVABLES)

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -10,8 +10,6 @@
 	var/delete_after
 	/// For items, lets us determine where things should be hit.
 	var/equipped_slot
-	/// it won't explode again if cooldown is on. This is necessary because explosion() proc through SSexplosion doesn't tell if it's exploded
-	COOLDOWN_DECLARE(explosion_cooling)
 
 /datum/component/explodable/Initialize(devastation_range, heavy_impact_range, light_impact_range, flash_range, uncapped = FALSE, delete_after = EXPLODABLE_DELETE_PARENT)
 	if(!isatom(parent))
@@ -125,9 +123,6 @@
 /// Expldoe and remove the object
 /datum/component/explodable/proc/detonate()
 	SIGNAL_HANDLER
-	if(!COOLDOWN_FINISHED(src, explosion_cooling))
-		return // If we don't do this and this doesn't delete it can lock the MC into only processing Input, Timers, and Explosions.
-	COOLDOWN_START(src, explosion_cooling, 1)
 
 	var/atom/bomb = parent
 	explosion(bomb, devastation_range, heavy_impact_range, light_impact_range, flash_range, uncapped) //epic explosion time

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -90,7 +90,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	. = ..()
 	if(ismovable(source))
 		source.AddElement(/datum/element/firestacker, amount=1)
-		source.AddComponent(/datum/component/explodable, 0, 0, amount / 1000, amount / 500, delete_after = EXPLODABLE_NO_DELETE)
+		source.AddComponent(/datum/component/explodable, 0, 0, amount / 1000, amount / 500, delete_after = EXPLODABLE_DELETE_PARENT)
 
 /datum/material/plasma/on_removed(atom/source, amount, material_flags)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This creates a permanent and effective fix for the issue of time freezing, which was caused by plasma exploding in a chain. There was an attempt to resolve this in a previous PR, however it doesn't work as chain-detonations still occur which causes time to freeze.

- Laggy byond map incoming from explosions now requires at least 10 turfs to be affected in order to trigger. This exists to tell the MC that it needs to skip the tick to allocate more time for maptick to run.
- Plasma will now just delete itself when it explodes. It is now impossible to make it so that explodable things can explode without being deleted, because that doesn't make much sense and allows for the failure condition to exist.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/298c77ce-3d5c-472b-9744-5d6badb9336f)

This is very hard to test, but I can confirm this is the reason:

![image](https://github.com/user-attachments/assets/f43ef346-6d08-4d74-9c07-5a0dad94d7ed)


## Changelog
:cl:
fix: Fixes issues with time freezing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
