### PR TITLE
Random Fixes: Nullspace mech, Mining Mech Spawn rate, and a random extra FALSE statement

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -141,4 +141,3 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible
 	hide = FALSE
 	layer = GAS_PIPE_VISIBLE_LAYER
-	hide = FALSE

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -21,5 +21,5 @@
 /obj/effect/spawner/lootdrop/whiteship_cere_ripley
 	name = "25% mech 75% wreckage ripley spawner"
 	loot = list(/obj/vehicle/sealed/mecha/working/ripley/mining = 1,
-				/obj/structure/mecha_wreckage/ripley = 5)
+				/obj/structure/mecha_wreckage/ripley = 3)
 	lootdoubles = FALSE

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -139,10 +139,6 @@
 
 /obj/vehicle/sealed/mecha/working/ripley/mining/Initialize(mapload)
 	. = ..()
-	take_damage(125) // Low starting health
-
-/obj/vehicle/sealed/mecha/working/ripley/mining/Initialize(mapload)
-	. = ..()
 	if(cell)
 		cell.charge = FLOOR(cell.charge * 0.25, 1) //Starts at very low charge
 	if(prob(70)) //Maybe add a drill
@@ -162,7 +158,7 @@
 	HC.attach(src)
 
 	take_damage(max_integrity * 0.5, sound_effect=FALSE) //Low starting health
-	
+
 	var/obj/item/mecha_parts/mecha_equipment/mining_scanner/scanner = new
 	scanner.attach(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

So apparently there was a 25% chance every time you loaded into a world that the mining ripley spawner will try to spawn a mining ripley, only to have it immediately qdel and cause issues (oversight from https://github.com/BeeStation/BeeStation-Hornet/pull/10979 ) since there were two Initialize() being executed one after another. Additionally, the "25% mech 75% wreckage" spawner was actually more like "16% mech 83% wreckage", another oversight from /tg/ I guess?

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Every fix helps

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

as expected, 25% chance

![image](https://github.com/user-attachments/assets/fc8d8ed4-063f-40f0-948b-64686cce1bb3)

</details>

## Changelog
:cl:
fix: Oversight which made infrequent runtimes with mining mechs
fix: Mining mechs should actually spawn 25% of the time instead of 16% of the time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
