### PR TITLE
Moves security techfab to the wardens office

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -27907,8 +27907,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "hRz" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -38210,12 +38208,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/exploration_dock)
-"mnG" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/main)
 "mnP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -38340,11 +38332,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mrB" = (
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
 /obj/machinery/light,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "mso" = (
@@ -96072,7 +96063,7 @@ gos
 tzr
 aEU
 aEU
-mnG
+aEU
 aEU
 eQj
 xTq

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -56389,13 +56389,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "sim" = (
-/obj/structure/table,
-/obj/item/melee/baton/loaded,
-/obj/item/restraints/handcuffs,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "siu" = (
@@ -59287,6 +59285,7 @@
 	dir = 1;
 	pixel_y = 24
 	},
+/obj/item/melee/baton/loaded,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "tgl" = (
@@ -70507,7 +70506,6 @@
 /area/maintenance/starboard/secondary)
 "wKV" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	pixel_x = -8;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -35689,11 +35689,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/security/main)
 "eQK" = (
@@ -63084,11 +63083,6 @@
 	},
 /turf/open/floor/prison,
 /area/security/prison)
-"nWG" = (
-/obj/effect/turf_decal/loading_area,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron,
-/area/security/main)
 "nWQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -74714,20 +74708,17 @@
 /turf/open/floor/iron/dark,
 /area/chapel/office)
 "rUM" = (
-/obj/structure/table/reinforced,
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -23
 	},
-/obj/item/clipboard,
-/obj/item/toy/figure/warden,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/security/warden)
 "rUZ" = (
@@ -89051,6 +89042,7 @@
 	dir = 4;
 	name = "Warden's Desk"
 	},
+/obj/item/toy/figure/warden,
 /turf/open/floor/iron,
 /area/security/warden)
 "wKK" = (
@@ -147072,7 +147064,7 @@ bgZ
 aaa
 bhe
 eQF
-nWG
+frY
 frY
 jjc
 kRr

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -3621,10 +3621,10 @@
 	dir = 6
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13","security")
 	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/security/brig)
 "btw" = (
@@ -24752,14 +24752,13 @@
 	alpha = 180;
 	dir = 4
 	},
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/bot,
 /obj/machinery/newscaster{
 	pixel_y = 33
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "mtK" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -30726,6 +30726,7 @@
 	id = "BrigFlashAft";
 	pixel_y = 25
 	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "hPW" = (
@@ -46753,10 +46754,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "lOm" = (
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/techmaint,
 /area/security/brig)
 "lOq" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -62330,6 +62330,7 @@
 	pixel_x = 4;
 	pixel_y = 2
 	},
+/obj/item/storage/box/deputy,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "oxq" = (
@@ -67502,8 +67503,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/security/main)
 "qgm" = (
@@ -71485,10 +71484,6 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rwa" = (
-/obj/structure/table,
-/obj/item/storage/box/deputy,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
@@ -71499,6 +71494,8 @@
 /obj/machinery/camera/autoname/directional/west{
 	network = list("ss13", "security")
 	},
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "rws" = (
@@ -76046,6 +76043,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/item/hand_labeler,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "sZF" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1758,9 +1758,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aqa" = (
@@ -28923,13 +28921,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
-"fPI" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/tile/red/anticorner,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 1
-	},
-/area/security/main)
 "fPP" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;27;37"
@@ -111362,7 +111353,7 @@ hPH
 kqh
 jgG
 kqh
-fPI
+itu
 aqa
 ajm
 dEQ

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -16617,21 +16617,10 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/pen/red{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/folder/red{
-	pixel_x = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "fkr" = (
@@ -20964,8 +20953,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/bot,
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/security/main{
 	name = "Security Locker Room"
@@ -32448,9 +32436,6 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/security/main{
@@ -50743,6 +50728,17 @@
 	},
 /obj/item/firing_pin/off_station{
 	pixel_y = 11
+	},
+/obj/item/folder/red{
+	pixel_x = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/pen/red{
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
 /area/security/warden)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the security techfab from a place accessible by security officers and detectives to a place limited to the HOS, Warden, and Captain, that place being the warden's office. Their office is a little cramped so on some maps they lose a table, others a photocopier, nothing of huge value was lost. Anything of value got pushed to a different table. 

In terms of difficulty to access, it is quite a bit harder to get access to on some maps and quite a bit easier on others than before. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Right now, you can waltz up to the techfab and print a ton of guns, then mindshield pin them, and have more guns than the armory without ever talking to the HOS or warden or raising the alert. That's a little shitty especially since the warden's whole job is taking care of the armory and distributing equipment from it. It doesn't help that a lot of the printable items are straight up better than their armory equivalent. 

This will give the warden more purpose, encourage cap/hos/etc promoting people to acting Warden/HOS, and makes gaming more difficult. Yeah, someone could still walk around with an ion carbine in their bag on green but now they'd have to get another person complicit. That's a lot bigger of a barrier to entry than just printing a gun silently and running off. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2024-08-05 153108](https://github.com/user-attachments/assets/79e24d14-dd04-42fc-9abd-585b74d2e5ab)
![Screenshot 2024-08-05 153120](https://github.com/user-attachments/assets/a11df008-dabd-4158-a2cb-673f0c212bcb)
![Screenshot 2024-08-05 153136](https://github.com/user-attachments/assets/c3c33ce6-3af6-4c02-a7f7-97cec3c69634)
![Screenshot 2024-08-05 153152](https://github.com/user-attachments/assets/d9177c8f-1ec3-4f1f-b80c-2df51a4ab187)
![Screenshot 2024-08-05 153206](https://github.com/user-attachments/assets/71b4c3b4-db8b-482a-8ebf-a75895e219e1)
![Screenshot 2024-08-05 153218](https://github.com/user-attachments/assets/f3acb791-17de-42a0-83b6-7f1b2442d399)
![Screenshot 2024-08-05 153234](https://github.com/user-attachments/assets/b79a5d3d-a1c6-43e6-90d7-d3c430d16716)
![Screenshot 2024-08-05 153247](https://github.com/user-attachments/assets/459067be-b3bc-46f5-95cc-9a6b7521cf85)

</details>

## Changelog
:cl:
tweak: Moved the security techfab to the warden office
balance: Security techfab is now inaccessible to security officers and detectives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
