### PR TITLE
Delta Science Doors Fix

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -81836,15 +81836,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"utb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/tcommsat/server)
 "utc" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -133213,7 +133204,7 @@ bUI
 bXa
 cSI
 cSI
-utb
+mUm
 ceA
 vCq
 dzh

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -29637,9 +29637,6 @@
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/spawner/sillycons{
-	pixel_x = 8
-	},
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/hor)
 "dCn" = (
@@ -70504,9 +70501,6 @@
 	},
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/effect/spawner/sillycons{
-	pixel_x = 8
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qAS" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1932,8 +1932,6 @@
 "anB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "anD" = (
@@ -28282,9 +28280,6 @@
 /area/science/misc_lab/range)
 "drC" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "drP" = (
@@ -52853,6 +52848,10 @@
 /turf/open/floor/iron,
 /area/quartermaster/office)
 "kFK" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "kFO" = (
@@ -72920,12 +72919,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Research Testing Range";
-	req_one_access_txt = "47"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	req_one_access_txt = "47";
+	name = "Research Testing Range"
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
@@ -76385,14 +76384,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "syU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -26344,7 +26344,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/maintenance/aft)
 "dbu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -29063,9 +29063,8 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
 "dxX" = (
-/obj/structure/cable/white,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -29643,6 +29642,9 @@
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/spawner/sillycons{
+	pixel_x = 8
+	},
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/hor)
 "dCn" = (
@@ -32005,7 +32007,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
+/area/maintenance/aft)
 "dTY" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
@@ -33506,7 +33508,7 @@
 	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Shuttle dock";
-	req_one_access = "47"
+	req_one_access_txt = "47"
 	},
 /turf/open/floor/iron,
 /area/science/shuttledock)
@@ -38548,7 +38550,7 @@
 	req_access_txt = "5"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/maintenance/starboard/aft)
 "fOK" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -47576,10 +47578,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/command{
-	name = "Research Director's Quarters";
-	req_access_txt = "30"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47965,7 +47963,7 @@
 	name = "isolation shutters"
 	},
 /turf/open/floor/iron,
-/area/medical/virology)
+/area/maintenance/aft)
 "iXX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70507,6 +70505,9 @@
 	},
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/effect/spawner/sillycons{
+	pixel_x = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qAS" = (
@@ -72921,7 +72922,7 @@
 	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Testing Range";
-	req_one_access = "47"
+	req_one_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81197,7 +81198,7 @@
 	name = "isolation shutters"
 	},
 /turf/open/floor/iron,
-/area/medical/surgery)
+/area/maintenance/starboard/aft)
 "uit" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"


### PR DESCRIPTION
## About The Pull Request
Fixes Delta Science doors to use the correct var. ("req_one_access_txt" instead of "req_one_access" lol)

Changed Medbay maintenance doors to use maintenance power to follow the rest of the maps standard for area placement.

And added a one more floor catwalk to telecomms.

## Why It's Good For The Game
Scientists wanna use the Science doors.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
These two doors.

![image](https://github.com/user-attachments/assets/9ee237a0-1f18-413a-940c-06f718ad9900)

![image](https://github.com/user-attachments/assets/9f259d2b-976d-4959-984f-86d5e1468311)

</details>

## Changelog
:cl:
fix: [Delta] Fixed aft Science doors to use the correct variable for access codes.
fix: [Delta] Changed Medbay areas to use the maintenance rooms' area instead to be affected by emergency mode.
tweak: [Delta] Changed glass door to Science testing range to not be see through to make it a better antag hideout.
/:cl:
