### PR TITLE
Removes sleep() from Zfall 

### DIFF
--- a/code/modules/multiz/movement/turf/turf_zfall.dm
+++ b/code/modules/multiz/movement/turf/turf_zfall.dm
@@ -53,16 +53,24 @@
 	if(!can_start_zFall(A, target, force, from_zfall))
 		return FALSE
 	if(from_zfall) // if this is a >1 level fall
-		sleep(2) // This is the delay between falling zlevels. Otherwise zfalls would be instant to the client, which does not look great.
-		var/turf/new_turf = get_turf(A) // make sure we didn't move onto a solid turf, if we did this will perform a zimpact via the caller
-		target = get_step_multiz(new_turf, DOWN)
-		if(!new_turf.can_start_zFall(A, target, force, from_zfall))
-			new_turf.do_z_impact(A, levels - 1)
-			return TRUE // skip parent zimpact - do a zimpact on new turf, the turf below us is solid
-		else if(new_turf != src) // our fall continues... no need to check can_start_zFall again, because we just checked it
-			new_turf.zFall_Move(A, levels, old_loc, target)
-			return TRUE // don't do an impact from the parent caller. essentially terminating the old fall with no actions
+		addtimer(CALLBACK(src, PROC_REF(zFall_Finish), A, levels, force, old_loc, from_zfall), 0.2 SECONDS) // This is the delay between falling zlevels. Otherwise zfalls would be instant to the client, which does not look great.
+	else
+		return zFall_Move(A, levels, old_loc, target)
+
+
+/turf/proc/zFall_Finish(atom/movable/A, levels = 1, force = FALSE, old_loc = null, from_zfall = FALSE)
+	var/turf/new_turf = get_turf(A) // make sure we didn't move onto a solid turf, if we did this will perform a zimpact via the caller
+	var/turf/target = get_step_multiz(new_turf, DOWN)
+	if(!new_turf.can_start_zFall(A, target, force, from_zfall))
+		new_turf.do_z_impact(A, levels - 1)
+		return TRUE // skip parent zimpact - do a zimpact on new turf, the turf below us is solid
+	else if(new_turf != src) // our fall continues... no need to check can_start_zFall again, because we just checked it
+		new_turf.zFall_Move(A, levels, old_loc, target)
+		return TRUE // don't do an impact from the parent caller. essentially terminating the old fall with no actions
+
+	//Duplicating from parent
 	return zFall_Move(A, levels, old_loc, target)
+
 
 /// Actually performs the zfall movement, regardless of if you can fall or not
 /// Pulls any pulls objects onto old turf, if anything is pulling the atom, it's removed

--- a/code/modules/multiz/movement/turf/turf_zfall.dm
+++ b/code/modules/multiz/movement/turf/turf_zfall.dm
@@ -54,6 +54,7 @@
 		return FALSE
 	if(from_zfall) // if this is a >1 level fall
 		addtimer(CALLBACK(src, PROC_REF(zFall_Finish), A, levels, force, old_loc, from_zfall), 0.2 SECONDS) // This is the delay between falling zlevels. Otherwise zfalls would be instant to the client, which does not look great.
+		return TRUE
 	else
 		return zFall_Move(A, levels, old_loc, target)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Zfall currently sleeps for 0.2 seconds to simulate the time spent "falling" from a floor to the floor below.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Sleep() sucks because it means it cannot be hooked into anything with signals. Which is problematic when you are trying to componentize or genericize code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Fall 1 floor vs. Fall 2 floors

![image](https://github.com/user-attachments/assets/f61b568f-bef6-49b7-b38d-34a181ee7ca2)

</details>

## Changelog
:cl:
code: converts zfall sleep() to a timer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
