### PR TITLE
Decluttering admin logs

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -29,6 +29,9 @@ GLOBAL_LIST_INIT(valid_keys, list(
 	"é" = 1, "è" = 1, "ç" = 1, "à" = 1, "ù" = 1,
 	// Scrolling support
 	"ScrollUp" = 1, "ScrollDown" = 1,
+	// CTRLKeys and ShiftKeys support to declutter logs
+	"CtrlW" = 1, "CtrlA" = 1, "CtrlS" = 1, "CtrlD" = 1, "CtrlNorth" = 1, "CtrlWest" = 1, "CtrlSouth" = 1, "CtrlEast" = 1,
+	"ShiftW" = 1, "ShiftA" = 1, "ShiftS" = 1, "ShiftD" = 1, "ShiftNorth" = 1, "ShiftWest" = 1, "ShiftSouth" = 1, "ShiftEast" = 1,
 ))
 
 /proc/input_sanity_check(client/C, key)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds CTRL and SHIFT movement keys to the file to avoid filling the admin log file with useless junk
This also stops the server from crashing out when someone tries to open the log file.

## Why It's Good For The Game

No more serverwide crash from opening and over-filled log file

Removes this -

![image](https://github.com/user-attachments/assets/2fd9e9e4-3200-4677-81d6-ae579e10b0af)

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
admin: sorted out keypress log clutter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
