### PR TITLE
Lets cyborgs close morgues with the tray and restores some old behaviour

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -350,6 +350,11 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	else
 		to_chat(user, "<span class='warning'>That's not connected to anything!</span>")
 
+/obj/structure/tray/attack_robot(mob/user)
+	if(!user.Adjacent(src))
+		return
+	return attack_hand(user)
+
 /obj/structure/tray/attackby(obj/P, mob/user, params)
 	if(!istype(P, /obj/item/riding_offhand))
 		return ..()
@@ -389,6 +394,10 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	name = "crematorium tray"
 	desc = "Apply body before burning."
 	icon_state = "cremat"
+
+/obj/structure/tray/c_tray/attack_robot(mob/user) //copied behaviour from /obj/structure/bodycontainer/crematorium
+	to_chat(user, "<span class='warning'>[src] is locked against you.</span>")
+	return
 
 /*
  * Morgue tray

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -406,7 +406,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	name = "morgue tray"
 	desc = "Apply corpse before closing."
 	icon_state = "morguet"
-	pass_flags_self = PASSTABLE
+	pass_flags_self = PASSTABLE|LETPASSTHROW
 
 /obj/structure/tray/m_tray/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Makes thrown items pass over trays and by extension also lets people click on the morgue itself to close it again.
Also lets cyborgs close morgues by clicking on the connected tray, the same behaviour as it is for humans right now.
Resolves #11321 

## Why It's Good For The Game

Easier time to close morgues and consistency for cyborgs to close them via the tray as well.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/3ecf467c-d3c5-4259-bbe2-c81a3fa8918d

https://github.com/user-attachments/assets/ff9f54fd-cea5-4a45-a7f1-df3b4d2efb9c

</details>

## Changelog
:cl:
fix: ability to close morgues when adjacent without having to click on the tray
fix: cyborgs can now close morgues by clicking on the tray
/:cl: