### PR TITLE
Mechs forcefully eject their occupants when destroyed

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 // uncomment this for a map you need to use
 // #define FORCE_MAP "corgstation"

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 // uncomment this for a map you need to use
 // #define FORCE_MAP "corgstation"

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -116,19 +116,25 @@
 		if (isliving(AM))
 			var/mob/living/L = AM
 			L.notransform = TRUE
-			L.Paralyze(20 SECONDS)
+			L.Paralyze(2 SECONDS)
+
+		if(ismecha(AM))
+			var/obj/vehicle/sealed/mecha/mech = AM
+			mech.canmove = FALSE
 
 		var/oldtransform = AM.transform
 		var/oldcolor = AM.color
 		var/oldalpha = AM.alpha
-		animate(AM, transform = matrix() - matrix(), alpha = 0, color = rgb(0, 0, 0), time = 10)
+		animate(AM, transform = matrix() - matrix(), alpha = 0, color = rgb(0, 0, 0), time = 15)
 		for(var/i in 1 to 5)
 			//Make sure the item is still there after our sleep
 			if(!AM || QDELETED(AM))
 				return
 			AM.pixel_y--
-			sleep(2)
-
+			sleep(3)
+			if(i == 2 && ismecha(AM))
+				var/obj/vehicle/sealed/mecha/mech = AM
+				mech.Eject() //ABORT ABORT
 		//Make sure the item is still there after our sleep
 		if(!AM || QDELETED(AM))
 			return

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -212,14 +212,20 @@
 	become_hearing_sensitive(trait_source = ROUNDSTART_TRAIT)
 	update_step_speed()
 
-/obj/vehicle/sealed/mecha/Destroy()
+//separate proc so that the ejection mechanism can be easily triggered by other things, such as admins
+/obj/vehicle/sealed/mecha/proc/Eject()
 	for(var/M in occupants)
 		var/mob/living/occupant = M
 		if(isAI(occupant))
 			occupant.gib() //No wreck, no AI to recover
 		else
-			occupant.forceMove(loc)
 			occupant.SetSleeping(destruction_sleep_duration)
+			occupant.throwing = TRUE //This is somewhat hacky, but is the best option available to avoid chasm detection for the split second between the next two lines
+			occupant.forceMove(loc)
+			occupant.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(5, 8),rand(5, 8)) //resets the variable above.
+			to_chat(occupant, "<span class='userdanger'>You are forcefully ejected from the mech!</span>")
+/obj/vehicle/sealed/mecha/Destroy()
+	Eject()
 	if(LAZYLEN(equipment))
 		for(var/E in equipment)
 			var/obj/item/mecha_parts/mecha_equipment/equip = E

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -127,8 +127,8 @@
 
 	///TIme taken to leave the mech
 	var/exit_delay = 2 SECONDS
-	///Time you get slept for if you get forcible ejected by the mech exploding
-	var/destruction_sleep_duration = 2 SECONDS
+	///Time you get knocked down for if you get forcible ejected by the mech exploding
+	var/destruction_knockdown_duration = 4 SECONDS
 	///Whether outside viewers can see the pilot inside
 	var/enclosed = TRUE
 	///In case theres a different iconstate for AI/MMI pilot(currently only used for ripley)
@@ -219,11 +219,14 @@
 		if(isAI(occupant))
 			occupant.gib() //No wreck, no AI to recover
 		else
-			occupant.SetSleeping(destruction_sleep_duration)
+			occupant.Knockdown(destruction_knockdown_duration)
 			occupant.throwing = TRUE //This is somewhat hacky, but is the best option available to avoid chasm detection for the split second between the next two lines
 			occupant.forceMove(loc)
-			occupant.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(5, 8),rand(5, 8)) //resets the variable above.
-			to_chat(occupant, "<span class='userdanger'>You are forcefully ejected from the mech!</span>")
+			occupant.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(5, 8),rand(5, 8)) //resets the throwing variable above.
+			occupant.visible_message("<span class='userdanger'>[occupant] is forcefully ejected from the mech!</span>", "<span class='userdanger'>You are forcefully ejected from the mech!</span>", null, COMBAT_MESSAGE_RANGE)
+			playsound(src, 'sound/machines/scanbuzz.ogg', 60, FALSE)
+			playsound(src, 'sound/vehicles/carcannon1.ogg', 150, TRUE)
+
 /obj/vehicle/sealed/mecha/Destroy()
 	Eject()
 	if(LAZYLEN(equipment))

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -223,7 +223,7 @@
 			occupant.Knockdown(destruction_knockdown_duration)
 			occupant.throwing = TRUE //This is somewhat hacky, but is the best option available to avoid chasm detection for the split second between the next two lines
 			occupant.forceMove(get_turf(loc))
-			occupant.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(5, 8),rand(5, 8)) //resets the throwing variable above.
+			occupant.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(5, 8),rand(5, 8)) //resets the throwing variable above. Random values are independant on purpose to give variance to damage on wallslams and the distance the occupant is ejected.
 			occupant.visible_message("<span class='userdanger'>[occupant] is forcefully ejected from the mech!</span>", "<span class='userdanger'>You are forcefully ejected from the mech!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(src, 'sound/machines/scanbuzz.ogg', 60, FALSE)
 			playsound(src, 'sound/vehicles/carcannon1.ogg', 150, TRUE)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -219,6 +219,7 @@
 		if(isAI(occupant))
 			occupant.gib() //No wreck, no AI to recover
 		else
+			occupant.Stun(2 SECONDS)
 			occupant.Knockdown(destruction_knockdown_duration)
 			occupant.throwing = TRUE //This is somewhat hacky, but is the best option available to avoid chasm detection for the split second between the next two lines
 			occupant.forceMove(loc)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -222,7 +222,7 @@
 			occupant.Stun(2 SECONDS)
 			occupant.Knockdown(destruction_knockdown_duration)
 			occupant.throwing = TRUE //This is somewhat hacky, but is the best option available to avoid chasm detection for the split second between the next two lines
-			occupant.forceMove(loc)
+			occupant.forceMove(get_turf(loc))
 			occupant.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(5, 8),rand(5, 8)) //resets the throwing variable above.
 			occupant.visible_message("<span class='userdanger'>[occupant] is forcefully ejected from the mech!</span>", "<span class='userdanger'>You are forcefully ejected from the mech!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(src, 'sound/machines/scanbuzz.ogg', 60, FALSE)

--- a/code/modules/vehicles/mecha/combat/combat.dm
+++ b/code/modules/vehicles/mecha/combat/combat.dm
@@ -4,7 +4,7 @@
 	internal_damage_threshold = 50
 	armor = list(MELEE = 30,  BULLET = 30, LASER = 15, ENERGY = 20, BOMB = 20, BIO = 0, RAD = 0, FIRE = 100, ACID = 100, STAMINA = 0, BLEED = 0)
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
-	destruction_sleep_duration = 40
+	destruction_knockdown_duration = 8 SECONDS
 	exit_delay = 40
 
 /obj/vehicle/sealed/mecha/combat/restore_equipment()

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -30,7 +30,7 @@
 	internals_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
 	max_equip = 5
-	destruction_sleep_duration = 20
+	destruction_knockdown_duration = 2 SECONDS //Syndi mechs get reduced knockdown
 
 /obj/vehicle/sealed/mecha/combat/gygax/dark/loaded/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/mecha/combat/marauder.dm
+++ b/code/modules/vehicles/mecha/combat/marauder.dm
@@ -74,7 +74,7 @@
 	internals_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/mauler
 	max_equip = 6
-	destruction_sleep_duration = 20
+	destruction_knockdown_duration = 2 SECONDS //Syndi mechs get reduced knockdown
 
 /obj/vehicle/sealed/mecha/combat/marauder/mauler/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Mechs now forcefully eject their occupants in a random direction, which guarantees* extra safety for miners that may fall into chasms with the new Clarke mech! This also means combat mechs will no longer drop the occupant on the same tile as the mech when destroyed and will instead forcefully eject them in a random direction, potentially into their attacker, or in some hilarious situations, straight into disposals!
* Mechs play two sound effects when this function happens, a buzzing sound and a launching sound
* Mechs no longer inflict sleeping when ejecting their occupant, instead they stun for two seconds (regardless of mech) and knockdown for 2-8 seconds depending on the mech. Syndicate mechs are two seconds (which overlaps the stun), non-combat NT mechs are 4 seconds and non-syndicate combat mechs are 8 seconds.
* Mechs are no longer able to move when falling into a chasm
* Since falling into a chasm takes two seconds, I extended the falling animation from 1 second to 1.5 seconds before the sprite fades from view. This was also done for better dramatic timing of the mech ejection and is not likely to be noticed by anyone. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It really *really* sucks getting dropped into a chasm under any circumstances, but even moreso when piloting a clunky mech that can't strafe. This greatly improves the chances for miners to survive chasm falls while using mechs, and at the very least almost guarantees a recoverable body. 

Likewise the forced ejection in a random direction made mech pilots a bit more slippery than before, and sleeping when ejected made no sense at all so I've swapped it for a hard stun + knockdown instead. The knockdown counteracts the ejection distance for most station mechs, while nuclear operative mechs will actually benefit from having their pilots be a bit more slippery after this PR. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

https://github.com/user-attachments/assets/8c378f09-6ea0-44c0-b82b-d025cec2ee9d

## Changelog
:cl:
tweak: Mechs now fling their occupants in a random direction upon destruction, including when a mech falls down a chasm. 
code: Mechs now have an Eject() proc that can be called directly without destroying the mech. 
fix: Mechs can no longer continue walking around when falling into a chasm
tweak: Mechs no longer put pilots to sleep when breaking, instead stunning the pilot and knocking them down for a time dependant on the type of mech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
