### PR TITLE
Pacifies all pets spawned by Xenobiology's Stabilized Gold

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -938,6 +938,7 @@
 	var/obj/item/slimecross/stabilized/gold/linked = linked_extract
 	if(QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
+		familiar.a_intent = "help"
 		familiar.name = linked.mob_name
 		familiar.del_on_death = TRUE
 		familiar.copy_languages(owner, LANGUAGE_MASTER)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -934,11 +934,16 @@
 	colour = "gold"
 	var/mob/living/simple_animal/familiar
 
+/datum/status_effect/stabilized/gold/proc/on_attack()
+	SIGNAL_HANDLER
+	return COMPONENT_HOSTILE_NO_ATTACK
+
 /datum/status_effect/stabilized/gold/tick()
 	var/obj/item/slimecross/stabilized/gold/linked = linked_extract
 	if(QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
 		familiar.a_intent = "help"
+		RegisterSignal(familiar, COMSIG_HOSTILE_ATTACKINGTARGET, PROC_REF(on_attack))
 		familiar.name = linked.mob_name
 		familiar.del_on_death = TRUE
 		familiar.copy_languages(owner, LANGUAGE_MASTER)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -939,8 +939,9 @@
 	if(QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
 		familiar.a_intent = "help"
-		ADD_TRAIT(familiar, TRAIT_PACIFISM, "stabilized gold")
+		ADD_TRAIT(familiar, TRAIT_PACIFISM, "stabilizedgold")
 		familiar.melee_damage = 0
+		familiar.remove_verb(/mob/living/simple_animal/parrot/proc/toggle_mode) // just in case
 		familiar.name = linked.mob_name
 		familiar.del_on_death = TRUE
 		familiar.copy_languages(owner, LANGUAGE_MASTER)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -938,7 +938,7 @@
 	var/obj/item/slimecross/stabilized/gold/linked = linked_extract
 	if(QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
-		familiar.a_intent = "help"
+		familiar.a_intent = INTENT_HELP
 		ADD_TRAIT(familiar, TRAIT_PACIFISM, "stabilizedgold")
 		familiar.melee_damage = 0
 		familiar.remove_verb(/mob/living/simple_animal/parrot/proc/toggle_mode) // just in case

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -934,16 +934,13 @@
 	colour = "gold"
 	var/mob/living/simple_animal/familiar
 
-/datum/status_effect/stabilized/gold/proc/on_attack()
-	SIGNAL_HANDLER
-	return COMPONENT_HOSTILE_NO_ATTACK
-
 /datum/status_effect/stabilized/gold/tick()
 	var/obj/item/slimecross/stabilized/gold/linked = linked_extract
 	if(QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
 		familiar.a_intent = "help"
-		RegisterSignal(familiar, COMSIG_HOSTILE_ATTACKINGTARGET, PROC_REF(on_attack))
+		ADD_TRAIT(familiar, TRAIT_PACIFISM, "stabilized gold")
+		familiar.melee_damage = 0
 		familiar.name = linked.mob_name
 		familiar.del_on_death = TRUE
 		familiar.copy_languages(owner, LANGUAGE_MASTER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
for all I can tell, the pet spawned by stabilized gold should be a pacifist
the pseudo-immortality is biggest argument in this sense
it's still a good question why there are hostile animals in friendly paths and why they have the FRIENDLY_SPAWN tag despite their attacks (perhaps referring to their default AI rather than capacity to harm, which is kind of an edge case considering sentience)

## Why It's Good For The Game

Fixes: #11328 

you can no longer have stabilized gold pets that can bite and poison you then come back each time you kill them
though they can still ventcrawl, pull and strip
took this route rather than removing the snake and lizard from the pool outright because:
- it allows them to be pets still,
- this should cover any other cases if pets were to be added to this

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/d21432e3-595f-4e47-93a8-e3c9f3d5dcf3

</details>

## Changelog
:cl: Aramix
tweak: pacified all pets spawned by Xenobiology's Stabilized Gold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
