### PR TITLE
Fixes runtimes when eminances are damaged

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -165,7 +165,7 @@
 		var/icon/I = icon(icon, icon_state, dir)
 		holder.pixel_y = I.Height() - world.icon_size
 	else
-		stack_trace("[src] does not have a HEALTH_HUD but updates it!")
+		CRASH("[src] does not have a HEALTH_HUD but updates it!")
 
 //for carbon suit sensors
 /mob/living/carbon/med_hud_set_health()
@@ -183,7 +183,7 @@
 		else
 			holder.icon_state = "hudhealthy"
 	else
-		stack_trace("[src] does not have a HEALTH_HUD but updates it!")
+		CRASH("[src] does not have a HEALTH_HUD but updates it!")
 
 /mob/living/carbon/med_hud_set_status()
 	var/image/holder = hud_list[STATUS_HUD]
@@ -234,7 +234,7 @@
 				if(null)
 					holder.icon_state = "hudhealthy"
 	else
-		stack_trace("[src] does not have a HEALTH_HUD but updates it!")
+		CRASH("[src] does not have a HEALTH_HUD but updates it!")
 
 
 /***********************************************

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -143,6 +143,9 @@
 /mob/living/simple_animal/eminence/med_hud_set_health()
 	return
 
+/mob/living/simple_animal/eminence/med_hud_set_status()
+	return
+
 /mob/living/simple_animal/eminence/update_health_hud()
 	return
 

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -140,6 +140,9 @@
 	tab_data["Cogs Available"] = GENERATE_STAT_TEXT("[cogs] Cogs")
 	return tab_data
 
+/mob/living/simple_animal/eminence/med_hud_set_health()
+	return
+
 /mob/living/simple_animal/eminence/update_health_hud()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The issue:
![image](https://github.com/user-attachments/assets/c5d3db94-7af3-465f-b234-ecb5699df7ef)

Any time an eminence takes damage, it creates a runtime while updating its health. This Just today we saw a massive amount (10000+) of this runtime produced during a single round, which shows that it *can* be problematic (still have yet to recreate whatever happened to cause such rapid health hud updates, which is just as concerning as this)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less runtimes = smoother running code = better game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/5078196b-4f58-43bd-87e7-62517cd72b39)

</details>

## Changelog
:cl:
fix: Eminences no longer attempt to update a non-existent health hud
code: Changed a few stack traces in hud code to crashes for less obfuscated runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
