### PR TITLE
Adds a missing cigarette pack to the vendor

### DIFF
--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -9,6 +9,7 @@
 					/obj/item/storage/fancy/cigarettes/cigpack_robust = 3,
 					/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
 					/obj/item/storage/fancy/cigarettes/cigpack_midori = 3,
+					/obj/item/storage/fancy/cigarettes/dromedaryco = 3,
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/greyscale = 4,
 					/obj/item/storage/fancy/rollingpapers = 5)


### PR DESCRIPTION
## About The Pull Request

![500-cigarettes-the-orville](https://github.com/user-attachments/assets/e8c0646a-fb3d-4add-b918-1798e512dc4d)

## Why It's Good For The Game

You can roll them in the smoker trait but not buy them in the vendor

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![imagen](https://github.com/user-attachments/assets/760dca14-a42f-4420-970a-e8feb2abf40f)

</details>

## Changelog
:cl: ClownMoff
add: Adds the Dromedaire Co cigarettes to the vendor
/:cl: