### PR TITLE
Creates a disposal pipe that filters items that haven't found a valid sorting pipe

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -56,6 +56,7 @@ GLOBAL_LIST_INIT(disposal_pipe_recipes, list(
 		new /datum/pipe_info/disposal("Y-Junction",		/obj/structure/disposalpipe/junction/yjunction),
 		new /datum/pipe_info/disposal("Sort Junction",	/obj/structure/disposalpipe/sorting/mail, PIPE_TRIN_M),
 		new /datum/pipe_info/disposal("Package Junction",	/obj/structure/disposalpipe/sorting/wrap, PIPE_TRIN_M),
+		new /datum/pipe_info/disposal("Unsorted Mail Junction",	/obj/structure/disposalpipe/sorting/unsorted, PIPE_TRIN_M),
 		new /datum/pipe_info/disposal("Trunk",			/obj/structure/disposalpipe/trunk),
 		new /datum/pipe_info/disposal("Bin",			/obj/machinery/disposal/bin, PIPE_ONEDIR),
 		new /datum/pipe_info/disposal("Outlet",			/obj/structure/disposaloutlet),

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -16,6 +16,7 @@
 	var/destinationTag = NONE	// changes if contains a delivery container
 	var/tomail = FALSE			// contains wrapped package
 	var/hasmob = FALSE			// contains a mob
+	var/unsorted = TRUE			// have we been sorted yet?
 
 /obj/structure/disposalholder/Destroy()
 	QDEL_NULL(gas)

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -10,6 +10,7 @@
 	var/sortdir = dpdir & ~(dir | turn(dir, 180))
 	if(H.dir != sortdir)		// probably came from the negdir
 		if(check_sorting(H))	// if destination matches filtered type...
+			H.unsorted = FALSE
 			return sortdir		// exit through sortdirection
 
 	// go with the flow to positive direction
@@ -23,7 +24,7 @@
 
 // Mail sorting junction, uses package tags to sort objects.
 /obj/structure/disposalpipe/sorting/mail
-	desc = "An underfloor disposal pipe that sorts wrapped objects based on their destination tags."
+	desc = "An underfloor disposal pipe that sorts wrapped objects based on their destination tags. Objects passing through it become sorted."
 	flip_type = /obj/structure/disposalpipe/sorting/mail/flip
 	var/sortType = 0
 	// sortType is to be set in map editor.
@@ -82,7 +83,7 @@
 // Wrap sorting junction, sorts objects destined for the mail office mail table (tomail = 1)
 /obj/structure/disposalpipe/sorting/wrap
 	name = "package sorting disposal pipe"
-	desc = "An underfloor disposal pipe which sorts wrapped and unwrapped objects."
+	desc = "An underfloor disposal pipe which sorts wrapped and unwrapped objects. Objects passing through it become sorted."
 	flip_type = /obj/structure/disposalpipe/sorting/wrap/flip
 	initialize_dirs = DISP_DIR_RIGHT | DISP_DIR_FLIP
 
@@ -93,3 +94,19 @@
 	icon_state = "pipe-j2s"
 	flip_type = /obj/structure/disposalpipe/sorting/wrap
 	initialize_dirs = DISP_DIR_LEFT | DISP_DIR_FLIP
+
+// Unsorted junction, will divert things based on whether or not they have been sorted.
+/obj/structure/disposalpipe/sorting/unsorted
+	name = "unsorted sorting disposal pipe"
+	desc = "An underfloor disposal pipe which sorts sorted and unsorted objects. Objects passing through it become sorted."
+	flip_type = /obj/structure/disposalpipe/sorting/wrap/flip
+	initialize_dirs = DISP_DIR_RIGHT | DISP_DIR_FLIP
+
+/obj/structure/disposalpipe/sorting/unsorted/check_sorting(obj/structure/disposalholder/H)
+	return H.unsorted
+
+/obj/structure/disposalpipe/sorting/unsorted/flip
+	icon_state = "pipe-j2s"
+	flip_type = /obj/structure/disposalpipe/sorting/unsorted
+	initialize_dirs = DISP_DIR_LEFT | DISP_DIR_FLIP
+

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -103,7 +103,7 @@
 	initialize_dirs = DISP_DIR_RIGHT | DISP_DIR_FLIP
 
 /obj/structure/disposalpipe/sorting/unsorted/check_sorting(obj/structure/disposalholder/H)
-	return H.unsorted
+	return H.unsorted && (H.destinationTag || H.tomail)
 
 /obj/structure/disposalpipe/sorting/unsorted/flip
 	icon_state = "pipe-j2s"

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -109,7 +109,7 @@
 	initialize_dirs = DISP_DIR_RIGHT | DISP_DIR_FLIP
 
 /obj/structure/disposalpipe/sorting/unsorted/check_sorting(obj/structure/disposalholder/H)
-	return H.unsorted && (H.destinationTag || H.tomail)
+	return H.unsorted && (H.destinationTag > 1 || H.tomail)
 
 /obj/structure/disposalpipe/sorting/unsorted/flip
 	icon_state = "pipe-j2s"

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -16,7 +16,9 @@
 			H.unsorted = FALSE
 			// exit through sortdirection
 			return sortdir
-
+	// If we are entering backwards, continue onwards
+	if (H.dir == turn(input_direction, 180))
+		return H.dir
 	// go with the flow to positive direction
 	return dir
 

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -103,7 +103,7 @@
 /obj/structure/disposalpipe/sorting/unsorted
 	name = "unsorted sorting disposal pipe"
 	desc = "An underfloor disposal pipe which sorts sorted and unsorted objects. Objects passing through it become sorted."
-	flip_type = /obj/structure/disposalpipe/sorting/wrap/flip
+	flip_type = /obj/structure/disposalpipe/sorting/unsorted/flip
 	initialize_dirs = DISP_DIR_RIGHT | DISP_DIR_FLIP
 
 /obj/structure/disposalpipe/sorting/unsorted/check_sorting(obj/structure/disposalholder/H)

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -8,10 +8,14 @@
 
 /obj/structure/disposalpipe/sorting/nextdir(obj/structure/disposalholder/H)
 	var/sortdir = dpdir & ~(dir | turn(dir, 180))
-	if(H.dir != sortdir)		// probably came from the negdir
-		if(check_sorting(H))	// if destination matches filtered type...
+	var/input_direction = dir
+	// probably came from the negdir
+	if(H.dir != input_direction)
+		// if destination matches filtered type...
+		if(check_sorting(H))
 			H.unsorted = FALSE
-			return sortdir		// exit through sortdirection
+			// exit through sortdirection
+			return sortdir
 
 	// go with the flow to positive direction
 	return dir

--- a/code/modules/recycling/disposal/pipe_sorting.dm
+++ b/code/modules/recycling/disposal/pipe_sorting.dm
@@ -10,7 +10,7 @@
 	var/sortdir = dpdir & ~(dir | turn(dir, 180))
 	var/input_direction = dir
 	// probably came from the negdir
-	if(H.dir != input_direction)
+	if(H.dir == input_direction)
 		// if destination matches filtered type...
 		if(check_sorting(H))
 			H.unsorted = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Creates a disposal pipe that filters items that haven't found a valid sorting pipe.
Also changes sorting pipe logic to be easier to understand and more consistent.

## Why It's Good For The Game

This pipe allows us to create loops where bins near the end of the loop will redirect things that need sorting to reach places earlier in the loop, meaning that when you enter a package into a disposal loop from anywhere, it will reach its destination.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/dca0f263-aa4d-4473-acaa-f3cddf737e16)

![image](https://github.com/user-attachments/assets/13679fd0-ab9d-47fb-b2e1-f9821ca7ee35)


## Changelog
:cl:
add: Adds a dispoal pipe that filters items which haven't been sorted but need to be sorted.
tweak: Tweaks the code of the disposal pipe filtering so that items not entering from the input will not be sorted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
