### PR TITLE
Ports TGUI bot menus

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -343,7 +343,6 @@
 				if (gas_id == id)
 					gasses[id] = !gasses[id]
 	update_icon()
-	return
 
 /mob/living/simple_animal/bot/atmosbot/update_icon()
 	if(action == ATMOSBOT_VENT_AIR && emagged == 2)

--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -313,48 +313,37 @@
 			to_check_turfs |= adjacent_turf
 	return null
 
-/mob/living/simple_animal/bot/atmosbot/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	dat += "<tt><b>Atmospheric Stabilizer Controls v1.1</b></tt><br><br>"
-	dat += "Status: <a href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</a><br>"
-	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<br>"
-	if(!locked || issilicon(user) || IsAdminGhost(user))
-		dat += "Breach Pressure: <a href='?src=[REF(src)];set_breach_pressure=1'>[breached_pressure]</a><br>"
-		dat += "Temperature Control: <a href='?src=[REF(src)];toggle_temp_control=1'>[temperature_control?"Enabled":"Disabled"]</a><br>"
-		dat += "Temperature Target: <a href='?src=[REF(src)];set_ideal_temperature=[ideal_temperature]'>[ideal_temperature]K</a><br>"
-		dat += "Gas Scrubbing Controls<br>"
-		for(var/gas_id in gasses)
-			var/gas_enabled = gasses[gas_id]
-			dat += "[GLOB.gas_data.names[gas_id]]: <a href='?src=[REF(src)];toggle_gas=[gas_id]'>[gas_enabled?"Scrubbing":"Not Scrubbing"]</a><br>"
-		dat += "Patrol Station: <A href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A><BR>"
-	return dat
+/mob/living/simple_animal/bot/atmosbot/ui_data(mob/user)
+	var/list/data = ..()
+	if (!locked || issilicon(user) || IsAdminGhost(user))
+		data["custom_controls"]["breach_pressure"] = breached_pressure
+		data["custom_controls"]["temperature_control"] = temperature_control
+		data["custom_controls"]["ideal_temperature"] = ideal_temperature
+		data["custom_controls"]["scrub_gasses"] = gasses
+	return data
 
-/mob/living/simple_animal/bot/atmosbot/Topic(href, href_list)
-	if(..())
-		return TRUE
-
-	if(href_list["set_breach_pressure"])
-		var/new_breach_pressure = input(usr, "Pressure to scan for breaches at? (0 to 100)", "Breach Pressure") as num
-		if(!isnum(new_breach_pressure) || new_breach_pressure < 0 || new_breach_pressure > 100)
-			return
-		breached_pressure = new_breach_pressure
-	else if(href_list["toggle_temp_control"])
-		temperature_control = temperature_control ? FALSE : TRUE
-	else if(href_list["toggle_gas"])
-		var/gas_id = href_list["toggle_gas"]
-		for(var/G in gasses)
-			if("[G]" == gas_id)
-				gasses[G] = gasses[G] ? FALSE : TRUE
-	else if(href_list["set_ideal_temperature"])
-		var/new_temp = input(usr, "Set Target Temperature ([T0C]K to [T20C + 20]K)", "Target Temperature") as num
-		if(!isnum(new_temp) || new_temp < T0C || new_temp > T20C + 20)
-			return
-		ideal_temperature = new_temp
-
-	update_controls()
+/mob/living/simple_animal/bot/atmosbot/ui_act(action, params)
+	. = ..()
+	if(. || (locked && !usr.has_unlimited_silicon_privilege))
+		return
+	switch(action)
+		if("breach_pressure")
+			var/adjust_num = round(text2num(params["pressure"]))
+			adjust_num = clamp(adjust_num, 0, 100)
+			breached_pressure = adjust_num
+		if("temperature_control")
+			temperature_control = !temperature_control
+		if("ideal_temperature")
+			var/adjust_num = round(text2num(params["temperature"]))
+			adjust_num = clamp(adjust_num, T0C, T20C + 20)
+			ideal_temperature = adjust_num
+		if("scrub_gasses")
+			var/id = params["id"]
+			for(var/gas_id in gasses)
+				if (gas_id == id)
+					gasses[id] = !gasses[id]
 	update_icon()
+	return
 
 /mob/living/simple_animal/bot/atmosbot/update_icon()
 	if(action == ATMOSBOT_VENT_AIR && emagged == 2)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -935,8 +935,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 		return
 	switch(action)
 		if("power")
-			//on = !on
-			// update_appearance() TODO-ARAMIX: check if this is needed, or if update_icon is ok
 			if(bot_core.allowed(usr) || !locked)
 				if (on)
 					turn_off()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -977,7 +977,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 				to_chat(usr, "<span class='notice'>You eject [paicard] from [bot_name]</span>")
 				ejectpai(usr)
 	//update_controls()
-	return
 
 /mob/living/simple_animal/bot/proc/show_controls(mob/M)
 	users |= M

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -306,18 +306,22 @@
 
 /mob/living/simple_animal/bot/attack_hand(mob/living/carbon/human/H)
 	if(H.a_intent == INTENT_HELP)
-		interact(H)
+		ui_interact(H)
 	else
 		return ..()
 
 /mob/living/simple_animal/bot/attack_ai(mob/user)
 	if(!topic_denied(user))
-		interact(user)
+		ui_interact(user)
 	else
 		to_chat(user, "<span class='warning'>[src]'s interface is not responding!</span>")
 
-/mob/living/simple_animal/bot/interact(mob/user)
-	show_controls(user)
+/mob/living/simple_animal/bot/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "SimpleBot", name)
+		ui.set_autoupdate(TRUE)
+		ui.open()
 
 /mob/living/simple_animal/bot/proc/togglelock(mob/living/user)
 	if(bot_core.allowed(user) && !open && !emagged)
@@ -898,6 +902,82 @@ Pass a positive integer as an argument to override a bot's default speed.
 		if(D.check_access(access_card))
 			D.open()
 			frustration = 0
+
+/mob/living/simple_animal/bot/ui_data(mob/user)
+	var/list/data = list()
+	data["can_hack"] = (issilicon(user) || IsAdminGhost(user))
+	data["custom_controls"] = list()
+	data["emagged"] = emagged
+	data["locked"] = locked
+	data["pai"] = list()
+	data["settings"] = list()
+	if(!locked || issilicon(user) || IsAdminGhost(user))
+		data["pai"]["allow_pai"] = allow_pai
+		data["pai"]["card_inserted"] = paicard
+		data["settings"]["airplane_mode"] = !remote_disabled
+		data["settings"]["maintenance_lock"] = !open
+		data["settings"]["power"] = on
+		data["settings"]["booting"] = booting
+		data["settings"]["patrol_station"] = auto_patrol
+	return data
+
+// Actions received from TGUI
+/mob/living/simple_animal/bot/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	if(!bot_core.allowed(usr) && !usr.has_unlimited_silicon_privilege)
+		to_chat(usr, "<span class='warning'>Access denied.</span>")
+		return
+	if(action == "lock")
+		locked = !locked
+	if(locked && !(issilicon(usr) || IsAdminGhost(usr)))
+		return
+	switch(action)
+		if("power")
+			//on = !on
+			// update_appearance() TODO-ARAMIX: check if this is needed, or if update_icon is ok
+			if(bot_core.allowed(usr) || !locked)
+				if (on)
+					turn_off()
+				else
+					boot_up_sequence()
+		if("maintenance")
+			open = !open
+		if("patrol")
+			if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
+				return TRUE
+			auto_patrol = !auto_patrol
+			bot_reset()
+		if("airplane")
+			remote_disabled = !remote_disabled
+		if("hack")
+			if(!issilicon(usr) && !IsAdminGhost(usr))
+				return TRUE
+			if(emagged != 2)
+				emagged = 2
+				hacked = TRUE
+				locked = TRUE
+				to_chat(usr, "<span class='warning'>[text_hack]</span>")
+				message_admins("Safety lock of [ADMIN_LOOKUPFLW(src)] was disabled by [ADMIN_LOOKUPFLW(usr)] in [ADMIN_VERBOSEJMP(src)]")
+				log_game("Safety lock of [src] was disabled by [key_name(usr)] in [AREACOORD(src)]")
+				bot_reset()
+			else if(!hacked)
+				to_chat(usr, "<span class='boldannounce'>[text_dehack_fail]</span>")
+			else
+				emagged = FALSE
+				hacked = FALSE
+				to_chat(usr, "<span class='notice'>[text_dehack]</span>")
+				log_game("Safety lock of [src] was re-enabled by [key_name(usr)] in [AREACOORD(src)]")
+				bot_reset()
+		if("eject_pai")
+			if(locked && !(issilicon(usr) || IsAdminGhost(usr)))
+				return
+			if(paicard)
+				to_chat(usr, "<span class='notice'>You eject [paicard] from [bot_name]</span>")
+				ejectpai(usr)
+	//update_controls()
+	return
 
 /mob/living/simple_animal/bot/proc/show_controls(mob/M)
 	users |= M

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -434,39 +434,31 @@
 /obj/machinery/bot_core/cleanbot
 	req_one_access = list(ACCESS_JANITOR, ACCESS_ROBOTICS)
 
-
-/mob/living/simple_animal/bot/cleanbot/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	// missing bot program name here
-	dat += "<BR>Status: <A href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</A>"
-	dat += "<BR>Behaviour controls are [locked ? "locked" : "unlocked"]"
-	dat += "<BR>Maintenance panel panel is [open ? "opened" : "closed"]"
-
+/mob/living/simple_animal/bot/cleanbot/ui_data(mob/user)
+	var/list/data = ..()
 	if(!locked || issilicon(user)|| IsAdminGhost(user))
-		dat += "<BR>Clean Blood: <A href='?src=[REF(src)];operation=blood'>[blood ? "Yes" : "No"]</A>"
-		dat += "<BR>Clean Trash: <A href='?src=[REF(src)];operation=trash'>[trash ? "Yes" : "No"]</A>"
-		dat += "<BR>Clean Graffiti: <A href='?src=[REF(src)];operation=drawn'>[drawn ? "Yes" : "No"]</A>"
-		dat += "<BR>Exterminate Pests: <A href='?src=[REF(src)];operation=pests'>[pests ? "Yes" : "No"]</A>"
-		dat += "<BR><BR>Patrol Station: <A href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A>"
-	return dat
+		data["custom_controls"]["clean_blood"] = blood
+		data["custom_controls"]["clean_trash"] = trash
+		data["custom_controls"]["clean_graffiti"] = drawn
+		data["custom_controls"]["pest_control"] = pests
+	return data
 
-/mob/living/simple_animal/bot/cleanbot/Topic(href, href_list)
-	if(..())
-		return 1
-	if(href_list["operation"])
-		switch(href_list["operation"])
-			if("blood")
-				blood = !blood
-			if("pests")
-				pests = !pests
-			if("trash")
-				trash = !trash
-			if("drawn")
-				drawn = !drawn
-		get_targets()
-		update_controls()
+/mob/living/simple_animal/bot/cleanbot/ui_act(action, params)
+	if (..())
+		return
+	if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
+		return
+	switch(action)
+		if("clean_blood")
+			blood = !blood
+		if("clean_trash")
+			trash = !trash
+		if("clean_graffiti")
+			drawn = !drawn
+		if("pest_control")
+			pests = !pests
+	get_targets()
+	return
 
 /obj/machinery/bot_core/cleanbot/medbay
 	req_one_access = list(ACCESS_JANITOR, ACCESS_ROBOTICS, ACCESS_MEDICAL)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -458,7 +458,6 @@
 		if("pest_control")
 			pests = !pests
 	get_targets()
-	return
 
 /obj/machinery/bot_core/cleanbot/medbay
 	req_one_access = list(ACCESS_JANITOR, ACCESS_ROBOTICS, ACCESS_MEDICAL)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -446,7 +446,7 @@
 /mob/living/simple_animal/bot/cleanbot/ui_act(action, params)
 	if (..())
 		return
-	if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
+	if(!(bot_core.allowed(usr) || usr.has_unlimited_silicon_privilege) || locked)
 		return
 	switch(action)
 		if("clean_blood")

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -98,27 +98,18 @@
 	text_dehack = "You restore [name]'s combat inhibitor."
 	text_dehack_fail = "[name] ignores your attempts to restrict him!"
 
-/mob/living/simple_animal/bot/ed209/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	dat += "<TT><B>Security Unit v2.6 controls</B></TT><BR>"
-	dat += "<BR>Status: <A href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</A>"
-	dat += "<BR>Behaviour controls are [locked ? "locked" : "unlocked"]"
-	dat += "<BR>Maintenance panel panel is [open ? "opened" : "closed"]"
-
-	if(!locked || issilicon(user)|| IsAdminGhost(user))
+/mob/living/simple_animal/bot/ed209/ui_data(mob/user)
+	var/list/data = ..()
+	if (!locked || issilicon(user) || IsAdminGhost(user))
 		if(!lasercolor)
-			dat += "<BR>"
-			dat += "<BR>Arrest Unidentifiable Persons: <A href='?src=[REF(src)];operation=idcheck'>[idcheck ? "Yes" : "No"]</A>"
-			dat += "<BR>Arrest for Unauthorized Weapons: <A href='?src=[REF(src)];operation=weaponscheck'>[weaponscheck ? "Yes" : "No"]</A>"
-			dat += "<BR>Arrest for Warrant: <A href='?src=[REF(src)];operation=ignorerec'>[check_records ? "Yes" : "No"]</A>"
-			dat += "<BR>Operating Mode: <A href='?src=[REF(src)];operation=switchmode'>[arrest_type ? "Detain" : "Arrest"]</A>"
-			dat += "<BR>Report Arrests <A href='?src=[REF(src)];operation=declarearrests'>[declare_arrests ? "Yes" : "No"]</A>"
-			dat += "<BR>Auto Patrol <A href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "On" : "Off"]</A>"
-	return dat
+			data["custom_controls"]["check_id"] = idcheck
+			data["custom_controls"]["check_weapons"] = weaponscheck
+			data["custom_controls"]["check_warrants"] = check_records
+			data["custom_controls"]["handcuff_targets"] = !arrest_type
+			data["custom_controls"]["arrest_alert"] = declare_arrests
+	return data
 
-/mob/living/simple_animal/bot/ed209/Topic(href, href_list)
+/mob/living/simple_animal/bot/ed209/ui_act(action, params)
 	if(lasercolor && ishuman(usr))
 		var/mob/living/carbon/human/H = usr
 		if((lasercolor == "b") && (istype(H.wear_suit, /obj/item/clothing/suit/redtag)))//Opposing team cannot operate it
@@ -126,24 +117,20 @@
 		else if((lasercolor == "r") && (istype(H.wear_suit, /obj/item/clothing/suit/bluetag)))
 			return
 	if(..())
-		return 1
+		return
 
-	switch(href_list["operation"])
-		if("idcheck")
+	switch(action)
+		if("check_id")
 			idcheck = !idcheck
-			update_controls()
-		if("weaponscheck")
+		if("check_weapons")
 			weaponscheck = !weaponscheck
-			update_controls()
-		if("ignorerec")
+		if("check_warrants")
 			check_records = !check_records
-			update_controls()
-		if("switchmode")
+		if("handcuff_targets")
 			arrest_type = !arrest_type
-			update_controls()
-		if("declarearrests")
+		if("arrest_alert")
 			declare_arrests = !declare_arrests
-			update_controls()
+	return
 
 /mob/living/simple_animal/bot/ed209/proc/judgment_criteria()
 	var/final = FALSE

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -130,7 +130,6 @@
 			arrest_type = !arrest_type
 		if("arrest_alert")
 			declare_arrests = !declare_arrests
-	return
 
 /mob/living/simple_animal/bot/ed209/proc/judgment_criteria()
 	var/final = FALSE

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -136,7 +136,7 @@
 /mob/living/simple_animal/bot/firebot/ui_act(action, params)
 	if(..())
 		return
-	if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
+	if(!(bot_core.allowed(usr) || usr.has_unlimited_silicon_privilege) || locked)
 		return
 	switch(action)
 		if("extinguish_fires")

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -146,7 +146,6 @@
 		if("stationary_mode")
 			stationary_mode = !stationary_mode
 	update_icon()
-	return
 
 /mob/living/simple_animal/bot/firebot/proc/is_burning(atom/target)
 	if(ismob(target))

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -105,22 +105,13 @@
 	text_dehack = "You detect errors in [name] and reset his programming."
 	text_dehack_fail = "[name] is not responding to reset commands!"
 
-/mob/living/simple_animal/bot/firebot/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	dat += "<TT><B>Mobile Fire Extinguisher v1.0</B></TT><BR><BR>"
-	dat += "Status: <A href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</A><BR>"
-	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<BR>"
-
-	dat += "Behaviour controls are [locked ? "locked" : "unlocked"]<BR>"
+/mob/living/simple_animal/bot/firebot/ui_data(mob/user)
+	var/list/data = ..()
 	if(!locked || issilicon(user) || IsAdminGhost(user))
-		dat += "Extinguish Fires: <A href='?src=[REF(src)];operation=extinguish_fires'>[extinguish_fires ? "Yes" : "No"]</A><BR>"
-		dat += "Extinguish People: <A href='?src=[REF(src)];operation=extinguish_people'>[extinguish_people ? "Yes" : "No"]</A><BR>"
-		dat += "Patrol Station: <A href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A><BR>"
-		dat += "Stationary Mode: <a href='?src=[REF(src)];operation=stationary_mode'>[stationary_mode ? "Yes" : "No"]</a><br>"
-
-	return dat
+		data["custom_controls"]["extinguish_fires"] = extinguish_fires
+		data["custom_controls"]["extinguish_people"] = extinguish_people
+		data["custom_controls"]["stationary_mode"] = stationary_mode
+	return data
 
 /mob/living/simple_animal/bot/firebot/on_emag(atom/target, mob/user)
 	..()
@@ -142,20 +133,20 @@
 		internal_ext.max_water = INFINITY
 		internal_ext.refill()
 
-/mob/living/simple_animal/bot/firebot/Topic(href, href_list)
+/mob/living/simple_animal/bot/firebot/ui_act(action, params)
 	if(..())
-		return TRUE
-
-	switch(href_list["operation"])
+		return
+	if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
+		return
+	switch(action)
 		if("extinguish_fires")
 			extinguish_fires = !extinguish_fires
 		if("extinguish_people")
 			extinguish_people = !extinguish_people
 		if("stationary_mode")
 			stationary_mode = !stationary_mode
-
-	update_controls()
 	update_icon()
+	return
 
 /mob/living/simple_animal/bot/firebot/proc/is_burning(atom/target)
 	if(ismob(target))

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -179,7 +179,6 @@
 					targetdirection = 8
 				if("disable")
 					targetdirection = null
-	return
 
 /mob/living/simple_animal/bot/floorbot/handle_automated_action()
 	if(!..())

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -84,35 +84,21 @@
 	text_dehack = "You detect errors in [name] and reset his programming."
 	text_dehack_fail = "[name] is not responding to reset commands!"
 
-/mob/living/simple_animal/bot/floorbot/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	dat += "<TT><B>Floor Repairer Controls v1.1</B></TT><BR><BR>"
-	dat += "Status: <A href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</A><BR>"
-	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<BR>"
-	dat += "Special tiles: "
-	if(tilestack)
-		dat += "<A href='?src=[REF(src)];operation=eject'>Loaded \[[tilestack.amount]/[maxtiles]\]</a><BR>"
-	else
-		dat += "None Loaded<BR>"
-
-	dat += "Behaviour controls are [locked ? "locked" : "unlocked"]<BR>"
+/mob/living/simple_animal/bot/floorbot/ui_data(mob/user)
+	var/list/data = ..()
 	if(!locked || issilicon(user) || IsAdminGhost(user))
-		dat += "Add tiles to new hull plating: <A href='?src=[REF(src)];operation=autotile'>[autotile ? "Yes" : "No"]</A><BR>"
-		dat += "Place floor tiles: <A href='?src=[REF(src)];operation=place'>[placetiles ? "Yes" : "No"]</A><BR>"
-		dat += "Replace existing floor tiles with custom tiles: <A href='?src=[REF(src)];operation=replace'>[replacetiles ? "Yes" : "No"]</A><BR>"
-		dat += "Repair damaged tiles and platings: <A href='?src=[REF(src)];operation=fix'>[fixfloors ? "Yes" : "No"]</A><BR>"
-		dat += "Traction Magnets: <A href='?src=[REF(src)];operation=magnet'>[HAS_TRAIT_FROM(src, TRAIT_IMMOBILIZED, BUSY_FLOORBOT_TRAIT) ? "Engaged" : "Disengaged"]</A><BR>"
-		dat += "Patrol Station: <A href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A><BR>"
-		var/bmode
+		data["custom_controls"]["tile_hull"] = autotile
+		data["custom_controls"]["place_tiles"] = placetiles
+		data["custom_controls"]["place_custom"] = replacetiles
+		data["custom_controls"]["repair_damage"] = fixfloors
+		data["custom_controls"]["traction_magnets"] = HAS_TRAIT_FROM(src, TRAIT_IMMOBILIZED, BUSY_FLOORBOT_TRAIT)
+		data["custom_controls"]["tile_stack"] = 0
+		data["custom_controls"]["line_mode"] = FALSE
+		if(tilestack)
+			data["custom_controls"]["tile_stack"] = tilestack.amount
 		if(targetdirection)
-			bmode = dir2text(targetdirection)
-		else
-			bmode = "disabled"
-		dat += "Line Mode : <A href='?src=[REF(src)];operation=linemode'>[bmode]</A><BR>"
-
-	return dat
+			data["custom_controls"]["line_mode"] = dir2text(targetdirection)
+	return data
 
 /mob/living/simple_animal/bot/floorbot/attackby(obj/item/W , mob/user, params)
 	if(istype(W, /obj/item/stack/tile/iron))
@@ -159,26 +145,26 @@
 		if(change_icon)
 			update_icon()
 
-/mob/living/simple_animal/bot/floorbot/Topic(href, href_list)
-	if(..())
-		return TRUE
+/mob/living/simple_animal/bot/floorbot/ui_act(action, params)
+	if (..() || (locked && !usr.has_unlimited_silicon_privilege))
+		return
 
-	switch(href_list["operation"])
-		if("replace")
+	switch(action)
+		if("place_custom")
 			replacetiles = !replacetiles
-		if("place")
+		if("place_tiles")
 			placetiles = !placetiles
-		if("fix")
+		if("repair_damage")
 			fixfloors = !fixfloors
-		if("autotile")
+		if("tile_hull")
 			autotile = !autotile
-		if("magnet")
+		if("traction_magnets")
 			toggle_magnet(!HAS_TRAIT_FROM(src, TRAIT_IMMOBILIZED, BUSY_FLOORBOT_TRAIT), FALSE)
-		if("eject")
+		if("eject_tiles")
 			if(tilestack)
 				tilestack.forceMove(drop_location())
 
-		if("linemode")
+		if("line_mode")
 			var/setdir = input("Select construction direction:") as null|anything in list("north","east","south","west","disable")
 			switch(setdir)
 				if("north")
@@ -191,7 +177,7 @@
 					targetdirection = 8
 				if("disable")
 					targetdirection = null
-	update_controls()
+	return
 
 /mob/living/simple_animal/bot/floorbot/handle_automated_action()
 	if(!..())

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -92,10 +92,12 @@
 		data["custom_controls"]["place_custom"] = replacetiles
 		data["custom_controls"]["repair_damage"] = fixfloors
 		data["custom_controls"]["traction_magnets"] = HAS_TRAIT_FROM(src, TRAIT_IMMOBILIZED, BUSY_FLOORBOT_TRAIT)
-		data["custom_controls"]["tile_stack"] = 0
 		data["custom_controls"]["line_mode"] = FALSE
-		if(tilestack)
-			data["custom_controls"]["tile_stack"] = tilestack.amount
+		data["custom_controls"]["tile_stack"] = list(
+			"tilestack" = tilestack,
+			"amount" = tilestack?.amount,
+			"max_amount" = tilestack?.max_amount
+		)
 		if(targetdirection)
 			data["custom_controls"]["line_mode"] = dir2text(targetdirection)
 	return data

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -84,20 +84,6 @@
 	text_dehack = "You reboot [name] and restore the sound control system."
 	text_dehack_fail = "[name] refuses to accept your authority!"
 
-/mob/living/simple_animal/bot/honkbot/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	dat += "<TT><B>Honkomatic Bike Horn Unit v1.0.7 controls</B></TT><BR>"
-	dat += "<BR>Status: <A href='?src=[REF(src)];power=[TRUE]'>[on ? "On" : "Off"]</A>"
-	dat += "<BR>Behaviour controls are [locked ? "locked" : "unlocked"]"
-	dat += "<BR>Maintenance panel panel is [open ? "opened" : "closed"]"
-
-	if(!locked || issilicon(user) || IsAdminGhost(user))
-		dat += "<BR>"
-		dat += "<BR> Auto Patrol: <A href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "On" : "Off"]</A>"
-	return	dat
-
 /mob/living/simple_animal/bot/honkbot/proc/judgment_criteria()
 	var/final = NONE
 	if(check_records)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -217,10 +217,7 @@ GLOBAL_VAR(medibot_unique_id_gen)
 				if(old_eff < efficiency)
 					speak("Surgical research data found! Efficiency increased by [round(efficiency/old_eff*100)]%!")
 					window_name = "Automatic Medical Unit v[efficiency]"
-
-	update_controls()
 	return
-
 
 /mob/living/simple_animal/bot/medbot/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/reagent_containers))

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -156,94 +156,68 @@ GLOBAL_VAR(medibot_unique_id_gen)
 /mob/living/simple_animal/bot/medbot/attack_paw(mob/user)
 	return attack_hand(user)
 
-/mob/living/simple_animal/bot/medbot/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	dat += "<TT><B>Medical Unit Controls v1.1</B></TT><BR><BR>"
-	dat += "Status: <A href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</A><BR>"
-	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<BR>"
-	dat += "<br>Behaviour controls are [locked ? "locked" : "unlocked"]<hr>"
+/mob/living/simple_animal/bot/medbot/ui_data(mob/user)
+	var/list/data = ..()
 	if(!locked || issilicon(user) || IsAdminGhost(user))
-		dat += "Beaker: "
-		if(reagent_glass)
-			dat += "<A href='?src=[REF(src)];eject=1'>Loaded \[[reagent_glass.name]: [reagent_glass.reagents.total_volume]/[reagent_glass.reagents.maximum_volume]\]</a><br>"
-		else
-			dat += "None Loaded<br>"
-		dat += "<TT>Healing Threshold: "
-		dat += "<a href='?src=[REF(src)];adj_threshold=-10'>--</a> "
-		dat += "<a href='?src=[REF(src)];adj_threshold=-5'>-</a> "
-		dat += "[heal_threshold] "
-		dat += "<a href='?src=[REF(src)];adj_threshold=5'>+</a> "
-		dat += "<a href='?src=[REF(src)];adj_threshold=10'>++</a>"
-		dat += "</TT><br>"
-		dat += "<TT>Injection Level: "
-		dat += "<a href='?src=[REF(src)];adj_inject=-5'>-</a> "
-		dat += "[injection_amount] "
-		dat += "<a href='?src=[REF(src)];adj_inject=5'>+</a> "
-		dat += "</TT><br>"
-		dat += "The speaker switch is [shut_up ? "off" : "on"]. <a href='?src=[REF(src)];togglevoice=[1]'>Toggle</a><br>"
-		dat += "Critical Patient Alerts: <a href='?src=[REF(src)];critalerts=1'>[declare_crit ? "Yes" : "No"]</a><br>"
-		dat += "Patrol Station: <a href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "Yes" : "No"]</a><br>"
-		dat += "Stationary Mode: <a href='?src=[REF(src)];stationary=1'>[stationary_mode ? "Yes" : "No"]</a><br>"
-		dat += "Synthesise Epinephrine: <a href='?src=[REF(src)];synth_epi=1'>[synth_epi ? "Yes" : "No"]</a><br>"
-		dat += "<a href='?src=[REF(src)];hptech=1'>Search for Technological Advancements</a><br>"
+		data["custom_controls"]["beaker"] = reagent_glass
+		data["custom_controls"]["heal_threshold"] = heal_threshold
+		data["custom_controls"]["injection_amount"] = injection_amount
+		data["custom_controls"]["speaker"] = !shut_up
+		data["custom_controls"]["crit_alerts"] = declare_crit
+		data["custom_controls"]["stationary_mode"] = stationary_mode
+		data["custom_controls"]["synth_epi"] = synth_epi
+		data["custom_controls"]["sync_tech"] = efficiency
+	return data
 
-	return dat
+// Actions received from TGUI
+/mob/living/simple_animal/bot/medbot/ui_act(action, params)
+	. = ..()
+	if(. || (locked && !usr.has_unlimited_silicon_privilege))
+		return
+	switch(action)
+		if("eject")
+			if (!isnull(reagent_glass))
+				reagent_glass.forceMove(drop_location())
+				reagent_glass = null
+				update_icon()
+		if("heal_threshold")
+			var/adjust_num = round(text2num(params["threshold"]))
+			heal_threshold = adjust_num
+			if(heal_threshold < 5)
+				heal_threshold = 5
+			if(heal_threshold > 120)
+				heal_threshold = 120
+		if("injection_amount")
+			var/adjust_num = round(text2num(params["inject"]))
+			injection_amount = adjust_num
+			if(injection_amount < 5)
+				injection_amount = 5
+			if(injection_amount > 30)
+				injection_amount = 30
+		if("speaker")
+			shut_up = !shut_up
+		if("crit_alerts")
+			declare_crit = !declare_crit
+		if("stationary_mode")
+			stationary_mode = !stationary_mode
+			path = list()
+			//update_appearance() //TODO-ARAMIX: perhaps replace with update_icon()
+		if("synth_epi")
+			synth_epi = !synth_epi
+		if("sync_tech")
+			var/old_eff = efficiency
+			var/tech_boosters
+			for(var/i in linked_techweb.researched_designs)
+				var/datum/design/surgery/healing/D = SSresearch.techweb_design_by_id(i)
+				if(!istype(D))
+					continue
+				tech_boosters++
+			if(tech_boosters)
+				efficiency = 1+(0.075*tech_boosters) //increase efficiency by 7.5% for every surgery researched
+				if(old_eff < efficiency)
+					speak("Surgical research data found! Efficiency increased by [round(efficiency/old_eff*100)]%!")
+					window_name = "Automatic Medical Unit v[efficiency]"
 
-/mob/living/simple_animal/bot/medbot/Topic(href, href_list)
-	if(..())
-		return 1
-
-	if(href_list["adj_threshold"])
-		var/adjust_num = text2num(href_list["adj_threshold"])
-		heal_threshold += adjust_num
-		if(heal_threshold < 5)
-			heal_threshold = 5
-		if(heal_threshold > 120)
-			heal_threshold = 120
-
-	else if(href_list["adj_inject"])
-		var/adjust_num = text2num(href_list["adj_inject"])
-		injection_amount += adjust_num
-		if(injection_amount < 5)
-			injection_amount = 5
-		if(injection_amount > 30)
-			injection_amount = 30
-
-
-	else if(href_list["eject"] && (!isnull(reagent_glass)))
-		reagent_glass.forceMove(drop_location())
-		reagent_glass = null
-		update_icon()
-
-	else if(href_list["togglevoice"])
-		shut_up = !shut_up
-
-	else if(href_list["critalerts"])
-		declare_crit = !declare_crit
-
-	else if(href_list["stationary"])
-		stationary_mode = !stationary_mode
-		path = list()
-		update_icon()
-
-	else if(href_list["synth_epi"])
-		synth_epi = !synth_epi
-
-	else if(href_list["hptech"])
-		var/old_eff = efficiency
-		var/tech_boosters
-		for(var/i in linked_techweb.researched_designs)
-			var/datum/design/surgery/healing/D = SSresearch.techweb_design_by_id(i)
-			if(!istype(D))
-				continue
-			tech_boosters++
-		if(tech_boosters)
-			efficiency = 1+(0.075*tech_boosters) //increase efficiency by 7.5% for every surgery researched
-			if(old_eff < efficiency)
-				speak("Surgical research data found! Efficiency increased by [round(efficiency/old_eff*100)]%!")
-				window_name = "Automatic Medical Unit v[efficiency]"
 	update_controls()
 	return
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -221,7 +221,6 @@ GLOBAL_VAR(medibot_unique_id_gen)
 				if(old_eff < efficiency)
 					speak("Surgical research data found! Efficiency increased by [round(efficiency/old_eff*100)]%!")
 					window_name = "Automatic Medical Unit v[efficiency]"
-	return
 
 /mob/living/simple_animal/bot/medbot/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/reagent_containers))

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -159,7 +159,11 @@ GLOBAL_VAR(medibot_unique_id_gen)
 /mob/living/simple_animal/bot/medbot/ui_data(mob/user)
 	var/list/data = ..()
 	if(!locked || issilicon(user) || IsAdminGhost(user))
-		data["custom_controls"]["beaker"] = reagent_glass
+		data["custom_controls"]["container"] = list(
+			"reagent_glass" = reagent_glass,
+			"total_volume" = reagent_glass?.reagents.total_volume,
+			"maximum_volume" = reagent_glass?.reagents.maximum_volume
+		)
 		data["custom_controls"]["heal_threshold"] = heal_threshold
 		data["custom_controls"]["injection_amount"] = injection_amount
 		data["custom_controls"]["speaker"] = !shut_up

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -205,7 +205,6 @@ GLOBAL_VAR(medibot_unique_id_gen)
 		if("stationary_mode")
 			stationary_mode = !stationary_mode
 			path = list()
-			//update_appearance() //TODO-ARAMIX: perhaps replace with update_icon()
 		if("synth_epi")
 			synth_epi = !synth_epi
 		if("sync_tech")

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -104,46 +104,33 @@
 	text_dehack = "You reboot [name] and restore the target identification."
 	text_dehack_fail = "[name] refuses to accept your authority!"
 
-/mob/living/simple_animal/bot/secbot/get_controls(mob/user)
-	var/dat
-	dat += hack(user)
-	dat += showpai(user)
-	dat += "<TT><B>Securitron v1.6 controls</B></TT><BR>"
-	dat += "<BR>Status: <A href='?src=[REF(src)];power=1'>[on ? "On" : "Off"]</A>"
-	dat += "<BR>Behaviour controls are [locked ? "locked" : "unlocked"]"
-	dat += "<BR>Maintenance panel panel is [open ? "opened" : "closed"]"
+/mob/living/simple_animal/bot/secbot/ui_data(mob/user)
+	var/list/data = ..()
+	if (!locked || issilicon(user) || IsAdminGhost(user))
+		data["custom_controls"]["check_id"] = idcheck
+		data["custom_controls"]["check_weapons"] = weaponscheck
+		data["custom_controls"]["check_warrants"] = check_records
+		data["custom_controls"]["handcuff_targets"] = !arrest_type
+		data["custom_controls"]["arrest_alert"] = declare_arrests
+	return data
 
-	if(!locked || issilicon(user) || IsAdminGhost(user))
-		dat += "<BR>"
-		dat += "<BR>Arrest Unidentifiable Persons: <A href='?src=[REF(src)];operation=idcheck'>[idcheck ? "Yes" : "No"]</A>"
-		dat += "<BR>Arrest for Unauthorized Weapons: <A href='?src=[REF(src)];operation=weaponscheck'>[weaponscheck ? "Yes" : "No"]</A>"
-		dat += "<BR>Arrest for Warrant: <A href='?src=[REF(src)];operation=ignorerec'>[check_records ? "Yes" : "No"]</A>"
-		dat += "<BR>Operating Mode: <A href='?src=[REF(src)];operation=switchmode'>[arrest_type ? "Detain" : "Arrest"]</A>"
-		dat += "<BR>Report Arrests <A href='?src=[REF(src)];operation=declarearrests'>[declare_arrests ? "Yes" : "No"]</A>"
-		dat += "<BR>Auto Patrol: <A href='?src=[REF(src)];operation=patrol'>[auto_patrol ? "On" : "Off"]</A>"
-	return	dat
-
-/mob/living/simple_animal/bot/secbot/Topic(href, href_list)
+/mob/living/simple_animal/bot/secbot/ui_act(action, params)
 	if(..())
-		return TRUE
+		return
 	if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
-		return TRUE
-	switch(href_list["operation"])
-		if("idcheck")
+		return
+	switch(action)
+		if("check_id")
 			idcheck = !idcheck
-			update_controls()
-		if("weaponscheck")
+		if("check_weapons")
 			weaponscheck = !weaponscheck
-			update_controls()
-		if("ignorerec")
+		if("check_warrants")
 			check_records = !check_records
-			update_controls()
-		if("switchmode")
+		if("handcuff_targets")
 			arrest_type = !arrest_type
-			update_controls()
-		if("declarearrests")
+		if("arrest_alert")
 			declare_arrests = !declare_arrests
-			update_controls()
+	return
 
 /mob/living/simple_animal/bot/secbot/proc/retaliate(mob/living/carbon/human/H)
 	var/judgment_criteria = judgment_criteria()

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -117,7 +117,7 @@
 /mob/living/simple_animal/bot/secbot/ui_act(action, params)
 	if(..())
 		return
-	if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
+	if(!(bot_core.allowed(usr) || usr.has_unlimited_silicon_privilege) || locked)
 		return
 	switch(action)
 		if("check_id")

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -106,7 +106,7 @@
 
 /mob/living/simple_animal/bot/secbot/ui_data(mob/user)
 	var/list/data = ..()
-	if (!locked || issilicon(user) || IsAdminGhost(user))
+	if(!locked || issilicon(user) || IsAdminGhost(user))
 		data["custom_controls"]["check_id"] = idcheck
 		data["custom_controls"]["check_weapons"] = weaponscheck
 		data["custom_controls"]["check_warrants"] = check_records

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -130,7 +130,6 @@
 			arrest_type = !arrest_type
 		if("arrest_alert")
 			declare_arrests = !declare_arrests
-	return
 
 /mob/living/simple_animal/bot/secbot/proc/retaliate(mob/living/carbon/human/H)
 	var/judgment_criteria = judgment_criteria()

--- a/tgui/packages/tgui/interfaces/SimpleBot.tsx
+++ b/tgui/packages/tgui/interfaces/SimpleBot.tsx
@@ -33,7 +33,7 @@ type Controls = {
 export const SimpleBot = (_, context) => {
   const { data } = useBackend<SimpleBotContext>(context);
   const { can_hack, locked } = data;
-  const access = (!locked || can_hack);
+  const access = !locked || can_hack;
 
   return (
     <Window width={450} height={320}>
@@ -41,9 +41,7 @@ export const SimpleBot = (_, context) => {
         <Stack fill vertical>
           <Stack.Item>
             <Section title="Settings" buttons={<TabDisplay />}>
-              {!access
-                ? (<NoticeBox>Locked!</NoticeBox>)
-                : (<SettingsDisplay />)}
+              {!access ? <NoticeBox>Locked!</NoticeBox> : <SettingsDisplay />}
             </Section>
           </Stack.Item>
           {access && (
@@ -93,11 +91,7 @@ const HackButton = (_, context) => {
       icon={emagged ? 'bug' : 'lock'}
       onClick={() => act('hack')}
       selected={!emagged}
-      tooltip={
-        !emagged
-          ? 'Unlocks the safety protocols.'
-          : 'Resets the bot operating system.'
-      }>
+      tooltip={!emagged ? 'Unlocks the safety protocols.' : 'Resets the bot operating system.'}>
       {emagged ? 'Malfunctional' : 'Safety Lock'}
     </Button>
   );
@@ -110,10 +104,7 @@ const PaiButton = (_, context) => {
 
   if (!card_inserted) {
     return (
-      <Button
-        color="transparent"
-        icon="robot"
-        tooltip={multiline`Insert an active PAI card to control this device.`}>
+      <Button color="transparent" icon="robot" tooltip={multiline`Insert an active PAI card to control this device.`}>
         No PAI Inserted
       </Button>
     );
@@ -136,59 +127,28 @@ const SettingsDisplay = (_, context) => {
   const { settings } = data;
   const { airplane_mode, patrol_station, power, booting, maintenance_lock } = settings;
 
-  const color = power ? 'good' : (booting ? 'bad' : 'gray');
+  const color = power ? 'good' : booting ? 'bad' : 'gray';
 
   return (
     <LabeledControls>
       <LabeledControls.Item label="Power">
         <Tooltip content={`Powers ${power ? 'off' : 'on'} the bot.`}>
-          <Icon
-            size={2}
-            name="power-off"
-            color={color}
-            onClick={() => act('power')}
-          />
+          <Icon size={2} name="power-off" color={color} onClick={() => act('power')} />
         </Tooltip>
       </LabeledControls.Item>
       <LabeledControls.Item label="Remote Control">
-        <Tooltip
-          content={`${
-            airplane_mode ? 'Disables' : 'Enables'
-          } remote access via PDA app.`}>
-          <Icon
-            size={2}
-            name="wifi"
-            color={airplane_mode ? 'yellow' : 'gray'}
-            onClick={() => act('airplane')}
-          />
+        <Tooltip content={`${airplane_mode ? 'Disables' : 'Enables'} remote access via PDA app.`}>
+          <Icon size={2} name="wifi" color={airplane_mode ? 'yellow' : 'gray'} onClick={() => act('airplane')} />
         </Tooltip>
       </LabeledControls.Item>
       <LabeledControls.Item label="Patrol Station">
-        <Tooltip
-          content={`${
-            patrol_station ? 'Disables' : 'Enables'
-          } automatic station patrol.`}>
-          <Icon
-            size={2}
-            name="map-signs"
-            color={patrol_station ? 'good' : 'gray'}
-            onClick={() => act('patrol')}
-          />
+        <Tooltip content={`${patrol_station ? 'Disables' : 'Enables'} automatic station patrol.`}>
+          <Icon size={2} name="map-signs" color={patrol_station ? 'good' : 'gray'} onClick={() => act('patrol')} />
         </Tooltip>
       </LabeledControls.Item>
       <LabeledControls.Item label="Maintenance Lock">
-        <Tooltip
-          content={
-            maintenance_lock
-              ? 'Opens the maintenance hatch for repairs.'
-              : 'Closes the maintenance hatch.'
-          }>
-          <Icon
-            size={2}
-            name="toolbox"
-            color={maintenance_lock ? 'yellow' : 'gray'}
-            onClick={() => act('maintenance')}
-          />
+        <Tooltip content={maintenance_lock ? 'Opens the maintenance hatch for repairs.' : 'Closes the maintenance hatch.'}>
+          <Icon size={2} name="toolbox" color={maintenance_lock ? 'yellow' : 'gray'} onClick={() => act('maintenance')} />
         </Tooltip>
       </LabeledControls.Item>
     </LabeledControls>
@@ -205,21 +165,14 @@ const ControlsDisplay = (_, context) => {
   return (
     <LabeledControls wrap>
       {Object.entries(custom_controls).map((control) => {
-        if (control[0] === "scrub_gasses") {
-          return (
-            <ControlHelper
-              key={control[0]}
-              control={control} />
-          );
+        if (control[0] === 'scrub_gasses') {
+          return <ControlHelper key={control[0]} control={control} />;
         }
         return (
           <LabeledControls.Item
             pb={2}
             key={control[0]}
-            label={control[0]
-              .replace('_', ' ')
-              .replace(/(^\w{1})|(\s+\w{1})/g, (letter) =>
-                letter.toUpperCase())}>
+            label={control[0].replace('_', ' ').replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase())}>
             <ControlHelper control={control} />
           </LabeledControls.Item>
         );
@@ -276,14 +229,13 @@ const MedbotSync = (props, context) => {
 
   return (
     <Tooltip
-      content={multiline`Synchronize surgical data with research network.
-       Currently at: ` + efficiency + `% efficiency.`}>
-      <Icon
-        color="purple"
-        name="cloud-download-alt"
-        size={2}
-        onClick={() => act('sync_tech')}
-      />
+      content={
+        multiline`Synchronize surgical data with research network.
+       Currently at: ` +
+        efficiency +
+        `% efficiency.`
+      }>
+      <Icon color="purple" name="cloud-download-alt" size={2} onClick={() => act('sync_tech')} />
     </Tooltip>
   );
 };
@@ -380,7 +332,12 @@ const FloorbotLine = (props, context) => {
         onClick={() => act('line_mode')}
         size={!control[1] ? 2 : 1.5}>
         {' '}
-        {control[1] ? control[1].toString().charAt(0).toUpperCase() : ''}
+        {control[1]
+          ? control[1]
+            .toString()
+            .charAt(0)
+            .toUpperCase()
+          : ''}
       </Icon>
     </Tooltip>
   );
@@ -433,19 +390,19 @@ const AtmosbotScrubbedGasses = (props, context) => {
   return (
     <Flex wrap>
       <Section title="Scrubbed gasses">
-          {gasses.map((gas) => {
-            const gas_id = gas[0];
-            const enabled = gas[1];
-            return (
-              <Button
-                key={gas_id}
-                icon={enabled ? 'check-square-o' : 'square-o'}
-                content={getGasLabel(gas_id)}
-                selected={enabled}
-                onClick={() => act(control[0], { id: gas_id })}
-              />
-            );
-          })}
+        {gasses.map((gas) => {
+          const gas_id = gas[0];
+          const enabled = gas[1];
+          return (
+            <Button
+              key={gas_id}
+              icon={enabled ? 'check-square-o' : 'square-o'}
+              content={getGasLabel(gas_id)}
+              selected={enabled}
+              onClick={() => act(control[0], { id: gas_id })}
+            />
+          );
+        })}
       </Section>
     </Flex>
   );

--- a/tgui/packages/tgui/interfaces/SimpleBot.tsx
+++ b/tgui/packages/tgui/interfaces/SimpleBot.tsx
@@ -196,7 +196,7 @@ const ControlHelper = (props, context) => {
   } else if (control[0] === 'injection_amount') {
     /** Control is a threshold - this is medbot specific */
     return <MedbotInjectionThreshold control={control} />;
-  } else if (control[0] === 'beaker') {
+  } else if (control[0] === 'container') {
     return <MedbotBeaker control={control} />;
   } else if (control[0] === 'tile_stack') {
     return <FloorbotTiles control={control} />;
@@ -291,14 +291,19 @@ const MedbotInjectionThreshold = (props, context) => {
 const MedbotBeaker = (props, context) => {
   const { act } = useBackend<SimpleBotContext>(context);
   const { control } = props;
+  const [reagent_glass, total_volume, maximum_volume] = [
+    control[1]['reagent_glass'],
+    control[1]['total_volume'],
+    control[1]['maximum_volume'],
+  ];
 
   return (
     <Button
-      disabled={!control[1]}
-      icon={control[1] ? 'eject' : ''}
+      disabled={!reagent_glass}
+      icon={reagent_glass ? 'eject' : ''}
       onClick={() => act('eject')}
-      tooltip="Beaker contained in the bot.">
-      {control[1] ? `${control[1]}` : 'Empty'}
+      tooltip="Container contained in the bot.">
+      {reagent_glass ? `${reagent_glass} [${total_volume}/${maximum_volume}]` : 'Empty'}
     </Button>
   );
 };
@@ -307,14 +312,15 @@ const MedbotBeaker = (props, context) => {
 const FloorbotTiles = (props, context) => {
   const { act } = useBackend<SimpleBotContext>(context);
   const { control } = props;
+  const [tilestack, amount, max_amount] = [control[1]['tilestack'], control[1]['amount'], control[1]['max_amount']];
 
   return (
     <Button
-      disabled={!control[1]}
-      icon={control[1] ? 'eject' : ''}
+      disabled={!tilestack}
+      icon={tilestack ? 'eject' : ''}
       onClick={() => act('eject_tiles')}
-      tooltip="Number of floor tiles contained in the bot.">
-      {control[1] ? `${control[1]}` : 'Empty'}
+      tooltip="Floor tiles contained in the bot.">
+      {tilestack ? `${tilestack} [${amount}/${max_amount}]` : 'Empty'}
     </Button>
   );
 };

--- a/tgui/packages/tgui/interfaces/SimpleBot.tsx
+++ b/tgui/packages/tgui/interfaces/SimpleBot.tsx
@@ -1,0 +1,373 @@
+import { multiline } from '../../common/string';
+import { useBackend } from '../backend';
+import { Button, Icon, LabeledControls, NoticeBox, Section, Slider, Stack, Tooltip } from '../components';
+import { Window } from '../layouts';
+
+type SimpleBotContext = {
+  can_hack: number;
+  locked: number;
+  emagged: number;
+  pai: Pai;
+  settings: Settings;
+  custom_controls: Controls;
+};
+
+type Pai = {
+  allow_pai: number;
+  card_inserted: number;
+};
+
+type Settings = {
+  power: number;
+  booting: boolean;
+  airplane_mode: number;
+  maintenance_lock: number;
+  patrol_station: number;
+};
+
+type Controls = {
+  [Control: string]: [Value: number];
+};
+
+export const SimpleBot = (_, context) => {
+  const { data } = useBackend<SimpleBotContext>(context);
+  const { can_hack, locked } = data;
+  const access = (!locked || can_hack);
+
+  return (
+    <Window width={450} height={300}>
+      <Window.Content>
+        <Stack fill vertical>
+          <Stack.Item>
+            <Section title="Settings" buttons={<TabDisplay />}>
+              {!access
+                ? (<NoticeBox>Locked!</NoticeBox>)
+                : (<SettingsDisplay />)}
+            </Section>
+          </Stack.Item>
+          {access && (
+            <Stack.Item grow>
+              <Section fill scrollable title="Controls">
+                <ControlsDisplay />
+              </Section>
+            </Stack.Item>
+          )}
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+/** Creates a lock button at the top of the controls */
+const TabDisplay = (_, context) => {
+  const { act, data } = useBackend<SimpleBotContext>(context);
+  const { can_hack, locked, pai } = data;
+  const { allow_pai } = pai;
+
+  return (
+    <>
+      {!!can_hack && <HackButton />}
+      {!!allow_pai && <PaiButton />}
+      <Button
+        color="transparent"
+        icon={locked ? 'lock' : 'lock-open'}
+        onClick={() => act('lock')}
+        selected={locked}
+        tooltip={`${locked ? 'Unlock' : 'Lock'} the control panel.`}>
+        Controls Lock
+      </Button>
+    </>
+  );
+};
+
+/** If user is a bad silicon, they can press this button to hack the bot */
+const HackButton = (_, context) => {
+  const { act, data } = useBackend<SimpleBotContext>(context);
+  const { can_hack, emagged } = data;
+
+  return (
+    <Button
+      color="danger"
+      disabled={!can_hack}
+      icon={emagged ? 'bug' : 'lock'}
+      onClick={() => act('hack')}
+      selected={!emagged}
+      tooltip={
+        !emagged
+          ? 'Unlocks the safety protocols.'
+          : 'Resets the bot operating system.'
+      }>
+      {emagged ? 'Malfunctional' : 'Safety Lock'}
+    </Button>
+  );
+};
+
+/** Creates a button indicating PAI status and offers the eject action */
+const PaiButton = (_, context) => {
+  const { act, data } = useBackend<SimpleBotContext>(context);
+  const { card_inserted } = data.pai;
+
+  if (!card_inserted) {
+    return (
+      <Button
+        color="transparent"
+        icon="robot"
+        tooltip={multiline`Insert an active PAI card to control this device.`}>
+        No PAI Inserted
+      </Button>
+    );
+  } else {
+    return (
+      <Button
+        disabled={!card_inserted}
+        icon="eject"
+        onClick={() => act('eject_pai')}
+        tooltip={multiline`Ejects the current PAI.`}>
+        Eject PAI
+      </Button>
+    );
+  }
+};
+
+/** Displays the bot's standard settings: Power, patrol, etc. */
+const SettingsDisplay = (_, context) => {
+  const { act, data } = useBackend<SimpleBotContext>(context);
+  const { settings } = data;
+  const { airplane_mode, patrol_station, power, booting, maintenance_lock } = settings;
+
+  const color = power ? 'good' : (booting ? 'bad' : 'gray');
+
+  return (
+    <LabeledControls>
+      <LabeledControls.Item label="Power">
+        <Tooltip content={`Powers ${power ? 'off' : 'on'} the bot.`}>
+          <Icon
+            size={2}
+            name="power-off"
+            color={color}
+            onClick={() => act('power')}
+          />
+        </Tooltip>
+      </LabeledControls.Item>
+      <LabeledControls.Item label="Remote Control">
+        <Tooltip
+          content={`${
+            airplane_mode ? 'Disables' : 'Enables'
+          } remote access via PDA app.`}>
+          <Icon
+            size={2}
+            name="wifi"
+            color={airplane_mode ? 'yellow' : 'gray'}
+            onClick={() => act('airplane')}
+          />
+        </Tooltip>
+      </LabeledControls.Item>
+      <LabeledControls.Item label="Patrol Station">
+        <Tooltip
+          content={`${
+            patrol_station ? 'Disables' : 'Enables'
+          } automatic station patrol.`}>
+          <Icon
+            size={2}
+            name="map-signs"
+            color={patrol_station ? 'good' : 'gray'}
+            onClick={() => act('patrol')}
+          />
+        </Tooltip>
+      </LabeledControls.Item>
+      <LabeledControls.Item label="Maintenance Lock">
+        <Tooltip
+          content={
+            maintenance_lock
+              ? 'Opens the maintenance hatch for repairs.'
+              : 'Closes the maintenance hatch.'
+          }>
+          <Icon
+            size={2}
+            name="toolbox"
+            color={maintenance_lock ? 'yellow' : 'gray'}
+            onClick={() => act('maintenance')}
+          />
+        </Tooltip>
+      </LabeledControls.Item>
+    </LabeledControls>
+  );
+};
+
+/** Iterates over custom controls.
+ * Calls the helper to identify which button to use.
+ */
+const ControlsDisplay = (_, context) => {
+  const { data } = useBackend<SimpleBotContext>(context);
+  const { custom_controls } = data;
+
+  return (
+    <LabeledControls wrap>
+      {Object.entries(custom_controls).map((control) => {
+        return (
+          <LabeledControls.Item
+            pb={2}
+            key={control[0]}
+            label={control[0]
+              .replace('_', ' ')
+              .replace(/(^\w{1})|(\s+\w{1})/g, (letter) =>
+                letter.toUpperCase())}>
+            <ControlHelper control={control} />
+          </LabeledControls.Item>
+        );
+      })}
+    </LabeledControls>
+  );
+};
+
+/** Helper function which identifies which button to create.
+ * Might need some fine tuning if you are using more advanced controls.
+ */
+const ControlHelper = (props, context) => {
+  const { act } = useBackend<SimpleBotContext>(context);
+  const { control } = props;
+  if (control[0] === 'sync_tech') {
+    /** Control is for sync - this is medbot specific */
+    return <MedbotSync control={control} />;
+  } else if (control[0] === 'heal_threshold') {
+    /** Control is a threshold - this is medbot specific */
+    return <MedbotThreshold control={control} />;
+  } else if (control[0] === 'injection_amount') {
+    /** Control is a threshold - this is medbot specific */
+    return <MedbotInjectionThreshold control={control} />;
+  } else if (control[0] === 'beaker') {
+    return <MedbotBeaker control={control} />;
+  } else if (control[0] === 'tile_stack') {
+    return <FloorbotTiles control={control} />;
+  } else if (control[0] === 'line_mode') {
+    return <FloorbotLine control={control} />;
+  } else {
+    /** Control is a boolean of some type */
+    return (
+      <Icon
+        color={control[1] ? 'good' : 'gray'}
+        name={control[1] ? 'toggle-on' : 'toggle-off'}
+        size={2}
+        onClick={() => act(control[0])}
+      />
+    );
+  }
+};
+
+/** Small button to sync medbots with research. */
+const MedbotSync = (props, context) => {
+  const { act } = useBackend<SimpleBotContext>(context);
+  const { control } = props;
+  const efficiency = Math.round(control[1] * 100);
+
+  return (
+    <Tooltip
+      content={multiline`Synchronize surgical data with research network.
+       Currently at: ` + efficiency + `% efficiency.`}>
+      <Icon
+        color="purple"
+        name="cloud-download-alt"
+        size={2}
+        onClick={() => act('sync_tech')}
+      />
+    </Tooltip>
+  );
+};
+
+/** Slider button for medbot healing thresholds */
+const MedbotThreshold = (props, context) => {
+  const { act } = useBackend<SimpleBotContext>(context);
+  const { control } = props;
+
+  return (
+    <Tooltip content="Adjusts the sensitivity for damage treatment.">
+      <Slider
+        minValue={5}
+        maxValue={95}
+        ranges={{
+          good: [-Infinity, 15],
+          average: [15, 55],
+          bad: [55, Infinity],
+        }}
+        step={5}
+        unit="%"
+        value={control[1]}
+        onChange={(_, value) => act(control[0], { threshold: value })}
+      />
+    </Tooltip>
+  );
+};
+
+/** Slider button for medbot healing thresholds */
+const MedbotInjectionThreshold = (props, context) => {
+  const { act } = useBackend<SimpleBotContext>(context);
+  const { control } = props;
+
+  return (
+    <Tooltip content="Adjusts the dose of chemicals administered.">
+      <Slider
+        minValue={5}
+        maxValue={30}
+        ranges={{
+          good: [-Infinity, 15],
+          average: [15, 25],
+          bad: [25, Infinity],
+        }}
+        step={5}
+        unit="u"
+        value={control[1]}
+        onChange={(_, value) => act(control[0], { inject: value })}
+      />
+    </Tooltip>
+  );
+};
+
+const MedbotBeaker = (props, context) => {
+  const { act } = useBackend<SimpleBotContext>(context);
+  const { control } = props;
+
+  return (
+    <Button
+      disabled={!control[1]}
+      icon={control[1] ? 'eject' : ''}
+      onClick={() => act('eject')}
+      tooltip="Beaker contained in the bot.">
+      {control[1] ? `${control[1]}` : 'Empty'}
+    </Button>
+  );
+};
+
+/** Tile stacks for floorbots - shows number and eject button */
+const FloorbotTiles = (props, context) => {
+  const { act } = useBackend<SimpleBotContext>(context);
+  const { control } = props;
+
+  return (
+    <Button
+      disabled={!control[1]}
+      icon={control[1] ? 'eject' : ''}
+      onClick={() => act('eject_tiles')}
+      tooltip="Number of floor tiles contained in the bot.">
+      {control[1] ? `${control[1]}` : 'Empty'}
+    </Button>
+  );
+};
+
+/** Direction indicator for floorbot when line mode is chosen. */
+const FloorbotLine = (props, context) => {
+  const { act } = useBackend<SimpleBotContext>(context);
+  const { control } = props;
+
+  return (
+    <Tooltip content="Enables straight line tiling mode.">
+      <Icon
+        color={control[1] ? 'good' : 'gray'}
+        name={control[1] ? 'compass' : 'toggle-off'}
+        onClick={() => act('line_mode')}
+        size={!control[1] ? 2 : 1.5}>
+        {' '}
+        {control[1] ? control[1].toString().charAt(0).toUpperCase() : ''}
+      </Icon>
+    </Tooltip>
+  );
+};

--- a/tgui/packages/tgui/interfaces/SimpleBot.tsx
+++ b/tgui/packages/tgui/interfaces/SimpleBot.tsx
@@ -35,7 +35,7 @@ export const SimpleBot = (_, context) => {
   const access = (!locked || can_hack);
 
   return (
-    <Window width={450} height={300}>
+    <Window width={450} height={320}>
       <Window.Content>
         <Stack fill vertical>
           <Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This ports TGUI bot menus from TG:
https://github.com/tgstation/tgstation/pull/62748

Mulebot interface is untouched by this and Atmosbot was done manually by scrapping some code from huge air scrubbers

Some things to be discussed
- medbots have no bandaging option, which was introduced here #11057 - this is a thing prior to this PR and in the case of beakers, the interface was adjusted to have a control for that as well
- adding custom icons, tooltips, names and so on would require defining specific components in SimpleBot.tsx - could probably benefit from modularizing bot interface files and/or datumizing the controls instead of using lists
- seems to be able to unlock emagged bots via interface, maybe it shouldn't
- consistency between showing either the beaker/tiles loaded or their quantity
- other TODOs I have yet to remember

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Replaces old HTML interface with a simpler looking TGUI interface
More options for layout and controls
Can include tooltips to explain what different controls do

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/1bb27293-3eaf-4ac8-a4a6-aaf72bdc09e5)

(older video in terms of used icons but showcases compatibility with booting sequence)

https://github.com/user-attachments/assets/39e65e57-51d6-4a2e-9e8b-e945e6e4a97b

</details>

## Changelog
:cl: Aramix, jlsnow301
add: Bots have received an update to their menus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
