### PR TITLE
Map and Admin Spawned IDs Access Lists

### DIFF
--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -10732,8 +10732,8 @@
 	pixel_x = 2
 	},
 /obj/item/card/id/job/atmospheric_technician{
-	access = list(11);
-	pixel_y = -5
+	pixel_y = -5;
+	give_job_access = 1
 	},
 /obj/item/clothing/glasses/meson/engine{
 	pixel_y = -6
@@ -26140,7 +26140,6 @@
 "mIY" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
-/obj/item/card/id/job/shaft_miner,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -26152,6 +26151,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/item/card/id/job/shaft_miner{
+	give_job_access = 1
 	},
 /turf/open/floor/iron/dark,
 /area/quartermaster/storage)
@@ -34632,12 +34634,14 @@
 "qZA" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
-/obj/item/card/id/job/shaft_miner,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/card/id/job/shaft_miner{
+	give_job_access = 1
 	},
 /turf/open/floor/iron/dark,
 /area/quartermaster/storage)

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -30076,9 +30076,9 @@
 /area/medical/genetics/cloning)
 "jBT" = (
 /obj/structure/closet/secure_closet/quartermaster,
-/obj/item/card/id/job/shaft_miner,
-/obj/item/card/id/job/shaft_miner,
-/obj/item/card/id/job/shaft_miner,
+/obj/item/card/id/job/shaft_miner{
+	give_job_access = 1
+	},
 /obj/effect/turf_decal/bot,
 /obj/item/computer_hardware/hard_drive/role/quartermaster{
 	pixel_y = 6
@@ -30094,6 +30094,12 @@
 	},
 /obj/item/gps/mining{
 	gpstag = "QM"
+	},
+/obj/item/card/id/job/shaft_miner{
+	give_job_access = 1
+	},
+/obj/item/card/id/job/shaft_miner{
+	give_job_access = 1
 	},
 /turf/open/floor/carpet/orange,
 /area/quartermaster/qm)
@@ -47640,7 +47646,9 @@
 /area/quartermaster/office)
 "oZI" = (
 /obj/structure/closet/wardrobe/miner,
-/obj/item/card/id/job/shaft_miner,
+/obj/item/card/id/job/shaft_miner{
+	give_job_access = 1
+	},
 /obj/item/clothing/suit/hooded/wintercoat/miner,
 /turf/open/floor/iron,
 /area/quartermaster/miningdock)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -402,6 +402,11 @@
 /obj/item/card/id/RemoveID()
 	return src
 
+/obj/item/card/id/job/Initialize()
+	. = ..()
+	var/datum/job/J = SSjob.GetJob(assignment)
+	access = J.get_access()
+
 /*
 /// Called on COMSIG_ATOM_UPDATED_ICON. Updates the visuals of the wallet this card is in.
 /obj/item/card/id/proc/update_in_wallet()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -17,6 +17,7 @@
 	icon = 'icons/obj/card.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	item_flags = ISWEAPON
+	var/give_job_access = FALSE
 
 	var/list/files = list()
 
@@ -402,13 +403,24 @@
 /obj/item/card/id/RemoveID()
 	return src
 
-/obj/item/card/id/job/Initialize()
+/obj/item/card/id/job/Initialize(mapload)
 	. = ..()
-	if(assignment != null){
-		var/datum/job/J = SSjob.GetJob(assignment)
-		access = J.get_access()
+	//ensure it has an assignment, it is meant to get the access and a mapper isn't trying to give it custom access
+	if(assignment != null && give_job_access && access_txt == null){
+		give_access(assignment)
 	}
 
+/obj/item/card/id/proc/give_access(A)
+	//if admin leaves it as null, set it to the default assignment
+	if(A == null){A = assignment}
+	//if a default assignment is still null, do nothing
+	if(A != null){
+		var/datum/job/J = SSjob.GetJob(A)
+		if(J != null){
+			access = J.get_access()
+		}
+
+	}
 
 /*
 /// Called on COMSIG_ATOM_UPDATED_ICON. Updates the visuals of the wallet this card is in.

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -404,8 +404,11 @@
 
 /obj/item/card/id/job/Initialize()
 	. = ..()
-	var/datum/job/J = SSjob.GetJob(assignment)
-	access = J.get_access()
+	if(assignment != null){
+		var/datum/job/J = SSjob.GetJob(assignment)
+		access = J.get_access()
+	}
+
 
 /*
 /// Called on COMSIG_ATOM_UPDATED_ICON. Updates the visuals of the wallet this card is in.

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -225,6 +225,7 @@
 	new /obj/item/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/flashlight/seclite(src)
+	new /obj/item/card/id/job/security_officer(src)
 
 /obj/structure/closet/secure_closet/security/sec
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -747,6 +747,14 @@
 	build_path = /obj/item/ammo_box/foambox
 	category = list("initial", "Misc")
 
+/datum/design/id_card
+	name = "Blank ID"
+	id = "id_card"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 500, /datum/material/copper = 500)
+	build_path = /obj/item/card/id
+	category = list("initial", "Misc")
+
 //hacked autolathe recipes
 /datum/design/flamethrower
 	name = "Flamethrower"


### PR DESCRIPTION
## About The Pull Request
Spawned IDs can be varedited to have the default access for that job and it should respect whether it has extra access or not. Admins can varedit using "call proc" to call "give_access" followed by one or zero arguments. Zero will use the assignment on the ID to determine the access it should have and one will let you specify the assignment.

I am not a proficient Byond programmer and would encourage to be nitpicky and thorough with this PR.

Due to a request from Bacon, I've changed it to no longer be assumed you want the access of the ID it is representing. It now needs give_access changed to 1 when mapping or to use the proc "give_access" with either one argument or none.

## Why It's Good For The Game
Allows mappers to put in free access IDs for emergency staff (such as when there is no HoP), for antagonists to get some extra access or for admins to get people a new ID with all the accesses included.

For Security, I want to enable Security to help each other in case they've lost an ID by at least getting them deputy access on a normal ID. So they are not stuck screaming for help at the top of their lungs until mommy HoP comes by to give them a new ID.

For the autolathe, I simply wanted a method of getting new IDs without praying to Space Jesus. This won't change much unless someone makes an ID forgery in the future.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
Tested out a few map spawned IDs, my own ID and admin spawned IDs. They worked and had the proper accesses.

![image](https://github.com/user-attachments/assets/58f83ff2-b871-4009-b315-05a9d543937e)

![image](https://github.com/user-attachments/assets/e8e7953a-2e33-442b-9241-f34643c700c9)

It now needs the give_access variable to be set to 1 in order to give access to the ID on mapload.

![image](https://github.com/user-attachments/assets/b5c3491a-c01e-4b2d-9bcd-830beb946008)

You can still use the var access_txt to give specific accesses and they will not conflict. This one takes priority over give_access.

![image](https://github.com/user-attachments/assets/72613bd9-f637-4d64-89f3-934dd4bd630a)

Showing how admins can utilize this proc. Setting it to zero arguments will make it use the assignment title to figure out what access it should have.

https://github.com/user-attachments/assets/f2bb5c26-dabb-45a2-9d00-78280228de35

</details>

## Changelog
:cl:
balance: Map and admin spawned IDs will carry the access of that ID in respect of their job.
fix: [Echo & Rad] Map spawned IDs now has access assigned to them.
code: Every job ID will now get the job assignment of the ID and give the ID the access expected of it.
balance: Every Security locker will now spawn with a Security themed ID with no access.
balance: Autolathes can now print blank IDs.
/:cl: