### PR TITLE
Multple ghosts can now once more orbit the same person.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -453,7 +453,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 // This is the ghost's follow verb with an argument
 /mob/dead/observer/check_orbitable(atom/movable/target_original)
 	var/atom/movable/target = target_original.get_orbitable()
-	if (!istype(target) || target_original.orbit_datum?.parent == target_original)
+	if (!istype(target) || orbiting?.parent == target_original)
 		return
 
 	var/icon/I = icon(target.icon,target.icon_state,target.dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Ghosts can now orbit the same person. Hooray.

## Why It's Good For The Game

Oversights are bad. Hopefully there are no more movement refactor bugs.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/a7440a68-4654-49be-beb3-9d66c50a116b

</details>

## Changelog
:cl: XeonMations
fix: Ghosts can now orbit the same person another ghost is orbiting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
