### PR TITLE
Edited some FLYING checks to also check for FLOATING

### DIFF
--- a/code/datums/components/conveyor_movement.dm
+++ b/code/datums/components/conveyor_movement.dm
@@ -24,7 +24,7 @@
 	source.delay = speed //We use the default delay
 	if(living_parent)
 		var/mob/living/moving_mob = parent
-		if((moving_mob.movement_type & FLYING) && !moving_mob.stat)
+		if((moving_mob.movement_type & FLOATING|FLYING) && !moving_mob.stat)
 			return MOVELOOP_SKIP_STEP
 	var/atom/movable/moving_parent = parent
 	if(moving_parent.anchored || !moving_parent.has_gravity())

--- a/code/datums/components/conveyor_movement.dm
+++ b/code/datums/components/conveyor_movement.dm
@@ -24,7 +24,7 @@
 	source.delay = speed //We use the default delay
 	if(living_parent)
 		var/mob/living/moving_mob = parent
-		if((moving_mob.movement_type & FLOATING|FLYING) && !moving_mob.stat)
+		if((moving_mob.movement_type & (FLOATING|FLYING)) && !moving_mob.stat)
 			return MOVELOOP_SKIP_STEP
 	var/atom/movable/moving_parent = parent
 	if(moving_parent.anchored || !moving_parent.has_gravity())

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -34,7 +34,7 @@
 	if(!isliving(arrived))
 		return
 	var/mob/living/victim = arrived
-	if(!(victim.movement_type & FLYING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(!(victim.movement_type & FLOATING|FLYING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)
 
 /datum/component/slippery/UnregisterFromParent()

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -34,7 +34,7 @@
 	if(!isliving(arrived))
 		return
 	var/mob/living/victim = arrived
-	if(!(victim.movement_type & FLOATING|FLYING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(!(victim.movement_type & (FLOATING|FLYING)) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)
 
 /datum/component/slippery/UnregisterFromParent()

--- a/code/datums/components/spikes.dm
+++ b/code/datums/components/spikes.dm
@@ -58,7 +58,7 @@
 		if(ishuman(C))
 			var/mob/living/carbon/human/H = C
 			var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-			if((H.movement_type & FLYING) || H.body_position == LYING_DOWN || H.buckled || H.shoes || feetCover)
+			if((H.movement_type & FLOATING|FLYING) || H.body_position == LYING_DOWN || H.buckled || H.shoes || feetCover)
 				prick(H, 0.5)
 			else
 				prick(H, 2)

--- a/code/datums/components/spikes.dm
+++ b/code/datums/components/spikes.dm
@@ -58,7 +58,7 @@
 		if(ishuman(C))
 			var/mob/living/carbon/human/H = C
 			var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-			if((H.movement_type & (FLOATING|FLYING))) || H.body_position == LYING_DOWN || H.buckled || H.shoes || feetCover)
+			if((H.movement_type & (FLOATING|FLYING)) || H.body_position == LYING_DOWN || H.buckled || H.shoes || feetCover)
 				prick(H, 0.5)
 			else
 				prick(H, 2)

--- a/code/datums/components/spikes.dm
+++ b/code/datums/components/spikes.dm
@@ -58,7 +58,7 @@
 		if(ishuman(C))
 			var/mob/living/carbon/human/H = C
 			var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-			if((H.movement_type & FLOATING|FLYING) || H.body_position == LYING_DOWN || H.buckled || H.shoes || feetCover)
+			if((H.movement_type & (FLOATING|FLYING))) || H.body_position == LYING_DOWN || H.buckled || H.shoes || feetCover)
 				prick(H, 0.5)
 			else
 				prick(H, 2)

--- a/code/datums/components/squashable.dm
+++ b/code/datums/components/squashable.dm
@@ -53,7 +53,7 @@
 
 	if(isliving(crossing_movable))
 		var/mob/living/crossing_mob = crossing_movable
-		if(crossing_mob.mob_size > MOB_SIZE_SMALL && !(crossing_mob.movement_type & FLOATING|FLYING))
+		if(crossing_mob.mob_size > MOB_SIZE_SMALL && !(crossing_mob.movement_type & (FLOATING|FLYING)))
 			if(HAS_TRAIT(crossing_mob, TRAIT_PACIFISM))
 				crossing_mob.visible_message("<span class='notice'>[crossing_mob] carefully steps over [parent_as_living].</span>", "<span class='notice'>You carefully step over [parent_as_living] to avoid hurting it.</span>")
 				return

--- a/code/datums/components/squashable.dm
+++ b/code/datums/components/squashable.dm
@@ -53,7 +53,7 @@
 
 	if(isliving(crossing_movable))
 		var/mob/living/crossing_mob = crossing_movable
-		if(crossing_mob.mob_size > MOB_SIZE_SMALL && !(crossing_mob.movement_type & FLYING))
+		if(crossing_mob.mob_size > MOB_SIZE_SMALL && !(crossing_mob.movement_type & FLOATING|FLYING))
 			if(HAS_TRAIT(crossing_mob, TRAIT_PACIFISM))
 				crossing_mob.visible_message("<span class='notice'>[crossing_mob] carefully steps over [parent_as_living].</span>", "<span class='notice'>You carefully step over [parent_as_living] to avoid hurting it.</span>")
 				return

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -62,7 +62,7 @@
 	if(!istype(turf))
 		return
 
-	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLOATING|FLYING))
+	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLOATING | FLYING))
 		return
 
 	if(source.body_position == LYING_DOWN) //play crawling sound if we're lying

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -62,7 +62,7 @@
 	if(!istype(turf))
 		return
 
-	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLYING))
+	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLOATING|FLYING))
 		return
 
 	if(source.body_position == LYING_DOWN) //play crawling sound if we're lying

--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -35,6 +35,6 @@
 		return
 	if(!L.client) //Only sentient people are going along with it!
 		return
-	if(L.movement_type & FLOATING|FLYING)
+	if(L.movement_type & (FLOATING|FLYING))
 		return
 	L.adjustFireLoss(3)

--- a/code/datums/weather/weather_types/floor_is_lava.dm
+++ b/code/datums/weather/weather_types/floor_is_lava.dm
@@ -35,6 +35,6 @@
 		return
 	if(!L.client) //Only sentient people are going along with it!
 		return
-	if(L.movement_type & FLYING)
+	if(L.movement_type & FLOATING|FLYING)
 		return
 	L.adjustFireLoss(3)

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -64,7 +64,7 @@
 
 	if(isliving(AM))
 		var/mob/living/L = AM
-		if(L.movement_type & FLYING)
+		if(L.movement_type & FLOATING|FLYING)
 			return
 		if(L.m_intent != MOVE_INTENT_WALK && prob(40))
 			var/acid_used = min(acid_level*0.05, 20)

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -64,7 +64,7 @@
 
 	if(isliving(AM))
 		var/mob/living/L = AM
-		if(L.movement_type & FLOATING|FLYING)
+		if(L.movement_type & (FLOATING|FLYING))
 			return
 		if(L.m_intent != MOVE_INTENT_WALK && prob(40))
 			var/acid_used = min(acid_level*0.05, 20)

--- a/code/game/objects/effects/mainttraps.dm
+++ b/code/game/objects/effects/mainttraps.dm
@@ -34,7 +34,7 @@
 	if(isturf(loc))
 		if(ismob(AM) && grounded)
 			var/mob/MM = AM
-			if(!(MM.movement_type & FLYING))
+			if(!(MM.movement_type & FLOATING|FLYING))
 				if(TrapEffect(AM))
 					if(!reusable)
 						qdel(src)

--- a/code/game/objects/effects/mainttraps.dm
+++ b/code/game/objects/effects/mainttraps.dm
@@ -34,7 +34,7 @@
 	if(isturf(loc))
 		if(ismob(AM) && grounded)
 			var/mob/MM = AM
-			if(!(MM.movement_type & FLOATING|FLYING))
+			if(!(MM.movement_type & (FLOATING|FLYING)))
 				if(TrapEffect(AM))
 					if(!reusable)
 						qdel(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -315,7 +315,7 @@
 		check_break(M)
 
 /obj/structure/table/glass/proc/check_break(mob/living/M)
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & FLYING))
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & FLOATING|FLYING))
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/living/victim)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -315,7 +315,7 @@
 		check_break(M)
 
 /obj/structure/table/glass/proc/check_break(mob/living/M)
-	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & FLOATING|FLYING))
+	if(M.has_gravity() && M.mob_size > MOB_SIZE_SMALL && !(M.movement_type & (FLOATING|FLYING)))
 		table_shatter(M)
 
 /obj/structure/table/glass/proc/table_shatter(mob/living/victim)

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -220,7 +220,7 @@
 	return TRUE
 
 /turf/open/handle_slip(mob/living/carbon/slipper, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
-	if(slipper.movement_type & FLYING)
+	if(slipper.movement_type & FLOATING|FLYING)
 		return 0
 	if(has_gravity(src))
 		var/obj/buckled_obj

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -220,7 +220,7 @@
 	return TRUE
 
 /turf/open/handle_slip(mob/living/carbon/slipper, knockdown_amount, obj/O, lube, paralyze_amount, force_drop)
-	if(slipper.movement_type & FLOATING|FLYING)
+	if(slipper.movement_type & (FLOATING|FLYING))
 		return 0
 	if(has_gravity(src))
 		var/obj/buckled_obj

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -125,7 +125,7 @@
 		else if (isliving(thing))
 			. = 1
 			var/mob/living/L = thing
-			if(L.movement_type & FLOATING|FLYING)
+			if(L.movement_type & (FLOATING|FLYING))
 				continue	//YOU'RE FLYING OVER IT
 			var/buckle_check = L.buckled
 			if(isobj(buckle_check))

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -125,7 +125,7 @@
 		else if (isliving(thing))
 			. = 1
 			var/mob/living/L = thing
-			if(L.movement_type & FLYING)
+			if(L.movement_type & FLOATING|FLYING)
 				continue	//YOU'RE FLYING OVER IT
 			var/buckle_check = L.buckled
 			if(isobj(buckle_check))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 /turf/attack_hand(mob/user)
 	// Show a zmove radial when clicked
 	if(get_turf(user) == src)
-		if(!user.has_gravity(src) || (user.movement_type & FLOATING|FLYING))
+		if(!user.has_gravity(src) || (user.movement_type & (FLOATING|FLYING)))
 			show_zmove_radial(user)
 			return
 		else if(allow_z_travel)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 /turf/attack_hand(mob/user)
 	// Show a zmove radial when clicked
 	if(get_turf(user) == src)
-		if(!user.has_gravity(src) || (user.movement_type & FLYING))
+		if(!user.has_gravity(src) || (user.movement_type & FLOATING|FLYING))
 			show_zmove_radial(user)
 			return
 		else if(allow_z_travel)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -122,7 +122,7 @@
 	if(armed)
 		if(ismob(AM))
 			var/mob/MM = AM
-			if(!(MM.movement_type & FLYING))
+			if(!(MM.movement_type & FLOATING|FLYING))
 				if(ishuman(AM))
 					var/mob/living/carbon/H = AM
 					if(H.m_intent == MOVE_INTENT_RUN)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -122,7 +122,7 @@
 	if(armed)
 		if(ismob(AM))
 			var/mob/MM = AM
-			if(!(MM.movement_type & FLOATING|FLYING))
+			if(!(MM.movement_type & (FLOATING|FLYING)))
 				if(ishuman(AM))
 					var/mob/living/carbon/H = AM
 					if(H.m_intent == MOVE_INTENT_RUN)

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -182,7 +182,7 @@
 		else if (isliving(thing))
 			. = 1
 			var/mob/living/L = thing
-			if(L.movement_type & FLYING)
+			if(L.movement_type & FLOATING|FLYING)
 				continue	//YOU'RE FLYING OVER IT
 			if("snow" in L.weather_immunities)
 				continue

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -182,7 +182,7 @@
 		else if (isliving(thing))
 			. = 1
 			var/mob/living/L = thing
-			if(L.movement_type & FLOATING|FLYING)
+			if(L.movement_type & (FLOATING|FLYING))
 				continue	//YOU'RE FLYING OVER IT
 			if("snow" in L.weather_immunities)
 				continue

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
 
-	if(movement_type & FLYING|FLOATING)
+	if(movement_type & (FLYING|FLOATING))
 		return FALSE
 	if((lube & NO_SLIP_ON_CATWALK) && (locate(/obj/structure/lattice/catwalk) in get_turf(src)))
 		return FALSE

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
 
-	if(movement_type & FLYING)
+	if(movement_type & FLYING|FLOATING)
 		return FALSE
 	if((lube & NO_SLIP_ON_CATWALK) && (locate(/obj/structure/lattice/catwalk) in get_turf(src)))
 		return FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2275,12 +2275,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			var/datum/gas_mixture/current = H.loc.return_air()
 			if(current && (current.return_pressure() >= ONE_ATMOSPHERE*0.85)) //as long as there's reasonable pressure and no gravity, flight is possible
 				return TRUE
-	if(H.movement_type & FLYING|FLOATING)
+	if(H.movement_type & (FLYING|FLOATING))
 		return TRUE
 	return FALSE
 
 /datum/species/proc/negates_gravity(mob/living/carbon/human/H)
-	if(H.movement_type & FLYING|FLOATING)
+	if(H.movement_type & (FLYING|FLOATING))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2275,12 +2275,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			var/datum/gas_mixture/current = H.loc.return_air()
 			if(current && (current.return_pressure() >= ONE_ATMOSPHERE*0.85)) //as long as there's reasonable pressure and no gravity, flight is possible
 				return TRUE
-	if(H.movement_type & FLYING)
+	if(H.movement_type & FLYING|FLOATING)
 		return TRUE
 	return FALSE
 
 /datum/species/proc/negates_gravity(mob/living/carbon/human/H)
-	if(H.movement_type & FLYING)
+	if(H.movement_type & FLYING|FLOATING)
 		return TRUE
 	return FALSE
 

--- a/code/modules/multiz/movement/atom/atom_zfall.dm
+++ b/code/modules/multiz/movement/atom/atom_zfall.dm
@@ -13,7 +13,7 @@
 		target = get_step_multiz(source, direction)
 		if(!target)
 			return FALSE
-	return !(movement_type & FLYING|FLOATING) && has_gravity(src) && !throwing
+	return !(movement_type & (FLYING|FLOATING)) && has_gravity(src) && !throwing
 
 /// Returns a set of flags, determining what the zfall system will consider this atom in its falling handling
 /atom/proc/intercept_zImpact(atom/movable/AM, levels = 1)

--- a/code/modules/multiz/movement/atom/atom_zfall.dm
+++ b/code/modules/multiz/movement/atom/atom_zfall.dm
@@ -13,7 +13,7 @@
 		target = get_step_multiz(source, direction)
 		if(!target)
 			return FALSE
-	return !(movement_type & FLYING) && has_gravity(src) && !throwing
+	return !(movement_type & FLYING|FLOATING) && has_gravity(src) && !throwing
 
 /// Returns a set of flags, determining what the zfall system will consider this atom in its falling handling
 /atom/proc/intercept_zImpact(atom/movable/AM, levels = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts some procs that check for FLYING movetype to now also check for FLOATING

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Revenants should not be able to fall. Also a few oversight fixes are nice.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/c27f269c-2a75-4338-9858-bd4ad0dd53fb

</details>

## Changelog
:cl: XeonMations
fix: Fixed revenants being able to fall down z levels
fix: Certain FLYING checks now also check for FLOATING movetypes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
