### PR TITLE
Fixes Double Ocular Warden Spawns

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_objects.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_objects.dm
@@ -24,13 +24,6 @@
 	new /obj/structure/destructible/clockwork/sigil/transmission(power_turf)
 	return ..()
 
-/obj/effect/spawner/ocular_warden_setup/Initialize(mapload)
-	var/turf/T = get_turf(src)
-	new /obj/structure/destructible/clockwork/ocular_warden(T)
-	var/turf/open/power_turf = locate() in shuffle(view(3, src))
-	new /obj/structure/destructible/clockwork/sigil/transmission(power_turf)
-	return ..()
-
 /obj/effect/spawner/interdiction_lens_setup/Initialize(mapload)
 	var/turf/T = get_turf(src)
 	new /obj/structure/destructible/clockwork/gear_base/interdiction_lens/free(T)


### PR DESCRIPTION
## About The Pull Request
Removes the double warden spawns occurring on derelict stations.

## Why It's Good For The Game
I hate taking an instant unavoidable 20+ damage per peek.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/04f7b134-e8af-438d-ac23-4735438dcf7c)

</details>

## Changelog
:cl:
fix: [Derelict Stations] Ocular Wardens will no longer double spawn.
/:cl: