### PR TITLE
Adds stamina damage to 'jumping'

### DIFF
--- a/code/modules/multiz/movement/mob/living_zmove.dm
+++ b/code/modules/multiz/movement/mob/living_zmove.dm
@@ -64,7 +64,7 @@
 		if(MOVETYPE_NONE_JUMP)
 			visible_message("<span class='warning'>[src] jumps into the air, as if [p_they()] expected to float... Gravity pulls [p_them()] back down quickly.</span>", "<span class='warning'>You try jumping into the space above you. Gravity pulls you back down quickly.</span>")
 			do_jump_animation()
-			adjustStaminaLoss(10, forced = TRUE)
+			adjustStaminaLoss(15, forced = TRUE)
 			return FALSE
 		if(MOVETYPE_JAUNT)
 			move_verb = "moving"

--- a/code/modules/multiz/movement/mob/living_zmove.dm
+++ b/code/modules/multiz/movement/mob/living_zmove.dm
@@ -64,6 +64,7 @@
 		if(MOVETYPE_NONE_JUMP)
 			visible_message("<span class='warning'>[src] jumps into the air, as if [p_they()] expected to float... Gravity pulls [p_them()] back down quickly.</span>", "<span class='warning'>You try jumping into the space above you. Gravity pulls you back down quickly.</span>")
 			do_jump_animation()
+			adjustStaminaLoss(10, forced = TRUE)
 			return FALSE
 		if(MOVETYPE_JAUNT)
 			move_verb = "moving"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A interaction between (failed) multi-z travel and set_resting() enabled players to basically jump indefinitely.

Rather than resolving the bug, this adds a stamina damage of 15 percent for every jump.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![Screenshot 2024-08-27 164629](https://github.com/user-attachments/assets/6a1d76e2-aaf6-476d-ac26-04196efcd6d6)

Its a funny interaction, and I don't really want to get rid of it, but its spammy as fuck. I got good feedback in coder channels when I presented this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/c6c62dbc-dc79-4431-b57d-cc066b1057f3

Dude tryin to be a fish?

</details>

## Changelog
:cl: rkz
tweak: 15 base stamina damage is dealt every time a failed jump is attempted on a multi-z map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
