### PR TITLE
Added Efficiency Board to be Printable

### DIFF
--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -146,6 +146,15 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/efficiency
+	name = "Core Module Design (Efficiency)"
+	desc = "Allows for the construction of a Corporate AI Core Module."
+	id = "maintain_module"
+	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
+	build_path = /obj/item/aiModule/core/full/maintain
+	category = list("AI Modules")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/board/default_module
 	name = "Core Module Design (Default)"
 	desc = "Allows for the construction of a Default AI Core Module."

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -156,7 +156,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/default_module
-	name = "Core Module Design (Default)"
+	name = "Core Module Design (Crewsimov)"
 	desc = "Allows for the construction of a Default AI Core Module."
 	id = "default_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -986,6 +986,7 @@
 		"asimov_module",
 		"borg_ai_control",
 		"corporate_module",
+		"maintain_module",
 		"default_module",
 		"freeform_module",
 		"freeformcore_module",
@@ -2265,7 +2266,7 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000, TECHWEB_POINT_TYPE_NANITES = 1000)
 	export_price = 5000
-	
+
 /datum/techweb_node/nanite_cc
 	id = "nanite_cc"
 	tech_tier = 5


### PR DESCRIPTION
## About The Pull Request
Allows the basic four law boards to be printed.

## Why It's Good For The Game
Feels weird that an AI can spawn with the efficiency lawset but can't have their laws changed to it without using a freeform law board.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/c3b6ce7a-420f-4a5a-984e-3dd9f97d423d)

</details>

## Changelog
:cl:
fix: Fixed so that Efficiency Law board can be printed.
tweak: Changed the name of the Crewsimov board from "Default" to "Crewsimov".
/:cl:
