### PR TITLE
Posibrains no longer limited to 1, but cyborgs cannot have repeat names

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -775,18 +775,24 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		return TRUE
 	return FALSE
 
-//// Special handler for cyborg naming to ensure no cyborgs ever take a name that has already been used. Prevents "respawning" when the same player takes two posibrains.
-/mob/proc/apply_cyborg_name(preference_type, client/C)
-	var/name = C?.prefs?.read_character_preference(preference_type)
+/// Special handler for cyborg naming to check if cyborg name preferences match a name that has already been used. Returns TRUE if preferences are good to use and FALSE if not.
+/mob/proc/check_cyborg_name(client/C, obj/item/mmi/mmi)
+	var/name = C?.prefs?.read_character_preference(/datum/preference/name/cyborg)
 
-	//This name has already been taken, refuse to pass it on and return false
-	if(name in GLOB.cyborg_name_list)
-		to_chat(C.mob, "<span class='warning'>Cyborg name randomized. Cyborg name already used this round by another character.</span>")
+	//Name is original, add it to the list to prevent it from being used again and return TRUE
+	if(!(name in GLOB.cyborg_name_list))
+		GLOB.cyborg_name_list += name
+		mmi.original_name = name
+		return TRUE
+
+	//Name is not original, but is this the original user of the name? If so we still return TRUE but do not need to add it to the list
+	else if(name == mmi.original_name)
+		return TRUE
+
+	//This name has already been taken and this is not the original user, return FALSE
+	else
+		to_chat(C.mob, "<span class='warning'>Cyborg name already used this round by another character, your name has been randomized</span>")
 		return FALSE
-
-	//Name is original, add it to the list to prevent it from being used again.
-	GLOB.cyborg_name_list += name
-	return apply_pref_name(preference_type, C)
 
 /proc/view_or_range(distance = world.view , center = usr , type)
 	switch(type)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -775,6 +775,18 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		return TRUE
 	return FALSE
 
+//// Special handler for cyborg naming to ensure no cyborgs ever take a name that has already been used. Prevents "respawning" when the same player takes two posibrains.
+/mob/proc/apply_cyborg_name(preference_type, client/C)
+
+	//This name has already been taken, refuse to pass it on and return false
+	if(preference_type in GLOB.cyborg_name_list)
+		to_chat(C.mob, "<span class='warning'>Cyborg name randomized. Cyborg name already used this round by another character.</span>")
+		return FALSE
+
+	//Name is original, add it to the list to prevent it from being used again.
+	GLOB.cyborg_name_list += preference_type
+	return apply_pref_name(preference_type, C)
+
 /proc/view_or_range(distance = world.view , center = usr , type)
 	switch(type)
 		if("view")

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -777,14 +777,15 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 //// Special handler for cyborg naming to ensure no cyborgs ever take a name that has already been used. Prevents "respawning" when the same player takes two posibrains.
 /mob/proc/apply_cyborg_name(preference_type, client/C)
+	var/name = C?.prefs?.read_character_preference(preference_type)
 
 	//This name has already been taken, refuse to pass it on and return false
-	if(preference_type in GLOB.cyborg_name_list)
+	if(name in GLOB.cyborg_name_list)
 		to_chat(C.mob, "<span class='warning'>Cyborg name randomized. Cyborg name already used this round by another character.</span>")
 		return FALSE
 
 	//Name is original, add it to the list to prevent it from being used again.
-	GLOB.cyborg_name_list += preference_type
+	GLOB.cyborg_name_list += name
 	return apply_pref_name(preference_type, C)
 
 /proc/view_or_range(distance = world.view , center = usr , type)

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(mob_config_movespeed_type_lookup)
 
 GLOBAL_LIST_EMPTY(emote_list)
 
-GLOBAL_LIST_EMPTY(posi_key_list)
+GLOBAL_LIST_EMPTY(cyborg_name_list)
 
 GLOBAL_LIST_INIT(construct_radial_images, list(
 	CONSTRUCT_JUGGERNAUT = image(icon = 'icons/mob/cult.dmi', icon_state = "juggernaut"),

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -504,5 +504,5 @@
 			mmi.brainmob.real_name = organic_name //the name of the brain inside the cyborg is the robotized human's name.
 			mmi.brainmob.name = organic_name
 	// If this checks fails, then the name will have been handled during initialization.
-	if(player_client.prefs.read_character_preference(/datum/preference/name/cyborg) != DEFAULT_CYBORG_NAME)
+	if(player_client.prefs.read_character_preference(/datum/preference/name/cyborg) != DEFAULT_CYBORG_NAME && check_cyborg_name(player_client, mmi))
 		apply_pref_name(/datum/preference/name/cyborg, player_client)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -13,6 +13,8 @@
 	var/datum/ai_laws/laws = new()
 	var/force_replace_ai_name = FALSE
 	var/overrides_aicore_laws = FALSE // Whether the laws on the MMI, if any, override possible pre-existing laws loaded on the AI core.
+	///Used to reserve an "original" cyborg name. When this mmi first becomes a cyborg, their name will be stored here in case of deconstruction.
+	var/original_name
 
 /obj/item/mmi/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -94,9 +94,6 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		return FALSE
 	if(is_occupied() || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
 		return FALSE
-	if(user.ckey in GLOB.posi_key_list)
-		to_chat(user, "<span class='warning'>Positronic brain spawns limited to 1 per round.</span>")
-		return FALSE
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SILICONS))
 		to_chat(user, "<span class='warning'>Central Command has temporarily outlawed posibrain sentience in this sector...</span>")
 		return FALSE
@@ -108,9 +105,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		return FALSE
 	if(brainmob.suiciding) //clear suicide status if the old occupant suicided.
 		brainmob.set_suicide(FALSE)
-	var/ckey = user.ckey
-	if(transfer_personality(user))
-		GLOB.posi_key_list += ckey
+	transfer_personality(user)
 
 	var/datum/job/posibrain/pj = SSjob.GetJob(JOB_NAME_POSIBRAIN)
 	pj.remove_posi_slot(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -297,8 +297,12 @@
 	if(custom_name)
 		changed_name = custom_name
 	if(changed_name == "" && C && C.prefs.read_character_preference(/datum/preference/name/cyborg) != DEFAULT_CYBORG_NAME)
-		if(apply_cyborg_name(/datum/preference/name/cyborg, C))
-			return //built in camera handled in proc
+		if(check_cyborg_name(C, mmi))
+			if(apply_pref_name(/datum/preference/name/cyborg, C))
+				return //built in camera handled in proc
+		else
+			//Failed the vibe check on name theft, time to randomize it
+			changed_name = get_standard_name()
 	if(!changed_name)
 		changed_name = get_standard_name()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -297,7 +297,7 @@
 	if(custom_name)
 		changed_name = custom_name
 	if(changed_name == "" && C && C.prefs.read_character_preference(/datum/preference/name/cyborg) != DEFAULT_CYBORG_NAME)
-		if(apply_pref_name(/datum/preference/name/cyborg, C))
+		if(apply_cyborg_name(/datum/preference/name/cyborg, C))
 			return //built in camera handled in proc
 	if(!changed_name)
 		changed_name = get_standard_name()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Effectively reverts #6807 in favor of one of the alternative ideas posted. 

Instead of limiting posibrain spawns to one, if you attempt to become a cyborg name that has already existed your name will be randomized obscuring your identity as a respawn. Even normal cyborg players are expected not to use meta knowledge they gained before spawning so this should not cause any more issues than any other ghost spawn may. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There is no reason to have a single ghost role restricted to single-use while others are not. 

This is also in line with the desire to enable more ghost spawns, allowing more players to rejoin the round after death, including silicon players. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/26614a68-cb5e-4d1a-a97a-b25e0e7ac049)
![image](https://github.com/user-attachments/assets/bda6ee77-4358-42c8-80b0-2f6ee89e7200)
![image](https://github.com/user-attachments/assets/1fd410c1-b257-447e-b354-2f02ccaa6961)

## Changelog
:cl:
tweak: Players are no longer limited to a single positronic brain per round. 
tweak: Cyborgs may no longer have duplicate names, unless they are being rebuilt from the same brain that was previously a cyborg - if you are respawning as a fresh cyborg and do not choose a different character profile first, you will be given the default cyborg name instead of becoming a second copy of the same cyborg.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
