### PR TITLE
Randomizes the interval between silicon law stating.

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -302,11 +302,14 @@
 	say("[radiomod] Current Active Laws:", ignore_spam = TRUE, forced = "state laws")
 	S.client?.silicon_spam_grace()
 
+	var/total_time = 0
+
 	for(var/law_index = 1 to length(laws_to_state))
 		var/law = laws_to_state[law_index]
-		addtimer(CALLBACK(src, PROC_REF(state_singular_law), S, law), 1 SECONDS * law_index)
+		total_time += rand(10,30)
+		addtimer(CALLBACK(src, PROC_REF(state_singular_law), S, law), total_time)
 
-	addtimer(CALLBACK(src, PROC_REF(finished_stating_laws), S, total_laws_count), 1 SECONDS * (length(laws_to_state) + 1))
+	addtimer(CALLBACK(src, PROC_REF(finished_stating_laws), S, total_laws_count), total_time)
 
 
 /mob/living/silicon/proc/finished_stating_laws(mob/living/silicon/silicon, total_laws_count)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so the interval between laws stated for borgs varies a bit between 1 and 3 seconds.

## Why It's Good For The Game

Now people manually typing laws is slightly less obvious. 

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/53a05e01-2eb1-443d-96cd-6b4193576512



## Changelog
:cl:
tweak: The delay in between silicon laws stated is slightly randomized
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
