### PR TITLE
Fixes Nanite Communication Remote and compatible programs

### DIFF
--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -123,9 +123,9 @@
 	var/datum/nanite_extra_setting/comm_code = extra_settings[NES_COMM_CODE]
 	if(!activated || !comm_code)
 		return
-	if(signal_comm_code == comm_code)
+	if(signal_comm_code == comm_code.get_value())
 		host_mob.investigate_log("'s [name] nanite program was messaged by [comm_source] with comm code [signal_comm_code] and message '[comm_message]'.", INVESTIGATE_NANITES)
-		trigger(comm_message)
+		trigger(comm_message=comm_message)
 
 /datum/nanite_program/comm/speech
 	name = "Forced Speech"

--- a/code/modules/research/nanites/nanite_remote.dm
+++ b/code/modules/research/nanites/nanite_remote.dm
@@ -216,7 +216,8 @@
 	return data
 
 /obj/item/nanite_remote/comm/ui_act(action, params)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	switch(action)
 		if("set_message")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

this PR fixes several problems with nanite comms programs and remote in order to allow them to work

- fixed nanite comms UI not updating with each change
- fixed a numerical code being compared to a datum instead of its value
- fixed improper argument passing resulting in ``comm_message`` being null inside trigger proc

impact of PR should be limited to nanite programs of comms type, namely Forced Speech, Skull Echo and Hallucination, the latter using its own custom values for the most part anyway
Hallucination with comm message on any hallucination type other than Message will fail per program's design

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

this allows more uses of nanites that aren't related to combat, such as backup or discrete communication channels and easier forced speech

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/fb48a376-afbc-4a25-a94a-27ffb8055abe

</details>

tested situations:
- [X] comm program with comm message (comm remote)
- [X] comm program with default message (regular remote)
- [X] message hallucination
- [X] other hallucinations
- [X] other nanite programs, for regression testing
- [X] empty string comm message (possible with a new comm remote) => forced speech doesn't say anything, skull echo outputs an empty string

## Changelog
:cl: Aramix
fix: fixed nanite comms programs (forced speech, skull echo, hallucination) to work with nanite communication remote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
