### PR TITLE
Fixes prison holodeck race condition

### DIFF
--- a/code/modules/security/workshop.dm
+++ b/code/modules/security/workshop.dm
@@ -6,7 +6,6 @@
 	desc = "a computer used to control the workshop in the prison"
 
 	mapped_start_area = /area/holodeck/prison
-	linked = /area/holodeck/prison //linked area
 	program_type = /datum/map_template/holodeck/prison //load workshop programs
 	req_access = list(ACCESS_SECURITY)
 	var/startup


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a race condition in the prison holodeck code, if qdel was called prior to LateInitialize() being called, then linked would be a type instead of null which throws errors. 

![image](https://github.com/user-attachments/assets/9ff26d04-3c35-4b12-97d4-f606c7969fcd)

Linked doesn't need to be a type, since mapped_start_area handles that.

## Why It's Good For The Game

Fixes CI randomly failing due to a race condition.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/65cef6e9-787a-4e69-940b-aedd04c8711e)

![image](https://github.com/user-attachments/assets/d49da03e-dcae-4bd8-b70f-7ea3e1ad8137)

Holodeck loads and changes as expected.

## Changelog
:cl:
fix: Fixes a race condition in the prison holodeck.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
