### PR TITLE
Fixes atmos processing race condition

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -42,7 +42,6 @@
 	var/on = FALSE
 	/// whether it can be painted
 	var/paintable = FALSE
-	var/process = FALSE
 
 /obj/machinery/atmospherics/examine(mob/user)
 	. = ..()
@@ -57,10 +56,11 @@
 	if(pipe_flags & PIPING_CARDINAL_AUTONORMALIZE)
 		normalize_cardinal_directions()
 	nodes = new(device_type)
-	src.process = process
 	if (!armor)
 		armor = list(MELEE = 25,  BULLET = 10, LASER = 10, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 100, ACID = 70, STAMINA = 0, BLEED = 0)
 	..()
+	if(process)
+		SSair.start_processing_machine(src)
 	SetInitDirections()
 
 /obj/machinery/atmospherics/Destroy()
@@ -119,9 +119,6 @@
 			if(can_be_node(target, i))
 				nodes[i] = target
 				break
-
-	if(process)
-		SSair.start_processing_machine(src)
 	update_icon()
 
 /obj/machinery/atmospherics/proc/setPipingLayer(new_layer)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -76,11 +76,6 @@
 	return ..()
 	//return QDEL_HINT_FINDREFERENCE
 
-/obj/machinery/atmospherics/atmosinit(list/node_connects)
-	. = ..()
-	if(process)
-		SSair.start_processing_machine(src)
-
 /obj/machinery/atmospherics/proc/destroy_network()
 	return
 
@@ -124,6 +119,9 @@
 			if(can_be_node(target, i))
 				nodes[i] = target
 				break
+
+	if(process)
+		SSair.start_processing_machine(src)
 	update_icon()
 
 /obj/machinery/atmospherics/proc/setPipingLayer(new_layer)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -42,6 +42,7 @@
 	var/on = FALSE
 	/// whether it can be painted
 	var/paintable = FALSE
+	var/process = FALSE
 
 /obj/machinery/atmospherics/examine(mob/user)
 	. = ..()
@@ -56,11 +57,10 @@
 	if(pipe_flags & PIPING_CARDINAL_AUTONORMALIZE)
 		normalize_cardinal_directions()
 	nodes = new(device_type)
+	src.process = process
 	if (!armor)
 		armor = list(MELEE = 25,  BULLET = 10, LASER = 10, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 100, ACID = 70, STAMINA = 0, BLEED = 0)
 	..()
-	if(process)
-		SSair.start_processing_machine(src)
 	SetInitDirections()
 
 /obj/machinery/atmospherics/Destroy()
@@ -75,6 +75,11 @@
 
 	return ..()
 	//return QDEL_HINT_FINDREFERENCE
+
+/obj/machinery/atmospherics/atmosinit(list/node_connects)
+	. = ..()
+	if(process)
+		SSair.start_processing_machine(src)
 
 /obj/machinery/atmospherics/proc/destroy_network()
 	return

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -63,7 +63,7 @@
 
 /obj/machinery/atmospherics/components/trinary/mixer/process_atmos()
 	..()
-	if(!on || !(nodes[1] && nodes[2] && nodes[3] && parents[1] && parents[2] && parents[3]) && !is_operational)
+	if(!on || !(nodes[1] && nodes[2] && nodes[3]) || !is_operational)
 		return
 
 	//Get those gases, mah boiiii


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Atmos demands that a machine starts processing on /New(), however this can cause it to start processing prior to its atmos being initialised. If a template is loaded post-roundstart then this has the potential to cause runtimes, which was the case for shuttles being loaded in the unit tests.

## Why It's Good For The Game

This should correct unit tests and fix some erronous behaviours.

## Testing Photographs and Procedure

Check to make sure atmos machines are still functioning as intended when mapped:

![image](https://github.com/user-attachments/assets/51434117-2d7e-4acc-9b8e-462d59758da6)

Check to make sure atmos machines are still functioning as intended when on shuttles:

![image](https://github.com/user-attachments/assets/21436cec-e6ff-4376-9d02-b994b085ec29)

Check to make sure atmos machines are still functioning as intended when constructed:

![image](https://github.com/user-attachments/assets/6b0748a0-603a-4cfb-b8a4-6b6ba4c656b3)


## Changelog
:cl:
fix: Fixes race condition in atmos processing which results in unit tests failing due to shuttles loading post-roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
