### PR TITLE
Fixes a critical mistake in shuttles.dm

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -169,7 +169,7 @@
 #define INIT_ORDER_XKEYSCORE		-10
 #define INIT_ORDER_STICKY_BAN		-10
 #define INIT_ORDER_LIGHTING			-20
-#define INIT_ORDER_SHUTTLE			-21
+#define INIT_ORDER_SHUTTLE			-21 // After atoms have been initialised to prevent mix-ups
 #define INIT_ORDER_ZCOPY			-22 // this should go after lighting and most objects being placed
 #define INIT_ORDER_MINOR_MAPPING	-40
 #define INIT_ORDER_PATH				-50

--- a/code/controllers/subsystem/async_map_generator.dm
+++ b/code/controllers/subsystem/async_map_generator.dm
@@ -2,6 +2,8 @@ SUBSYSTEM_DEF(async_map_generator)
 	name = "Async Map Generator"
 	wait = 1
 	flags = SS_TICKER | SS_NO_INIT
+	init_stage = INITSTAGE_EARLY
+	// We need to be running while shuttles are loading
 	runlevels = ALL
 
 	/// List of all currently executing generator datums


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This introduces a hotfix for shuttles.dm, allowing map generators to start running before other systems start running.

Currently, shuttles doesn't init until all shuttles have been placed but the map generators don't run until shuttles have finished init, causing it to block for 30 seconds.

This PR serves as a hotfix to quickly fix the issue, but there is still time wasted during init unnecessarilly and a proper fix which involves a much more in-depth rework of initialisation in the MC will come later. (We need to be able to wait for asynchronous tasks that are raised during initialisation)

## Why It's Good For The Game

Shuttles will no longer take 30 seconds to load, and  #11448 will be resolved.

Fixes  #11448

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/39ad0047-5cf1-4dad-b54f-6fa9c5a7d589)

## Changelog
:cl:
fix: Fixes shuttle loading taking 30 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
