### PR TITLE
Disables broken uplink items

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -12,6 +12,7 @@
 	var/limit //used to prevent a spellbook_entry from being bought more than X times with one wizard spellbook
 	var/list/no_coexistence_typecache //Used so you can't have specific spells together
 	var/no_random = FALSE // This is awful one to be a part of randomness - i.e.) soul tap
+	var/disabled = FALSE // Is this item disabled due to having issues? Must provide an issue reference and description of issue.
 
 /datum/spellbook_entry/New()
 	..()
@@ -21,6 +22,8 @@
 	return TRUE
 
 /datum/spellbook_entry/proc/CanBuy(mob/living/carbon/human/user,obj/item/spellbook/book) // Specific circumstances
+	if (disabled)
+		return FALSE
 	if(book.uses<cost || limit == 0)
 		return FALSE
 	for(var/spell in user.mind.spell_list)
@@ -397,6 +400,7 @@
 	It would be wise to avoid buying these with anything capable of causing you to swap bodies with others."
 	item_path = /obj/item/holoparasite_creator/wizard
 	category = "Assistance"
+	disabled = TRUE	// #11096: Currently in a broken state, cannot recall as they will immediately manifest and cannot move despite having range stats.
 
 /datum/spellbook_entry/item/bloodbottle
 	name = "Bottle of Blood"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -7,6 +7,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		var/datum/uplink_item/I = new path
 		if(!I.item)
 			continue
+		if (I.disabled)
+			continue
 		if (!(I.purchasable_from & uplink_flag))
 			continue
 		if(I.player_minimum && I.player_minimum > GLOB.joined_player_list.len)
@@ -137,6 +139,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	var/spawn_amount = 1	//How many times we should run the spawn
 	var/additional_uplink_entry	= null	//Bonus items you gain if you purchase it
 	var/is_bonus = FALSE // entry in 'additional_uplink_entry' will have this as TRUE. Used for logging detail
+	var/disabled = FALSE
 
 /datum/uplink_item/New()
 	. = ..()
@@ -623,6 +626,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	player_minimum = 25
 	restricted = TRUE
 	refundable = TRUE
+	disabled = TRUE	// #11096: Currently in a broken state, cannot recall as they will immediately manifest and cannot move despite having range stats.
 
 /**
  * Only allow holoparasites to be refunded if the injector is unused.
@@ -2119,6 +2123,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	item = /obj/item/gun/blastcannon
 	cost = 14							//High cost because of the potential for extreme damage in the hands of a skilled scientist.
 	restricted_roles = list(JOB_NAME_RESEARCHDIRECTOR, JOB_NAME_SCIENTIST)
+	disabled = TRUE // ! #11288 - Reported as non-functional
 
 /datum/uplink_item/role_restricted/crushmagboots
 	name = "Crushing Magboots"
@@ -2363,6 +2368,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	player_minimum = 25
 	restricted = TRUE
 	restricted_roles = list(JOB_NAME_COOK, JOB_NAME_CHAPLAIN)
+	disabled = TRUE	// #11096: Currently in a broken state, cannot recall as they will immediately manifest and cannot move despite having range stats.
 
 /datum/uplink_item/role_restricted/ez_clean_bundle
 	name = "EZ Clean Grenade Bundle"
@@ -2572,3 +2578,4 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	item = /obj/item/mob_lasso/traitor
 	cost = 3
 	surplus = 0
+	disabled = TRUE	// #11346 Currently in a broken state, lasso'd mobs will never unregister a target once they have locked onto one, making them unusable.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the following items:
- Blast cannon
- Holoparasites
- Mindslave lasso

These items are in bugged states that will screw oevr anyone purchasing them and will not be re-instated until they are fixed.

## Why It's Good For The Game

Players should not be able to purchase broken items. Creates a simple system for quickly disabling bugged items.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/a42cdf28-a4f3-431c-8734-e4e825aa48a4)

![image](https://github.com/user-attachments/assets/dcda75c0-ca0d-4e00-8985-06b475089e81)

![image](https://github.com/user-attachments/assets/f9e1526e-4640-467b-afee-bfe24eb5e75e)

## Changelog
:cl:
tweak: Holoparasites, Mindslave Lasso and The Blast Cannon are no longer purchasable by wizards or traitors due to being broken.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
