### PR TITLE
Revert "Don't run CI on gh-readonly-queue/master (merge group does it already)"

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -4,6 +4,8 @@ on:
     branches:
     - master
     - 'project/**'
+    - 'gh-readonly-queue/master/**'
+    - 'gh-readonly-queue/project/**'
   pull_request:
     branches:
     - master


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#11461