### PR TITLE
Move see through darkness to the lighting plane backdrops

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -195,6 +195,7 @@
 	show_when_dead = TRUE
 
 /atom/movable/screen/fullscreen/see_through_darkness
+	invisibility = INVISIBILITY_LIGHTING
 	icon_state = "nightvision"
 	plane = LIGHTING_PLANE
 	blend_mode = BLEND_ADD

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/hud_version = HUD_STYLE_STANDARD	//Current displayed version of the HUD
 	var/inventory_shown = FALSE		//Equipped item inventory
 	var/hotkey_ui_hidden = FALSE	//This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
+	/// Should the mob be able to see in the darkness immediately surrounding their mob?
 
 	var/atom/movable/screen/ling/chems/lingchemdisplay
 	var/atom/movable/screen/ling/sting/lingstingdisplay
@@ -90,7 +91,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	for(var/mytype in subtypesof(/atom/movable/plane_master_controller))
 		var/atom/movable/plane_master_controller/controller_instance = new mytype(null, src)
 		plane_master_controllers[controller_instance.name] = controller_instance
-
 
 /datum/hud/Destroy()
 	if(mymob?.hud_used == src)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -80,8 +80,6 @@
 
 /datum/hud/human/New(mob/living/carbon/human/owner)
 	..()
-	owner.overlay_fullscreen("see_through_darkness", /atom/movable/screen/fullscreen/see_through_darkness)
-
 	var/atom/movable/screen/using
 	var/atom/movable/screen/inventory/inv_box
 

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -109,6 +109,8 @@
 	. = ..()
 	mymob.overlay_fullscreen("lighting_backdrop_lit", /atom/movable/screen/fullscreen/lighting_backdrop/lit)
 	mymob.overlay_fullscreen("lighting_backdrop_unlit", /atom/movable/screen/fullscreen/lighting_backdrop/unlit)
+	if (isliving(mymob))
+		mymob.overlay_fullscreen("lighting_backdrop_seenear", /atom/movable/screen/fullscreen/see_through_darkness)
 
 /atom/movable/screen/plane_master/lighting/Initialize(mapload)
 	. = ..()

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -75,8 +75,6 @@
 	..()
 	var/mob/living/silicon/robot/mymobR = mymob
 
-	mymobR.overlay_fullscreen("see_through_darkness", /atom/movable/screen/fullscreen/see_through_darkness)
-
 	var/atom/movable/screen/using
 
 	using = new/atom/movable/screen/language_menu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #11457

Moves see through darkness to the lighting plane instead of in /datum/hud, where it belongs.
Makes it so all living mobs recieve it.

## Why It's Good For The Game

All non-humans and non-robots cannot see in the dark around them, making it impossible for them to interact with objects near them. This changes that and allows them to see in the dark as a QOL change.

## Testing Photographs and Procedure

Check ghosts

![image](https://github.com/user-attachments/assets/1d5e70ed-71b3-4691-b64c-d63f4e9ec5d3)

Check humans

![image](https://github.com/user-attachments/assets/74ea8faa-4a3e-4307-b59b-bb62029fa565)

Check xenos

![image](https://github.com/user-attachments/assets/8f50191c-9a8e-4693-a2a8-afaab12aa170)

![image](https://github.com/user-attachments/assets/3014a34b-375d-4df6-8438-a585d7fbec14)

![image](https://github.com/user-attachments/assets/2f6013e4-d642-4b57-a04f-4bdaf4590210)

Check swarmers

![image](https://github.com/user-attachments/assets/37de90d4-5561-4259-b73f-8655a8b6568d)

Check dog

![image](https://github.com/user-attachments/assets/983da44b-1e5b-42b7-835f-f967124cf1e7)

Check robot

![image](https://github.com/user-attachments/assets/1ef06efb-a6df-4d49-8b6d-7215410c1986)

Check AI

![image](https://github.com/user-attachments/assets/a1778316-feb0-4012-a0dc-12ecb8a3e416)

## Changelog
:cl:
balance: All living mobs can now see in the darkness around them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
