### PR TITLE
Adds the Rainbow Knife (of xenobiology fame) to Chaplain Null Rod selection.

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -212,8 +212,10 @@
 			"Unholy Pitchfork" = /obj/item/nullrod/pitchfork,
 			"Egyptian Staff" = /obj/item/nullrod/egyptian,
 			"Hypertool" = /obj/item/nullrod/hypertool,
-			"Ancient Spear" = /obj/item/nullrod/spear
+			"Ancient Spear" = /obj/item/nullrod/spear,
+			"Rainbow Knife" = /obj/item/nullrod/rainbow_knife
 		)
+
 	if(isnull(unique_reskin_icon))
 		unique_reskin_icon = list(
 			"Null Rod" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "nullrod"),
@@ -249,8 +251,10 @@
 			"Unholy Pitchfork" = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "pitchfork0"),
 			"Egyptian Staff" = image(icon = 'icons/obj/guns/magic.dmi', icon_state = "pharoah_sceptre"),
 			"Hypertool" = image(icon = 'icons/obj/device.dmi', icon_state = "hypertool"),
-			"Ancient Spear" = image(icon = 'icons/obj/clockwork_objects.dmi', icon_state = "ratvarian_spear")
-	)
+			"Ancient Spear" = image(icon = 'icons/obj/clockwork_objects.dmi', icon_state = "ratvarian_spear"),
+			"Rainbow Knife" = image(icon = 'icons/obj/slimecrossing.dmi', icon_state = "rainbowknife")
+		)
+
 	var/choice = show_radial_menu(M, src, unique_reskin_icon, radius = 42, require_near = TRUE, tooltips = TRUE)
 	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[choice]") //Keeping this here just in case removing it breaks something
 	if(!QDELETED(src) && choice && !current_skin && !M.incapacitated() && in_range(M,src))
@@ -818,3 +822,46 @@
 	attack_verb_continuous = list("stabs", "pokes", "slashes", "clocks")
 	attack_verb_simple = list("stab", "poke", "slash", "clock")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+
+/obj/item/nullrod/rainbow_knife
+	name = "rainbow knife"
+	desc = "A strange, transparent knife which constantly shifts color. This one glitters with a holy aura."
+	icon = 'icons/obj/slimecrossing.dmi'
+	icon_state = "rainbowknife"
+	item_state = "rainbowknife"
+	force = 15
+	throwforce = 15
+	damtype = BRUTE
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	throw_speed = 3
+	throw_range = 6
+	tool_behaviour = TOOL_KNIFE
+	sharpness = IS_SHARP_ACCURATE
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/nullrod/rainbow_knife/afterattack(atom/O, mob/user, proximity)
+	if(proximity && istype(O, /mob/living))
+		damtype = pick(BRUTE, BURN, TOX, OXY, CLONE)
+	switch(damtype)
+		if(BRUTE)
+			hitsound = 'sound/weapons/bladeslice.ogg'
+			attack_verb_continuous = list("slashes", "slices", "cuts")
+			attack_verb_simple = list("slash", "slice", "cut")
+		if(BURN)
+			hitsound = 'sound/weapons/sear.ogg'
+			attack_verb_continuous = list("burns", "sings", "heats")
+			attack_verb_simple = list("burn", "sing", "heat")
+		if(TOX)
+			hitsound = 'sound/weapons/pierce.ogg'
+			attack_verb_continuous = list("poisons", "doses", "toxifies")
+			attack_verb_simple = list("poison", "dose", "toxify")
+		if(OXY)
+			hitsound = 'sound/effects/space_wind.ogg'
+			attack_verb_continuous = list("suffocates", "winds", "vacuums")
+			attack_verb_simple = list("suffocate", "wind", "vacuum")
+		if(CLONE)
+			hitsound = 'sound/items/geiger/ext1.ogg'
+			attack_verb_continuous = list("irradiates", "mutates", "maligns")
+			attack_verb_simple = list("irradiate", "mutate", "malign")
+	return ..()
+


### PR DESCRIPTION
## About The Pull Request
This just adds a variant of the rainbow knife to the chaplain's null rod selection, allowing them to use a sickass knife.

## Why It's Good For The Game
Makes xenobiology content less exclusive and means you don't need either a spare hour or a hyperfixation, saves a feature for when that department inevitably catches fire, it's cool?

## Testing Photographs and Procedure
<details>

I went into the game with this version of the code. The option was there to select it as my Null Rod and it did everything you would expect a rainbow knife to do, like random damage types, custom attack messages, and fitting in pockets.
![image](https://github.com/user-attachments/assets/fd59a95b-794e-493b-8a11-c4bbddef89cb)
there it is
![image](https://github.com/user-attachments/assets/bd8e8536-b85f-4624-b9a8-a714adc5637d)
fits in your pocket, like a knife
![image](https://github.com/user-attachments/assets/e82de098-56d6-4d79-a001-186e0ea2b4b5)
does the random damage text, like a knife
![image](https://github.com/user-attachments/assets/4892f86a-c33b-4075-a598-329b07f951a3)
there's evidence that it's actually doing what it says it does.

</details>

## Changelog
:cl:
add: Chaplains now have access to the exotic Rainbow Knife! They may now go gambling on the type of the damage they deal.
/:cl:
