### PR TITLE
Fixes lighteater for nightmares

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -99,6 +99,8 @@
 		failed = TRUE
 
 /obj/item/organ/heart/get_availability(datum/species/S)
+	if(S.mutantheart)
+		return TRUE //always give heart if mutant is defined
 	return !(NOBLOOD in S.species_traits)
 
 /obj/item/organ/heart/cursed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check for mutant hearts to `get_availability()` so that races with mutant hearts defined will always get their heart inserted, even if the race would normally not qualify for getting a heart. 

Nightmare's light eater is tied to the race's heart, but having the `NO_BLOOD` trait excluded nightmares from receiving a heart as of #10005 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/be94a27e-8411-40ca-a358-0724ac5a8d6c)

## Changelog
:cl:
fix: Races with a mutant heart will always spawn with their heart now. This means nightmares are no longer totally heartless. This means nightmares spawn with a light eater again, since this is directly tied to them having a heart. We love spaghetti in coderhaus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
