### PR TITLE
fix kapulimbs mind nulls

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -312,9 +312,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				if(!brain.decoy_override)//"Just keep it if it's fake" - confucius, probably
 					brain.Remove(C,TRUE, TRUE) //brain argument used so it doesn't cause any... sudden death.
 					QDEL_NULL(brain)
-			oldorgan.Remove(C,TRUE)
-			required_organs -= oldorgan
-			QDEL_NULL(oldorgan)
+			else
+				oldorgan.Remove(C,TRUE)
+				required_organs -= oldorgan
+				QDEL_NULL(oldorgan) //we cannot just tab this out because we need to skip the deleting if it is a decoy brain.
 
 		if(oldorgan)
 			oldorgan.setOrganDamage(0)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -306,7 +306,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		neworgan = new neworgan()
 		var/should_have = neworgan.get_availability(src) //organ proc that points back to a species trait (so if the species is supposed to have this organ)
 
-		if(oldorgan && (!should_have || replace_current) && !(oldorgan.zone in excluded_zones))
+		if(oldorgan && (!should_have || replace_current) && !(oldorgan.zone in excluded_zones) && !(oldorgan.organ_flags & (ORGAN_UNREMOVABLE)))
 			if(slot == ORGAN_SLOT_BRAIN)
 				var/obj/item/organ/brain/brain = oldorgan
 				if(!brain.decoy_override)//"Just keep it if it's fake" - confucius, probably

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -98,6 +98,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	//Breathing! Most changes are in mutantlungs, though
 	var/breathid = "o2"
 
+	//Blank list. As it runs through regenerate_organs, organs that are missing are added in sequential order to the list
+	//List is called in health analyzer and displays all missing organs
 	var/list/required_organs = list()
 
 	//Do NOT remove by setting to null. use OR make a RESPECTIVE TRAIT (removing stomach? add the NOSTOMACH trait to your species)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -312,8 +312,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				if(!brain.decoy_override)//"Just keep it if it's fake" - confucius, probably
 					brain.Remove(C,TRUE, TRUE) //brain argument used so it doesn't cause any... sudden death.
 					QDEL_NULL(brain)
+					oldorgan = null
 			else
-				oldorgan.Remove(C,TRUE)
+				oldorgan.Remove(C, special = TRUE)
 				required_organs -= oldorgan
 				QDEL_NULL(oldorgan) //we cannot just tab this out because we need to skip the deleting if it is a decoy brain.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Two issues currently occur:
1. Lings lose all their abilities upon transformation, as it nulls their mind as it turns into the new body. The ckey gets pulled, but a bunch of shit thats important gets cleared including the antag datum(all of their powers)
2. Species transformations disconnects known languages on the mind, rendering the mob unable to speak. The prefs exist, its just... doesnt work.


A simple else statement fixes both

Ports:
- https://github.com/tgstation/tgstation/pull/52292


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These are kinda important

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

there is no to_chat for transformations. I changed from humam (Jaylen) to lizard (Kelsey) and retained my speech

![image](https://github.com/user-attachments/assets/ddbc39fe-13b2-49eb-a08a-0354149b9f08)

![image](https://github.com/user-attachments/assets/f213954d-c2db-488e-ad6a-6f1ddb7b1fea)



</details>

## Changelog
:cl: rkz, cobby
fix: fixes mind nulls upon transformation. Should resolve antag datums leaving lings and mobs losing the ability to speak after transforming
fix: regen organs now considers unremovable organs, like heretic hearts. You wont have your heretic heart qdel'd if you are ahealed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
