### PR TITLE
Makes Ashwalkers Always spawn

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -43,6 +43,7 @@
 	suffix = "lavaland_surface_seed_vault.dmm"
 	cost = 5
 	allow_duplicates = FALSE
+	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/ash_walker
 	name = "Ash Walker Nest"
@@ -52,6 +53,7 @@
 	suffix = "lavaland_surface_ash_walker1.dmm"
 	cost = 5
 	allow_duplicates = FALSE
+	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/syndicate_base
 	name = "Syndicate Lava Base"
@@ -69,6 +71,7 @@
 	cost = 5
 	suffix = "lavaland_surface_golem_ship.dmm"
 	allow_duplicates = FALSE
+	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/animal_hospital
 	name = "Animal Hospital"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -43,7 +43,6 @@
 	suffix = "lavaland_surface_seed_vault.dmm"
 	cost = 5
 	allow_duplicates = FALSE
-	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/ash_walker
 	name = "Ash Walker Nest"
@@ -71,7 +70,6 @@
 	cost = 5
 	suffix = "lavaland_surface_golem_ship.dmm"
 	allow_duplicates = FALSE
-	always_place = TRUE
 
 /datum/map_template/ruin/lavaland/animal_hospital
 	name = "Animal Hospital"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since we have been on a "get players back into the game via ghost roles", you would think it would be a good idea to have the premiere Lavaland ghost roles readily available, but the available threat for them is often taken up by Megafauna or Biodome/Lavaland Vets.

This PR simply sets the always_place flag to always place the necessary ruins to get the good ghost roles on LL.

To Maintainers: I did this mostly because I ded and tired of having no good ghost roles. If this is not wanted, it can be closed, but it took me literally longer to write this paragraph than it did to actually implement this change and test it.

## Why It's Good For The Game

Getting players back into the game is always good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/16f7732a-9933-404e-9335-e3962595f956)

</details>

## Changelog
:cl:
tweak: Ashwalkers always spawn on Lavaland now.
/:cl: