### PR TITLE
Fixes recently angered age old issue related to mutant bodyparts (Moths Felinids and Lizards rejoice!)

### DIFF
--- a/code/datums/diseases/advance/symptoms/clockwork.dm
+++ b/code/datums/diseases/advance/symptoms/clockwork.dm
@@ -350,7 +350,7 @@
 	if(istype(H))
 		if(!(H.dna.species.mutant_bodyparts["tail_human"]))
 			H.dna.features["tail_human"] = tail_type
-			H.dna.species.mutant_bodyparts |= "tail_human"
+			H.dna.species.mutant_bodyparts["tail_human"] = tail_type
 		H.update_body()
 
 /obj/item/organ/tail/clockwork/Remove(mob/living/carbon/human/H,  special = 0, pref_load = FALSE)

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -142,11 +142,11 @@
 	var/datum/species/species = H.dna.species
 	if(wagging)
 		species.mutant_bodyparts |= list("waggingtail_lizard" = species.mutant_bodyparts["tail_lizard"],
-										 "waggingspines" = species.mutant_bodyparts["spines"])
+										"waggingspines" = species.mutant_bodyparts["spines"])
 		species.mutant_bodyparts -= list("tail_lizard", "spines")
 		. = TRUE
 	else
 		species.mutant_bodyparts |= list("tail_lizard" = species.mutant_bodyparts["waggingtail_lizard"],
-										 "spines" = species.mutant_bodyparts["waggingspines"])
+										"spines" = species.mutant_bodyparts["waggingspines"])
 		species.mutant_bodyparts -= list("waggingtail_lizard", "waggingspines")
 	H.update_body()

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -30,7 +30,8 @@
 	if(istype(H))
 		var/default_part = H.dna.species.mutant_bodyparts["tail_human"]
 		if(!default_part || default_part == "None")
-			H.dna.features["tail_human"] = H.dna.species.mutant_bodyparts["tail_human"] = tail_type
+			H.dna.species.mutant_bodyparts["tail_human"] = tail_type
+			H.dna.features["tail_human"] = tail_type
 			H.update_body()
 
 /obj/item/organ/tail/cat/Remove(mob/living/carbon/human/H,  special = 0, pref_load = FALSE)
@@ -56,12 +57,12 @@
 		return FALSE
 	var/datum/species/species = H.dna.species
 	if(wagging)
+		species.mutant_bodyparts["waggingtail_human"] = species.mutant_bodyparts["tail_human"]
 		species.mutant_bodyparts -= "tail_human"
-		species.mutant_bodyparts |= "waggingtail_human"
 		. = TRUE
 	else
+		species.mutant_bodyparts["tail_human"] = species.mutant_bodyparts["waggingtail_human"]
 		species.mutant_bodyparts -= "waggingtail_human"
-		species.mutant_bodyparts |= "tail_human"
 	H.update_body()
 
 /obj/item/organ/tail/lizard
@@ -100,10 +101,10 @@
 		var/obj/item/organ/tail/lizard/new_tail = new /obj/item/organ/tail/lizard()
 
 		new_tail.tail_type = C.dna.features["tail_lizard"]
-		C.dna.species.mutant_bodyparts |= "tail_lizard"
+		C.dna.species.mutant_bodyparts["tail_lizard"] = new_tail.tail_type
 
 		new_tail.spines = C.dna.features["spines"]
-		C.dna.species.mutant_bodyparts |= "spines"
+		C.dna.species.mutant_bodyparts["spines"] = new_tail.spines
 
 		// organ.Insert will qdel any existing organs in the same slot, so
 		// we don't need to manage that.
@@ -140,10 +141,12 @@
 		return
 	var/datum/species/species = H.dna.species
 	if(wagging)
+		species.mutant_bodyparts |= list("waggingtail_lizard" = species.mutant_bodyparts["tail_lizard"],
+										 "waggingspines" = species.mutant_bodyparts["spines"])
 		species.mutant_bodyparts -= list("tail_lizard", "spines")
-		species.mutant_bodyparts |= list("waggingtail_lizard", "waggingspines")
 		. = TRUE
 	else
+		species.mutant_bodyparts |= list("tail_lizard" = species.mutant_bodyparts["waggingtail_lizard"],
+										 "spines" = species.mutant_bodyparts["waggingspines"])
 		species.mutant_bodyparts -= list("waggingtail_lizard", "waggingspines")
-		species.mutant_bodyparts |= list("tail_lizard", "spines")
 	H.update_body()

--- a/code/modules/surgery/organs/wings.dm
+++ b/code/modules/surgery/organs/wings.dm
@@ -57,17 +57,17 @@
 		playsound(H, wingsound, 100, 7)
 	if(basewings == "wings" || basewings == "moth_wings")
 		if(H.dna.species.mutant_bodyparts["wings"])
+			H.dna.species.mutant_bodyparts["wingsopen"] = H.dna.species.mutant_bodyparts["wings"]
 			H.dna.species.mutant_bodyparts -= "wings"
-			H.dna.species.mutant_bodyparts |= "wingsopen"
 		else if(H.dna.species.mutant_bodyparts["wingsopen"])
+			H.dna.species.mutant_bodyparts["wings"] = H.dna.species.mutant_bodyparts["wingsopen"]
 			H.dna.species.mutant_bodyparts -= "wingsopen"
-			H.dna.species.mutant_bodyparts |= "wings"
 		else if(H.dna.species.mutant_bodyparts["moth_wings"])
-			H.dna.species.mutant_bodyparts |= "moth_wingsopen"
+			H.dna.species.mutant_bodyparts["moth_wingsopen"] = H.dna.species.mutant_bodyparts["moth_wings"]
 			H.dna.species.mutant_bodyparts -= "moth_wings"
 		else if(H.dna.species.mutant_bodyparts["moth_wingsopen"])
+			H.dna.species.mutant_bodyparts["moth_wings"] = H.dna.species.mutant_bodyparts["moth_wingsopen"]
 			H.dna.species.mutant_bodyparts -= "moth_wingsopen"
-			H.dna.species.mutant_bodyparts |= "moth_wings"
 		else //it appears we don't actually have wing icons. apply them!!
 			Refresh(H)
 		H.update_body()

--- a/code/modules/surgery/organs/wings.dm
+++ b/code/modules/surgery/organs/wings.dm
@@ -25,7 +25,7 @@
 /obj/item/organ/wings/proc/Refresh(mob/living/carbon/human/H)
 	H.dna.species.mutant_bodyparts -= "[basewings]open"
 	if(!(H.dna.species.mutant_bodyparts[basewings]))
-		H.dna.species.mutant_bodyparts |= basewings
+		H.dna.species.mutant_bodyparts[basewings] = wing_type
 		H.dna.features[basewings] = wing_type
 		H.update_body()
 	if(flight_level >= WINGS_FLYING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#10005 uncovered an ages old issue going back to the creation of tail code and moth wing code: people didn't treat `/datum/species/var/mutant_bodyparts` as an associative list.

Reason this was uncovered is because `thing in list` is **not** the same as `list[thing]`, the former returns if thing was found in the list, the latter returns the value associated with thing. In this case, people were mistreating the list and not associating any values with stuff put into it, which went uncaught because of the prevalent use of `thing in list` over `list[thing]'.

TL;DR I hate byond.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Broken things being fixed is good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/b7902d4e-be2b-40f5-acf7-78e17647fd12

</details>

## Changelog
:cl:
fix: Tails and wings now no longer lose their appearance upon emoting or otherwise using them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
