### PR TITLE
Doubles the max character slots, ups beecoin and Byondmember additions accordingly.

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -87,8 +87,8 @@ GLOBAL_LIST_INIT(helmet_styles, list(
 	HELMET_PROTECTIVE,
 ))
 
-// True value of max save slots (3 is default, 8 is byond member, +1 to either if you have the extra slot loadout entry). Potential max is 9
-#define TRUE_MAX_SAVE_SLOTS 9
+// True value of max save slots (10 is default, 16 is byond member, +2 to either if you have the extra slot loadout entry). Potential max is 18
+#define TRUE_MAX_SAVE_SLOTS 18
 
 // Values for /datum/preference/preference_type
 /// This preference is character specific.

--- a/code/modules/client/loadout/loadout_ooc.dm
+++ b/code/modules/client/loadout/loadout_ooc.dm
@@ -5,14 +5,14 @@
 	is_equippable = FALSE
 
 /datum/gear/ooc/char_slot
-	display_name = "extra character slot"
-	description = "An extra charslot. Pretty self-explanatory."
+	display_name = "two extra character slots"
+	description = "An extra two charslots. Pretty self-explanatory."
 	cost = 10000
 	path = /obj/item/toy/figure/captain
 
 /datum/gear/ooc/char_slot/purchase(var/client/C)
 	// This is only locally immediately after purchase - this will be incremented on load in preferences.dm
-	C.prefs.max_save_slots += 1
+	C.prefs.max_save_slots += 2
 
 /datum/gear/ooc/real_antagtoken
 	display_name = "antag token"

--- a/code/modules/client/preferences/preferences.dm
+++ b/code/modules/client/preferences/preferences.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// The current active slot, and the one that will be saved as active
 	var/default_slot = 1
 	/// The maximum number of slots we're allowed to contain
-	var/max_save_slots = 3
+	var/max_save_slots = 10
 	/// Cache for the current active character slot
 	var/datum/preferences_holder/preferences_character/character_data
 	/// Cache for player datumized preferences
@@ -115,7 +115,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if(!IS_GUEST_KEY(parent.key))
 			unlock_content = !!parent.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 8
+				max_save_slots = 16
 			log_preferences("[parent.ckey]: Checked BYOND membership: [unlock_content ? "MEMBER" : "NONMEMBER"].")
 	else
 		CRASH("attempted to create a preferences datum without a client!")
@@ -131,7 +131,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(pref_load == PREFERENCE_LOAD_SUCCESS || pref_load == PREFERENCE_LOAD_NO_DATA)
 		log_preferences("[parent?.ckey]: Player preferences loaded and applied.")
 		if("6030fe461e610e2be3a2c3e75c06067e" in purchased_gear) //MD5 hash of, "extra character slot"
-			max_save_slots += 1
+			max_save_slots += 2
 		// Apply the loaded preferences!!
 		if(istype(parent))
 			apply_all_client_preferences()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the amount of character slots available to players.

Default is now 10. 

Byond members get +6

Beeshop slot purchasers get +2

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As a roleplay server, I think it is a terrible state of things that you can only have *three* characters as a normal player.

Some servers like Baystation have had dozens of character slots for years, whilst even some lower rp servers have also made a shift in letting people play more characters. 

My statement is this: An arbitrary limit on characters is an arbitrary limit on creativity. We want people to get immersed and create more characters that have interesting backstories or try new species, and not be worried about having to sacrifice one of their 3 character slots to do so. I've sacrificed numerous characters since I started playing in 2020, so this is something I am passionate about.

Before I made this pr, I went around and got feedback from others who also play multiple characters on the regular, and received pretty positive results. I think this will be a net good for us.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/3c6b03eb-209a-4e08-b8ab-85797df70545)


</details>

## Changelog
:cl: rkz
config: The maximum number of character slots has been doubled from 9 to 18. Regular users will be able to access 10 of these slots, with Byond donors being able to access another 6, and those purchasing the beeshop character slots receiving the remaining two.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
