### PR TITLE
 Fixes EchoStation's Medbay Central APC Power Cable [Now With 100% Fewer Merge Conflicts]

### DIFF
--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -31820,9 +31820,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/vending/wallmed{
 	pixel_x = -32
 	},
@@ -31830,6 +31827,9 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/layer_4,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/iron/grid/steel,
 /area/medical/medbay/central)
 "pHp" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Echo's Medbay Central APC had a power cable... but it was facing the wrong way.

This now fixes it.

## Why It's Good For The Game

Medbay can't fix spessmen if medbay has no power.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/a4f3fce0-073a-4b74-a8b4-f32d4b1d3676)

</details>

## Changelog
:cl:
fix: The electricians have rewired Echostation's Medbay APC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
