### PR TITLE
Expands shoulderholster valid slots

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -79,7 +79,11 @@
 	cold_protection = CHEST|GROIN|ARMS
 	heat_protection = CHEST|GROIN|ARMS
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
-	allowed = list(/obj/item/tank/internals, /obj/item/melee/classic_baton) //Trench coats are a little more apt at carrying larger objects.
+	allowed = list(
+		/obj/item/tank/internals,
+		/obj/item/melee/classic_baton,
+		/obj/item/clothing/accessory/holster/detective,
+		) //Trench coats are a little more apt at carrying larger objects.
 
 /obj/item/clothing/suit/jacket/det_suit/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -378,6 +378,7 @@
 	icon_state = "holster"
 	item_state = "holster"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/holster
+	slot_flags = ITEM_SLOT_SUITSTORE|ITEM_SLOT_BELT
 
 /obj/item/clothing/accessory/holster/detective
 	name = "detective's shoulder holster"

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -1,4 +1,4 @@
-/obj/item/clothing/accessory //Ties moved to neck slot items, but as there are still things like medals and armbands, this accessory system is being kept as-is
+/obj/item/clothing/accessory
 	name = "Accessory"
 	desc = "Something has gone wrong!"
 	icon = 'icons/obj/clothing/accessories.dmi'
@@ -34,14 +34,19 @@
 	layer = FLOAT_LAYER
 	plane = FLOAT_PLANE
 	if(minimize_when_attached)
-		transform *= 0.5	//halve the size so it doesn't overpower the under
+		transform *= 0.5 //halve the size so it doesn't overpower the under
 		pixel_x += 8
 		pixel_y -= 8
 	U.add_overlay(src)
 
-	if (islist(U.armor) || isnull(U.armor)) 										// This proc can run before /obj/Initialize has run for U and src,
-		U.armor = getArmor(arglist(U.armor))	// we have to check that the armor list has been transformed into a datum before we try to call a proc on it
-																					// This is safe to do as /obj/Initialize only handles setting up the datum if actually needed.
+	/**
+	** This proc can run before /obj/Initialize has run for U and src,
+	** we have to check that the armor list has been transformed into a datum before we try to call a proc on it
+	** This is safe to do as /obj/Initialize only handles setting up the datum if actually needed.
+	**/
+	if (islist(U.armor) || isnull(U.armor))
+		U.armor = getArmor(arglist(U.armor))
+
 	if (islist(armor) || isnull(armor))
 		armor = getArmor(arglist(armor))
 
@@ -377,8 +382,9 @@
 	desc = "A holster to carry a handgun and ammo. WARNING: Badasses only."
 	icon_state = "holster"
 	item_state = "holster"
+	worn_icon_state = "holster"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/holster
-	slot_flags = ITEM_SLOT_SUITSTORE|ITEM_SLOT_BELT|ITEM_SLOT_OCLOTHING
+	slot_flags = ITEM_SLOT_SUITSTORE|ITEM_SLOT_BELT
 
 /obj/item/clothing/accessory/holster/detective
 	name = "detective's shoulder holster"

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -378,7 +378,7 @@
 	icon_state = "holster"
 	item_state = "holster"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/holster
-	slot_flags = ITEM_SLOT_SUITSTORE|ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_SUITSTORE|ITEM_SLOT_BELT|ITEM_SLOT_OCLOTHING
 
 /obj/item/clothing/accessory/holster/detective
 	name = "detective's shoulder holster"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[Old functionality of shoulderholster](#2486) had them as a belt.

This expands it to suitstorage, and belt slots.

Ideally, we should just make a cowboy belt for det and give him the option of keeping the gun with his gear in the belt or in an accessory.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I want to wear a vest accessory and my shoulder holster as detective. I dont want to put my accessory in my detbelt, then have to go through two storage items to get it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/f9938d47-5502-40cb-aeb0-61b16d4d540f)

</details>

## Changelog
:cl:
tweak: Allows equipping of det should holster in belt again. You can also wear it in exosuit or suit storage slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
