### PR TITLE
Fixes electronic paper reader looping infinitely

### DIFF
--- a/code/modules/paperwork/paper_reader.dm
+++ b/code/modules/paperwork/paper_reader.dm
@@ -39,6 +39,6 @@
 		in_use = FALSE
 		return
 	say(strip_html_tags(to_read[1]))
-	to_read.Remove(1)
+	to_read.Remove(to_read[1])
 	sleep(1 SECONDS)
 	INVOKE_ASYNC(src, PROC_REF(handle_todo))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

the electronic paper reader currently has a problem with infinite looping
it has some logic that is supposed to split the paper in paragraphs and read out each one separately
however, it does not properly remove the elements from the list it builds
this means it will loop infinitely on the first element until interrupted with a click or by reading a blank paper
testing evidence shows both the bug and the behavior after fixing

PR represents a one-line fix to this problem
``to_read.Remove(1)`` seems to have been used with ``1`` as an index in semantics
replaced that ``1`` with a ``to_read[1]`` to match the element semantics described in the documentation for the ``list.Remove()`` proc

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

this means no more annoying infinite reader spam and having to find workarounds the problem of it infinitely repeating such as by reading a blank paper
PR might not be desirable if the reader is **intended** to read in an infinite loop

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

before the fix:

https://github.com/user-attachments/assets/2a4f8c27-2a0c-43fb-bb62-66ba30633bc5

after the fix:

https://github.com/user-attachments/assets/1685f78a-be67-4e65-8e91-78cc638e3f8f

testing procedure involved testing with an empty paper (does nothing), then a paper with one paragraph, then one with multiple (such as video above), additionally one with a stamp (doesn't seem to be read out)
interrupting with a click also seems to work when reading out multiple paragraphs

</details>

## Changelog
:cl: Aramix
fix: fixed the electronic paper reader infinitely reading out the first paragraph in a paper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
