### PR TITLE
Removes a random period that appears when examining silicons

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -612,7 +612,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom)
   * Produces a signal COMSIG_PARENT_EXAMINE
   */
 /atom/proc/examine(mob/user)
-	. = list("[get_examine_string(user, TRUE)].")
+	. = list("[get_examine_string(user, TRUE)]")
 
 	if(desc)
 		. += desc

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -601,7 +601,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/atom)
 
 ///Generate the full examine string of this atom (including icon for goonchat)
 /atom/proc/get_examine_string(mob/user, thats = FALSE)
-	return "[icon2html(src, user)] [thats? "That's ":""][get_examine_name(user)]"
+	return "[icon2html(src, user)] [thats? "That's ":""][get_examine_name(user)]."
 
 /**
   * Called when a mob examines (shift click or verb) this atom


### PR DESCRIPTION
## About The Pull Request

Removes a random period that appears when examining a silicon. See testing photographs for an example.

## Why It's Good For The Game

Looks nicer, no reason for this to be there.

## Testing Photographs and Procedure
Moving the period fixes this issue without affecting anything else that I can see. I've examined a few different types of things to check if it's removed elsewhere by doing this.
<details>
<summary>Screenshots&Videos</summary>

Before, you can see a period above laws.
![image](https://github.com/user-attachments/assets/faf5fd01-4fd1-42f7-92f6-5db00e4ea749)

After.
![image](https://github.com/user-attachments/assets/0049cd20-6663-49ae-82bb-6eb26effceed)

</details>

:cl: ktlwjec
spellcheck: Removed a random period that appeared when examining silicons.
/:cl: