### PR TITLE
adds a playtime requirement for obsessed

### DIFF
--- a/code/modules/antagonists/obsessed/obsessed.dm
+++ b/code/modules/antagonists/obsessed/obsessed.dm
@@ -3,6 +3,7 @@
 	show_in_antagpanel = TRUE
 	antagpanel_category = "Other"
 	banning_key = ROLE_OBSESSED
+	required_living_playtime = 4
 	show_name_in_check_antagonists = TRUE
 	roundend_category = "obsessed"
 	count_against_dynamic_roll_chance = FALSE


### PR DESCRIPTION
## About The Pull Request
Adds a requirement of 4 hours playtime to obsessed, the same as traitor and the other midround antagonists.

## Why It's Good For The Game
Currently, brand new players can roll obsessed. This seems unintended. We should probably not have players who don't know how to speak in-game yet playing this role.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Current (manually toggled off i cba to go back and grab a new image):
![image](https://github.com/user-attachments/assets/ca6162ef-7da4-4836-93a8-fdbc8020dcbe)

With this change:
![image](https://github.com/user-attachments/assets/ec2140f2-37e3-4456-b23d-873f07325ed7)

</details>

## Changelog
:cl: ktlwjec
tweak: Obsessed requires 4 hours of playtime to roll, instead of 0.
/:cl: