### PR TITLE
Changes async map generator to have a synchronous generation proc

### DIFF
--- a/code/controllers/subsystem/async_map_generator.dm
+++ b/code/controllers/subsystem/async_map_generator.dm
@@ -2,7 +2,6 @@ SUBSYSTEM_DEF(async_map_generator)
 	name = "Async Map Generator"
 	wait = 1
 	flags = SS_TICKER | SS_NO_INIT
-	init_stage = INITSTAGE_EARLY
 	// We need to be running while shuttles are loading
 	runlevels = ALL
 
@@ -54,3 +53,12 @@ SUBSYSTEM_DEF(async_map_generator)
 			//to_chat(world, "<span class='announce'>Fully completed running map generator [current_run_index + 1].</span>")
 		//Continue to the next process
 		MC_SPLIT_TICK
+
+/datum/controller/subsystem/async_map_generator/proc/run_to_completion()
+	for (var/datum/async_map_generator/generator in executing_generators)
+		while (!generator.execute_run())
+			CHECK_TICK
+		executing_generators -= generator
+		generator.complete()
+	current_run_index = 1
+	current_run_length = 0

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -61,8 +61,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/shuttles_loaded = FALSE
 
 /datum/controller/subsystem/shuttle/Initialize()
-	// 30 seconds max to load, don't hold up everything if SSshuttles throws an exception and fails to load
-	AWAIT(initial_load(), 30 SECONDS)
+	initial_load()
 
 	if(!arrivals)
 		WARNING("No /obj/docking_port/mobile/arrivals placed on the map!")
@@ -75,13 +74,11 @@ SUBSYSTEM_DEF(shuttle)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/shuttle/proc/initial_load()
-	RETURN_TYPE(/datum/task)
 	shuttles_loaded = TRUE
-	var/datum/task/parent_task = new()
 	for(var/s in stationary)
 		var/obj/docking_port/stationary/S = s
-		parent_task.add_subtask(S.load_roundstart())
-	return parent_task
+		S.load_roundstart()
+	SSasync_map_generator.run_to_completion()
 
 /datum/controller/subsystem/shuttle/fire()
 	for(var/thing in mobile)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -264,7 +264,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/docking_port)
 	. = ..()
 
 /obj/docking_port/stationary/proc/load_roundstart()
-	DECLARE_ASYNC
 	if(json_key)
 		var/sid = SSmapping.config.shuttles[json_key]
 		roundstart_template = SSmapping.shuttle_templates[sid]
@@ -278,9 +277,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/docking_port)
 			CRASH("Invalid path ([roundstart_template]) passed to docking port.")
 
 	if(roundstart_template)
-		var/datum/async_map_generator/shuttle_loader = SSshuttle.action_load(roundstart_template, src)
-		UNTIL(shuttle_loader.completed)
-	ASYNC_FINISH
+		SSshuttle.action_load(roundstart_template, src)
 
 /obj/docking_port/stationary/transit
 	name = "In Transit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shuttle generator will run async map generator to completion before it finishes its initialisation. This removes an inconvenient sleep and should fix our shuttle loading issues that occurred on dev.

## Why It's Good For The Game

Shuttles have been failing to load recently, and I am not super happy with the previous fix anyway.

## Testing Photographs and Procedure

I've run it 3 times with the conditions that previously resulted in failure and haven't seen anything.

![image](https://github.com/user-attachments/assets/c7e26799-8cb2-42a8-8b70-6834c3715822)

![image](https://github.com/user-attachments/assets/38cd432d-a949-4ff1-98f7-11355fd34352)

No failures on any shuttles on any run.

## Changelog
:cl:
fix: Fixes shuttle roundstart loading issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
