### PR TITLE
Reverts some monstermos-era changes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -27517,8 +27517,7 @@
 "hFx" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Air to Distro";
-	target_pressure = 500
+	name = "Air to Distro"
 	},
 /obj/machinery/light{
 	dir = 1

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -43208,8 +43208,7 @@
 "nOz" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Air to Distro";
-	target_pressure = 500
+	name = "Air to Distro"
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -34949,8 +34949,7 @@
 "ffT" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Air to Distro";
-	target_pressure = 500
+	name = "Air to Distro"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron,

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -45053,8 +45053,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	dir = 4;
-	name = "Air to Distro";
-	target_pressure = 500
+	name = "Air to Distro"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -26230,8 +26230,7 @@
 "gHl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Air to Distro";
-	target_pressure = 500
+	name = "Air to Distro"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24222,8 +24222,7 @@
 "eaC" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Air to Distro";
-	target_pressure = 500
+	name = "Air to Distro"
 	},
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 25

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -68207,8 +68207,7 @@
 "vEV" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Air to Distro";
-	target_pressure = 500
+	name = "Air to Distro"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/tech,

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -214,7 +214,7 @@
 /// -14°C kitchen coldroom, just might lose your tail; higher amount of mol to reach about 101.3 kpA
 #define KITCHEN_COLDROOM_ATMOS "o2=26;n2=97;TEMP=[COLD_ROOM_TEMP]"
 /// used in the holodeck burn test program
-#define BURNMIX_ATMOS "o2=100;plasma=200;TEMP=370" //used in the holodeck burn test program
+#define BURNMIX_ATMOS "o2=2500;plasma=5000;TEMP=370" //used in the holodeck burn test program
 
 //ATMOSPHERICS DEPARTMENT GAS TANK TURFS
 #define ATMOS_TANK_N2O				"n2o=6000;TEMP=293.15"

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -2,9 +2,9 @@
 	name = "Anomaly: Hyper-Energetic Flux"
 	typepath = /datum/round_event/anomaly/anomaly_flux
 
-	min_players = 40
+	min_players = 20
 	max_occurrences = 5
-	weight = 5
+	weight = 10
 
 /datum/round_event/anomaly/anomaly_flux
 	startWhen = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts:
- https://github.com/BeeStation/BeeStation-Hornet/pull/1922
- https://github.com/BeeStation/BeeStation-Hornet/pull/2244
- https://github.com/BeeStation/BeeStation-Hornet/pull/3079


Reverts several monstermos-era changes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

All of these changes staked their existence on "cuz monstermos". Well, its 3-4 years later and we don't have that anymore, so any system changes we were "accounting for" back then should not be slipping into the new system we want to transition to.

Whether any of them have merit, they should be in their own pr with good *new* reasoning.

The last one might actually be a fair change, so I've just found a middleground between the old and monstermos values so it actually appears atleast once in player's lifetimes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Compiles.

![image](https://github.com/user-attachments/assets/3cb17097-5f32-423f-9ab0-c54d0e3ed241)


</details>

## Changelog
:cl:
tweak: reverted change to air pump value set default
tweak: reverted change reducing holodeck plasmafire volume
balance: Upped weight and lowered minimum playercount for Energetic Flux anomaly to appear
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
