### PR TITLE
Medbot no longer opens (unused) menu upon beaker insertion

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -241,7 +241,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/bot/medbot)
 		var/reagentlist = pretty_string_from_reagent_list(reagent_glass.reagents.reagent_list)
 		log_combat(user, src, "inserted a [W] with [reagentlist]" )
 		add_fingerprint(user)
-		show_controls(user)
 		update_icon()
 
 	if(istype(W, /obj/item/pen)&&!locked)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

removes the functionality where inserting a container into a medbot would open its menu if it wasn't open already (not lock/unlock, just popping the menu on the screen of the user)
for comparison, floorbots do not do this when having a stack of tiles inserted into them

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

since #11378, the removed behavior caused a minor issue where the old and now unused menu got opened automatically on the screen

<details>
<summary>Image from report</summary>

![image](https://github.com/user-attachments/assets/82e88e1b-6556-49ed-bc83-c619888ea05f)


</details>

having things that are not supposed to appear on the screen no longer appear on the screen is ideal, but otherwise does not cause loss of functionality or other issues than an extra window appearing

## Alternative

based on further discussion, this could be changed to instead open the new menu
however, taking a decision upon this is difficult to do because I am personally not familiar with this mechanic being used or useful - at a first glance, opinions are divided almost evenly on this
depending on discussion and arguments on this PR, it could be later adjusted to go that way instead

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

testing video with medbot not automatically opening the menu anymore

https://github.com/user-attachments/assets/4b0177d7-a3fe-41b8-82e0-56af7daea9cf

</details>

## Changelog
:cl: Aramix
tweak: medbot no longer automatically opens its menu to the user inserting a container into it if the menu wasn't already open
fix: as a result, the old and now unused menu is no longer opened, as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
