### PR TITLE
Fix Holoparasites with Range 1 being unable to recall and seeing barriers

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -400,7 +400,6 @@
 	It would be wise to avoid buying these with anything capable of causing you to swap bodies with others."
 	item_path = /obj/item/holoparasite_creator/wizard
 	category = "Assistance"
-	disabled = TRUE	// #11096: Currently in a broken state, cannot recall as they will immediately manifest and cannot move despite having range stats.
 
 /datum/spellbook_entry/item/bloodbottle
 	name = "Bottle of Blood"

--- a/code/modules/holoparasite/holoparasite_barriers.dm
+++ b/code/modules/holoparasite/holoparasite_barriers.dm
@@ -17,7 +17,7 @@
 /mob/living/simple_animal/hostile/holoparasite/proc/setup_barriers()
 	cut_barriers()
 
-	if(!client || !isturf(loc) || !summoner.current || range <= 1)
+	if(!client || !isturf(loc) || !summoner.current || stats.range == 1)
 		return
 
 	var/list/view_size = getviewsize(world.view)

--- a/code/modules/holoparasite/holoparasite_helpers.dm
+++ b/code/modules/holoparasite/holoparasite_helpers.dm
@@ -32,7 +32,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/hostile/holoparasite)
 		return FALSE
 	if(range <= 0)
 		return FALSE
-	return (!permanently && attached_to_summoner) || stats?.range == 1
+	return (!permanently && attached_to_summoner)
 
 /**
  * Returns whether the holoparasite is within range of its summoner or not.

--- a/code/modules/holoparasite/holoparasite_movement.dm
+++ b/code/modules/holoparasite/holoparasite_movement.dm
@@ -12,6 +12,9 @@
 	if(!can_be_manifested())
 		recall(forced = TRUE)
 		return FALSE
+	// If you got no range, you shouldn't be able to move
+	if(stats?.range == 1)
+		return FALSE
 	// You can't move out of your range yourself.
 	if(is_in_range() && !is_in_range(new_loc))
 		if(COOLDOWN_FINISHED(src, range_balloon_cooldown))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -626,7 +626,6 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	player_minimum = 25
 	restricted = TRUE
 	refundable = TRUE
-	disabled = TRUE	// #11096: Currently in a broken state, cannot recall as they will immediately manifest and cannot move despite having range stats.
 
 /**
  * Only allow holoparasites to be refunded if the injector is unused.
@@ -2368,7 +2367,6 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	player_minimum = 25
 	restricted = TRUE
 	restricted_roles = list(JOB_NAME_COOK, JOB_NAME_CHAPLAIN)
-	disabled = TRUE	// #11096: Currently in a broken state, cannot recall as they will immediately manifest and cannot move despite having range stats.
 
 /datum/uplink_item/role_restricted/ez_clean_bundle
 	name = "EZ Clean Grenade Bundle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

range 1 holoparasites are supposed not to be able to move away from their summoner, and are a special case
however, it has been reported in #11096 that they are forced to manifest and that they get barriers
those are unintentional and this PR now allows said holoparas to manifest and recall as usual, while still being unable to move, then hides the barrier from appearing to them as it suggests they should be able to move while that is not the case

for this, range 1 check was moved from attachment update (which is probably the source of recall issue, being snapped back to attachment while not manifested) to Move instead to prevent movement within the apparent range
then redid the range 1 check in ``set_barrier`` to use the range as seen in stats

now also partially reverts #11096 by re-enabling holoparasites and holocarps in uplink, respectively guardian deck in wizard spellbook

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

1. fixes #11096: inability to recall and appearance of boundary visuals (obsolete for range 1)
2. contributes towards a revert of #11454
- [x] TODO: discuss if this PR should also include readding the holoparasite injector to the uplink
3. now also partially reverts #11096

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/184e7390-7d9e-4399-a75b-0f46558c37c5

tested successfully that holoparasites with range other than 1 are not affected

- [x] further possible tests: checking with specific holoparasites
  - [x] wizard tarot deck
  - [x] holocarps
conclusion: for what I can tell, these types of holoparasites mostly change sprite/flavor or ability to have multiple of them at the same time, and have no apparent changes to manifestation such as making it permanent

</details>

## Changelog
:cl: Aramix
fix: fixed holoparasites with range 1 seeing a barrier
fix: fixed holoparasites with range 1 being forced to manifest and unable to recall
tweak: holoparasites, holocarps and guardian decks are now available once again following these fixes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
