### PR TITLE
Fixes Echo's engineering

### DIFF
--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -1182,7 +1182,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/engine,
@@ -2303,7 +2303,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/asteroid/basalt/planetary,
-/area/asteroid/paradise)
+/area/engine/atmos)
 "aSX" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
@@ -9953,7 +9953,7 @@
 /obj/structure/window/plasma/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/layer2/flipped{
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/layer2/flipped/inverse{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -10231,7 +10231,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/asteroid/basalt/planetary,
-/area/asteroid/paradise)
+/area/engine/atmos)
 "eUf" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname/directional/east,
@@ -16522,12 +16522,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "iad" = (
-/obj/machinery/power/solar{
-	id = "portsolar";
-	name = "Port Solar Array"
-	},
-/turf/open/floor/iron/solarpanel,
-/area/asteroid/paradise/surface)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/asteroid/planetary,
+/area/engine/atmos)
 "ial" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/dirt/planetary,
@@ -18259,7 +18256,8 @@
 /area/engine/atmos)
 "iZg" = (
 /obj/machinery/power/apc/auto_name/directional/north{
-	pixel_y = 24
+	pixel_y = 24;
+	cell_type = /obj/item/stock_parts/cell/hyper
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -18705,7 +18703,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/planetary,
-/area/asteroid/paradise)
+/area/engine/atmos)
 "jmY" = (
 /turf/open/floor/plating/beach/coastline_b,
 /area/asteroid/paradise/surface/water)
@@ -24780,8 +24778,8 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/engine/engineering)
@@ -27011,7 +27009,7 @@
 	req_access_txt = "10"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
@@ -30623,7 +30621,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/planetary,
-/area/asteroid/paradise)
+/area/engine/atmos)
 "oZT" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -30684,7 +30682,7 @@
 	dir = 8;
 	name = "Gas to Filter"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/iron/dark,
@@ -32719,6 +32717,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/quartermaster/storage)
+"qcU" = (
+/turf/open/floor/plating/asteroid/basalt/planetary,
+/area/engine/atmos)
 "qcV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -34377,8 +34378,9 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/techmaint/planetary,
-/area/asteroid/paradise/surface)
+/area/hallway/primary/fore)
 "qZA" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
@@ -36001,11 +36003,11 @@
 	name = "Gas to Chamber"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc/auto_name/directional/east{
 	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -45493,7 +45495,7 @@
 "wAx" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/planetary,
-/area/asteroid/paradise)
+/area/engine/atmos)
 "wAN" = (
 /obj/effect/turf_decal/tile/dark_green/fourcorners/contrasted,
 /obj/effect/turf_decal/siding/white/corner{
@@ -45627,6 +45629,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/iron/dark,
 /area/engine/engineering)
@@ -47344,7 +47349,7 @@
 "xtP" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/iron/dark,
@@ -60624,9 +60629,9 @@ fUV
 ozj
 qUD
 fus
-sLz
+qcU
 oZL
-mVg
+iad
 lCB
 jsp
 jsp
@@ -60883,7 +60888,7 @@ uKf
 oWL
 eTK
 aST
-xqU
+bJq
 lCB
 jsp
 jsp
@@ -61140,7 +61145,7 @@ dwq
 fus
 wAx
 jmP
-sLz
+qcU
 oJl
 jsp
 jsp
@@ -262881,7 +262886,7 @@ vvg
 lEc
 sol
 elM
-iad
+yfQ
 mTe
 sol
 vKW
@@ -263138,7 +263143,7 @@ mPv
 pdW
 sol
 xRg
-iad
+yfQ
 kqB
 sol
 bkP
@@ -263395,7 +263400,7 @@ rAu
 wQy
 sol
 xRg
-iad
+yfQ
 bIK
 sol
 xRg
@@ -263652,7 +263657,7 @@ fuQ
 bIK
 sol
 auy
-iad
+yfQ
 kqB
 bGP
 auy
@@ -263909,7 +263914,7 @@ sBX
 bIK
 sol
 auy
-iad
+yfQ
 bIK
 sol
 auy
@@ -264166,7 +264171,7 @@ tgt
 uXr
 sol
 xRg
-iad
+yfQ
 bIK
 sol
 auy
@@ -264423,7 +264428,7 @@ evc
 kqB
 sol
 auy
-iad
+yfQ
 bIK
 sol
 bkP
@@ -265451,7 +265456,7 @@ qZw
 vFz
 sol
 epm
-iad
+yfQ
 bIK
 sol
 mYe
@@ -265708,7 +265713,7 @@ qdf
 xCK
 sol
 epm
-iad
+yfQ
 bIK
 sol
 uVq
@@ -265965,7 +265970,7 @@ xbj
 uXr
 sol
 uVq
-iad
+yfQ
 kqB
 bGP
 epm
@@ -266222,7 +266227,7 @@ xXl
 pAy
 sol
 uVq
-iad
+yfQ
 bIK
 sol
 epm
@@ -266479,7 +266484,7 @@ lDM
 wQy
 sol
 adk
-iad
+yfQ
 bIK
 sol
 epm
@@ -266736,7 +266741,7 @@ nIF
 bIK
 sol
 sna
-iad
+yfQ
 bIK
 sol
 eWs


### PR DESCRIPTION
## About The Pull Request

Fixes the many issues that engineering got after a recent update to Echostation. More details in the changelog.
Changing atmos to have a tier 3 cell may be too much, I won't complain if it's silently removed or I'm requested to change that. Though the cell is there in the first place to make sure that the energy-demanding atmospherics can stay active until a source of power is set up.

## Why It's Good For The Game

It's good to:
- Have an SM that doesn't delam because it's only waste outlet injector isn't powered.
- Have a Solar Array that can be used without moving the solar control console inside the station.
- Having the distro loop be filled with actual air instead of 79% oxygen and 21% nitrogen. Wasn't that fixed before?

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![изображение](https://github.com/user-attachments/assets/6239fb60-7304-4dc2-8c7e-9a38e42ea939)

![изображение](https://github.com/user-attachments/assets/7a0d05ca-8444-4826-89a5-6bc56b41036a)

![изображение](https://github.com/user-attachments/assets/044916af-5d73-4ce3-bd78-6644da1ec945)

![изображение](https://github.com/user-attachments/assets/c63b01d6-1146-4a0e-8e2a-60e6f6455a7e)
(Note: Node 1 is the arrow highlighted in red, and node 2 in blue. On Echo, the N2 actually comes through node 2 (hey, it rhymes!), and O2 through node 1.)

![изображение](https://github.com/user-attachments/assets/9a662e53-33f7-4bf6-95ed-e186fe48bff5)

</details>

## Changelog
:cl: Swatblack
fix: Connected the supermatter's APC to the main power grid
fix: Added a powered area on top of the solar control console to make it usable
add: Added a floor light under said solar control console, totally just aesthetic reasons
fix: Added wires under 12 solar panels which were missing for some reason
fix: Added a powered area to engineering's waste exhaust to make them actually powered and working
fix: Changed the air mixer to mix 71% nitrogen and 29% oxygen instead of 71% oxygen and 29% nitrogen
tweak: Made the atmos APC have a tier 3 cell
/:cl:

am i doing this right
i didn't even read any guides i just rushed in to edit one map file
