### PR TITLE
makes donut boxes start closed

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -71,10 +71,9 @@
 	name = "donut box"
 	desc = "Mmm. Donuts."
 	icon = 'icons/obj/food/donuts.dmi'
-	icon_state = "donutbox_inner"
+	icon_state = "donutbox"
 	base_icon_state = "donutbox"
 	spawn_type = /obj/item/food/donut/premade
-	is_open = TRUE
 	appearance_flags = KEEP_TOGETHER
 	contents_tag = "donut"
 


### PR DESCRIPTION
## About The Pull Request

Makes donut boxes start closed, instead of open.
As a little bonus treat this makes them show up properly on map editors too.

## Why It's Good For The Game

I don't really know why this box in particular would start open. A surprise of which donuts you will get when you open the box, surprises are nice.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Tested opening/closing, adding/removing donuts.
In-game:
![image](https://github.com/user-attachments/assets/b49ed83c-50af-4bbe-a50c-85553a15d67c)

Map editor:
![image](https://github.com/user-attachments/assets/1190857d-3291-4fda-8cf0-5635c5060a2c)

</details>

:cl: ktlwjec
tweak: Donut boxes start closed.
/:cl: