### PR TITLE
Compilation Speedup (~2.3 seconds) - Reduces compilation overhead by disabling icon-cutter & DMTarget inputs/outputs

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -36,30 +36,6 @@ Juke.setup({ file: import.meta.url }).then((code) => {
 
 const DME_NAME = 'beestation';
 
-// Stores the contents of dependencies.sh as a key value pair
-// Best way I could figure to get ahold of this stuff
-/*
-const dependencies = fs.readFileSync('dependencies.sh', 'utf8')
-  .split("\n")
-  .map((statement) => statement.replace("export", "").trim())
-  .filter((value) => !(value == "" || value.startsWith("#")))
-  .map((statement) => statement.split("="))
-  .reduce((acc, kv_pair) => {
-    acc[kv_pair[0]] = kv_pair[1];
-    return acc
-  }, {})
-
-// Canonical path for the cutter exe at this moment
-const getCutterPath = () => {
-  const ver = dependencies.CUTTER_VERSION;
-  const suffix = process.platform === 'win32' ? '.exe' : '';
-  const file_ver = ver.split('.').join('-');
-  return `tools/icon_cutter/cache/hypnagogic${file_ver}${suffix}`;
-};
-
-const cutter_path = getCutterPath();
-*/
-
 export const DefineParameter = new Juke.Parameter({
   type: 'string[]',
   alias: 'D',
@@ -81,11 +57,6 @@ export const ForceRecutParameter = new Juke.Parameter({
   name: "force-recut",
 });
 
-export const SkipIconCutter = new Juke.Parameter({
-  type: 'boolean',
-  name: "skip-icon-cutter",
-});
-
 export const WarningParameter = new Juke.Parameter({
   type: 'string[]',
   alias: 'W',
@@ -95,105 +66,6 @@ export const NoWarningParameter = new Juke.Parameter({
   type: 'string[]',
   alias: 'I',
 });
-
-/*
-export const CutterTarget = new Juke.Target({
-  onlyWhen: () => {
-    const files = Juke.glob(cutter_path);
-    return files.length == 0;
-  },
-  executes: async () => {
-    const repo = dependencies.CUTTER_REPO;
-    const ver = dependencies.CUTTER_VERSION;
-    const suffix = process.platform === 'win32' ? '.exe' : '';
-    const download_from = `https://github.com/${repo}/releases/download/${ver}/hypnagogic${suffix}`
-    await download_file(download_from, cutter_path);
-    if(process.platform !== 'win32') {
-      await Juke.exec("chmod", [
-        '+x',
-        cutter_path,
-      ]);
-    }
-  },
-});
-
-async function download_file(url, file) {
-  return new Promise((resolve, reject) => {
-    let file_stream = fs.createWriteStream(file);
-    https.get(url, function(response) {
-      if (response.statusCode === 302) {
-        file_stream.close();
-        download_file(response.headers.location, file)
-          .then((value) => resolve());
-        return;
-      }
-      if (response.statusCode !== 200) {
-        Juke.logger.error(`Failed to download ${url}: Status ${response.statusCode}`);
-        file_stream.close();
-        reject()
-        return
-      }
-      response.pipe(file_stream);
-
-      // after download completed close filestream
-      file_stream.on("finish", () => {
-        file_stream.close();
-        resolve()
-      });
-
-    }).on("error", (err) => {
-      file_stream.close();
-      Juke.rm(download_into);
-      Juke.logger.error(`Failed to download ${url}: ${err.message}`);
-      reject()
-    });
-  });
-}
-
-export const IconCutterTarget = new Juke.Target({
-  parameters: [ForceRecutParameter],
-  dependsOn: () => [
-    CutterTarget,
-  ],
-  inputs: ({ get }) => {
-    const standard_inputs = [
-      `icons\/**\/*.png.toml`,
-      `icons\/**\/*.dmi.toml`,
-      `cutter_templates\/**\/*.toml`,
-cutter_path,
-    ]
-    // Alright we're gonna search out any existing toml files and convert
-    // them to their matching .dmi or .png file
-    const existing_configs = [
-      ...Juke.glob(`icons\/**\/*.png.toml`),
-      ...Juke.glob(`icons\/**\/*.dmi.toml`),
-    ];
-    return [
-      ...standard_inputs,
-      ...existing_configs.map((file) => file.replace('.toml', '')),
-    ]
-  },
-  outputs: ({ get }) => {
-    if(get(ForceRecutParameter))
-      return [];
-    const folders = [
-      ...Juke.glob(`icons\/**\/*.png.toml`),
-      ...Juke.glob(`icons\/**\/*.dmi.toml`),
-    ];
-    return folders
-      .map((file) => file.replace(`.png.toml`, '.dmi'))
-      .map((file) => file.replace(`.dmi.toml`, '.png'));
-  },
-  executes: async () => {
-    await Juke.exec(cutter_path, [
-      '--dont-wait',
-      '--templates',
-      'cutter_templates',
-      'icons',
-    ]);
-  },
-});
-*/
 
 export const DmMapsIncludeTarget = new Juke.Target({
   executes: async () => {
@@ -213,11 +85,9 @@ export const DmMapsIncludeTarget = new Juke.Target({
 });
 
 export const DmTarget = new Juke.Target({
-  parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter, SkipIconCutter],
+  parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
   dependsOn: ({ get }) => [
     get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
-    // BeeStation: Disabled while iconCutter is not in use
-    //!get(SkipIconCutter) && IconCutterTarget,
   ],
   executes: async ({ get }) => {
     await DreamMaker(`${DME_NAME}.dme`, {
@@ -233,7 +103,6 @@ export const DmTestTarget = new Juke.Target({
   parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
   dependsOn: ({ get }) => [
     get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
-    IconCutterTarget,
   ],
   executes: async ({ get }) => {
     fs.copyFileSync(`${DME_NAME}.dme`, `${DME_NAME}.test.dme`);
@@ -264,46 +133,6 @@ export const DmTestTarget = new Juke.Target({
     }
   },
 });
-
-/*
-export const AutowikiTarget = new Juke.Target({
-  parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
-  dependsOn: ({ get }) => [
-    get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
-    IconCutterTarget,
-  ],
-  outputs: [
-    'data/autowiki_edits.txt',
-  ],
-  executes: async ({ get }) => {
-    fs.copyFileSync(`${DME_NAME}.dme`, `${DME_NAME}.test.dme`);
-    await DreamMaker(`${DME_NAME}.test.dme`, {
-      defines: ['CBT', 'AUTOWIKI', ...get(DefineParameter)],
-      warningsAsErrors: get(WarningParameter).includes('error'),
-      ignoreWarningCodes: get(NoWarningParameter),
-      namedDmVersion: get(DmVersionParameter),
-    });
-    Juke.rm('data/autowiki_edits.txt');
-    Juke.rm('data/autowiki_files', { recursive: true });
-    Juke.rm('data/logs/ci', { recursive: true });
-
-    const options = {
-      dmbFile: `${DME_NAME}.test.dmb`,
-      namedDmVersion: get(DmVersionParameter),
-    }
-    await DreamDaemon(
-      options,
-      '-close', '-trusted', '-verbose',
-      '-params', 'log-directory=ci',
-    );
-    Juke.rm('*.test.*');
-    if (!fs.existsSync('data/autowiki_edits.txt')) {
-      Juke.logger.error('Autowiki did not generate an output, exiting');
-      throw new Juke.ExitCode(1);
-    }
-  },
-})
-*/
 
 export const YarnTarget = new Juke.Target({
   parameters: [CiParameter],

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -134,6 +134,45 @@ export const DmTestTarget = new Juke.Target({
   },
 });
 
+/*
+export const AutowikiTarget = new Juke.Target({
+  parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter],
+  dependsOn: ({ get }) => [
+    get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
+  ],
+  outputs: [
+    'data/autowiki_edits.txt',
+  ],
+  executes: async ({ get }) => {
+    fs.copyFileSync(`${DME_NAME}.dme`, `${DME_NAME}.test.dme`);
+    await DreamMaker(`${DME_NAME}.test.dme`, {
+      defines: ['CBT', 'AUTOWIKI', ...get(DefineParameter)],
+      warningsAsErrors: get(WarningParameter).includes('error'),
+      ignoreWarningCodes: get(NoWarningParameter),
+      namedDmVersion: get(DmVersionParameter),
+    });
+    Juke.rm('data/autowiki_edits.txt');
+    Juke.rm('data/autowiki_files', { recursive: true });
+    Juke.rm('data/logs/ci', { recursive: true });
+
+    const options = {
+      dmbFile: `${DME_NAME}.test.dmb`,
+      namedDmVersion: get(DmVersionParameter),
+    }
+    await DreamDaemon(
+      options,
+      '-close', '-trusted', '-verbose',
+      '-params', 'log-directory=ci',
+    );
+    Juke.rm('*.test.*');
+    if (!fs.existsSync('data/autowiki_edits.txt')) {
+      Juke.logger.error('Autowiki did not generate an output, exiting');
+      throw new Juke.ExitCode(1);
+    }
+  },
+})
+*/
+
 export const YarnTarget = new Juke.Target({
   parameters: [CiParameter],
   inputs: [

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -38,6 +38,7 @@ const DME_NAME = 'beestation';
 
 // Stores the contents of dependencies.sh as a key value pair
 // Best way I could figure to get ahold of this stuff
+/*
 const dependencies = fs.readFileSync('dependencies.sh', 'utf8')
   .split("\n")
   .map((statement) => statement.replace("export", "").trim())
@@ -57,6 +58,7 @@ const getCutterPath = () => {
 };
 
 const cutter_path = getCutterPath();
+*/
 
 export const DefineParameter = new Juke.Parameter({
   type: 'string[]',
@@ -94,6 +96,7 @@ export const NoWarningParameter = new Juke.Parameter({
   alias: 'I',
 });
 
+/*
 export const CutterTarget = new Juke.Target({
   onlyWhen: () => {
     const files = Juke.glob(cutter_path);
@@ -154,16 +157,16 @@ export const IconCutterTarget = new Juke.Target({
   ],
   inputs: ({ get }) => {
     const standard_inputs = [
-      `icons/**/*.png.toml`,
-      `icons/**/*.dmi.toml`,
-      `cutter_templates/**/*.toml`,
-      cutter_path,
+      `icons\/**\/*.png.toml`,
+      `icons\/**\/*.dmi.toml`,
+      `cutter_templates\/**\/*.toml`,
+cutter_path,
     ]
     // Alright we're gonna search out any existing toml files and convert
     // them to their matching .dmi or .png file
     const existing_configs = [
-      ...Juke.glob(`icons/**/*.png.toml`),
-      ...Juke.glob(`icons/**/*.dmi.toml`),
+      ...Juke.glob(`icons\/**\/*.png.toml`),
+      ...Juke.glob(`icons\/**\/*.dmi.toml`),
     ];
     return [
       ...standard_inputs,
@@ -174,8 +177,8 @@ export const IconCutterTarget = new Juke.Target({
     if(get(ForceRecutParameter))
       return [];
     const folders = [
-      ...Juke.glob(`icons/**/*.png.toml`),
-      ...Juke.glob(`icons/**/*.dmi.toml`),
+      ...Juke.glob(`icons\/**\/*.png.toml`),
+      ...Juke.glob(`icons\/**\/*.dmi.toml`),
     ];
     return folders
       .map((file) => file.replace(`.png.toml`, '.dmi'))
@@ -190,6 +193,7 @@ export const IconCutterTarget = new Juke.Target({
     ]);
   },
 });
+*/
 
 export const DmMapsIncludeTarget = new Juke.Target({
   executes: async () => {
@@ -212,30 +216,9 @@ export const DmTarget = new Juke.Target({
   parameters: [DefineParameter, DmVersionParameter, WarningParameter, NoWarningParameter, SkipIconCutter],
   dependsOn: ({ get }) => [
     get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
-    IconCutterTarget,
-    !get(SkipIconCutter) && IconCutterTarget,
+    // BeeStation: Disabled while iconCutter is not in use
+    //!get(SkipIconCutter) && IconCutterTarget,
   ],
-  inputs: [
-    '_maps/map_files/generic/**',
-    'maps/**/*.dm',
-    'code/**',
-    'goon/**',
-    'html/**',
-    'icons/**',
-    'interface/**',
-    'sound/**',
-    `${DME_NAME}.dme`,
-    NamedVersionFile,
-  ],
-  outputs: ({ get }) => {
-    if (get(DmVersionParameter)) {
-      return []; // Always rebuild when dm version is provided
-    }
-    return [
-      `${DME_NAME}.dmb`,
-      `${DME_NAME}.rsc`,
-    ]
-  },
   executes: async ({ get }) => {
     await DreamMaker(`${DME_NAME}.dme`, {
       defines: ['CBT', ...get(DefineParameter)],
@@ -434,7 +417,7 @@ export const LintTarget = new Juke.Target({
 });
 
 export const BuildTarget = new Juke.Target({
-  dependsOn: [TguiTarget, DmTarget],
+  dependsOn: [DmTarget, TguiTarget],
 });
 
 export const ServerTarget = new Juke.Target({


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Removes icon-cutter from the compilation step since we don't actually use it and it introduces A LOT of overhead.
- Changes it so that DM will always compile. GLOBing every single code file in the codebase adds a small amount of overhead.
- Executes DM step before TGUI step, which will probably save a zero amount of time.

People with faster CPUs (and ones with turboboost) will see less improvements than I am seeing since I have quite an old PC.

## Why It's Good For The Game

Our compilation time is starting to get a bit ridiculous and there are some easy savings to be had by removing high-overhead systems from the build steps.

## Testing Photographs and Procedure

All tests were done with the same programs opened and visual studio focused. (Unfocusing it increases compilation times by ~2x).

Overhead was measured by taking the total build time and subtracting the DM target build time from it.

### Baseline

|Test-Run|Overhead (/s)|
|-|-|
|1|2.632|
|2|2.543|
|3|2.634|

### With Icon-Cutter Change Only

|Test-Run|Overhead (/s)|
|-|-|
|1|2.208|
|2|2.174|

~0.4 seconds saved

### With DM-Step Change Only

|Test-Run|Overhead (/s)|
|-|-|
|1|1.299|
|2|1.323|
|3|1.296|

~1.3s saved

### After

|Test-Run|Overhead (/s)|
|-|-|
|1|0.337|
|2|0.352|
|3|0.344|

~2.3s saved

If you do the math there are 0.6s of savings unaccounted for, so I will chalk that down to re-ordering the DMtarget and the TGUI target.

## Changelog
:cl:
tweak: Improves compilation times by ~2.3 seconds by removing unnecessary build process overhead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
