### PR TITLE
Diona no longer die when splitting (Fixes confusing message)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/diona.dm
+++ b/code/modules/mob/living/carbon/human/species_types/diona.dm
@@ -181,7 +181,7 @@
 	if(!isdiona(user))
 		return FALSE
 	if(special)
-		fakeDeath(FALSE, user) //This runs when you are dead.
+		startSplitting(FALSE, user) //This runs when you are dead.
 		return TRUE
 	if(user.incapacitated(ignore_restraints = TRUE)) //Are we incapacitated right now?
 		return FALSE
@@ -190,15 +190,15 @@
 	if(do_after(user, 8 SECONDS, user, hidden = TRUE))
 		if(user.incapacitated(ignore_restraints = TRUE)) //Second check incase the ability was activated RIGHT as we were being cuffed, and thus now in cuffs when this triggers
 			return FALSE
-		fakeDeath(FALSE, user) //This runs when you manually activate the ability.
+		startSplitting(FALSE, user) //This runs when you manually activate the ability.
 		return TRUE
 
-/datum/action/diona/split/proc/fakeDeath(gibbed, mob/living/carbon/H)
+/datum/action/diona/split/proc/startSplitting(gibbed, mob/living/carbon/H)
 	if(Activated || gibbed)
 		return
 	Activated = TRUE
-	H.death() //Ha ha, we're totally dead right now
-	addtimer(CALLBACK(src, PROC_REF(split), gibbed, H), 5 SECONDS, TIMER_DELETE_ME) //Or are we?
+	H.Stun(6 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(split), gibbed, H), 5 SECONDS, TIMER_DELETE_ME)
 
 /datum/action/diona/split/proc/split(gibbed, mob/living/carbon/human/H)
 	if(gibbed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Headmins agreed that dionae splitting into nymphs should not cause memory issues. 
This PR removes the death proc from splitting, so that players do not receive mixed messages about dying and following memory rules when they didn't actually die. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mixed messages for players are bad. If the rules are being enforced such that splitting does not count as a death, then players should not be told that it counts as a death. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/822eacc3-08e3-47d1-a705-987b2eb60fe3)


## Changelog
:cl:
fix: Dionae are no longer forced to die in order to split, which prevents players from getting mixed messages. Unless you die as a nymph, you have not actually died and retain your memories, but dying as a nymph is usually permanent so be careful!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
