### PR TITLE
adds some missing genetics descriptions

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -12,7 +12,7 @@
 
 /datum/mutation/wacky
 	name = "Wacky"
-	desc = "Effects not tested..."
+	desc = "A mutation that causes the user to talk in an odd manner."
 	quality = MINOR_NEGATIVE
 
 /datum/mutation/wacky/on_acquiring(mob/living/carbon/owner)
@@ -138,7 +138,7 @@
 
 /datum/mutation/chav
 	name = "Chav"
-	desc = "Unknown"
+	desc = "A mutation that causes the user to construct sentences in a more rudimentary manner."
 	quality = MINOR_NEGATIVE
 
 /datum/mutation/chav/on_acquiring(mob/living/carbon/owner)


### PR DESCRIPTION
## About The Pull Request
Chav description changed from "Unknown" to "A mutation that causes the user to construct sentences in a more rudimentary manner."
Wacky description changed from "Effects not tested..." to "A mutation that causes the user to talk in an odd manner."

## Why It's Good For The Game

This makes it a little clearer what they do, instead of just having to guess if they are related to speech, movement, or something else.

## Testing Photographs and Procedure
I haven't tested this, it shouldn't need it as it's just a description change, but I can if needed.
<details>
<summary>Screenshots&Videos</summary>
</details>

## Changelog
:cl: ktlwjec
spellcheck: Adds descriptions to chav and wacky genes.
/:cl: