### PR TITLE
Adds needed chat filters to NT chat

### DIFF
--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -73,7 +73,7 @@
 			var/message = stripped_input(usr, message = "Enter message to be sent to remote cyborg.", title = "Send Message")
 			if(!message)
 				return
-			if(CHAT_FILTER_CHECK(message))
+			if(OOC_FILTER_CHECK(message))
 				to_chat(usr, "<span class='warning'>ERROR: Prohibited word(s) detected in message.</span>")
 				return
 			to_chat(usr, "<br><br><span class='notice'>Message to [R] (as [sender_name]) -- \"[message]\"</span><br>")

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -129,7 +129,7 @@
 	return data
 
 /datum/computer_file/program/proc/check_filename(name)
-	if(CHAT_FILTER_CHECK(name))
+	if(OOC_FILTER_CHECK(name))
 		alert(usr, "Filename contains prohibited words.")
 		return
 	if(!reject_bad_text(name, 32, ascii_only = TRUE, alphanumeric_only = TRUE, underscore_allowed = TRUE) || LOWER_TEXT(name) != name)

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -287,7 +287,7 @@
 		message += "\nSent from my PDA"
 
 	// Filter
-	if(CHAT_FILTER_CHECK(message))
+	if(OOC_FILTER_CHECK(message))
 		to_chat(user, "<span class='warning'>ERROR: Prohibited word(s) detected in message.</span>")
 		return
 

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -51,7 +51,7 @@
 			if(src in channel.muted_clients)
 				to_chat(usr, "<span class='warning'>ERROR: You are muted from this channel.</span>")
 				return
-			if(CHAT_FILTER_CHECK(message))
+			if(OOC_FILTER_CHECK(message))
 				to_chat(usr, "<span class='warning'>ERROR: Prohibited word(s) detected in message.</span>")
 				return
 			if(channel.password && (!(src in channel.active_clients) && !(src in channel.offline_clients)))
@@ -90,7 +90,7 @@
 			var/channel_title = reject_bad_text(params["new_channel_name"])
 			if(!channel_title)
 				return
-			if(CHAT_FILTER_CHECK(channel_title))
+			if(OOC_FILTER_CHECK(channel_title))
 				to_chat(usr, "<span class='warning'>ERROR: Channel title contains prohibited word(s).</span>")
 				return
 			var/datum/ntnet_conversation/C = new /datum/ntnet_conversation()
@@ -116,7 +116,7 @@
 			newname = replacetext(newname, " ", "_")
 			if(!newname || newname == username)
 				return
-			if(CHAT_FILTER_CHECK(newname))
+			if(OOC_FILTER_CHECK(newname))
 				to_chat(usr, "<span class='warning'>ERROR: Prohibited word(s) detected in new username.</span>")
 				return
 			for(var/datum/ntnet_conversation/anychannel as anything in SSnetworks.station_network.chat_channels)
@@ -151,7 +151,7 @@
 			var/newname = reject_bad_text(params["new_name"])
 			if(!newname || !channel)
 				return
-			if(CHAT_FILTER_CHECK(newname))
+			if(OOC_FILTER_CHECK(newname))
 				to_chat(usr, "<span class='warning'>ERROR: New channel title contains prohibited word(s).</span>")
 				return
 			channel.add_status_message("Channel renamed from [channel.title] to [newname] by operator.")
@@ -167,7 +167,7 @@
 				return
 
 			var/new_password = sanitize(params["new_password"])
-			if(CHAT_FILTER_CHECK(new_password))
+			if(OOC_FILTER_CHECK(new_password))
 				to_chat(usr, "<span class='warning'>ERROR: New password contains prohibited word(s).</span>")
 				return
 

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -90,6 +90,9 @@
 			var/channel_title = reject_bad_text(params["new_channel_name"])
 			if(!channel_title)
 				return
+			if(CHAT_FILTER_CHECK(channel_title))
+				to_chat(usr, "<span class='warning'>ERROR: Channel title contains prohibited word(s).</span>")
+				return
 			var/datum/ntnet_conversation/C = new /datum/ntnet_conversation()
 			C.add_client(src)
 			C.operator = src
@@ -112,6 +115,9 @@
 			var/newname = sanitize(params["new_name"])
 			newname = replacetext(newname, " ", "_")
 			if(!newname || newname == username)
+				return
+			if(CHAT_FILTER_CHECK(newname))
+				to_chat(usr, "<span class='warning'>ERROR: Prohibited word(s) detected in new username.</span>")
 				return
 			for(var/datum/ntnet_conversation/anychannel as anything in SSnetworks.station_network.chat_channels)
 				if(src in anychannel.active_clients)
@@ -145,6 +151,9 @@
 			var/newname = reject_bad_text(params["new_name"])
 			if(!newname || !channel)
 				return
+			if(CHAT_FILTER_CHECK(newname))
+				to_chat(usr, "<span class='warning'>ERROR: New channel title contains prohibited word(s).</span>")
+				return
 			channel.add_status_message("Channel renamed from [channel.title] to [newname] by operator.")
 			channel.title = newname
 			return TRUE
@@ -158,7 +167,8 @@
 				return
 
 			var/new_password = sanitize(params["new_password"])
-			if(!authed)
+			if(CHAT_FILTER_CHECK(new_password))
+				to_chat(usr, "<span class='warning'>ERROR: New password contains prohibited word(s).</span>")
 				return
 
 			channel.password = new_password


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The NT Chat computer program now uses filtering in more than just the chat portion of the app, now including the channel name, password and usernames of its users.

Also made PDAs use OOC filtering instead, to allow for netspeak.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Do I need to say why user provided content should be filtered consistently?
Also netspeak makes sense to allow in the part of the game that literally is a network for communication.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/34e133c9-cc2b-423b-aebd-dd76aed00956)

</details>

## Changelog
:cl:
fix: The Chat Client program now uses chat filters fully.
tweak: PDAs now use OOC filtering instead, allowing for netspeak \o/.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
