### PR TITLE
Fixes ninja movement speed updates

### DIFF
--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -168,6 +168,7 @@ Contents:
 	n_shoes.slowdown -= 0.5
 	n_gloves = H.gloves
 	ADD_TRAIT(n_gloves, TRAIT_NODROP, NINJA_SUIT_TRAIT)
+	H.update_equipment_speed_mods()
 	return TRUE
 
 /obj/item/clothing/suit/space/space_ninja/proc/lockIcons(mob/living/carbon/human/H)
@@ -193,6 +194,9 @@ Contents:
 		REMOVE_TRAIT(n_gloves, TRAIT_NODROP, NINJA_SUIT_TRAIT)
 		n_gloves.candrain = FALSE
 		n_gloves.draining = FALSE
+	if (isliving(loc))
+		var/mob/living/worn_mob = loc
+		worn_mob.update_equipment_speed_mods()
 
 /obj/item/clothing/suit/space/space_ninja/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/initialize_ninja_suit))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ninja updates movement speed but it doesn't actually update the equipment speeds on the mob, meaning that it just doesn't work.

## Why It's Good For The Game

You are meant to call update_equipment_speed_slowdowns when you change them.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/63486d92-454c-4850-8a93-69da7b95f7e1

## Changelog
:cl:
fix: Properly updates ninja movement speed when the suit activates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
