### PR TITLE
Fixes Revolutionary antag preferences being in legacy

### DIFF
--- a/code/modules/antagonists/role_preference/role_antagonists.dm
+++ b/code/modules/antagonists/role_preference/role_antagonists.dm
@@ -177,7 +177,6 @@
 	Kill or exile all heads of staff on the station."
 	antag_datum = /datum/antagonist/rev/head
 	preview_outfit = /datum/outfit/revolutionary
-	category = ROLE_PREFERENCE_CATEGORY_LEGACY
 
 /datum/outfit/revolutionary
 	name = "Revolutionary (Preview only)"

--- a/code/modules/antagonists/role_preference/role_antagonists.dm
+++ b/code/modules/antagonists/role_preference/role_antagonists.dm
@@ -171,7 +171,7 @@
 	head = /obj/item/clothing/head/helmet/clockcult
 	gloves = /obj/item/clothing/gloves/clockcult
 
-/datum/role_preference/antagonist/revolutionary a
+/datum/role_preference/antagonist/revolutionary
 	name = "Head Revolutionary"
 	description = "Armed with a flash, convert as many people to the revolution as you can.\n\
 	Kill or exile all heads of staff on the station."

--- a/code/modules/antagonists/role_preference/role_antagonists.dm
+++ b/code/modules/antagonists/role_preference/role_antagonists.dm
@@ -171,7 +171,7 @@
 	head = /obj/item/clothing/head/helmet/clockcult
 	gloves = /obj/item/clothing/gloves/clockcult
 
-/datum/role_preference/antagonist/revolutionary
+/datum/role_preference/antagonist/revolutionary a
 	name = "Head Revolutionary"
 	description = "Armed with a flash, convert as many people to the revolution as you can.\n\
 	Kill or exile all heads of staff on the station."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Revolutionary isn't legacy anymore, its in rotation.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/ec78b88e-7853-4ce0-9a5f-086cf540512b)
![image](https://github.com/user-attachments/assets/58a4a843-0187-492e-9533-8a9cf19d68df)



Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:Therealdoooc
fix: Revolutionary now appears in the correct section in antag preferences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
