### PR TITLE
Ninja invisibility rework (And consolidates /datum/action cooldowns to a single place)

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -201,7 +201,7 @@
 /datum/action/proc/finish_cooldown()
 	if(!button || !cooldown_timer_end)
 		return
-	button.overlays -= timer_overlay
+	button.cut_overlay(timer_overlay)
 	QDEL_NULL(timer_overlay)
 	cooldown_timer_end = null
 	UpdateButtonIcon(TRUE, FALSE)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -171,7 +171,7 @@
 //===Timer animation===
 
 /datum/action/proc/set_cooldown(duration)
-	if(!button || cooldown_timer_end)
+	if(!button)
 		return
 
 	cooldown_timer_end = world.time + duration

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -57,7 +57,7 @@
 	var/vomiting = FALSE
 	var/vomitCoefficient = 1
 	var/vomitTimeBonus = 0
-	var/datum/action/cooldown/vomit/goosevomit
+	var/datum/action/vomit/goosevomit
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/Initialize(mapload)
 	. = ..()
@@ -178,14 +178,13 @@
 	if (tasty)
 		feed(tasty)
 
-/datum/action/cooldown/vomit
+/datum/action/vomit
 	name = "Vomit"
 	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "vomit"
 	icon_icon = 'icons/mob/animal.dmi'
-	cooldown_time = 250
 
-/datum/action/cooldown/vomit/Trigger()
+/datum/action/vomit/Trigger()
 	if(!..())
 		return FALSE
 	if(!istype(owner, /mob/living/simple_animal/hostile/retaliate/goose/vomit))
@@ -195,6 +194,7 @@
 		vomit.vomit_prestart(vomit.vomitTimeBonus + 25)
 		vomit.vomitCoefficient = 1
 		vomit.vomitTimeBonus = 0
+	set_cooldown(25 SECONDS)
 	return TRUE
 
 #undef GOOSE_SATIATED

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -72,7 +72,7 @@
 	/// Whether space dragon is swallowing a body currently
 	var/is_swallowing = FALSE
 	/// The cooldown ability to use wing gust
-	var/datum/action/cooldown/gust_attack/gust
+	var/datum/action/gust_attack/gust
 	/// The ability to make your sprite smaller
 	var/datum/action/small_sprite/space_dragon/small_sprite
 	/// The color of the space dragon.
@@ -456,15 +456,14 @@
 			var/link = FOLLOW_LINK(S, src)
 			to_chat(S, "[link] [rendered]")
 
-/datum/action/cooldown/gust_attack
+/datum/action/gust_attack
 	name = "Gust Attack"
 	desc = "Use your wings to knock back foes with gusts of air, pushing them away and stunning them. Using this too often will leave you vulnerable for longer periods of time."
 	background_icon_state = "bg_default"
 	icon_icon = 'icons/hud/actions/actions_space_dragon.dmi'
 	button_icon_state = "gust_attack"
-	cooldown_time = 5 SECONDS // the ability takes up around 2-3 seconds
 
-/datum/action/cooldown/gust_attack/Trigger()
+/datum/action/gust_attack/Trigger()
 	if(!..() || !istype(owner, /mob/living/simple_animal/hostile/space_dragon))
 		return FALSE
 	var/mob/living/simple_animal/hostile/space_dragon/S = owner
@@ -474,7 +473,7 @@
 	S.icon_state = "spacedragon_gust"
 	S.update_dragon_overlay()
 	S.useGust(TRUE)
-	StartCooldown()
+	set_cooldown(5 SECONDS)
 	return TRUE
 
 #undef DARKNESS_THRESHOLD

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -39,6 +39,16 @@
 
 /obj/item/energy_katana/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
+	if (ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		if(istype(human_user.wear_suit, /obj/item/clothing/suit/space/space_ninja))
+			var/obj/item/clothing/suit/space/space_ninja/ninja_suit = human_user.wear_suit
+			if (ninja_suit.stealth)
+				ninja_suit.cancel_stealth()
+		else
+			return
+	else
+		return
 	if(dash_toggled)
 		jaunt.Teleport(user, target)
 	if(proximity_flag && (isobj(target) || issilicon(target)))

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -6,7 +6,7 @@ Contents:
 
 */
 
-#define STEALTH_COOLDOWN 1 MINUTES
+#define STEALTH_COOLDOWN 30 SECONDS
 
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_stealth()
 	var/mob/living/carbon/human/U = affecting

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -6,6 +6,7 @@ Contents:
 
 */
 
+#define STEALTH_COOLDOWN 1 MINUTES
 
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_stealth()
 	var/mob/living/carbon/human/U = affecting
@@ -14,6 +15,10 @@ Contents:
 	if(stealth)
 		cancel_stealth()
 	else
+		var/datum/action/item_action/ninja_stealth/stealth_action = locate() in actions
+		if (!stealth_action.IsAvailable())
+			U.balloon_alert("Stealth not ready.")
+			return
 		if(cell.charge <= 0)
 			to_chat(U, "<span class='warning'>You don't have enough power to enable Stealth!</span>")
 			return
@@ -32,9 +37,10 @@ Contents:
 		animate(U, alpha = 255, time = 15)
 		U.visible_message("<span class='warning'>[U.name] appears from thin air!</span>", \
 						"<span class='notice'>You are now visible.</span>")
+		var/datum/action/item_action/ninja_stealth/stealth_action = locate() in actions
+		stealth_action.set_cooldown(STEALTH_COOLDOWN)
 		return 1
 	return 0
-
 
 /obj/item/clothing/suit/space/space_ninja/proc/stealth()
 	if(!s_busy)

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -17,7 +17,7 @@ Contents:
 	else
 		var/datum/action/item_action/ninja_stealth/stealth_action = locate() in actions
 		if (!stealth_action.IsAvailable())
-			U.balloon_alert("Stealth not ready.")
+			U.balloon_alert(U, "Stealth not ready.")
 			return
 		if(cell.charge <= 0)
 			to_chat(U, "<span class='warning'>You don't have enough power to enable Stealth!</span>")
@@ -47,3 +47,5 @@ Contents:
 		toggle_stealth()
 	else
 		to_chat(affecting, "<span class='danger'>Stealth does not appear to work!</span>")
+
+#undef STEALTH_COOLDOWN

--- a/code/modules/spells/__DEFINES/spell.dm
+++ b/code/modules/spells/__DEFINES/spell.dm
@@ -310,6 +310,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/proc/start_recharge()
 	recharging = TRUE
 	action.set_cooldown(charge_max)
+	START_PROCESSING(SSfastprocessing, src)
 
 /obj/effect/proc_holder/spell/process(delta_time)
 	if(recharging && charge_type == "recharge" && (charge_counter < charge_max))
@@ -319,10 +320,12 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			action.finish_cooldown()
 			charge_counter = charge_max
 			recharging = FALSE
+			return PROCESS_KILL
 	else
 		action.finish_cooldown()
 		charge_counter = charge_max
 		recharging = FALSE
+		return PROCESS_KILL
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
 	if(!cast_check())

--- a/code/modules/spells/__DEFINES/spell.dm
+++ b/code/modules/spells/__DEFINES/spell.dm
@@ -310,7 +310,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/proc/start_recharge()
 	recharging = TRUE
 	action.set_cooldown(charge_max)
-	START_PROCESSING(SSfastprocessing, src)
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/effect/proc_holder/spell/process(delta_time)
 	if(recharging && charge_type == "recharge" && (charge_counter < charge_max))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks ninja invisibility
- Upon de-activating starts a 30 second cooldown before it can be activated again.
- Upon attacking or teleporting, invisbility will be disabled.

This made me desire better cooldown feedback on the action button, which lead to consolidating the action cooldowns.

Consolidates action cooldowns:
- Action cooldowns were a right mess, spread between /datum/action, /datum/action/cooldown and /datum/proc_holder/spell
- All actions can now be given a cooldown by calling set_cooldown on them.
- Actions with a cooldown will now display the timer animation and show their time remaining

## Why It's Good For The Game

- Ninja shouldn't be able to combat while invisible, since it lets them dodge lasers.
- Ninja stealth shouldn't be able to just be turned on and off during combat, so has a cooldown.
- Actions with a cooldown should be well coded and standardised.

## Testing Photographs and Procedure

### Test ninja stealth disable on attack

![image](https://github.com/user-attachments/assets/857075aa-b892-47f6-b7fe-f7b2c6269850)

![image](https://github.com/user-attachments/assets/d16820e5-7076-4553-aea4-7af21b7a229d)


### Test ninja cooldown

![image](https://github.com/user-attachments/assets/7c75c805-b556-44d9-a0e1-1061487e8683)

### Test Psychoza cooldown

![image](https://github.com/user-attachments/assets/b6f4183a-0832-41be-a62e-9225510edfe4)

![image](https://github.com/user-attachments/assets/6949bad8-6bb3-4fa2-83ac-480dc65d1195)

### Test dragon cooldown

![image](https://github.com/user-attachments/assets/1c92e36d-23e0-48ad-8f5e-0afe6462bbc8)

### Test spell recharging cooldown

![image](https://github.com/user-attachments/assets/39001094-7787-4074-9218-7e51db89d5ba)

![image](https://github.com/user-attachments/assets/49cb19a7-055d-43a4-b69d-c7a6e23aeb84)


## Changelog
:cl:
balance: Ninja invisibility now has a 30 second cooldown and disables when teleporting or attacking with the katana.
tweak: Standardises the code for action cooldowns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
