### PR TITLE
Removes unused variable in tonfa code

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -972,8 +972,6 @@
 			log_combat(user, target, "attempted to attack", src, "(blocked by martial arts)")
 			return
 
-		var/mob/living/carbon/human/T = target
-
 		target.visible_message("[user] strikes [target] in the [parse_zone(target_zone)].", "You strike [target] in the [parse_zone(target_zone)].")
 		log_combat(user, target, "attacked", src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes an unused variable which is making the compiler currently cry a bit on live:

![image](https://github.com/user-attachments/assets/c0a6fa4c-c735-4457-bec0-f629e55d218b)

I did attempt to make warnings for this stuff turn to errors in #11634 but eventually realized why we can't at the moment; we're still working with 514 and as such we cannot check for unused variables at all, so this is the best we get for now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less compiler whining the better- this just seemed to be an oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

If the CI is compiling, it should be good; as long as the build output stops crying; this one line change removes a redundant piece of code that literally did nothing. (Okay technically two line if you count the newline on the line below as well)

## Changelog
:cl:
fix: Removed unused variable in tonfa code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
