### PR TITLE
adds a sink to boxstation kitchen

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -35823,6 +35823,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"kQw" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/checker,
+/area/crew_quarters/kitchen)
 "kQF" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -108249,7 +108257,7 @@ lzP
 aEY
 dZF
 sZa
-psd
+kQw
 eSw
 vqg
 rzF


### PR DESCRIPTION
## About The Pull Request

Adds a sink to boxstation kitchen. See testing.

## Why It's Good For The Game

This was removed unintentionally I believe. Some maps get three sinks but poor boxstation doesn't even get one anymore. It's just an annoyance to have to source water from elsewhere.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
Top-right. Doesn't block the fridge.

![image](https://github.com/user-attachments/assets/43469d08-a7d2-4e9d-875e-ae97d20f7b1f)

</details>

:cl: ktlwjec
add: A sink has been installed in Boxstation kitchen.
/:cl: