### PR TITLE
Removes hard-stun from mjolnir

### DIFF
--- a/code/game/objects/items/mjolnir.dm
+++ b/code/game/objects/items/mjolnir.dm
@@ -31,7 +31,6 @@
 	. = ..()
 
 /obj/item/mjolnir/proc/shock(mob/living/target)
-	target.Stun(60)
 	var/datum/effect_system/lightning_spread/s = new /datum/effect_system/lightning_spread
 	s.set_up(5, 1, target.loc)
 	s.start()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the 6 second hard-stun applied on hit with the Mjolnir. This was never intended and the stun was meant to come from the wall, but was an artifact from when I modified the Mjolnir.

## Why It's Good For The Game

Hard-stuns are not fun to play against, getting hard-stunned for 6 seconds means that you get chain attacked and have no way to fight back.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/5b48ecf1-416b-4e76-9209-cbafab9ce1d6)

![image](https://github.com/user-attachments/assets/8ea53b85-8207-4822-afc7-7ef1798f0b64)

![image](https://github.com/user-attachments/assets/fb403dca-71cf-4beb-a0fd-57d7ed415a1f)

It still stuns you if you are hit into a wall.

## Changelog
:cl:
balance: Removes hard-stun from Mjolnir every time you take a hit from it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
