### PR TITLE
Fixes being unable to wirehack MULEbot

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -172,7 +172,10 @@
 						"<span class='notice'>You pry [cell] out of [src].</span>")
 		cell = null
 	else if(is_wire_tool(I) && open)
-		return attack_hand(user)
+		if (user.a_intent == INTENT_HELP)
+			return interact(user)
+		else
+			return ..()
 	else if(load && ismob(load))  // chance to knock off rider
 		if(prob(1 + I.force * 2))
 			unload(0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

with #11378, a loss of functionality occured in MULEbot where trying to hack their wires would instead open their regular menu
this PR gives attacking the MULEbot with a wire-related tool its old code in order to re-enable said functionality rather than the generic bot one (because MULEbots are quite an exception of a bot with wires to hack)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

fixes an unintended loss of functionality caused by #11378 and re-enables fun MULEbot interactions

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
tested but not shown was also the capability to hurt MULEbots with wire tools when panel is open but not on HELP intent, which seems to work properly
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/5a6b5ddb-03fc-4892-9b07-0e63cd6be168

</details>
trying to open the wire menu with panel open but empty hand will instead open the bot menu, but that still doesn't allow a bot to start with the maintenance panel open

## Changelog
:cl: Aramix
fix: MULEbots can now have their wires hacked again when using wire-related tools
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
