### PR TITLE
Fixes some uplink failsafe bugs

### DIFF
--- a/code/modules/antagonists/traitor/backstory/traitor_backstory_ui.dm
+++ b/code/modules/antagonists/traitor/backstory/traitor_backstory_ui.dm
@@ -43,8 +43,8 @@
 	if(has_codewords)
 		data["phrases"] = jointext(GLOB.syndicate_code_phrase, ", ")
 		data["responses"] = jointext(GLOB.syndicate_code_response, ", ")
-	data["code"] = uplink?.unlock_code
-	data["failsafe_code"] = uplink?.failsafe_code
+	data["code"] = islist(uplink?.unlock_code) ? english_list(uplink?.unlock_code) : uplink?.unlock_code
+	data["failsafe_code"] = islist(uplink?.failsafe_code) ? english_list(uplink?.failsafe_code) : uplink?.failsafe_code
 	data["has_uplink"] = uplink ? TRUE : FALSE
 	if(uplink)
 		data["uplink_unlock_info"] = uplink.unlock_text

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1824,9 +1824,12 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/device_tools/failsafe/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
-	if(!U)
+	if(!U || !U.unlock_code)
+		to_chat(user, "<span class='warning'>A failsafe code could not be assigned to this uplink.")
 		return
-	U.failsafe_code = U.generate_code()
+	do
+		U.failsafe_code = U.generate_code()
+	while(islist(U.failsafe_code) ? compare_list(U.failsafe_code, U.unlock_code) : U.failsafe_code == U.unlock_code)
 	var/code = "[islist(U.failsafe_code) ? english_list(U.failsafe_code) : U.failsafe_code]"
 	to_chat(user, "<span class='warning'>The new failsafe code for this uplink is now : [code].</span>")
 	if(user.mind)

--- a/tgui/packages/tgui/interfaces/AntagInfoIncursion.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoIncursion.tsx
@@ -44,7 +44,7 @@ const UplinkSubsection = (_props, context) => {
             <Stack.Divider />
             {failsafe_code && (
               <>
-                <Stack.Item bold>{code && <span style={goalstyle}>Code: {code}</span>}</Stack.Item>
+                <Stack.Item bold>{failsafe_code && <span style={goalstyle}>Failsafe: {failsafe_code}</span>}</Stack.Item>
                 <Stack.Divider />
               </>
             )}

--- a/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
@@ -46,7 +46,7 @@ const UplinkSection = (_props, context) => {
             <Stack.Divider />
             {failsafe_code && (
               <>
-                <Stack.Item bold>{code && <span style={goalstyle}>Code: {code}</span>}</Stack.Item>
+                <Stack.Item bold>{failsafe_code && <span style={goalstyle}>Failsafe: {failsafe_code}</span>}</Stack.Item>
                 <Stack.Divider />
               </>
             )}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #11284 

Fixes some bugs and oversights with the traitor uplink's failsafe: 
- There was a chance of the failsafe code being the same as the unlock code, as high as 1/26 for radio uplinks
- The Traitor UI panel duplicated the unlock code instead of showing the failsafe code when it was bought
- The Traitor UI panel incorrectly formatted unlock and failsafe codes for pen uplinks
- When buying a failsafe with an implant uplink, the message shown in the chat was "The new failsafe code for this uplink is now : ."

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The failsafe code shouldn't have a random chance to be the same as the unlock code, and it should be correctly added to the Traitor UI panel.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

To test wether or not failsafe codes could be the same as unlock codes, I replaced the wordlist for radio uplink codes with one containing only two elements, then I had 10 characters spend their 20 TC on failsafe codes. None of the 200 generated failsafe codes were the same as the unlock codes, which I believe is a good enough sample size.

PDA uplink: 

https://github.com/user-attachments/assets/eb582c7c-f6b1-4070-9375-0443b15d68bc

Radio uplink:

https://github.com/user-attachments/assets/5b78f802-c354-46d4-b5eb-6d240fc2d7bf

Pen uplink:

https://github.com/user-attachments/assets/2b5225aa-1129-443b-bf92-6d92985a3dc5

Implant uplink (error message):

https://github.com/user-attachments/assets/a9a5a993-a6db-4f4f-b6c3-38bdc97f3ce6


</details>

## Changelog
:cl:
fix: Uplink failsafe code no longer has a chance of being the same as the unlock code
fix: Uplink failsafe code is now shown properly on the traitor UI panel
fix: Uplink unlock and failsafe codes are formatted properly for the pen uplink
fix: Buying a failsafe for an implant uplink now shows an error message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
