### PR TITLE
Makes manuals a small sized item (NO MORE SECURITY HEIRLOOM PROBLEMS)

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/library.dmi'
 	due_date = 0 // Game time in 1/10th seconds
 	unique = TRUE   // FALSE - Normal book, TRUE - Should not be treated as normal book, unable to be copied, unable to be modified
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/book/manual/hydroponics_pod_people
 	name = "The Human Harvest - From seed to market"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sometimes, this weird thing happens where you play security officer, and you got the heirloom perk on. And then you open your backpack. And you see that your heirloom is the Space Law book. And you then you experience this weird thing where you are constantly undergoing CBT trying to manage your inventory with an useless item in your backpack that does nothing except being a nuissance, since you rarely consult Space Law, so you are playing with an item that takes a huge chunk of your inventory for no reason.

## Why It's Good For The Game

Because heirloom is a 1 point perk and having an 4 sized item in your backpack that you can't put ANYWHERE ELSE but your backpack is a horrible, HORRIBLE experience. Also a book should be a small item, not a big one. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![imagen](https://github.com/user-attachments/assets/efb30657-3ead-4a54-989c-0bc02df7c7ef)

</details>

## Changelog
:cl: ClownMoff
balance: Manual books (guides, space law, etc.) are no small sized items instead of normal sized.
/:cl: