### PR TITLE
Automatically mark unmergable PRs as stale.

### DIFF
--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This PR has been marked as stale due to being in an unmergable state for 7 days. Please resolve any conflicts and add testing evidence, then contact a project maintainer to have the stale label removed."

--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -13,7 +13,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This PR has been marked as stale due to being in an unmergable state for 7 days. Please resolve any conflicts and add testing evidence, then contact a project maintainer to have the stale label removed."
         stale-pr-label: 'Stale'
-        only-pr-labels: 'Stale,Needs Testing Evidence,Merge Conflict'
+        any-of-pr-labels: 'Needs Testing Evidence,Merge Conflict'
         days-before-stale: 7
         days-before-close: 5
         remove-pr-stale-when-updated: true

--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -11,8 +11,10 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being closed by a maintainer if it is not updated or reviews are not addressed. If your PR is closed as stale, feel free to open a new one after dealing with the issues. This may also be an indication that the maintainers do not have interest in this change, you can try to convince them otherwise, or persist in the doomed world you have created."
+        stale-pr-message: "This PR has been marked as stale due to being in an unmergable state for 7 days. Please resolve any conflicts and add testing evidence, then contact a project maintainer to have the stale label removed."
         stale-pr-label: 'Stale'
-        exempt-pr-label: 'Needs Review'
-        days-before-stale: 100000
+        only-pr-labels: 'Stale,Needs Testing Evidence,Merge Conflict'
+        days-before-stale: 7
         days-before-close: 5
+        remove-pr-stale-when-updated: true
+        labels-to-remove-when-unstale: 'Stale'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PRs with the following labels will now be marked as stale if they have no activity after 7 days:
- Merge Conflict
- Needs testing evidence

If they get updated during this time, they will become unstale unless they remain in this state and become stale again.

## Why It's Good For The Game

I don't want to manually be closing merge conflicted PRs and PRs that won't be reviewed due to not having testing evidence and having an automated system do this would help clean up some old PRs that are no longer being worked on.

## Testing Photographs and Procedure

Unable to test.

## Changelog
:cl:
code: Modifies the github workflows so that unmergable PRs become stale.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
