### PR TITLE
Fixes minor camera bugs

### DIFF
--- a/_maps/Prefab/Departments.dmm
+++ b/_maps/Prefab/Departments.dmm
@@ -1769,7 +1769,7 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/theatre/backstage)
 "Tm" = (
-/obj/machinery/computer/security/telescreen,
+/obj/machinery/computer/security/telescreen/entertainment,
 /turf/open/floor/iron/dark,
 /area/space)
 "Tn" = (

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -257,8 +257,7 @@
 /obj/machinery/door/poddoor{
 	icon_state = "pdoor1";
 	id = "spacebattlepod3";
-	name = "Front Hull Door";
-	opacity = 1
+	name = "Front Hull Door"
 	},
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate2)
@@ -538,49 +537,35 @@
 "cC" = (
 /obj/structure/table/reinforced,
 /obj/item/food/sausage,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cD" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/enzyme,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cE" = (
 /obj/structure/table/reinforced,
 /obj/item/knife/kitchen,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cF" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cG" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cH" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cJ" = (
 /obj/machinery/door/unpowered/shuttle,
@@ -608,9 +593,7 @@
 /turf/open/floor/iron,
 /area/awaymission/spacebattle/cruiser)
 "cP" = (
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cQ" = (
 /obj/item/stack/sheet/iron,
@@ -626,29 +609,21 @@
 /area/awaymission/spacebattle/cruiser)
 "cT" = (
 /obj/machinery/door/unpowered/shuttle,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cU" = (
 /obj/structure/table/reinforced,
 /obj/item/food/fries,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cV" = (
 /obj/structure/table/reinforced,
 /obj/item/food/soup/stew,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cW" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "cY" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
@@ -1030,7 +1005,6 @@
 /area/awaymission/spacebattle/cruiser)
 "ff" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "spacebattlestorage";
 	name = "Secure Storage";
 	pixel_x = 32
@@ -1056,7 +1030,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/cruiser)
 "fj" = (
-/obj/machinery/computer/security/telescreen,
+/obj/machinery/computer/security/telescreen/station,
 /turf/closed/wall/mineral/titanium,
 /area/awaymission/spacebattle/cruiser)
 "fl" = (
@@ -1178,9 +1152,7 @@
 /area/awaymission/spacebattle/cruiser)
 "fI" = (
 /obj/effect/landmark/awaystart,
-/turf/open/floor/iron/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/iron/cafeteria,
 /area/awaymission/spacebattle/cruiser)
 "fL" = (
 /obj/item/stack/sheet/iron,
@@ -1361,7 +1333,6 @@
 /area/awaymission/spacebattle/cruiser)
 "gr" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "spacebattlestorage";
 	name = "Secure Storage";
 	pixel_x = 24
@@ -1370,38 +1341,28 @@
 /area/awaymission/spacebattle/cruiser)
 "gs" = (
 /obj/machinery/computer/operating,
-/turf/open/floor/iron/white/side{
-	dir = 2
-	},
+/turf/open/floor/iron/white/side,
 /area/awaymission/spacebattle/cruiser)
 "gt" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
 /obj/item/circular_saw,
-/turf/open/floor/iron/white/side{
-	dir = 2
-	},
+/turf/open/floor/iron/white/side,
 /area/awaymission/spacebattle/cruiser)
 "gu" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
-/turf/open/floor/iron/white/side{
-	dir = 2
-	},
+/turf/open/floor/iron/white/side,
 /area/awaymission/spacebattle/cruiser)
 "gv" = (
 /obj/structure/table/reinforced,
 /obj/item/hemostat,
-/turf/open/floor/iron/white/side{
-	dir = 2
-	},
+/turf/open/floor/iron/white/side,
 /area/awaymission/spacebattle/cruiser)
 "gw" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
-/turf/open/floor/iron/white/side{
-	dir = 2
-	},
+/turf/open/floor/iron/white/side,
 /area/awaymission/spacebattle/cruiser)
 "gx" = (
 /obj/machinery/vending/cigarette,
@@ -2366,7 +2327,6 @@
 "nQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	dir = 2;
 	id = "spacebattlearmory2";
 	name = "Weapon Cache"
 	},
@@ -2385,7 +2345,6 @@
 "ow" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	dir = 2;
 	id = "spacebattlearmory1";
 	name = "Weapon Cache"
 	},
@@ -2695,7 +2654,6 @@
 "XU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	dir = 2;
 	id = "spacebattlearmory";
 	name = "Weapon Cache"
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36351,12 +36351,12 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/station{
+	dir = 8;
+	pixel_x = 32
 	},
 /turf/open/floor/carpet/green,
 /area/security/detectives_office)

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -15769,12 +15769,12 @@
 	pixel_y = 30
 	},
 /obj/item/camera/detective,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/camera/directional/north,
 /obj/item/holosign_creator/security,
+/obj/machinery/computer/security/telescreen/station{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "hDY" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -34618,14 +34618,14 @@
 /turf/open/floor/iron/sepia,
 /area/engine/engineering)
 "iOM" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/security/telescreen/station{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/green,
 /area/security/detectives_office)
 "iON" = (
@@ -39794,9 +39794,9 @@
 /obj/machinery/computer/communications{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/security/telescreen/station{
 	dir = 1;
-	pixel_y = -30
+	pixel_y = -32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -89724,15 +89724,15 @@
 /turf/open/floor/iron/dark,
 /area/security/brig/aft)
 "xFp" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/hand_labeler,
 /obj/item/taperecorder,
 /obj/item/camera/detective,
+/obj/machinery/computer/security/telescreen/station{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/green,
 /area/security/detectives_office)
 "xFB" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24382,13 +24382,11 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching output from station security cameras.";
-	name = "Security Camera Monitor";
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/red/anticorner{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/station{
+	pixel_y = 32
 	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/hallway/secondary/exit/departure_lounge)

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -23831,11 +23831,11 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/directional/north,
-/obj/machinery/computer/security/telescreen{
-	pixel_y = 25
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/station{
+	pixel_y = 32
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
@@ -50218,10 +50218,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	pixel_y = 31
-	},
 /obj/structure/chair,
+/obj/machinery/computer/security/telescreen/station{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "pTh" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -57970,8 +57970,8 @@
 	dir = 4
 	},
 /obj/machinery/computer/secure_data,
-/obj/machinery/computer/security/telescreen{
-	pixel_y = 31
+/obj/machinery/computer/security/telescreen/medical{
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1028,7 +1028,6 @@
 /turf/open/floor/sepia,
 /area/centcom/evac)
 "dX" = (
-/obj/machinery/computer/security/telescreen,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6972,6 +6972,15 @@
 	},
 /turf/open/floor/circuit/green,
 /area/centcom/ferry)
+"AO" = (
+/obj/structure/chair,
+/obj/effect/landmark/thunderdome/observe,
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/tdome/tdomeobserve)
 "AP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8568,6 +8577,9 @@
 "GH" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/stripes/end,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/tdome/tdomeobserve)
 "GJ" = (
@@ -10931,7 +10943,6 @@
 /turf/open/floor/iron,
 /area/centcom/control)
 "PD" = (
-/obj/machinery/computer/security/telescreen,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 1
@@ -11067,6 +11078,9 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/tdome/tdomeobserve)
 "Qg" = (
@@ -11305,7 +11319,6 @@
 /turf/open/floor/iron,
 /area/centcom/ferry)
 "QZ" = (
-/obj/machinery/computer/security/telescreen,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
@@ -56586,7 +56599,7 @@ Ev
 Ev
 Ev
 Ep
-Lx
+AO
 uf
 Lx
 Il
@@ -57614,7 +57627,7 @@ Ev
 Ev
 Ev
 Ep
-Lx
+AO
 uf
 Lx
 Il

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -80,7 +80,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 		c_tag = "[format_text(camera_area.name)] #[++autonames_in_areas[camera_area]]"
 		if (get_area(src) != camera_area)
 			c_tag = "[c_tag] (External)"
-	network = camera_area.camera_networks
+	if (!islist(network))
+		network = camera_area.camera_networks
 	var/obj/structure/camera_assembly/assembly
 	if(CA)
 		assembly = CA

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -13,7 +13,7 @@
 	max_integrity = 100
 	integrity_failure = 0.5
 	var/default_camera_icon = "camera" //the camera's base icon used by update_icon - icon_state is primarily used for mapping display purposes.
-	var/list/network = list(CAMERA_NETWORK_STATION)
+	var/list/network
 	var/c_tag = null
 	var/status = TRUE
 	var/current_state = TRUE
@@ -81,7 +81,10 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 		if (get_area(src) != camera_area)
 			c_tag = "[c_tag] (External)"
 	if (!islist(network))
-		network = camera_area.camera_networks
+		if (camera_area.camera_networks)
+			network = camera_area.camera_networks
+		else if (is_station_level(z))
+			network = list(CAMERA_NETWORK_STATION)
 	var/obj/structure/camera_assembly/assembly
 	if(CA)
 		assembly = CA

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -420,4 +420,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 	desc = "A telescreen that connects to the camera network of the bunker."
 	network = list(CAMERA_NETWORK_BUNKER)
 
+/obj/machinery/computer/security/telescreen/station
+	name = "station monitor"
+	desc = "A telescreen that monitors the station's camera network."
+	network = list(CAMERA_NETWORK_STATION)
+
 #undef DEFAULT_MAP_SIZE

--- a/tools/maplint/lints/telescreen.yml
+++ b/tools/maplint/lints/telescreen.yml
@@ -1,0 +1,5 @@
+help:
+  Found a telescreen with no subtype, if you intended for this to be a thunderdome monitor please use
+  the /obj/machinery/computer/security/telescreen/entertainment subtype instead.
+=/obj/machinery/computer/security/telescreen:
+  banned: true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes toxins test site camera not being viewable. (Fixes #11608)
- Fixes radstation medbay having a thunderdome camera viewer.
- Adds a maplint that makes sure nobody uses the base telescreen since they should use entertainment instead.
- Fixes almost all maps having entertainment monitors in the detective's room (thanks maplint)

## Why It's Good For The Game

Fixes some minor issues.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/a2a01292-1401-4f62-af16-45deea273f4f)

![image](https://github.com/user-attachments/assets/7879c9c0-b0e2-41b9-b76a-54f16e1625d7)


## Changelog
:cl:
fix: Fixes toxins test site camera.
fix: Fixes Radstation security output medbay telescreen.
fix: Detective's room telescreens are now station cameras and not thunderdome monitors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
