### PR TITLE
Adds a diona-exclusive martial art for traitors

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -936,6 +936,7 @@
 #include "code\datums\martial\cqc.dm"
 #include "code\datums\martial\karate.dm"
 #include "code\datums\martial\krav_maga.dm"
+#include "code\datums\martial\living_fist.dm"
 #include "code\datums\martial\mushpunch.dm"
 #include "code\datums\martial\plasma_fist.dm"
 #include "code\datums\martial\psychotic_brawl.dm"

--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -10,3 +10,4 @@
 #define MARTIALART_PLASMAFIST "plasma fist"
 #define MARTIALART_KARATE "karate"
 #define MARTIALART_TRIBALCLAW "tribal claw"
+#define MARTIALART_LIVINGFIST "living fist"

--- a/code/datums/martial/living_fist.dm
+++ b/code/datums/martial/living_fist.dm
@@ -1,0 +1,100 @@
+#define GRAPPLE_COMBO "GGH"
+#define LACERATE_COMBO "DHD"
+#define BLAST_COMBO "HDDDH"
+
+/datum/martial_art/living_fist
+	name = "Living Fist"
+	id = MARTIALART_LIVINGFIST
+	help_verb = /mob/living/carbon/human/proc/living_fist_help
+
+
+/datum/martial_art/living_fist/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(findtext(streak,GRAPPLE_COMBO))
+		streak = ""
+		Grapple(A,D)
+		return 1
+	if(findtext(streak,LACERATE_COMBO))
+		streak = ""
+		Lacerate(A,D)
+		return 1
+	if(findtext(streak,BLAST_COMBO))
+		streak = ""
+		Blast(A,D)
+		return 1
+	return 0
+
+/datum/martial_art/living_fist/proc/Grapple(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.say("VINE LASH!", forced="living fist")
+	log_combat(A, D, "vine grabbed (Living Fist)", name)
+	D.visible_message("<span class='warning'>[A] lashes out and grabs [D] with their vines!</span>", \
+						"<span class='userdanger'>[A] grabs you with their vines!</span>")
+	D.grabbedby(A, 1)
+	D.Knockdown(5) //Without knockdown target still stands up while T3 grabbed.
+	A.setGrabState(GRAB_NECK)
+	playsound(A.loc, 'sound/weapons/whipgrab.ogg', 15, 1, -1)
+
+
+/datum/martial_art/living_fist/proc/Lacerate(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	var/def_check = D.getarmor(BODY_ZONE_CHEST, MELEE)
+	if(A.pulling == D && A.grab_state >= GRAB_NECK)
+		for (var/i in 1 to 6)
+			if(!A)
+				break
+			A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
+			playsound(A.loc, 'sound/weapons/slash.ogg', 15, 1, -1)
+			sleep(1)
+		D.visible_message("<span class='warning'>[A] lacerates [D]'s chest with their jagged vines!</span>", \
+							"<span class='userdanger'>[A] lashes at you with vines!</span>")
+		D.apply_damage(20, BRUTE, BODY_ZONE_CHEST, def_check)
+		D.add_bleeding(BLEED_CRITICAL)
+		D.apply_status_effect(/datum/status_effect/neck_slice)
+		A.say("BLEED!", forced="living fist")
+		log_combat(A, D, "lacerated (Living Fist)", name)
+		return
+
+/datum/martial_art/living_fist/proc/Blast(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
+	A.say("NYMPH BLAST!", forced="living fist")
+	D.visible_message("<span class='danger'>[A] hits [D] with THE NYMPH BLAST!</span>", \
+					"<span class='userdanger'>You're suddenly hit with THE NYMPH BLAST TECHNIQUE by [A]!</span>", "<span class='hear'>You hear a sickening sound of plant matter hitting flesh!</span>", null, A)
+	to_chat(A, "<span class='danger'>You hit [D] with THE NYMPH BLAST TECHNIQUE!</span>")
+	D.set_species(/datum/species/diona)
+	D.apply_damage(400, BRUTE, BODY_ZONE_CHEST)
+	log_combat(A, D, "dionafied and obliterated (Living Fist)", name)
+	return
+
+/datum/martial_art/living_fist/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	add_to_streak("H",D)
+	if(check_streak(A,D))
+		return 1
+	basic_hit(A,D)
+	return 1
+
+/datum/martial_art/living_fist/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	add_to_streak("D",D)
+	if(check_streak(A,D))
+		return 1
+	basic_hit(A,D)
+	return 1
+
+/datum/martial_art/living_fist/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	add_to_streak("G",D)
+	if(check_streak(A,D))
+		return 1
+	basic_hit(A,D)
+	return 1
+
+/mob/living/carbon/human/proc/living_fist_help()
+	set name = "Recall Teachings"
+	set desc = "Remember the martial techniques of the Living Fist."
+	set category = "Living Fist"
+
+	to_chat(usr, "<b><i>You clench your fists and have a flashback of knowledge...</i></b>")
+	to_chat(usr, "<span class='notice'>Vine Grab</span>: Grab Grab Harm. Grabs a target in an immediate neck grab.")
+	to_chat(usr, "<span class='notice'>Lacerate</span>: Disarm Harm Disarm. Shreds the target with vines, causing damage and bleeding. Requires a neck-tier grab.")
+	to_chat(usr, "<span class='notice'>The Nymph Blast</span>: Harm Disarm Disarm Disarm Harm. Blows whoever it hits into a pile of nymphs, even if they're not a Diona.")
+
+#undef GRAPPLE_COMBO
+#undef LACERATE_COMBO
+#undef BLAST_COMBO

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -421,6 +421,32 @@
 		name = "empty scroll"
 		icon_state = "blankscroll"
 
+/obj/item/book/granter/martial/living_fist
+	martial = /datum/martial_art/living_fist
+	name = "cloth scroll"
+	martialname = "living nymph fist"
+	desc = "An aged and grayed scrap of cloth, scrawled on with shifting ink. There are illustrations of Diona, punching people."
+	greet = "<span class='boldannounce'>You have learned the ancient Living Nymph Fist technique. Your combos are difficult to pull off, especially with your slow speed, but they allow you to strike \
+	with great ferocity. Your strongest strike, the Nymph Blast, will reduce someone to a pile of diona nymphs."
+	icon = 'icons/obj/wizard.dmi'
+	icon_state ="scroll2"
+	remarks = list("Balance...", "Power...", "Control...", "Mastery...", "Vigilance...", "Skill...")
+
+/obj/item/book/granter/martial/living_fist/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse == TRUE)
+		desc = "It's completely blank."
+		name = "empty scroll"
+		icon_state = "blankscroll"
+
+
+/obj/item/book/granter/martial/tribal_claw/already_known(mob/user)
+	if(isdiona(user))
+		return FALSE
+	else
+		to_chat(user, "<span class='warning'>You try to read the scroll but can't comprehend any of it.</span>")
+		return TRUE
+
 /obj/item/book/granter/martial/karate
 	martial = /datum/martial_art/karate
 	name = "dusty scroll"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2118,6 +2118,16 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	surplus = 0
 	restricted_species = list(SPECIES_LIZARD)
 
+/datum/uplink_item/race_restricted/living_fist
+	name = "Old Fabric Scroll"
+	desc = "We stole this scroll from a diona gestalt floating in space. \
+			It teaches you how to blow people up into nymphs with your fists, \
+			but only Diona can perform the techniques properly. Don't buy this if you aren't one."
+	item = /obj/item/book/granter/martial/living_fist
+	cost = 10
+	surplus = 0
+	restricted_species = list(SPECIES_DIONA)
+
 // Role-specific items
 /datum/uplink_item/role_restricted
 	category = "Role-Restricted"


### PR DESCRIPTION

## About The Pull Request
Disclaimer: This is stupid

Adds a martial art for dionae, known as the living-fist technique, loosely inspired by plasma fist. It has three combos, and is bought from the traitor uplink for 10tc by dionae only. It also removes shoves and grabs, replacing them with basic hits. Combos are as follows:
**Vine Lash** (Grab, Grab, Harm): Immediately neck grabs a target. 
**Lacerate** (Disarm, Harm, Disarm): Plays a short animation, and deals 20 chest damage to a target, as well as inflicting 3.6 bleeding. Can only be done on a target in a neck grab, requiring Vine Lash to have been used first. 
**NYMPH BLAST** (case sensitive) (Harm, Disarm, Disarm, Disarm, Harm): Turns someone into a diona, then deals 400 brute damage to their chest, instantly killing them and forcing them to scatter into a pile of nymphs. 

## Why It's Good For The Game
I like plasma fist, and dionae don't have any exclusive traitor items. They're also a good candidate for a powerful martial art because they're slow, meaning that combatants can just walk away to avoid confrontation.  

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Since I can't record, it's hard to capture video footage of combos in use, so please take my word for it that everything works.
![image](https://github.com/user-attachments/assets/396e409a-1fe3-46ea-b201-fcb54219af42)
Here's a picture of the scroll in the traitor inventory.

</details>

## Changelog
:cl:
add: Traitor dionae can now purchase a scroll detailing the Living Fist technique! Punch people so hard they explode into a shower of nymphs. Do other stuff too, if you're not cool.
/:cl:


