### PR TITLE
Adds a simple medkit to the uplink

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -414,6 +414,27 @@
 		/obj/item/clothing/glasses/hud/health/night = 1)
 	generate_items_inside(items_inside,src)
 
+//infiltrator kit, buyable by traitors
+/obj/item/storage/firstaid/infiltrator
+	name = "infiltrator medical kit"
+	desc = "(Un)fortunately for you, the Syndicate has a good medical plan."
+	icon_state = "firstaid-combat"
+	item_state = "firstaid-combat"
+	skin_type = MEDBOT_SKIN_SYNDI
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/firstaid/infiltrator/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/reagent_containers/pill/patch/synthflesh = 2,
+		/obj/item/storage/pill_bottle/kelotane = 1,
+		/obj/item/storage/pill_bottle/bicardine = 1,
+		/obj/item/storage/pill_bottle/charcoal = 1,
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/healthanalyzer = 1)
+	generate_items_inside(items_inside,src)
+
 //medibot assembly
 /obj/item/storage/firstaid/attackby(obj/item/bodypart/S, mob/user, params)
 	if((!istype(S, /obj/item/bodypart/l_arm/robot)) && (!istype(S, /obj/item/bodypart/r_arm/robot)))

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -429,7 +429,7 @@
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/synthflesh = 2,
 		/obj/item/storage/pill_bottle/kelotane = 1,
-		/obj/item/storage/pill_bottle/bicardine = 1,
+		/obj/item/storage/pill_bottle/bicaridine = 1,
 		/obj/item/storage/pill_bottle/charcoal = 1,
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/healthanalyzer = 1)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1921,6 +1921,14 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	cost = 4
 	purchasable_from = (UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
+/datum/uplink_item/device_tools/medkit_infiltration
+	name = "Syndicate Infiltrator's Medical Kit"
+	desc = "This first aid kit, filled with supplies stolen from Nanotrasen forces, is intended to be \
+			used by infiltrators on enemy stations. It contains some basic first-aid tools for self-treatment \
+			in dire situations. Fits in your bag, but is visually obvious as non-Nanotrasen."
+	item = /obj/item/storage/firstaid/infiltrator
+	cost = 2
+
 /datum/uplink_item/device_tools/soap
 	name = "Syndicate Soap"
 	desc = "A sinister-looking surfactant used to clean blood stains to hide murders and prevent DNA analysis. \


### PR DESCRIPTION

## About The Pull Request
This adds a normal-sized medkit to the traitor uplink. It contains:
-A health analyzer
-A stack of gauze
-A pill bottle each for bicaridine, kelotane, and charcoal
-Two patches of synthflesh

It currently costs 2tc, but it should probably cost more. Taking suggestions.

## Why It's Good For The Game
It gives traitors the ability to heal themselves in emergencies, and closes #11670. 

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/6f3da3fd-f08c-4815-8ff1-e419acc558e1)
shows up in the uplink

![image](https://github.com/user-attachments/assets/22b1254a-15af-4791-a9c0-b68f09a1a6da)
![image](https://github.com/user-attachments/assets/8f369fcd-2426-465e-acb0-990a24c6bbff)
here's the kit and the contents

</details>

## Changelog
:cl:
add: Syndicate Traitors can now purchase a medkit at the low low cost of 2 telecrystals. Contains medicine for emergency healing.
/:cl:

