### PR TITLE
Fixes the plastic bug

### DIFF
--- a/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
+++ b/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
@@ -85,7 +85,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	singular_name = "plastic sheet"
 	icon_state = "sheet-plastic"
 	item_state = "sheet-plastic"
-	custom_materials = list(/datum/material/plastic=MINERAL_MATERIAL_AMOUNT)
+	mats_per_unit = list(/datum/material/plastic=MINERAL_MATERIAL_AMOUNT)
 	throwforce = 7
 	merge_type = /obj/item/stack/sheet/plastic
 	material_type = /datum/material/plastic


### PR DESCRIPTION
## About The Pull Request
Squashes a very annoying bug relating to plastic and lathes. When spawning plastic, the game would set the value of the stack to 2000, rather than (2000 * sheet amount). This resulted in a lot of weirdness.

## Why It's Good For The Game
Bug gone, I was making a lot of feature PR's recently so I figured I should do a bug. Specifically closes #11493.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

how do i even screenshot this. Like, it works as intended. What do you want from me.

</details>

## Changelog
:cl:
fix: The government will no longer steal all but one of your plastic stack when you add it to a lathe. Chemists rejoice!
/:cl:
