### PR TITLE
AIs and Cyborgs can now turn on floodlights; and harvest hydroponics bins.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -886,6 +886,10 @@
 		return
 	harvest_plant(user)
 
+/obj/machinery/hydroponics/attack_robot(mob/living/user) // robots have little manipulator bits
+	if(Adjacent(user))
+		return harvest_plant(user)
+
 /obj/machinery/hydroponics/proc/harvest_plant(mob/user)
 	if(harvest)
 		return myseed.harvest(user)

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -109,6 +109,9 @@
 	change_setting(current, user)
 	..()
 
+/obj/machinery/power/floodlight/attack_silicon(mob/user)
+	return attack_hand(user)
+
 /obj/machinery/power/floodlight/obj_break(damage_flag)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Cyborgs can now harvest hydroponics bins. AIs and Cyborgs can now toggle floodlights.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
I think it makes sense that cyborgs, who are adjacent, can at least harvest whats inside the bin. AIs and Cyborgs should be able to turn on floodlights since they are electronic.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Testest interaction with the floodlight and bin
![image](https://github.com/user-attachments/assets/10314ebb-790d-40c6-81e1-eeec6e04342a)

</details>

## Changelog
:cl:
add: Cyborgs can now harvest plants from the hydroponics bin.
add: AI and Cyborgs can now toggle floodlights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
