### PR TITLE
Fixes the worn sprite of the Doctor's Bag

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -58,6 +58,7 @@
 	name = "doctor's bag"
 	icon_state = "firstaid-surgeryalt"
 	item_state = "firstaid-surgeryalt"
+	worn_icon = 'icons/mob/clothing/belt.dmi'
 	worn_icon_state = "firstaid_surgeryalt"
 	desc = "A fancy high capacity aid kit for doctors, full of medical supplies and basic surgical equipment"
 	skin_type = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There was a worn sprite for this item when it's on your belt, but the code to make it show up was broken. This PR just specifies what file it is, and makes it work.

## Why It's Good For The Game
Bug bad. Closes #10981.

## Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/91ad5033-be7b-4000-9bcc-9235bacd028f)
it works

## Changelog
:cl:
fix: Doctor's bags are no longer invisible on your belt. Now you can see the cool sprite that someone made!
/:cl:
