### PR TITLE
Fixes gibbed dionae qdeleting items

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -89,6 +89,10 @@
 	if (death_message)
 		to_chat(src, death_message)
 
+/mob/living/carbon/human/gib(no_brain, no_organs, no_bodyparts)
+	dna.species.spec_gib(no_brain, no_organs, no_bodyparts, src)
+	return
+
 /mob/living/carbon/human/proc/reagents_readout()
 	var/readout = "Blood:"
 	for(var/datum/reagent/reagent in reagents?.reagent_list)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1137,6 +1137,23 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/spec_death(gibbed, mob/living/carbon/human/H)
 	return
 
+/datum/species/proc/spec_gib(no_brain, no_organs, no_bodyparts, mob/living/carbon/human/H)
+	var/prev_lying = H.lying_prev
+	if(H.stat != DEAD)
+		H.death(TRUE)
+
+	if(!prev_lying)
+		H.gib_animation()
+
+	H.spill_organs(no_brain, no_organs, no_bodyparts)
+
+	if(!no_bodyparts)
+		H.spread_bodyparts(no_brain, no_organs)
+
+	H.spawn_gibs(no_bodyparts)
+	qdel(src)
+	return
+
 /datum/species/proc/auto_equip(mob/living/carbon/human/H)
 	// handles the equipping of species-specific gear
 	return

--- a/code/modules/mob/living/carbon/human/species_types/diona.dm
+++ b/code/modules/mob/living/carbon/human/species_types/diona.dm
@@ -127,6 +127,13 @@
 		return
 	split_ability.Trigger(TRUE)
 
+/datum/species/diona/spec_gib(no_brain, no_organs, no_bodyparts, mob/living/carbon/human/H)
+	H.unequip_everything()
+	H.gib_animation()
+	H.spawn_gibs()
+	QDEL_NULL(H)
+	return
+
 /datum/species/diona/on_species_gain(mob/living/carbon/human/H)
 	. = ..()
 	var/obj/item/organ/appendix/appendix = H.getorganslot("appendix") //No appendixes for plant people

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,10 +1,4 @@
 /mob/living/gib(no_brain, no_organs, no_bodyparts)
-
-	if(ishuman(src)) //Called this before any of the other variables due to diona shitcode.
-		var/mob/living/carbon/human/human = src
-		human.dna.species.spec_gib(no_brain, no_organs, no_bodyparts, src)
-		return
-
 	var/prev_lying = lying_angle
 	if(stat != DEAD)
 		death(TRUE)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,4 +1,10 @@
 /mob/living/gib(no_brain, no_organs, no_bodyparts)
+
+	if(ishuman(src)) //Called this before any of the other variables due to diona shitcode.
+		var/mob/living/carbon/human/human = src
+		human.dna.species.spec_gib(no_brain, no_organs, no_bodyparts, src)
+		return
+
 	var/prev_lying = lying_angle
 	if(stat != DEAD)
 		death(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Gibbed dionae used to call gib twice, especially during adminbus due to code shenanigens, which would result in deleted items, this fixes the issue. (hopefully)

## Why It's Good For The Game

Having the captain's antique qdel'd because of a plant is not intended game design.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/63977663-4b38-4d2b-96e6-c7f3908781b9

</details>

## Changelog
:cl: XeonMations
fix: Fixed gibbed dionae deleting items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
