### PR TITLE
Fixes radio channels defaulting to common

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -32,6 +32,7 @@
 
 	sec_radio = new/obj/item/radio(src)
 	sec_radio.set_listening(FALSE)
+	sec_radio.set_frequency(FREQ_SECURITY)
 
 	if(id != null)
 		for(var/obj/machinery/door/window/brigdoor/M in urange(20, src))
@@ -123,8 +124,7 @@
 		return 0
 
 	if(!forced)
-		sec_radio.set_frequency(FREQ_SECURITY)
-		sec_radio.talk_into(src, "Timer has expired. Releasing prisoner.", FREQ_SECURITY)
+		sec_radio.talk_into(src, "Timer has expired. Releasing prisoner.")
 
 	timing = FALSE
 	activation_time = null

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -284,8 +284,8 @@
 
 	// From the channel, determine the frequency and get a reference to it.
 	var/freq
-	if(channel && channels && channels.len > 0)
-		if(channel == MODE_DEPARTMENT)
+	if(channel && channels)
+		if(channel == MODE_DEPARTMENT && channels.len > 0)
 			channel = channels[1]
 		freq = secure_radio_connections[channel]
 		if(istype(talking_movable, /mob) && !freq && channel != RADIO_CHANNEL_UPLINK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #11345 .

In order to avoid a runtime with brig doors, #10362 reintroduced a bug where radios with no encryption key would transmit over common, no matter the frequency specified by the user (#10129 for details). This PR fixes the brig door runtime in a separate way, so both fixes can be implemented at once.
This PR also cleans up a misplaced line in the brig door code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix. Notably, civilian crewmembers shouldn't transmit their code over common when trying to access their radio uplink.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/17647855-8979-4bb0-911f-353844b96ff4

No brig door runtime: 
![corg](https://github.com/user-attachments/assets/ed45d39a-4855-4e9c-b39b-8e069e95b57b)


</details>

## Changelog
:cl:
fix: Radio channels no longer always default to common when no encryption key is installed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
