### PR TITLE
fixes broken grilles dropping 0 rods

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -288,7 +288,7 @@
 		rods_amount = 1
 		rods_broken = FALSE
 		var/drop_loc = drop_location()
-		var/obj/R = new rods_type(drop_loc, rods_broken)
+		var/obj/R = new rods_type(drop_loc, rods_amount)
 		if(QDELETED(R)) // the rods merged with something on the tile
 			R = locate(rods_type) in drop_loc
 		if(R)


### PR DESCRIPTION
## About The Pull Request

Fixes #11687 
Breaking a grille spawned a stack of 0 rods instead of 1, sprite was invisible of course.
This makes it spawn 1 rod, for a total of 2 rods when fully broken.

## Why It's Good For The Game

Bug fix.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/2103e25c-3282-45a5-9fb9-efbbf282e8eb)
![image](https://github.com/user-attachments/assets/c4411395-8b7c-443b-9bc2-886c7700bfca)
![image](https://github.com/user-attachments/assets/38caff49-f1c4-4f41-9799-45c8e91aecf5)
![image](https://github.com/user-attachments/assets/852d774b-9085-4ac4-b948-e23de520d0a2)

</details>

:cl: ktlwjec
fix: Breaking grilles no longer drop invisible rods.
/:cl: