### PR TITLE
Fixes gibbing for humanoids

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1151,7 +1151,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		H.spread_bodyparts(no_brain, no_organs)
 
 	H.spawn_gibs(no_bodyparts)
-	qdel(src)
+	qdel(H) //src doesn't work, we aren't in the mob anymore, this just deletes the species!!
 	return
 
 /datum/species/proc/auto_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an oversight introduced in #11598 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Humanoids other than Diona are not able to gib properly, this causes notable problems with ashwalker tendrils doing infinite gibbing cycles with infinite eggs. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/1e7c3a43-d5c5-4df8-a75e-ff97b0c64a0c)

</details>

## Changelog
:cl:
fix: Humanoids now gib properly again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
