### PR TITLE
Tweaks to heirlooms

### DIFF
--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -141,18 +141,8 @@
 	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/heirloom_type
 
-	if(prob(33)) //Generic heirloom
-		heirloom_type = pick(/obj/item/coin/random, /obj/item/key)
-
-	if(prob(33)) //racial heirlooms
-		if(islizard(H))
-			heirloom_type = /obj/item/heirloom_skull
-		if((ismoth(H)))
-			heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
-		if(isipc(H))
-			heirloom_type = /obj/item/disk/tech_disk
-
-	if(!heirloom_type) //Safety catch to ensure heirlooms still work if the above probability passes, but nothing was generated.
+	//33% chance for job related heirloom
+	if(prob(33))
 		switch(quirk_holder.assigned_role)
 			//Service jobs
 			if(JOB_NAME_CLOWN)
@@ -227,11 +217,24 @@
 			if(JOB_NAME_SHAFTMINER)
 				heirloom_type = pick(/obj/item/pickaxe/mini, /obj/item/shovel)
 
+	//When compounded with the above this makes a 33% chance for racial heirloom, even though this says prob(50)
+	if(prob(50))
+		if(islizard(H))
+			heirloom_type = /obj/item/heirloom_skull
+		if((ismoth(H)))
+			heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
+		if(isipc(H))
+			heirloom_type = /obj/item/disk/tech_disk
+
+
+	//Generic heirloom, anywhere from 33% chance to 100% chance depending on race/job combination.
+	// Functions as a failsafe in the event that no other heirlooms were available, that's why this isn't a switch.
 	if(!heirloom_type)
 		heirloom_type = pick(
-		/obj/item/toy/cards/deck,
-		/obj/item/lighter,
-		/obj/item/dice/d20)
+			pick(subtypesof(/obj/item/coin)),
+			/obj/item/key,
+			/obj/item/lighter)
+
 	heirloom = new heirloom_type(get_turf(quirk_target))
 	var/list/slots = list(
 		"in your left pocket" = ITEM_SLOT_LPOCKET,
@@ -285,6 +288,7 @@
 /obj/item/heirloom_skull
 	name = "trophy skull"
 	desc = "A trophy taken from something felled many generations ago."
+	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "legion_skull"
 
 //Moth heirloom

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -141,10 +141,18 @@
 	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/heirloom_type
 
-	if((ismoth(H)) && prob(10))
-		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
+	if(prob(33)) //Generic heirloom
+		heirloom_type = pick(/obj/item/coin/random, /obj/item/key)
 
-	else
+	if(prob(33)) //racial heirlooms
+		if(islizard(H))
+			heirloom_type = /obj/item/heirloom_skull
+		if((ismoth(H)))
+			heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
+		if(isipc(H))
+			heirloom_type = /obj/item/disk/tech_disk
+
+	if(!heirloom_type) //Safety catch to ensure heirlooms still work if the above probability passes, but nothing was generated.
 		switch(quirk_holder.assigned_role)
 			//Service jobs
 			if(JOB_NAME_CLOWN)
@@ -254,6 +262,36 @@
 	else
 		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom")
 		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "family_heirloom_missing", /datum/mood_event/family_heirloom_missing)
+
+//Items that exist only as heirlooms because the flavor of an original item was good, but we don't want the heirloom to be too functional
+
+//Assistant heirloom toolbox, so they don't have an oversized heirloom but also don't have a functional toolbox that fits in their bag.
+/obj/item/heirloomtoolbox //Not actually a toolbox at all
+	name = "family toolbox"
+	icon = 'icons/obj/storage/toolbox.dmi'
+	icon_state = "toolbox_blue_old"
+	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
+	flags_1 = CONDUCT_1
+	desc = "It may be rusted shut, but it's still an important keepsake."
+	force = 5
+	throw_speed = 2
+	throw_range = 7
+	attack_verb_continuous = list("robusts")
+	attack_verb_simple = list("robust")
+	hitsound = 'sound/weapons/smash.ogg'
+
+//Lizard heirloom skull
+/obj/item/heirloom_skull
+	name = "trophy skull"
+	desc = "A trophy taken from something felled many generations ago."
+	icon_state = "legion_skull"
+
+//Moth heirloom
+/obj/item/flashlight/lantern/heirloom_moth
+	name = "old lantern"
+	desc = "An old lantern that has seen plenty of use."
+	light_range = 4
 
 /datum/quirk/frail
 	name = "Frail"

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -141,7 +141,7 @@
 	var/mob/living/carbon/human/H = quirk_target
 	var/obj/item/heirloom_type
 
-	if((ismoth(H)) && prob(50))
+	if((ismoth(H)) && prob(10))
 		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
 	else
 		switch(quirk_holder.assigned_role)
@@ -151,19 +151,19 @@
 			if(JOB_NAME_MIME)
 				heirloom_type = /obj/item/food/baguette/mime
 			if(JOB_NAME_JANITOR)
-				heirloom_type = pick(/obj/item/mop, /obj/item/clothing/suit/caution, /obj/item/reagent_containers/glass/bucket)
+				heirloom_type = pick(/obj/item/mop, /obj/item/reagent_containers/glass/bucket)
 			if(JOB_NAME_COOK)
-				heirloom_type = pick(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin, /obj/item/clothing/head/utility/chefhat)
+				heirloom_type = pick(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin)
 			if(JOB_NAME_BOTANIST)
-				heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket, /obj/item/storage/bag/plants, /obj/item/toy/plush/beeplushie)
+				heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket, /obj/item/toy/plush/beeplushie)
 			if(JOB_NAME_BARTENDER)
-				heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/clothing/head/hats/tophat, /obj/item/reagent_containers/food/drinks/shaker)
+				heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/reagent_containers/food/drinks/shaker)
 			if(JOB_NAME_CURATOR)
 				heirloom_type = pick(/obj/item/pen/fountain, /obj/item/storage/pill_bottle/dice)
 			if(JOB_NAME_CHAPLAIN)
 				heirloom_type = pick(/obj/item/toy/windupToolbox, /obj/item/reagent_containers/food/drinks/bottle/holywater)
 			if(JOB_NAME_ASSISTANT)
-				heirloom_type = pick(/obj/item/heirloomtoolbox, /obj/item/clothing/gloves/cut/heirloom)
+				heirloom_type = pick(/obj/item/heirloomtoolbox)
 			if(JOB_NAME_BARBER)
 				heirloom_type = /obj/item/handmirror
 			if(JOB_NAME_STAGEMAGICIAN)
@@ -176,13 +176,13 @@
 			if(JOB_NAME_WARDEN)
 				heirloom_type = /obj/item/book/manual/wiki/security_space_law
 			if(JOB_NAME_SECURITYOFFICER)
-				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
+				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law)
 			if(JOB_NAME_DETECTIVE)
 				heirloom_type = /obj/item/reagent_containers/food/drinks/bottle/whiskey
 			if(JOB_NAME_LAWYER)
 				heirloom_type = pick(/obj/item/gavelhammer, /obj/item/book/manual/wiki/security_space_law)
 			if(JOB_NAME_BRIGPHYSICIAN)
-				heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/book/manual/wiki/security_space_law)
+				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law)
 			//RnD
 			if(JOB_NAME_RESEARCHDIRECTOR)
 				heirloom_type = pick(typesof(/obj/item/toy/plush/slimeplushie) - /obj/item/toy/plush/slimeplushie/random)
@@ -202,12 +202,12 @@
 			if(JOB_NAME_VIROLOGIST)
 				heirloom_type = /obj/item/reagent_containers/dropper
 			if(JOB_NAME_GENETICIST)
-				heirloom_type = /obj/item/clothing/under/shorts/purple
+				heirloom_type = /obj/item/dnainjector //This is non-functional
 			//Engineering
 			if(JOB_NAME_CHIEFENGINEER)
-				heirloom_type = pick(/obj/item/clothing/head/utility/hardhat/white, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
+				heirloom_type = pick(/obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
 			if(JOB_NAME_STATIONENGINEER)
-				heirloom_type = pick(/obj/item/clothing/head/utility/hardhat, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
+				heirloom_type = pick(/obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
 			if(JOB_NAME_ATMOSPHERICTECHNICIAN)
 				heirloom_type = pick(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
 			//Supply

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -143,6 +143,7 @@
 
 	if((ismoth(H)) && prob(10))
 		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
+
 	else
 		switch(quirk_holder.assigned_role)
 			//Service jobs
@@ -151,11 +152,11 @@
 			if(JOB_NAME_MIME)
 				heirloom_type = /obj/item/food/baguette/mime
 			if(JOB_NAME_JANITOR)
-				heirloom_type = pick(/obj/item/mop, /obj/item/reagent_containers/glass/bucket)
+				heirloom_type = /obj/item/reagent_containers/spray/cleaner
 			if(JOB_NAME_COOK)
 				heirloom_type = pick(/obj/item/reagent_containers/food/condiment/saltshaker, /obj/item/kitchen/rollingpin)
 			if(JOB_NAME_BOTANIST)
-				heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket, /obj/item/toy/plush/beeplushie)
+				heirloom_type = pick(/obj/item/cultivator, /obj/item/toy/plush/beeplushie)
 			if(JOB_NAME_BARTENDER)
 				heirloom_type = pick(/obj/item/reagent_containers/glass/rag, /obj/item/reagent_containers/food/drinks/shaker)
 			if(JOB_NAME_CURATOR)
@@ -163,7 +164,7 @@
 			if(JOB_NAME_CHAPLAIN)
 				heirloom_type = pick(/obj/item/toy/windupToolbox, /obj/item/reagent_containers/food/drinks/bottle/holywater)
 			if(JOB_NAME_ASSISTANT)
-				heirloom_type = pick(/obj/item/heirloomtoolbox)
+				heirloom_type = /obj/item/heirloomtoolbox
 			if(JOB_NAME_BARBER)
 				heirloom_type = /obj/item/handmirror
 			if(JOB_NAME_STAGEMAGICIAN)
@@ -176,13 +177,13 @@
 			if(JOB_NAME_WARDEN)
 				heirloom_type = /obj/item/book/manual/wiki/security_space_law
 			if(JOB_NAME_SECURITYOFFICER)
-				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law)
+				heirloom_type = /obj/item/book/manual/wiki/security_space_law
 			if(JOB_NAME_DETECTIVE)
 				heirloom_type = /obj/item/reagent_containers/food/drinks/bottle/whiskey
 			if(JOB_NAME_LAWYER)
 				heirloom_type = pick(/obj/item/gavelhammer, /obj/item/book/manual/wiki/security_space_law)
 			if(JOB_NAME_BRIGPHYSICIAN)
-				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law)
+				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/sensor_device)
 			//RnD
 			if(JOB_NAME_RESEARCHDIRECTOR)
 				heirloom_type = pick(typesof(/obj/item/toy/plush/slimeplushie) - /obj/item/toy/plush/slimeplushie/random)
@@ -192,9 +193,9 @@
 				heirloom_type = pick(subtypesof(/obj/item/toy/mecha)) //look at this nerd
 			//Medical
 			if(JOB_NAME_CHIEFMEDICALOFFICER)
-				heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/flashlight/pen)
+				heirloom_type = /obj/item/flashlight/pen
 			if(JOB_NAME_MEDICALDOCTOR)
-				heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/flashlight/pen, /obj/item/scalpel)
+				heirloom_type = pick(/obj/item/flashlight/pen, /obj/item/scalpel)
 			if(JOB_NAME_PARAMEDIC)
 				heirloom_type = pick(/obj/item/flashlight/pen, /obj/item/sensor_device)
 			if(JOB_NAME_CHEMIST)
@@ -207,9 +208,9 @@
 			if(JOB_NAME_CHIEFENGINEER)
 				heirloom_type = pick(/obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
 			if(JOB_NAME_STATIONENGINEER)
-				heirloom_type = pick(/obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters)
+				heirloom_type = pick(/obj/item/multitool, /obj/item/geiger_counter, /obj/item/t_scanner)
 			if(JOB_NAME_ATMOSPHERICTECHNICIAN)
-				heirloom_type = pick(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
+				heirloom_type = pick(/obj/item/lighter, /obj/item/analyzer, /obj/item/t_scanner)
 			//Supply
 			if(JOB_NAME_QUARTERMASTER)
 				heirloom_type = pick(/obj/item/stamp, /obj/item/stamp/denied)

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -218,7 +218,7 @@
 				heirloom_type = pick(/obj/item/pickaxe/mini, /obj/item/shovel)
 
 	//When compounded with the above this makes a 33% chance for racial heirloom, even though this says prob(50)
-	if(prob(50))
+	else if(prob(50))
 		if(islizard(H))
 			heirloom_type = /obj/item/heirloom_skull
 		if((ismoth(H)))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -369,11 +369,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	light_range = 6			// luminosity when on
 	light_system = MOVABLE_LIGHT
 
-/obj/item/flashlight/lantern/heirloom_moth
-	name = "old lantern"
-	desc = "An old lantern that has seen plenty of use."
-	light_range = 4
-
 /obj/item/flashlight/lantern/syndicate
 	name = "suspicious lantern"
 	desc = "A suspicious looking lantern."

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -87,22 +87,6 @@
 	has_latches = FALSE
 	material_flags = NONE
 
-/obj/item/heirloomtoolbox //Not actually a toolbox at all, just an heirloom
-	name = "family toolbox"
-	icon = 'icons/obj/storage/toolbox.dmi'
-	icon_state = "toolbox_blue_old"
-	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
-	flags_1 = CONDUCT_1
-	desc = "It may be rusted shut, but it's still an important keepsake."
-	force = 5
-	throw_speed = 2
-	throw_range = 7
-	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb_continuous = list("robusts")
-	attack_verb_simple = list("robust")
-	hitsound = 'sound/weapons/smash.ogg'
-
 /obj/item/storage/toolbox/mechanical/old/clean
 	name = "toolbox"
 	desc = "A old, blue toolbox, it looks robust."

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -176,3 +176,14 @@
 	value = 0
 
 /obj/item/coin/iron
+	name = "iron coin"
+	desc = "A hefty coin made of iron"
+
+/obj/item/coin/random
+	name = "random coin"
+	desc = "You should really never see this"
+
+/obj/item/coin/random/Initialize(mapload)
+	var/coin_type = pick(subtypesof(/obj/item/coin) - /obj/item/coin/random)
+	new coin_type (loc)
+	return INITIALIZE_HINT_QDEL

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -179,11 +179,3 @@
 	name = "iron coin"
 	desc = "A hefty coin made of iron"
 
-/obj/item/coin/random
-	name = "random coin"
-	desc = "You should really never see this"
-
-/obj/item/coin/random/Initialize(mapload)
-	var/coin_type = pick(subtypesof(/obj/item/coin) - /obj/item/coin/random)
-	new coin_type (loc)
-	return INITIALIZE_HINT_QDEL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Removes wearable heirlooms entirely
* Re-organizes heirloom code logic
  * First is a 33% chance at job-specific heirloom
  * Then a 33% chance at racial heirloom (using prob(50) because of how compound probability works)
  * Then finally a generic heirloom is assigned if the first two failed, functioning as both the final 33% and also a failsafe
* Adds lizard and IPC racial heirlooms
* Adds generic heirlooms (key and random coin) that anyone may get regardless of race/job
* Removes D20 and Deck of cards heirlooms as generic options, now that generic will be popping up a lot more often. These didn't seem particularly heirloom-y to me, and a deck of cards has a very real chance of being accidentally destroyed just by dealing all of the cards out of it. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Free or almost free negatives just encourage gaming the quirk system instead of using it to build a character. Likewise these changes help to smooth the curve out at least somewhat so that certain jobs/races are not consistently getting heirlooms of a different size and impact than others. There is still going to be some disparity, but there should be less of it now. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/5532889c-f3e3-408b-a069-4cff82e8d535)

![image](https://github.com/user-attachments/assets/05950d75-774f-41b0-8fc1-40b51a5e9573)

![image](https://github.com/user-attachments/assets/52e8f2c5-9241-4af3-a919-1a1ec93815c8)

![image](https://github.com/user-attachments/assets/d30c6f61-1e7a-436c-85af-21f3e78a7b59)

</details>

## Changelog
:cl:
tweak: Adjusted the pool of heirlooms increase variety of the type of heirloom you will receive, there is now a 33% chance to get a job heirloom, 33% chance to get a species heirloom (if your species has one) and a 33% chance to get a generic heirloom not related to job/race.
del: Removed all wearable family heirlooms, as well as D20 and deck of cards from the failsafe. 
add: Added random coin and key to generic heirlooms
add: Added racial heirlooms to lizard and IPC
tweak: Various job heirlooms have been shuffled and adjusted
code: All items that only exist as heirlooms are now in the same place as the rest of heirloom code instead of scattered through files. Heirloom logic was also re-organized. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
