### PR TITLE
Specifically defines days-before-pr-stale

### DIFF
--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -14,6 +14,8 @@ jobs:
         stale-pr-message: "This PR has been marked as stale due to being in an unmergable state for 7 days. Please resolve any conflicts and add testing evidence, then contact a project maintainer to have the stale label removed."
         stale-pr-label: 'Stale'
         any-of-pr-labels: 'Needs Testing Evidence,Merge Conflict'
+        days-before-stale: -1
+        days-before-close: -1
         days-before-pr-stale: 7
         days-before-pr-close: 5
         remove-pr-stale-when-updated: true

--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -14,7 +14,7 @@ jobs:
         stale-pr-message: "This PR has been marked as stale due to being in an unmergable state for 7 days. Please resolve any conflicts and add testing evidence, then contact a project maintainer to have the stale label removed."
         stale-pr-label: 'Stale'
         any-of-pr-labels: 'Needs Testing Evidence,Merge Conflict'
-        days-before-stale: 7
-        days-before-close: 5
+        days-before-pr-stale: 7
+        days-before-pr-close: 5
         remove-pr-stale-when-updated: true
         labels-to-remove-when-unstale: 'Stale'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Specifically uses days-before-pr-stale instead of days-before-stale. I assume by updating to version 9, these were added at some point and it now needs to be defined explicitly instead of being implicit.

## Why It's Good For The Game

Issues are being marked as stale after 7 days instead of 30.

## Testing Photographs and Procedure

N/A

## Changelog
:cl:
fix: Github issues will correctly be marked as stale after 30 days instead of 7
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
