### PR TITLE
Deltastation misc fixes

### DIFF
--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -1,6 +1,6 @@
 {
 	"map_name": "Delta Station",
-	"map_link": "deltsatation",
+	"map_link": "deltastation",
 	"map_path": "map_files/Deltastation",
 	"map_file": "DeltaStation2.dmm",
 	"shuttles": {

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -88604,7 +88604,7 @@
 /area/science/mixing)
 "wkM" = (
 /turf/open/floor/holofloor/plating,
-/area/security/prison)
+/area/holodeck/prison)
 "wkS" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/machinery/computer/med_data{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -35665,6 +35665,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
+/obj/machinery/camera/directional/west,
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
 "fyj" = (
@@ -37924,7 +37925,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "ggf" = (
@@ -39846,9 +39846,6 @@
 /obj/machinery/light,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
-	},
-/obj/machinery/camera{
-	dir = 10
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/yellow,
@@ -42687,6 +42684,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/camera/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "hEN" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Initially this PR was just fixing the prison workshop, then I noticed another issue and then another one, so here's some misc fixes involving DeltaStation.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing the game is a good thing, or so I've been told...

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Brig now loads the holodeck
![image](https://github.com/user-attachments/assets/b84bd2de-96fe-44f7-afa7-ac8ffac14eb9)

View-Webmap now works:
![image](https://github.com/user-attachments/assets/d70936a7-a3fd-42f5-b94c-c8df934a7e26)

Camera still retains view:
![image](https://github.com/user-attachments/assets/59f7bb58-477f-4b2c-a168-13c2c5e880e8)

</details>

## Changelog
:cl:
fix: [DeltaStation]: Prison holodeck now actually works
fix: [DeltaStation]: View-Webmap no longer sends you to a bad link for viewing Delta Station
fix: [DeltaStation]: Moves medbay lobby cameras to not be on top of lights, and also actually sticking on walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
