### PR TITLE
Brainwashing Minimum Player Limit

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1769,7 +1769,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
-	player_minimum = 25
+	player_minimum = 10
 	cost = 5
 
 /datum/uplink_item/device_tools/briefcase_launchpad
@@ -1879,6 +1879,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	name = "Hypnotic Flash"
 	desc = "A modified flash able to hypnotize targets. If the target is not in a mentally vulnerable state, it will only confuse and pacify them temporarily."
 	item = /obj/item/assembly/flash/hypnotic
+	player_minimum = 20
 	cost = 7
 
 /datum/uplink_item/device_tools/medgun


### PR DESCRIPTION
## About The Pull Request
Changed the minimum pop for both the brainwashing surgery disk and hypnotic flash to 10 and 20 players respectively. 
This is because hypnotic flash can be very easy to utilize and has even been seen used mid-combat. Meanwhile brainwashing surgery requires proper surgery and doctors have 99% of the time no reason to crack open the skull of their patients unless Exploration brought in the brain implant research disks.

In a future PR I hope to change brainwashing even more.

## Why It's Good For The Game
Balances brainwashing somewhat appropriately.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
</details>

## Changelog
:cl:
balance: [Uplink] Changed brainwashing surgery to a minimum of 10 players and hypnotic flash to a minimum of 20 players.
/:cl:
