### PR TITLE
Techstorage Buff

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2350,12 +2350,12 @@
 /turf/open/space/basic,
 /area/engine/atmos)
 "aGG" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/spawner/lootdrop/techstorage/AI,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
+/obj/effect/spawner/lootdrop/techstorage/secure/science,
+/obj/structure/rack,
 /turf/open/floor/iron/grid/steel,
 /area/storage/tech)
 "aGZ" = (
@@ -9155,6 +9155,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/lootdrop/techstorage/chemistry,
+/obj/effect/spawner/lootdrop/techstorage/genetics,
 /turf/open/floor/iron/techmaint,
 /area/storage/tech)
 "bTO" = (
@@ -11752,6 +11754,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/lootdrop/techstorage/botany,
+/obj/effect/spawner/lootdrop/techstorage/kitchen,
+/obj/effect/spawner/lootdrop/techstorage/games,
 /turf/open/floor/iron/techmaint,
 /area/storage/tech)
 "cim" = (
@@ -17207,14 +17212,13 @@
 /area/security/warden)
 "dDw" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/item/aicard,
-/obj/item/aiModule/reset,
-/turf/open/floor/iron/grid/steel,
+/obj/effect/spawner/lootdrop/techstorage/shuttles,
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/turf/open/floor/iron/dark,
 /area/storage/tech)
 "dDy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -19377,7 +19381,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/spawner/lootdrop/techstorage/command,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -19385,6 +19388,7 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 31
 	},
+/obj/effect/spawner/lootdrop/techstorage/secure/engineering,
 /turf/open/floor/iron/grid/steel,
 /area/storage/tech)
 "evf" = (
@@ -21270,12 +21274,8 @@
 /turf/open/floor/iron/dark,
 /area/engine/gravity_generator)
 "fgq" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
-	},
-/obj/item/kirbyplants/photosynthetic{
-	pixel_y = 6
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -21284,6 +21284,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/spawner/lootdrop/techstorage/secure/command,
+/obj/structure/rack,
 /turf/open/floor/iron/grid/steel,
 /area/storage/tech)
 "fgG" = (
@@ -23698,9 +23700,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/spawner/lootdrop/techstorage/RnD_secure,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
 /obj/machinery/camera/directional/north,
+/obj/item/aicard,
+/obj/effect/spawner/lootdrop/techstorage/secure/AI,
+/obj/item/aiModule/reset,
 /turf/open/floor/iron/grid/steel,
 /area/storage/tech)
 "gfd" = (
@@ -51025,6 +51029,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/item/kirbyplants/photosynthetic{
+	pixel_y = 6
+	},
 /turf/open/floor/engine/light,
 /area/storage/tech)
 "rhN" = (
@@ -66126,16 +66133,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xfZ" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/tank_dispenser/oxygen{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/grid/steel,
+/obj/effect/spawner/lootdrop/techstorage/cargo,
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
+/obj/structure/rack,
+/turf/open/floor/iron/dark,
 /area/storage/tech)
 "xgj" = (
 /obj/effect/turf_decal/bot,
@@ -67801,6 +67806,8 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/techstorage/robotics,
+/obj/effect/spawner/lootdrop/techstorage/nanites,
 /turf/open/floor/iron/techmaint,
 /area/storage/tech)
 "xQz" = (

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -399,114 +399,221 @@
 // Tech storage circuit board spawners
 
 /obj/effect/spawner/lootdrop/techstorage
-
 	name = "generic circuit board spawner"
 	icon_state = "random_board"
 	lootdoubles = FALSE
 	fan_out_items = TRUE
 	lootcount = INFINITY
 
+/obj/effect/spawner/lootdrop/techstorage/shuttles
+	name = "shuttles circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/computer/shuttle/mining_shuttle,
+		/obj/item/circuitboard/computer/shuttle/labor_shuttle,
+		/obj/item/circuitboard/computer/shuttle/science_shuttle,
+		/obj/item/circuitboard/computer/shuttle/exploration_shuttle,
+		/obj/item/circuitboard/computer/shuttle/flight_control
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/games
+	name = "games circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/computer/arcade/battle,
+		/obj/item/circuitboard/computer/arcade/orion_trail,
+		/obj/item/circuitboard/computer/slot_machine
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/cargo
+	name = "cargo circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/machine/autolathe,
+		/obj/item/circuitboard/computer/mining,
+		/obj/item/circuitboard/machine/mining_equipment_vendor,
+		/obj/item/circuitboard/machine/ore_redemption,
+		/obj/item/circuitboard/computer/cargo/request,
+		/obj/item/circuitboard/computer/cargo,
+		/obj/item/circuitboard/computer/bounty
+	)
+
 /obj/effect/spawner/lootdrop/techstorage/service
 	name = "service circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/arcade/battle,
-				/obj/item/circuitboard/computer/arcade/orion_trail,
-				/obj/item/circuitboard/machine/autolathe,
-				/obj/item/circuitboard/computer/mining,
-				/obj/item/circuitboard/machine/ore_redemption,
-				/obj/item/circuitboard/machine/mining_equipment_vendor,
-				/obj/item/circuitboard/machine/microwave,
-				/obj/item/circuitboard/machine/chem_dispenser/drinks,
-				/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
-				/obj/item/circuitboard/computer/slot_machine
-				)
+		/obj/item/circuitboard/machine/chem_dispenser/drinks,
+		/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
+		/obj/item/circuitboard/machine/reagentgrinder,
+		/obj/item/circuitboard/machine/chem_master
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/kitchen
+	name = "kitchen circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/machine/microwave,
+		/obj/item/circuitboard/machine/griddle,
+		/obj/item/circuitboard/machine/microwave,
+		/obj/item/circuitboard/machine/gibber,
+		/obj/item/circuitboard/machine/processor,
+		/obj/item/circuitboard/machine/oven,
+		/obj/item/circuitboard/machine/smartfridge
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/botany
+	name = "botany circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/machine/hydroponics,
+		/obj/item/circuitboard/machine/hydroponics,
+		/obj/item/circuitboard/machine/hydroponics,
+		/obj/item/circuitboard/machine/chem_dispenser/botany,
+		/obj/item/circuitboard/machine/biogenerator,
+		/obj/item/circuitboard/machine/plantgenes,
+		/obj/item/circuitboard/machine/seed_extractor
+	)
 
 /obj/effect/spawner/lootdrop/techstorage/rnd
 	name = "RnD circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/aifixer,
-				/obj/item/circuitboard/machine/rdserver,
-				/obj/item/circuitboard/machine/mechfab,
-				/obj/item/circuitboard/machine/circuit_imprinter/department,
-				/obj/item/circuitboard/computer/teleporter,
-				/obj/item/circuitboard/machine/destructive_analyzer,
-				/obj/item/circuitboard/computer/rdconsole,
-				/obj/item/circuitboard/computer/nanite_chamber_control,
-				/obj/item/circuitboard/computer/nanite_cloud_controller,
-				/obj/item/circuitboard/machine/nanite_chamber,
-				/obj/item/circuitboard/machine/nanite_programmer,
-				/obj/item/circuitboard/machine/nanite_program_hub,
-				/obj/item/circuitboard/machine/xenoartifact_inbox,
-				/obj/item/circuitboard/computer/xenoartifact_console
-				)
+		/obj/item/circuitboard/computer/aifixer,
+		/obj/item/circuitboard/machine/rdserver,
+		/obj/item/circuitboard/machine/rdserver,
+		/obj/item/circuitboard/machine/rdserver,
+		/obj/item/circuitboard/machine/rdserver,
+		/obj/item/circuitboard/machine/destructive_analyzer,
+		/obj/item/circuitboard/computer/rdconsole,
+		/obj/item/circuitboard/machine/xenoartifact_inbox,
+		/obj/item/circuitboard/computer/xenoartifact_console,
+		/obj/item/circuitboard/computer/xenobiology,
+		/obj/item/circuitboard/machine/exploration_equipment_vendor
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/nanites
+	name = "nanites circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/computer/nanite_chamber_control,
+		/obj/item/circuitboard/computer/nanite_cloud_controller,
+		/obj/item/circuitboard/machine/nanite_chamber,
+		/obj/item/circuitboard/machine/nanite_programmer,
+		/obj/item/circuitboard/machine/nanite_program_hub
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/robotics
+	name = "science circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/machine/mechfab,
+		/obj/item/circuitboard/machine/circuit_imprinter/department,
+		/obj/item/circuitboard/machine/cyborgrecharger,
+		/obj/item/circuitboard/computer/mech_bay_power_console,
+		/obj/item/circuitboard/machine/mech_recharger,
+		/obj/item/circuitboard/machine/ecto_sniffer
+	)
 
 /obj/effect/spawner/lootdrop/techstorage/security
 	name = "security circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/secure_data,
-				/obj/item/circuitboard/computer/security,
-				/obj/item/circuitboard/computer/prisoner
-				)
+		/obj/item/circuitboard/computer/secure_data,
+		/obj/item/circuitboard/computer/security,
+		/obj/item/circuitboard/computer/prisoner,
+		/obj/item/circuitboard/computer/gulag_teleporter_console,
+		/obj/item/circuitboard/machine/gulag_teleporter,
+		/obj/item/circuitboard/machine/recharger,
+		/obj/item/circuitboard/computer/warrant
+	)
 
 /obj/effect/spawner/lootdrop/techstorage/engineering
 	name = "engineering circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/atmos_alert,
-				/obj/item/circuitboard/computer/stationalert,
-				/obj/item/circuitboard/computer/powermonitor
-				)
+		/obj/item/circuitboard/computer/atmos_alert,
+		/obj/item/circuitboard/computer/stationalert,
+		/obj/item/circuitboard/computer/powermonitor,
+		/obj/item/circuitboard/machine/pacman,
+		/obj/item/circuitboard/machine/smes,
+		/obj/item/circuitboard/machine/emitter,
+		/obj/item/circuitboard/machine/emitter,
+		/obj/item/circuitboard/machine/suit_storage_unit,
+		/obj/item/circuitboard/machine/circuit_imprinter,
+		/obj/item/circuitboard/machine/thermomachine,
+		/obj/item/circuitboard/machine/cell_charger,
+		/obj/item/circuitboard/machine/mass_driver,
+		/obj/item/circuitboard/machine/fax
+	)
 
 /obj/effect/spawner/lootdrop/techstorage/tcomms
 	name = "tcomms circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/message_monitor,
-				/obj/item/circuitboard/machine/telecomms/broadcaster,
-				/obj/item/circuitboard/machine/telecomms/bus,
-				/obj/item/circuitboard/machine/telecomms/server,
-				/obj/item/circuitboard/machine/telecomms/receiver,
-				/obj/item/circuitboard/machine/telecomms/processor,
-				/obj/item/circuitboard/machine/announcement_system,
-				/obj/item/circuitboard/computer/comm_server,
-				/obj/item/circuitboard/computer/comm_monitor
-				)
+		/obj/item/circuitboard/computer/message_monitor,
+		/obj/item/circuitboard/machine/telecomms/broadcaster,
+		/obj/item/circuitboard/machine/telecomms/bus,
+		/obj/item/circuitboard/machine/telecomms/server,
+		/obj/item/circuitboard/machine/telecomms/receiver,
+		/obj/item/circuitboard/machine/telecomms/processor,
+		/obj/item/circuitboard/machine/announcement_system,
+		/obj/item/circuitboard/computer/comm_server,
+		/obj/item/circuitboard/computer/comm_monitor
+	)
 
 /obj/effect/spawner/lootdrop/techstorage/medical
 	name = "medical circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/cloning,
-				/obj/item/circuitboard/machine/clonepod,
-				/obj/item/circuitboard/machine/chem_dispenser,
-				/obj/item/circuitboard/computer/scan_consolenew,
-				/obj/item/circuitboard/computer/med_data,
-				/obj/item/circuitboard/machine/smoke_machine,
-				/obj/item/circuitboard/machine/chem_master,
-				/obj/item/circuitboard/machine/clonescanner,
-				/obj/item/circuitboard/computer/pandemic
-				)
+		/obj/item/circuitboard/computer/med_data,
+		/obj/item/circuitboard/computer/crew,
+		/obj/item/circuitboard/machine/stasis,
+		/obj/item/circuitboard/machine/stasis,
+		/obj/item/circuitboard/computer/operating,
+		/obj/item/circuitboard/computer/operating,
+		/obj/item/circuitboard/computer/operating,
+		/obj/item/stack/sheet/mineral/silver,
+		/obj/item/circuitboard/machine/cryo_tube,
+		/obj/item/circuitboard/computer/pandemic
+	)
 
-/obj/effect/spawner/lootdrop/techstorage/AI
+/obj/effect/spawner/lootdrop/techstorage/chemistry
+	name = "chemistry circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/machine/chem_master,
+		/obj/item/circuitboard/machine/smoke_machine,
+		/obj/item/circuitboard/machine/chem_dispenser,
+		/obj/item/circuitboard/machine/reagentgrinder,
+		/obj/item/circuitboard/machine/chem_heater
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/genetics
+	name = "genetics circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/machine/clonescanner,
+		/obj/item/circuitboard/computer/scan_consolenew,
+		/obj/item/circuitboard/computer/cloning,
+		/obj/item/circuitboard/machine/clonepod
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/secure/AI
 	name = "secure AI circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/aiupload,
-				/obj/item/circuitboard/computer/borgupload,
-				/obj/item/circuitboard/aicore
-				)
+		/obj/item/circuitboard/aicore,
+		/obj/item/aiModule/reset,
+		/obj/effect/spawner/lootdrop/aimodule_harmless
+	)
 
-/obj/effect/spawner/lootdrop/techstorage/command
+/obj/effect/spawner/lootdrop/techstorage/secure/command
 	name = "secure command circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/crew,
-				/obj/item/circuitboard/computer/communications,
-				/obj/item/circuitboard/computer/card
-				)
+		/obj/item/circuitboard/computer/communications,
+		/obj/item/circuitboard/computer/card
+	)
 
-/obj/effect/spawner/lootdrop/techstorage/RnD_secure
-	name = "secure RnD circuit board spawner"
+/obj/effect/spawner/lootdrop/techstorage/secure/science
+	name = "secure science circuit board spawner"
 	loot = list(
-				/obj/item/circuitboard/computer/mecha_control,
-				/obj/item/circuitboard/computer/apc_control,
-				/obj/item/circuitboard/computer/robotics
-				)
+		/obj/item/circuitboard/computer/aiupload,
+		/obj/item/circuitboard/computer/borgupload,
+		/obj/item/circuitboard/computer/robotics
+	)
+
+/obj/effect/spawner/lootdrop/techstorage/secure/engineering
+	name = "secure engineering circuit board spawner"
+	loot = list(
+		/obj/item/circuitboard/computer/teleporter,
+		/obj/item/circuitboard/machine/teleporter_station,
+		/obj/item/circuitboard/computer/apc_control,
+		/obj/item/circuitboard/machine/teleporter_hub
+	)
 
 /obj/effect/spawner/lootdrop/trap
 	name = "10% pressure plate spawner"


### PR DESCRIPTION
## About The Pull Request
Significantly increased the available boards in the tech storage.
Currently this is just changing Box Station as a proof of concept.
When adding boards I tried to add at least one of each board without duplicates unless it is a highly desired item like life stasis beds.

I am contemplating making further changes depending on the feedback.
- Should I remove Roboticists, Scientists and the RD from having access to the tech storage?
- Should some of the items have a random chance of spawning or should it all be guaranteed?

Fixes #11682.

<details>
<summary>All Boards</summary>
This could also simply be looked at in the code.

/obj/effect/spawner/lootdrop/techstorage/shuttles
		/obj/item/circuitboard/computer/shuttle/mining_shuttle,
		/obj/item/circuitboard/computer/shuttle/labor_shuttle,
		/obj/item/circuitboard/computer/shuttle/science_shuttle,
		/obj/item/circuitboard/computer/shuttle/exploration_shuttle,
		/obj/item/circuitboard/computer/shuttle/flight_control

/obj/effect/spawner/lootdrop/techstorage/games
		/obj/item/circuitboard/computer/arcade/battle,
		/obj/item/circuitboard/computer/arcade/orion_trail,
		/obj/item/circuitboard/computer/slot_machine

/obj/effect/spawner/lootdrop/techstorage/cargo
		/obj/item/circuitboard/machine/autolathe,
		/obj/item/circuitboard/computer/mining,
		/obj/item/circuitboard/machine/mining_equipment_vendor,
		/obj/item/circuitboard/machine/ore_redemption,
		/obj/item/circuitboard/computer/cargo/request,
		/obj/item/circuitboard/computer/cargo,
		/obj/item/circuitboard/computer/bounty

/obj/effect/spawner/lootdrop/techstorage/service
		/obj/item/circuitboard/machine/chem_dispenser/drinks,
		/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
		/obj/item/circuitboard/machine/reagentgrinder,
		/obj/item/circuitboard/machine/chem_master

/obj/effect/spawner/lootdrop/techstorage/kitchen
		/obj/item/circuitboard/machine/microwave,
		/obj/item/circuitboard/machine/griddle,
		/obj/item/circuitboard/machine/microwave,
		/obj/item/circuitboard/machine/gibber,
		/obj/item/circuitboard/machine/processor,
		/obj/item/circuitboard/machine/oven,
		/obj/item/circuitboard/machine/smartfridge

/obj/effect/spawner/lootdrop/techstorage/botany
		/obj/item/circuitboard/machine/hydroponics,
		/obj/item/circuitboard/machine/hydroponics,
		/obj/item/circuitboard/machine/hydroponics,
		/obj/item/circuitboard/machine/chem_dispenser/botany,
		/obj/item/circuitboard/machine/biogenerator,
		/obj/item/circuitboard/machine/plantgenes,
		/obj/item/circuitboard/machine/seed_extractor

/obj/effect/spawner/lootdrop/techstorage/rnd
		/obj/item/circuitboard/computer/aifixer,
		/obj/item/circuitboard/machine/rdserver,
		/obj/item/circuitboard/machine/rdserver,
		/obj/item/circuitboard/machine/rdserver,
		/obj/item/circuitboard/machine/rdserver,
		/obj/item/circuitboard/machine/destructive_analyzer,
		/obj/item/circuitboard/computer/rdconsole,
		/obj/item/circuitboard/machine/xenoartifact_inbox,
		/obj/item/circuitboard/computer/xenoartifact_console,
		/obj/item/circuitboard/computer/xenobiology,
		/obj/item/circuitboard/machine/exploration_equipment_vendor

/obj/effect/spawner/lootdrop/techstorage/nanites
		/obj/item/circuitboard/computer/nanite_chamber_control,
		/obj/item/circuitboard/computer/nanite_cloud_controller,
		/obj/item/circuitboard/machine/nanite_chamber,
		/obj/item/circuitboard/machine/nanite_programmer,
		/obj/item/circuitboard/machine/nanite_program_hub

/obj/effect/spawner/lootdrop/techstorage/robotics
		/obj/item/circuitboard/machine/mechfab,
		/obj/item/circuitboard/machine/circuit_imprinter/department,
		/obj/item/circuitboard/machine/cyborgrecharger,
		/obj/item/circuitboard/computer/mech_bay_power_console,
		/obj/item/circuitboard/machine/mech_recharger,
		/obj/item/circuitboard/machine/ecto_sniffer

/obj/effect/spawner/lootdrop/techstorage/security
		/obj/item/circuitboard/computer/secure_data,
		/obj/item/circuitboard/computer/security,
		/obj/item/circuitboard/computer/prisoner,
		/obj/item/circuitboard/computer/gulag_teleporter_console,
		/obj/item/circuitboard/machine/gulag_teleporter,
		/obj/item/circuitboard/machine/recharger,
		/obj/item/circuitboard/computer/warrant

/obj/effect/spawner/lootdrop/techstorage/engineering
		/obj/item/circuitboard/computer/atmos_alert,
		/obj/item/circuitboard/computer/stationalert,
		/obj/item/circuitboard/computer/powermonitor,
		/obj/item/circuitboard/machine/pacman,
		/obj/item/circuitboard/machine/smes,
		/obj/item/circuitboard/machine/emitter,
		/obj/item/circuitboard/machine/emitter,
		/obj/item/circuitboard/machine/suit_storage_unit,
		/obj/item/circuitboard/machine/circuit_imprinter,
		/obj/item/circuitboard/machine/thermomachine,
		/obj/item/circuitboard/machine/cell_charger,
		/obj/item/circuitboard/machine/mass_driver,
		/obj/item/circuitboard/machine/fax

/obj/effect/spawner/lootdrop/techstorage/tcomms
		/obj/item/circuitboard/computer/message_monitor,
		/obj/item/circuitboard/machine/telecomms/broadcaster,
		/obj/item/circuitboard/machine/telecomms/bus,
		/obj/item/circuitboard/machine/telecomms/server,
		/obj/item/circuitboard/machine/telecomms/receiver,
		/obj/item/circuitboard/machine/telecomms/processor,
		/obj/item/circuitboard/machine/announcement_system,
		/obj/item/circuitboard/computer/comm_server,
		/obj/item/circuitboard/computer/comm_monitor

/obj/effect/spawner/lootdrop/techstorage/medical
		/obj/item/circuitboard/computer/med_data,
		/obj/item/circuitboard/computer/crew,
		/obj/item/circuitboard/machine/stasis,
		/obj/item/circuitboard/machine/stasis,
		/obj/item/circuitboard/computer/operating,
		/obj/item/circuitboard/computer/operating,
		/obj/item/circuitboard/computer/operating,
		/obj/item/stack/sheet/mineral/silver,
		/obj/item/circuitboard/machine/cryo_tube,
		/obj/item/circuitboard/computer/pandemic

/obj/effect/spawner/lootdrop/techstorage/chemistry
		/obj/item/circuitboard/machine/chem_master,
		/obj/item/circuitboard/machine/smoke_machine,
		/obj/item/circuitboard/machine/chem_dispenser,
		/obj/item/circuitboard/machine/reagentgrinder,
		/obj/item/circuitboard/machine/chem_heater

/obj/effect/spawner/lootdrop/techstorage/genetics
		/obj/item/circuitboard/machine/clonescanner,
		/obj/item/circuitboard/computer/scan_consolenew,
		/obj/item/circuitboard/computer/cloning,
		/obj/item/circuitboard/machine/clonepod

/obj/effect/spawner/lootdrop/techstorage/secure/AI
		/obj/item/circuitboard/aicore,
		/obj/item/aiModule/reset,
		/obj/effect/spawner/lootdrop/aimodule_harmless

/obj/effect/spawner/lootdrop/techstorage/secure/command
		/obj/item/circuitboard/computer/communications,
		/obj/item/circuitboard/computer/card

/obj/effect/spawner/lootdrop/techstorage/secure/science
		/obj/item/circuitboard/computer/aiupload,
		/obj/item/circuitboard/computer/borgupload,
		/obj/item/circuitboard/computer/robotics

/obj/effect/spawner/lootdrop/techstorage/secure/engineering
		/obj/item/circuitboard/computer/teleporter,
		/obj/item/circuitboard/machine/teleporter_station,
		/obj/item/circuitboard/computer/apc_control,
		/obj/item/circuitboard/machine/teleporter_hub
</details

## Why It's Good For The Game
Makes it more attractive for antagonists and non-antagonists alike.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
It is a bit more clutter with all these boards around. I've stacked some similar categories of boards like science having R&D, Nanites and Robotics on the same rack.

![image](https://github.com/user-attachments/assets/9c71a219-7be9-4f12-9ff5-c9a1c4d24e49)

</details>

## Changelog
:cl:
tweak: Adds some unprintable boards to the tech storage.
tweak: Divided the different tech storage departments into their own loot drop category.
balance: Significantly increased the available boards in the tech storage.
/:cl:
