### PR TITLE
(IMPORTANT) Adds the missing oven in Fland

### DIFF
--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -46210,6 +46210,12 @@
 /obj/structure/sign/departments/minsky/security/security,
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"lJu" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/oven,
+/turf/open/floor/iron/cafeteria,
+/area/crew_quarters/kitchen)
 "lJz" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -119702,7 +119708,7 @@ mib
 dam
 czD
 mib
-iyS
+lJu
 wRF
 hvk
 vmw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fland is missing an oven

## Why It's Good For The Game

Cooks are locked out of a big chunk of recipes

## Testing Photographs and Procedure
![68747470733a2f2f616666656374656461726330372e626c6f622e636f72652e77696e646f77732e6e65742f6d6462322f696d616765732f3136323335363932372f33313631373034373439312f6d2f5f6d6170735f6d61705f66696c65735f466c616e6453746174](https://github.com/user-attachments/assets/45c82a47-55e3-4350-acef-5ed155213ff6)

## Changelog
:cl: ClownMoff
add: FlandStation: Adds a missing oven on the kitchen
del: FlandStation: Deletes one of the 2 deepfryers on the kitchen.
/:cl:
