### PR TITLE
Cyborg Head Size Fix

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -238,6 +238,7 @@
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
+	w_class = WEIGHT_CLASS_NORMAL
 
 	brute_reduction = 5
 	burn_reduction = 4


### PR DESCRIPTION
## About The Pull Request
Changed Robotic Head from bulky to normal. This also applies to the clockwork head, where ever this might be used nowadays.

## Why It's Good For The Game
It looks tiny and should easily fit in a backpack, but it doesn't. Weirdly enough, once it is attached to a shell it, the shell does fit in the backpack! Multiple even.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

</details>

## Changelog
:cl:
fix: Changed Robotic Head from bulky to normal.
/:cl:
