### PR TITLE
Clockcult deconversion message

### DIFF
--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -56,6 +56,10 @@
 	GLOB.all_servants_of_ratvar -= owner
 	GLOB.human_servants_of_ratvar -= owner
 	GLOB.cyborg_servants_of_ratvar -= owner
+	if(!silent)
+		owner.current.visible_message("<span class='deconversion_message'>[owner.current] looks like [owner.current.p_theyve()] just reverted to [owner.current.p_their()] old faith!</span>", null, null, null, owner.current)
+		to_chat(owner.current, "<span class='userdanger'>An unfamiliar white light flashes through your mind, cleansing the taint of the Clockwork Justicar and all your memories as his servant.</span>")
+		owner.current.log_message("has renounced the cult of Rat'var!", LOG_ATTACK, color="#960000")
 	. = ..()
 
 /datum/antagonist/servant_of_ratvar/apply_innate_effects(mob/living/M)


### PR DESCRIPTION
## About The Pull Request

Adds a deconversion message for clock cultists.
Copied and modified from blood cult message.

Fixes #11666 

## Why It's Good For The Game

Getting feedback for deconverting a cultist is good.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Messages onself sees:
![Screenshot_7](https://github.com/user-attachments/assets/5991df89-8287-4e41-9675-75942ad09f61)

Message other people see:
![Screenshot_8](https://github.com/user-attachments/assets/dcb37ab3-75f5-46db-aaae-e2e252026770)

</details>

## Changelog
:cl:
fix: Deconverting clock cultists now show a message when it was successful
/:cl: