### PR TITLE
Updates auto-transfer configuration

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -601,10 +601,10 @@ CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 VOTE_AUTOTRANSFER_ENABLED
 
 ## Percentage of votes required to call shuttle before decay is applied, value 0-1.
-AUTOTRANSFER_PERCENTAGE 0.75
+AUTOTRANSFER_PERCENTAGE 0.7
 
 ## Time until decay starts to reduce the required percentage of votes to leave (In deciseconds)
-AUTOTRANSFER_DECAY_START 36000
+AUTOTRANSFER_DECAY_START 24000
 
 ## How much is subtracted from the percentage above every time the vote ticks (ticks are every five minutes)
 AUTOTRANSFER_DECAY_AMOUNT 0.025


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alright, it's been a little while with the initial default values and it's become clear that rounds are still *mostly* ending in chaos and destruction. The majority of players are still not actually taking part in the vote even when absolute shit has hit the fan and half the station is dead. 

These config changes effective shave 30 minutes off of the old configuration from the front, and also result in more frequent reminders to vote. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The average round length should be about two hours without forcing a two hour limit. These configuration settings have already been applied to the game to see how they affected things and have been shown to produce the desired results already - this PR (like all config PRs) exist primarily to announce the change to other players since config files are not actually changed on the server by PRs. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Here is a screenshot of the current round with these changes already live:
![image](https://github.com/user-attachments/assets/0aa64a02-45f5-408e-af85-f9edd9cc065f)


## Changelog
:cl:
config: The percentage of votes required to leave now starts at 70% instead of 75%
config: Auto-transfer reminders to vote now happen every 40 minutes, and decay of the required votes to leave now begins at 40 minutes instead of 60.
config: These changes mean the maximum round length before a shuttle is forcibly called is now 3 hours instead of 3.5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
