### PR TITLE
fixes emitter welding

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -262,7 +262,7 @@
 
 /obj/machinery/power/emitter/wrench_act(mob/living/user, obj/item/item)
 	. = ..()
-	default_unfasten_wrench(user, item)
+	default_unfasten_wrench(user, item, 15)
 	return TRUE
 
 /obj/machinery/power/emitter/welder_act(mob/living/user, obj/item/item)
@@ -277,7 +277,7 @@
 		user.visible_message("<span class='notice'>[user.name] starts to cut the [name] free from the floor.</span>", \
 			"<span class='notice'>You start to cut [src] free from the floor...</span>", \
 			"<span class='hear'>You hear welding.</span>")
-		if(!item.use_tool(src, user, 20, volume=50) || !welded)
+		if(!item.use_tool(src, user, 20, amount=7, volume=50)  || !welded)
 			return
 		welded = FALSE
 		to_chat(user, "<span class='notice'>You cut [src] free from the floor.</span>")
@@ -293,7 +293,7 @@
 	user.visible_message("<span class='notice'>[user.name] starts to weld the [name] to the floor.</span>", \
 		"<span class='notice'>You start to weld [src] to the floor...</span>", \
 		"<span class='hear'>You hear welding.</span>")
-	if(!item.use_tool(src, user, amount=20, volume=50) || !anchored)
+	if(!item.use_tool(src, user, 20, amount=7, volume=50) || !anchored)
 		return
 	welded = TRUE
 	to_chat(user, "<span class='notice'>You weld [src] to the floor.</span>")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Emitters would weld to the floor instantly using 20 fuel, and unweld with the proper delay but not consume any welder fuel. This fixes all of the above
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
An industrial welder should be able to weld more than 2 emitters without needing to refuel
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
not really applicable
 
![Zrzut ekranu 2023-08-26 033224](https://github.com/user-attachments/assets/f6e5886f-c458-410e-938f-b54988c9e439)


</details>

## Changelog
:cl:
fix: fixed emitter welding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
