### PR TITLE
[PORT] Syndicate medibots

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6404,11 +6404,9 @@
 /turf/open/floor/carpet,
 /area/wizard_station)
 "xB" = (
-/mob/living/simple_animal/bot/medbot{
-	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
-	name = "Hattori";
-	radio_key = null;
-	stationary_mode = 1
+/mob/living/simple_animal/bot/medbot/nukie{
+	name = "\improper Hattori";
+	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern."
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -14067,11 +14067,9 @@
 /turf/open/floor/iron/dark,
 /area/centcom/control)
 "Zx" = (
-/mob/living/simple_animal/bot/medbot{
-	desc = "A little medical robot. You can make out the word \"sincerity\" on its chassis.";
-	name = "Hijikata";
-	radio_key = null;
-	stationary_mode = 1
+/mob/living/simple_animal/bot/medbot/nukie{
+	name = "\improper Hijikata";
+	desc = "A little medical robot. You can make out the word \"sincerity\" on its chassis."
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6406,7 +6406,9 @@
 "xB" = (
 /mob/living/simple_animal/bot/medbot/nukie{
 	name = "\improper Hattori";
-	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern."
+	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
+	radio_key = null;
+	radio_channel = null
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -14067,7 +14069,8 @@
 "Zx" = (
 /mob/living/simple_animal/bot/medbot/nukie{
 	name = "\improper Hijikata";
-	desc = "A little medical robot. You can make out the word \"sincerity\" on its chassis."
+	desc = "A little medical robot. You can make out the word \"sincerity\" on its chassis.";
+	radio_key = null
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)

--- a/_maps/shuttles/infiltrator/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator/infiltrator_advanced.dmm
@@ -1099,6 +1099,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/bot/medbot/nukie,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/medical)
 "cd" = (

--- a/_maps/shuttles/infiltrator/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator/infiltrator_basic.dmm
@@ -395,6 +395,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/mob/living/simple_animal/bot/medbot/nukie,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/medical)
 "bJ" = (

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -79,6 +79,17 @@ GLOBAL_VAR(medibot_unique_id_gen)
 	heal_threshold = 0
 	declare_crit = 0
 
+/mob/living/simple_animal/bot/medbot/nukie
+	name = "\improper Oppenheimer"
+	desc = "A medibot stolen from a Nanotrasen station and upgraded by the Syndicate."
+	skin = MEDBOT_SKIN_BEZERK
+	health = 40
+	maxHealth = 40
+	radio_key = /obj/item/encryptionkey/syndicate
+	radio_channel = RADIO_CHANNEL_SYNDICATE
+	heal_threshold = 30
+	reagent_glass = new /obj/item/reagent_containers/cup/beaker/large/nanites
+
 /mob/living/simple_animal/bot/medbot/filled
 	skin = MEDBOT_SKIN_ADVANCED
 	heal_threshold = 30
@@ -117,8 +128,10 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/bot/medbot)
 
 /mob/living/simple_animal/bot/medbot/Initialize(mapload, new_skin)
 	. = ..()
-	skin = new_skin
-	update_icon()
+
+	if(!isnull(new_skin))
+		skin = new_skin
+	update_appearance()
 
 	var/datum/job/J = SSjob.GetJob(JOB_NAME_MEDICALDOCTOR)
 	access_card.access = J.get_access()

--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -50,3 +50,7 @@
 /obj/item/reagent_containers/chem_bag/antitoxin
 	name = "anti-toxin reserve bag"
 	list_reagents=  list(/datum/reagent/medicine/antitoxin = 100)
+
+/obj/item/reagent_containers/chem_bag/syndicate
+	name = "suspicious reserve bag"
+	list_reagents = list(/datum/reagent/medicine/leporazine = 30, /datum/reagent/medicine/syndicate_nanites = 40, /datum/reagent/medicine/stabilizing_nanites = 30)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -286,6 +286,10 @@
 /obj/item/reagent_containers/cup/beaker/synthflesh
 	list_reagents = list(/datum/reagent/medicine/synthflesh = 50)
 
+/obj/item/reagent_containers/cup/beaker/large/nanites
+    name = "suspicious nanite reserve tank"
+    list_reagents = list(/datum/reagent/medicine/leporazine = 30, /datum/reagent/medicine/syndicate_nanites = 40, /datum/reagent/medicine/stabilizing_nanites = 30)
+
 /obj/item/reagent_containers/cup/bucket
 	name = "bucket"
 	desc = "It's a bucket."

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -287,8 +287,8 @@
 	list_reagents = list(/datum/reagent/medicine/synthflesh = 50)
 
 /obj/item/reagent_containers/cup/beaker/large/nanites
-    name = "suspicious nanite reserve tank"
-    list_reagents = list(/datum/reagent/medicine/leporazine = 30, /datum/reagent/medicine/syndicate_nanites = 40, /datum/reagent/medicine/stabilizing_nanites = 30)
+	name = "suspicious nanite reserve tank"
+	list_reagents = list(/datum/reagent/medicine/leporazine = 30, /datum/reagent/medicine/syndicate_nanites = 40, /datum/reagent/medicine/stabilizing_nanites = 30)
 
 /obj/item/reagent_containers/cup/bucket
 	name = "bucket"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Partially ports Oppenheimer from TG, and replaces Hijikata with a syndicate medibot.
Also fixes medibot icons not updating upon mapload

(redo of https://github.com/BeeStation/BeeStation-Hornet/pull/11737 since i fucked it lol)

partially ports : 
- https://github.com/tgstation/tgstation/pull/77582

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Accidents are common! If a nuclear operative is in critical condition and manages to crawl their way back to the ship but theres nobody else, they deserve a bit of healing. Also theres been a problem of ninjas putting people into hardcrit and then they die at the dojo, while Hijikata the medibot stands there, doing nothing.

The syndicate medibot contains 30 units of Leporazine (for temperature fixing), 40 units of Syndicate Nanites for healing your extreme wounds, and 30 units of epinephrine to prevent you from dying from oxy damage, while helping with the healing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/18a88b93-0a3c-499e-aa77-1c19bb4bf5ff)
![image](https://github.com/user-attachments/assets/64c42562-25e2-4f50-a6f9-8ce49c0d2869)


</details>

## Changelog
:cl: carlarctg
add: New medibot syndicate type!
balance: The Syndicate Infiltraitor and the Ninja Dojo now spawn with syndicate medibots, Oppenheimer and Hijikata respectively.
fix: medibots now properly spawn with correct icons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->