### PR TITLE
Bot access and MULEbot fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -325,9 +325,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/bot/atmosbot)
 	return data
 
 /mob/living/simple_animal/bot/atmosbot/ui_act(action, params)
-	. = ..()
-	if(. || (locked && !usr.has_unlimited_silicon_privilege))
-		return
+	if(..())
+		return TRUE
 	switch(action)
 		if("breach_pressure")
 			var/adjust_num = round(text2num(params["pressure"]))

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -923,34 +923,36 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 // Actions received from TGUI
 /mob/living/simple_animal/bot/ui_act(action, params)
+	// according to base proc ui_act(),
+	// if interaction is to be denied, return TRUE
+	// if operation was successful, return FALSE
 	. = ..()
 	if(.)
-		return
-	if(!bot_core.allowed(usr) && !usr.has_unlimited_silicon_privilege)
-		to_chat(usr, "<span class='warning'>Access denied.</span>")
-		return
+		return TRUE
 	if(action == "lock")
+		if (!bot_core.allowed(usr) && !usr.has_unlimited_silicon_privilege)
+			to_chat(usr, "<span class='warning'>Access denied.</span>")
+			return TRUE
 		locked = !locked
-	if(locked && !(issilicon(usr) || IsAdminGhost(usr)))
-		return
+		return FALSE
+	if(!usr.has_unlimited_silicon_privilege && locked)
+		to_chat(usr, "<span class='warning'>Access denied.</span>")
+		return TRUE
 	switch(action)
 		if("power")
-			if(bot_core.allowed(usr) || !locked)
-				if (on)
-					turn_off()
-				else
-					boot_up_sequence()
+			if (on)
+				turn_off()
+			else
+				boot_up_sequence()
 		if("maintenance")
 			open = !open
 		if("patrol")
-			if(!issilicon(usr) && !IsAdminGhost(usr) && !(bot_core.allowed(usr) || !locked))
-				return TRUE
 			auto_patrol = !auto_patrol
 			bot_reset()
 		if("airplane")
 			remote_disabled = !remote_disabled
 		if("hack")
-			if(!issilicon(usr) && !IsAdminGhost(usr))
+			if(!usr.has_unlimited_silicon_privilege)
 				return TRUE
 			if(emagged != 2)
 				emagged = 2
@@ -969,12 +971,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 				log_game("Safety lock of [src] was re-enabled by [key_name(usr)] in [AREACOORD(src)]")
 				bot_reset()
 		if("eject_pai")
-			if(locked && !(issilicon(usr) || IsAdminGhost(usr)))
-				return
-			if(paicard)
-				to_chat(usr, "<span class='notice'>You eject [paicard] from [bot_name]</span>")
-				ejectpai(usr)
-	//update_controls()
+			to_chat(usr, "<span class='notice'>You eject [paicard] from [bot_name]</span>")
+			ejectpai(usr)
 
 /mob/living/simple_animal/bot/proc/show_controls(mob/M)
 	users |= M

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -445,9 +445,7 @@
 
 /mob/living/simple_animal/bot/cleanbot/ui_act(action, params)
 	if (..())
-		return
-	if(!(bot_core.allowed(usr) || usr.has_unlimited_silicon_privilege) || locked)
-		return
+		return TRUE
 	switch(action)
 		if("clean_blood")
 			blood = !blood

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -115,11 +115,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/bot/ed209)
 	if(lasercolor && ishuman(usr))
 		var/mob/living/carbon/human/H = usr
 		if((lasercolor == "b") && (istype(H.wear_suit, /obj/item/clothing/suit/redtag)))//Opposing team cannot operate it
-			return
+			return TRUE
 		else if((lasercolor == "r") && (istype(H.wear_suit, /obj/item/clothing/suit/bluetag)))
-			return
+			return TRUE
 	if(..())
-		return
+		return TRUE
 
 	switch(action)
 		if("check_id")

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -135,9 +135,7 @@
 
 /mob/living/simple_animal/bot/firebot/ui_act(action, params)
 	if(..())
-		return
-	if(!(bot_core.allowed(usr) || usr.has_unlimited_silicon_privilege) || locked)
-		return
+		return TRUE
 	switch(action)
 		if("extinguish_fires")
 			extinguish_fires = !extinguish_fires

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -150,8 +150,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/bot/floorbot)
 			update_icon()
 
 /mob/living/simple_animal/bot/floorbot/ui_act(action, params)
-	if (..() || (locked && !usr.has_unlimited_silicon_privilege))
-		return
+	if (..())
+		return TRUE
 
 	switch(action)
 		if("place_custom")

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -177,9 +177,8 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/bot/medbot)
 
 // Actions received from TGUI
 /mob/living/simple_animal/bot/medbot/ui_act(action, params)
-	. = ..()
-	if(. || (locked && !usr.has_unlimited_silicon_privilege))
-		return
+	if(..())
+		return TRUE
 	switch(action)
 		if("eject")
 			if (!isnull(reagent_glass))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -280,44 +280,37 @@
 	return data
 
 /mob/living/simple_animal/bot/mulebot/ui_act(action, params)
-	if(..() || (locked && !usr.has_unlimited_silicon_privilege))
-		return
-	switch(action)
-		if("lock")
-			if(usr.has_unlimited_silicon_privilege)
-				locked = !locked
-				. = TRUE
-		if("power")
-			if(on)
-				turn_off()
-			else if(open)
-				to_chat(usr, "<span class='warning'>[name]'s maintenance panel is open!</span>")
-				return
-			else if(cell)
-				if(!turn_on())
-					to_chat(usr, "<span class='warning'>You can't switch on [src]!</span>")
-					return
-			. = TRUE
-		else
-			. = bot_control(action, usr, params) // Kill this later.
+	if (action == "power")
+		if(locked && !usr.has_unlimited_silicon_privilege)
+			return TRUE
+		if(on)
+			turn_off()
+		else if(open)
+			to_chat(usr, "<span class='warning'>[name]'s maintenance panel is open!</span>")
+			return TRUE
+		else if(cell)
+			if(!turn_on())
+				to_chat(usr, "<span class='warning'>You can't switch on [src]!</span>")
+				return TRUE
+	else
+		if(..())
+			return TRUE
+		. = bot_control(action, usr, params) // Kill this later.
 
 /mob/living/simple_animal/bot/mulebot/bot_control(command, mob/user, list/params = list(), pda = FALSE)
 	if(pda && wires.is_cut(WIRE_RX)) // MULE wireless is controlled by wires.
-		return
+		return TRUE
 
 	switch(command)
 		if("stop")
 			if(mode >= BOT_DELIVER)
 				bot_reset()
-				. = TRUE
 		if("go")
 			if(mode == BOT_IDLE)
 				start()
-				. = TRUE
 		if("home")
 			if(mode == BOT_IDLE || mode == BOT_DELIVER)
 				start_home()
-				. = TRUE
 		if("destination")
 			var/new_dest
 			if(pda)
@@ -326,7 +319,6 @@
 				new_dest = params["value"]
 			if(new_dest)
 				set_destination(new_dest)
-				. = TRUE
 		if("setid")
 			var/new_id
 			if(pda)
@@ -335,7 +327,6 @@
 				new_id = params["value"]
 			if(new_id)
 				set_id(new_id)
-				. = TRUE
 		if("sethome")
 			var/new_home
 			if(pda)
@@ -344,26 +335,20 @@
 				new_home = params["value"]
 			if(new_home)
 				home_destination = new_home
-				. = TRUE
 		if("unload")
 			if(load && mode != BOT_HUNT)
 				if(loc == target)
 					unload(loaddir)
 				else
 					unload(0)
-				. = TRUE
 		if("autoret")
 			auto_return = !auto_return
-			. = TRUE
 		if("autopick")
 			auto_pickup = !auto_pickup
-			. = TRUE
 		if("report")
 			report_delivery = !report_delivery
-			. = TRUE
 		if("ejectpai")
 			ejectpairemote(user)
-			. = TRUE
 
 // TODO: remove this; PDAs currently depend on it
 /mob/living/simple_animal/bot/mulebot/get_controls(mob/user)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -116,9 +116,7 @@
 
 /mob/living/simple_animal/bot/secbot/ui_act(action, params)
 	if(..())
-		return
-	if(!(bot_core.allowed(usr) || usr.has_unlimited_silicon_privilege) || locked)
-		return
+		return TRUE
 	switch(action)
 		if("check_id")
 			idcheck = !idcheck

--- a/tgui/packages/tgui/interfaces/Mule.js
+++ b/tgui/packages/tgui/interfaces/Mule.js
@@ -92,7 +92,7 @@ export const Mule = (props, context) => {
                 <Button icon="home" content="Go Home" onClick={() => act('home')} />
               </LabeledList.Item>
               <LabeledList.Item label="Settings">
-                <Button.Checkbox checked={autoReturn} content="Auto-Return" onClick={() => act('autored')} />
+                <Button.Checkbox checked={autoReturn} content="Auto-Return" onClick={() => act('autoret')} />
                 <br />
                 <Button.Checkbox checked={autoPickup} content="Auto-Pickup" onClick={() => act('autopick')} />
                 <br />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

this PR simplifies bot access code and makes sure the following checks are performed regarding access:
1) if the user has access, they can unlock or lock the bot
2) if the bot is unlocked or the user is a silicon, access is granted

this means that bots can be locked only if you have access (allows tampering with a bot's settings, but not denial of others' access to it). reasoning for this is a door analogy: if it's unlocked, it can be opened or closed, but without the key, you can't lock it

these checks are no longer performed by each bot redundantly, relying on the parent proc from bot instead. mulebot is a bit of an exception as it has to perform its own power toggling logic before. checks like ``IsAdminGhost()`` and ``is_silicon()`` were replaced with the shared ``has_unlimited_silicon_privilege``

additionally, given that previously this parent proc call (``..()``) has been checked against to see if the control should be interrupted, the return value was inverted so that it reflects the explanation given in ``ui_act()`` base proc: ``TRUE`` values interrupt the operation while ``FALSE`` ones mean no obstacle has been found

a number of fixes have been done to mulebots in particular:
1) power button now works
2) auto-return can now be toggled

TODO:
- [ ] discuss whether mulebots should start immediately - currently they do, as they cannot be picked up or dragged, unlike other bots
- [ ] discuss whether ``ui_act()`` return value negation is actually needed and change code accordingly

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

fixes a number of issues with bot controls:
1) silicons previously had to unlock bots to change their settings despite their silicon access
2) if the bot was unlocked but the user lacked access, the settings would be changed, but also show an incorrect "Access Denied" message
3) fixes previously mentioned issues with mulebots which caused loss of functionality

also cleans the code regarding access checks a bit and removes what I considered to be redundant checks

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

bot access as a humanoid

https://github.com/user-attachments/assets/3067b524-8703-4726-a0d3-c7c7bd1a9fa0

bot access as AI

https://github.com/user-attachments/assets/e9c6d87d-03cb-43fb-a371-21852296fad5

</details>

## Changelog
:cl: Aramix
fix: fixed being unable to toggle mulebot power or auto-return
fix: fixed getting irrelevant "access denied" messages in chat whenever trying to change settings of an unlocked bot that you normally don't have access to
fix: silicons don't have to unlock bots to change their settings anymore
code: cleaned up bot access code
code: changed ui_act() return value to TRUE if unsuccessful or interrupted (as previously expected in some places)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
