### PR TITLE
Fix lavaland explosives

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -558,6 +558,7 @@
 			mineralAmt = 0
 			stage = GIBTONITE_DETONATE
 			explosion(bombturf,1,3,5, adminlog = notify_admins)
+			turf_destruction()
 
 /turf/closed/mineral/gibtonite/proc/defuse()
 	if(stage == GIBTONITE_ACTIVE)
@@ -580,6 +581,8 @@
 		mineralAmt = 0
 		stage = GIBTONITE_DETONATE
 		explosion(bombturf,1,2,5, adminlog = 0)
+		turf_destruction()
+
 	if(stage == GIBTONITE_STABLE) //Gibtonite deposit is now benign and extractable. Depending on how close you were to it blowing up before defusing, you get better quality ore.
 		var/obj/item/gibtonite/G = new (src)
 		if(det_time <= 0)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -352,11 +352,16 @@
 	icon_state = "map-overspace"
 	fixed_underlay = list("space"=1)
 
-/turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
-	var/obj/item/bombcore/large/bombcore = new(get_turf(src))
+/turf/closed/wall/mineral/plastitanium/explosive
+	var/obj/item/bombcore/large/bombcore
+
+/turf/closed/wall/mineral/plastitanium/explosive/Initialize(mapload)
+	. = ..()
+	bombcore = new(get_turf(src))
 	bombcore.installed = TRUE
+
+/turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
 	bombcore.detonate()
-	..()
 
 //have to copypaste this code
 /turf/closed/wall/mineral/plastitanium/interior/copyTurf(turf/T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the plastitanium/explosive walls that are used in the lavaland syndicate base so that activating them doesn't mercilessly crash the server in an infinite loop not unlike the past gibtonite issues. 

Likewise, this also fixes the gibtonite issues completely, by making the turf self-destruct appropriately whenever the gibtonite detonates. The turfs remaining in a flashing state semi-permanently was a fragment of the previous game-breaking bug fix and considered an acceptable loss compared to crashing the server.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The game literally crashes if the self destruct is triggered in the syndi base right now. It also crashes if gibtonite blows up just a little too close to the syndicate base, or if something else triggers an explosion in or anywhere near it. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/e1fe4a0c-6103-4ddb-8848-3ae8b46bf4cc)


## Changelog
:cl:
fix: fixed a game-crashing bug with the syndicate explosive walls
fix: fixed gibtonite rocks remaining behind after blowing up indefinitely
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
