### PR TITLE
Bumps DB version to 7.3 a month late

### DIFF
--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -505,7 +505,7 @@ CREATE TABLE IF NOT EXISTS `SS13_schema_revision` (
   `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`major`,`minor`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (7, 2);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (7, 3);
 
 
 

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
   *
   * make sure you add an update to the schema_version stable in the db changelog
   */
-#define DB_MINOR_VERSION 2
+#define DB_MINOR_VERSION 3
 
 
 //! ## Timing subsystem


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Relevant PR: #10919

Bumps the DB version to 7.3 because dionae's addition created changes to the database and recorded a new version in the changelog, but did not change anything anywhere else.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Consistent DB version enforcement is vital for making sure things don't break

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Schema Works
![image](https://github.com/user-attachments/assets/762990cc-6e61-4036-9985-68f6f85eac50)

Schema revision is 7.3
![image](https://github.com/user-attachments/assets/2bc585c2-e63f-4f96-b7ff-505901359976)

Game loads prefs
![image](https://github.com/user-attachments/assets/60e33869-9244-4683-a108-8b942454c7ee)

</details>

## Changelog
:cl:
config: Database version is now 7.3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
