### PR TITLE
fixes bronze desk bell changing color

### DIFF
--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -79,7 +79,7 @@
 	check_clapper(user)
 	// The lack of varying is intentional. The only variance occurs on the strike the bell breaks.
 	playsound(src, ring_sound, 70, vary = broken_ringer, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)
-	flick("desk_bell_ring", src)
+	flick("[initial(icon_state)]_ring", src)
 	times_rang++
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Fixes #11769 
The bronze colored desk bell changed to silver when rang.

## Why It's Good For The Game
Bug fix.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

I rang the bells and there was no color changing.
![image](https://github.com/user-attachments/assets/4bde04b8-68f4-444c-9f4e-e4ca6a3a1726)


</details>

:cl: ktlwjec
fix: Bronze desk bell will not change color while ringing.
/:cl: