### PR TITLE
Funny Conveyer to Fland Toxin Storage

### DIFF
--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -672,8 +672,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "ajn" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
 "ajo" = (
@@ -2205,11 +2208,14 @@
 /turf/open/floor/iron/grid/steel,
 /area/hallway/primary/central)
 "aDB" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -22
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
 "aDF" = (
@@ -8554,8 +8560,11 @@
 /area/chapel/office)
 "cjd" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/science/storage)
 "cje" = (
@@ -9834,6 +9843,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"cBs" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/conveyor/inverted{
+	id = "plasma_conveyor";
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/science/storage)
 "cBt" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/delivery,
@@ -11897,6 +11914,14 @@
 	},
 /turf/open/floor/iron,
 /area/quartermaster/office)
+"ddm" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/conveyor/inverted{
+	id = "plasma_conveyor";
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/science/storage)
 "ddo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12726,11 +12751,11 @@
 /turf/open/floor/iron/dark,
 /area/bridge)
 "dpl" = (
-/obj/structure/table,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
-/obj/item/clothing/mask/gas,
-/obj/item/crowbar,
-/obj/item/wrench,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "dpq" = (
@@ -13345,9 +13370,13 @@
 /area/maintenance/department/medical)
 "dxM" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "o2_conveyor";
+	name = "O2 Conveyor";
+	pixel_x = -12
 	},
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
@@ -36070,6 +36099,17 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/storage/primary)
+"jml" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/conveyor{
+	id = "plasma_conveyor";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/science/storage)
 "jmr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -36078,6 +36118,14 @@
 	broken = 1
 	},
 /area/maintenance/starboard/aft)
+"jmu" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/conveyor{
+	id = "plasma_conveyor";
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/science/storage)
 "jmQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -36505,12 +36553,14 @@
 /area/science/shuttle)
 "jtK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/radio/intercom{
 	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -38926,6 +38976,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "jYW" = (
@@ -40465,6 +40518,15 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engine/atmos)
+"kta" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "o2_conveyor"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine,
+/area/science/storage)
 "ktg" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room";
@@ -41637,6 +41699,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
+"kHO" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "canister_conveyor"
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/engine,
+/area/science/storage)
 "kHU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/end{
@@ -43185,9 +43256,12 @@
 	},
 /area/janitor)
 "kZv" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/bot,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine,
 /area/science/storage)
 "kZw" = (
@@ -45801,11 +45875,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "lFr" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
 "lFs" = (
@@ -46032,15 +46108,17 @@
 /turf/open/floor/iron/techmaint,
 /area/maintenance/department/engine)
 "lIE" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/machinery/conveyor/inverted{
+	id = "plasma_conveyor";
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/science/storage)
 "lIM" = (
 /obj/structure/cable/yellow{
@@ -46661,11 +46739,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lSw" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine,
 /area/science/storage)
 "lSH" = (
@@ -47589,6 +47670,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "mfN" = (
@@ -48184,8 +48268,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -52432,6 +52516,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -57033,6 +57120,15 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"oHz" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "plasma_conveyor"
+	},
+/turf/open/floor/engine,
+/area/science/storage)
 "oHE" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /obj/effect/turf_decal/stripes/closeup{
@@ -65009,9 +65105,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "qLW" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "canister_conveyor"
+	},
+/turf/open/floor/plating,
 /area/science/storage)
 "qMc" = (
 /obj/effect/turf_decal/bot,
@@ -65580,9 +65679,12 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "qSX" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "o2_conveyor"
+	},
+/turf/open/floor/plating,
 /area/science/storage)
 "qTa" = (
 /obj/structure/cable/yellow{
@@ -67964,13 +68066,13 @@
 /area/science/nanite)
 "rBk" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Science - Toxins Storage Passtrough";
-	name = "science camera"
+/obj/machinery/conveyor_switch/oneway{
+	id = "canister_conveyor";
+	name = "Canister Conveyor";
+	pixel_x = -12
 	},
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
@@ -69963,6 +70065,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"rYX" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "plasma_conveyor"
+	},
+/turf/open/floor/plating,
+/area/science/storage)
 "rZb" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -75647,12 +75757,15 @@
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
 "twn" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "o2_conveyor"
+	},
+/turf/open/floor/plating,
 /area/science/storage)
 "twu" = (
 /obj/structure/cable{
@@ -77852,12 +77965,15 @@
 /turf/open/floor/wood,
 /area/library/lounge)
 "tZC" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "canister_conveyor"
+	},
+/turf/open/floor/plating,
 /area/science/storage)
 "tZF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -82209,8 +82325,11 @@
 /area/medical/morgue)
 "vbQ" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "plasma_conveyor"
+	},
+/turf/open/floor/plating,
 /area/science/storage)
 "vcf" = (
 /obj/structure/table,
@@ -84638,12 +84757,18 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "vAQ" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	id = "plasma_conveyor";
+	dir = 9
+	},
+/turf/open/floor/plating,
 /area/science/storage)
 "vAS" = (
 /obj/effect/turf_decal/siding/wood{
@@ -87609,7 +87734,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/camera/directional/north,
+/obj/machinery/conveyor_switch/oneway{
+	id = "plasma_conveyor";
+	name = "Plasma Conveyor";
+	pixel_x = -12
+	},
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
 "wmC" = (
@@ -91418,14 +91548,13 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xfs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /obj/machinery/light/small,
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "xfu" = (
@@ -93921,11 +94050,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"xEy" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/science/storage)
 "xEG" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
@@ -96840,6 +96964,14 @@
 	burnt = 1
 	},
 /area/space/nearstation)
+"ykA" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/conveyor{
+	id = "plasma_conveyor";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/science/storage)
 "ykE" = (
 /obj/item/radio/intercom{
 	pixel_x = 28
@@ -136725,9 +136857,9 @@ xCA
 oqW
 oqW
 oqW
-oqW
-oqW
-oqW
+oHz
+kHO
+kta
 oqW
 sOH
 oqW
@@ -136980,8 +137112,8 @@ vKD
 mho
 mho
 oqW
-vbQ
-vbQ
+ddm
+cBs
 vbQ
 qLW
 qSX
@@ -137237,11 +137369,11 @@ cYE
 wQe
 qYB
 oqW
-vbQ
-vbQ
-vbQ
+ykA
+jmu
+rYX
 qLW
-xEy
+qSX
 kZv
 uxw
 kHV
@@ -137495,7 +137627,7 @@ wQe
 ccQ
 oqW
 lIE
-vAQ
+jml
 vAQ
 tZC
 twn

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -13378,6 +13378,7 @@
 	name = "O2 Conveyor";
 	pixel_x = -12
 	},
+/obj/effect/turf_decal/tile/blue/fourcorners/contrasted,
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
 "dxQ" = (
@@ -68074,6 +68075,7 @@
 	name = "Canister Conveyor";
 	pixel_x = -12
 	},
+/obj/effect/turf_decal/tile/yellow/fourcorners/contrasted,
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
 "rBl" = (
@@ -87740,6 +87742,7 @@
 	name = "Plasma Conveyor";
 	pixel_x = -12
 	},
+/obj/effect/turf_decal/tile/purple/fourcorners/contrasted,
 /turf/open/floor/iron/techmaint,
 /area/science/storage)
 "wmC" = (


### PR DESCRIPTION
## About The Pull Request
Adds three conveyer belts to the three main canisters in the toxin storage, O2, empty canister and plasma. The amount of canisters hasn't changed but they have been shuffled around.

## Why It's Good For The Game
It looks cool and makes it not painful to get canisters from toxin storage.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/798f6b75-0b4e-49af-87b0-c084c0d1cd56

</details>

## Changelog
:cl:
tweak: (Fland) Makes the toxin storage cool by adding a conveyer system to it.
/:cl:
