### PR TITLE
fixes spray paint being able to spray paint with a cap on

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -265,6 +265,9 @@
 	if(!proximity || !check_allowed_items(target))
 		return
 
+	if(is_capped)
+		return
+
 	var/static/list/punctuation = list("!","?",".",",","/","+","-","=","%","#","&")
 
 	var/cost = 1
@@ -584,6 +587,7 @@
 	icon_uncapped = "spraycan"
 	use_overlays = TRUE
 	paint_color = null
+	drawtype = "splatter"
 
 	item_state = "spraycan"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes spray paint being able to spray paint with a cap on and changes it's default drawtype from a rune to a splatter because i think it makes more sense for an accidental click to be a splatter rather than an elaborate symbol 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The cap is meant to cap
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
there's none


https://github.com/user-attachments/assets/e6a84032-fe59-47cb-8d32-45a178921128





</details>

## Changelog
:cl:
fix: fixed spray paint's cap not working properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
