### PR TITLE
Fixes wooden door assemblies being invincible

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -64,7 +64,11 @@
 			return
 
 		if(mineral)
-			var/obj/item/stack/sheet/mineral/mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
+			var/mineral_path
+			if(mineral == "wood")
+				mineral_path = text2path("/obj/item/stack/sheet/wood")
+			else
+				mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 			user.visible_message("[user] welds the [mineral] plating off the airlock assembly.", "You start to weld the [mineral] plating off the airlock assembly...")
 			if(W.use_tool(src, user, 40, volume=50))
 				to_chat(user, "<span class='notice'>You weld the [mineral] plating off.</span>")
@@ -229,7 +233,7 @@
 								G.use(1)
 								glass = TRUE
 					if(!mineral)
-						if(istype(G, /obj/item/stack/sheet/mineral) && G.sheettype)
+						if((istype(G, /obj/item/stack/sheet/mineral) || istype(G, /obj/item/stack/sheet/wood)) && G.sheettype)
 							var/M = G.sheettype
 							if(G.get_amount() >= 2)
 								playsound(src, 'sound/items/crowbar.ogg', 100, 1)
@@ -341,7 +345,11 @@
 			else
 				new /obj/item/shard(T)
 		if(mineral)
-			var/obj/item/stack/sheet/mineral/mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
+			var/mineral_path
+			if(mineral == "wood")
+				mineral_path = text2path("/obj/item/stack/sheet/wood")
+			else
+				mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 			new mineral_path(T, 2)
 	qdel(src)
 

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -66,7 +66,7 @@
 		if(mineral)
 			var/mineral_path
 			if(mineral == "wood")
-				mineral_path = text2path("/obj/item/stack/sheet/wood")
+				mineral_path = /obj/item/stack/sheet/wood
 			else
 				mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 			user.visible_message("[user] welds the [mineral] plating off the airlock assembly.", "You start to weld the [mineral] plating off the airlock assembly...")
@@ -347,7 +347,7 @@
 		if(mineral)
 			var/mineral_path
 			if(mineral == "wood")
-				mineral_path = text2path("/obj/item/stack/sheet/wood")
+				mineral_path = /obj/item/stack/sheet/wood
 			else
 				mineral_path = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 			new mineral_path(T, 2)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
wooden airlock assemblies were invincible due to a `obj/item/stack/sheet/mineral /wood` vs `/obj/item/stack/sheet/wood` mishap. This also prevented you from making wooden assemblies with planks. This fixes both of these

is also a fix for #11732
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
stuff should generally work rather than not
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
there's none

![mogus](https://github.com/user-attachments/assets/77280b90-9c40-437e-b37b-6600258e093f)

</details>

## Changelog
:cl:
fix: fixed wooden airlock assemblies 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
