### PR TITLE
fixes Hyperkinetic Dampening projector field not vanishing sometimes

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -730,6 +730,13 @@
 	. = ..()
 	host = loc
 
+/obj/item/borg/projectile_dampen/cyborg_unequip(mob/user)
+	if(!active)
+		return
+	deactivate_field()
+	update_appearance()
+	to_chat(user, "<span class='boldnotice'>[src] deactivates itself.</span>")
+
 /obj/item/borg/projectile_dampen/on_mob_death()
 	deactivate_field()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes #11786 
Makes the item deactivate when unequipped, which then prevents this bug from happening. Just to clarify, unequip as in placed back in storage/borg "bag", not unselected in the three item slots.

## Why It's Good For The Game
Bug fix, but also I assume it would be intended for unequipped items to not be active.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Turning it on, turning it off, putting it back in storage, deselecting it, every combination of it.
![image](https://github.com/user-attachments/assets/3dbf0b44-8b90-4b7c-8ce1-b6a2172dadec)

</details>

:cl: ktlwjec
tweak: Cyborg Hyperkinetic Dampening projector deactivates when put away.
fix: Stops the cyborg Hyperkinetic Dampening projector field being visible sometimes when the projector is deleted.
/:cl: