### PR TITLE
allows hair styling with the magic mirror

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -224,7 +224,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/mirror)
 			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 				return
 			if(hairchoice == "Style") //So you just want to use a mirror then?
-				var/new_style = tgui_input_list(user, "Select a hair style", "Grooming", GLOB.hair_styles_list, H.hair_style)
+				var/new_style = tgui_input_list(user, "Select a hair style", "Hair Style", GLOB.hair_styles_list, H.hair_style)
 				if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 					return
 				if(new_style)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -224,7 +224,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/mirror)
 			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 				return
 			if(hairchoice == "Style") //So you just want to use a mirror then?
-				..()
+				var/new_style = tgui_input_list(user, "Select a hair style", "Grooming", GLOB.hair_styles_list, H.hair_style)
+				if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+					return
+				if(new_style)
+					H.hair_style = new_style
 			else
 				var/new_hair_color = tgui_color_picker(H, "Choose your hair color", "Hair Color","#"+H.hair_color)
 				if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
@@ -237,7 +241,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/mirror)
 					if(new_face_color)
 						H.facial_hair_color = sanitize_hexcolor(new_face_color)
 						H.dna.update_ui_block(DNA_FACIAL_HAIR_COLOR_BLOCK)
-				H.update_hair()
+			H.update_hair()
 
 		if(BODY_ZONE_PRECISE_EYES)
 			var/new_eye_color = tgui_color_picker(H, "Choose your eye color", "Eye Color","#"+H.eye_color)


### PR DESCRIPTION
## About The Pull Request
Fixes #10437 
When selecting "style" it would just close the menu.
This PR allows you to change your hairstyle.

## Why It's Good For The Game
I assume this was intended judging by the comment there, but I don't see why it should be like this. There's no reason why the magic mirror shouldn't be able to do things a regular mirror can do.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/0eda9b5b-b5e9-4cc3-a94e-13847dd95dc8)
![image](https://github.com/user-attachments/assets/8bb2a1df-ccdf-4281-a099-20018f18f6cc)
![image](https://github.com/user-attachments/assets/abef9d2a-8666-483c-a827-1f7360be41f7)
![image](https://github.com/user-attachments/assets/c93411b3-c496-443c-87da-97d383284e45)

Tested changing everything else too (eye color, hair color, etc) just to double check it breaks nothing.

</details>

:cl: ktlwjec
fix: You can change your hairstyle using magic mirrors.
/:cl: