### PR TITLE
Changes maximum limb damage from 50 to 40

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -713,7 +713,7 @@
 	//icon_state = "default_human_l_arm"
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	max_damage = 50
+	max_damage = 40
 	max_stamina_damage = 50
 	body_zone = BODY_ZONE_L_ARM
 	body_part = ARM_LEFT
@@ -818,7 +818,7 @@
 	//icon_state = "default_human_r_arm"
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	max_damage = 50
+	max_damage = 40
 	max_stamina_damage = 50
 	body_zone = BODY_ZONE_R_ARM
 	body_part = ARM_RIGHT
@@ -924,7 +924,7 @@
 	//icon_state = "default_human_l_leg"
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	max_damage = 50
+	max_damage = 40
 	body_zone = BODY_ZONE_L_LEG
 	body_part = LEG_LEFT
 	plaintext_zone = "left leg"
@@ -1023,7 +1023,7 @@
 	//icon_state = "default_human_r_leg"
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	max_damage = 50
+	max_damage = 40
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT
 	plaintext_zone = "right leg"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I suppose this is technically a port of: https://github.com/Royale-Station-13/Royale-Station-13/pull/38

### This changes limbs from a max HP of 50 to 40 instead, causing limbs to be disabled 20% sooner than they currently are. 

**Various things to consider**
* Stamina damage may now be aimed at specific limbs without it nearly always being a better choice to aim for the chest 100% of the time. It is still generally going to be better to aim for the chest, but this has notable break points with the service pistol and stun prod in particular. 
* This means limbs can be more easily disabled with lethal damage as well - items with damage values between 20 and 24 are the most affected by this change, notably including lethal lasers, fire axes, and energy swords. 
* This will *also* mean that sharp melee weapons will have a somewhat easier time cutting limbs off than they currently do.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It greatly increases the possibilities in combat without greatly increasing the skill requirement for it. 

Right now the primary goal when doing damage is usually to make the other person horizontal, whether using lethal or non-lethal means the goal is usually either crit or stamcrit. Even in situations where you may prefer to only disarm or partially disable someone, with exception to a few exceedingly powerful weapons/antagonists that can easily delimb you are going to end up sending them horizontal first most of the time. 

After this PR, the primary goal will continue to be horizontal for most players I would imagine, but it opens up more possibilities for those that choose to engage with the system now. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Here is a screenshot showing it compiles and works. 
![image](https://github.com/user-attachments/assets/d9ee86f2-be59-46bd-b8fe-20f9a9b322fe)

As far as actual testing is concerned, this was done pretty early on in the battle royale server's run: https://github.com/Royale-Station-13/Royale-Station-13/pull/38 
@XeonMations @itsmeow and @kit-katz to name a few can all attest to the exact impact it had on combat there and that it was a pretty thoroughly tested and overall fun change to the Bee combat equation. I don't think even a single person ever voiced dissent for the effect this had on our combat experience there. 

## Changelog
:cl:
tweak: limbs are now disabled upon taking 40 damage instead of 50.
balance: This means stamina weapons can be strategically used to disable limbs without chest-aimed full stamcrit always being the better option.
balance: This also means it is somewhat easier for sharp weapons to de-limb. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
