### PR TITLE
fixes being unable to interact with mysterious bottle 

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -299,10 +299,10 @@
 	flip_chance = 100 // FLIPP
 
 /obj/item/reagent_containers/cup/glass/waterbottle/relic/Initialize(mapload)
+	. = ..()
 	var/reagent_id = get_random_reagent_id()
 	var/datum/reagent/random_reagent = new reagent_id
 	list_reagents = list(random_reagent.type = 50)
-	. = ..()
 	desc += "<span class='notice'>The writing reads '[random_reagent.name]'.</span>"
 	update_appearance()
 

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -292,6 +292,17 @@
 	list_reagents = list()
 	cap_on = FALSE
 
+// Admin spawn
+/obj/item/reagent_containers/cup/glass/waterbottle/random
+	name = "mysterious bottle"
+	desc = "A bottle quite similar to a water bottle, with some faded words scribbled on with a marker. It seems to be radiating some kind of energy."
+	flip_chance = 100 // FLIPP
+	list_reagents = list()
+
+/obj/item/reagent_containers/cup/glass/waterbottle/random/Initialize(mapload)
+	list_reagents = list(get_random_reagent_id(CHEMICAL_RNG_FUN) = 50)
+	. = ..()
+
 /obj/item/reagent_containers/cup/glass/sillycup
 	name = "paper cup"
 	desc = "A paper water cup."

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -292,21 +292,6 @@
 	list_reagents = list()
 	cap_on = FALSE
 
-// Admin spawn
-/obj/item/reagent_containers/cup/glass/waterbottle/relic
-	name = "mysterious bottle"
-	desc = "A bottle quite similar to a water bottle, but with some words scribbled on with a marker. It seems to be radiating some kind of energy."
-	flip_chance = 100 // FLIPP
-
-/obj/item/reagent_containers/cup/glass/waterbottle/relic/Initialize(mapload)
-	. = ..()
-	var/reagent_id = get_random_reagent_id()
-	var/datum/reagent/random_reagent = new reagent_id
-	list_reagents = list(random_reagent.type = 50)
-	desc += "<span class='notice'>The writing reads '[random_reagent.name]'.</span>"
-	update_appearance()
-
-
 /obj/item/reagent_containers/cup/glass/sillycup
 	name = "paper cup"
 	desc = "A paper water cup."


### PR DESCRIPTION
## About The Pull Request

Fixes #11804 
You couldn't interact with it at all (examine, click on, take the cap off, drink) unless using the right-click menu to manually do it.
The bottle wasn't filling with any reagent.

Update:
So, turns out there were two bottles with the same path.

I've repathed the admin only one and fixed it so it gives a random reagent instead of just not working.

I can't get the label working on the admin only bottle so I've just added some flavor to the description and removed the additional desc, if someone wants to help with that then please but it doesn't seem like a big enough issue to fix considering it's admin spawn only.

I removed the admin bottle originally but it's kind of cool to have and is different to the other bottle, but I can just remove it if wanted.
## Why It's Good For The Game

Bug fix.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
I spawned a lot of them and interacted with a few.

![image](https://github.com/user-attachments/assets/045c3bb9-688f-4e06-8b4c-7e0a616764b8)

Updated:

![image](https://github.com/user-attachments/assets/89453322-88e6-4e50-b7c3-019a31e5fccd)

</details>

:cl: ktlwjec
fix: Mysterious bottle can be interacted with.
fix: Mysterious bottle isn't empty.
/:cl: