### PR TITLE
Public access to lavaland

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2465,8 +2465,7 @@
 /area/lavaland/surface/outdoors)
 "rh" = (
 /obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_one_access_txt = "54;18"
+	name = "Mining Station EVA"
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
@@ -3360,8 +3359,7 @@
 "xW" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_one_access_txt = "54;18"
+	name = "Mining Station EVA"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/eva)
@@ -3934,8 +3932,7 @@
 /area/mine/gateway)
 "CC" = (
 /obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station";
-	req_one_access_txt = "54;18"
+	name = "Mining Station"
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/fans/tiny,
@@ -4750,8 +4747,7 @@
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station";
-	req_one_access_txt = "54;18"
+	name = "Mining Station"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/eva)
@@ -6979,8 +6975,7 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/mining/glass{
-	name = "Mining Station EVA";
-	req_one_access_txt = "54;18"
+	name = "Mining Station EVA"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/eva)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates the main doors out to lavaland so that they are public access. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It lets players (such as paramedics) actually access the planet after going through the gateway and/or gaining gateway access. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_dNTJzCDLVU](https://github.com/user-attachments/assets/329c1092-5c6e-4a55-a9d8-5f8824bc4c78)

## Changelog
:cl:
tweak: Access requirements have been removed from the main entrance/exit to the lavaland base. Any crew with access to an activated gateway will now be able to freely access the planet as well. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
