### PR TITLE
Gatfruit now hold .38 revolvers chambered with random ammo

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -124,7 +124,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/seeds/galaxythistle)
 // Gatfruit
 /obj/item/seeds/gatfruit
 	name = "pack of gatfruit seeds"
-	desc = "These seeds grow into .357 revolvers."
+	desc = "These seeds grow into .38 revolvers."
 	icon_state = "seed-gatfruit"
 	species = "gatfruit"
 	plantname = "Gatfruit Tree"
@@ -146,7 +146,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/seeds/galaxythistle)
 	name = "gatfruit"
 	desc = "It smells like burning."
 	icon_state = "gatfruit"
-	trash_type = /obj/item/gun/ballistic/revolver
+	trash_type = /obj/item/gun/ballistic/revolver/detective/random
 	bite_consumption_mod = 2
 	foodtypes = FRUIT
 	tastes = list("gunpowder" = 1)

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -7,6 +7,16 @@
 /obj/item/ammo_box/magazine/internal/cylinder/rev38/rubber
 	ammo_type = /obj/item/ammo_casing/c38/match/bouncy
 
+/obj/item/ammo_box/magazine/internal/cylinder/rev38/random
+	start_empty = TRUE //We have to handle adding dynamic ammo types on init
+
+/obj/item/ammo_box/magazine/internal/cylinder/rev38/random/Initialize(mapload)
+	var/obj/item/ammo_casing/c38/boolet
+	for(var/i in 1 to max_ammo)
+		boolet = pick(typesof(/obj/item/ammo_casing/c38) -/obj/item/ammo_casing/c38/dart -/obj/item/ammo_casing/caseless/mime)
+		stored_ammo += new boolet(src)
+	. = ..()
+
 /obj/item/ammo_box/magazine/internal/der38
 	name = "derringer internal chambering"
 	ammo_type = /obj/item/ammo_casing/c38/match

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -12,8 +12,9 @@
 
 /obj/item/ammo_box/magazine/internal/cylinder/rev38/random/Initialize(mapload)
 	var/obj/item/ammo_casing/c38/boolet
+	var/list/possible_boolets = typesof(/obj/item/ammo_casing/c38) -/obj/item/ammo_casing/c38/dart -/obj/item/ammo_casing/caseless/mime
 	for(var/i in 1 to max_ammo)
-		boolet = pick(typesof(/obj/item/ammo_casing/c38) -/obj/item/ammo_casing/c38/dart -/obj/item/ammo_casing/caseless/mime)
+		boolet = pick(possible_boolets)
 		stored_ammo += new boolet(src)
 	. = ..()
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -114,6 +114,10 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	unique_reskin_icon = null
 
+/obj/item/gun/ballistic/revolver/detective/random
+	name = "\improper Colt .38 revolver"
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38/random
+
 /obj/item/gun/ballistic/revolver/detective/reskin_obj(mob/M)
 	if(isnull(unique_reskin))
 		unique_reskin = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes gatfruit produce .38 revolvers with a random assortment of .38 rounds instead of .357 revolvers

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

.357 revolvers do 60 damage per shot, a power level so obscenely high that they're only held back by their rarity, a rarity that is enforced against antagonists via a very high uplink cost and a population restriction. Gatfruit have neither of these and are available to both miners and a neutral ghost spawn. 

This change brings them down to be on par with standard ranged weaponry rather than 2HKO even against armor, while still maintaining some of the chaos by having random bullet types loaded within it. Most of the time you'll do 25 damage, sometimes you'll also ignite or freeze your target. Other times you'll do abysmal damage with a rubber bullet. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/204e764c-931e-4233-a91d-6ae38a502952)


## Changelog
:cl:
balance: Gatfruit now spawn .38 revolvers instead of .357. Gatfruit revolvers will have random ammunition loaded into them. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
