### PR TITLE
Fixes erronous mob buckling progress bars

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -70,6 +70,10 @@
 	if(can_buckle && istype(M) && istype(user))
 		return user_buckle_mob(M, user)
 
+// Mobs have custom behaviour for buckling
+/mob/mouse_buckle_handling(mob/living/M, mob/living/user)
+	return FALSE
+
 /**
   * Returns TRUE if there are mobs buckled to this atom and FALSE otherwise
   */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #11822

## About The Pull Request

Fixes dragging a mob onto you causing a progress bar to appear.

## Why It's Good For The Game

Trivial issue present due to lack of testing and QA on PRs. Stop getting lazy.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/8771a007-6d3a-4ac3-922b-069a9d93e634

![image](https://github.com/user-attachments/assets/3c137282-ab60-4e75-9e8a-52820cd24c88)

## Changelog
:cl:
fix: Fixes progress bars appearing when dragging mobs onto yourself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
