### PR TITLE
Tones down dynamic lategame rulesets

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -17,11 +17,6 @@
 /// This ruleset will be logged in persistence, to reduce the chances of it repeatedly rolling several rounds in a row.
 #define PERSISTENT_RULESET (1 << 5)
 
-/// Can this ruleset be executed once we consider the round to be in the late game context?
-/// We generally want lategame rulesets to be chaotic and antagonists which do not require a long setup in order to get started.
-/// These are rulesets that should push the round to a close
-#define LATEGAME_RULESET (1 << 6)
-
 /// This is a "heavy" midround ruleset, and should be run later into the round
 #define MIDROUND_RULESET_STYLE_HEAVY "Heavy"
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -93,8 +93,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// The upper bound for the midround roll time splits.
 	/// This number influences where to place midround rolls, making this larger
 	/// will make midround rolls less frequent, and vice versa.
-	/// Once this time has passed, only midround antags with the LATEGAME_RULESET
-	/// flag may roll, and these will roll independent of threat requirements.
+	/// Once this time has passed, midrounds become free
 	var/midround_upper_bound = 100 MINUTES
 
 	/// The distance between the chosen midround roll point (which is deterministic),
@@ -745,7 +744,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				continue
 			if (CHECK_BITFIELD(rule.flags, INTACT_STATION_RULESET) && !is_station_intact())
 				continue
-			if (rule.acceptable(current_players[CURRENT_LIVING_PLAYERS].len, threat_level) && (mid_round_budget >= rule.cost || (is_lategame() && (rule.flags & LATEGAME_RULESET))))
+			if (rule.acceptable(current_players[CURRENT_LIVING_PLAYERS].len, threat_level) && (mid_round_budget >= rule.cost || is_lategame()))
 				// No stacking : only one round-ender, unless threat level > stacking_limit.
 				if (threat_level < GLOB.dynamic_stacking_limit && GLOB.dynamic_no_stacking)
 					if(CHECK_BITFIELD(rule.flags, HIGH_IMPACT_RULESET) && high_impact_ruleset_active())

--- a/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
+++ b/code/game/gamemodes/dynamic/dynamic_midround_rolling.dm
@@ -48,7 +48,7 @@
 			log_game("DYNAMIC: FAIL: [ruleset] is not acceptable with the current parameters. Alive players: [SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len], threat level: [threat_level]")
 			continue
 
-		if (mid_round_budget < ruleset.cost && !(is_lategame() && (ruleset.flags & LATEGAME_RULESET)))
+		if (mid_round_budget < ruleset.cost && !is_lategame())
 			log_game("DYNAMIC: FAIL: [ruleset] is too expensive, and cannot be bought. Midround budget: [mid_round_budget], ruleset cost: [ruleset.cost]")
 			continue
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -297,7 +297,7 @@
 	weight = 1
 	cost = 15
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
-	flags = HIGH_IMPACT_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
+	flags = HIGH_IMPACT_RULESET|PERSISTENT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard/ready(forced = FALSE)
 	if(!length(GLOB.wizardstart))
@@ -366,7 +366,7 @@
 	weight = 3
 	cost = 12
 	minimum_players = 22
-	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
+	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/blob/generate_ruleset_body(mob/applicant)
 	var/body = applicant.become_overmind()
@@ -390,7 +390,7 @@
 	weight = 3
 	cost = 12
 	minimum_players = 22
-	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
+	flags = HIGH_IMPACT_RULESET|INTACT_STATION_RULESET|PERSISTENT_RULESET
 	var/list/vents
 
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph/acceptable(population=0, threat=0)
@@ -491,7 +491,7 @@
 	cost = 11
 	minimum_players = 22
 	repeatable = TRUE
-	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
+	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET
 	var/list/spawn_locs
 
 /datum/dynamic_ruleset/midround/from_ghosts/space_dragon/ready(forced = FALSE)
@@ -625,7 +625,6 @@
 	cost = 8
 	minimum_players = 25
 	repeatable = FALSE
-	flags = LATEGAME_RULESET
 
 /datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
 	if (!SSmapping.empty_space)
@@ -691,7 +690,7 @@
 	weight = 3
 	cost = 11
 	repeatable = TRUE
-	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET|LATEGAME_RULESET
+	flags = INTACT_STATION_RULESET|PERSISTENT_RULESET
 	minimum_players = 25
 	var/fed = 1
 	var/list/vents
@@ -936,7 +935,6 @@
 	minimum_players = 20
 	repeatable = TRUE
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/nuclear, /datum/dynamic_ruleset/roundstart/clockcult)
-	flags = LATEGAME_RULESET
 	var/spawn_loc
 
 /datum/dynamic_ruleset/midround/from_ghosts/ninja/ready(forced)

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -24,7 +24,7 @@
 		if (ruleset.weight == 0)
 			continue
 
-		if (ruleset.cost > max_threat_level && !(is_lategame() && (ruleset.flags & LATEGAME_RULESET)))
+		if (ruleset.cost > max_threat_level && !is_lategame())
 			continue
 
 		if (!ruleset.acceptable(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS].len, threat_level))

--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -90,7 +90,7 @@
 	var/datum/dynamic_ruleset/rule = sent_rule
 	if(mid_round_budget >= rule.cost)
 		spend_midround_budget(rule.cost, threat_log, "[worldtime2text()]: [rule.ruletype] [rule.name]")
-	else if((rule.flags & LATEGAME_RULESET) && is_lategame())
+	else if(is_lategame())
 		rule.lategame_spawned = TRUE
 	else
 		CRASH("execute_midround_latejoin_rule was somehow called with an invalid state - cost is too high, but it's also not a lategame execution?")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Dynamic lategame will now just grant it infinite threat to spend, but won't force it to pick chaotic gamemodes.

This is a balance between outright removing it (which enters a problem with dynamic where it can't spawn anything after 100 minutes) and the current state.

## Why It's Good For The Game

Should hopefully ease up some tensions that come from dynamic lategame. This isn't a solution to the problem, and dynamic still has serious flaws that need to be resolved.

For the sake of argument, these are the flaws with dynamic that I think need resolving:
- Too many variables make it hard to configure correctly
  - Threat and weight achieve the same thing
  - Dynamic threat doesn't respond to how much chaos the station is in, a simple heuristic could far out-perform threat
  - Changing threat based on the requirement is silly and again makes it harder to balance, it should instead be based on %crew as antag (for traitor/ling/heretic)
  - Requirments adapting to pop is silly and should just be a minimum and maximum pop (something either shouldn't appear at that pop, or it should, it doesn't need to be unlikely to spawn if it doesn't work at that pop).
- Dynamic can't handle longer rounds very well
- Dynamic doesn't handle our (relatively) new space-law well, which is in extreme conflict with it. Not being able to execute the vast majority of dangerous antags creates serious problems with how dynamic was designed to work.
- Dynamic's randomness makes it almost always in one of the either extremes, randomness should come from the picked antags and not from whether or not we spawn too few/many antags.

## Testing Photographs and Procedure

[dynamic_simulations.json](https://github.com/user-attachments/files/17606115/dynamic_simulations.json) (Open it by dragging the file into firefox)

## Changelog
:cl:
tweak: Dynamic will no longer be forced to run high-impact rulesets after 100 minutes, and will instead resort to spawning whatever it wants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
