### PR TITLE
fixes turf integrity check

### DIFF
--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -1,8 +1,3 @@
-/turf
-	///what /mob/oranges_ear instance is already assigned to us as there should only ever be one.
-	///used for guaranteeing there is only one oranges_ear per turf when assigned, speeds up view() iteration
-	var/mob/oranges_ear/assigned_oranges_ear
-
 /** # Oranges Ear
  *
  * turns out view() spends a significant portion of its processing time generating lists of contents of viewable turfs which includes EVERYTHING on it visible

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -6,6 +6,13 @@ CREATION_TEST_IGNORE_SELF(/turf)
 /turf
 	icon = 'icons/turf/floors.dmi'
 	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE // Important for interaction with and visualization of openspace.
+	flags_1 = CAN_BE_DIRTY_1
+	uses_integrity = TRUE
+
+
+	///what /mob/oranges_ear instance is already assigned to us as there should only ever be one.
+	///used for guaranteeing there is only one oranges_ear per turf when assigned, speeds up view() iteration
+	var/mob/oranges_ear/assigned_oranges_ear
 
 	/// If there's a tile over a basic floor that can be ripped out
 	var/overfloor_placed = FALSE
@@ -35,8 +42,6 @@ CREATION_TEST_IGNORE_SELF(/turf)
 
 	//If true, turf will allow users to float up and down in 0 grav.
 	var/allow_z_travel = FALSE
-
-	flags_1 = CAN_BE_DIRTY_1
 
 	/// For the station blueprints, images of objects eg: pipes
 	var/list/image/blueprint_data

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -39,6 +39,7 @@
 	if(!ranged && thrower)
 		thrower.put_in_hands(B)
 	B.mimic_broken(src, target)
+	B.item_state = broken_item_state
 
 	qdel(src)
 	target.Bumped(B)
@@ -434,7 +435,7 @@
 	icon_state = "champagne_bottle"
 	base_icon_state = "champagne_bottle"
 	reagent_flags = TRANSPARENT
-	spillable = FALSE
+	//spillable = FALSE //This bottle should really be using a cork, but we'll leave it alone for now
 	list_reagents = list(/datum/reagent/consumable/ethanol/champagne = 100)
 
 /obj/item/reagent_containers/cup/glass/bottle/blazaam

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -992,7 +992,8 @@
 			flick(icon_deny,src)
 			vend_ready = TRUE
 			return
-		else if(!C.registered_account.account_job)
+		// Department cards cannot be used to order stuff in vendors, we make an exception for the debug card
+		else if(!C.registered_account.account_job && !istype(C, /obj/item/card/id/syndicate/debug))
 			say("Departmental accounts have been blacklisted from personal expenses due to embezzlement.")
 			flick(icon_deny, src)
 			vend_ready = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #11808 

Fixes the check that was preventing mobs w/o attack_hand from properly breaking down walls

included some misc fixes as well

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Simplemob

https://github.com/user-attachments/assets/b88ef4da-92d8-4ee7-afaa-12c8e0aa8ca0

carbon w/o attack_hand


https://github.com/user-attachments/assets/4f9b34c8-5598-4771-b53a-1e8651b029d4



</details>

## Changelog
:cl:
fix: simplemobs should be able to break down walls again
fix: champagne can be poured again
admin: fixed debug id not working with vending machines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
