### PR TITLE
fixes being unable to orbit explosives

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -131,7 +131,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] planted [name] on [target.name] at [ADMIN_VERBOSEJMP(target)] with [det_time] second fuse")
 		log_game("[key_name(user)] planted [name] on [target.name] at [AREACOORD(user)] with a [det_time] second fuse")
 
-		notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = target, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Explosive Planted")
+		notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = AM, action = (isturf(target) ? NOTIFY_JUMP : NOTIFY_ORBIT), flashwindow = FALSE, header = "Explosive Planted")
 
 		moveToNullspace()	//Yep
 


### PR DESCRIPTION
## About The Pull Request

Fixes #11831 
Ports [Fixes orbitting planted C4s](https://github.com/tgstation/tgstation/pull/66011)
It would runtime if you pressed the button to orbit an explosive if it was planted on certain things. This fixes that.

## Why It's Good For The Game

Bug fix.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

I've tested planting it on multiple things.
![image](https://github.com/user-attachments/assets/a1ac1828-0fd9-4750-b331-67f02051cf44)
![image](https://github.com/user-attachments/assets/0013cc6f-fa97-473d-8b24-eda0a99f34ec)


</details>

## Changelog
:cl: ghost
fix: Ghosts can now correctly jump to C4's planted on walls/floors when they get the notification
/:cl: