### PR TITLE
fixes light step leaving footprints

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -78,7 +78,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/decal/cleanable)
 //This is on /cleanable because fuck this ancient mess
 /obj/effect/decal/cleanable/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
-	if(iscarbon(AM) && blood_state && bloodiness >= 40)
+	if(iscarbon(AM) && blood_state && bloodiness >= 40 && !HAS_TRAIT(AM, TRAIT_LIGHT_STEP))
 		SEND_SIGNAL(AM, COMSIG_STEP_ON_BLOOD, src)
 		update_appearance()
 


### PR DESCRIPTION
## About The Pull Request

Fixes #11158 
Ports [Fixes light step's prevention of leaving footprints](https://github.com/yogstation13/Yogstation/pull/21542)

The light step quirk left footprints and caused shoes to be bloody. This fixes that.

## Why It's Good For The Game

Bug fix.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

With lightstep:
![image](https://github.com/user-attachments/assets/4f9ac009-eb03-4488-9f90-d95e76a1681f)

Without lightstep:
![image](https://github.com/user-attachments/assets/c8b9fa5e-fe5b-4751-9149-1118064e739a)

</details>

## Changelog
:cl: mqiib
fix: Light step now stops your shoes from getting dirty again
/:cl: