### PR TITLE
Off-Station Laser for Science Security Locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -252,7 +252,7 @@
 	..()
 	new /obj/item/clothing/accessory/armband/science(src)
 	new /obj/item/encryptionkey/headset_sci(src)
-	new /obj/item/gun/energy/laser/off_station(src)
+	new /obj/item/gun/energy/laser(src)
 
 /obj/structure/closet/secure_closet/security/med
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -252,6 +252,7 @@
 	..()
 	new /obj/item/clothing/accessory/armband/science(src)
 	new /obj/item/encryptionkey/headset_sci(src)
+	new /obj/item/gun/energy/laser/off_station(src)
 
 /obj/structure/closet/secure_closet/security/med
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -23,7 +23,7 @@
 	/// These accesses will be given in after_spawn()
 	var/list/dept_access_supply = list(ACCESS_CARGO, ACCESS_MAILSORTING, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_AUX_BASE)
 	var/list/dept_access_medical = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_CLONING)
-	var/list/dept_access_science = list(ACCESS_RESEARCH, ACCESS_TOX, ACCESS_AUX_BASE)
+	var/list/dept_access_science = list(ACCESS_RESEARCH, ACCESS_TOX, ACCESS_AUX_BASE, ACCESS_EXPLORATION)
 	var/list/dept_access_engineering = list(ACCESS_ENGINE, ACCESS_CONSTRUCTION, ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE)
 
 	departments = DEPT_BITFLAG_SEC

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -9,6 +9,9 @@
 	ammo_x_offset = 1
 	shaded_charge = TRUE
 
+/obj/item/gun/energy/laser/off_station
+	pin = /obj/item/firing_pin/off_station
+
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
 	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -9,9 +9,6 @@
 	ammo_x_offset = 1
 	shaded_charge = TRUE
 
-/obj/item/gun/energy/laser/off_station
-	pin = /obj/item/firing_pin/off_station
-
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
 	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."


### PR DESCRIPTION
## About The Pull Request
Adds a laser gun in the Science Security Locker to be used by the stationed officer to help with Explorers' assassination objectives. They are also getting Exploration access to not be entirely reliant of Explorers being their door knobs.

## Why It's Good For The Game
Streamlines the process of getting a Security Officer to help the Explorers as the mission objective suggests. No longer do you have to get to the armoury, wait 5 minutes for a Warden, HoS or Captain to show up and get you a gun.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/ec09359b-644d-4166-8fd4-5edff5ca381b)

![image](https://github.com/user-attachments/assets/c6c09fa5-e92d-44fb-a08f-503742298814)

![image](https://github.com/user-attachments/assets/681d73b3-5939-46ac-ba3f-266a31c5fe74)

</details>

## Changelog
:cl:
balance: Adds an laser gun to Science Security lockers for stationed Security Officer use to help Explorers with Assassination objectives.
balance: Gives Science Security Officer Exploration access.
/:cl:
