### PR TITLE
Restrict Mech Locks to Mech Access Codes

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -358,3 +358,6 @@ GLOBAL_LIST_INIT(access_desc_list, list( \
 	if(I_hud)
 		return I_hud
 	return "unknown"
+
+/proc/get_mech_accesses()
+	return list(ACCESS_MECH_ENGINE, ACCESS_MECH_MEDICAL, ACCESS_MECH_MINING, ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY, ACCESS_SYNDICATE, ACCESS_CENT_SPECOPS)

--- a/code/modules/vehicles/mecha/mecha_topic.dm
+++ b/code/modules/vehicles/mecha/mecha_topic.dm
@@ -175,6 +175,8 @@
 	for(var/a in id_card.access)
 		if(a in operation_req_access)
 			continue
+		if(!(a in get_mech_accesses()))
+			continue
 		var/a_name = get_access_desc(a)
 		if(!a_name)
 			continue //there's some strange access without a name


### PR DESCRIPTION
## About The Pull Request
Makes it only possible to lock mechs to 7 different access codes. Including Syndicate and SpecOps access.

## Why It's Good For The Game
Who would use Chemistry access to lock a Durand? It makes it confusing for new people and annoying when you're the Captain with like 200 access codes when you're looking for SPECIFICALLY the mining mech access code.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/75fa489a-0d96-40b4-b45b-38cf6b58518e)

![image](https://github.com/user-attachments/assets/47390692-a39a-4402-90d2-d3eb1940dd07)

</details>

## Changelog
:cl:
tweak: Restricted the available codes to choose from to only show mech access codes and some special codes.
/:cl: