### PR TITLE
New nuclear operative item, The Macho Wrestler Bundle!

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -749,3 +749,13 @@
 	new /obj/item/clothing/mask/gas/clown_hat(src)
 	new /obj/item/bikehorn(src)
 	new /obj/item/implanter/sad_trombone(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/macho
+	desc = "Become the ultimate Macho Man!"
+
+/obj/item/storage/backpack/duffelbag/syndie/macho/PopulateContents()
+	new /obj/item/storage/belt/champion/wrestling(src)
+	new /obj/item/reagent_containers/hypospray/combat(src)
+	new /obj/item/implanter/adrenalin(src)
+	new /obj/item/clothing/mask/luchador/rudos(src)
+

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -266,8 +266,8 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 
 /datum/uplink_item/bundles_TC/machoman
 	name = "The Macho Wrestler Bundle"
-	desc = "For the STRONGEST operatives! Master your wrastling abilitys with this bundle. \
-			Contains: A wrestling belt, for only the strongest, a adrenalin implanter, a mask to strike fear into your enemys, and a combat hypospray!"
+	desc = "For the STRONGEST operatives! Master your wrastling abilities with this bundle. \
+			Contains: A wrestling belt, only for the strongest machos, an adrenaline implanter, a luchador mask to strike fear into your enemies, and a combat hypospray!"
 	item = /obj/item/storage/backpack/duffelbag/syndie/macho
 	cost = 18
 	purchasable_from = UPLINK_NUKE_OPS

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -264,6 +264,14 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	cost = 30
 	purchasable_from = UPLINK_NUKE_OPS
 
+/datum/uplink_item/bundles_TC/machoman
+	name = "The Macho Wrestler Bundle"
+	desc = "For the STRONGEST operatives! Master your wrastling abilitys with this bundle. \
+			Contains: A wrestling belt, for only the strongest, a adrenalin implanter, a mask to strike fear into your enemys, and a combat hypospray!"
+	item = /obj/item/storage/backpack/duffelbag/syndie/macho
+	cost = 18
+	purchasable_from = UPLINK_NUKE_OPS
+
 /datum/uplink_item/bundles_TC/contract_kit
 	name = "Contract Kit"
 	desc = "The Syndicate have offered you the chance to become a contractor, take on kidnapping contracts for TC and cash payouts. Upon purchase, \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -266,7 +266,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 
 /datum/uplink_item/bundles_TC/machoman
 	name = "The Macho Wrestler Bundle"
-	desc = "For the STRONGEST operatives! Master your wrastling abilities with this bundle. \
+	desc = "For the STRONGEST operatives! Master your wrasslin' abilities with this bundle. \
 			Contains: A wrestling belt, only for the strongest machos, an adrenaline implanter, a luchador mask to strike fear into your enemies, and a combat hypospray!"
 	item = /obj/item/storage/backpack/duffelbag/syndie/macho
 	cost = 18


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new nuclear operative item, The Macho Wrestler bundle! (18 TC, trademark pending) It contains a Rudos mask (modifies speech), a wrestling belt (grants martial arts), a adrenalin implant, and combat hypospray for healing! Strike fear into your enemys when you throw the captain at a wall and stomp on their head!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nukies have a severe lack of fun items or flavor, which restricts their gameplay to mainly be Fake centcom, war, or stealth. If there are more nukie items it encourages them to try new gimmicks, plans, and think!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/231d2adc-b328-49d1-a42c-c9fa4dad978a



</details>

## Changelog
:cl:
add: A new nuclear operative bundle, The Macho Wrestler! Contains everything you need to wrestle the captain into giving you the disk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
