### PR TITLE
VIPs and Assassinations get Tracker Implants

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -87,6 +87,7 @@
 	back = /obj/item/storage/backpack
 	r_hand = /obj/item/gps
 
+
 /datum/outfit/vip_target/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
 		return
@@ -96,6 +97,8 @@
 		if(I)
 			I.registered_name = H.real_name
 			I.update_label()
+
+	implants = list(/obj/item/implant/tracking)
 
 
 //=====================


### PR DESCRIPTION
## About The Pull Request
Makes VIP and Assassination targets of Exploration missions start with a tracker implant implanted into them.
Explorers start with a tracker for tracking them. It only work at a range.

## Why It's Good For The Game
#10479 made GPSs start turned off, this makes it difficult for Explorers to find their target if it is a large derelict station. Risking the target sneaking past them and plasma flooding their shuttle, even if no one does it anymore. This forces a confrontation. 

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Roughly the range they can be detected.

![image](https://github.com/user-attachments/assets/87e7db55-fb00-4665-bbfc-65782c2be525)

</details>

## Changelog
:cl:
balance: Implants Exploration targets (VIP and Assassinations) with a tracker implant.
balance: Gives Explorers a tracker.
/:cl:
