### PR TITLE
Reduces CQC Kick and Chokehold sleeping

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -82,7 +82,7 @@
 						"<span class='userdanger'>You're knocked unconscious by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
 		to_chat(A, "<span class='danger'>You kick [D]'s head, knocking [D.p_them()] out!</span>")
 		playsound(get_turf(A), 'sound/weapons/genhit1.ogg', 50, 1, -1)
-		D.SetSleeping(300)
+		D.SetSleeping(10 SECONDS)
 		D.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
 	return TRUE
 
@@ -215,7 +215,7 @@
 		D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \
 						"<span class='userdanger'>You're put into a chokehold by [A]!</span>", "<span class='hear'>You hear shuffling and a muffled groan!</span>", null, A)
 		to_chat(A, "<span class='danger'>You put [D] into a chokehold!</span>")
-		D.SetSleeping(400)
+		D.SetSleeping(15 SECONDS)
 		restraining = FALSE
 		if(A.grab_state < GRAB_NECK)
 			A.setGrabState(GRAB_NECK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the sleep on kick (previously 30 seconds) and chokehold (40 seconds) to 10 and 15 respectively.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being put out of the game for 30-40 seconds in 2-3 hits isnt fun for the receiver, nukies dont need 40 seconds to loot/kill people.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/5943760f-e2d1-4b37-af94-7fdc6ec459d3

https://github.com/user-attachments/assets/5343a248-469c-4154-86c2-f4a4c4825e43




</details>

## Changelog
:cl:
balance: CQC Kick and Chokehold do 10 and 15 seconds of sleep respectively now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
