### PR TITLE
Adds a new variable for force-calling the shuttle

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -610,6 +610,9 @@
 	min_val = 0
 	max_val = 1
 
+/datum/config_entry/number/autotransfer_force_call
+	config_entry_value = 60000
+
 /datum/config_entry/flag/respect_upstream_bans
 
 /datum/config_entry/flag/respect_upstream_permabans

--- a/config/config.txt
+++ b/config/config.txt
@@ -609,6 +609,9 @@ AUTOTRANSFER_DECAY_START 24000
 ## How much is subtracted from the percentage above every time the vote ticks (ticks are every five minutes)
 AUTOTRANSFER_DECAY_AMOUNT 0.025
 
+## What time the shuttle is forcibly called, votes be damned
+AUTOTRANSFER_FORCE_CALL 60000
+
 ## Ghost role cooldown time after death (In deciseconds)
 GHOST_ROLE_COOLDOWN 3000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a new variable to the autotransfer system, actually intended for enforcing an upper limit to round length instead of using the decay as an incidental upper limit. 

When this variable triggers a shuttle call, it uses the pre-defined "auto evacuation" time of **25 minutes**, which is longer than even a green alert call. Players of all kinds doing almost anything will receive ample warning that the round is beginning to wind down when this system is triggered.

**Currently this system is set to fire at 1:40, causing rounds to end by 2:05** 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Something something staff meeting + something something player poll. 

I'm not 100% on board with this being a good idea (I'm also not against it). The results of the poll are still coming in, as well as the results of the recent dynamic change, but we are getting the vibe that rounds are still taking far too long to end on average, especially when antagonists are too quiet or already removed. The station has no incentive to evacuate when there are no threats, and players are clearly still not inclined to vote for round ends unless the station is absolutely falling apart.

This offers another solution, capping rounds at the length that was *originally* requested of me when I tackled the autotransfer system, by providing an upper limit of just over two hours long for a round.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

**I have fixed the missing space after the period, but I didn't feel like retesting with a whitespace being the only change**

![image](https://github.com/user-attachments/assets/181c2c91-15e4-4d85-873c-9ac372c571df)

## Changelog
:cl:
add: Adds a setting specifically for forcing rounds to end with a shuttle call
config: Rounds are configured to call a 25 minute shuttle at 1:40
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
