### PR TITLE
Adds vv color RGB hint

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -20,8 +20,8 @@ GLOBAL_VAR_INIT(magic_appearance_detecting_image, new /image) // appearances are
 GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 #define isfilter(thing) (!hascall(thing, "Cut") && TYPEID(thing) == GLOB.refid_filter)
 
-GLOBAL_DATUM_INIT(regex_rgb_text, /regex, regex(@"^#?(([0-9a-fA-F]{8})|([0-9a-fA-F]{6})|([0-9a-fA-F]{3}))"))
-#define iscolortext(thing) (istext(thing) && GLOB.regex_rgb_text.Find(thing) && (length(GLOB.regex_rgb_text.match) == length(thing)))
+GLOBAL_DATUM_INIT(regex_rgb_text, /regex, regex(@"^#?(([0-9a-fA-F]{8})|([0-9a-fA-F]{6})|([0-9a-fA-F]{3}))$"))
+#define iscolortext(thing) (istext(thing) && GLOB.regex_rgb_text.Find(thing))
 
 // simple check whether or not a player is a guest using their key
 #define IS_GUEST_KEY(key)	(findtextEx(key, "Guest-", 1, 7))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -20,6 +20,9 @@ GLOBAL_VAR_INIT(magic_appearance_detecting_image, new /image) // appearances are
 GLOBAL_VAR_INIT(refid_filter, TYPEID(filter(type="angular_blur")))
 #define isfilter(thing) (!hascall(thing, "Cut") && TYPEID(thing) == GLOB.refid_filter)
 
+GLOBAL_DATUM_INIT(regex_rgb_text, /regex, regex(@"^#?(([0-9a-fA-F]{8})|([0-9a-fA-F]{6})|([0-9a-fA-F]{3}))"))
+#define iscolortext(thing) (istext(thing) && GLOB.regex_rgb_text.Find(thing) && (length(GLOB.regex_rgb_text.match) == length(thing)))
+
 // simple check whether or not a player is a guest using their key
 #define IS_GUEST_KEY(key)	(findtextEx(key, "Guest-", 1, 7))
 

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -36,6 +36,9 @@
 	if(isnull(value))
 		return "<span class='value'>null</span>"
 
+	if(iscolortext(value))
+		return "<span class='value'>\"[value]\" <span class='colorbox' style='background-color:[value]'>_________</span></span>"
+
 	if(istext(value))
 		return "<span class='value'>\"[VV_HTML_ENCODE(value)]\"</span>"
 

--- a/html/admin/view_variables.css
+++ b/html/admin/view_variables.css
@@ -7,6 +7,11 @@ body {
 	font-size: 8pt;
 	display: inline-block;
 }
+.value.colorbox {
+	font-size: 7pt;
+	border: 1px solid black;
+}
+
 
 table.matrix {
 	border-collapse: collapse; border-spacing: 0;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds vv color RGB hint

This PR makes vv shows a color plate near to the RGB text (FFF, F00, etc)
This may show non-color related stuff like hex when a hex length is 3/6/8 since these length is often used for color RGB
but whatever. It'd be better to show it to recognise stuff. It's old coders' sin who didn't put `#` on color text.

* follow up PR: https://github.com/BeeStation/BeeStation-Hornet/pull/12577

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better debugging tool good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/4daa3088-22b3-4b24-a75c-cdfb9cee42d2)


## Changelog
:cl:
code: VV now shows which color a RGB text refers to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
