### PR TITLE
Fixes server air alarm directions on some maps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -40028,11 +40028,11 @@
 /turf/open/floor/iron,
 /area/quartermaster/storage)
 "mKv" = (
-/obj/machinery/airalarm/server{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm/server{
+	pixel_x = -22;
 	dir = 8
 	},
 /turf/open/floor/iron/dark/telecomms,
@@ -44859,7 +44859,6 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "oJY" = (
-/obj/machinery/airalarm/directional/south,
 /obj/machinery/light,
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -54831,8 +54830,8 @@
 "sGv" = (
 /obj/machinery/telecomms/processor/preset_exploration,
 /obj/machinery/airalarm/server{
-	dir = 4;
-	pixel_x = -28
+	pixel_x = -22;
+	dir = 8
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/quartermaster/exploration_dock)
@@ -57863,8 +57862,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/airalarm/server{
-	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	dir = 8
 	},
 /turf/open/floor/circuit/telecomms,
 /area/tcommsat/server)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -52853,8 +52853,8 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/mapping_helpers/atmos_auto_connect,
 /obj/machinery/airalarm/server{
-	pixel_x = -22;
-	dir = 4
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/open/floor/iron,
 /area/tcommsat/server)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -52854,7 +52854,7 @@
 /obj/effect/mapping_helpers/atmos_auto_connect,
 /obj/machinery/airalarm/server{
 	dir = 8;
-	pixel_x = -28
+	pixel_x = -22
 	},
 /turf/open/floor/iron,
 /area/tcommsat/server)

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -696,6 +696,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/airalarm/server{
+	pixel_x = -22;
+	dir = 8
+	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "aoY" = (
@@ -42771,7 +42775,6 @@
 	pixel_x = -23;
 	pixel_y = 25
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -696,10 +696,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/airalarm/server{
-	pixel_x = -22;
-	dir = 8
-	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "aoY" = (
@@ -42782,6 +42778,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "vnm" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -62849,15 +62849,15 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "svQ" = (
-/obj/machinery/airalarm/server{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
+	},
+/obj/machinery/airalarm/server{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
@@ -67061,15 +67061,15 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "tWN" = (
-/obj/machinery/airalarm/server{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Telecomms - Server Room - Aft-Port"
+	},
+/obj/machinery/airalarm/server{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Something broke the direction of server air alarms, causing them to be flipped around (deltastation for example)
![image](https://github.com/user-attachments/assets/95be0427-6caa-4124-90c6-41f5a9a10b12)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Air alarms should be facing the correct direction

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://github.com/user-attachments/assets/a6f03877-df95-4887-b043-12b95d77735b)
![image](https://github.com/user-attachments/assets/4975b2a4-57fc-4ebf-ab5c-4846ce85932c)
![image](https://github.com/user-attachments/assets/1408620d-8970-4582-9df9-b69d02e586b2)
![image](https://github.com/user-attachments/assets/d7c3e043-1749-402a-878b-33513b2a47ed)
![image](https://github.com/user-attachments/assets/c8f17642-69b7-4ed7-ae77-117477cdb70a)
![image](https://github.com/user-attachments/assets/527200ee-ec6e-4dff-b358-886062ce4140)


</details>

## Changelog
:cl:
fix: [Deltastation] Air alarm in telecomms now spawns the correct direction
fix: [Metastation] Air alarm in telecomms and the server room spawn in the correct direction
fix: [Boxstation] Air alarm in telecomms, server room, and exploration telecomms now spawn in the correct direction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
