### PR TITLE
Refurbishes the lavaland science outpost

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -39,7 +39,7 @@
 /area/mine/gateway)
 "ap" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "ar" = (
 /obj/structure/chair/stool/directional/south,
@@ -237,10 +237,6 @@
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "bx" = (
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -473,7 +469,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "cI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -507,7 +503,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "cY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -739,7 +735,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "eD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -766,7 +762,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "eN" = (
 /obj/structure/table/reinforced,
@@ -1111,7 +1107,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "gU" = (
 /obj/structure/stone_tile/block/cracked{
@@ -1445,17 +1441,16 @@
 	dir = 8;
 	name = "Robotics Operating Computer"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "jd" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "je" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1555,14 +1550,14 @@
 /turf/open/floor/iron/dark,
 /area/mine/production)
 "jY" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "ka" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -1594,7 +1589,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "kl" = (
 /obj/structure/frame/computer{
@@ -1869,7 +1864,7 @@
 /area/mine/living_quarters)
 "mf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "mh" = (
 /obj/structure/stone_tile/block,
@@ -1968,13 +1963,13 @@
 "mP" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /obj/machinery/door/airlock/research/glass{
 	name = "science Shuttle Dock";
 	req_one_access_txt = "49";
 	req_access_txt = "47"
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
@@ -2117,7 +2112,7 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "ob" = (
 /obj/structure/chair/stool/directional/west,
@@ -2152,7 +2147,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "oq" = (
 /obj/structure/table,
@@ -2169,7 +2164,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "os" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -2206,7 +2201,7 @@
 	cell_type = /obj/item/stock_parts/cell/high/empty
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "pb" = (
 /turf/open/floor/carpet/black,
@@ -2367,7 +2362,7 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "pW" = (
 /turf/open/floor/carpet/purple,
@@ -2390,14 +2385,13 @@
 /turf/open/floor/iron/dark,
 /area/mine/science)
 "qd" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4/lavaland{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "qg" = (
 /obj/effect/turf_decal/stripes/line,
@@ -2541,14 +2535,13 @@
 /turf/closed/wall,
 /area/mine/laborcamp)
 "rz" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "rA" = (
 /obj/structure/cable/yellow{
@@ -2569,7 +2562,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "rL" = (
 /obj/structure/cable/yellow{
@@ -2623,7 +2616,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "rY" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2761,7 +2754,7 @@
 /area/mine/production)
 "tk" = (
 /obj/machinery/camera/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "tm" = (
 /obj/structure/stone_tile/cracked{
@@ -3213,7 +3206,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "wr" = (
 /obj/structure/stone_tile/slab,
@@ -3360,10 +3353,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/directional/west,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/stairs/left,
 /area/mine/science)
 "xy" = (
 /obj/machinery/photocopier,
@@ -3392,14 +3382,14 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "xL" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/item/bot_assembly/cleanbot{
 	desc = "It's a bucket with a sensor attached. It tried it's best when it was assembled."
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "xP" = (
 /obj/structure/stone_tile/cracked{
@@ -3561,7 +3551,7 @@
 "zv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "zx" = (
 /obj/effect/turf_decal/bot_white/right,
@@ -3578,7 +3568,6 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "zA" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -3589,7 +3578,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/greenglow/filled,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "zD" = (
 /obj/structure/table,
@@ -3643,7 +3632,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "zP" = (
 /obj/machinery/mineral/unloading_machine{
@@ -3687,7 +3676,7 @@
 "As" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/beacon,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Au" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -3768,7 +3757,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Ba" = (
 /obj/machinery/door/firedoor,
@@ -3890,7 +3879,11 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/textured,
+/area/mine/science)
+"BQ" = (
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "BR" = (
 /obj/structure/stone_tile/block,
@@ -3905,7 +3898,7 @@
 /obj/item/storage/backpack/duffelbag/med{
 	name = "surgical duffel bag"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "BZ" = (
 /turf/closed/wall/r_wall,
@@ -4116,7 +4109,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Dk" = (
 /obj/structure/fence,
@@ -4376,7 +4369,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Fr" = (
 /obj/structure/punching_bag,
@@ -4449,7 +4442,7 @@
 /obj/structure/table,
 /obj/item/toy/plush/slimeplushie,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "FK" = (
 /obj/structure/stone_tile/block/cracked{
@@ -4530,7 +4523,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "Gl" = (
 /obj/machinery/chem_master,
@@ -4611,6 +4604,10 @@
 /obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/mine/production)
+"GQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/greyish,
+/area/mine/science)
 "GR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -4715,7 +4712,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Hx" = (
 /obj/machinery/computer/shuttle_flight/mining{
@@ -4816,7 +4813,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "HV" = (
 /obj/effect/turf_decal/loading_area{
@@ -4825,6 +4822,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"HZ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/greyish,
+/area/mine/science)
 "Ic" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -4833,6 +4836,9 @@
 	},
 /turf/open/floor/iron/checker,
 /area/mine/production)
+"Ig" = (
+/turf/open/floor/iron/stairs/right,
+/area/mine/science)
 "Ih" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -4851,7 +4857,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Iw" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -4947,7 +4953,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "IV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5005,7 +5011,7 @@
 /area/lavaland/surface/outdoors)
 "Ji" = (
 /obj/item/target/clown,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "Jm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5020,7 +5026,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Jo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5029,7 +5035,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Jq" = (
 /obj/structure/closet/crate,
@@ -5133,9 +5139,11 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "JK" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "JP" = (
 /obj/effect/turf_decal/bot_white/right,
@@ -5184,9 +5192,8 @@
 	},
 /area/mine/living_quarters)
 "Kh" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "Ki" = (
 /obj/machinery/camera/directional/west{
@@ -5327,7 +5334,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Le" = (
 /obj/structure/stone_tile{
@@ -5367,7 +5374,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "LI" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5381,7 +5388,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4/lavaland{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "LK" = (
 /obj/structure/stone_tile,
@@ -5410,7 +5417,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "LP" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -5421,7 +5428,7 @@
 "LW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "LX" = (
 /obj/machinery/light{
@@ -5527,7 +5534,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "MM" = (
 /obj/structure/cable/yellow{
@@ -5586,7 +5593,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Nj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -5613,7 +5620,7 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
-/turf/open/floor/iron/techmaint,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "NB" = (
 /obj/structure/chair/foldable,
@@ -5708,7 +5715,7 @@
 /area/mine/laborcamp/security)
 "NX" = (
 /obj/structure/table_frame,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "Od" = (
 /obj/structure/closet/crate/critter,
@@ -5902,7 +5909,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Pm" = (
 /obj/effect/turf_decal/bot,
@@ -6199,7 +6206,7 @@
 /obj/item/target/clown,
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -6243,7 +6250,7 @@
 "RX" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "RZ" = (
 /obj/machinery/door/firedoor,
@@ -6317,7 +6324,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6348,7 +6355,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "SL" = (
 /obj/structure/fence/cut/large{
@@ -6367,7 +6374,7 @@
 /area/mine/living_quarters)
 "SR" = (
 /obj/item/stack/ore/glass/basalt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "SX" = (
 /obj/effect/turf_decal/stripes/closeup{
@@ -6411,7 +6418,7 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "Tm" = (
-/turf/open/floor/plating,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "To" = (
 /obj/machinery/processor,
@@ -6784,6 +6791,11 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"VR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced,
+/turf/open/floor/engine,
+/area/mine/science)
 "VW" = (
 /obj/structure/stone_tile/cracked{
 	dir = 1
@@ -6864,7 +6876,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Wn" = (
 /obj/effect/turf_decal/loading_area{
@@ -6920,7 +6932,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/plasma,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured,
 /area/mine/science)
 "Ww" = (
 /obj/structure/stone_tile/block{
@@ -6983,7 +6995,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Xd" = (
 /obj/item/radio/intercom/directional/north,
@@ -7010,7 +7022,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "Xq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -7058,6 +7070,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"XA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/greyish,
+/area/mine/science)
 "XF" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -7286,7 +7307,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "YV" = (
 /obj/effect/turf_decal/stripes/closeup,
@@ -7391,8 +7412,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_half,
 /area/mine/science)
 "ZC" = (
 /obj/machinery/door/firedoor,
@@ -7425,7 +7445,7 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
+/turf/open/floor/iron/greyish,
 /area/mine/science)
 "ZP" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -48534,7 +48554,7 @@ Zd
 Zd
 jh
 MJ
-im
+Tm
 It
 jh
 mp
@@ -48791,7 +48811,7 @@ mp
 jh
 jh
 Wm
-NH
+GQ
 pS
 jh
 Ry
@@ -49048,11 +49068,11 @@ HT
 HT
 HT
 Lc
-im
+Tm
 FJ
 jh
 tk
-im
+BQ
 xL
 BL
 Gf
@@ -49298,11 +49318,11 @@ ET
 Hy
 im
 mP
-im
+Ig
 LJ
 SR
-NH
-im
+GQ
+Tm
 As
 rK
 wq
@@ -49555,20 +49575,20 @@ im
 bd
 fx
 jh
-im
-im
-NH
-im
-im
-im
+HZ
+Tm
+GQ
+Tm
+Tm
+Tm
 Fn
 eM
 oV
 jh
 SF
 gS
-im
-im
+BQ
+BQ
 eC
 jh
 IJ
@@ -50333,7 +50353,7 @@ aB
 vP
 lv
 xI
-gS
+XA
 mf
 jh
 Gl
@@ -50847,13 +50867,13 @@ Xs
 kp
 lv
 Lq
-gS
+XA
 Tm
 gm
 ZA
 jd
 Kh
-YW
+VR
 mp
 Zd
 Zd

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -620,7 +620,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "eh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -802,7 +802,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4/lavaland{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/mine/science)
 "eX" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -850,6 +850,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/mine/science)
 "fk" = (
@@ -1410,7 +1411,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "iV" = (
 /obj/structure/stone_tile/block/cracked,
@@ -1938,7 +1939,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "mK" = (
 /obj/structure/stone_tile/block{
@@ -2169,7 +2173,7 @@
 /area/mine/science)
 "os" = (
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "ov" = (
 /obj/structure/stone_tile/slab/cracked{
@@ -2648,7 +2652,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "sl" = (
 /obj/structure/cable/yellow{
@@ -5277,7 +5282,10 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "KS" = (
 /obj/structure/stone_tile/block{
@@ -5483,6 +5491,16 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"MA" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/white/full,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/mine/science)
 "MB" = (
 /obj/structure/table/wood/bar,
 /turf/open/floor/carpet/black,
@@ -5600,7 +5618,7 @@
 "NB" = (
 /obj/structure/chair/foldable,
 /obj/machinery/camera/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "ND" = (
 /turf/closed/wall/r_wall,
@@ -5694,7 +5712,7 @@
 /area/mine/science)
 "Od" = (
 /obj/structure/closet/crate/critter,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white/textured_large,
 /area/mine/science)
 "Oe" = (
 /obj/structure/cable/yellow{
@@ -51071,7 +51089,7 @@ Zd
 Zd
 Zd
 jq
-hr
+MA
 Ps
 pI
 jh

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -218,9 +218,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/mine/maintenance)
 "bu" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "EVA Atrium"
-	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
@@ -232,6 +229,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "EVA Atrium";
+	req_access_txt = "47"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
@@ -713,14 +714,15 @@
 /area/mine/gateway)
 "ey" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "47"
 	},
 /turf/open/floor/plating,
 /area/mine/science)
@@ -836,7 +838,7 @@
 /area/mine/living_quarters)
 "fh" = (
 /obj/machinery/computer/mecha,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/purple,
 /area/mine/science)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1005,10 +1007,11 @@
 /area/mine/living_quarters)
 "gm" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab"
-	},
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "47"
+	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "go" = (
@@ -1137,7 +1140,7 @@
 	pixel_y = 1;
 	pixel_x = 2
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/purple,
 /area/mine/science)
 "he" = (
 /obj/machinery/door/firedoor,
@@ -1821,12 +1824,13 @@
 /area/mine/science)
 "lV" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/machinery/door/airlock/research{
-	name = "Robotics Lab"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/research{
+	name = "Robotics Lab";
+	req_access_txt = "47"
+	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "lX" = (
@@ -2361,6 +2365,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/mine/science)
+"pW" = (
+/turf/open/floor/carpet/purple,
+/area/mine/science)
 "pX" = (
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/explored)
@@ -2823,7 +2830,7 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/purple,
 /area/mine/science)
 "tU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3538,7 +3545,7 @@
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/purple,
 /area/mine/science)
 "zp" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -4349,7 +4356,7 @@
 /area/mine/eva)
 "Ff" = (
 /obj/structure/chair/wood/wings,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/purple,
 /area/mine/science)
 "Fl" = (
 /obj/structure/stone_tile/block/cracked{
@@ -5035,7 +5042,7 @@
 /area/mine/laborcamp)
 "Jt" = (
 /obj/machinery/computer/rdconsole/core,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/purple,
 /area/mine/science)
 "Ju" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -6086,11 +6093,12 @@
 /area/mine/science)
 "QN" = (
 /obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/research{
-	name = "tachyon-doppler Array Booth"
-	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
+	},
+/obj/machinery/door/airlock/research{
+	name = "tachyon-doppler Array Booth";
+	req_access_txt = "47"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
@@ -7212,12 +7220,13 @@
 /area/mine/laborcamp)
 "YD" = (
 /obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/external{
-	name = "Science Outpost Airlock";
-	req_one_access_txt = "54;18;47"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Science Outpost Airlock";
+	req_one_access_txt = "54;18;47";
+	req_access_txt = "47"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
@@ -7298,7 +7307,7 @@
 /area/mine/science)
 "Zh" = (
 /obj/machinery/computer/security/research,
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/purple,
 /area/mine/science)
 "Zl" = (
 /obj/structure/extinguisher_cabinet{
@@ -51071,7 +51080,7 @@ sj
 eV
 mp
 Jt
-dt
+pW
 tS
 nw
 aZ
@@ -51585,7 +51594,7 @@ eg
 Od
 mp
 Zh
-dt
+pW
 zn
 tU
 aZ

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -84,7 +84,6 @@
 /area/lavaland/surface/outdoors)
 "aB" = (
 /obj/structure/table/reinforced,
-/obj/structure/spider/stickyweb,
 /obj/item/stock_parts/micro_laser,
 /turf/open/floor/carpet/black,
 /area/mine/science)
@@ -207,6 +206,10 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"bp" = (
+/obj/machinery/computer/security/telescreen/aiupload,
+/turf/closed/wall/r_wall,
+/area/mine/science)
 "br" = (
 /obj/machinery/telecomms/relay/preset/mining,
 /obj/machinery/light/small{
@@ -218,7 +221,6 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "EVA Atrium"
 	},
-/obj/structure/barricade/wooden/crude,
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
@@ -227,6 +229,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
@@ -243,6 +248,10 @@
 	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Research Division Atrium";
+	req_access_txt = "47"
 	},
 /turf/open/floor/plating,
 /area/mine/science)
@@ -488,6 +497,15 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "cY" = (
@@ -522,12 +540,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
-"dG" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/mine/science)
 "dJ" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -565,18 +577,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"dT" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 4
-	},
-/obj/item/circuitboard/computer/research,
-/obj/item/stack/cable_coil/cut/white,
-/turf/open/floor/iron,
-/area/mine/science)
 "dW" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -594,13 +594,13 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ed" = (
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/command{
-	name = "Research Director's Office"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Office";
+	req_access_txt = "30"
+	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "ef" = (
@@ -712,7 +712,6 @@
 /turf/open/floor/iron,
 /area/mine/gateway)
 "ey" = (
-/obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab"
@@ -835,12 +834,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/carpet/purple,
 /area/mine/living_quarters)
+"fh" = (
+/obj/machinery/computer/mecha,
+/turf/open/floor/carpet/royalblue,
+/area/mine/science)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark,
 /area/mine/science)
@@ -853,6 +859,9 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"fr" = (
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "fw" = (
 /obj/structure/closet/crate,
 /obj/item/dice/d6/space,
@@ -959,14 +968,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
-"ga" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/bookcase,
-/turf/open/floor/iron,
-/area/mine/science)
 "gb" = (
 /obj/machinery/recharge_station,
 /obj/item/radio/intercom/directional/west,
@@ -991,6 +992,12 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
+"gj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "gl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/item/kirbyplants/random,
@@ -998,7 +1005,6 @@
 /area/mine/living_quarters)
 "gm" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab"
 	},
@@ -1126,6 +1132,11 @@
 /area/mine/production)
 "hd" = (
 /obj/structure/table/wood/fancy/royalblack,
+/obj/item/book/manual/wiki/sopscience,
+/obj/item/book/manual/wiki/sopcommand{
+	pixel_y = 1;
+	pixel_x = 2
+	},
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
 "he" = (
@@ -1159,6 +1170,16 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/white,
 /area/mine/laborcamp)
+"hr" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/white/full,
+/turf/open/floor/plating,
+/area/mine/science)
 "ht" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -1356,6 +1377,11 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/carpet/purple,
 /area/mine/living_quarters)
+"iM" = (
+/obj/structure/table,
+/obj/item/discovery_scanner,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "iP" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
@@ -1378,6 +1404,9 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "iU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark,
 /area/mine/science)
 "iV" = (
@@ -1408,9 +1437,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/frame/computer{
-	anchored = 1;
-	dir = 8
+/obj/machinery/computer/operating{
+	dir = 8;
+	name = "Robotics Operating Computer"
 	},
 /turf/open/floor/iron,
 /area/mine/science)
@@ -1544,16 +1573,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/mine/maintenance)
-"kf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/mine/science)
 "ki" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -1589,6 +1608,18 @@
 /obj/effect/decal/cleanable/vomit/old,
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
+/area/mine/science)
+"kr" = (
+/mob/living/simple_animal/hostile/poison/giant_spider{
+	desc = "No sane person would ever have one of these as a pet.";
+	maxHealth = 350;
+	name = "enlarged giant spider";
+	poison_type = /datum/reagent/growthserum;
+	resize = 2;
+	faction = list("neutral")
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid,
 /area/mine/science)
 "ks" = (
 /obj/structure/stone_tile,
@@ -1630,6 +1661,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "kO" = (
@@ -1641,25 +1675,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
-"kS" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/item/reagent_containers/cup/glass/drinkingglass,
-/obj/item/reagent_containers/cup/glass/drinkingglass,
-/obj/item/reagent_containers/cup/glass/drinkingglass,
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing=15);
-	name = "Delta-Down";
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/cup/glass/bottle/champagne,
-/obj/item/reagent_containers/cup/glass/bottle/cognac,
-/obj/item/reagent_containers/cup/glass/bottle/lizardwine,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/carpet/black,
-/area/mine/science)
 "kU" = (
 /obj/machinery/portable_thermomachine,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -1675,9 +1690,6 @@
 	},
 /turf/open/floor/iron/grid/steel,
 /area/mine/living_quarters)
-"ld" = (
-/turf/closed/wall/r_wall,
-/area/lavaland/surface/outdoors)
 "lf" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -1809,7 +1821,6 @@
 /area/mine/science)
 "lV" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab"
 	},
@@ -1851,6 +1862,10 @@
 	},
 /turf/open/floor/wood,
 /area/mine/living_quarters)
+"mf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/mine/science)
 "mh" = (
 /obj/structure/stone_tile/block,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1906,13 +1921,18 @@
 /turf/closed/indestructible/riveted/boss/see_through,
 /area/lavaland/surface/outdoors)
 "mG" = (
-/obj/structure/showcase/machinery/signal_decrypter,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "mH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/iron,
 /area/mine/science)
@@ -1939,10 +1959,15 @@
 /area/mine/living_quarters)
 "mP" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/machinery/door/airlock/research/glass{
-	name = "Research Division Atrium"
-	},
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/research/glass{
+	name = "science Shuttle Dock";
+	req_one_access_txt = "49";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "mR" = (
@@ -1989,6 +2014,10 @@
 "np" = (
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"nq" = (
+/obj/item/stack/ore/glass/basalt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "nt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -2003,7 +2032,6 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "nw" = (
-/obj/structure/spider/stickyweb,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -2075,24 +2103,12 @@
 /obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/mine/production)
-"nU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/stack/rods,
-/turf/open/floor/catwalk_floor,
-/area/mine/science)
 "nV" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/mine/science)
 "ob" = (
@@ -2120,6 +2136,16 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"op" = (
+/obj/machinery/camera/directional/north,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/mine/science)
 "oq" = (
 /obj/structure/table,
 /obj/item/stack/ore/slag{
@@ -2131,10 +2157,15 @@
 /turf/open/floor/iron,
 /area/mine/science)
 "or" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/rnd/destructive_analyzer,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
+/area/mine/science)
+"os" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark,
 /area/mine/science)
 "ov" = (
 /obj/structure/stone_tile/slab/cracked{
@@ -2166,11 +2197,10 @@
 /obj/machinery/power/apc/auto_name/directional/south{
 	cell_type = /obj/item/stock_parts/cell/high/empty
 	},
-/obj/effect/mapping_helpers/apc/discharged,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/mine/science)
 "pb" = (
-/obj/structure/spider/stickyweb,
 /turf/open/floor/carpet/black,
 /area/mine/science)
 "pc" = (
@@ -2193,17 +2223,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/gateway)
-"po" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/folder/white{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/mine/science)
 "pr" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -2253,6 +2272,11 @@
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"pE" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "pF" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp External";
@@ -2276,7 +2300,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "pJ" = (
@@ -2334,6 +2358,7 @@
 /obj/machinery/airalarm/directional/south{
 	pixel_y = -22
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/mine/science)
 "pX" = (
@@ -2471,6 +2496,10 @@
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
 /area/mine/eva)
+"rn" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "rq" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/north{
@@ -2532,6 +2561,9 @@
 /turf/open/floor/iron,
 /area/mine/science)
 "rL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "rM" = (
@@ -2554,6 +2586,15 @@
 	},
 /turf/open/floor/iron,
 /area/mine/science)
+"rO" = (
+/obj/structure/table,
+/obj/item/pickaxe,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"rP" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "rQ" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -2573,18 +2614,10 @@
 	},
 /turf/open/floor/iron,
 /area/mine/science)
-"rW" = (
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/carpet/royalblue,
-/area/mine/science)
 "rY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors)
-"sb" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/carpet/royalblue,
-/area/mine/science)
 "se" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -2604,6 +2637,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron,
 /area/mine/science)
@@ -2677,6 +2713,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/techmaint,
 /area/mine/laborcamp)
+"sJ" = (
+/obj/structure/table/wood/bar,
+/obj/machinery/recharger,
+/turf/open/floor/carpet/black,
+/area/mine/science)
 "sM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2719,10 +2760,6 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"tz" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/carpet/royalblue,
-/area/mine/science)
 "tC" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -2924,6 +2961,12 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"uL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "uP" = (
 /obj/structure/closet/crate/critter,
 /turf/open/floor/iron,
@@ -2937,14 +2980,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp)
-"uS" = (
-/obj/structure/windoor_assembly{
-	anchored = 1;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/mine/science)
 "uW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -3281,6 +3316,10 @@
 	},
 /turf/open/floor/wood,
 /area/mine/living_quarters)
+"xs" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "xu" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -3309,6 +3348,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "xy" = (
@@ -3333,6 +3375,12 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid,
+/area/mine/science)
+"xI" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/mine/science)
 "xL" = (
 /obj/effect/decal/cleanable/robot_debris,
@@ -3398,6 +3446,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/carpet/red,
 /area/mine/living_quarters)
+"yq" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/toy/plush/lizard_plushie/green{
+	name = "Fears-The-Spiders"
+	},
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "yv" = (
 /turf/closed/mineral/random/labormineral/volcanic,
 /area/lavaland/surface/outdoors/explored)
@@ -3430,12 +3487,17 @@
 	},
 /turf/open/floor/iron/grid/steel,
 /area/mine/laborcamp)
+"yM" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "yP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/gateway)
 "yS" = (
-/obj/structure/spider/stickyweb,
 /obj/structure/table/wood/bar,
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/carpet/black,
@@ -3475,7 +3537,7 @@
 "zn" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen/fountain,
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
 "zp" = (
@@ -3514,6 +3576,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/greenglow/filled,
 /turf/open/floor/iron,
 /area/mine/science)
 "zD" = (
@@ -3564,6 +3627,12 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/laborcamp)
+"zN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/mine/science)
 "zP" = (
 /obj/machinery/mineral/unloading_machine{
 	icon_state = "unloader-corner2";
@@ -3603,6 +3672,11 @@
 	},
 /turf/open/floor/iron/grid/steel,
 /area/mine/laborcamp)
+"As" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/beacon,
+/turf/open/floor/iron,
+/area/mine/science)
 "Au" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -3617,6 +3691,10 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/checker,
 /area/mine/production)
+"Ax" = (
+/mob/living/simple_animal/hostile/asteroid/goldgrub,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "AA" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -3782,7 +3860,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "BH" = (
@@ -4023,6 +4101,9 @@
 /area/mine/eva)
 "Dj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4/lavaland,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Dk" = (
@@ -4059,6 +4140,12 @@
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp)
+"DI" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "DJ" = (
 /obj/structure/stone_tile/cracked{
 	dir = 4
@@ -4164,6 +4251,14 @@
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
+"EN" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "EO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -4192,6 +4287,7 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "EW" = (
@@ -4253,13 +4349,6 @@
 /area/mine/eva)
 "Ff" = (
 /obj/structure/chair/wood/wings,
-/mob/living/simple_animal/hostile/poison/giant_spider{
-	desc = "No sane person would ever have one of these as a pet.";
-	maxHealth = 350;
-	name = "enlarged giant spider";
-	poison_type = /datum/reagent/growthserum;
-	resize = 2
-	},
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
 "Fl" = (
@@ -4347,6 +4436,7 @@
 "FJ" = (
 /obj/structure/table,
 /obj/item/toy/plush/slimeplushie,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/mine/science)
 "FK" = (
@@ -4517,14 +4607,19 @@
 /turf/open/floor/iron/grid/steel,
 /area/mine/living_quarters)
 "GV" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Research Division Atrium"
-	},
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "science Shuttle Dock";
+	req_one_access_txt = "49";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
@@ -4600,8 +4695,14 @@
 /turf/open/floor/carpet/blue,
 /area/mine/living_quarters)
 "Hu" = (
-/obj/structure/window/reinforced,
-/obj/structure/easel,
+/obj/structure/frame/machine,
+/obj/item/paper/crumpled{
+	default_raw_text = "Sorry, we had to confiscate your protolathe and circuit printer boards due to %^8%#^))). Please contact your research director for further directions.";
+	name = "research memo"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Hx" = (
@@ -4671,6 +4772,12 @@
 	},
 /turf/open/floor/iron,
 /area/mine/gateway)
+"HO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "HR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4694,6 +4801,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "HV" = (
@@ -4712,7 +4822,6 @@
 /turf/open/floor/iron/checker,
 /area/mine/production)
 "Ih" = (
-/obj/structure/spider/stickyweb,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
@@ -4727,6 +4836,9 @@
 "It" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Iw" = (
@@ -4746,6 +4858,16 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
+"Iy" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/techmaint,
+/area/mine/science)
 "IC" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/closeup,
@@ -4793,6 +4915,13 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp)
+"IS" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "IT" = (
 /obj/machinery/shower{
 	pixel_y = 12
@@ -4802,7 +4931,10 @@
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp)
 "IU" = (
-/obj/structure/chair/fancy/sofa/old/left,
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "IV" = (
@@ -4873,6 +5005,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Jo" = (
@@ -4899,7 +5034,7 @@
 /turf/open/floor/iron/techmaint,
 /area/mine/laborcamp)
 "Jt" = (
-/obj/structure/frame/computer,
+/obj/machinery/computer/rdconsole/core,
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
 "Ju" = (
@@ -4952,6 +5087,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "JB" = (
@@ -4983,10 +5121,6 @@
 /turf/open/floor/iron/dark,
 /area/mine/eva)
 "JK" = (
-/obj/item/circuitboard/machine/smoke_machine{
-	pixel_x = 12;
-	pixel_y = -7
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/iron,
@@ -5088,6 +5222,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/mine/science)
+"KC" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "KF" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -5171,6 +5309,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Le" = (
@@ -5204,23 +5345,13 @@
 /turf/open/floor/iron/grid/steel,
 /area/mine/laborcamp)
 "Lq" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/toggle/labcoat/science{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/toggle/labcoat/science{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/toggle/labcoat/science,
-/obj/item/clothing/suit/toggle/labcoat/science{
-	pixel_x = 3;
-	pixel_y = -4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/iron,
 /area/mine/science)
 "LI" = (
@@ -5258,6 +5389,12 @@
 /area/mine/living_quarters)
 "LN" = (
 /obj/effect/decal/cleanable/greenglow,
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "LP" = (
@@ -5339,6 +5476,10 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"MB" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/carpet/black,
+/area/mine/science)
 "MC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -5357,6 +5498,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/mine/science)
@@ -5380,7 +5524,6 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "MX" = (
-/obj/structure/spider/stickyweb,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
@@ -5415,7 +5558,9 @@
 "Ng" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Nj" = (
@@ -5434,7 +5579,6 @@
 /obj/machinery/door/airlock/research{
 	name = "Subspace Listening Lab"
 	},
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -5538,26 +5682,24 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "NX" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
-	},
+/obj/structure/table_frame,
 /turf/open/floor/iron,
 /area/mine/science)
 "Od" = (
 /obj/structure/closet/crate/critter,
 /turf/open/floor/iron/dark,
 /area/mine/science)
-"Oo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+"Oe" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/item/stack/cable_coil/cut/yellow,
-/obj/item/stack/rods,
-/turf/open/floor/catwalk_floor,
-/area/mine/science)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"On" = (
+/obj/effect/decal/cleanable/greenglow/filled,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Oq" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm1";
@@ -5613,10 +5755,19 @@
 /turf/open/floor/iron/dark,
 /area/mine/science)
 "OE" = (
-/obj/item/bot_assembly/atmosbot{
-	created_name = "Fastmosky Senior";
-	name = "old atmosbot assembly"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "OH" = (
@@ -5638,10 +5789,6 @@
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
-"OL" = (
-/obj/structure/chair/fancy/sofa/old/right,
-/turf/open/floor/iron,
-/area/mine/science)
 "OO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup{
@@ -5678,6 +5825,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
+"OU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/techmaint,
+/area/mine/science)
 "OV" = (
 /obj/structure/stone_tile/slab/cracked{
 	dir = 4
@@ -5687,15 +5843,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"OX" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/blood/gibs/torso{
-	dir = 4;
-	pixel_x = -8;
-	pixel_y = -8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/mine/science)
 "Pa" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5727,6 +5874,9 @@
 "Pk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Pm" = (
@@ -5747,6 +5897,19 @@
 	},
 /turf/open/floor/iron,
 /area/mine/production)
+"Ps" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/bot_assembly/atmosbot{
+	created_name = "Fastmosky Senior";
+	name = "old atmosbot assembly"
+	},
+/turf/open/floor/iron/techmaint,
+/area/mine/science)
 "Pz" = (
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 22
@@ -5843,6 +6006,11 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/laborcamp)
+"Qq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/xenoblood,
+/turf/open/floor/iron,
+/area/mine/science)
 "Qs" = (
 /turf/closed/mineral/random/high_chance/volcanic,
 /area/lavaland/surface/outdoors)
@@ -6014,7 +6182,6 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "RG" = (
-/obj/effect/decal/cleanable/insectguts,
 /obj/machinery/light/small,
 /turf/open/floor/carpet/black,
 /area/mine/science)
@@ -6049,6 +6216,7 @@
 /area/lavaland/surface/outdoors)
 "RX" = (
 /obj/structure/bookcase/manuals/research_and_development,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/mine/science)
 "RZ" = (
@@ -6069,9 +6237,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
 /obj/item/circuitboard/machine/rad_collector,
-/obj/item/circuitboard/machine/smoke_machine{
-	pixel_x = 12;
-	pixel_y = -7
+/obj/item/circuitboard/machine/chem_dispenser{
+	pixel_y = 5
 	},
 /turf/open/floor/engine,
 /area/mine/science)
@@ -6121,6 +6288,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Sy" = (
@@ -6154,6 +6324,12 @@
 	},
 /turf/open/floor/iron,
 /area/mine/science)
+"SL" = (
+/obj/structure/fence/cut/large{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "SM" = (
 /obj/structure/chair/fancy/bench/pew/right{
 	dir = 4
@@ -6163,6 +6339,10 @@
 	},
 /turf/open/floor/wood,
 /area/mine/living_quarters)
+"SR" = (
+/obj/item/stack/ore/glass/basalt,
+/turf/open/floor/iron,
+/area/mine/science)
 "SX" = (
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 5
@@ -6177,11 +6357,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp)
-"SZ" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/carpet/royalblue,
-/area/mine/science)
 "Ta" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -6197,10 +6372,21 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
+"Td" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/cocoon,
+/turf/open/floor/plating/asteroid,
+/area/mine/science)
 "Te" = (
 /obj/structure/ore_box,
 /turf/open/floor/iron,
 /area/mine/eva)
+"Tm" = (
+/turf/open/floor/plating,
+/area/mine/science)
 "To" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -6295,13 +6481,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "TU" = (
-/obj/effect/turf_decal/stripes/closeup,
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external/glass{
-	name = "Science Outpost Airlock";
-	req_one_access_txt = "54;18;47"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/iron/techmaint,
+/obj/effect/turf_decal/stripes/white/full,
+/turf/open/floor/plating,
 /area/mine/science)
 "TX" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6350,7 +6534,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "UE" = (
-/obj/structure/spider/stickyweb,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
@@ -6530,10 +6713,6 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "VH" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Research Division Atrium"
-	},
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -6543,6 +6722,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Research Division Atrium";
+	req_access_txt = "47"
+	},
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/techmaint,
 /area/mine/living_quarters)
 "VL" = (
@@ -6651,6 +6835,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/mine/science)
 "Wn" = (
@@ -6706,6 +6893,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/plasma,
 /turf/open/floor/iron,
 /area/mine/science)
 "Ww" = (
@@ -6727,14 +6915,6 @@
 	},
 /turf/open/floor/iron/grid/steel,
 /area/mine/laborcamp)
-"WI" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/asteroid,
-/area/mine/science)
 "WS" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block{
@@ -6776,6 +6956,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/mine/science)
 "Xd" = (
@@ -6799,11 +6980,13 @@
 "Xj" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp/security)
+"Xm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/iron,
+/area/mine/science)
 "Xq" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Research Division Atrium"
-	},
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -6813,11 +6996,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Research Division Atrium";
+	req_access_txt = "47"
+	},
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
 "Xs" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4/lavaland{
 	dir = 4
 	},
@@ -6937,10 +7123,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/asteroid,
 /area/mine/science)
 "Ya" = (
@@ -6991,8 +7174,8 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "Yx" = (
-/obj/structure/spider/stickyweb,
 /obj/structure/table/wood/bar,
+/obj/item/food/burger/crazy,
 /turf/open/floor/carpet/black,
 /area/mine/science)
 "Yz" = (
@@ -7032,6 +7215,9 @@
 /obj/machinery/door/airlock/external{
 	name = "Science Outpost Airlock";
 	req_one_access_txt = "54;18;47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/techmaint,
 /area/mine/science)
@@ -7111,8 +7297,7 @@
 /turf/open/floor/iron,
 /area/mine/science)
 "Zh" = (
-/obj/structure/frame/computer,
-/obj/structure/spider/stickyweb,
+/obj/machinery/computer/security/research,
 /turf/open/floor/carpet/royalblue,
 /area/mine/science)
 "Zl" = (
@@ -7209,6 +7394,10 @@
 	pixel_y = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/mine/science)
 "ZP" = (
@@ -30599,9 +30788,9 @@ IJ
 IJ
 IJ
 IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
 xT
 IJ
 IJ
@@ -30856,10 +31045,10 @@ IJ
 IJ
 IJ
 IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
@@ -31113,10 +31302,10 @@ IJ
 IJ
 IJ
 IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
@@ -31370,10 +31559,10 @@ BZ
 BZ
 BZ
 BZ
-IJ
-IJ
-IJ
-IJ
+TL
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
@@ -31628,9 +31817,9 @@ Fb
 Bo
 BZ
 IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
@@ -31885,10 +32074,10 @@ tL
 We
 BZ
 IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
@@ -32143,10 +32332,10 @@ ah
 BZ
 IJ
 IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
@@ -32401,14 +32590,14 @@ BZ
 BZ
 BZ
 BZ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-RR
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 RR
 RR
 RR
@@ -32658,14 +32847,14 @@ TR
 ER
 ct
 BZ
-ld
-ld
-ld
-ld
-ld
-ld
-ld
-RR
+Bq
+Bq
+Bq
+Bq
+Bq
+Bq
+IJ
+IJ
 RR
 RR
 RR
@@ -32915,14 +33104,14 @@ CL
 lz
 PI
 BZ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-RR
+Zd
 RR
 RR
 RR
@@ -33172,13 +33361,13 @@ rw
 rw
 rw
 BZ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 RR
 RR
 RR
@@ -33429,13 +33618,13 @@ sH
 ER
 ct
 BZ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 RR
 RR
 RR
@@ -33686,13 +33875,13 @@ CL
 lz
 PI
 BZ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 RR
 RR
 RR
@@ -33943,11 +34132,11 @@ rw
 rw
 rw
 BZ
-IJ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
+Zd
 Zd
 RR
 RR
@@ -34200,10 +34389,10 @@ fF
 Fy
 ct
 BZ
-IJ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
+Zd
 Zd
 RR
 RR
@@ -34457,9 +34646,9 @@ CL
 lz
 PI
 BZ
-IJ
-IJ
-IJ
+Zd
+Zd
+Zd
 Zd
 Zd
 RR
@@ -34714,8 +34903,8 @@ BZ
 BZ
 BZ
 BZ
-IJ
-IJ
+Zd
+Zd
 Zd
 Zd
 RR
@@ -46518,7 +46707,7 @@ Zd
 Zd
 RR
 mp
-nU
+ef
 mp
 RR
 RR
@@ -47284,12 +47473,12 @@ RR
 RR
 RR
 RR
-Zd
-Zd
+RR
+RR
 Zd
 Zd
 mp
-Oo
+ef
 mp
 RR
 RR
@@ -48067,7 +48256,7 @@ jh
 Zd
 Zd
 jh
-mG
+Qq
 fH
 mG
 jh
@@ -48289,9 +48478,9 @@ Zd
 Zd
 Zd
 RR
-RR
-RR
-RR
+IJ
+IJ
+IJ
 RR
 Zd
 Zd
@@ -48546,8 +48735,8 @@ Zd
 Zd
 Zd
 Zd
-Zd
-RR
+IJ
+IJ
 Zd
 Zd
 Zd
@@ -48804,7 +48993,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -49061,7 +49250,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -49084,13 +49273,13 @@ im
 mP
 im
 LJ
-im
+SR
 NH
 im
-NH
+As
 rK
 wq
-LW
+zN
 lV
 LW
 Wv
@@ -49318,7 +49507,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -49339,11 +49528,11 @@ im
 bd
 fx
 jh
-po
-dT
-uS
-ga
-OL
+im
+im
+NH
+im
+im
 im
 Fn
 eM
@@ -49575,7 +49764,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -49832,7 +50021,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -49850,7 +50039,7 @@ rf
 rf
 mp
 im
-kf
+bd
 WV
 lv
 lv
@@ -49859,7 +50048,7 @@ lv
 lv
 lv
 lv
-EV
+Iy
 aV
 EV
 jh
@@ -50089,7 +50278,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -50110,15 +50299,15 @@ KX
 kG
 TY
 lv
+sJ
 Yx
-Yx
-kS
+pb
 aB
 vP
 lv
-im
+xI
 gS
-im
+mf
 jh
 Gl
 rR
@@ -50346,7 +50535,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -50368,14 +50557,14 @@ bu
 jh
 lv
 wV
-sb
-SZ
-sb
+dt
+dt
+dt
 pb
 lv
 Dj
 AP
-NH
+Xm
 mp
 qy
 zA
@@ -50603,7 +50792,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 Zd
@@ -50624,15 +50813,15 @@ qj
 fj
 qa
 mp
-sb
 dt
-sb
+dt
+dt
 Xs
 kp
 lv
 Lq
 gS
-im
+Tm
 gm
 ZA
 jd
@@ -50860,6 +51049,7 @@ Zd
 Zd
 Zd
 Zd
+PV
 Zd
 Zd
 Zd
@@ -50871,23 +51061,22 @@ Zd
 Zd
 Zd
 Zd
-Zd
-Zd
-mp
-rL
+jq
+hr
+Ps
 pI
 jh
-qj
+os
 sj
 eV
 mp
 Jt
-tz
+dt
 tS
 nw
 aZ
 lv
-tk
+op
 Jo
 Xb
 mp
@@ -51117,6 +51306,7 @@ Zd
 Zd
 Zd
 Zd
+Mw
 Zd
 Zd
 Zd
@@ -51127,9 +51317,8 @@ Zd
 Zd
 Zd
 Zd
-Zd
-Zd
-Zd
+DI
+Oe
 TU
 OE
 rL
@@ -51138,7 +51327,7 @@ iU
 mH
 KR
 mp
-Jt
+fh
 Ff
 hd
 UE
@@ -51374,6 +51563,7 @@ Zd
 Zd
 Zd
 Zd
+Mw
 Zd
 Zd
 Zd
@@ -51384,11 +51574,10 @@ Zd
 Zd
 Zd
 Zd
-Zd
-Zd
-Zd
-mp
-rL
+uL
+jq
+hr
+OU
 BC
 jh
 NB
@@ -51396,7 +51585,7 @@ eg
 Od
 mp
 Zh
-dG
+dt
 zn
 tU
 aZ
@@ -51631,6 +51820,7 @@ Zd
 Zd
 Zd
 Zd
+Mw
 Zd
 Zd
 Zd
@@ -51639,10 +51829,9 @@ Zd
 Zd
 Zd
 Zd
-Zd
-Zd
-Zd
-Zd
+IS
+HO
+gj
 iW
 jh
 mp
@@ -51652,9 +51841,9 @@ qj
 eh
 Vr
 mp
-sb
-dG
-sb
+dt
+dt
+dt
 Ih
 RG
 lv
@@ -51888,7 +52077,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 IJ
 IJ
@@ -51908,11 +52097,11 @@ jh
 jh
 QN
 jh
-lv
+bp
 dt
-OX
-sb
-rW
+dt
+dt
+dt
 pb
 lv
 Kl
@@ -52145,7 +52334,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 IJ
 IJ
@@ -52166,7 +52355,7 @@ sR
 ra
 vS
 lv
-Yx
+MB
 yS
 cf
 Ph
@@ -52402,7 +52591,7 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 IJ
 IJ
@@ -52411,7 +52600,7 @@ IJ
 Zd
 Zd
 Zd
-Zd
+iM
 Zd
 Zd
 Zd
@@ -52423,11 +52612,11 @@ Kw
 eu
 OA
 lv
-pM
+yM
 xB
 XZ
-WI
-xB
+pM
+yq
 lv
 YF
 mR
@@ -52659,18 +52848,18 @@ Zd
 Zd
 Zd
 Zd
-Zd
+Mw
 Zd
 Zd
 IJ
 IJ
-IJ
 Zd
 Zd
 Zd
 Zd
-Zd
-Zd
+rO
+EN
+rP
 Zd
 Zd
 Zd
@@ -52680,11 +52869,11 @@ jh
 jh
 jh
 lv
-lv
-lv
-lv
-lv
-lv
+rn
+fr
+fr
+KC
+fr
 lv
 jh
 jh
@@ -52916,12 +53105,7 @@ qt
 Zd
 Zd
 Zd
-Zd
-Zd
-Zd
-IJ
-IJ
-IJ
+Mw
 Zd
 Zd
 Zd
@@ -52932,17 +53116,22 @@ Zd
 Zd
 Zd
 Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
 IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
+lv
+kr
+pE
+Td
+fr
+xs
+lv
 IJ
 IJ
 IJ
@@ -53173,11 +53362,7 @@ qt
 qt
 Zd
 Zd
-Zd
-Zd
-Zd
-IJ
-IJ
+Mw
 Zd
 Zd
 Zd
@@ -53188,18 +53373,22 @@ Zd
 Zd
 Zd
 Zd
+Zd
+Zd
+Zd
+Zd
 IJ
 IJ
 IJ
 IJ
 IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
-IJ
+lv
+lv
+lv
+lv
+lv
+lv
+lv
 IJ
 IJ
 IJ
@@ -53430,13 +53619,13 @@ qt
 qt
 Zd
 Zd
+SL
 Zd
-Zd
-Zd
-Zd
-Zd
-Zd
-Zd
+hu
+Bq
+Bq
+Bq
+Kb
 Zd
 Zd
 Zd
@@ -53687,13 +53876,13 @@ qt
 qt
 Zd
 Zd
+Mw
 Zd
+Mw
 Zd
+Ax
 Zd
-Zd
-Zd
-IJ
-IJ
+Mw
 Zd
 Zd
 Zd
@@ -53944,14 +54133,14 @@ qt
 qt
 Zd
 Zd
+Mw
+Zd
+Mw
 Zd
 Zd
 Zd
+PV
 Zd
-IJ
-IJ
-IJ
-IJ
 Zd
 Zd
 Zd
@@ -54201,14 +54390,14 @@ qt
 qt
 Zd
 Zd
+Mw
 Zd
+Mw
 Zd
+nq
+On
+Mw
 Zd
-Zd
-Zd
-IJ
-IJ
-IJ
 Zd
 Zd
 Zd
@@ -54458,14 +54647,14 @@ qt
 qt
 qt
 Zd
+Mw
 Zd
+hQ
+Bq
+Bq
+Bq
+ED
 Zd
-Zd
-Zd
-Zd
-Zd
-IJ
-IJ
 Zd
 Zd
 Zd
@@ -54715,14 +54904,14 @@ qt
 qt
 qt
 Zd
+Mw
 Zd
 Zd
 Zd
 Zd
 Zd
 Zd
-IJ
-IJ
+Zd
 Zd
 Zd
 Zd
@@ -54972,14 +55161,14 @@ qt
 qt
 qt
 Zd
+Mw
 Zd
 Zd
 Zd
 Zd
 Zd
 Zd
-IJ
-IJ
+Zd
 Zd
 Zd
 Zd
@@ -55229,6 +55418,7 @@ qt
 qt
 qt
 Zd
+Mw
 Zd
 Zd
 Zd
@@ -55236,7 +55426,6 @@ Zd
 Zd
 Zd
 Zd
-IJ
 Zd
 Zd
 Zd
@@ -55486,8 +55675,8 @@ qt
 qt
 qt
 qt
-Zd
-Zd
+IJ
+IJ
 Zd
 Zd
 Zd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This updates the lavaland science outpost so it no longer looks like a very dusty ruin, and its now capable of producing chemical bombs (for research) with a little bit of help, or alternatively scientists can head out with the science hardsuit to go scan mobs instead of relying on miners.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Since lavaland is accessible by the crew for the majority of the shift, i think the science bay deserves some love instead of being discarded, only used by antagonists/assistants for the shuttle. I'm hoping the semi-refurbished state & the research console will encourage scientists to head down to lavaland to do some real science!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/6db08167-5a23-406d-9c20-a6b7d0f586d9)
![image](https://github.com/user-attachments/assets/dff64cc9-4737-44f7-a2af-124e83c01da3)
![image](https://github.com/user-attachments/assets/408ac5a4-e265-494e-8f76-776c04143d0d)
![image](https://github.com/user-attachments/assets/33b39225-2e0a-4ba0-84a3-42a9584b2afd)
![image](https://github.com/user-attachments/assets/f47df84d-4e87-4607-8677-c6329f8ef399)
![image](https://github.com/user-attachments/assets/6083e057-1f0f-46dc-bb8a-d4184c9a644e)


</details>

## Changelog
:cl:
add: The lavaland science division now starts with a research console and destructive analyzer (no protolathe board)
add: Lavaland Research directors office starts with a core R&D console, exosuit control console, and a research camera console
tweak: lavaland research division now has proper access
add: Lavaland research directors office no longer spawns with a hostile spider, it now spawns with a friendly spider!
tweak: The gulag no longer spawns with a incredibly ugly 6 tile long r wall 'fence'
add: lavaland science chemistry starts with a chem dispenser board
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
