### PR TITLE
Update smartfridge.dm

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -16,7 +16,7 @@
 
 	var/tgui_theme = null // default theme as null is Nanotrasen theme.
 
-	var/max_n_of_items = 1500
+	var/max_n_of_items = 300
 	var/allow_ai_retrieve = FALSE
 	var/list/initial_contents
 	var/visible_contents = TRUE
@@ -37,7 +37,7 @@
 
 /obj/machinery/smartfridge/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-		max_n_of_items = 1500 * B.rating
+		max_n_of_items = 300 * B.rating
 
 /obj/machinery/smartfridge/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the maximum storage of smartfridges from 6000 to 1200

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It takes about 1500 explosives stored in the same place to crash the server. Making it possible to store extremely excessive amounts of produce makes this possible. 300 is plenty for roundstart storage, and 1200 is plenty for upgraded storage - there is no situation in which the chef will need more food or crew will need more weaponized produce stored all in the exact same location. 

This extends to the subtypes as well, so this will likewise apply to Xenobiology and their extracts which also have the potential for game crashing explosions that haven't been realized yet. I suspect Xenobiology will feel this change the most. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/user-attachments/assets/d2c3e42a-fd9b-4719-8b55-3b8c4333c06d)

## Changelog
:cl:
tweak: smart fridges now hold 300 x tier of matter bin items, bringing their maximum storage down from 6000 to 1200. This was done to help reduce/prevent accidental server crashes caused by stockpiling of explosives. Said crashes are not always the fault of the person stockpiling. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
