### PR TITLE
Fixes Toxin and Turbine Airlocks

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6177,6 +6177,7 @@
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aMy" = (
@@ -6375,9 +6376,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aNT" = (
@@ -6466,6 +6464,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aPA" = (
@@ -37591,6 +37590,9 @@
 /obj/machinery/airlock_sensor/incinerator_toxmix{
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "gbW" = (
@@ -44631,9 +44633,14 @@
 /turf/open/floor/iron,
 /area/crew_quarters/kitchen)
 "ijv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -58958,6 +58965,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "mXa" = (
@@ -64539,7 +64549,6 @@
 "oIE" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "oIF" = (
@@ -86883,11 +86892,14 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -228,8 +228,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "aeZ" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "afw" = (
@@ -1040,6 +1047,9 @@
 /obj/machinery/airlock_sensor/incinerator_toxmix{
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "aul" = (
@@ -1448,9 +1458,6 @@
 "aFj" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "aFp" = (
@@ -3933,6 +3940,9 @@
 	id = "EmergancyescapeShutter";
 	name = "Emergancy Escape Shutters";
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -3137,18 +3137,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
-"aMc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/toxins,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/techmaint,
-/area/science/mixing)
 "aMf" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -3262,6 +3250,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"aNJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/end{
+	dir = 8
+	},
+/obj/machinery/airalarm/mixingchamber{
+	dir = 4;
+	pixel_x = 22
+	},
+/turf/open/floor/iron/techmaint,
+/area/science/mixing/chamber)
 "aNW" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -6420,11 +6424,14 @@
 /turf/open/floor/noslip/standard,
 /area/crew_quarters/fitness/recreation)
 "bCW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/airalarm/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/toxins,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/techmaint,
+/turf/open/floor/iron/grid/steel,
 /area/science/mixing)
 "bCZ" = (
 /obj/structure/window/reinforced{
@@ -6532,15 +6539,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/storage/primary)
-"bEi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
 "bEq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -11912,18 +11910,6 @@
 	},
 /turf/open/floor/iron/grid/steel,
 /area/quartermaster/exploration_prep)
-"dcw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/science/mixing)
 "dcM" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -15568,12 +15554,6 @@
 	dir = 8
 	},
 /area/science/robotics/lab)
-"ecx" = (
-/obj/effect/turf_decal/stripes/closeup,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/machinery/door/poddoor/incinerator_toxmix,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
 "ecM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -23648,13 +23628,21 @@
 /turf/open/floor/iron/sepia,
 /area/engine/engineering)
 "fZL" = (
-/obj/machinery/airlock_sensor/incinerator_toxmix{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/tech/grid,
 /area/science/mixing/chamber)
 "gab" = (
 /obj/structure/cable/yellow{
@@ -26759,13 +26747,6 @@
 /mob/living/basic/cockroach,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gNB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/grid/steel,
-/area/science/mixing)
 "gNU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
@@ -28043,13 +28024,10 @@
 	},
 /area/hallway/primary/central)
 "hfo" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
+/obj/effect/turf_decal/stripes/closeup,
+/turf/open/floor/iron/tech/grid,
 /area/science/mixing/chamber)
 "hfx" = (
 /obj/effect/turf_decal/delivery,
@@ -30689,15 +30667,23 @@
 	},
 /area/hallway/primary/aft)
 "hPe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Science - Toxins Mixing Lab Burn Chamber";
+	name = "science camera"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/iron/grid/steel,
 /area/science/mixing)
 "hPh" = (
@@ -31346,17 +31332,6 @@
 	dir = 9
 	},
 /area/teleporter)
-"hZk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/science/mixing)
 "hZm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -37963,14 +37938,33 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/solars/port)
 "jJy" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/button/door/incinerator_vent_toxmix{
+	pixel_x = 40;
+	pixel_y = 4
+	},
+/obj/machinery/button/door{
+	id = "mixwindows";
+	name = "Toxin Chamber Shutters Control";
+	pixel_x = 24;
+	pixel_y = 4
+	},
+/obj/machinery/button/ignition/incinerator/toxmix{
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/machinery/computer/atmos_control/tank/toxins_mixing_tank{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/white/end{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/iron/techmaint,
 /area/science/mixing/chamber)
 "jJI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -38755,6 +38749,15 @@
 	name = "mainframe floor"
 	},
 /area/tcommsat/server)
+"jSD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/effect/turf_decal/stripes/red/end,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/iron/grid/steel,
+/area/science/mixing)
 "jTf" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable/yellow{
@@ -39626,17 +39629,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "kdD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/science/mixing)
@@ -42022,16 +42025,12 @@
 /turf/open/floor/iron,
 /area/hydroponics)
 "kIn" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "mix to port"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "mixwindows";
-	name = "Toxin Mix Chamber Blast Door"
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/grid/steel,
+/area/science/mixing)
 "kIo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -45905,11 +45904,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
-"lBE" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/techmaint,
-/area/science/mixing)
 "lBL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -48800,6 +48794,12 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"mss" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 4
+	},
+/turf/open/floor/iron/grid/steel,
+/area/science/mixing)
 "msy" = (
 /obj/effect/turf_decal/guideline/guideline_out_arrow_con/blue{
 	dir = 1
@@ -49241,9 +49241,6 @@
 /turf/open/floor/iron,
 /area/crew_quarters/locker)
 "myi" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -50986,13 +50983,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
-"mUQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/grid/steel,
-/area/science/mixing)
 "mUS" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
@@ -52252,22 +52242,12 @@
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "nno" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
-/obj/machinery/airalarm/mixingchamber{
-	dir = 4;
-	pixel_x = 22
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/end{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/techmaint,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/grid/steel,
+/area/science/mixing)
 "nnq" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -52956,19 +52936,6 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/bridge)
-"nwM" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/end{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/science/mixing)
 "nwT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -55783,6 +55750,15 @@
 /obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/engine/storage)
+"olO" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/red/box,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/iron/grid/steel,
+/area/science/mixing)
 "olW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56857,6 +56833,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
+"oyX" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/iron/techmaint,
+/area/science/mixing)
 "ozc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58700,6 +58682,13 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/maintenance/aft)
+"oZZ" = (
+/obj/machinery/air_sensor/atmos/toxins_mixing_tank{
+	pixel_x = 25
+	},
+/obj/machinery/igniter/incinerator_toxmix,
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "pam" = (
 /obj/effect/turf_decal/guideline/guideline_in/red{
 	dir = 8
@@ -63608,16 +63597,18 @@
 	},
 /area/docking/bridge)
 "qnY" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "mix to port"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor/iron_smooth,
+/obj/effect/turf_decal/stripes/red/end{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/iron/grid/steel,
 /area/science/mixing)
 "qnZ" = (
 /obj/structure/cable/yellow{
@@ -63686,10 +63677,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/quartermaster/storage)
-"qpm" = (
-/obj/machinery/air_sensor/atmos/toxins_mixing_tank,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
 "qpD" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/structure/cable/yellow{
@@ -64068,6 +64055,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engine/gravity_generator)
+"qtN" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/techmaint,
+/area/science/mixing)
 "qtS" = (
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
@@ -66257,15 +66250,6 @@
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
-"qTZ" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/closeup,
-/turf/open/floor/iron/tech/grid,
-/area/science/mixing/chamber)
 "qUj" = (
 /obj/machinery/chem_master,
 /turf/open/floor/iron/grid/steel,
@@ -66473,10 +66457,6 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/science/shuttle)
-"qYB" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/science/mixing/chamber)
 "qYE" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -67600,17 +67580,22 @@
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "rpo" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/machinery/light,
-/turf/open/floor/iron/techmaint,
+/turf/open/floor/iron/grid/steel,
 /area/science/mixing)
 "rpq" = (
-/obj/machinery/atmospherics/components/trinary/mixer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/grid/steel,
 /area/science/mixing)
 "rpu" = (
@@ -68989,16 +68974,14 @@
 /turf/closed/wall/r_wall,
 /area/engine/engine_room)
 "rHf" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Science - Toxins Mixing Lab Burn Chamber";
-	name = "science camera"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/grid/steel,
 /area/science/mixing)
@@ -70152,10 +70135,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"rUi" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/grid/steel,
-/area/science/mixing)
 "rUk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70256,6 +70235,14 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron/grid/steel,
 /area/science/robotics/lab)
+"rVE" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "mixwindows";
+	name = "Toxin Mix Chamber Blast Door"
+	},
+/turf/open/floor/plating,
+/area/science/mixing/chamber)
 "rVS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -72521,6 +72508,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/main)
+"szM" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "mixwindows";
+	name = "Toxin Mix Chamber Blast Door"
+	},
+/turf/open/floor/plating,
+/area/science/mixing/chamber)
 "szO" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -76805,10 +76803,6 @@
 /obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/iron/techmaint,
 /area/maintenance/solars/port)
-"tEI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
 "tFc" = (
 /obj/structure/railing{
 	dir = 8
@@ -80523,13 +80517,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/grid/steel,
 /area/science/research)
-"uAE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/science/mixing)
 "uAG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -85987,15 +85974,6 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/maintenance/department/engine)
-"vLy" = (
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/grid/steel,
-/area/science/mixing)
 "vLF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -86800,15 +86778,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
-"vTM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/iron/grid/steel,
-/area/science/mixing)
 "vTP" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -86987,10 +86956,6 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/quartermaster/exploration_prep)
-"vWi" = (
-/obj/machinery/igniter/incinerator_toxmix,
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
 "vWl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -87182,19 +87147,6 @@
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/engine_room)
-"vZw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/iron/grid/steel,
-/area/science/mixing)
 "vZJ" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/bot,
@@ -90333,16 +90285,8 @@
 /turf/open/floor/vault,
 /area/ai_monitored/security/armory)
 "wPG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/science/mixing/chamber)
 "wPJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -92851,12 +92795,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engine/engine_smes)
-"xpc" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/grid/steel,
-/area/science/mixing)
 "xpd" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
@@ -93898,12 +93836,17 @@
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
 "xzW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
+	pixel_x = 24
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor/incinerator_toxmix{
+	pixel_y = 24
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -94179,17 +94122,13 @@
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
 "xCA" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
 	},
-/obj/machinery/airalarm/directional/south{
-	pixel_y = -22
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/iron/grid/steel,
+/turf/open/floor/iron/techmaint,
 /area/science/mixing)
 "xCD" = (
 /obj/structure/cable/yellow{
@@ -95431,16 +95370,20 @@
 /turf/open/floor/iron/grid/steel,
 /area/science/misc_lab/range)
 "xNK" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/turf/open/floor/iron/tech/grid,
-/area/science/mixing/chamber)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
+	pixel_y = 26
+	},
+/turf/open/floor/iron/grid/steel,
+/area/science/mixing)
 "xNL" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -95704,34 +95647,11 @@
 /turf/closed/wall,
 /area/engine/engine_room)
 "xQG" = (
-/obj/machinery/button/door{
-	id = "mixwindows";
-	name = "Toxin Chamber Shutters Control";
-	pixel_x = 24;
-	pixel_y = 4
-	},
-/obj/machinery/button/door/incinerator_vent_toxmix{
-	pixel_x = 40;
-	pixel_y = 4
-	},
-/obj/machinery/button/ignition/incinerator/toxmix{
-	pixel_x = 24;
-	pixel_y = -6
-	},
-/obj/machinery/computer/atmos_control/tank/toxins_mixing_tank{
+/obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/end{
-	dir = 8
-	},
-/turf/open/floor/iron/techmaint,
-/area/science/mixing/chamber)
+/turf/open/floor/iron/grid/steel,
+/area/science/mixing)
 "xRi" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -96759,10 +96679,11 @@
 /turf/open/floor/iron/dark,
 /area/chapel/main)
 "ydO" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/iron/grid/steel,
+/turf/open/floor/iron/techmaint,
 /area/science/mixing)
 "ydP" = (
 /obj/machinery/suit_storage_unit/atmos,
@@ -97403,12 +97324,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ylR" = (
-/obj/effect/landmark/blobstart,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/landmark/blobstart,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -136405,16 +136330,16 @@ wBR
 cTl
 pCA
 xSV
-uAE
+wgV
 myi
 qMM
-nwM
 wgV
 wgV
 wgV
+qtN
 qBX
 tNd
-aMc
+oYh
 vpQ
 bZw
 loZ
@@ -136664,11 +136589,11 @@ oCl
 xSV
 hPe
 rpq
-mUQ
-gNB
-xpc
-rUi
-lBE
+acB
+izY
+izY
+izY
+izY
 kdD
 aiW
 aiW
@@ -136920,13 +136845,13 @@ oZY
 wgM
 xSV
 rHf
-vZw
-acB
-hZk
+wgV
+olO
+wgV
 qnY
-izY
-izY
-dcw
+jSD
+wgV
+wgV
 bCW
 rpo
 oqW
@@ -137176,11 +137101,11 @@ pnp
 ydi
 eZy
 xSV
-vLy
-vTM
+rHf
+wgV
 xQG
-oSF
-oSF
+wgV
+mss
 nno
 ydO
 xCA
@@ -137432,15 +137357,15 @@ ylJ
 ylJ
 ydi
 ylJ
-vKD
+xSV
 xNK
 jJy
-vKD
+oSF
+wgV
 kIn
-kIn
-vKD
-mho
-mho
+aNJ
+ape
+oyX
 oqW
 ddm
 cBs
@@ -137691,13 +137616,13 @@ ydi
 lyl
 vKD
 fZL
-bEi
 vKD
-rVe
-rdZ
-cYE
-wQe
-qYB
+szM
+rVE
+szM
+vKD
+mho
+mho
 oqW
 ykA
 jmu
@@ -137949,10 +137874,10 @@ gNA
 vKD
 ylR
 hfo
-qTZ
-vWi
-qpm
-ecx
+rdZ
+lhz
+rVe
+cYE
 wQe
 ccQ
 oqW
@@ -138206,8 +138131,8 @@ vzI
 vKD
 xzW
 wPG
-vKD
 lhz
+oZZ
 hCb
 cYE
 wQe
@@ -138460,7 +138385,7 @@ ieR
 uUs
 ydi
 ylJ
-tEI
+vKD
 vKD
 vKD
 vKD

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2152,6 +2152,9 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "auI" = (
@@ -5142,10 +5145,19 @@
 /obj/machinery/airlock_sensor/incinerator_toxmix{
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bbD" = (
 /obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bbE" = (
@@ -5161,6 +5173,9 @@
 "bbF" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -21047,9 +21062,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "eSG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -23186,9 +23198,6 @@
 /obj/effect/landmark/start/scientist,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -26987,6 +26996,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -32797,9 +32812,11 @@
 /area/engine/atmos)
 "iFj" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "iFq" = (
@@ -32922,6 +32939,12 @@
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
@@ -36112,6 +36135,9 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "jHj" = (
@@ -37402,13 +37428,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "keS" = (
@@ -43684,10 +43710,8 @@
 "mgE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "mgF" = (
@@ -53753,6 +53777,8 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "ptG" = (
@@ -71127,12 +71153,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/airalarm/mixingchamber{
-	pixel_y = 22;
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing/chamber)
@@ -73808,6 +73836,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -81710,6 +81744,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24530,6 +24530,9 @@
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "emH" = (
@@ -35738,8 +35741,15 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/checkpoint/science/research)
 "iwf" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "iwl" = (
@@ -49733,6 +49743,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 8;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -69456,7 +69469,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -291,11 +291,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -17896,6 +17899,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "fDQ" = (
@@ -23400,6 +23404,7 @@
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "hqy" = (
@@ -28924,9 +28929,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -29427,11 +29429,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jsN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -33045,6 +33050,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "kCk" = (
@@ -58927,6 +58933,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "sLf" = (
@@ -60664,9 +60671,6 @@
 /area/engine/engine_room)
 "tmS" = (
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)


### PR DESCRIPTION
## About The Pull Request
Standardizes the airlocks to allow pipes to run across the airlock without connecting to a layer pipe and fixes Kilo Toxins trapping you forever.

I've left Kilo and Corg turbine because they need a LOT of reworking to fix in an elegant fashion. The Kilo one will still trap you, but everyone in Engineering at least have toolbelts on them.

Changed the Fland Toxins as it is just awful.

## Why It's Good For The Game
I'd rather not get stuck...

![image](https://github.com/user-attachments/assets/b8f2b18c-0e47-4b22-a8a6-c324a3e80a68)

And I'd rather not have to remove the pump pipes soley to pipe through the airlock.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

</details>

## Changelog
:cl:
fix: [Kilo] Fixes air cycling in toxins.
tweak: [Rad, Delta] Standardizes the turbine airlock.
tweak: [Echo, Rad, Meta, Kilo, Delta] Standardizes the toxin airlocks.
tweak: [Fland] Tweaked Toxins a bit.
/:cl:
