### PR TITLE
Explosion batching

### DIFF
--- a/code/controllers/subsystem/explosion.dm
+++ b/code/controllers/subsystem/explosion.dm
@@ -1,4 +1,7 @@
 #define EXPLOSION_THROW_SPEED 4
+/// Max amount of explosions that we accept in a row from the same turf
+#define EXPLOSION_TURF_MAX 100
+
 GLOBAL_LIST_EMPTY(explosions)
 
 SUBSYSTEM_DEF(explosions)
@@ -35,6 +38,8 @@ SUBSYSTEM_DEF(explosions)
 
 	var/currentpart = SSAIR_REBUILD_PIPENETS
 
+	var/turf/last_exploded_turf = null
+	var/last_explosion_count = 0
 
 /datum/controller/subsystem/explosions/stat_entry(msg)
 	msg += "C:{"
@@ -186,6 +191,15 @@ SUBSYSTEM_DEF(explosions)
 	epicenter = get_turf(epicenter)
 	if(!epicenter)
 		return
+
+	// If we get a lot of explosions on the same turfs, do a lot of explosions but skip some of the ones towards the end
+	if (epicenter == last_exploded_turf)
+		last_explosion_count ++
+		if (last_explosion_count > EXPLOSION_TURF_MAX)
+			return
+	else
+		last_explosion_count = 0
+		last_exploded_turf = epicenter
 
 	if(isnull(flame_range))
 		flame_range = light_impact_range
@@ -626,7 +640,7 @@ SUBSYSTEM_DEF(explosions)
 	currentpart = SSEXPLOSIONS_TURFS
 
 #undef SSAIR_REBUILD_PIPENETS
-
 #undef EXPLOSION_THROW_SPEED
+#undef EXPLOSION_TURF_MAX
 #undef SSEX_TURF
 #undef SSEX_OBJ

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -650,10 +650,19 @@
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
 
+GLOBAL_VAR_INIT(s_flickering_lights, FALSE)
+
+/// Flickers all lights the next time we sleep, or yield to byond.
+/// Concatenates all the flicking operations together.
 /proc/flicker_all_lights()
-	for(var/obj/machinery/light/L in GLOB.machines)
-		if(is_station_level(L.z))
-			addtimer(CALLBACK(L, TYPE_PROC_REF(/obj/machinery/light, flicker), rand(3, 6)), rand(0, 15))
+	if (GLOB.s_flickering_lights)
+		return
+	GLOB.s_flickering_lights = TRUE
+	spawn(0)
+		GLOB.s_flickering_lights = FALSE
+		for(var/obj/machinery/light/L in GLOB.machines)
+			if(is_station_level(L.z))
+				addtimer(CALLBACK(L, TYPE_PROC_REF(/obj/machinery/light, flicker), rand(3, 6)), rand(0, 15))
 
 #undef LIGHT_ON_DELAY_UPPER
 #undef LIGHT_ON_DELAY_LOWER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Significantly optimises mass-explosions by only flickering the lights a maximum of once per non-sleep execution.
- Implements a limit of 101 explosions in a row for any particular turf, so that >1000 explosions from a single turf will likely get caught before the server freezes for a few seconds.

## Why It's Good For The Game

Fixes an issue with explosive lemons in fridges causing the server to freeze 

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/8b33bf96-e124-4bcd-a97d-5a564e662429

## Changelog
:cl:
fix: Fixes some issues related to mass explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
