### PR TITLE
Adds In-game Player Report Template (configurable template)

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1836,6 +1836,7 @@
 #include "code\modules\admin\verbs\diagnostics.dm"
 #include "code\modules\admin\verbs\forcecryo.dm"
 #include "code\modules\admin\verbs\fps.dm"
+#include "code\modules\admin\verbs\get_ingame_report.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\ghost_pool_protection.dm"
 #include "code\modules\admin\verbs\healall.dm"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -631,6 +631,6 @@
 
 /datum/config_entry/string/discord_ooc_tag
 
-// Showes 'player_report_template.txt' to players, in admin verb tab.
+// Shows 'player_report_template.txt' to players, in admin verb tab.
 /datum/config_entry/flag/use_player_report_template
 	config_entry_value = FALSE

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -630,3 +630,7 @@
 /datum/config_entry/flag/enable_mrat
 
 /datum/config_entry/string/discord_ooc_tag
+
+// Showes 'player_report_template.txt' to players, in admin verb tab.
+/datum/config_entry/flag/use_player_report_template
+	config_entry_value = FALSE

--- a/code/modules/admin/verbs/get_ingame_report.dm
+++ b/code/modules/admin/verbs/get_ingame_report.dm
@@ -1,0 +1,64 @@
+
+#define HTML_LISTIFY(_text) "<li>[_text]</li>"
+/client/verb/get_ingame_report()
+	set category = "Admin"
+	set name = "Copy In-game Report Template"
+
+	var/list/contents = list(
+		HTML_LISTIFY("# In-game report: (by In-game template)"),
+		HTML_LISTIFY("&lt!-- \[READ ME\] Title should be: \[Offender's CKEY\] Player Report --&gt"),
+		HTML_LISTIFY("CKEY: [src.key]"),
+		HTML_LISTIFY("Your Character Name: [mob.name]"),
+		HTML_LISTIFY("Your Discord: "),
+		HTML_LISTIFY("Offender's CKEY: "),
+		HTML_LISTIFY("Offender's In-Game Name: "),
+		HTML_LISTIFY("Date (YYYY-MM-DD): (UST) [time2text(world.realtime, "YYYY-MM-DD, hh:mm")] (template copied)"),
+		HTML_LISTIFY("Round Number: [GLOB.round_id || "Unknown"] ([CONFIG_GET(string/servername) || "Unnamed Server"])"),
+		HTML_LISTIFY("Rules Broken: "),
+		HTML_LISTIFY("Incident Description: "),
+		HTML_LISTIFY("Additional Information: ")
+	)
+
+// NOTE: Because Byond uses IE11 (alike), Javascript is limited. You're welcome to change this someday.
+	var/body = {"\
+<script>
+function copyToClipboard() {
+	var textToCopy = document.getElementById('copy_content').innerText;
+	var tempTextarea = document.createElement('textarea');
+	tempTextarea.value = textToCopy;
+	document.body.appendChild(tempTextarea);
+	tempTextarea.select();
+	var successful = document.execCommand('copy');
+	if (successful) {
+		var copy_button = document.getElementById('copy_button');
+		copy_button.innerText = 'Copy Successful!';
+	} else {
+		var copy_button = document.getElementById('copy_button');
+		copy_button.innerText = 'Copy Failed!';
+	}
+	document.body.removeChild(tempTextarea);
+}
+</script>
+<style>
+#copy_content br{
+	margin: 10px 0;
+}
+#copy_content ul{
+	margin: 0px;
+	list-style-type: none;
+}
+</style>
+<html>
+	<body>
+		<button id='copy_button' onclick='copyToClipboard()'>Copy to Clipboard</button>
+		<span id='copy_content'>
+			<ul>
+				[contents.Join("<br/>")]
+			</ul>
+		</span>
+	</html>
+</body>
+"}
+
+	usr << browse(body, "window=template_report")
+#undef HTML_LISTIFY

--- a/code/modules/admin/verbs/get_ingame_report.dm
+++ b/code/modules/admin/verbs/get_ingame_report.dm
@@ -1,33 +1,32 @@
+/client/proc/_replacetext_player_report(text)
+		text = replacetext(text, "%CKEY%", src.key)
+		text = replacetext(text, "%MOB_NAME%", mob.name)
+		text = replacetext(text, "%DATE%", time2text(world.realtime, "YYYY-MM-DD, hh:mm"))
+		text = replacetext(text, "%ROUND_ID%", GLOB.round_id || "Unknown")
+		text = replacetext(text, "%SERVER_NAME%", CONFIG_GET(string/servername) || "Unnamed Server")
+		return text
 
-#define HTML_LISTIFY(_text) "<li>[_text]</li>"
 /client/verb/get_ingame_report()
 	set category = "Admin"
 	set name = "Copy In-game Report Template"
 
-	var/list/contents = list(
-		HTML_LISTIFY("# In-game report: (by In-game template)"),
-		HTML_LISTIFY("&lt!-- \[READ ME\] Title should be: \[Offender's CKEY\] Player Report --&gt"),
-		HTML_LISTIFY("CKEY: [src.key]"),
-		HTML_LISTIFY("Your Character Name: [mob.name]"),
-		HTML_LISTIFY("Your Discord: "),
-		HTML_LISTIFY("Offender's CKEY: "),
-		HTML_LISTIFY("Offender's In-Game Name: "),
-		HTML_LISTIFY("Date (YYYY-MM-DD): (UST) [time2text(world.realtime, "YYYY-MM-DD, hh:mm")] (template copied)"),
-		HTML_LISTIFY("Round Number: [GLOB.round_id || "Unknown"] ([CONFIG_GET(string/servername) || "Unnamed Server"])"),
-		HTML_LISTIFY("Rules Broken: "),
-		HTML_LISTIFY("Incident Description: "),
-		HTML_LISTIFY("Additional Information: ")
-	)
+	var/static/list/template_content = world.file2list("config/player_report_template.txt")
+	var/list/textlines = template_content.Copy(2) // do not copy first line
+	for(var/idx in 1 to length(textlines))
+		var/text = textlines[idx]
+		if(length(text))
+			textlines[idx] = "<li>[text] </li>"
+		else
+			textlines[idx] = "<br class='no_text'>"
 
 // NOTE: Because Byond uses IE11 (alike), Javascript is limited. You're welcome to change this someday.
 	var/body = {"\
 <script>
 function copyToClipboard() {
-	var textToCopy = document.getElementById('copy_content').innerText;
-	var tempTextarea = document.createElement('textarea');
-	tempTextarea.value = textToCopy;
-	document.body.appendChild(tempTextarea);
-	tempTextarea.select();
+	var textarea = document.getElementById('copy_area');
+	textarea.value = document.getElementById('copy_content').innerText;
+	textarea.style.display = 'inline';
+	textarea.select();
 	var successful = document.execCommand('copy');
 	if (successful) {
 		var copy_button = document.getElementById('copy_button');
@@ -36,24 +35,28 @@ function copyToClipboard() {
 		var copy_button = document.getElementById('copy_button');
 		copy_button.innerText = 'Copy Failed!';
 	}
-	document.body.removeChild(tempTextarea);
+	textarea.style.display = 'none';
 }
 </script>
 <style>
-#copy_content br{
-	margin: 10px 0;
-}
 #copy_content ul{
 	margin: 0px;
 	list-style-type: none;
+}
+#copy_area {
+	display: none
+}
+.no_text br{
+	margin: 10px 0;
 }
 </style>
 <html>
 	<body>
 		<button id='copy_button' onclick='copyToClipboard()'>Copy to Clipboard</button>
+		<textarea id='copy_area' rows='0' cols='0'></textarea>
 		<span id='copy_content'>
 			<ul>
-				[contents.Join("<br/>")]
+				[_replacetext_player_report(textlines.Join())]
 			</ul>
 		</span>
 	</html>
@@ -61,4 +64,3 @@ function copyToClipboard() {
 "}
 
 	usr << browse(body, "window=template_report")
-#undef HTML_LISTIFY

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -242,6 +242,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			var/datum/admin_rank/localhost_rank = new("!localhost!", R_EVERYTHING, R_DBRANKS, R_EVERYTHING) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
 
+	if(!CONFIG_GET(flag/use_player_report_template))
+		remove_verb(/client/verb/get_ingame_report)
+
 	// This needs to go after admin loading but before prefs
 	assign_mentor_datum_if_exists()
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -639,4 +639,4 @@ ENABLE_MRAT
 #DISCORD_OOC_TAG thisServer
 
 ## Showes 'template' in admin tab to players.
-USE_PLAYER_REPORT_TEMPLATE
+#USE_PLAYER_REPORT_TEMPLATE

--- a/config/config.txt
+++ b/config/config.txt
@@ -638,5 +638,5 @@ ENABLE_MRAT
 ## For Beestation, it will be "SA"(sage) and "AC"(acacia) for this value, then it will be `[SA] (OOC) beeboi: I love bee!`
 #DISCORD_OOC_TAG thisServer
 
-## Showes 'template' in admin tab to players.
+## Shows 'player_report_template.txt' to players, in admin verb tab.
 #USE_PLAYER_REPORT_TEMPLATE

--- a/config/config.txt
+++ b/config/config.txt
@@ -637,3 +637,6 @@ ENABLE_MRAT
 ## Discord OOC tag. As long as this is enabled, the message will be concatenated with `[thisServer] (OOC) beeboi: hello guys!`. if it's commented, it will be `(OOC) beeboi: hello guys!`
 ## For Beestation, it will be "SA"(sage) and "AC"(acacia) for this value, then it will be `[SA] (OOC) beeboi: I love bee!`
 #DISCORD_OOC_TAG thisServer
+
+## Showes 'template' in admin tab to players.
+USE_PLAYER_REPORT_TEMPLATE

--- a/config/player_report_template.txt
+++ b/config/player_report_template.txt
@@ -1,0 +1,24 @@
+// check 'get_ingame_report.dm' for the detail. Enable 'USE_PLAYER_REPORT_TEMPLATE' config if you want to use this. (Also this first is not copied)
+# In-game report: (by In-game template)
+
+&lt!-- [READ ME] Title should be: [Offender's CKEY] Player Report --&gt
+
+CKEY: %CKEY%
+
+Your Character Name: %MOB_NAME%
+
+Your Discord:
+
+Offender's CKEY:
+
+Offender's In-Game Name:
+
+Date (YYYY-MM-DD): (UST) %DATE% (template copied)
+
+Round Number: %ROUND_ID% (%SERVER_NAME%)
+
+Rules Broken:
+
+Incident Description:
+
+Additional Information:


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds In-game Player Report Template

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players sometimes face tedious times to write basic stuff like date, round number, sort of it.
This helps them to feel less tedious.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/56c1eede-1599-4b55-bcc0-a4ca2e45429c)

https://forums.beestation13.com/t/testing-ingame-report-template-system/26385

Copypasta result

forgot to deadmin atm, but it works well without admin rank.

NOTE: unknown round number is because it was ran in my local. It will work in in live servers with actual round IDs

## Changelog
:cl:
config: "Admin" tab now has "Copy In-game Report Template". You can copy ingame information for player report. To use this, enable 'USE_PLAYER_REPORT_TEMPLATE' in the config file, and change the template file 'player_report_template.txt' as how you want.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
