### PR TITLE
Update CONTRIBUTING.md to ensure ports highlight original content

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,6 +110,7 @@ Any pull-request that does not adequately complete the provided template may be 
  - The section labeled "why it's good for the game" should include the reasons behind the changes and how they will be good for the game.
  - The testing section should contain screenshots, videos, and/or reproducible testing procedures showing that the PR works as specified. Pull-requests that ignore this section, or are not tested, may be closed by maintainers. This applies to small PRs that may seem trivial.
  - The changelog should include a short summary of the changes made. If your pull request includes things made by other people, you should list everybody who contributed, including yourself, after the :cl: tag.
+ - Ports with a significant number of file changes (roughly more than 10) must indicate which parts of the code are ported, and which parts are original code.
 
 If a pull-request requires updates to the wiki, these changes should be made on your user account page (For example: https://wiki.beestation13.com/view/User:PowerfulBacon), so that the original page can be updated on merge.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Any pull-request that does not adequately complete the provided template may be 
  - The section labeled "why it's good for the game" should include the reasons behind the changes and how they will be good for the game.
  - The testing section should contain screenshots, videos, and/or reproducible testing procedures showing that the PR works as specified. Pull-requests that ignore this section, or are not tested, may be closed by maintainers. This applies to small PRs that may seem trivial.
  - The changelog should include a short summary of the changes made. If your pull request includes things made by other people, you should list everybody who contributed, including yourself, after the :cl: tag.
- - Ports should indicate any original code that they have added for the port. This includes highlighting any mass-edit statements done via regex, and any bee specific cnotent that had to be modified to accomodate the changes.
+ - Ports should indicate any original code that they have added for the port. This includes highlighting any mass-edit statements done via regex, and any bee specific content that had to be modified to accomodate the changes.
 
 If a pull-request requires updates to the wiki, these changes should be made on your user account page (For example: https://wiki.beestation13.com/view/User:PowerfulBacon), so that the original page can be updated on merge.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Any pull-request that does not adequately complete the provided template may be 
  - The section labeled "why it's good for the game" should include the reasons behind the changes and how they will be good for the game.
  - The testing section should contain screenshots, videos, and/or reproducible testing procedures showing that the PR works as specified. Pull-requests that ignore this section, or are not tested, may be closed by maintainers. This applies to small PRs that may seem trivial.
  - The changelog should include a short summary of the changes made. If your pull request includes things made by other people, you should list everybody who contributed, including yourself, after the :cl: tag.
- - Ports with a significant number of file changes (roughly more than 10) must indicate which parts of the code are ported, and which parts are original code.
+ - Ports should indicate any original code that they have added for the port. This includes highlighting any mass-edit statements done via regex, and any bee specific cnotent that had to be modified to accomodate the changes.
 
 If a pull-request requires updates to the wiki, these changes should be made on your user account page (For example: https://wiki.beestation13.com/view/User:PowerfulBacon), so that the original page can be updated on merge.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Large ports must now include details of which parts are original code, to make reviewing easier.

## Why It's Good For The Game

When it comes to ports, the most likely thing to fail is the original code (since the TG code already has had significant testing on TG).

To make reviewing easier, contributors porting code from another codebase should indicate all the parts of their PR that is original code.

## Testing Photographs and Procedure

N/A

## Changelog
:cl:
code: (Github) Large ports must now indicate which part of their port is original code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
