### PR TITLE
Fixes natural wigs not showing the proper hair color.

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -119,6 +119,13 @@
 	hair_style = pick(GLOB.hair_styles_list - "Bald")
 	. = ..()
 
+/obj/item/clothing/head/wig/natural/equipped(mob/user, slot)
+	if(ishuman(user) && slot == ITEM_SLOT_HEAD)
+		var/mob/living/carbon/human/human_mob = user
+		hair_color = "#[human_mob.hair_color]"
+		update_icon()
+	. = ..()
+
 /obj/item/clothing/head/kitty/visual_equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(ishuman(user) && (slot == ITEM_SLOT_HEAD || slot == ITEM_SLOT_NECK))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Natural wigs were broken before this due to the fact that their hair color was never set after the initialize, resulting in races like moths permanently only having white (default) hair.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Bugfix good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/83220f53-9dab-45c7-a125-48097d27413b



</details>

## Changelog
:cl: XeonMations
fix: Fixed natural wigs not showing the correct color for nonhuman races.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
