### PR TITLE
Fixes Meteor Sats: Now Uses Proximity Monitors instead of Processing

### DIFF
--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -108,10 +108,8 @@
 		return //no need to process if we didn't change anything.
 	active = anchorvalue
 	if(anchorvalue)
-		begin_processing()
 		animate(src, pixel_y = 2, time = 10, loop = -1)
 	else
-		end_processing()
 		animate(src, pixel_y = 0, time = 10)
 	update_icon()
 
@@ -146,9 +144,14 @@
 	name = "\improper Meteor Shield Satellite"
 	desc = "A meteor point-defense satellite."
 	mode = "M-SHIELD"
-	processing_flags = START_PROCESSING_MANUALLY
-	subsystem_type = /datum/controller/subsystem/processing/fastprocess
 	var/kill_range = 14
+	///Proximity monitor associated with this atom, needed for proximity checks.
+	var/datum/proximity_monitor/proximity_monitor
+
+
+/obj/machinery/satellite/meteor_shield/Initialize(mapload)
+	. = ..()
+	proximity_monitor = new(src, kill_range)
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)
 	for(var/turf/T in getline(src,meteor))
@@ -156,21 +159,18 @@
 			return FALSE
 	return TRUE
 
-/obj/machinery/satellite/meteor_shield/process()
-	if(!active)
-		return
-	for(var/obj/effect/meteor/M in GLOB.meteor_list)
-		if(M.get_virtual_z_level() != get_virtual_z_level())
-			continue
-		if(get_dist(M,src) > kill_range)
-			continue
-		if(!(obj_flags & EMAGGED) && space_los(M))
-			Beam(get_turf(M),icon_state="sat_beam", time = 5)
-			qdel(M)
+/obj/machinery/satellite/meteor_shield/HasProximity(atom/movable/AM)
+	if(istype(AM, /obj/effect/meteor))
+		if(!(obj_flags & EMAGGED) && space_los(AM))
+			Beam(get_turf(AM),icon_state="sat_beam", time = 5)
+			qdel(AM)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
 	if(!..(user))
 		return FALSE
+
+	proximity_monitor.set_range(active ? src.kill_range : 0)
+
 	if(obj_flags & EMAGGED)
 		if(active)
 			change_meteor_chance(2)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -121,6 +121,7 @@
 	if(user)
 		to_chat(user, "<span class='notice'>You [active ? "deactivate": "activate"] [src].</span>")
 	set_anchored(!anchored)
+	return TRUE
 
 /obj/machinery/satellite/update_icon()
 	icon_state = active ? "sat_active" : "sat_inactive"
@@ -151,7 +152,7 @@
 
 /obj/machinery/satellite/meteor_shield/Initialize(mapload)
 	. = ..()
-	proximity_monitor = new(src, kill_range)
+	proximity_monitor = new(src, 0)
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)
 	for(var/turf/T in getline(src,meteor))
@@ -169,7 +170,7 @@
 	if(!..(user))
 		return FALSE
 
-	proximity_monitor.set_range(active ? src.kill_range : 0)
+	proximity_monitor.set_range(active ? kill_range : 0)
 
 	if(obj_flags & EMAGGED)
 		if(active)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With the merging of #11709, we probably should update our Meteor Sats to actually use this, instead of triggering in process.

## Why It's Good For The Game

Meteor Sats will now actually shoot down meteors that get close to them. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Off Satellite does not destroy meteors.

![image](https://github.com/user-attachments/assets/66d20c60-2a58-40d4-9fdf-ea284696ad28)

![image](https://github.com/user-attachments/assets/96004e2a-5f9e-400f-be3a-213e724cac47)

On Satellite destroys meteors.
![image](https://github.com/user-attachments/assets/378a131e-e55a-44cf-9a16-bc5240b33e42)


Excessive amounts of Satellites Shooting down several catastrophic meteor waves. Kill range is still 14 tiles.

https://github.com/user-attachments/assets/0067ef4e-4b92-408e-8358-dfdea321f03e


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Meteor Shield Satellites now use Proximity Monitors instead of Processing. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
