### PR TITLE
Refactors ghost-role sentience

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -667,6 +667,7 @@
 #include "code\datums\components\explodable.dm"
 #include "code\datums\components\force_move.dm"
 #include "code\datums\components\forensics.dm"
+#include "code\datums\components\ghost_spawner.dm"
 #include "code\datums\components\gps.dm"
 #include "code\datums\components\grillable.dm"
 #include "code\datums\components\haircolor_clothes.dm"

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
@@ -31,7 +31,7 @@
 	#define COMPONENT_CANCEL_ATTACK_CHAIN (1<<0)
 	///Skips the specific attack step, continuing for the next one to happen.
 	#define COMPONENT_SKIP_ATTACK (1<<1)
-///from base of atom/attack_ghost(): (mob/dead/observer/ghost)
+///from base of atom/attack_ghost(): (mob/dead/observer/ghost, direct)
 #define COMSIG_ATOM_ATTACK_GHOST "atom_attack_ghost"
 ///from base of atom/attack_hand(): (mob/user)
 #define COMSIG_ATOM_ATTACK_HAND "atom_attack_hand"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob.dm
@@ -69,3 +69,5 @@
 ///Called after a client connects to a mob and all UI elements have been setup
 #define COMSIG_MOB_CLIENT_LOGIN "comsig_mob_client_login"
 #define COMSIG_MOB_MOUSE_SCROLL_ON "comsig_mob_mouse_scroll_on"	//! from base of /mob/MouseWheelOn(): (atom/A, delta_x, delta_y, params)
+/// Called when a mob ghostizes (mob/target, can_reenter_corpse, sentience_retention)
+#define COMSIG_MOB_GHOSTIZE "comsig_mob_ghostize"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -431,8 +431,7 @@ GLOBAL_LIST_INIT(available_random_trauma_list, list(
 // Mob Playability Set By Admin Or Ghosting
 #define SENTIENCE_SKIP 0
 #define SENTIENCE_RETAIN 1	//a player ghosting out of the mob will make the mob playable for others, if it was already playable
-#define SENTIENCE_FORCE 2		//the mob will be made playable by force when a player is forcefully ejected from a mob (by admin, for example)
-#define SENTIENCE_ERASE 3
+#define SENTIENCE_ERASE 2
 
 //Flavor Text When Entering A Playable Mob
 #define FLAVOR_TEXT_EVIL "evil"	//mob antag

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -626,7 +626,10 @@ so as to remain in compliance with the most up-to-date laws."
 /atom/movable/screen/alert/notify_action/Click()
 	if(!usr || !usr.client || usr != owner)
 		return
-	if(!target)
+	// Send the signal to be able to handle additional intercepts
+
+	// If the thing isn't an atom, or is null, stop
+	if(!istype(target))
 		return
 	var/mob/dead/observer/ghost_owner = usr
 	if(!istype(ghost_owner))
@@ -639,7 +642,7 @@ so as to remain in compliance with the most up-to-date laws."
 	//Other additional actions
 	switch(action)
 		if(NOTIFY_ATTACK)
-			target.attack_ghost(ghost_owner)
+			target.attack_ghost(ghost_owner, FALSE)
 		if(NOTIFY_ORBIT)
 			ghost_owner.check_orbitable(target)
 

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -43,11 +43,11 @@
 		return
 	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below
-	A.attack_ghost(src)
+	A.attack_ghost(src, TRUE)
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
-/atom/proc/attack_ghost(mob/dead/observer/user)
-	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_GHOST, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+/atom/proc/attack_ghost(mob/dead/observer/user, direct)
+	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_GHOST, user, direct) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 	if(user.client)
 		if(user.gas_scan && atmosanalyzer_scan(user, src))

--- a/code/datums/components/ghost_spawner.dm
+++ b/code/datums/components/ghost_spawner.dm
@@ -1,0 +1,217 @@
+
+#define GHOST_SPAWNER_MURDERBONE "You are a smart, but primitive being. You kill either out of instinct, fear, or to protect your race. Protect yourself, your allies and survive no matter the cost."
+#define GHOST_SPAWNER_NEUTRAL "Your story is yours and yours alone, you are a neutral being that exists to serve its own goals and desires. You may find allies along the way, or betray those in order to climb higher. Whatever you do, it should be done out of the desire to survive."
+#define GHOST_SPAWNER_STATION "You are a creature of the station, help and protect your friends from danger!"
+#define GHOST_SPAWNER_HOSTILE "The station operates as normal while injustice spreads across the world like a plague. Whatever your motive, your actions should be driven by it and it should push your story forward."
+#define GHOST_SPAWNER_SLAVE "You exist to serve your master. Your master's goals are your goals and you pledge eternal servitude towards them."
+
+/**
+ * Attaching this component to an object will cause observers to be able to interact with
+ * to spawn in as a provided mob.
+ */
+
+/datum/component/ghost_spawner
+	/// What ban setting to use for the spawner
+	var/ban_key
+	/// If this is set, then upon activation the owner will be deleted
+	/// and this will be spawned instead.
+	var/spawned_type = null
+	/// If you want to create the mob via a proc instead, then use this.
+	/// Arguments: mob/user (person performing the action)
+	/// Only executed if we are attached to a structure
+	var/datum/callback/spawn_proc = null
+	/// If a spawner is set to unique, then it will show up multiple times
+	/// for each individual spawner on the ghost alert. Otherwise they will
+	/// be grouped together and players will be distributed amongst the available
+	/// mobs for that type (A unique alert will not appear if another exists at the
+	/// same time, which prevents spamming)
+	var/unique = FALSE
+	/// If we are using a spawned type, should we delete the parent after spawning?
+	var/remove_after_spawn = FALSE
+	/// Flavour message to be shown upon spawn
+	var/flavour_message = null
+	/// If set, we will become bound to this mob upon spawning
+	var/datum/mind/master = null
+	/// If set
+	/// Have we alerted already?
+	var/_alerted = FALSE
+
+/datum/component/ghost_spawner/Initialize(
+		ban_key,
+		unique = FALSE,
+		spawned_type = null,
+		datum/callback/spawn_proc = null,
+		remove_after_spawn = TRUE,
+		flavour_message = GHOST_SPAWNER_NEUTRAL,
+		mob/living/master = null,
+		)
+	if (spawned_type && !ispath(spawned_type, /mob/living))
+		stack_trace("Attempted to create a ghost spawner with an invalid spawned type, the spawned type must be a typepath derived from /mob/living.")
+		return COMPONENT_INCOMPATIBLE
+	src.ban_key = ban_key
+	src.spawned_type = spawned_type
+	src.unique = unique
+	src.remove_after_spawn = remove_after_spawn
+	src.master = master
+	src.flavour_message = flavour_message
+	src.spawn_proc = spawn_proc
+
+/datum/component/ghost_spawner/RegisterWithParent()
+	var/mob/living/parent_mob = parent
+	raise_spawner_alert()
+	// Handle the attack
+	RegisterSignal(parent_mob, COMSIG_ATOM_ATTACK_GHOST, PROC_REF(on_ghost_interaction))
+	RegisterSignal(parent_mob, COMSIG_LIVING_DEATH, PROC_REF(on_mob_death))
+	RegisterSignal(parent_mob, COMSIG_MOB_GHOSTIZE, PROC_REF(on_mob_ghost))
+
+/datum/component/ghost_spawner/UnregisterFromParent()
+	var/mob/living/parent_mob = parent
+	parent_mob.RemoveElement(/datum/element/point_of_interest)
+	remove_from_spawner_menu()
+	UnregisterSignal(parent_mob, COMSIG_ATOM_ATTACK_GHOST)
+
+/datum/component/ghost_spawner/proc/remove_from_spawner_menu()
+	_alerted = FALSE
+	var/mob/living/parent_mob = parent
+	for(var/spawner in GLOB.mob_spawners)
+		GLOB.mob_spawners[spawner] -= parent_mob
+		if(!length(GLOB.mob_spawners[spawner]))
+			GLOB.mob_spawners -= spawner
+	SSmobs.update_spawners()
+
+/datum/component/ghost_spawner/proc/on_mob_ghost(datum/source, can_reenter_corpse, sentience_retention)
+	SIGNAL_HANDLER
+	if (sentience_retention == SENTIENCE_SKIP)
+		return
+	if (sentience_retention == SENTIENCE_ERASE)
+		qdel(src)
+		return
+	raise_spawner_alert()
+
+/// When the mob dies, remove from the spawner menu but don't remove this
+/// component.
+/datum/component/ghost_spawner/proc/on_mob_death()
+	SIGNAL_HANDLER
+	remove_from_spawner_menu()
+
+/datum/component/ghost_spawner/proc/raise_spawner_alert()
+	var/mob/living/parent_mob = parent
+	// Don't showcase dead mobs that become controllable
+	if (parent_mob.key || parent_mob.stat == DEAD)
+		return
+	if (_alerted)
+		return
+	_alerted = TRUE
+	// Send out the notification
+	notify_ghosts(
+		"[parent_mob.name] can be controlled",
+		enter_link="<a href=?src=[REF(src)];activate=1>(Click to play)</a>",
+		source=parent_mob,
+		action=NOTIFY_ATTACK,
+		notification_key=unique ? "[REF(parent_mob)]_notify_action" : "[parent_mob.type]_notify_action"
+		)
+	// Add the spawner
+	// Use the initial name if it has random numbers at the end of the name
+	LAZYADD(GLOB.mob_spawners[get_source_name()], parent_mob)
+	parent_mob.AddElement(/datum/element/point_of_interest)
+	SSmobs.update_spawners()
+
+/datum/component/ghost_spawner/proc/on_ghost_interaction(datum/source, mob/dead/observer/ghost, direct)
+	SIGNAL_HANDLER
+	// Check if we need to hand off to a group
+	if (!unique && !direct)
+		spawn_into_group(ghost)
+	else
+		// Spawn into the specific mob
+		spawn_into_mob(ghost, parent)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/datum/component/ghost_spawner/proc/spawn_into_group(mob/dead/observer/player)
+	set waitfor = FALSE
+	// Find an uninhabited mob from the group that we can spawn in
+	var/list/mob_spawn_group = GLOB.mob_spawners[get_source_name()]
+	if (!mob_spawn_group)
+		return
+	if (!player.client)
+		return
+	var/mob/living/closest_mob = null
+	var/closest_distance = INFINITY
+	// Order by the ones closest to the player
+	for (var/mob/living/target in mob_spawn_group)
+		var/distance = get_dist(target, player)
+		if (distance > closest_distance)
+			continue
+		if (!can_become_role(player.client, target))
+			continue
+		closest_mob = target
+		closest_distance = distance
+	if (!closest_mob)
+		return
+	// Will perform the role check again to safely handle sleeping code
+	spawn_into_mob(player, closest_mob)
+
+/datum/component/ghost_spawner/proc/spawn_into_mob(mob/dead/observer/player, mob/living/target)
+	set waitfor = FALSE
+	if (!player.client)
+		return
+	var/mob/living/parent_mob = parent
+	if (!can_become_role(player.client, parent_mob))
+		return
+	// If the parent is not a mob, then delete it if necessary
+	if (!istype(parent_mob))
+		var/atom/parent_atom = parent
+		if (spawn_proc)
+			parent_mob = spawn_proc.Invoke(player)
+			if (!parent_mob)
+				return
+			if (remove_after_spawn)
+				qdel(parent)
+		else
+			parent_mob = new spawned_type(parent_atom.loc)
+			if (remove_after_spawn)
+				qdel(parent)
+	// Perform the spawning
+	parent_mob.key = player.key
+	log_game("[key_name(player)] took control of [parent_mob.name] ([parent_mob.type]) at [COORD(parent_mob)].")
+	remove_from_spawner_menu()
+	var/list/spawn_message = list()
+	spawn_message += "<span class='big bold spawn_header'>You are [parent_mob.name]!</span>"
+	// Setup master stuff
+	if (!parent_mob.mind)
+		parent_mob.mind_initialize()
+	// Master overrides flavour text
+	if (master)
+		parent_mob.mind.enslave_mind_to_creator(master)
+		log_game("[key_name(parent_mob)] had their master set to '[master.name]'")
+		spawn_message += "Your master is [master.name], serve them. They may not be an antagonist, and you should not act like one unless otherwise told."
+	else
+		spawn_message += flavour_message
+	spawn_message += "<font color='red'>Please do not use memories from previous lives!</font>"
+	to_chat(parent_mob, "<span class='spawn_message'>[jointext(spawn_message, "<br />")]</span>")
+	parent_mob.sentience_act()
+
+/datum/component/ghost_spawner/proc/can_become_role(client/user, mob/living/target)
+	// This sleeps if the DB call isn't cached, so do it first
+	if (!user.can_take_ghost_spawner(ban_key, TRUE, target.flags_1 & ADMIN_SPAWNED_1))
+		return FALSE
+	if (!SSticker.HasRoundStarted())
+		return FALSE
+	if (!user)
+		return FALSE
+	if (target.key)
+		return FALSE
+	return TRUE
+
+/datum/component/ghost_spawner/Topic(href, list/href_list)
+	if (..())
+		return TRUE
+	if(href_list["activate"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			on_ghost_interaction(parent, ghost, FALSE)
+
+/datum/component/ghost_spawner/proc/get_source_name()
+	var/mob/living/parent_mob = parent
+	. = (parent_mob.unique_name && !unique) ? initial(parent_mob.name) : parent_mob.name
+	if (master)
+		. += " (Master: [master.name])"

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -94,7 +94,7 @@
 	SIGNAL_HANDLER
 	remove_circuit()
 
-/datum/component/shell/proc/on_attack_ghost(datum/source, mob/dead/observer/ghost)
+/datum/component/shell/proc/on_attack_ghost(datum/source, mob/dead/observer/ghost, direct)
 	SIGNAL_HANDLER
 	if(attached_circuit)
 		INVOKE_ASYNC(attached_circuit, TYPE_PROC_REF(/datum, ui_interact), ghost)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -80,7 +80,7 @@
 /datum/disease/transformation/proc/replace_banned_player(var/mob/living/new_mob) // This can run well after the mob has been transferred, so need a handle on the new mob to kill it if needed.
 	set waitfor = FALSE
 
-	affected_mob.AddComponent(/datum/component/ghost_spawner, bantype, TRUE)
+	affected_mob.AddComponent(/datum/component/ghost_spawner, bantype, TRUE, flavour_message="You are a cyborg! You are bound by your laws and your master AI.")
 	to_chat(affected_mob, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
 
 	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as [affected_mob.name]?", bantype, null, 7.5 SECONDS, affected_mob, ignore_category = FALSE)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -80,8 +80,7 @@
 /datum/disease/transformation/proc/replace_banned_player(var/mob/living/new_mob) // This can run well after the mob has been transferred, so need a handle on the new mob to kill it if needed.
 	set waitfor = FALSE
 
-	affected_mob.playable_bantype = bantype
-	affected_mob.ghostize(TRUE,SENTIENCE_FORCE)
+	affected_mob.AddComponent(/datum/component/ghost_spawner, bantype, TRUE)
 	to_chat(affected_mob, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
 
 	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as [affected_mob.name]?", bantype, null, 7.5 SECONDS, affected_mob, ignore_category = FALSE)

--- a/code/datums/soullink.dm
+++ b/code/datums/soullink.dm
@@ -5,8 +5,6 @@
 	var/list/sharedSoullinks //soullinks we are a/the sharer of
 
 /mob/living/Destroy()
-	if(playable)
-		remove_from_spawner_menu()
 	for(var/s in ownedSoullinks)
 		var/datum/soullink/S = s
 		S.ownerDies(FALSE)

--- a/code/datums/spawners_menu.dm
+++ b/code/datums/spawners_menu.dm
@@ -27,11 +27,8 @@
 					this["important_info"] = MS.important_info
 				else
 					var/atom/movable/O = spawner_obj
-					if(isslime(O))
-						this["short_desc"] = O.get_spawner_desc()
-						this["flavor_text"] = O.get_spawner_flavour_text()
-					else
-						this["desc"] = O.desc
+					this["short_desc"] = O.get_spawner_desc()
+					this["flavor_text"] = O.get_spawner_flavour_text()
 
 		this["amount_left"] = LAZYLEN(GLOB.mob_spawners[spawner])
 		data["spawners"] += list(this)
@@ -61,5 +58,5 @@
 				. = TRUE
 		if("spawn")
 			if(MS)
-				MS.attack_ghost(usr)
+				MS.attack_ghost(usr, FALSE)
 				. = TRUE

--- a/code/game/machinery/computer/arena.dm
+++ b/code/game/machinery/computer/arena.dm
@@ -409,7 +409,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/computer/arena)
 			_controller = A
 			return _controller
 
-/obj/machinery/arena_spawn/attack_ghost(mob/user)
+/obj/machinery/arena_spawn/attack_ghost(mob/user, direct)
 	var/obj/machinery/computer/arena/C = get_controller()
 	if(!C) //Unlinked spawn
 		return

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -44,7 +44,7 @@
 		if(lock_override & CAMERA_LOCK_CENTCOM)
 			z_lock |= SSmapping.levels_by_trait(ZTRAIT_CENTCOM)
 
-/obj/machinery/computer/camera_advanced/attack_ghost(mob/dead/observer/ghost)
+/obj/machinery/computer/camera_advanced/attack_ghost(mob/dead/observer/ghost, direct)
 	. = ..()
 	if(.)
 		return

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -27,7 +27,7 @@
 	radio.canhear_range = 0
 	radio.recalculateChannels()
 
-/obj/machinery/ecto_sniffer/attack_ghost(mob/user)
+/obj/machinery/ecto_sniffer/attack_ghost(mob/user, direct)
 	if(!on || !sensor_enabled || !is_operational)
 		return
 

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -73,7 +73,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/launchpad)
 
 	return ..()
 
-/obj/machinery/launchpad/attack_ghost(mob/dead/observer/ghost)
+/obj/machinery/launchpad/attack_ghost(mob/dead/observer/ghost, direct)
 	. = ..()
 	if(.)
 		return

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -131,7 +131,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/quantumpad)
 	s.set_up(5, 1, get_turf(src))
 	s.start()
 
-/obj/machinery/quantumpad/attack_ghost(mob/dead/observer/ghost)
+/obj/machinery/quantumpad/attack_ghost(mob/dead/observer/ghost, direct)
 	. = ..()
 	if(.)
 		return

--- a/code/game/objects/effects/anomalies/anomaly_pyro.dm
+++ b/code/game/objects/effects/anomalies/anomaly_pyro.dm
@@ -33,4 +33,4 @@
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
 	S.flavor_text = FLAVOR_TEXT_EVIL
-	S.set_playable(ROLE_PYRO_SLIME)
+	S.AddComponent(/datum/component/ghost_spawner, ROLE_PYRO_SLIME, unique = TRUE)

--- a/code/game/objects/effects/anomalies/anomaly_pyro.dm
+++ b/code/game/objects/effects/anomalies/anomaly_pyro.dm
@@ -33,4 +33,4 @@
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
 	S.flavor_text = FLAVOR_TEXT_EVIL
-	S.AddComponent(/datum/component/ghost_spawner, ROLE_PYRO_SLIME, unique = TRUE)
+	S.AddComponent(/datum/component/ghost_spawner, ROLE_PYRO_SLIME, unique = TRUE, flavour_message=GHOST_SPAWNER_MURDERBONE)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -163,7 +163,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/portal)
 		linked = null
 	return ..()
 
-/obj/effect/portal/attack_ghost(mob/dead/observer/O)
+/obj/effect/portal/attack_ghost(mob/dead/observer/O, direct)
 	if(!teleport(O, TRUE))
 		return ..()
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -198,7 +198,7 @@
 	random_spider = new random_spider(get_turf(src))
 	random_spider.faction = faction.Copy()
 	random_spider.spider_team = spider_team
-	random_spider.set_playable(ROLE_SPIDER, POLL_IGNORE_SPIDER)
+	random_spider.set_playable(ROLE_SPIDER)
 	spawns_remaining--
 	if(!spawns_remaining)
 		qdel(src)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -169,7 +169,7 @@
 	random_spider = new random_spider(get_turf(src))
 	random_spider.faction = faction.Copy()
 	random_spider.spider_team = spider_team
-	random_spider.AddComponent(/datum/component/ghost_spawner, ROLE_SPIDER)
+	random_spider.AddComponent(/datum/component/ghost_spawner, ROLE_SPIDER, flavour_message=GHOST_SPAWNER_MURDERBONE)
 	spawns_remaining--
 	if(!spawns_remaining)
 		qdel(src)

--- a/code/game/objects/items/eightball.dm
+++ b/code/game/objects/items/eightball.dm
@@ -111,7 +111,7 @@
 	return FALSE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/item/toy/eightball/haunted/attack_ghost(mob/user)
+/obj/item/toy/eightball/haunted/attack_ghost(mob/user, direct)
 	if(!shaking)
 		to_chat(user, "<span class='warning'>[src] is not currently being shaken.</span>")
 		return

--- a/code/game/objects/items/hourglass.dm
+++ b/code/game/objects/items/hourglass.dm
@@ -73,7 +73,7 @@
 	if(user.client && user.client.holder)
 		toggle(user)
 
-/obj/item/hourglass/admin/attack_ghost(mob/user)
+/obj/item/hourglass/admin/attack_ghost(mob/user, direct)
 	if(user.client && user.client.holder)
 		toggle(user)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -222,7 +222,7 @@ CREATION_TEST_IGNORE_SELF(/obj)
 				obj_flags &= ~IN_USE
 
 
-/obj/attack_ghost(mob/user)
+/obj/attack_ghost(mob/user, direct)
 	. = ..()
 	if(.)
 		return

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -186,7 +186,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/ladder)
 		return use(R)
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/structure/ladder/attack_ghost(mob/dead/observer/user)
+/obj/structure/ladder/attack_ghost(mob/dead/observer/user, direct)
 	use(user, TRUE)
 	return ..()
 

--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -22,7 +22,7 @@
 
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/structure/spirit_board/attack_ghost(mob/dead/observer/user)
+/obj/structure/spirit_board/attack_ghost(mob/dead/observer/user, direct)
 	spirit_board_pick_letter(user)
 	return ..()
 

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -136,7 +136,7 @@
 			return FALSE
 	return TRUE
 
-/obj/structure/stairs/attack_ghost(mob/user)
+/obj/structure/stairs/attack_ghost(mob/user, direct)
 	stair_ascend(user)
 
 #undef STAIR_TERMINATOR_AUTOMATIC

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -81,7 +81,7 @@
 	return ..()
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/turf/open/space/attack_ghost(mob/dead/observer/user)
+/turf/open/space/attack_ghost(mob/dead/observer/user, direct)
 	if(destination_z)
 		var/turf/T = locate(destination_x, destination_y, destination_z)
 		user.forceMove(T)

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -32,7 +32,7 @@
 	qdel(src)
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/fun_balloon/attack_ghost(mob/user)
+/obj/effect/fun_balloon/attack_ghost(mob/user, direct)
 	if(!user.client || !user.client.holder || popped)
 		return
 	var/confirmation = alert("Pop [src]?","Fun Balloon","Yes","No")

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -711,7 +711,7 @@ GLOBAL_DATUM_INIT(admin_secrets, /datum/admin_secrets, new)
 					continue
 				if((L in GLOB.player_list) || L.mind || (L.flags_1 & HOLOGRAM_1))
 					continue
-				L.AddComponent(/datum/component/ghost_spawner, ROLE_SENTIENT_ANIMAL)
+				L.AddComponent(/datum/component/ghost_spawner, ROLE_SENTIENT_ANIMAL, flavour_message=GHOST_SPAWNER_NEUTRAL)
 
 		if("flipmovement")
 			if(!check_rights(R_FUN))

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -711,7 +711,7 @@ GLOBAL_DATUM_INIT(admin_secrets, /datum/admin_secrets, new)
 					continue
 				if((L in GLOB.player_list) || L.mind || (L.flags_1 & HOLOGRAM_1))
 					continue
-				L.set_playable(ROLE_SENTIENT_ANIMAL)
+				L.AddComponent(/datum/component/ghost_spawner, ROLE_SENTIENT_ANIMAL)
 
 		if("flipmovement")
 			if(!check_rights(R_FUN))

--- a/code/modules/admin/smites/ghostize.dm
+++ b/code/modules/admin/smites/ghostize.dm
@@ -5,5 +5,5 @@
 	. = ..()
 	if(target.key)
 		target.ghostize(FALSE)
-	target.AddComponent(/datum/component/ghost_spawner, BAN_ROLE_ALL_GHOST, TRUE)
+	target.AddComponent(/datum/component/ghost_spawner, BAN_ROLE_ALL_GHOST, TRUE, flavour_message="You have inhabited the body of [target.real_name].")
 

--- a/code/modules/admin/smites/ghostize.dm
+++ b/code/modules/admin/smites/ghostize.dm
@@ -4,7 +4,6 @@
 /datum/smite/ghostize/effect(client/user, mob/living/target)
 	. = ..()
 	if(target.key)
-		target.ghostize(FALSE,SENTIENCE_FORCE)
-	else
-		target.set_playable()
+		target.ghostize(FALSE)
+	target.AddComponent(/datum/component/ghost_spawner, BAN_ROLE_ALL_GHOST, TRUE)
 

--- a/code/modules/admin/sound_emitter.dm
+++ b/code/modules/admin/sound_emitter.dm
@@ -45,7 +45,7 @@
 		. += "<b>Alt-click it to quickly activate it!</b>"
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/sound_emitter/attack_ghost(mob/user)
+/obj/effect/sound_emitter/attack_ghost(mob/user, direct)
 	if(!check_rights_for(user.client, R_SOUND))
 		examine(user)
 		return

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -153,8 +153,8 @@ GLOBAL_LIST(admin_antag_list)
 		owner.current.ghostize(FALSE)
 		owner.current.key = C.key
 	else
-		owner.current.playable_bantype = banning_key
-		owner.current.ghostize(FALSE,SENTIENCE_FORCE)
+		owner.current.AddComponent(/datum/component/ghost_spawner, banning_key, TRUE)
+		owner.current.ghostize(FALSE)
 
 ///Called by the remove_antag_datum() and remove_all_antag_datums() mind procs for the antag datum to handle its own removal and deletion.
 /datum/antagonist/proc/on_removal()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST(admin_antag_list)
 		owner.current.ghostize(FALSE)
 		owner.current.key = C.key
 	else
-		owner.current.AddComponent(/datum/component/ghost_spawner, banning_key, TRUE)
+		owner.current.AddComponent(/datum/component/ghost_spawner, banning_key, TRUE, flavour_message="You have inhabited the body of [name].")
 		owner.current.ghostize(FALSE)
 
 ///Called by the remove_antag_datum() and remove_all_antag_datums() mind procs for the antag datum to handle its own removal and deletion.

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -167,8 +167,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/hostile/blob/blobspore)
 	oldguy = H
 	update_icons()
 	visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
-	if(!key)
-		set_playable(ROLE_BLOB)
+	AddComponent(/datum/component/ghost_spawner, ROLE_BLOB, unique = TRUE, flavour_message = GHOST_SPAWNER_SLAVE)
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
 	// On death, create a small smoke of harmful gas (s-Acid)
@@ -256,7 +255,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/hostile/blob/blobspore)
 	pressure_resistance = 50
 	mob_size = MOB_SIZE_LARGE
 	hud_type = /datum/hud/blobbernaut
-	flavor_text = FLAVOR_TEXT_GOAL_ANTAG
 	move_resist = MOVE_FORCE_STRONG
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life()

--- a/code/modules/antagonists/clock_cult/clockwork_massive.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_massive.dm
@@ -296,7 +296,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/eldritch/ratvar)
 		T = get_step(A, A.dir) //please don't slam into a window like a bird, Ratvar
 	forceMove(T)
 
-/obj/eldritch/ratvar/attack_ghost(mob/user)
+/obj/eldritch/ratvar/attack_ghost(mob/user, direct)
 	. = ..()
 	var/mob/living/simple_animal/drone/D = new /mob/living/simple_animal/drone/cogscarab(get_turf(src))
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)

--- a/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 	you have a set of quick tools, as well as a replica fabricator that can create brass for construction. Work with the servants of Ratvar \
 	to construct and maintain defenses at the City of Cogs."
 
-/obj/effect/mob_spawn/drone/cogscarab/attack_ghost(mob/user)
+/obj/effect/mob_spawn/drone/cogscarab/attack_ghost(mob/user, direct)
 	if(is_banned_from(user.ckey, ROLE_SERVANT_OF_RATVAR) || QDELETED(src) || QDELETED(user))
 		return
 	if(!SSticker.mode)

--- a/code/modules/antagonists/cult/narsie.dm
+++ b/code/modules/antagonists/cult/narsie.dm
@@ -88,7 +88,7 @@
 
 	return ..()
 
-/obj/eldritch/narsie/attack_ghost(mob/user)
+/obj/eldritch/narsie/attack_ghost(mob/user, direct)
 	makeNewConstruct(/mob/living/simple_animal/hostile/construct/harvester, user, cultoverride = TRUE, loc_override = loc)
 
 /obj/eldritch/narsie/process(delta_time)

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -136,7 +136,7 @@
 	last_carp_inc += delta_time
 	update_check()
 
-/obj/structure/carp_rift/attack_ghost(mob/user)
+/obj/structure/carp_rift/attack_ghost(mob/user, direct)
 	. = ..()
 	if(user?.client?.can_take_ghost_spawner(ROLE_SPACE_DRAGON, TRUE, is_ghost_role = FALSE))
 		summon_carp(user)

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -247,7 +247,7 @@
 	instagib_gear = /datum/outfit/ctf/blue/instagib
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/machinery/capture_the_flag/attack_ghost(mob/user)
+/obj/machinery/capture_the_flag/attack_ghost(mob/user, direct)
 	if(ctf_enabled == FALSE)
 		if(user.client?.holder)
 			var/response = tgui_alert(usr,"Enable this CTF game?", "CTF", list("Yes", "No"))
@@ -352,7 +352,7 @@
 	if(href_list["join"])
 		var/mob/dead/observer/ghost = usr
 		if(istype(ghost))
-			attack_ghost(ghost)
+			attack_ghost(ghost, FALSE)
 
 /obj/machinery/capture_the_flag/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/ctf))

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -37,7 +37,7 @@ CREATION_TEST_IGNORE_SELF(/obj/effect/mob_spawn)
 	var/is_antagonist = FALSE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/attack_ghost(mob/user)
+/obj/effect/mob_spawn/attack_ghost(mob/user, direct)
 	if(!loc || !ghost_usable)
 		return
 	if(!uses)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -289,6 +289,8 @@ Works together with spawning an observer, noted above.
 
 /mob/proc/ghostize(can_reenter_corpse = TRUE,sentience_retention = SENTIENCE_SKIP)
 	SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, can_reenter_corpse, sentience_retention)
+	if (client && !can_reenter_corpse)
+		client.next_ghost_role_tick = max(client.next_ghost_role_tick, world.time + CONFIG_GET(number/ghost_role_cooldown))
 	if(key)
 		if(key[1] != "@") // Skip aghosts.
 			stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -288,6 +288,7 @@ Works together with spawning an observer, noted above.
 */
 
 /mob/proc/ghostize(can_reenter_corpse = TRUE,sentience_retention = SENTIENCE_SKIP)
+	SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, can_reenter_corpse, sentience_retention)
 	if(key)
 		if(key[1] != "@") // Skip aghosts.
 			stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -70,7 +70,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		visible_message(fail_message)
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/item/mmi/posibrain/attack_ghost(mob/user)
+/obj/item/mmi/posibrain/attack_ghost(mob/user, direct)
 	activate(user)
 
 /obj/item/mmi/posibrain/proc/is_occupied()

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -27,15 +27,11 @@
 	var/max_grown = 100
 	var/time_of_birth
 
-	flavor_text = FLAVOR_TEXT_EVIL
-	playable = TRUE
-
-
 //This is fine right now, if we're adding organ specific damage this needs to be updated
 /mob/living/carbon/alien/larva/Initialize(mapload)
-
 	AddAbility(new/obj/effect/proc_holder/alien/hide(null))
 	AddAbility(new/obj/effect/proc_holder/alien/larva_evolve(null))
+	AddComponent(/datum/component/ghost_spawner, ROLE_ALIEN, flavour_message = GHOST_SPAWNER_MURDERBONE)
 	. = ..()
 
 /mob/living/carbon/alien/larva/create_internal_organs()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -63,8 +63,6 @@
 			deadchat_broadcast(rendered, follow_target = src, turf_target = T, message_type=DEADCHAT_DEATHRATTLE)
 		mind.store_memory("Time of death: [tod]", 0)
 	remove_from_alive_mob_list()
-	if(playable)
-		remove_from_spawner_menu()
 	if(!gibbed && !was_dead_before)
 		add_to_dead_mob_list()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -18,10 +18,6 @@
 		diag_hud.add_to_hud(src)
 	faction += "[REF(src)]"
 	GLOB.mob_living_list += src
-	if (playable)
-		addtimer(CALLBACK(src, PROC_REF(set_playable)), 2 SECONDS) //announce playable mobs to ghosts
-		// this should be delayed because some 'playable=TRUE' mobs are not actually playable because mob key is automatically given
-		// it prevents 'GLOB.poi_list' being glitched. without this, it will show xeno(or some mobs) twice in orbit panel.
 	//color correction
 	RegisterSignal(src, COMSIG_MOVABLE_ENTERED_AREA, PROC_REF(apply_color_correction))
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -160,8 +160,6 @@
 	/// Is this mob allowed to be buckled/unbuckled to/from things?
 	var/can_buckle_to = TRUE
 
-	//is mob player controllable
-	var/playable = FALSE
 	var/flavor_text = FLAVOR_TEXT_NONE
 
 	///The y amount a mob's sprite should be offset due to the current position they're in (e.g. lying down moves your sprite down)

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -1,63 +1,5 @@
 //WHY ISN'T THIS COMPONENT
 
-/// The ban type to check if somebody attempts to play this "playable mob"
-/mob/living/var/playable_bantype
-
-/mob/living/ghostize(can_reenter_corpse, sentience_retention)
-	. = ..()
-	switch(sentience_retention)
-		if (SENTIENCE_RETAIN)
-			if (playable)	//so the alert goes through for observing ghosts
-				set_playable(playable_bantype)
-		if (SENTIENCE_FORCE)
-			set_playable(playable_bantype)
-		if (SENTIENCE_ERASE)
-			playable = FALSE
-			playable_bantype = null
-
-/mob/living/attack_ghost(mob/user)
-	. = ..()
-	if(.)
-		return
-	give_mind(user)
-
-/mob/living/Topic(href, href_list)
-	if(..())
-		return
-	if(href_list["activate"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost) && playable)
-			give_mind(ghost)
-
-/mob/living/proc/give_mind(mob/user)
-	if(key || !playable || stat)
-		return FALSE
-	var/question = alert("Do you want to become [name]?", "[name]", "Yes", "No")
-	if(question != "Yes" || !src || QDELETED(src))
-		return FALSE
-	if(key)
-		to_chat(user, "<span class='notice'>Someone else already took [name].</span>")
-		return FALSE
-	if(!SSticker.HasRoundStarted())
-		return FALSE
-	if(!user?.client?.can_take_ghost_spawner(playable_bantype, TRUE, flags_1 & ADMIN_SPAWNED_1))
-		return FALSE
-	key = user.key
-	log_game("[key_name(src)] took control of [name].")
-	remove_from_spawner_menu()
-	if(get_spawner_flavour_text())
-		to_chat(src, "<span class='spawn_message'><span class='big bold'>You are [src]!</span><br/>[get_spawner_flavour_text()]<br>Please do not use memories from previous lives!</span>")
-	return TRUE
-
-/mob/living/proc/set_playable(ban_type = null)
-	playable = TRUE
-	playable_bantype = ban_type
-	if (!key)	//check if there is nobody already inhibiting this mob
-		notify_ghosts("[name] can be controlled", null, enter_link="<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source=src, action=NOTIFY_ATTACK, ignore_key = poll_ignore_key)
-		LAZYADD(GLOB.mob_spawners["[name]"], src)
-		AddElement(/datum/element/point_of_interest)
-		SSmobs.update_spawners()
-
 /mob/living/get_spawner_desc()
 	return "Become [name]."
 
@@ -71,9 +13,5 @@
 			return "You have a disdain for the inhabitants of this station, but your goals are more important. Make sure you work towards your objectives with your kin, instead of attacking everything on sight."
 	return flavor_text
 
-/mob/living/proc/remove_from_spawner_menu()
-	for(var/spawner in GLOB.mob_spawners)
-		GLOB.mob_spawners[spawner] -= src
-		if(!length(GLOB.mob_spawners[spawner]))
-			GLOB.mob_spawners -= spawner
-		SSmobs.update_spawners()
+/mob/living/proc/sentience_act(mob/user)
+	return

--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -46,10 +46,10 @@
 	log_game("[key_name(src)] took control of [name].")
 	remove_from_spawner_menu()
 	if(get_spawner_flavour_text())
-		to_chat(src, "<span class='notice'>[get_spawner_flavour_text()]</span>")
+		to_chat(src, "<span class='spawn_message'><span class='big bold'>You are [src]!</span><br/>[get_spawner_flavour_text()]<br>Please do not use memories from previous lives!</span>")
 	return TRUE
 
-/mob/living/proc/set_playable(ban_type = null, poll_ignore_key = null)
+/mob/living/proc/set_playable(ban_type = null)
 	playable = TRUE
 	playable_bantype = ban_type
 	if (!key)	//check if there is nobody already inhibiting this mob
@@ -57,9 +57,6 @@
 		LAZYADD(GLOB.mob_spawners["[name]"], src)
 		AddElement(/datum/element/point_of_interest)
 		SSmobs.update_spawners()
-	else // it's spawned but someone occupied already
-		notify_ghosts("[name] has appeared!", source=src, action=NOTIFY_ORBIT, header="Something's Interesting!")
-
 
 /mob/living/get_spawner_desc()
 	return "Become [name]."

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -40,7 +40,7 @@
 			possible_seasonal_hats += holiday.drone_hat
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/drone/attack_ghost(mob/user)
+/obj/effect/mob_spawn/drone/attack_ghost(mob/user, direct)
 	if(is_banned_from(user.ckey, ROLE_DRONE) || QDELETED(src) || QDELETED(user))
 		return
 	if(!SSticker.mode)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -102,13 +102,9 @@
 		return FALSE
 	SSmove_manager.stop_looping(src) // Just in case the AI's doing anything when we give them the mind
 	GLOB.spidermobs[src] = TRUE
-
-/mob/living/simple_animal/hostile/poison/giant_spider/give_mind(mob/user)
-	..()
 	var/datum/antagonist/spider/spider_antag = mind?.has_antag_datum(/datum/antagonist/spider)
 	if(spider_antag.spider_team.directive)
 		log_game("[key_name(src)] took control of [name] with the objective: '[spider_antag.spider_team.directive]'.")
-	return TRUE
 
 // Allows spiders to take damage slowdown. 2 max, but they don't start moving slower until under 75% health
 /mob/living/simple_animal/hostile/poison/giant_spider/updatehealth()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -680,7 +680,7 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 		ready_to_deploy = TRUE
 		notify_ghosts("An anomalous crystal has been activated in [get_area(src)]! This crystal can always be used by ghosts hereafter.", enter_link = "<a href=?src=[REF(src)];ghostjoin=1>(Click to enter)</a>", ghost_sound = 'sound/effects/ghost2.ogg', source = src, action = NOTIFY_ATTACK, header = "Anomalous crystal activated")
 
-/obj/machinery/anomalous_crystal/helpers/attack_ghost(mob/dead/observer/user)
+/obj/machinery/anomalous_crystal/helpers/attack_ghost(mob/dead/observer/user, direct)
 	. = ..()
 	if(.)
 		return
@@ -695,7 +695,7 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 	if(href_list["ghostjoin"])
 		var/mob/dead/observer/ghost = usr
 		if(istype(ghost))
-			attack_ghost(ghost)
+			attack_ghost(ghost, FALSE)
 
 /mob/living/simple_animal/hostile/lightgeist
 	name = "lightgeist"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
@@ -66,6 +66,7 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	GLOB.poi_list |= src
+	set_playable(BAN_ROLE_ALL_GHOST)
 
 /mob/living/simple_animal/hostile/retaliate/nymph/get_stat_tab_status()
 	var/list/tab_data = ..()
@@ -145,22 +146,8 @@
 	new /obj/effect/decal/cleanable/insectguts(drop_location())
 	playsound(drop_location(), 'sound/effects/blobattack.ogg', 60, TRUE)
 
-/mob/living/simple_animal/hostile/retaliate/nymph/attack_ghost(mob/dead/observer/user)
-	if(client || key || ckey)
-		to_chat(user, "<span class='warning'>\The [src] already has a player.")
-		return
-	if(!is_ghost_spawn || stat == DEAD || is_drone)
-		to_chat(user, "<span class='warning'>\The [src] is not possessable!")
-		return
-	var/control_ask = tgui_alert(usr, "Do you wish to take control of \the [src]", "Chirp Time?", list("Yes", "No"))
-	if(control_ask != "Yes" || !src || QDELETED(src) || QDELETED(user))
-		return FALSE
-	if(QDELETED(src) || QDELETED(user) || !user.client)
-		return
-	var/mob/living/simple_animal/hostile/retaliate/nymph/newnymph = src
-	newnymph.key = user.key
-	newnymph.unique_name = TRUE
-	to_chat(newnymph, "<span class='boldwarning'>Remember that you have forgotten all of your past lives and are a new person!</span>")
+/mob/living/simple_animal/hostile/retaliate/nymph/get_spawner_flavour_text()
+	return "You have inhabited a nymph!"
 
 /mob/living/simple_animal/hostile/retaliate/nymph/proc/update_progression()
 	if(amount_grown < max_grown)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
@@ -63,7 +63,7 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	GLOB.poi_list |= src
-	AddComponent(/datum/component/ghost_spawner, BAN_ROLE_ALL_GHOST)
+	AddComponent(/datum/component/ghost_spawner, BAN_ROLE_ALL_GHOST, flavour_message=GHOST_SPAWNER_STATION)
 
 /mob/living/simple_animal/hostile/retaliate/nymph/get_stat_tab_status()
 	var/list/tab_data = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
@@ -33,13 +33,13 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	attack_sound = 'sound/emotes/diona/hit.ogg'
 	minbodytemp = 2.7
+	unique_name = TRUE
 	var/can_namepick_as_adult = FALSE
 	var/death_msg = "expires with a pitiful chirrup..."
 
 	var/amount_grown = 0
 	var/max_grown = 150
 	var/time_of_birth
-	var/instance_num
 	var/is_ghost_spawn = TRUE //For if a ghost can become this.
 	var/is_drone = FALSE //Is a remote controlled nymph from a diona.
 	var/drone_parent //The diona which can control the nymph, if there is one
@@ -56,9 +56,6 @@
 	time_of_birth = world.time
 	evolve_ability = new
 	evolve_ability.Grant(src)
-	instance_num = rand(1, 1000)
-	name = "[initial(name)] ([instance_num])"
-	real_name = name
 	regenerate_icons()
 	ADD_TRAIT(src, TRAIT_MUTE, "nymph")
 	var/static/list/loc_connections = list(
@@ -66,7 +63,7 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	GLOB.poi_list |= src
-	set_playable(BAN_ROLE_ALL_GHOST)
+	AddComponent(/datum/component/ghost_spawner, BAN_ROLE_ALL_GHOST)
 
 /mob/living/simple_animal/hostile/retaliate/nymph/get_stat_tab_status()
 	var/list/tab_data = ..()
@@ -147,7 +144,7 @@
 	playsound(drop_location(), 'sound/effects/blobattack.ogg', 60, TRUE)
 
 /mob/living/simple_animal/hostile/retaliate/nymph/get_spawner_flavour_text()
-	return "You have inhabited a nymph!"
+	return "You have inhabited a nymph, you are a plant-like creature waiting to grow up!"
 
 /mob/living/simple_animal/hostile/retaliate/nymph/proc/update_progression()
 	if(amount_grown < max_grown)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -201,7 +201,7 @@
 	. = ..()
 	to_chat(src, "<span class='boldwarning'>You are venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!</span>")
 
-/mob/living/simple_animal/hostile/venus_human_trap/attack_ghost(mob/user)
+/mob/living/simple_animal/hostile/venus_human_trap/attack_ghost(mob/user, direct)
 	. = ..()
 	if(. || !(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER))
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -539,7 +539,7 @@
 		animate(src, transform = ntransform, time = 2, easing = EASE_IN|EASE_OUT)
 	UPDATE_OO_IF_PRESENT
 
-/mob/living/simple_animal/proc/sentience_act(mob/user) //Called when a simple animal gains sentience via gold slime potion
+/mob/living/simple_animal/sentience_act() //Called when a simple animal gains sentience via gold slime potion
 	toggle_ai(AI_OFF) // To prevent any weirdness.
 	can_have_ai = FALSE
 
@@ -689,8 +689,3 @@
 	if (AIStatus == AI_Z_OFF)
 		SSidlenpcpool.idle_mobs_by_zlevel[old_z] -= src
 		toggle_ai(initial(AIStatus))
-
-/mob/living/simple_animal/give_mind(mob/user)
-	. = ..()
-	if(.)
-		sentience_act(user)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -118,7 +118,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime)
 	. = ..()
 	set_nutrition(SLIME_DEFAULT_NUTRITION)
 	if(transformeffects & SLIME_EFFECT_LIGHT_PINK)
-		set_playable(ROLE_SENTIENCE)
+		AddComponent(/datum/component/ghost_spawner, ROLE_SENTIENCE, flavour_message=GHOST_SPAWNER_SLAVE, master=master?.mind)
 
 /mob/living/simple_animal/slime/Destroy()
 	set_target(null)
@@ -534,13 +534,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime/random)
 
 /mob/living/simple_animal/slime/get_discovery_id()
 	return "[colour] slime"
-
-/mob/living/simple_animal/slime/give_mind(mob/user)
-	. = ..()
-	if (.)
-		if(mind && master)
-			mind.store_memory("<b>Serve [master.real_name], your master.</b>")
-	return .
 
 /mob/living/simple_animal/slime/get_spawner_desc()
 	return "be a slime[master ? " under the command of [master.real_name]" : ""]."

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -118,7 +118,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime)
 	. = ..()
 	set_nutrition(SLIME_DEFAULT_NUTRITION)
 	if(transformeffects & SLIME_EFFECT_LIGHT_PINK)
-		AddComponent(/datum/component/ghost_spawner, ROLE_SENTIENCE, flavour_message=GHOST_SPAWNER_SLAVE, master=master?.mind)
+		AddComponent(/datum/component/ghost_spawner, ROLE_SENTIENCE, master=master?.mind)
 
 /mob/living/simple_animal/slime/Destroy()
 	set_target(null)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -409,9 +409,25 @@
   * * notify_suiciders If it should notify suiciders (who do not qualify for many ghost roles)
   * * notify_volume How loud the sound should be to spook the user
   */
-/proc/notify_ghosts(var/message, var/ghost_sound = null, var/enter_link = null, var/atom/source = null, var/mutable_appearance/alert_overlay = null, var/action = NOTIFY_JUMP, flashwindow = TRUE, ignore_mapload = TRUE, ignore_key, header = null, notify_suiciders = TRUE, var/notify_volume = 100) //Easy notification of ghosts.
+/proc/notify_ghosts(
+		message,
+		ghost_sound = null,
+		enter_link = null,
+		var/atom/source = null,
+		var/mutable_appearance/alert_overlay = null,
+		action = NOTIFY_JUMP,
+		flashwindow = TRUE,
+		ignore_mapload = TRUE,
+		ignore_key,
+		header = null,
+		notify_suiciders = TRUE,
+		notify_volume = 100,
+		notification_key
+	) //Easy notification of ghosts.
 	if(ignore_mapload && SSatoms.initialized != INITIALIZATION_INNEW_REGULAR)	//don't notify for objects created during a map load
 		return
+	if (!notification_key)
+		notification_key = "[REF(source)]_notify_action"
 	for(var/mob/dead/observer/O in GLOB.player_list)
 		if(O.client)
 			if(!notify_suiciders && (O in GLOB.suicided_mob_list))
@@ -427,7 +443,7 @@
 			if(flashwindow)
 				window_flash(O.client)
 			if(source)
-				var/atom/movable/screen/alert/notify_action/A = O.throw_alert("[REF(source)]_notify_action", /atom/movable/screen/alert/notify_action)
+				var/atom/movable/screen/alert/notify_action/A = O.throw_alert(notification_key, /atom/movable/screen/alert/notify_action)
 				if(A)
 					var/ui_style = O.client?.prefs?.read_player_preference(/datum/preference/choiced/ui_style)
 					if(ui_style)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -559,7 +559,7 @@
 		message_admins("[key_name_admin(chosen_candidate)] has taken control of ([key_name_admin(src)]) to replace a jobbanned player.")
 		key = chosen_candidate.key
 	else
-		set_playable(JOB_NAME_CYBORG)
+		AddComponent(/datum/component/ghost_spawner, JOB_NAME_CYBORG, unique = TRUE)
 
 //human -> alien
 /mob/living/carbon/human/proc/Alienize()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -559,7 +559,7 @@
 		message_admins("[key_name_admin(chosen_candidate)] has taken control of ([key_name_admin(src)]) to replace a jobbanned player.")
 		key = chosen_candidate.key
 	else
-		AddComponent(/datum/component/ghost_spawner, JOB_NAME_CYBORG, unique = TRUE)
+		AddComponent(/datum/component/ghost_spawner, JOB_NAME_CYBORG, unique = TRUE, flavour_message="You are a cyborg, bound by your laws and master AI.")
 
 //human -> alien
 /mob/living/carbon/human/proc/Alienize()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -238,7 +238,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 /obj/item/modular_computer/attack_silicon(mob/user)
 	return attack_self(user)
 
-/obj/item/modular_computer/attack_ghost(mob/dead/observer/user)
+/obj/item/modular_computer/attack_ghost(mob/dead/observer/user, direct)
 	. = ..()
 	if(.)
 		return

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -62,7 +62,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/modular_computer/processor)
 	machinery_computer.update_icon()
 	return
 
-/obj/item/modular_computer/processor/attack_ghost(mob/user)
+/obj/item/modular_computer/processor/attack_ghost(mob/user, direct)
 	ui_interact(user)
 
 /obj/item/modular_computer/processor/alert_call(datum/computer_file/program/caller, alerttext)

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -40,12 +40,12 @@
 	. = ..()
 	. += get_modular_computer_parts_examine(user)
 
-/obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user)
+/obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user, direct)
 	. = ..()
 	if(.)
 		return
 	if(cpu)
-		cpu.attack_ghost(user)
+		cpu.attack_ghost(user, direct)
 
 /obj/machinery/modular_computer/should_emag(mob/user)
 	if(!cpu)

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -588,7 +588,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/cerulean_slime_crystal)
 /obj/structure/slime_crystal/lightpink
 	colour = "light pink"
 
-/obj/structure/slime_crystal/lightpink/attack_ghost(mob/user)
+/obj/structure/slime_crystal/lightpink/attack_ghost(mob/user, direct)
 	. = ..()
 	var/mob/living/simple_animal/hostile/lightgeist/slime/L = new(get_turf(src))
 	L.ckey = user.ckey

--- a/code/modules/research/xenobiology/crossbreeding/transformative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/transformative.dm
@@ -26,7 +26,9 @@ transformative extracts:
 /obj/item/slimecross/transformative/proc/do_effect(mob/living/simple_animal/slime/S, mob/user)
 	SHOULD_CALL_PARENT(TRUE)
 	if(S.transformeffects & SLIME_EFFECT_LIGHT_PINK)
-		S.remove_from_spawner_menu()
+		var/spawner_effect = S.GetComponent(/datum/component/ghost_spawner)
+		if (spawner_effect)
+			qdel(spawner_effect)
 		S.master = null
 	if(S.transformeffects & SLIME_EFFECT_METAL)
 		S.maxHealth = round(S.maxHealth/1.3)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -755,7 +755,7 @@
 		var/mob/dead/observer/C = pick(candidates)
 		SM.key = C.key
 		SM.mind.enslave_mind_to_creator(user)
-		SM.sentience_act(user)
+		SM.sentience_act()
 		to_chat(SM, "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>")
 		to_chat(SM, "<span class='userdanger'>You are grateful to be self aware and owe [user.real_name] a great debt. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
 		if(SM.flags_1 & HOLOGRAM_1) //Check to see if it's a holodeck creature
@@ -823,7 +823,7 @@
 
 	user.mind.transfer_to(SM)
 	SM.faction = user.faction.Copy()
-	SM.sentience_act(user) //Same deal here as with sentience
+	SM.sentience_act() //Same deal here as with sentience
 	user.death()
 	to_chat(SM, "<span class='notice'>In a quick flash, you feel your consciousness flow into [SM]!</span>")
 	to_chat(SM, "<span class='warning'>You are now [SM]. Your allegiances, alliances, and role is still the same as it was prior to consciousness transfer!</span>")

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -278,7 +278,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	user.forceMove(get_turf(pickedstart))
 	user.throw_at(pickedgoal, 7, 3)
 
-/turf/closed/indestructible/hoteldoor/attack_ghost(mob/dead/observer/user)
+/turf/closed/indestructible/hoteldoor/attack_ghost(mob/dead/observer/user, direct)
 	if(!isobserver(user) || !parentSphere)
 		return ..()
 	user.forceMove(get_turf(parentSphere))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -35,7 +35,7 @@
 /datum/orbital_objective/assassination/generate_objective_stuff(turf/chosen_turf)
 	var/mob/living/carbon/human/created_human = new(chosen_turf)
 	//Maybe polling ghosts would be better than the shintience code
-	created_human.set_playable(ROLE_SURVIVALIST)
+	created_human.AddComponent(/datum/component/ghost_spawner, ROLE_SURVIVALIST, unique = TRUE)
 	created_human.mind_initialize()
 	//Remove nearby dangers
 	for(var/mob/living/simple_animal/hostile/SA in range(10, created_human))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -35,7 +35,7 @@
 /datum/orbital_objective/assassination/generate_objective_stuff(turf/chosen_turf)
 	var/mob/living/carbon/human/created_human = new(chosen_turf)
 	//Maybe polling ghosts would be better than the shintience code
-	created_human.AddComponent(/datum/component/ghost_spawner, ROLE_SURVIVALIST, unique = TRUE)
+	created_human.AddComponent(/datum/component/ghost_spawner, ROLE_SURVIVALIST, unique = TRUE, flavour_message=GHOST_SPAWNER_HOSTILE)
 	created_human.mind_initialize()
 	//Remove nearby dangers
 	for(var/mob/living/simple_animal/hostile/SA in range(10, created_human))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -36,7 +36,7 @@
 /datum/orbital_objective/vip_recovery/generate_objective_stuff(turf/chosen_turf)
 	var/mob/living/carbon/human/created_human = new(chosen_turf)
 	//Maybe polling ghosts would be better than the shintience code
-	created_human.AddComponent(/datum/component/ghost_spawner, ROLE_EXPLORATION_VIP, unique = TRUE)
+	created_human.AddComponent(/datum/component/ghost_spawner, ROLE_EXPLORATION_VIP, unique = TRUE, flavour_message=GHOST_SPAWNER_NEUTRAL)
 	created_human.mind_initialize()
 	//Remove nearby dangers
 	for(var/mob/living/simple_animal/hostile/SA in range(10, created_human))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -36,7 +36,7 @@
 /datum/orbital_objective/vip_recovery/generate_objective_stuff(turf/chosen_turf)
 	var/mob/living/carbon/human/created_human = new(chosen_turf)
 	//Maybe polling ghosts would be better than the shintience code
-	created_human.set_playable(ROLE_EXPLORATION_VIP)
+	created_human.AddComponent(/datum/component/ghost_spawner, ROLE_EXPLORATION_VIP, unique = TRUE)
 	created_human.mind_initialize()
 	//Remove nearby dangers
 	for(var/mob/living/simple_animal/hostile/SA in range(10, created_human))

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -357,7 +357,7 @@
 	add_fingerprint(user)
 	ui_interact(user)
 
-/obj/machinery/power/bluespace_tap/attack_ghost(mob/user)
+/obj/machinery/power/bluespace_tap/attack_ghost(mob/user, direct)
 	ui_interact(user)
 
 /obj/machinery/power/bluespace_tap/attack_silicon(mob/user)

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -266,7 +266,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/circuit_component/bci_action)
 		return
 
 	if (href_list["open_bci"])
-		parent.attack_ghost(usr)
+		parent.attack_ghost(usr, TRUE)
 
 /datum/action/innate/bci_charge_action
 	name = "Check BCI Charge"

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -103,6 +103,16 @@ h1.alert, h2.alert		{color: #000000;}
 	padding: 10px;
 	margin: 10px 20px;
 }
+.spawn_message {
+	display: block;
+	color: white;
+	text-align: center;
+	background-color: black;
+	border: 2px solid rgb(100, 222, 91);
+	border-radius: 10px;
+	padding: 10px;
+	margin: 10px 20px;
+}
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -113,6 +113,9 @@ h1.alert, h2.alert		{color: #000000;}
 	padding: 10px;
 	margin: 10px 20px;
 }
+.spawn_header {
+	color: rgb(100, 222, 91);
+}
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -634,6 +634,19 @@ em {
   padding: 10px;
   margin: 10px 20px;
 }
+.spawn_message {
+	display: block;
+	color: white;
+	text-align: center;
+	background-color: black;
+	border: 2px solid rgb(100, 222, 91);
+	border-radius: 10px;
+	padding: 10px;
+	margin: 10px 20px;
+}
+.spawn_header {
+	color: rgb(100, 222, 91);
+}
 .unconscious {
   color: #a4bad6;
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -635,17 +635,17 @@ em {
   margin: 10px 20px;
 }
 .spawn_message {
-	display: block;
-	color: white;
-	text-align: center;
-	background-color: black;
-	border: 2px solid rgb(100, 222, 91);
-	border-radius: 10px;
-	padding: 10px;
-	margin: 10px 20px;
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: 2px solid rgb(100, 222, 91);
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px 20px;
 }
 .spawn_header {
-	color: rgb(100, 222, 91);
+  color: rgb(100, 222, 91);
 }
 .unconscious {
   color: #a4bad6;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -634,6 +634,19 @@ h2.alert {
   padding: 10px;
   margin: 10px 20px;
 }
+.spawn_message {
+	display: block;
+	color: white;
+	text-align: center;
+	background-color: black;
+	border: 2px solid rgb(100, 222, 91);
+	border-radius: 10px;
+	padding: 10px;
+	margin: 10px 20px;
+}
+.spawn_header {
+	color: rgb(100, 222, 91);
+}
 .unconscious {
   color: #0000ff;
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -635,17 +635,17 @@ h2.alert {
   margin: 10px 20px;
 }
 .spawn_message {
-	display: block;
-	color: white;
-	text-align: center;
-	background-color: black;
-	border: 2px solid rgb(100, 222, 91);
-	border-radius: 10px;
-	padding: 10px;
-	margin: 10px 20px;
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: 2px solid rgb(100, 222, 91);
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px 20px;
 }
 .spawn_header {
-	color: rgb(100, 222, 91);
+  color: rgb(100, 222, 91);
 }
 .unconscious {
   color: #0000ff;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

I encountered an issue where diona nymphs could bypass the ghost-role cooldown, allowing for you to have infinite lives in combat scenarios. Simple fix right, wrong. This uncovered one hell of a mob spawning rabbit hole that goes deeper than you could have ever imagined.

## About The Pull Request

- Converts ghost role sentience into a component.
- Refactors most ghost role spawns to use this component, and erases the many different implementations of ghost role sentience that we had.

Things are now standardised:
- All sentience spawns will appear in the spawner menu
- Nymphs now respect the ghost role cooldown

There are 2 types of ghost sentience options:
- Unique: Will appear as its own unique entry inside the spawners menu
- Grouped: Will concatenate mobs with the same non-unique name into the same category and will spawn the player in the closest mob to their ghost when they click spawn

Makes the spawn message when you enter a body more clear:

![image](https://github.com/user-attachments/assets/9edbb941-59d9-46d9-9714-dd5c216e2011)

Also ghosting will now give you a ghost role cooldown.

The following sentience spawns are affected:
- Transform disease (replacing banned players)
- Pyro anomaly slimes
- Spiders (Structures can be given the ghost spawner too, though spiders use their own unique spawning behaviour to setup teams)
- Mass sentience secret
- Ghostize smite
- Antagonists replacing banned players (Only if nobody accepts the prompt)
- Blob zombies
- Xeno larvae (They require a ghost to spawn, so this only really affects if a larvae ghosts)
- Nymphs
- Light pink slime potioned slimes
- Replace banned cyborg (Only if nobody accepts the prompt)
- Exploration ghost roles

Other changes:
- Spawners menu will always show flavour text

Note that this doesn't quite convert everything, only the stuff that was previously going through the sentience system. Convertnig mob_spawner would be a lot of work.

## Why It's Good For The Game

Things being standard is good, it means that any issues will be shared across all ghost spawners making them much easier to fix.

## Testing Photographs and Procedure

<details>
<summary>
Nymphs
</summary>

![image](https://github.com/user-attachments/assets/8f16c934-2756-4c21-bf5b-9f05584fd64c)

1 alert for all nymphs

![image](https://github.com/user-attachments/assets/8348e7f5-82ef-45ea-b7e0-230308a11c46)

Clicking on a specific message gives you that specific mob

![image](https://github.com/user-attachments/assets/ee127e36-fe01-446a-b104-ed0714c379f2)

Spawner menu:

![image](https://github.com/user-attachments/assets/23377bad-d668-4b29-a7fd-1ef59669560a)

![image](https://github.com/user-attachments/assets/796ad060-4a24-44e1-8db7-535319e60457)


</details>

<details>
<summary>Pyro Slime</summary>

![image](https://github.com/user-attachments/assets/c7c84778-76af-45f7-83c9-484a7ebb9624)

![image](https://github.com/user-attachments/assets/d6f9453b-36e3-48b4-a1fe-020fa44b4b62)

![image](https://github.com/user-attachments/assets/54ac92e7-e40c-4c4c-a0e4-17901fcb0db4)

Ghosting:

![image](https://github.com/user-attachments/assets/ebffb4e3-9c52-47f3-8ce7-e7992402923e)

</details>

<details>
<summary>Spiders</summary>

![image](https://github.com/user-attachments/assets/5bf12cf2-74f5-4c6a-8682-d2707361a565)

![image](https://github.com/user-attachments/assets/1d76d171-e48d-4499-9e58-550eddd98bd4)

![image](https://github.com/user-attachments/assets/643b516e-6bd4-4c0e-9d7c-1244cfb3a008)

![image](https://github.com/user-attachments/assets/c2954164-a1bd-4e5b-9c96-2ea06ec1f787)

![image](https://github.com/user-attachments/assets/96e7066b-3beb-4ce6-9594-27075012aecf)


</details>

## Changelog
:cl:
fix: Nymphs now appear in the ghost menu and respect respawn delay.
add: Adds a message for ghost role spawning
fix: Standardises ghost sentience spawning and ensures that enslaving works for all spawned mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
