### PR TITLE
Makes the Cat Surgeon no longer instantly pacify consious felinids.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -60,7 +60,7 @@
 			var/obj/item/organ/tail/cat/newtail = new
 			newtail.Insert(L)
 			return
-		else if(!L.has_trauma_type(/datum/brain_trauma/severe/pacifism) && L.getorgan(/obj/item/organ/ears/cat) && L.getorgan(/obj/item/organ/tail/cat)) //still does damage. This also lacks a Stat check- felinids beware.
+		else if(!L.has_trauma_type(/datum/brain_trauma/severe/pacifism) && L.getorgan(/obj/item/organ/ears/cat) && L.getorgan(/obj/item/organ/tail/cat) && L.stat) //still does damage.
 			visible_message("[src] drills a hole in [L]'s skull!", "<span class='notice'>You pacify [L]. Another successful creation.</span>")
 			if(L.stat)
 				L.emote("scream")


### PR DESCRIPTION
## About The Pull Request
The cattification of the cat surgeon _intentionally_ lacked a stat check, so as long as you had a cat ears or tail the cat surgeon's first attack against you would instantly pacify you irrespective of circumstance. This was technically an intended feature, but sucks to play against.

## Why It's Good For The Game
This "feature" was dumb as fuck. Being permanently pacified, with a brain trauma, through blocks and hardsuit helmets and any sort of counterplay just really sucks. This at least means that, even if you're a felinid, he has to knock you out first.


## Testing Photographs and Procedure
<summary>Screenshots&Videos</summary>
<details>

Note that the cat surgeon has to render the felinid unconscious before pacifying them. On master, they could just pax them on the first attack. (I just realised that you can't see the chat bar, but everything displayed as normal, and since the cat surgeon doesn't target pacified people we can confirm that it worked by their switching targets as the video ends and not before)

https://github.com/user-attachments/assets/03bff9c1-438c-4249-8ffa-794a018f29f6

</details>

## Changelog
:cl:
balance: The cat surgeon can no longer extendo-grip around blocks to pacify conscious felinids.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
