### PR TITLE
Fixes an oopsie with potted plants

### DIFF
--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -48,13 +48,6 @@
 
 	current_slot = slot
 
-	// update the item name to remove the wielded status, copied from twohanded.dm
-	var/sf = findtext(source.name, " (Wielded)", -10) // 10 == length(" (Wielded)")
-	if(sf)
-		source.name = copytext(source.name, 1, sf)
-	else
-		source.name = "[initial(source.name)]"
-
 	on_icon_update(source)
 
 /datum/component/tactical/proc/on_icon_update(obj/item/source)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -322,6 +322,7 @@
 
 /obj/item/kirbyplants/ComponentInitialize()
 	. = ..()
+	AddComponent(/datum/component/tactical)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=10, force_wielded=10)
 	AddComponent(/datum/component/storage/concrete/kirbyplants)
 
@@ -330,10 +331,6 @@
 	max_w_class = WEIGHT_CLASS_NORMAL
 	insert_while_closed = FALSE // We don't want clicking plants with items to insert it, you have to alt click then click the slots
 	animated = FALSE
-
-/obj/item/kirbyplants/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/tactical)
 
 /obj/item/kirbyplants/random
 	icon = 'icons/obj/flora/_flora.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes a bug related to TRAIT_UNKNOWN and potted plants. Previously, picking up a potter plant with one hand would drop the plant and not remove your TRAIT_UNKNOWN, resulting in being unable to be shift clicked on ever.

Now that is fixed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

bugfix good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/7aeb5ad2-61f0-43b5-9d62-3f164271ee7f


https://github.com/user-attachments/assets/89777534-c9dc-413f-af9d-d5caedbd5f58



</details>

## Changelog
:cl: XeonMations
fix: Fixed picking up a potted plant with one hand making you unrecognizable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
