### PR TITLE
Fix TgFont being excluded from build process

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -198,12 +198,7 @@ export const TgFontTarget = new Juke.Target({
     'tgui/packages/tgfont/dist/tgfont.eot',
     'tgui/packages/tgfont/dist/tgfont.woff2',
   ],
-  executes: async () => {
-    await yarn('tgfont:build');
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.css', 'tgui/packages/tgfont/static/tgfont.css');
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.eot', 'tgui/packages/tgfont/static/tgfont.eot');
-    fs.copyFileSync('tgui/packages/tgfont/dist/tgfont.woff2', 'tgui/packages/tgfont/static/tgfont.woff2');
-  }
+  executes: async () => yarn('tgfont:build'),
 });
 
 export const TguiTarget = new Juke.Target({
@@ -285,7 +280,7 @@ export const LintTarget = new Juke.Target({
 });
 
 export const BuildTarget = new Juke.Target({
-  dependsOn: [DmTarget, TguiTarget],
+  dependsOn: [DmTarget, TgFontTarget, TguiTarget],
 });
 
 export const ServerTarget = new Juke.Target({
@@ -352,7 +347,7 @@ const prependDefines = (...defines) => {
 };
 
 export const TgsTarget = new Juke.Target({
-  dependsOn: [TguiTarget],
+  dependsOn: [TguiTarget, TgFontTarget],
   executes: async () => {
     Juke.logger.info('Prepending TGS define');
     prependDefines('TGS');


### PR DESCRIPTION
## About The Pull Request

Closes #11643.

During #11364, https://github.com/tgstation/tgstation/pull/63358 was accidentally ported. We do not want that, because it works just fine as is and updates correctly without manual intervention. We could port it, but ideally separately so that behavior is documented.

This also explains why the server is missing them, but most clients will work - the assets were previously generated on the client, but were not generated by TGS, since the folder is cleared on each deploy.

Also, isn't a funny coincidence that issue #11643 was caused by PR #11364? What a silly.

## Why It's Good For The Game

Having working TGFont icons is good.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/9cd94b9a-94ce-4252-8c3e-0fa6ac205a49)

![image](https://github.com/user-attachments/assets/27ac2451-664b-498a-814b-6857df2cb97a)


</details>

## Changelog
:cl:
fix: Fix TGFont icons (nonbinary character icon, Nanotrasen, Syndicate, etc.) not displaying in TGUIs on the live server.
code: Re-adds TGFont to the juke build process.
/:cl: