### PR TITLE
Shaft miners start with gauze

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -211,8 +211,7 @@
 	mask_type = /obj/item/clothing/mask/gas/explorer
 
 /obj/item/storage/box/survival/mining/PopulateContents()
-	new mask_type(src)
-	new internal_type(src)
+	..()
 	new /obj/item/stack/medical/gauze(src)
 
 // Engineer survival box

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -210,6 +210,11 @@
 /obj/item/storage/box/survival/mining
 	mask_type = /obj/item/clothing/mask/gas/explorer
 
+/obj/item/storage/box/survival/mining/PopulateContents()
+	new mask_type(src)
+	new internal_type(src)
+	new /obj/item/stack/medical/gauze(src)
+
 // Engineer survival box
 /obj/item/storage/box/survival/engineer
 	name = "extended-capacity survival box"

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -45,8 +45,7 @@
 		/obj/item/knife/combat/survival=1,\
 		/obj/item/mining_voucher=1,\
 		/obj/item/stack/marker_beacon/ten=1,\
-		/obj/item/discovery_scanner=1,
-		/obj/item/stack/medical/gauze=1)
+		/obj/item/discovery_scanner=1)
 
 	backpack = /obj/item/storage/backpack/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -45,7 +45,8 @@
 		/obj/item/knife/combat/survival=1,\
 		/obj/item/mining_voucher=1,\
 		/obj/item/stack/marker_beacon/ten=1,\
-		/obj/item/discovery_scanner=1)
+		/obj/item/discovery_scanner=1,
+		/obj/item/stack/medical/gauze=1)
 
 	backpack = /obj/item/storage/backpack/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shaft miners will not start with medical gauze in their backpack

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Shaft miners bleed often and the medipen doesnt fix that, they shouldnt have to go out of their way to medical for gauze, summon a survival pod, or bleed to death.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/000ec7d0-0e65-435d-8898-fbc0d8a8fb36)


</details>

## Changelog
:cl:
tweak: miners start with gauze in their backpack now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
