### PR TITLE
Headset tampering

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -395,6 +395,10 @@
 		result["name"] = item.name
 		result["alternate"] = item_data.get_alternate_action(owner, user)
 
+		var/datum/strip_context/context = new()
+		result["extra_actions"] = context.extra_actions
+		item.add_strip_actions(context)
+
 		items[strippable_key] = result
 
 	data["items"] = items
@@ -556,3 +560,14 @@
 		strippable_items[strippable_item.key] = strippable_item
 
 	return strippable_items
+
+/datum/strip_context
+	var/mob/living/actor
+	var/mob/living/wearer
+	var/list/extra_actions = list()
+
+/datum/strip_context/proc/add_item_action(action_name, action_key)
+	extra_actions += list(list(
+		"action_name" = action_name,
+		"action_key" = action_key,
+	))

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -534,6 +534,24 @@
 			strippable_item.alternate_action(owner, user)
 
 			LAZYREMOVEASSOC(interactions, user, key)
+		if ("extra_act")
+			var/slot_id = params["key"]
+			var/datum/strippable_item/strippable_item = strippable.items[slot_id]
+
+			if(isnull(strippable_item))
+				return
+
+			if(!strippable_item.should_show(owner, user))
+				return
+
+			if(strippable_item.get_obscuring(owner) == STRIPPABLE_OBSCURING_COMPLETELY)
+				return
+
+			var/obj/item/item = strippable_item.get_item(owner)
+			if(isnull(item))
+				return
+
+			item.perform_strip_actions(params["action"], user)
 
 /datum/strip_menu/ui_host(mob/user)
 	return owner
@@ -570,4 +588,20 @@
 	extra_actions += list(list(
 		"action_name" = action_name,
 		"action_key" = action_key,
+	))
+
+/datum/strip_context/proc/add_power_off_action(action_name, action_key)
+	extra_actions += list(list(
+		"action_name" = action_name,
+		"action_key" = action_key,
+		"action_icon" = "power-off",
+		"action_color" = "green"
+	))
+
+/datum/strip_context/proc/add_power_on_action(action_name, action_key)
+	extra_actions += list(list(
+		"action_name" = action_name,
+		"action_key" = action_key,
+		"action_icon" = "power-off",
+		"action_color" = "red"
 	))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1484,3 +1484,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(ismob(loc))
 		var/mob/mob_loc = loc
 		mob_loc.regenerate_icons()
+
+/obj/item/proc/add_strip_actions(datum/strip_context/context)
+
+/obj/item/proc/perform_strip_actions(action_key, mob/actor)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -380,7 +380,7 @@
 	return FALSE
 
 /obj/item/radio/ui_state(mob/user)
-	return GLOB.inventory_state
+	return GLOB.hands_state
 
 /obj/item/radio/ui_interact(mob/user, datum/tgui/ui, datum/ui_state/state)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -538,6 +538,7 @@
 			if (obj_flags & EMPED)
 				return
 			// Strip, silently
+			add_fingerprint(actor)
 			if (do_after(actor, 1 SECONDS, loc))
 				set_on(!on)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -19,6 +19,8 @@
 
 	///if FALSE, broadcasting and listening dont matter and this radio shouldnt do anything
 	VAR_PRIVATE/on = TRUE
+	/// Previous vlaue of on for when you are EMPed
+	VAR_PRIVATE/previous_on = TRUE
 	///the "default" radio frequency this radio is set to, listens and transmits to this frequency by default. wont work if the channel is encrypted
 	VAR_PRIVATE/frequency = FREQ_COMMON
 
@@ -426,6 +428,11 @@
 				. = TRUE
 			if(.)
 				set_frequency(sanitize_frequency(tune, freerange))
+		if ("enable")
+			if (obj_flags & EMPED)
+				return FALSE
+			set_on(!on)
+			. = TRUE
 		if("listen")
 			set_listening(!listening)
 			. = TRUE
@@ -483,6 +490,9 @@
 	. = ..()
 	if (. & EMP_PROTECT_SELF)
 		return
+	if (!emped)
+		previous_on = on
+	obj_flags |= OBJ_EMPED
 	emped++ //There's been an EMP; better count it
 	var/curremp = emped //Remember which EMP this was
 	if (listening && ismob(loc))	// if the radio is turned on and on someone's person they notice
@@ -503,14 +513,31 @@
 /obj/item/radio/proc/end_emp_effect(curremp)
 	if(emped != curremp) //Don't fix it if it's been EMP'd again
 		return FALSE
+	obj_flags &= ~OBJ_EMPED
 	emped = FALSE
-	set_on(TRUE)
+	set_on(previous_on)
 	return TRUE
 
 /obj/item/radio/proc/get_specific_hearers()
 	if(istype(loc, /obj/item/implant))
 		var/obj/item/implant/radio_implant = loc
 		return radio_implant.imp_in
+
+/obj/item/radio/add_strip_actions(datum/strip_context/context)
+	context.add_item_action("Turn [on ? "off" : "on"]", "toggle")
+	context.add_item_action("[broadcasting ? "Disable" : "Enable"] always broadcasting", "broadcast")
+	context.add_item_action("[listening ? "Disable" : "Enable"] always listening", "listening")
+
+/obj/item/radio/perform_strip_actions(action_key, mob/actor)
+	switch (action_key)
+		if ("toggle")
+			if (obj_flags & EMPED)
+				return
+			set_on(!on)
+		if ("broadcast")
+			set_broadcasting(!broadcasting)
+		if ("listening")
+			set_listening(!listening)
 
 ///////////////////////////////
 //////////Borg Radios//////////

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -393,6 +393,7 @@
 /obj/item/radio/ui_data(mob/user)
 	var/list/data = list()
 
+	data["enabled"] = on
 	data["broadcasting"] = broadcasting
 	data["listening"] = listening
 	data["frequency"] = frequency
@@ -524,20 +525,21 @@
 		return radio_implant.imp_in
 
 /obj/item/radio/add_strip_actions(datum/strip_context/context)
-	context.add_item_action("Turn [on ? "off" : "on"]", "toggle")
-	context.add_item_action("[broadcasting ? "Disable" : "Enable"] always broadcasting", "broadcast")
-	context.add_item_action("[listening ? "Disable" : "Enable"] always listening", "listening")
+	if (on)
+		context.add_power_off_action("The radio is on", "toggle")
+	else
+		context.add_power_on_action("The radio is off", "toggle")
 
 /obj/item/radio/perform_strip_actions(action_key, mob/actor)
+	set waitfor = FALSE
+
 	switch (action_key)
 		if ("toggle")
 			if (obj_flags & EMPED)
 				return
-			set_on(!on)
-		if ("broadcast")
-			set_broadcasting(!broadcasting)
-		if ("listening")
-			set_listening(!listening)
+			// Strip, silently
+			if (do_after(actor, 1 SECONDS, loc))
+				set_on(!on)
 
 ///////////////////////////////
 //////////Borg Radios//////////

--- a/tgui/packages/tgui/interfaces/Radio.js
+++ b/tgui/packages/tgui/interfaces/Radio.js
@@ -59,13 +59,7 @@ export const Radio = (props, context) => {
               )}
             </LabeledList.Item>
             <LabeledList.Item label="Audio">
-              <Button
-                textAlign="center"
-                width="37px"
-                icon={'power-off'}
-                selected={enabled}
-                onClick={() => act('enable')}
-              />
+              <Button textAlign="center" width="37px" icon={'power-off'} selected={enabled} onClick={() => act('enable')} />
               <Button
                 textAlign="center"
                 width="37px"

--- a/tgui/packages/tgui/interfaces/Radio.js
+++ b/tgui/packages/tgui/interfaces/Radio.js
@@ -12,6 +12,7 @@ export const Radio = (props, context) => {
     frequency,
     minFrequency,
     maxFrequency,
+    enabled,
     listening,
     broadcasting,
     command,
@@ -58,6 +59,13 @@ export const Radio = (props, context) => {
               )}
             </LabeledList.Item>
             <LabeledList.Item label="Audio">
+              <Button
+                textAlign="center"
+                width="37px"
+                icon={enabled ? 'power-off' : 'power-off'}
+                selected={enabled}
+                onClick={() => act('enable')}
+              />
               <Button
                 textAlign="center"
                 width="37px"

--- a/tgui/packages/tgui/interfaces/Radio.js
+++ b/tgui/packages/tgui/interfaces/Radio.js
@@ -62,7 +62,7 @@ export const Radio = (props, context) => {
               <Button
                 textAlign="center"
                 width="37px"
-                icon={enabled ? 'power-off' : 'power-off'}
+                icon={'power-off'}
                 selected={enabled}
                 onClick={() => act('enable')}
               />

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -169,10 +169,10 @@ type StripMenuItem =
       Partial<Unavailable>);
 
 type StripMenuActions = {
-  action_name: string,
-  action_key: string,
-  action_color: string | undefined,
-  action_icon: string | undefined
+  action_name: string;
+  action_key: string;
+  action_color: string | undefined;
+  action_icon: string | undefined;
 }[];
 
 type StripMenuData = {
@@ -236,7 +236,13 @@ const StripMenuRow = (props: StripMenuRowProps, context) => {
           ))}
           {props.extra_actions?.map((alternate) => (
             <Flex.Item key={alternate.action_name}>
-              <Button compact content={alternate.action_name} color={alternate.action_color || 'default'} icon={alternate.action_icon} onClick={() => act('extra_act', { key: props.slotID, action: alternate.action_key })} />
+              <Button
+                compact
+                content={alternate.action_name}
+                color={alternate.action_color || 'default'}
+                icon={alternate.action_icon}
+                onClick={() => act('extra_act', { key: props.slotID, action: alternate.action_key })}
+              />
             </Flex.Item>
           ))}
         </Flex>

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -159,6 +159,7 @@ type StripMenuItem =
           icon?: string;
           name: string;
           alternate?: string;
+          extra_actions?: StripMenuActions;
         }
       | {
           obscured: ObscuringLevel;
@@ -166,6 +167,11 @@ type StripMenuItem =
     ) &
       Partial<Interactable> &
       Partial<Unavailable>);
+
+type StripMenuActions = {
+  action_name,
+  action_key
+}[];
 
 type StripMenuData = {
   items: Record<keyof typeof SLOTS, StripMenuItem>;
@@ -183,9 +189,10 @@ interface StripMenuRowProps {
 
   interacting: BooleanLike;
   indented: BooleanLike;
-  obscured: ObscuringLevel;
+  obscured: ObscuringLevel | null;
   empty: BooleanLike;
   unavailable: BooleanLike;
+  extra_actions: StripMenuActions;
 }
 
 const StripMenuRow = (props: StripMenuRowProps, context) => {
@@ -225,6 +232,11 @@ const StripMenuRow = (props: StripMenuRowProps, context) => {
               <Button compact content={alternate.text} onClick={() => act('alt', { key: props.slotID })} />
             </Flex.Item>
           ))}
+          {props.extra_actions?.map((alternate) => (
+            <Flex.Item key={alternate.action_name}>
+              <Button compact content={alternate.action_name} onClick={() => act('extra_act', { key: props.slotID, action: alternate.action_key })} />
+            </Flex.Item>
+          ))}
         </Flex>
       </Table.Cell>
     </Table.Row>
@@ -253,17 +265,21 @@ export const StripMenu = (props, context) => {
           name = item['name'];
         }
 
+        const extra_interactions = item && item['extra_actions'] !== undefined ? item['extra_actions'] : [];
+
         return (
           <StripMenuRow
             slotName={SLOTS[slot.id]}
             itemName={name}
-            obscured={item && 'obscured' in item ? item.obscured : 0}
+            obscured={item && 'obscured' in item ? item.obscured : null}
             indented={slot.indented}
             slotID={slot.id}
             unavailable={item && 'unavailable' in item && item.unavailable}
             alternates={alternate ? [alternate] : undefined}
             empty={!item || !('name' in item || 'obscured' in item)}
             interacting={item && 'interacting' in item && item.interacting}
+            extra_actions={extra_interactions}
+            /* @ts-ignore: Key is a mandatory property for .map return values */
             key={slot.id}
           />
         );

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -169,8 +169,10 @@ type StripMenuItem =
       Partial<Unavailable>);
 
 type StripMenuActions = {
-  action_name,
-  action_key
+  action_name: string,
+  action_key: string,
+  action_color: string | undefined,
+  action_icon: string | undefined
 }[];
 
 type StripMenuData = {
@@ -234,7 +236,7 @@ const StripMenuRow = (props: StripMenuRowProps, context) => {
           ))}
           {props.extra_actions?.map((alternate) => (
             <Flex.Item key={alternate.action_name}>
-              <Button compact content={alternate.action_name} onClick={() => act('extra_act', { key: props.slotID, action: alternate.action_key })} />
+              <Button compact content={alternate.action_name} color={alternate.action_color || 'default'} icon={alternate.action_icon} onClick={() => act('extra_act', { key: props.slotID, action: alternate.action_key })} />
             </Flex.Item>
           ))}
         </Flex>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the ability to tamper with people's headsets via the stripping menu. This action takes 1 second and has no cue to the other person. Also adds the ability to turn your own headset on and off.

In addition to this, headsets can only have their UI used while in the user's hands to prevent people keeping the interface open 24/7, which apparently might become an issue.

## Why It's Good For The Game

Players have been getting too good at calling out an attack the second it happens, resulting in instantaneous response times from sec. We can't keep nerfing movement speed forever, so the only solution is to try and slow the spread of information. This gives some benefits to craftier antags who take their time and prepare, and it's not completely unnoticable as a non-antag since you'll suddenly notice that you have no comms.

As a disclaimer, I don't think this changes all that much since you need to be near your target and then get pretty lucky with them suddenly and miraculously being alone for it to really have much effect but its a tool for antagonists who like to take their time.

It also adds a nice framework for this to be added to more things.

If you do happen to notice it, then fingerprints will be left by the user.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/ae585a6c-56c8-4a38-ab89-96475fa11dac)

![image](https://github.com/user-attachments/assets/2f668741-dcab-4fe5-87d0-692b5c8060fc)

![image](https://github.com/user-attachments/assets/32d3265f-8288-479c-b4b2-7b6c829b0bcf)

![image](https://github.com/user-attachments/assets/3f3a6d79-78c2-46b6-96b2-20ba3dca3220)

![image](https://github.com/user-attachments/assets/b658e727-2e25-4a39-9163-588d5570b9ed)

![image](https://github.com/user-attachments/assets/c5fcbeda-a77f-452e-b1bd-de41498ace44)


## Changelog
:cl:
add: Adds the ability to turn someones headset on/off via the stripping menu, if you find your headset randomly becomes disabled then getting the detective to scan it could bring some clues as to an individual that is after you... or maybe it was a prank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
