### PR TITLE
New security heirloom

### DIFF
--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -172,11 +172,11 @@
 			if(JOB_NAME_CAPTAIN)
 				heirloom_type = /obj/item/reagent_containers/cup/glass/flask/gold
 			if(JOB_NAME_HEADOFSECURITY)
-				heirloom_type = /obj/item/book/manual/wiki/security_space_law
+				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/gun/energy/e_gun/advtaser/heirloom)
 			if(JOB_NAME_WARDEN)
 				heirloom_type = /obj/item/book/manual/wiki/security_space_law
 			if(JOB_NAME_SECURITYOFFICER)
-				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
+				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec, /obj/item/gun/energy/e_gun/advtaser/heirloom)
 			if(JOB_NAME_DETECTIVE)
 				heirloom_type = /obj/item/reagent_containers/cup/glass/bottle/whiskey
 			if(JOB_NAME_LAWYER)

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -174,7 +174,7 @@
 			if(JOB_NAME_HEADOFSECURITY)
 				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/gun/energy/e_gun/advtaser/heirloom)
 			if(JOB_NAME_WARDEN)
-				heirloom_type = /obj/item/book/manual/wiki/security_space_law
+				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/gun/energy/e_gun/advtaser/heirloom)
 			if(JOB_NAME_SECURITYOFFICER)
 				heirloom_type = pick(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec, /obj/item/gun/energy/e_gun/advtaser/heirloom)
 			if(JOB_NAME_DETECTIVE)

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -18,6 +18,10 @@
 /obj/item/ammo_casing/energy/electrode/old
 	e_cost = 1000
 
+/obj/item/ammo_casing/energy/electrode/broken
+	projectile_type = /obj/projectile/energy/electrode/broken
+
+
 /obj/item/ammo_casing/energy/disabler
 	projectile_type = /obj/projectile/beam/disabler
 	select_name = "disable"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -36,6 +36,13 @@
 /obj/item/gun/energy/e_gun/advtaser/cyborg/add_seclight_point()
 	return
 
+/obj/item/gun/energy/e_gun/advtaser/heirloom
+	name = "old hybrid taser"
+	desc = "A old and dusty taser, used so much its cell no longer charges. there is a text scribbled on the side saying \"Dont forget your origins.\""
+	w_class = WEIGHT_CLASS_NORMAL
+	can_charge = FALSE
+	dead_cell = TRUE
+
 /obj/item/gun/energy/disabler
 	name = "disabler"
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -42,6 +42,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	can_charge = FALSE
 	dead_cell = TRUE
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/broken) //Fool, you think you can outsmart me. But i am smarter.
 
 /obj/item/gun/energy/disabler
 	name = "disabler"

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -33,3 +33,9 @@
 /obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, TRUE, src)
 	..()
+
+/obj/projectile/energy/electrode/broken
+	nodamage = TRUE
+	jitter = 0
+	knockdown = 0
+	stutter = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Security can now roll a nonfunctional taser as a heirloom item. (If you manage to charge it, it fires fake electrodes)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Security have been plagued with only TWO heirlooms! the HOS and warden only get a space law book! The taser (rest in peace) is the greatest weapon of all time, so why wouldnt have some officers passed it down to their kids?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/1ffff14c-e698-40b2-addf-d4e72d7289d3



</details>

## Changelog
:cl:
add: security can now get non-functional hybrid tasers as a heirloom item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
