### PR TITLE
Disables Shadow Sect Until #11766 is merged.

### DIFF
--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -24,8 +24,8 @@
 	var/faithful_used = FALSE
 
 /datum/religion_sect/shadow_sect/is_available(mob/user)
-	if(isshadow(user))
-		return TRUE
+	//if(isshadow(user))
+	//	return TRUE
 	return FALSE
 
 //Shadow sect doesn't heal

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -108,10 +108,8 @@
 		return //no need to process if we didn't change anything.
 	active = anchorvalue
 	if(anchorvalue)
-		begin_processing()
 		animate(src, pixel_y = 2, time = 10, loop = -1)
 	else
-		end_processing()
 		animate(src, pixel_y = 0, time = 10)
 	update_icon()
 
@@ -146,9 +144,14 @@
 	name = "\improper Meteor Shield Satellite"
 	desc = "A meteor point-defense satellite."
 	mode = "M-SHIELD"
-	processing_flags = START_PROCESSING_MANUALLY
-	subsystem_type = /datum/controller/subsystem/processing/fastprocess
 	var/kill_range = 14
+	///Proximity monitor associated with this atom, needed for proximity checks.
+	var/datum/proximity_monitor/proximity_monitor
+
+
+/obj/machinery/satellite/meteor_shield/Initialize(mapload)
+	. = ..()
+	proximity_monitor = new(src, kill_range)
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)
 	for(var/turf/T in getline(src,meteor))
@@ -156,21 +159,18 @@
 			return FALSE
 	return TRUE
 
-/obj/machinery/satellite/meteor_shield/process()
-	if(!active)
-		return
-	for(var/obj/effect/meteor/M in GLOB.meteor_list)
-		if(M.get_virtual_z_level() != get_virtual_z_level())
-			continue
-		if(get_dist(M,src) > kill_range)
-			continue
-		if(!(obj_flags & EMAGGED) && space_los(M))
-			Beam(get_turf(M),icon_state="sat_beam", time = 5)
-			qdel(M)
+/obj/machinery/satellite/meteor_shield/HasProximity(atom/movable/AM)
+	if(istype(AM, /obj/effect/meteor))
+		if(!(obj_flags & EMAGGED) && space_los(AM))
+			Beam(get_turf(AM),icon_state="sat_beam", time = 5)
+			qdel(AM)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)
 	if(!..(user))
 		return FALSE
+
+	proximity_monitor.set_range(active ? src.kill_range : 0)
+
 	if(obj_flags & EMAGGED)
 		if(active)
 			change_meteor_chance(2)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -121,6 +121,7 @@
 	if(user)
 		to_chat(user, "<span class='notice'>You [active ? "deactivate": "activate"] [src].</span>")
 	set_anchored(!anchored)
+	return TRUE
 
 /obj/machinery/satellite/update_icon()
 	icon_state = active ? "sat_active" : "sat_inactive"
@@ -151,7 +152,7 @@
 
 /obj/machinery/satellite/meteor_shield/Initialize(mapload)
 	. = ..()
-	proximity_monitor = new(src, kill_range)
+	proximity_monitor = new(src, 0)
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)
 	for(var/turf/T in getline(src,meteor))
@@ -169,7 +170,7 @@
 	if(!..(user))
 		return FALSE
 
-	proximity_monitor.set_range(active ? src.kill_range : 0)
+	proximity_monitor.set_range(active ? kill_range : 0)
 
 	if(obj_flags & EMAGGED)
 		if(active)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The Shadow Chaplain Sect is basically just used to murderbone and brainwash continuously. Yes, it requires collaboration with science, but it's fairly easy to do. The sect needs to be reworked to be less murderboney, and should just be disabled until #11766 is merged.

(Yes, this is a blatant I Ded PR, please appropriately tag)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This sect needs a rework, and causes lots of problems in dead pop. This last round, the round was held effectively hostage because everyone died to the shadow creatures so nobody could call the shuttle, and it was on green alert. 

I left in all the code so that the sect can be granted, but is not available unless admin bussed (I think). I could strip it out completely if desired.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Disabled Shadow Sect from being available. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
