### PR TITLE
Science lootdrop changes

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/mapping.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/mapping.dm
@@ -82,6 +82,7 @@
 		/obj/item/disk/tech_disk = 5,
 		/obj/item/assembly/prox_sensor = 6,
 		/obj/item/bodypart/r_arm/robot = 4,
+		/obj/item/gun/energy/wormhole_projector = 1,
 		/obj/item/assembly/flash/handheld/weak = 2,
 		/obj/item/stock_parts/cell/high = 1,
 		/obj/item/stock_parts/manipulator/nano = 1,

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/mapping.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/mapping.dm
@@ -104,7 +104,6 @@
 		/obj/item/flamethrower = 2,
 		/obj/item/tank/internals/plasma/full = 2,
 		/obj/item/gps/science = 3,
-		/obj/item/hand_tele = 1,
 		/obj/item/inducer/sci = 3,
 		/obj/item/megaphone = 1,
 		/obj/item/modular_computer/tablet/pda/roboticist = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes hand teleporters from the lootdrop 'science' and replaces it with a portal gun

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hand teleporters are supposed to be a extremely limited item, it shouldnt be able to be found on space ruins/some maps.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

View code.

</details>

## Changelog
:cl:
tweak: hand teleporters are no longer available via science lootdrop spawners, now replaced with a portal gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
