### PR TITLE
Ore silos can no longer be eaten by swarmers.

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -425,6 +425,10 @@
 	to_chat(S, "<span class='warning'>This object does not contain solid matter. Aborting.</span>")
 	return FALSE
 
+/obj/machinery/ore_silo/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S,"<span class='warning'>The ore silo should be preserved, it will be a useful resource to our masters in the future. Aborting.</span>")
+	return FALSE
+
 ////END CTRL CLICK FOR SWARMERS////
 
 /mob/living/simple_animal/hostile/swarmer/proc/Fabricate(atom/fabrication_object,fabrication_cost = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the title, swarmers are no longer capable of eating ore silos

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Let me give you a situation here.
You are a engineer working on a fun project, BSA, custom shuttle, etc. You go your lathe, and it says there's no ores? Weird. You ask the AI to let you into the vault and you're met with the ore silo board destroyed, and all of the iron and glass eaten. Is this fun for the crew? No. Is it fun for the quartermaster/HOP who has to go around relinking everything with a new ore silo? No, not at all.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/08821a64-3b61-40e0-b197-a214a83ae0fe



</details>

## Changelog
:cl:
balance: swarmers can no longer eat ore silos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
