### PR TITLE
Fixes radio transceiver menu not showing up for silicons

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -380,7 +380,7 @@
 	return FALSE
 
 /obj/item/radio/ui_state(mob/user)
-	if(isAI(user))
+	if(issilicon(user))
 		return GLOB.inventory_state
 	else
 		return GLOB.hands_state

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -380,7 +380,10 @@
 	return FALSE
 
 /obj/item/radio/ui_state(mob/user)
-	return GLOB.hands_state
+	if(isAI(user))
+		return GLOB.inventory_state
+	else
+		return GLOB.hands_state
 
 /obj/item/radio/ui_interact(mob/user, datum/tgui/ui, datum/ui_state/state)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Due to Bacon's https://github.com/BeeStation/BeeStation-Hornet/pull/11911 PR, it checked for if the radio was in someone's hands before allowing the menu to popup. Due to silicons lacking hands, this broke their transceivers. This solves that issue.

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/11931

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Bugfix good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/cf3e4181-53a4-40f1-b885-f17078ceb78a


https://github.com/user-attachments/assets/457e2898-29d0-47ec-b18c-498a08362fc9


</details>

## Changelog
:cl: XeonMations
fix: Fixed a bug in silicon software that would not allow the radio menu to popup.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
