### PR TITLE
Adds lathes to the service department + minor map stuff

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1503,21 +1503,25 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "avu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Foyer";
-	req_one_access_txt = "32"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/structure/desk_bell{
+	pixel_x = -6
+	},
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engi Desk";
+	req_one_access_txt = "32;19"
+	},
+/turf/open/floor/iron/dark,
 /area/engine/break_room)
 "avy" = (
 /obj/structure/closet/firecloset,
@@ -9078,12 +9082,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"bTg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/iron,
-/area/engine/break_room)
 "bTp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -9615,23 +9613,12 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "bWt" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/cup/bucket,
+/obj/machinery/modular_fabricator/autolathe,
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/dark_green/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "bWB" = (
 /obj/machinery/telecomms/processor/preset_four,
@@ -10087,7 +10074,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engine/break_room)
 "bYQ" = (
@@ -10176,11 +10171,24 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "bZe" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Foyer";
+	req_one_access_txt = "32"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/engine/break_room)
 "bZf" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -10189,6 +10197,15 @@
 "bZg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/iron,
 /area/engine/break_room)
@@ -10266,33 +10283,32 @@
 /turf/open/floor/iron,
 /area/engine/break_room)
 "bZC" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy Shutter"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bZD" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy Shutter"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "bZG" = (
@@ -10519,6 +10535,10 @@
 /area/maintenance/port/aft)
 "caA" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "caC" = (
@@ -11449,13 +11469,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy Shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
@@ -15838,6 +15858,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"cWy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron,
+/area/engine/break_room)
 "cWH" = (
 /obj/machinery/power/apc/auto_name/directional/west{
 	pixel_x = -24
@@ -26555,20 +26585,17 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "hpn" = (
-/obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/crew_quarters/heads/chief";
 	dir = 4;
 	name = "CE Office APC";
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/chief)
 "hpw" = (
@@ -27335,11 +27362,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hGa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron,
 /area/engine/break_room)
 "hGn" = (
@@ -27585,6 +27616,15 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -30416,6 +30456,15 @@
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "iPA" = (
@@ -33195,11 +33244,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "jQJ" = (
@@ -34475,19 +34528,6 @@
 	},
 /turf/open/floor/iron,
 /area/hydroponics/garden)
-"ksC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "ksS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -36431,6 +36471,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "lcg" = (
@@ -36854,12 +36897,12 @@
 /area/security/detectives_office)
 "llo" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/chief)
 "llq" = (
@@ -40511,6 +40554,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron,
 /area/engine/break_room)
 "mVY" = (
@@ -41969,6 +42018,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nAC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "nAF" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron,
@@ -42840,16 +42897,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nQL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -43556,6 +43607,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/storage/tech)
+"oeb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "oed" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -43623,6 +43684,13 @@
 /obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"ofv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "ofI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45903,6 +45971,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "phD" = (
@@ -48005,6 +48082,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"pXv" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/engine/break_room)
 "pXG" = (
 /obj/machinery/airalarm/directional/south{
 	pixel_y = -22
@@ -49605,14 +49686,14 @@
 /turf/open/floor/iron,
 /area/engine/engineering)
 "qHS" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west{
 	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron,
 /area/engine/break_room)
@@ -50814,21 +50895,6 @@
 	},
 /turf/open/floor/iron,
 /area/crew_quarters/fitness)
-"rew" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engine/break_room)
 "rex" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51247,6 +51313,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron,
 /area/engine/break_room)
@@ -53074,6 +53143,16 @@
 /obj/item/taperecorder,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rUI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Engi Desk";
+	req_one_access_txt = "32;19"
+	},
+/turf/open/floor/iron/dark,
+/area/engine/break_room)
 "rUR" = (
 /obj/structure/chair{
 	dir = 4
@@ -61048,9 +61127,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "vfh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
@@ -63025,18 +63101,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"vSa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "vSj" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -65630,17 +65694,17 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "wUH" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy Shutter"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "wUU" = (
@@ -66235,6 +66299,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xiX" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/plating/rust,
+/area/maintenance/starboard/fore)
 "xiZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -66445,13 +66514,14 @@
 /turf/open/floor/wood/big,
 /area/crew_quarters/bar)
 "xmP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_x = -31;
 	pixel_y = -3
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/checker,
 /area/hallway/secondary/service)
@@ -98058,7 +98128,7 @@ pYc
 dZz
 cSc
 pYc
-vSa
+bQg
 phv
 cfb
 cfb
@@ -98315,7 +98385,7 @@ bVo
 bYH
 bYH
 kHz
-ksC
+baG
 iPs
 cfb
 cfF
@@ -98571,7 +98641,7 @@ aWd
 khn
 ppE
 bYH
-bVo
+rUI
 avu
 bZe
 cfb
@@ -98828,8 +98898,8 @@ hYV
 bZy
 bZy
 qHS
-bTg
-rew
+bZy
+bZy
 bYO
 cfc
 tgu
@@ -99085,7 +99155,7 @@ bYL
 uJp
 rls
 mVI
-vyz
+cWy
 hGa
 bZg
 bZD
@@ -99340,11 +99410,11 @@ bRD
 bXL
 reG
 avz
-bTg
+bZy
 vfh
-bTg
+bZy
 nQL
-bTg
+bZy
 bZC
 hpn
 llo
@@ -99597,9 +99667,9 @@ bWQ
 bWQ
 bYN
 lca
+nAC
 caA
-caA
-bZy
+pXv
 haz
 ceQ
 cfb
@@ -99855,7 +99925,7 @@ cWH
 kMw
 jcZ
 jeB
-caA
+oeb
 bZy
 haz
 bZy
@@ -100112,7 +100182,7 @@ uhI
 dwU
 hRP
 xaY
-caA
+oeb
 bZy
 jto
 vyz
@@ -100369,7 +100439,7 @@ lqv
 aqd
 mRi
 qLc
-caA
+ofv
 nCY
 sJB
 bZw
@@ -110332,7 +110402,7 @@ apE
 fyV
 alP
 awG
-gYi
+xiX
 anf
 mGN
 aIp

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -53148,7 +53148,7 @@
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	name = "Engi Desk";
+	name = "Engi Autolathe";
 	req_one_access_txt = "32;19"
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -20089,6 +20089,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "gvN" = (
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "gvT" = (
@@ -23408,7 +23409,8 @@
 	name = "Service Hall";
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/green/fourcorners/contrasted,
+/turf/open/floor/iron,
 /area/hallway/secondary/service)
 "hyr" = (
 /obj/effect/turf_decal/tile/red{
@@ -33176,6 +33178,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
+"kFb" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/turf/open/floor/iron,
+/area/hallway/secondary/service)
 "kFB" = (
 /obj/machinery/camera/directional/west,
 /obj/machinery/light{
@@ -34414,6 +34421,8 @@
 	dir = 4;
 	pixel_y = -5
 	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "lbV" = (
@@ -40679,6 +40688,8 @@
 "mVc" = (
 /obj/structure/table,
 /obj/machinery/fax/service,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "mVi" = (
@@ -44841,13 +44852,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oqq" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/drone,
-/obj/item/multitool,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/item/book/manual/wiki/sopservice,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "oqF" = (
@@ -61291,6 +61298,8 @@
 /area/engine/atmos)
 "tQE" = (
 /obj/machinery/rnd/production/protolathe/department/service,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "tQQ" = (
@@ -72196,7 +72205,15 @@
 /turf/open/floor/iron/dark,
 /area/crew_quarters/bar)
 "xsn" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/table,
+/obj/item/storage/toolbox/drone,
+/obj/item/multitool,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/item/book/manual/wiki/sopservice,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "xsp" = (
@@ -107977,7 +107994,7 @@ lzJ
 fKx
 hzU
 oqq
-xsn
+kFb
 gvN
 mVc
 fuh

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -3378,9 +3378,6 @@
 /area/science/test_area)
 "aQi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/item/radio/intercom{
-	pixel_x = -26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -8872,6 +8869,36 @@
 	},
 /turf/open/floor/carpet/grimy,
 /area/chapel/office)
+"cHk" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/item/folder/yellow{
+	pixel_x = -4
+	},
+/obj/item/pen{
+	pixel_x = -4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/structure/desk_bell{
+	pixel_x = 8
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Engineering Autolathe";
+	req_access_txt = "32";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "cHl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -10847,6 +10874,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dqF" = (
@@ -19550,14 +19580,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig)
-"gmj" = (
-/obj/machinery/camera/directional/east,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/shuttle)
 "gmt" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -30882,6 +30904,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/camera/directional/east,
 /turf/open/floor/iron,
 /area/science/shuttle)
 "jTw" = (
@@ -37450,6 +37473,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/genetics/cloning)
+"lZz" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = 29;
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/science/shuttle)
 "lZI" = (
 /obj/item/flashlight/glowstick/cyan,
 /obj/structure/cable/yellow{
@@ -42915,17 +42949,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/chapel/monastery)
-"nKp" = (
-/obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/shuttle)
 "nKB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -59597,6 +59620,20 @@
 /obj/item/book/manual/wiki/sopsecurity,
 /turf/open/floor/iron/dark,
 /area/security/main)
+"tmR" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engidesk";
+	name = "engineering Security Door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	req_access_txt = "32";
+	name = "Engineering Autolathe"
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/primary/fore)
 "tmY" = (
 /obj/machinery/camera/directional/north,
 /obj/machinery/light{
@@ -62512,12 +62549,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "ukb" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = -26
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -99979,9 +100016,9 @@ fdU
 amI
 jTo
 pwC
-gmj
-nKp
 oEa
+oEa
+lZz
 oEa
 oEa
 oEa
@@ -100236,8 +100273,8 @@ aMd
 amI
 nIH
 cpe
-nIH
-nIH
+tmR
+cHk
 ihY
 klB
 ihY

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -43633,15 +43633,14 @@
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast Door"
 	},
-/obj/machinery/door/window/westright{
-	name = "Atmospherics Desk";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/window/eastright,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/structure/desk_bell{
 	pixel_x = 8
+	},
+/obj/machinery/door/window/westleft{
+	name = "Atmospherics Desk";
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engine/atmos)
@@ -60431,6 +60430,19 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"nsE" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engidesk";
+	name = "engineering Security Door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/machinery/door/window/westright{
+	name = "Atmospherics Autolathe";
+	req_access_txt = "24"
+	},
+/turf/open/floor/iron/dark,
+/area/engine/atmos)
 "nsJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -123258,7 +123270,7 @@ bso
 bwy
 bxU
 kdY
-bxU
+nsE
 hTj
 haw
 aRF

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5518,10 +5518,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/item/book/manual/wiki/sopservice,
+/obj/machinery/fax/service,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aHs" = (
@@ -16295,7 +16294,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "cho" = (
@@ -25655,6 +25656,8 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/item/food/pie/cream,
+/obj/item/food/pie/cream,
 /turf/open/floor/iron,
 /area/crew_quarters/theatre)
 "doi" = (
@@ -37546,8 +37549,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/fax/service,
-/obj/structure/table,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "gbQ" = (
@@ -83951,6 +83954,13 @@
 	},
 /turf/open/floor/iron,
 /area/engine/storage_shared)
+"uOv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/hallway/secondary/service)
 "uOD" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/door/airlock/atmos/glass{
@@ -129649,7 +129659,7 @@ gbI
 aHq
 chm
 aOA
-aOA
+uOv
 xPU
 aOA
 aQj

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -48365,6 +48365,9 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/crew_quarters/toilet/auxiliary)
+"mlo" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/port)
 "mlt" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "medcell";
@@ -62098,12 +62101,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/machinery/modular_fabricator/autolathe,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "pVL" = (
@@ -117250,7 +117253,7 @@ qCS
 jYF
 jYF
 jYF
-jYF
+mlo
 wbE
 nck
 ocu

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -13302,7 +13302,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dwQ" = (
@@ -38068,6 +38067,20 @@
 /obj/machinery/camera/directional/west,
 /turf/open/floor/iron,
 /area/storage/primary)
+"jKV" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engidesk";
+	name = "engineering Security Door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/machinery/door/window/westright{
+	name = "Atmospherics Autolathe";
+	req_access_txt = "24";
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/engine/atmos)
 "jLa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57985,11 +57998,6 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/door/window/westright{
-	dir = 2;
-	name = "Atmospherics Desk";
-	req_access_txt = "24"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/desk_bell{
@@ -57997,6 +58005,11 @@
 	},
 /obj/item/folder/yellow{
 	pixel_x = 4
+	},
+/obj/machinery/door/window/westleft{
+	name = "Atmospherics Desk";
+	req_access_txt = "24";
+	dir = 2
 	},
 /turf/open/floor/iron/techmaint,
 /area/engine/atmos)
@@ -59745,6 +59758,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pou" = (
@@ -138890,7 +138904,7 @@ hEL
 pGC
 aYo
 dwC
-uUs
+jKV
 kpZ
 xDY
 uLr

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22909,17 +22909,6 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
 "fvg" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Service Production";
-	req_one_access_txt = "25;26;35;28;22;37;46;38"
-	},
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -38690,23 +38679,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating{
 	burnt = 1
 	},
@@ -41619,10 +41599,8 @@
 /obj/structure/table,
 /obj/machinery/light/small,
 /obj/machinery/fax/service,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/item/hand_labeler,
+/obj/item/stack/package_wrap,
 /turf/open/floor/plating{
 	burnt = 1
 	},
@@ -46874,12 +46852,7 @@
 /area/medical/genetics/cloning)
 "njA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/wiki/sopservice,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -59714,35 +59687,24 @@
 /turf/open/floor/iron,
 /area/engine/engineering)
 "rmm" = (
-/obj/structure/grille/broken,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/grille/broken,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_access_txt = "null";
 	req_one_access_txt = "25;26;35;28;22;37;46;38"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "rmr" = (
@@ -62357,17 +62319,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_access_txt = "null";
@@ -69841,18 +69794,8 @@
 /area/hallway/primary/fore)
 "uzT" = (
 /obj/structure/table,
-/obj/item/stack/package_wrap,
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 4
-	},
-/obj/item/hand_labeler,
 /obj/machinery/light/small,
 /obj/machinery/fax/service,
-/obj/item/book/manual/wiki/sopservice,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/modular_fabricator/autolathe,
 /turf/open/floor/plating,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3549,13 +3549,13 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aHX" = (
-/obj/machinery/rnd/production/techfab/department/service,
-/obj/effect/turf_decal/stripes/box,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/rnd/production/techfab/department/service,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
-/area/maintenance/central)
+/area/hallway/secondary/service)
 "aIa" = (
 /turf/closed/wall/rust,
 /area/science/lab)
@@ -3677,7 +3677,7 @@
 "aIN" = (
 /obj/structure/sign/departments/botany,
 /turf/closed/wall,
-/area/maintenance/central)
+/area/hallway/secondary/service)
 "aIO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/closed/wall,
@@ -7563,7 +7563,7 @@
 "byy" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/rust,
-/area/maintenance/central)
+/area/hallway/secondary/service)
 "byI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20807,6 +20807,9 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/showroomfloor,
 /area/crew_quarters/kitchen)
+"eOM" = (
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "eOS" = (
 /obj/effect/spawner/randomvend/snack,
 /obj/structure/sign/poster/official/the_owl{
@@ -22182,9 +22185,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -22916,8 +22916,15 @@
 /obj/effect/turf_decal/stripes/closeup{
 	dir = 1
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark,
-/area/maintenance/central)
+/area/hallway/secondary/service)
 "fvk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -25607,6 +25614,20 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
+"goy" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engidesk";
+	name = "engineering Security Door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engi Desk";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/modular_fabricator/autolathe,
+/turf/open/floor/iron/dark,
+/area/engine/break_room)
 "goJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -34911,6 +34932,17 @@
 	burnt = 1
 	},
 /area/maintenance/fore)
+"jnG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating{
+	broken = 1
+	},
+/area/hallway/secondary/service)
 "jnH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -38652,6 +38684,33 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/port/aft)
+"kye" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating{
+	burnt = 1
+	},
+/area/hallway/secondary/service)
 "kyj" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/grille/broken,
@@ -41556,6 +41615,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/crew_quarters/kitchen)
+"lyj" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/obj/machinery/fax/service,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/hand_labeler,
+/turf/open/floor/plating{
+	burnt = 1
+	},
+/area/hallway/secondary/service)
 "lyC" = (
 /obj/structure/table,
 /obj/item/wallframe/airalarm,
@@ -46801,6 +46872,22 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/genetics/cloning)
+"njA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/wiki/sopservice,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/plating{
+	burnt = 1
+	},
+/area/hallway/secondary/service)
 "njE" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -53764,6 +53851,9 @@
 	broken = 1
 	},
 /area/maintenance/port/aft)
+"psO" = (
+/turf/closed/wall/rust,
+/area/hallway/secondary/service)
 "psP" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/radio/intercom{
@@ -59631,8 +59721,30 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_access_txt = "null";
+	req_one_access_txt = "25;26;35;28;22;37;46;38"
+	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/hallway/secondary/service)
 "rmr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -62238,6 +62350,31 @@
 	broken = 1
 	},
 /area/maintenance/port/fore)
+"sfS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_access_txt = "null";
+	req_one_access_txt = "25;26;35;28;22;37;46;38"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "sfW" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -67577,9 +67714,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
@@ -69715,10 +69849,14 @@
 /obj/machinery/light/small,
 /obj/machinery/fax/service,
 /obj/item/book/manual/wiki/sopservice,
-/turf/open/floor/plating{
-	burnt = 1
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
 	},
-/area/maintenance/central)
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/modular_fabricator/autolathe,
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "uAh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -78209,9 +78347,6 @@
 /area/maintenance/fore)
 "xdm" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -114777,10 +114912,10 @@ hTH
 ajt
 fVI
 bpq
-apX
-aox
-aox
-aox
+psO
+eOM
+eOM
+eOM
 aox
 tJK
 asx
@@ -115033,9 +115168,9 @@ boT
 dqV
 kfA
 jka
-aox
+nbl
 aHX
-boc
+njA
 uzT
 byy
 iCd
@@ -115291,9 +115426,9 @@ lyi
 afd
 fVI
 bqb
-nbl
+eOM
 fvg
-nbl
+lyj
 aIN
 eIt
 oMg
@@ -115549,9 +115684,9 @@ bwi
 sGS
 wTZ
 rmm
-txO
-loK
-pFr
+kye
+jnG
+sfS
 huh
 nRm
 asx
@@ -116353,7 +116488,7 @@ awN
 awN
 aGv
 wgp
-aGv
+goy
 buT
 nTi
 aGv

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -69795,8 +69795,6 @@
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/fore)
 "uzT" = (
-/obj/structure/table,
-/obj/machinery/fax/service,
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/modular_fabricator/autolathe,
 /turf/open/floor/plating,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3549,11 +3549,11 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "aHX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/effect/turf_decal/stripes/box,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aIa" = (
@@ -34928,6 +34928,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	broken = 1
 	},
@@ -41597,7 +41600,6 @@
 /area/crew_quarters/kitchen)
 "lyj" = (
 /obj/structure/table,
-/obj/machinery/light/small,
 /obj/machinery/fax/service,
 /obj/item/hand_labeler,
 /obj/item/stack/package_wrap,
@@ -69794,7 +69796,6 @@
 /area/hallway/primary/fore)
 "uzT" = (
 /obj/structure/table,
-/obj/machinery/light/small,
 /obj/machinery/fax/service,
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/modular_fabricator/autolathe,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -25622,7 +25622,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/northright{
 	dir = 4;
-	name = "Engi Desk";
+	name = "Engi AutoLathe";
 	req_one_access_txt = "32;19"
 	},
 /obj/machinery/modular_fabricator/autolathe,
@@ -75005,7 +75005,7 @@
 	},
 /obj/machinery/door/window/eastleft{
 	name = "Engineering Desk";
-	req_access_txt = "10"
+	req_access_txt = "32"
 	},
 /obj/item/folder/yellow{
 	pixel_x = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9121,6 +9121,9 @@
 	name = "Engineering Foyer";
 	req_one_access_txt = "32"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engine/break_room)
 "bne" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8606,12 +8606,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"bjF" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/iron,
-/area/engine/break_room)
 "bjK" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9095,15 +9089,39 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bmY" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Foyer";
+	req_one_access_txt = "32"
+	},
+/turf/open/floor/iron,
 /area/engine/break_room)
 "bne" = (
 /obj/machinery/newscaster{
@@ -17777,10 +17795,17 @@
 	dir = 8;
 	sortType = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -22021,6 +22046,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/dark,
 /area/engine/break_room)
 "dpU" = (
@@ -22279,6 +22307,9 @@
 "dtO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron,
 /area/engine/storage_shared)
 "dtT" = (
@@ -33292,6 +33323,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/iron,
 /area/engine/storage_shared)
 "hES" = (
@@ -39672,12 +39706,6 @@
 	},
 /turf/open/floor/iron,
 /area/crew_quarters/dorms)
-"jXT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall,
-/area/engine/break_room)
 "jXW" = (
 /turf/open/floor/iron/dark/textured,
 /area/security/brig)
@@ -40798,12 +40826,6 @@
 	},
 /turf/open/floor/iron/grid/steel,
 /area/medical/patients_rooms)
-"ktu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall,
-/area/engine/storage_shared)
 "ktJ" = (
 /obj/machinery/computer/card/minor/cmo,
 /obj/structure/window/reinforced{
@@ -43572,11 +43594,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "lxk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron,
 /area/engine/break_room)
@@ -44309,21 +44330,6 @@
 	},
 /turf/open/floor/iron,
 /area/hydroponics)
-"lKM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "lKP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48151,11 +48157,17 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "nde" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/door/poddoor/preopen{
+	id = "Engidesk";
+	name = "engineering Security Door"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/machinery/door/window/eastleft{
+	name = "Engineering Autolathe";
+	req_access_txt = "32"
+	},
+/turf/open/floor/iron/dark,
 /area/engine/break_room)
 "ndq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
@@ -52173,16 +52185,16 @@
 /turf/open/floor/iron/dark,
 /area/chapel/main)
 "oza" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/yellow,
 /obj/machinery/power/apc/auto_name/directional/west{
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -54137,12 +54149,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	pixel_x = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron,
 /area/engine/break_room)
@@ -54733,14 +54751,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -64004,33 +64019,24 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "sSz" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Foyer";
-	req_one_access_txt = "32"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "Engineering Blast Doors"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/item/folder/yellow{
+	pixel_x = 4
 	},
-/turf/open/floor/iron,
+/obj/structure/desk_bell{
+	pixel_x = -8
+	},
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Engineering Desk";
+	req_access_txt = "32"
+	},
+/turf/open/floor/plating,
 /area/engine/break_room)
 "sSA" = (
 /obj/structure/closet/bombcloset/security,
@@ -66598,16 +66604,23 @@
 /turf/open/floor/iron/dark,
 /area/bridge)
 "tNI" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Shared Engineering Storage";
-	req_one_access_txt = "32"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "Engineering Blast Doors"
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Engineering Desk";
+	req_access_txt = "10"
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4
+	},
+/obj/structure/desk_bell{
+	pixel_x = -8
+	},
+/turf/open/floor/plating,
 /area/engine/storage_shared)
 "tNJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -73489,21 +73502,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/prison)
-"wnz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engine/break_room)
 "wnH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -74837,8 +74835,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/iron,
 /area/engine/break_room)
 "wNi" = (
@@ -77153,14 +77161,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "xAw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/iron,
 /area/engine/break_room)
@@ -118983,7 +118991,7 @@ pCj
 aWw
 qDP
 bjE
-lKM
+bjE
 cxK
 oUz
 vKl
@@ -119496,11 +119504,11 @@ qfP
 neU
 bfQ
 iBo
-bjF
-wnz
+bjL
+bjL
 pmL
-jXT
-ktu
+iKI
+owR
 oza
 xhN
 bxd

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14008,7 +14008,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bSe" = (
-/obj/effect/landmark/blobstart,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bSi" = (
@@ -14198,11 +14200,8 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bTe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -14695,10 +14694,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hydroponics)
-"bVz" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/hallway/secondary/service)
 "bVA" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -14708,6 +14703,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bVB" = (
@@ -15544,6 +15540,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/hydroponics)
 "ccC" = (
@@ -15556,6 +15555,9 @@
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron{
 	dir = 1
@@ -16269,14 +16271,11 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/starboard)
 "cjr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -16781,9 +16780,6 @@
 /turf/open/floor/iron/freezer,
 /area/crew_quarters/toilet/restrooms)
 "cow" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/turf_decal/tile/dark_green/opposingcorners{
@@ -23917,6 +23913,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/aisat)
+"dXA" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dYi" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/map/left{
@@ -24066,9 +24076,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -29432,7 +29439,7 @@
 /area/crew_quarters/heads/captain/private)
 "gba" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -30659,9 +30666,6 @@
 /turf/open/floor/carpet/grimy,
 /area/chapel/office)
 "gET" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/light_switch{
@@ -30678,6 +30682,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "gEX" = (
@@ -31807,6 +31812,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "hbA" = (
@@ -33353,6 +33361,7 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "hEV" = (
@@ -38411,10 +38420,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "jzS" = (
@@ -38526,9 +38535,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jBq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
 	req_access_txt = "35"
@@ -40138,7 +40144,6 @@
 /turf/open/floor/iron,
 /area/maintenance/department/science)
 "kfb" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table,
 /obj/item/storage/bag/plants,
 /obj/item/reagent_containers/cup/bucket,
@@ -46196,12 +46201,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"mvj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/hallway/secondary/service)
 "mvo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -48993,6 +48992,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "nuZ" = (
@@ -49815,9 +49815,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/security/main)
 "nKe" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
 /obj/structure/table,
 /obj/machinery/fax/service,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -51065,9 +51062,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ogw" = (
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 21
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -51084,6 +51078,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "ogE" = (
@@ -55289,9 +55286,6 @@
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
 "pJc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -55300,6 +55294,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "pJd" = (
@@ -60244,11 +60241,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "rAr" = (
@@ -61041,9 +61036,6 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "rPM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -63298,17 +63290,14 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "sDH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "sEf" = (
@@ -63818,6 +63807,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "sOp" = (
@@ -65320,13 +65312,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	sortType = 20
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "tpV" = (
@@ -66924,14 +66917,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tUh" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 20
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "tUi" = (
@@ -68815,6 +68807,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "uBG" = (
@@ -69613,6 +69608,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "uRl" = (
@@ -70909,13 +70907,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21;
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "vpq" = (
@@ -75192,12 +75193,6 @@
 /turf/open/floor/iron,
 /area/crew_quarters/locker)
 "wUi" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 24
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/modular_fabricator/autolathe,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -75704,9 +75699,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "xdM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -116700,10 +116692,10 @@ soM
 byN
 rPM
 tUh
-bVz
+xVl
 kfb
 nKe
-bVz
+xVl
 ogw
 vph
 msY
@@ -117473,7 +117465,7 @@ bSe
 rAc
 xVl
 xVl
-mvj
+xVl
 xVl
 xAq
 bcd
@@ -117984,7 +117976,7 @@ wjj
 fnk
 tfc
 sDH
-uRd
+dXA
 hbz
 uRd
 pJc

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16767,6 +16767,10 @@
 	dir = 4
 	},
 /obj/machinery/rnd/production/techfab/department/service,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "cpd" = (
@@ -30633,6 +30637,16 @@
 	pixel_x = -23;
 	pixel_y = -23
 	},
+/obj/item/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "gEX" = (
@@ -33295,10 +33309,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "hET" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "hEV" = (
@@ -40099,6 +40119,10 @@
 	},
 /obj/item/kitchen/rollingpin,
 /obj/item/book/manual/wiki/sopservice,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "kfm" = (
@@ -49784,6 +49808,14 @@
 	},
 /obj/structure/table,
 /obj/machinery/fax/service,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "nKu" = (
@@ -75152,9 +75184,6 @@
 /turf/open/floor/iron,
 /area/crew_quarters/locker)
 "wUi" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/service";
 	dir = 1;
@@ -75162,7 +75191,11 @@
 	pixel_y = 24
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/item/kirbyplants/random,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/effect/turf_decal/tile/dark_green/opposingcorners{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "wUu" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -2221,6 +2221,8 @@
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/book/manual/wiki/sopservice,
+/obj/item/stack/sticky_tape,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "aJa" = (
@@ -17209,11 +17211,11 @@
 	dir = 9
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/rnd/production/techfab/department/service,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/dark_green/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "fsB" = (
@@ -23670,9 +23672,9 @@
 /area/security/main)
 "hvH" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/rack,
-/obj/item/stack/sticky_tape,
-/obj/item/book/manual/wiki/sopservice,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/effect/turf_decal/tile/dark_green/anticorner/contrasted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "hvL" = (
@@ -40010,9 +40012,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -53999,6 +53998,8 @@
 /area/science/robotics)
 "rev" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating{
 	burnt = 1
 	},
@@ -54684,6 +54685,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/iron/techmaint,
 /area/hallway/secondary/service)

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -17210,7 +17210,6 @@
 /obj/effect/turf_decal/tile/neutral/anticorner{
 	dir = 9
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 4

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -40480,7 +40480,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/northright{
 	dir = 2;
-	name = "Engi Desk";
+	name = "Engi Autolathe";
 	req_one_access_txt = "32;19"
 	},
 /obj/machinery/modular_fabricator/autolathe,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds lathes to the service department, adds missing lathes to engineering in maps missing them, adds 2 pies to the clown arsenal in Delta,  electrifies the cables in the sec outpost in engineering and removes unnecesary cables in CE room, both on BoxStation.

## Why It's Good For The Game

The grand majority of stuff lathes spit out are mostly used by civilians and service. Why not give them their own lathe?. I gave engineering lathes too to standarize it (like RadStaiton), clowns usually get more than one cpie (in Delta they only get 1), security should be electrified and extra cables on a single tiles are bad. I did not add more lathes to Echo since it's so small.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

There are too much changes to put them all here, check the MapDiff bot
 
![imagen](https://github.com/user-attachments/assets/deff318d-8c1d-4d76-939b-4000562dce4d)

</details>

## Changelog
:cl: ClownMoff
add: All maps except Echo: Gives service an autolathe in the service protolatheroom.
add: DeltaStation: Gives the clowns 2 extra pies.
add: CorgStation: Gives CorgStation service lathe room an APC
add: BoxStation: Electrifies the engineering security room.
add: Adds missing autolathes and reception desk in either engineering or atmospheric facing the public in the stations that are missing them (Except EchoStation).
del: BoxStation: Removed unnecesary extra cables on the CE room.
tweak: BoxStation: Reorganized soem disposals that went through walls on the service lathe room to not go through walls
/:cl: