### PR TITLE
makes badges tiny

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -428,6 +428,7 @@
 	desc = "A badge of the Nanotrasen Security Division, made of silver and set on false black leather."
 	icon_state = "officerbadge"
 	worn_icon_state = "officerbadge"
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/clothing/accessory/badge/officer/attack_self(mob/user)
 	if(Adjacent(user))


### PR DESCRIPTION
## About The Pull Request

gives badges the tiny weight class

![Screenshot_7](https://github.com/user-attachments/assets/95338cfa-b8fa-484d-8703-538233ed37b0)

## Why It's Good For The Game

this was sort of intended from the getgo as badges are smaller than your hand

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![Screenshot_7](https://github.com/user-attachments/assets/95338cfa-b8fa-484d-8703-538233ed37b0)

</details>

## Changelog
:cl:
tweak: security badges are now tiny
/:cl: