### PR TITLE
Clown planet fuel rod.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -303,12 +303,7 @@
 /area/ruin/powered/clownplanet)
 "bQ" = (
 /obj/structure/table/glass,
-/obj/item/grown/bananapeel/bluespace,
-/turf/open/floor/carpet,
-/area/ruin/powered/clownplanet)
-"bR" = (
-/obj/structure/table/glass,
-/obj/item/clothing/shoes/clown_shoes/banana_shoes,
+/obj/item/fuel_rod/material/bananium,
 /turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bS" = (
@@ -324,6 +319,7 @@
 "bT" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/waterflower/superlube,
+/obj/item/grown/bananapeel/bluespace,
 /turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bU" = (
@@ -333,6 +329,7 @@
 "bV" = (
 /obj/structure/table/glass,
 /obj/item/gun/magic/staff/honk,
+/obj/item/clothing/shoes/clown_shoes/banana_shoes,
 /turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bW" = (
@@ -1524,7 +1521,7 @@ xf
 XS
 cc
 bM
-bR
+bQ
 bV
 bM
 cc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Clown Planet Biodome ruin now spawns with 2 bananium fuel rods for the RBMK.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Completely unused code from the RBMK, gives a little more treasure to such a rare ruin.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/002f9d60-1e10-440a-88e5-a085c8b418b8)


</details>

## Changelog
:cl:
add: clown planet biodome now has 2 bananium fuel rods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
