### PR TITLE
Lone Operative Landmarks.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -46640,6 +46640,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pxq" = (
+/obj/effect/landmark/loneops,
+/turf/open/space/basic,
+/area/space)
 "pxz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -104140,7 +104144,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+pxq
 ahn
 obt
 ahn
@@ -131713,7 +131717,7 @@ bNG
 bNG
 aaf
 aaf
-aaa
+pxq
 aaa
 aaa
 aaa

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -13205,6 +13205,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"edQ" = (
+/obj/structure/lattice,
+/obj/effect/landmark/loneops,
+/turf/open/space/basic,
+/area/space/nearstation)
 "edS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -46664,6 +46669,10 @@
 	},
 /turf/open/floor/iron,
 /area/bridge)
+"oXo" = (
+/obj/effect/landmark/loneops,
+/turf/open/space/basic,
+/area/space)
 "oXu" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -81241,7 +81250,7 @@ aMT
 aMT
 aMT
 aMT
-aMT
+oXo
 aMT
 aMT
 aMT
@@ -88608,7 +88617,7 @@ aMT
 aMT
 oTx
 anT
-anT
+edQ
 anT
 anT
 anT
@@ -97446,7 +97455,7 @@ aMT
 aMT
 aMT
 aMT
-aMT
+oXo
 aMT
 aMT
 aMT

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -58813,6 +58813,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/janitor/custodian)
+"mUj" = (
+/obj/effect/landmark/loneops,
+/turf/open/space/basic,
+/area/space)
 "mUm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -123074,7 +123078,7 @@ aaa
 aad
 aaa
 aaa
-aaa
+mUj
 aad
 aaa
 aaa
@@ -146454,7 +146458,7 @@ cIW
 cHU
 aaa
 aaa
-aaa
+mUj
 aaa
 aaa
 aaa

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -26262,6 +26262,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gIB" = (
+/obj/effect/landmark/loneops,
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "gIC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
@@ -28174,6 +28178,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/quartermaster/storage)
+"hhI" = (
+/obj/effect/landmark/loneops,
+/turf/open/floor/plating/asteroid/airless,
+/area/space/nearstation)
 "hhW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -125671,7 +125679,7 @@ nnx
 nnx
 csJ
 tsN
-tsN
+gIB
 tsN
 xJu
 hSG
@@ -135847,7 +135855,7 @@ kHH
 kHH
 kHH
 abN
-abN
+hhI
 abN
 abN
 abN

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -16334,6 +16334,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/engine/atmos)
+"duw" = (
+/obj/structure/flora/rock/pile,
+/obj/effect/landmark/loneops,
+/turf/open/floor/plating/asteroid/airless,
+/area/space/nearstation)
 "duy" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -40571,6 +40576,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"lgU" = (
+/obj/effect/landmark/loneops,
+/turf/open/floor/plating/asteroid/airless,
+/area/space/nearstation)
 "lhi" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "1;4"
@@ -93735,7 +93744,7 @@ cnm
 cnm
 cnm
 ajd
-aeU
+lgU
 aeU
 aeU
 aeU
@@ -120377,7 +120386,7 @@ aaa
 aaa
 aaa
 aeU
-aUz
+duw
 aeu
 aeu
 alB

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -68346,6 +68346,10 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/security/prison)
+"uuk" = (
+/obj/effect/landmark/loneops,
+/turf/open/space/basic,
+/area/space)
 "uuF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "transittube";
@@ -92505,7 +92509,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+uuk
 aaa
 aaa
 aaa
@@ -125867,7 +125871,7 @@ aaa
 aaa
 aaa
 aaf
-aaa
+uuk
 aaf
 aaa
 aaa

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -24024,6 +24024,11 @@
 /obj/item/bedsheet/double/rd,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"hAw" = (
+/obj/structure/lattice,
+/obj/effect/landmark/loneops,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hAA" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload";
@@ -25769,6 +25774,10 @@
 	},
 /turf/open/floor/iron,
 /area/quartermaster/qm)
+"ifu" = (
+/obj/effect/landmark/loneops,
+/turf/open/space/basic,
+/area/space)
 "ifv" = (
 /obj/machinery/camera/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -96779,7 +96788,7 @@ sLX
 ibS
 utc
 lfC
-gsA
+hAw
 yeA
 yeA
 yeA
@@ -118888,7 +118897,7 @@ jxz
 dJS
 qSl
 hGK
-yeA
+ifu
 yeA
 yeA
 gsA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

LoneOperative spawner landmarks were added in #11331 because lone operatives would spawn on top of carp and instantly die, but it was never implemented on other maps.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lone operatives shouldnt be spawning next to space carp and getting attacked right after being spawned?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/0cf78e63-32d6-4613-99a5-0f62ad3eaa9e)

RADSTATION:
![image](https://github.com/user-attachments/assets/ffdddcf8-8dd1-4c33-8fcf-fa55c588bfe5)
![image](https://github.com/user-attachments/assets/6f2c19ce-387d-4278-b52e-a802ea4fbc81)

METASTATION:
![image](https://github.com/user-attachments/assets/befdee81-c205-4c6c-ba01-39c73aee5717)
![image](https://github.com/user-attachments/assets/7660e2f7-dddd-43ee-9e15-adc4bba63aec)

CORGSTATION:
![image](https://github.com/user-attachments/assets/297179e8-a0fb-43f8-8ae2-91e749ad80cc)
![image](https://github.com/user-attachments/assets/e27b9d7b-c30b-4ed2-aadc-94e372f9f6b4)
![image](https://github.com/user-attachments/assets/78aa508f-f138-42ed-a2f9-db8d0255c367)

BOXSTATION:
![image](https://github.com/user-attachments/assets/9e002a1a-3f14-4b56-b797-adfad2945934)
![image](https://github.com/user-attachments/assets/222bdf9c-7270-4a6c-8213-6733414e840b)

DELTASTATION:
![image](https://github.com/user-attachments/assets/46f28e5b-6359-4868-b8dd-ef15fbecafe6)
![image](https://github.com/user-attachments/assets/51196352-de08-4068-8f02-fd404689bc62)

FLANDSTATION:
![image](https://github.com/user-attachments/assets/307a0d8f-2850-4d19-9f9b-95b14620281e)
![image](https://github.com/user-attachments/assets/bcf92ed9-9472-4df5-9d2b-bbb8660431e9)

KILOSTATION:
![image](https://github.com/user-attachments/assets/736b9195-4ca2-4116-9eb6-ec998ac6f9f7)
![image](https://github.com/user-attachments/assets/5000fc3d-b5f2-4d3d-93b4-e1e8310b0e27)





</details>

## Changelog
:cl:
add: All maps now use lone operative landmark spawners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
