### PR TITLE
Fix clock cult armor

### DIFF
--- a/code/modules/antagonists/clock_cult/items/brass_clothing.dm
+++ b/code/modules/antagonists/clock_cult/items/brass_clothing.dm
@@ -18,10 +18,10 @@
 
 /obj/item/clothing/suit/clockwork/equipped(mob/living/user, slot)
 	. = ..()
-	if(istype(user, /mob/living/carbon/human/consistent) || istype(user, /mob/living/carbon/human/dummy))
+	if((istype(user, /mob/living/carbon/human/consistent) && !user.client) || (istype(user, /mob/living/carbon/human/dummy) && !user.client))
 		//Fake people need not apply (it fucks up my unit tests)
 		return
-	if(is_servant_of_ratvar(user) && allow_any)
+	if(is_servant_of_ratvar(user) || allow_any)
 		return
 	to_chat(user, "<span class='userdanger'>You feel a shock of energy surge through your body!</span>")
 	user.dropItemToGround(src, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I put in a new check in #11749 that makes it so UI dummies could correctly wear the cult armor without it processing and shocking.

Something fucked up, so I have reinforced the check and the clockcult check is now a OR operator.

closes #11954 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Clockcult can wear

![Screenshot 2024-11-29 095516](https://github.com/user-attachments/assets/8de8a480-548c-411a-a2db-346b4024de3d)

Regular crew cannot

https://github.com/user-attachments/assets/43e3c229-5d03-499a-9d10-f952399edc69



</details>

## Changelog
:cl:
fix: inverted clockcult armor checks. Cultists can wear armor again, normals cannot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
