### PR TITLE
Buffs the derringer

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -616,8 +616,9 @@
 
 /obj/item/storage/box/syndie_kit/derringer
 	name = "'Infiltrator' pistol bundle"
-	desc = "Contains a Syndicate issued coat pistol, and one Match grade .38-special speed loader."
+	desc = "Contains a Syndicate issued coat pistol, and one Match grade .357 speed loader."
 
 /obj/item/storage/box/syndie_kit/derringer/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/pistol/der38(src)
-	new /obj/item/ammo_box/c38/match(src)
+	for (var/i in 1 to 6)
+		new /obj/item/ammo_casing/a357(src)

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -77,12 +77,6 @@
 	. = ..()
 	create_reagents(reagent_amount, OPENCONTAINER)
 
-/obj/item/ammo_casing/c38/emp
-	name = ".38 'BLK_OUT' bullet casing"
-	desc = "A specialized .38 bullet casing that releases a small electromagnetic burst on impact."
-	icon_state = "sS-casing"
-	projectile_type = /obj/projectile/bullet/c38/emp
-
 /obj/item/ammo_casing/c38/improv
 	name = "improv .38 bullet casing"
 	desc = "An improvised .38 bullet casing."

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -55,11 +55,6 @@
 	desc = "Designed to quickly reload revolvers. Blister rounds can be injected with up to 10 units of chemicals."
 	ammo_type = /obj/item/ammo_casing/c38/dart
 
-/obj/item/ammo_box/c38/emp
-	name = "speed loader (.38 BLK_OUT)"
-	desc = "Designed to quickly reload revolvers. 'BLK_OUT' rounds unleash a small EMP on impact."
-	ammo_type = /obj/item/ammo_casing/c38/emp
-
 /obj/item/ammo_box/c38/mime
 	name = "speed loader (.38 finger)"
 	max_ammo = 6

--- a/code/modules/projectiles/boxes_magazines/internal/revolver.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/revolver.dm
@@ -20,8 +20,8 @@
 
 /obj/item/ammo_box/magazine/internal/der38
 	name = "derringer internal chambering"
-	ammo_type = /obj/item/ammo_casing/c38/match
-	caliber = "38"
+	ammo_type = /obj/item/ammo_casing/a357
+	caliber = "357"
 	max_ammo = 2
 
 /obj/item/ammo_box/magazine/internal/der38/twelveshooter

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -31,7 +31,7 @@
 
 /obj/item/gun/ballistic/automatic/pistol/der38
 	name = "palm pistol"
-	desc = "An 'Infiltrator' double-barreled derringer, chambered in .38-special. Not the best for head-on engagements."
+	desc = "An 'Infiltrator' double-barreled derringer, chambered in the powerful .357. Useful in a pinch but inadequate for longer engagements."
 	icon_state = "derringer"
 	w_class = WEIGHT_CLASS_SMALL
 	item_state = null //Too small to show in hand, unless examined
@@ -47,8 +47,6 @@
 	fire_sound_volume = 60
 	spread = 18 //Innate spread of 18 degrees, unwielded spread of 48; Stechkin is unwielded 40
 	weapon_weight = WEAPON_LIGHT * 0.5 //Equivelant weight to 0.5 (Stechkin has weight 1)
-	wild_spread = TRUE
-	wild_factor = 0.70 //Minimum spread is 70% of spread value
 	equip_time = 0
 	has_weapon_slowdown = FALSE
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -89,15 +89,6 @@
 		var/mob/living/M = target
 		M.adjust_bodytemperature(((100-blocked)/100)*(temperature - M.bodytemperature))
 
-/obj/projectile/bullet/c38/emp
-	name = ".38 BLK_OUT bullet"
-	damage = 8
-	ricochets_max = 0
-
-/obj/projectile/bullet/c38/emp/on_hit(atom/target)
-	. = ..()
-	empulse(target, 0, 2)
-
 /obj/projectile/bullet/c38/improv
 	damage = 25
 	ricochets_max = 1

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -697,8 +697,9 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 
 /datum/uplink_item/dangerous/derringer
 	name = "'Infiltrator' Coat Pistol"
-	desc = "For the deeply embedded agent; a very compact dual-barreled handgun chambered in .38-special. Compatible with \
-			standard production NT speed loaders. Loaded with .38 Match ammunition and includes a spare speedloader."
+	desc = "For the deeply embedded agent; a very compact dual-barreled handgun chambered with highly powerful .357 rounds. \
+		It's small ammo capacity and difficult to obtain ammo make it poor at prolonged engagements, but it's saved the lives of \
+		many agents that find themselves in sticky situations."
 	item = /obj/item/storage/box/syndie_kit/derringer
 	cost = 4
 	purchasable_from = ~UPLINK_CLOWN_OPS

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1031,60 +1031,6 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	illegal_tech = FALSE
 	contents_are_illegal_tech = FALSE
 
-/datum/uplink_item/ammo/c38
-	name = ".38-special Speed Loader"
-	desc = "A standard issue .38-special speed loader, for use with the Detective's revolver or 'Infiltrator' coat pistol."
-	item = /obj/item/ammo_box/c38
-	cost = 1
-	purchasable_from = ~UPLINK_CLOWN_OPS
-	illegal_tech = FALSE
-	contents_are_illegal_tech = FALSE
-
-/datum/uplink_item/ammo/c38blister
-	name = ".38-special 'Blister' Speed Loader"
-	desc = "For when you can't deside between a coat pistol and a dart pistol! These 6 cartridges can \
-			be injected with up to 10 units of your favorite poison for remote application via sidearm."
-	item = /obj/item/ammo_box/c38/dart
-	cost = 1
-	purchasable_from = ~UPLINK_CLOWN_OPS
-	illegal_tech = FALSE
-	contents_are_illegal_tech = FALSE
-
-/datum/uplink_item/ammo/c38dumdum
-	name = ".38-special DumDum Speed Loader"
-	desc = "6 specialized fragmenting .38-special catridges, excellent for dispatching unarmored targets. \
-			Shrapnel can embed within the victim and provide a debilitating effect. Not advised for use \
-			against armored targets."
-	item = /obj/item/ammo_box/c38/dumdum
-	cost = 1
-	purchasable_from = ~UPLINK_CLOWN_OPS
-
-/datum/uplink_item/ammo/c38iceblox
-	name = ".38-special Iceblox Speed Loader"
-	desc = "6 .38-special Iceblox cartridges, 'guaranteed' to free your target to the core."
-	item = /obj/item/ammo_box/c38/iceblox
-	cost = 1
-	purchasable_from = ~UPLINK_CLOWN_OPS
-
-/datum/uplink_item/ammo/c38hotshot
-	name = ".38-special Hot Shot Speed Loader"
-	desc = "6 .38-special Hot Shot cartridges. Set your target ablaze with this specialized thermal payload."
-	item = /obj/item/ammo_box/c38/hotshot
-	cost = 1
-	purchasable_from = ~UPLINK_CLOWN_OPS
-	illegal_tech = FALSE
-	contents_are_illegal_tech = FALSE
-
-/datum/uplink_item/ammo/c38emp
-	name = ".38-special 'BLK_OUT' Speed Loader"
-	desc = "6 specialized 'anti-silicon' .38-special cartridges that release a minor EMP on impact with a hard surface. \
-			From Silicons, to IPCs, to any machinery or energy-based weapons in use by security, leave them in the dark."
-	item = /obj/item/ammo_box/c38/emp
-	cost = 1
-	purchasable_from = ~UPLINK_CLOWN_OPS
-	illegal_tech = FALSE
-	contents_are_illegal_tech = FALSE
-
 /datum/uplink_item/ammo/a40mm
 	name = "40mm Grenade Box"
 	desc = "A box of 40mm HE grenades for use with the M-90gl's under-barrel grenade launcher. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the derringer was made, it was made to be pretty useless. This gives it the following buffs:
- It is now chambered in .357, rounds that deal 60 damage but are harder to obtain
- It now starts with lethal rounds
- You get 6 extra bullets instead of an ammo box
- Removes the forced inaccuracy

## Why It's Good For The Game

We have been letting antags slowly become less and less powerful over-time, which has resulted in them being unable to do anything due to losing the second they get into any form of combat. This is not how things should be, in order to have roleplay opportunities you need to have things that are powerful.

I am never going to choose anything bold as a traitor, when I know that its going to suck.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/7f7a15df-0583-4a75-a11e-3ec2e57baf96)

![image](https://github.com/user-attachments/assets/c488ea9a-0f59-42a7-bc0f-01c1a6068fcd)

## Changelog
:cl:
balance: Derringer now uses the highly lethal .357 rounds.
del: Removes the now pointless .38 ammo from the uplink, and removes the now-unused EMP .38 ammo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
