### PR TITLE
Adds a Better Warning to the RBMK Fuel Rod Crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1138,7 +1138,7 @@
 
 /datum/supply_pack/engineering/fuel_rods
 	name = "Uranium Fuel Rod Crate"
-	desc = "A five nuclear reactor grade fuel rod crate. Don't forget to wear radiation protection!"
+	desc = "A five nuclear reactor grade fuel rod crate. Warning: Due to budget constraints, this crate is not lead-lined! Wear radiation protection around this crate."
 	cost = 3000
 	max_supply = 2
 	access_budget = ACCESS_ENGINE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Fuel Rod Crate for the RBMK contains fuel rods, which are radioactive, but the description doesn't clearly show that the crate itself does not block the rads from the fuel rods. 

With the behavior of a very similar crate (the supermatter shard), it can be inferred that the danger occurs AFTER the crate is opened and the rods exposed, and not as soon as the crate arrives.

This PR clarifies that the RBMK fuel is radioactive as soon as it arrives, and not after it is opened.

## Why It's Good For The Game

Clarity is good for the game. Suddenly dying for no apparent reason in cargo is not good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Budget Constraints Clarified in the RBMK Fuel Rod Crate
/:cl:
