### PR TITLE
removes references to polycrystals

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -116,11 +116,11 @@ Charged extracts:
 
 /obj/item/slimecross/charged/bluespace
 	colour = "bluespace"
-	effect_desc = "Makes a bluespace polycrystal."
+	effect_desc = "Makes a bluespace crystal."
 
 /obj/item/slimecross/charged/bluespace/do_effect(mob/user)
 	new /obj/item/stack/ore/bluespace_crystal/refined(get_turf(user), 10)
-	user.visible_message("<span class='notice'>[src] produces several sheets of polycrystal!</span>")
+	user.visible_message("<span class='notice'>[src] produces several sheets of crystal!</span>")
 	..()
 
 /obj/item/slimecross/charged/sepia


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removed in https://github.com/BeeStation/BeeStation-Hornet/pull/7035

these references should not exist

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We need to hold contributors to policy. 

Contributors need to make sure the changes they make are appropriately reflected on the wiki and in the game. 

While it may not be easy to make references match 1:1 all the time, we need focus especially on Guides to roles or tasks such as Guide to Xenobiology, Guide to Chemistry, Guide to Supermatter, and Guide to Food. These are all resources that are used heavily by both new and experienced player alike.

There shouldnt have been polycrystal references for 2 years. These mistakes generate confusion for new players and way too much time for mentors to debate upon. This can be found easily with search & find ctrl+f. C'mon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/4cd25024-0ee0-4e91-b3f6-64ef0bc586a9)

It compiles.

</details>

## Changelog
:cl:
fix: removes references to obsolete polycrystals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
