### PR TITLE
RadStation centre holopad Move-al

### DIFF
--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -440,7 +440,10 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "agj" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -2231,7 +2234,10 @@
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
 "aJb" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/carpet/blue,
 /area/medical/exam_room)
@@ -2492,7 +2498,10 @@
 /turf/open/floor/iron,
 /area/maintenance/department/security)
 "aMw" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
@@ -3684,7 +3693,10 @@
 /turf/open/floor/iron/dark,
 /area/quartermaster/exploration_prep)
 "bgF" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -4189,7 +4201,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/security/main)
@@ -4296,7 +4311,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "bqz" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -5894,7 +5912,10 @@
 /turf/open/floor/iron,
 /area/science/explab)
 "bRf" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -7048,7 +7069,10 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "ckP" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -7084,7 +7108,10 @@
 /turf/open/floor/iron,
 /area/science/robotics)
 "clu" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -7917,7 +7944,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/bar)
@@ -8007,7 +8037,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
@@ -8413,7 +8446,10 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cHl" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain/private)
@@ -9261,7 +9297,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -9748,7 +9787,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /turf/open/floor/iron,
 /area/engine/break_room)
 "dea" = (
@@ -10765,7 +10807,10 @@
 /turf/open/floor/iron/tech,
 /area/engine/atmos)
 "dwo" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/light/small{
 	dir = 4
@@ -10795,7 +10840,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/guideline/guideline_edge_alt/purple{
 	dir = 8
 	},
@@ -11071,7 +11119,10 @@
 	color = "#DE3A3A"
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig/dock)
 "dAL" = (
@@ -11700,7 +11751,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -12366,7 +12420,10 @@
 /turf/open/floor/iron/white,
 /area/crew_quarters/kitchen)
 "dVe" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/security/prison)
@@ -12595,7 +12652,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "dXS" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -13691,7 +13751,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/theatre/backstage)
@@ -13968,7 +14031,8 @@
 	dir = 8
 	},
 /obj/machinery/holopad{
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
@@ -15121,7 +15185,10 @@
 /turf/open/floor/iron/tech,
 /area/engine/atmos)
 "eNQ" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17498,7 +17565,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/storage/primary)
@@ -17597,7 +17667,10 @@
 /turf/open/floor/iron/dark,
 /area/engine/storage)
 "fzg" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -18174,7 +18247,10 @@
 /turf/open/floor/iron,
 /area/crew_quarters/heads/hop)
 "fIv" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -19721,7 +19797,10 @@
 	},
 /area/science/research)
 "ghm" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/grid/steel,
 /area/science/xenobiology)
@@ -20959,7 +21038,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/wood,
 /area/security/detectives_office)
@@ -21950,7 +22032,10 @@
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "gTA" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -22194,7 +22279,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -27104,7 +27192,10 @@
 /turf/open/floor/iron/grid/steel,
 /area/science/xenobiology)
 "iFF" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -30317,7 +30408,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "jHs" = (
@@ -31194,7 +31288,10 @@
 /area/maintenance/department/medical/morgue)
 "jVx" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -32641,7 +32738,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -32978,7 +33078,10 @@
 /turf/open/floor/iron/techmaint,
 /area/gateway)
 "kAi" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -33916,6 +34019,25 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/tech,
 /area/engine/engine_room)
+"kRd" = (
+/obj/effect/turf_decal/guideline/guideline_in/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_red/half{
+	color = "#DE3A3A"
+	},
+/obj/effect/turf_decal/tile/dark_red/half{
+	color = "#DE3A3A"
+	},
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
+/turf/open/floor/iron/large,
+/area/hallway/primary/central)
 "kRj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -35907,7 +36029,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "lwI" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/cafeteria,
 /area/crew_quarters/kitchen)
@@ -37217,7 +37342,8 @@
 	dir = 4
 	},
 /obj/machinery/holopad{
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=13-Engi";
@@ -38361,7 +38487,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig/dock)
 "mnU" = (
@@ -39141,7 +39270,10 @@
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "mAB" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -39339,7 +39471,8 @@
 /area/security/brig)
 "mDq" = (
 /obj/machinery/holopad{
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /turf/open/floor/iron/sepia,
 /area/quartermaster/office)
@@ -39995,7 +40128,10 @@
 /area/medical/sleeper)
 "mKX" = (
 /obj/effect/landmark/start/chaplain,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/glass/reinforced,
 /area/chapel/main)
@@ -40463,7 +40599,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/box,
@@ -42120,7 +42259,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -42263,7 +42405,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
@@ -42764,7 +42909,10 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
 /area/medical/genetics)
@@ -44266,7 +44414,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/engine/engine_room)
@@ -45474,7 +45625,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/hydroponics)
@@ -46090,7 +46244,10 @@
 "oJg" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/engine/storage)
@@ -47497,7 +47654,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "paD" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/tech,
 /area/engine/atmos)
@@ -48052,7 +48212,8 @@
 	dir = 8
 	},
 /obj/machinery/holopad{
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /obj/effect/turf_decal/guideline/guideline_in/darkblue{
 	dir = 4
@@ -48352,7 +48513,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
@@ -48740,7 +48904,8 @@
 /area/solar/starboard/aft)
 "pwb" = (
 /obj/machinery/holopad{
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/storage/eva)
@@ -50632,7 +50797,10 @@
 /area/medical/virology)
 "pZQ" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/wood,
 /area/maintenance/central)
@@ -50885,7 +51053,10 @@
 /turf/open/floor/iron,
 /area/engine/engine_room)
 "qde" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -51423,7 +51594,10 @@
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
 "qol" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -51554,7 +51728,10 @@
 /area/quartermaster/exploration_prep)
 "qpA" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -53654,7 +53831,10 @@
 /area/engine/atmos)
 "qZa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
@@ -54578,7 +54758,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "rnV" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -55007,7 +55190,10 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "rur" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
@@ -55950,7 +56136,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/carpet,
 /area/library)
@@ -56204,7 +56393,10 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -59770,12 +59962,18 @@
 "sYQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "sYS" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/medical/cryo)
@@ -60214,7 +60412,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /turf/open/floor/iron/tech/grid,
 /area/engine/gravity_generator)
 "tfT" = (
@@ -60639,7 +60840,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -61684,7 +61888,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9-Disp";
 	location = "8-WSci"
@@ -61766,7 +61973,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/holopad{
-	pixel_x = 16
+	pixel_x = 16;
+	pixel_y = 16
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -63652,7 +63860,10 @@
 /turf/open/floor/iron,
 /area/engine/atmos)
 "ugj" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	alpha = 180;
 	dir = 4
@@ -66905,7 +67116,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "vof" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/gateway)
@@ -67754,7 +67968,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -67887,7 +68104,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/engine/atmospherics_engine)
@@ -68225,7 +68445,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/security/warden)
@@ -68613,7 +68836,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -69632,7 +69858,10 @@
 /area/maintenance/department/medical)
 "wlj" = (
 /obj/effect/landmark/start/cook,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
 /area/crew_quarters/kitchen)
@@ -71356,7 +71585,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wNH" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/wood,
 /area/security/prison)
@@ -71559,7 +71791,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/carpet/royalblack,
 /area/lawoffice)
@@ -72261,7 +72496,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
@@ -72610,7 +72848,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/holopad,
+/obj/machinery/holopad{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -108278,7 +108519,7 @@ tnC
 vOn
 lrB
 uKo
-xdo
+kRd
 fCN
 xdo
 ghK

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -37491,10 +37491,6 @@
 "maU" = (
 /obj/effect/landmark/start/randommaint/vip,
 /obj/effect/landmark/observer_start,
-/obj/machinery/holopad{
-	pixel_x = 16;
-	pixel_y = 16
-	},
 /obj/item/beacon{
 	pixel_x = 16;
 	pixel_y = 19


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the holopad from the centre of RadStation, machinery doesnt look good ontop of glass floor tiles.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Its ugly.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/98060180-7c23-405f-b909-7a65aa21014c)


</details>

## Changelog
:cl:
tweak: moves the holopad from the centre of RadStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
