### PR TITLE
Condenses language holders, unit tests them

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -22,9 +22,22 @@
 
 
 // LANGUAGE SOURCE DEFINES
-#define LANGUAGE_ALL "all"	// For use in full removal only.
+/// For use in full removal only.
+#define LANGUAGE_ALL "all"
+
+// Generic language sources.
+/// Language is linked to the movable directly.
 #define LANGUAGE_ATOM "atom"
+/// Language is linked to the mob's mind.
+/// If a mind transfer happens, language follows.
 #define LANGUAGE_MIND "mind"
+/// Language is linked to the mob's species.
+/// If a species change happens, language goes away.
+/// If applied to a non-human (no species) atom, this is effectively the same as [LANGUAGE_ATOM].
+#define LANGUAGE_SPECIES "species"
+
+// More specific language sources.
+// Only ever goes away when dismissed directly.
 #define LANGUAGE_FRIEND	"friend"
 #define LANGUAGE_ABSORB	"absorb"
 #define LANGUAGE_APHASIA "aphasia"
@@ -46,6 +59,13 @@
 #define LANGUAGE_MULTILINGUAL "multilingual"
 #define LANGUAGE_EMP "emp"
 #define LANGUAGE_HOLOPARA "holoparasite"
+#define LANGUAGE_BABEL "babel"
+
+// Language flags. Used in granting and removing languages.
+/// This language can be spoken.
+#define SPOKEN_LANGUAGE (1<<0)
+/// This language can be understood.
+#define UNDERSTOOD_LANGUAGE (1<<1)
 
 // Languages available from Multilingual
 GLOBAL_LIST_INIT(multilingual_language_list, typecacheof(list(

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -96,9 +96,7 @@
 	screen_loc = ui_language_menu
 
 /atom/movable/screen/language_menu/Click()
-	var/mob/M = usr
-	var/datum/language_holder/H = M.get_language_holder()
-	H.open_language_menu(usr)
+	usr.get_language_holder().open_language_menu(usr)
 
 /atom/movable/screen/inventory
 	var/slot_id

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -20,6 +20,9 @@
 
 	var/motd
 
+	/// If the configuration is loaded
+	var/loaded = FALSE
+
 	var/static/regex/ic_filter_regex
 	var/static/regex/ooc_filter_regex
 
@@ -59,6 +62,8 @@
 	LoadTopicRateWhitelist()
 	LoadProtectedIDs()
 	LoadChatFilter()
+
+	loaded = TRUE
 
 	if (Master)
 		Master.OnConfigLoad()

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -718,20 +718,6 @@
 	icon_icon = 'icons/hud/actions/actions_items.dmi'
 	button_icon_state = "jetboot"
 
-/datum/action/language_menu
-	name = "Language Menu"
-	desc = "Open the language menu to review your languages, their keys, and select your default language."
-	button_icon_state = "language_menu"
-	check_flags = NONE
-
-/datum/action/language_menu/Trigger()
-	if(!..())
-		return FALSE
-	if(ismob(owner))
-		var/mob/M = owner
-		var/datum/language_holder/H = M.get_language_holder()
-		H.open_language_menu(usr)
-
 /datum/action/item_action/wheelys
 	name = "Toggle Wheely-Heel's Wheels"
 	desc = "Pops out or in your wheely-heel's wheels."

--- a/code/datums/brain_damage/mrat.dm
+++ b/code/datums/brain_damage/mrat.dm
@@ -123,7 +123,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/camera/imaginary_friend/mrat)
 	leave = new
 	leave.Grant(src)
 
-	grant_all_languages(spoken=FALSE) // they understand all language, but doesn't have to speak that
+	grant_all_languages(UNDERSTOOD_LANGUAGE) // they understand all language, but doesn't have to speak that
 	// mentor rats default language is set to metalanguage from imaginary friend init
 	// everything mrat says will be understandable to all people
 

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -28,13 +28,15 @@
 	lose_text = "<span class='notice'>You suddenly remember how languages work.</span>"
 
 /datum/brain_trauma/severe/aphasia/on_gain()
-	owner.add_blocked_language(subtypesof(/datum/language/) - /datum/language/aphasia, LANGUAGE_APHASIA)
-	owner.grant_language(/datum/language/aphasia, TRUE, TRUE, LANGUAGE_APHASIA)
+	owner.add_blocked_language(subtypesof(/datum/language) - /datum/language/aphasia, LANGUAGE_APHASIA)
+	owner.grant_language(/datum/language/aphasia, source = LANGUAGE_APHASIA)
 	..()
 
 /datum/brain_trauma/severe/aphasia/on_lose()
-	owner.remove_blocked_language(subtypesof(/datum/language/), LANGUAGE_APHASIA)
-	owner.remove_language(/datum/language/aphasia, TRUE, TRUE, LANGUAGE_APHASIA)
+	if(!QDELING(owner))
+		owner.remove_blocked_language(subtypesof(/datum/language), LANGUAGE_APHASIA)
+		owner.remove_language(/datum/language/aphasia, LANGUAGE_APHASIA)
+
 	..()
 
 /datum/brain_trauma/severe/blindness

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -70,7 +70,7 @@ Bonus
 				if(scramble_language && !current_language)	// Last part prevents rerolling language with small amounts of cure.
 					current_language = pick(subtypesof(/datum/language) - /datum/language/common)
 					H.add_blocked_language(subtypesof(/datum/language) - current_language, LANGUAGE_VOICECHANGE)
-					H.grant_language(current_language, TRUE, TRUE, LANGUAGE_VOICECHANGE)
+					H.grant_language(current_language, source = LANGUAGE_VOICECHANGE)
 
 /datum/symptom/voice_change/End(datum/disease/advance/A)
 	..()

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -344,11 +344,6 @@
 		dna.species = new_race
 		dna.species.on_species_gain(src, old_species, pref_load)
 		SEND_SIGNAL(src, COMSIG_CARBON_SPECIESCHANGE, new_race)
-		if(ishuman(src))
-			qdel(language_holder)
-			var/species_holder = initial(mrace.species_language_holder)
-			language_holder = new species_holder(src)
-		update_atom_languages()
 		if(icon_update)
 			update_mutations_overlay()// no lizard with human hulk overlay please.
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -163,7 +163,7 @@
 	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
-	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
+	transfer_antag_huds(hud_to_transfer) //inherit the antag HUD
 	transfer_actions(new_character)
 	transfer_martial_arts(new_character)
 	RegisterSignal(new_character, COMSIG_MOB_DEATH, PROC_REF(set_death_time))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1,24 +1,24 @@
-/*	Note from Carnie:
+/* Note from Carnie:
 		The way datum/mind stuff works has been changed a lot.
 		Minds now represent IC characters rather than following a client around constantly.
 
 	Guidelines for using minds properly:
 
-	-	Never mind.transfer_to(ghost). The var/current and var/original of a mind must always be of type mob/living!
+	- Never mind.transfer_to(ghost). The var/current and var/original of a mind must always be of type mob/living!
 		ghost.mind is however used as a reference to the ghost's corpse
 
-	-	When creating a new mob for an existing IC character (e.g. cloning a dead guy or borging a brain of a human)
-		the existing mind of the old mob should be transfered to the new mob like so:
+	- When creating a new mob for an existing IC character (e.g. cloning a dead guy or borging a brain of a human)
+		the existing mind of the old mob should be transferred to the new mob like so:
 
 			mind.transfer_to(new_mob)
 
-	-	You must not assign key= or ckey= after transfer_to() since the transfer_to transfers the client for you.
+	- You must not assign key= or ckey= after transfer_to() since the transfer_to transfers the client for you.
 		By setting key or ckey explicitly after transferring the mind with transfer_to you will cause bugs like DCing
 		the player.
 
-	-	IMPORTANT NOTE 2, if you want a player to become a ghost, use mob.ghostize() It does all the hard work for you.
+	- IMPORTANT NOTE 2, if you want a player to become a ghost, use mob.ghostize() It does all the hard work for you.
 
-	-	When creating a new mob which will be a new IC character (e.g. putting a shade in a construct or randomly selecting
+	- When creating a new mob which will be a new IC character (e.g. putting a shade in a construct or randomly selecting
 		a ghost to become a xeno during an event). Simply assign the key or ckey like you've always done.
 
 			new_mob.key = key
@@ -30,22 +30,28 @@
 */
 
 /datum/mind
+	/// Key of the mob
 	var/key
-	var/name				//replaces mob/var/original_name
-	var/ghostname			//replaces name for observers name if set
-	/// The last living mob this mind occupied - if the player is dead, this is their body.
+	/// The name linked to this mind
+	var/name
+	/// replaces name for observers name if set
+	var/ghostname
+	/// Current mob this mind datum is attached to
 	var/mob/living/current
-	var/active = 0
+	/// Is this mind active?
+	var/active = FALSE
 
 	var/memory
 	var/list/quirks = list()
 
-	var/assigned_role
+	/// Job datum indicating the mind's role. This should always exist after initialization, as a reference to a singleton.
+	var/datum/job/assigned_role
 	var/special_role
 	var/list/restricted_roles = list()
 	var/list/spell_list = list() // Wizard mode & "Give Spell" badmin button.
 
 	var/linglink
+	/// Martial art on this mind
 	var/datum/martial_art/martial_art
 	var/static/default_martial_art = new/datum/martial_art
 	var/miming = 0 // Mime's vow of silence
@@ -130,9 +136,9 @@
 
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud//we need this because leave_hud() will clear this list
 	var/mob/living/old_current = current
-	if(current)
+	if(old_current)
 		//transfer anyone observing the old character to the new one
-		current.transfer_observers_to(new_character)
+		old_current.transfer_observers_to(new_character)
 
 		// Offload all mind languages from the old holder to a temp one
 		var/datum/language_holder/empty/temp_holder = new()
@@ -163,7 +169,7 @@
 	RegisterSignal(new_character, COMSIG_MOB_DEATH, PROC_REF(set_death_time))
 	if(active || force_key_move)
 		new_character.key = key		//now transfer the key to link the client to our new body
-		
+
 	SEND_SIGNAL(src, COMSIG_MIND_TRANSFER_TO, old_current, new_character)
 	// Update SSD indicators
 	if(isliving(old_current))

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -237,12 +237,12 @@
 
 /datum/mutation/stoner/on_acquiring(mob/living/carbon/owner)
 	..()
-	owner.grant_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_STONER)
+	owner.grant_language(/datum/language/beachbum, source = LANGUAGE_STONER)
 	owner.add_blocked_language(subtypesof(/datum/language) - /datum/language/beachbum, LANGUAGE_STONER)
 
 /datum/mutation/stoner/on_losing(mob/living/carbon/owner)
 	..()
-	owner.remove_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_STONER)
+	owner.remove_language(/datum/language/beachbum, source = LANGUAGE_STONER)
 	owner.remove_blocked_language(subtypesof(/datum/language) - /datum/language/beachbum, LANGUAGE_STONER)
 
 /datum/mutation/medieval

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1048,11 +1048,11 @@
 	. = ..()
 	to_chat(owner, "<span class='warning'>Alert: Vocal cords are malfunctioning.</span>")
 	owner.add_blocked_language(subtypesof(/datum/language/) - /datum/language/uncommon, LANGUAGE_EMP)
-	owner.grant_language(/datum/language/uncommon, FALSE, TRUE, LANGUAGE_EMP)
+	owner.grant_language(/datum/language/uncommon, SPOKEN_LANGUAGE, source = LANGUAGE_EMP)
 
 /datum/status_effect/spanish/on_remove()
 	owner.remove_blocked_language(subtypesof(/datum/language/), LANGUAGE_EMP)
-	owner.remove_language(/datum/language/uncommon, TRUE, TRUE, LANGUAGE_EMP)
+	owner.remove_language(/datum/language/uncommon, source = LANGUAGE_EMP)
 	to_chat(owner, "<span class='warning'>Alert: Vocal cords restored to normal function.</span>")
 	return ..()
 

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -129,7 +129,7 @@
 	if(quirk_holder.assigned_role == JOB_NAME_CURATOR)
 		return
 	var/obj/item/organ/tongue/T = quirk_target.getorganslot(ORGAN_SLOT_TONGUE)
-	var/list/languages_possible = T.languages_possible
+	var/list/languages_possible = T.get_possible_languages()
 	languages_possible = languages_possible - typecacheof(/datum/language/codespeak) - typecacheof(/datum/language/narsie) - typecacheof(/datum/language/ratvar)
 	languages_possible = languages_possible - LH.understood_languages
 	languages_possible = languages_possible - LH.spoken_languages

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -125,7 +125,7 @@
 	var/datum/language/known_language
 
 /datum/quirk/multilingual/proc/set_up_language()
-	var/datum/language_holder/LH = quirk_holder.get_language_holder()
+	var/datum/language_holder/LH = quirk_target.get_language_holder()
 	if(quirk_holder.assigned_role == JOB_NAME_CURATOR)
 		return
 	var/obj/item/organ/tongue/T = quirk_target.getorganslot(ORGAN_SLOT_TONGUE)
@@ -142,14 +142,14 @@
 	known_language = read_choice_preference(/datum/preference/choiced/quirk/multilingual_language)
 	if(!known_language) // default to random
 		set_up_language()
-	var/datum/language_holder/LH = quirk_holder.get_language_holder()
-	LH.grant_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
+	var/datum/language_holder/LH = quirk_target.get_language_holder()
+	LH.grant_language(known_language, source = LANGUAGE_MULTILINGUAL)
 
 /datum/quirk/multilingual/remove()
 	if(!known_language)
 		return
-	var/datum/language_holder/LH = quirk_holder.get_language_holder()
-	LH.remove_language(known_language, TRUE, TRUE, LANGUAGE_MULTILINGUAL)
+	var/datum/language_holder/LH = quirk_target.get_language_holder()
+	LH.remove_language(known_language, source = LANGUAGE_MULTILINGUAL)
 
 /datum/quirk/night_vision
 	name = "Night Vision"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -14,8 +14,10 @@
 	var/throw_speed = 2 //How many tiles to move per ds when being thrown. Float values are fully supported
 	var/throw_range = 7
 	var/mob/pulledby = null
+	/// What language holder type to init as
 	var/initial_language_holder = /datum/language_holder
-	var/datum/language_holder/language_holder	// Mindless mobs and objects need language too, some times. Mind holder takes prescedence.
+	/// Holds all languages this mob can speak and understand
+	VAR_PRIVATE/datum/language_holder/language_holder
 
 	var/verb_say = "says"
 	var/verb_ask = "asks"
@@ -1025,50 +1027,47 @@
 */
 
 /// Gets or creates the relevant language holder. For mindless atoms, gets the local one. For atom with mind, gets the mind one.
-/atom/movable/proc/get_language_holder(get_minds = TRUE)
+/atom/movable/proc/get_language_holder()
+	RETURN_TYPE(/datum/language_holder)
+	if(QDELING(src))
+		CRASH("get_language_holder() called on a QDELing atom, \
+			this will try to re-instantiate the language holder that's about to be deleted, which is bad.")
+
 	if(!language_holder)
 		language_holder = new initial_language_holder(src)
 	return language_holder
 
 /// Grants the supplied language and sets omnitongue true.
-/atom/movable/proc/grant_language(language, understood = TRUE, spoken = TRUE, source = LANGUAGE_ATOM)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.grant_language(language, understood, spoken, source)
+/atom/movable/proc/grant_language(language, language_flags = ALL, source = LANGUAGE_ATOM)
+	return get_language_holder().grant_language(language, language_flags, source)
 
 /// Grants every language.
-/atom/movable/proc/grant_all_languages(understood = TRUE, spoken = TRUE, grant_omnitongue = TRUE, source = LANGUAGE_MIND)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.grant_all_languages(understood, spoken, grant_omnitongue, source)
+/atom/movable/proc/grant_all_languages(language_flags = ALL, grant_omnitongue = TRUE, source = LANGUAGE_MIND)
+	return get_language_holder().grant_all_languages(language_flags, grant_omnitongue, source)
 
 /// Removes a single language.
-/atom/movable/proc/remove_language(language, understood = TRUE, spoken = TRUE, source = LANGUAGE_ALL)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.remove_language(language, understood, spoken, source)
+/atom/movable/proc/remove_language(language, language_flags = ALL, source = LANGUAGE_ALL)
+	return get_language_holder().remove_language(language, language_flags, source)
 
 /// Removes every language and sets omnitongue false.
 /atom/movable/proc/remove_all_languages(source = LANGUAGE_ALL, remove_omnitongue = FALSE)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.remove_all_languages(source, remove_omnitongue)
+	return get_language_holder().remove_all_languages(source, remove_omnitongue)
 
 /// Adds a language to the blocked language list. Use this over remove_language in cases where you will give languages back later.
 /atom/movable/proc/add_blocked_language(language, source = LANGUAGE_ATOM)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.add_blocked_language(language, source)
+	return get_language_holder().add_blocked_language(language, source)
 
 /// Removes a language from the blocked language list.
 /atom/movable/proc/remove_blocked_language(language, source = LANGUAGE_ATOM)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.remove_blocked_language(language, source)
+	return get_language_holder().remove_blocked_language(language, source)
 
 /// Checks if atom has the language. If spoken is true, only checks if atom can speak the language.
-/atom/movable/proc/has_language(language, spoken = FALSE)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.has_language(language, spoken)
+/atom/movable/proc/has_language(language, flags_to_check)
+	return get_language_holder().has_language(language, flags_to_check)
 
 /// Checks if atom can speak the language.
 /atom/movable/proc/can_speak_language(language)
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.can_speak_language(language)
+	return get_language_holder().can_speak_language(language)
 
 /// Returns the result of tongue specific limitations on spoken languages.
 /atom/movable/proc/could_speak_language(datum/language/language_path)
@@ -1076,33 +1075,32 @@
 
 /// Returns selected language, if it can be spoken, or finds, sets and returns a new selected language if possible.
 /atom/movable/proc/get_selected_language()
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.get_selected_language()
+	return get_language_holder().get_selected_language()
 
 /// Gets a random understood language, useful for hallucinations and such.
 /atom/movable/proc/get_random_understood_language()
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.get_random_understood_language()
+	return get_language_holder().get_random_understood_language()
 
 /// Gets a random spoken language, useful for forced speech and such.
 /atom/movable/proc/get_random_spoken_language()
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.get_random_spoken_language()
+	return get_language_holder().get_random_spoken_language()
 
 /// Copies all languages into the supplied atom/language holder. Source should be overridden when you
 /// do not want the language overwritten by later atom updates or want to avoid blocked languages.
-/atom/movable/proc/copy_languages(from_holder, source_override=FALSE, spoken=TRUE, understood=TRUE, blocked=TRUE)
-	if(isatom(from_holder))
+/atom/movable/proc/copy_languages(datum/language_holder/from_holder, source_override=FALSE, spoken=TRUE, understood=TRUE, blocked=TRUE)
+	if(ismovable(from_holder))
 		var/atom/movable/thing = from_holder
 		from_holder = thing.get_language_holder()
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.copy_languages(from_holder, source_override, spoken, understood, blocked)
 
-/// Empties out the atom specific languages and updates them according to the current atoms language holder.
-/// As a side effect, it also creates missing language holders in the process.
-/atom/movable/proc/update_atom_languages()
-	var/datum/language_holder/LH = get_language_holder()
-	return LH.update_atom_languages(src)
+	return get_language_holder().copy_languages(from_holder, source_override, spoken, understood, blocked)
+
+/// Sets the passed path as the active language
+/// Returns the currently selected language if successful, if the language was not valid, returns null
+/atom/movable/proc/set_active_language(language_path)
+	var/datum/language_holder/our_holder = get_language_holder()
+	our_holder.selected_language = language_path
+
+	return our_holder.get_selected_language() // verifies its validity, returns it if successful.
 
 /* End language procs */
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1071,7 +1071,7 @@
 	return LH.can_speak_language(language)
 
 /// Returns the result of tongue specific limitations on spoken languages.
-/atom/movable/proc/could_speak_language(language)
+/atom/movable/proc/could_speak_language(datum/language/language_path)
 	return TRUE
 
 /// Returns selected language, if it can be spoken, or finds, sets and returns a new selected language if possible.

--- a/code/game/objects/items/debug_items.dm
+++ b/code/game/objects/items/debug_items.dm
@@ -334,8 +334,8 @@
 	. = ..()
 	for(var/each in traits_to_give)
 		ADD_TRAIT(user, each, "debug")
-	user.grant_all_languages(TRUE, TRUE, TRUE, "debug")
-	user.grant_language(/datum/language/metalanguage, TRUE, TRUE, "debug")
+	grant_all_languages(source = "debug")
+	user.grant_language(/datum/language/metalanguage, source = "debug")
 
 	var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 	hud.add_hud_to(user)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -524,8 +524,7 @@
 		S.fully_replace_character_name(null, "The spirit of [name]")
 		S.status_flags |= GODMODE
 		S.copy_languages(user, LANGUAGE_MASTER)	//Make sure the sword can understand and communicate with the user.
-		S.update_atom_languages()
-		grant_all_languages(FALSE, FALSE, TRUE)	//Grants omnitongue
+		S.get_language_holder().omnitongue = TRUE //Grants omnitongue
 		var/input = sanitize_name(stripped_input(S,"What are you named?", ,"", MAX_NAME_LEN))
 
 		if(src && input)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1319,8 +1319,7 @@
 		if(!ismob(M))
 			to_chat(usr, "This can only be used on instances of type /mob.")
 			return
-		var/datum/language_holder/H = M.get_language_holder()
-		H.open_language_menu(usr)
+		M.get_language_holder().open_language_menu(usr)
 
 	else if(href_list["traitor"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -135,12 +135,12 @@
 /obj/item/organ/heart/gland/slime/Insert(mob/living/carbon/M, special = 0, pref_load = FALSE)
 	..()
 	owner.faction |= "slime"
-	owner.grant_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_GLAND)
+	owner.grant_language(/datum/language/slime, source = LANGUAGE_GLAND)
 
 /obj/item/organ/heart/gland/slime/Remove(mob/living/carbon/M, special = 0, pref_load = FALSE)
 	..()
 	owner.faction -= "slime"
-	owner.remove_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_GLAND)
+	owner.remove_language(/datum/language/slime, source = LANGUAGE_GLAND)
 
 /obj/item/organ/heart/gland/slime/activate()
 	to_chat(owner, "<span class='warning'>You feel nauseated!</span>")

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -97,7 +97,8 @@
 	if(give_objectives)
 		forge_objectives()
 	handle_clown_mutation(owner.current, "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself.")
-	owner.current.grant_all_languages(FALSE, FALSE, TRUE)	//Grants omnitongue. We are able to transform our body after all.
+	owner.current.get_language_holder().omnitongue = TRUE
+	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 	. = ..()
 
 /datum/antagonist/changeling/on_removal()

--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -74,7 +74,7 @@
 	owner.current.throw_alert("clockinfo", /atom/movable/screen/alert/clockwork/clocksense)
 	SSticker.mode.update_clockcult_icons_added(owner)
 	var/datum/language_holder/LH = owner.current.get_language_holder()
-	LH.grant_language(/datum/language/ratvar, TRUE, TRUE, LANGUAGE_CULTIST)
+	LH.grant_language(/datum/language/ratvar, source = LANGUAGE_CULTIST)
 
 /datum/antagonist/servant_of_ratvar/remove_innate_effects(mob/living/M)
 	owner.current.faction -= "ratvar"
@@ -86,7 +86,7 @@
 		owner_mob.remove_overlay(forbearance)
 		qdel(forbearance)
 	var/datum/language_holder/LH = owner.current.get_language_holder()
-	LH.remove_language(/datum/language/ratvar, TRUE, TRUE, LANGUAGE_CULTIST)
+	LH.remove_language(/datum/language/ratvar, source = LANGUAGE_CULTIST)
 	. = ..()
 
 /datum/antagonist/servant_of_ratvar/proc/equip_servant_conversion()

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -114,7 +114,7 @@
 	if(mob_override)
 		current = mob_override
 	current.faction |= "cult"
-	current.grant_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)
+	current.grant_language(/datum/language/narsie, source = LANGUAGE_CULTIST)
 	if(!cult_team.cult_master)
 		vote.Grant(current)
 	communion.Grant(current)
@@ -142,7 +142,7 @@
 	if(mob_override)
 		current = mob_override
 	current.faction -= "cult"
-	current.remove_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)
+	current.remove_language(/datum/language/narsie, source = LANGUAGE_CULTIST)
 	vote.Remove(current)
 	communion.Remove(current)
 	magic.Remove(current)

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -65,12 +65,12 @@
 	. = ..()
 	var/mob/living/owner_mob = mob_override || owner.current
 	var/datum/language_holder/holder = owner_mob.get_language_holder()
-	holder.grant_language(/datum/language/piratespeak, TRUE, TRUE, LANGUAGE_PIRATE)
+	holder.grant_language(/datum/language/piratespeak, source = LANGUAGE_PIRATE)
 	holder.selected_language = /datum/language/piratespeak
 
 /datum/antagonist/pirate/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/owner_mob = mob_override || owner.current
-	owner_mob.remove_language(/datum/language/piratespeak, TRUE, TRUE, LANGUAGE_PIRATE)
+	owner_mob.remove_language(/datum/language/piratespeak, source = LANGUAGE_PIRATE)
 	return ..()
 
 /datum/team/pirate

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -84,7 +84,7 @@
 	check_rev_teleport() // they're spawned in non-station for some reason...
 	random_revenant_name()
 	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE, "#490066")
-	grant_all_languages(TRUE, FALSE, FALSE, LANGUAGE_REVENANT) // rev can understand every langauge
+	grant_all_languages(UNDERSTOOD_LANGUAGE, grant_omnitongue = FALSE, source = LANGUAGE_REVENANT) // rev can understand every langauge
 	ADD_TRAIT(src, TRAIT_FREE_HYPERSPACE_MOVEMENT, INNATE_TRAIT)
 	AddElement(/datum/element/movetype_handler)
 	ADD_TRAIT(src, TRAIT_MOVE_FLOATING, "ghost")

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -96,7 +96,7 @@
 		if(TRAITOR_AI)
 			add_law_zero()
 			owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/malf.ogg', vol = 100, vary = FALSE, channel = CHANNEL_ANTAG_GREETING, pressure_affected = FALSE, use_reverb = FALSE)
-			owner.current.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MALF)
+			owner.current.grant_language(/datum/language/codespeak, source = LANGUAGE_MALF)
 		if(TRAITOR_HUMAN)
 			ui_interact(owner.current)
 			owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', vol = 100, vary = FALSE, channel = CHANNEL_ANTAG_GREETING, pressure_affected = FALSE, use_reverb = FALSE)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -353,9 +353,9 @@
 	S.real_name = "Shade of [T.real_name]"
 	S.key = shade_controller.key
 	S.copy_languages(T, LANGUAGE_MIND)//Copies the old mobs languages into the new mob holder.
-	S.copy_languages(user, LANGUAGE_MASTER)
-	S.update_atom_languages()
-	grant_all_languages(FALSE, FALSE, TRUE)	//Grants omnitongue
+	if(user)
+		S.copy_languages(user, LANGUAGE_MASTER)
+	S.get_language_holder().omnitongue = TRUE //Grants omnitongue
 	if(user)
 		S.faction |= "[REF(user)]" //Add the master as a faction, allowing inter-mob cooperation
 	if(user && iscultist(user))

--- a/code/modules/clothing/head/pirate.dm
+++ b/code/modules/clothing/head/pirate.dm
@@ -13,7 +13,7 @@
 	if(!ishuman(user))
 		return
 	if(slot == ITEM_SLOT_HEAD)
-		user.grant_language(/datum/language/piratespeak/, TRUE, TRUE, LANGUAGE_HAT)
+		user.grant_language(/datum/language/piratespeak/, source = LANGUAGE_HAT)
 		to_chat(user, "You suddenly know how to speak like a pirate!")
 
 /obj/item/clothing/head/costume/pirate/dropped(mob/user)
@@ -22,7 +22,7 @@
 		return
 	var/mob/living/carbon/human/H = user
 	if(H.get_item_by_slot(ITEM_SLOT_HEAD) == src && !QDELETED(src)) //This can be called as a part of destroy
-		user.remove_language(/datum/language/piratespeak/, TRUE, TRUE, LANGUAGE_HAT)
+		user.remove_language(/datum/language/piratespeak/, source = LANGUAGE_HAT)
 		to_chat(user, "You can no longer speak like a pirate.")
 
 /obj/item/clothing/head/costume/pirate/captain

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -128,7 +128,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		var/const/viewtext = "\[view]" // Nesting these in other brackets went poorly
 		//log_debug("Runtime in <b>[e.file]</b>, line <b>[e.line]</b>: <b>[html_encode(e.name)]</b> [error_entry.make_link(viewtext)]")
 		var/err_msg_delay
-		if(config)
+		if(config?.loaded)
 			err_msg_delay = CONFIG_GET(number/error_msg_delay)
 		else
 			var/datum/config_entry/CE = /datum/config_entry/number/error_msg_delay

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 
 		SA.key = SG.key
 
-		SA.grant_all_languages(TRUE, FALSE, FALSE)
+		SA.grant_all_languages(UNDERSTOOD_LANGUAGE, grant_omnitongue = FALSE, source = LANGUAGE_ATOM)
 
 		SA.sentience_act()
 

--- a/code/modules/holoparasite/abilities/lesser/babel.dm
+++ b/code/modules/holoparasite/abilities/lesser/babel.dm
@@ -6,7 +6,7 @@
 
 /datum/holoparasite_ability/lesser/babelfish/apply()
 	..()
-	owner.grant_all_languages(TRUE, TRUE, TRUE, LANGUAGE_HOLOPARA)
+	owner.grant_all_languages(source = LANGUAGE_HOLOPARA)
 
 /datum/holoparasite_ability/lesser/babelfish/remove()
 	..()

--- a/code/modules/holoparasite/holoparasite_language.dm
+++ b/code/modules/holoparasite/holoparasite_language.dm
@@ -7,10 +7,8 @@
 	/// The parent holder of the holoparasite, which is the holder of the summoner.
 	var/datum/holoparasite_holder/holder
 
-/datum/language_holder/holoparasite/New(atom/owner, datum/holoparasite_holder/_holder)
-	if(!istype(_holder))
-		CRASH("Attempted to create holoparasite language holder for [key_name(owner)] without a valid holoparasite holder!")
-	holder = _holder
+/datum/language_holder/holoparasite/New(atom/owner, datum/holoparasite_holder/new_holder)
+	holder = new_holder
 	return ..()
 
 /**

--- a/code/modules/holoparasite/holoparasite_language.dm
+++ b/code/modules/holoparasite/holoparasite_language.dm
@@ -16,27 +16,23 @@
 /**
  * Ensures that the holoparasite can understand any language that its summoner can understand.
  */
-/datum/language_holder/holoparasite/has_language(language, spoken)
-	var/datum/language_holder/summoner_mind_language_holder = holder.owner.get_language_holder()
+/datum/language_holder/holoparasite/has_language(language, flags_to_check)
 	var/datum/language_holder/summoner_body_language_holder = holder.owner.current?.get_language_holder()
-	return ..() || summoner_mind_language_holder.has_language(language, spoken) || summoner_body_language_holder?.has_language(language, spoken)
+	return ..() || summoner_body_language_holder?.has_language(language, flags_to_check)
 
 /**
  * Ensures that the holoparasite can speak any language that its summoner can understand.
  */
 /datum/language_holder/holoparasite/can_speak_language(language)
-	var/datum/language_holder/summoner_mind_language_holder = holder.owner.get_language_holder()
 	var/datum/language_holder/summoner_body_language_holder = holder.owner.current?.get_language_holder()
-	return ..() || summoner_mind_language_holder.can_speak_language(language) || summoner_body_language_holder?.can_speak_language(language)
+	return ..() || summoner_body_language_holder?.can_speak_language(language)
 
 /**
  * Picks a random understood language, combining the holoparasite's understood languages with that of the summoner's mind and body.
  */
 /datum/language_holder/holoparasite/get_random_understood_language()
-	var/datum/language_holder/summoner_mind_language_holder = holder.owner.get_language_holder()
 	var/datum/language_holder/summoner_body_language_holder = holder.owner.current?.get_language_holder()
 	var/list/choices = understood_languages.Copy()
-	choices |= summoner_mind_language_holder.understood_languages
 	if(summoner_body_language_holder)
 		choices |= summoner_body_language_holder.understood_languages
 	return pick(choices)
@@ -45,10 +41,8 @@
  * Picks a random spoken language, combining the holoparasite's spoken languages with that of the summoner's mind and body.
  */
 /datum/language_holder/holoparasite/get_random_spoken_language()
-	var/datum/language_holder/summoner_mind_language_holder = holder.owner.get_language_holder()
 	var/datum/language_holder/summoner_body_language_holder = holder.owner.current?.get_language_holder()
 	var/list/choices = spoken_languages.Copy()
-	choices |= summoner_mind_language_holder.spoken_languages
 	if(summoner_body_language_holder)
 		choices |= summoner_body_language_holder.spoken_languages
 	return pick(choices)

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -57,4 +57,4 @@
 	if(visualsOnly)
 		return
 
-	H.grant_all_languages(TRUE, TRUE, TRUE, LANGUAGE_CURATOR)
+	H.grant_all_languages(source = LANGUAGE_CURATOR)

--- a/code/modules/language/codespeak.dm
+++ b/code/modules/language/codespeak.dm
@@ -47,7 +47,7 @@
 		return
 
 	to_chat(user, "<span class='boldannounce'>You start skimming through [src], and suddenly your mind is filled with codewords and responses.</span>")
-	user.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
+	user.grant_language(/datum/language/codespeak, source = LANGUAGE_MIND)
 
 	use_charge(user)
 
@@ -66,7 +66,7 @@
 		M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", "<span class='userdanger'>[user] beats you over the head with [src]!</span>", "<span class='italics'>You hear smacking.</span>")
 	else
 		M.visible_message("<span class='notice'>[user] teaches [M] by beating [M.p_them()] over the head with [src]!</span>", "<span class='boldnotice'>As [user] hits you with [src], codewords and responses flow through your mind.</span>", "<span class='italics'>You hear smacking.</span>")
-		M.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
+		M.grant_language(/datum/language/codespeak, source = LANGUAGE_MIND)
 		use_charge(user)
 
 /obj/item/codespeak_manual/proc/use_charge(mob/user)

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -159,10 +159,8 @@ Key procs
 /// Checks if you can speak the language. Tongue limitations should be supplied as an argument.
 /datum/language_holder/proc/can_speak_language(language)
 	var/atom/movable/our_atom = get_atom()
-	var/tongue = our_atom.could_speak_language(language)
-	if((omnitongue || tongue) && has_language(language, TRUE))
-		return TRUE
-	return FALSE
+	var/can_speak_language_path = omnitongue || our_atom.could_speak_language(language)
+	return (can_speak_language_path && has_language(language, TRUE))
 
 /// Returns selected language if it can be spoken, or decides, sets and returns a new selected language if possible.
 /datum/language_holder/proc/get_selected_language()

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -1,4 +1,4 @@
-/*!Language holders will either exist in an atom/movable or a mind. Creation of language holders happens
+/*!Language holders will either exist in an atom/movable. Creation of language holders happens
 automatically when they are needed, for example when something tries to speak.
 Where a mind is available, the mind language holder will be the one "in charge". The mind holder
 will update its languages based on the atom holder, and will get updated as part of
@@ -33,35 +33,36 @@ Key procs
 * [has_language](atom/movable.html#proc/has_language)
 * [can_speak_language](atom/movable.html#proc/can_speak_language)
 * [get_selected_language](atom/movable.html#proc/get_selected_language)
-* [update_atom_languages](atom/movable.html#proc/update_atom_languages)
 */
 
 /datum/language_holder
-	/// Understood languages.
-	var/list/understood_languages = list(/datum/language/common = list(LANGUAGE_MIND))
-	/// A list of languages that can be spoken. Tongue organ may also set limits beyond this list.
+	/// Lazyassoclist of all understood languages
+	var/list/understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
+	/// Lazyassoclist of languages that can be spoken.
+	/// Tongue organ may also set limits beyond this list.
 	var/list/spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
-	/// A list of blocked languages. Used to prevent understanding and speaking certain languages, ie for certain mobs, mutations etc.
-	var/list/blocked_languages = list()
-	/// If true, overrides tongue limitations.
+	/// Lazyassoclist of blocked languages.
+	/// Used to prevent understanding and speaking certain languages, ie for certain mobs, mutations etc.
+	var/list/blocked_languages
+	/// If true, overrides tongue aforementioned limitations.
 	var/omnitongue = FALSE
 	/// Handles displaying the language menu UI.
 	var/datum/language_menu/language_menu
 	/// Currently spoken language
 	var/selected_language
 	/// Tracks the entity that owns the holder.
-	var/atom/owner
+	var/atom/movable/owner
 
 /// Initializes, and copies in the languages from the current atom if available.
-/datum/language_holder/New(atom/_owner)
-	if(_owner && QDELING(_owner))
-		CRASH("Langauge holder added to a qdeleting thing, what the fuck [REF(_owner)]")
-	owner = _owner
-	if(istype(owner, /datum/mind))
-		var/datum/mind/M = owner
-		if(M.current)
-			update_atom_languages(M.current)
-	grant_language(/datum/language/metalanguage, understood=TRUE, spoken=FALSE, source=LANGUAGE_MIND) // Gets metalanguage that you can only understand
+/datum/language_holder/New(atom/new_owner)
+	if(new_owner)
+		if(QDELETED(new_owner))
+			CRASH("Langauge holder added to a qdeleting thing, what the fuck [text_ref(new_owner)]")
+		if(!ismovable(new_owner))
+			CRASH("Language holder being added to a non-movable thing, this is invalid (was: [new_owner] / [new_owner.type])")
+
+	owner = new_owner
+	grant_language(/datum/language/metalanguage, language_flags = ALL, source = LANGUAGE_MIND) // Gets metalanguage that you can only understand
 	// If we have an owner, we'll set a default selected language
 	if(owner)
 		get_selected_language()
@@ -72,54 +73,50 @@ Key procs
 	return ..()
 
 /// Grants the supplied language.
-/datum/language_holder/proc/grant_language(language, understood = TRUE, spoken = TRUE, source = LANGUAGE_MIND)
-	if(understood)
-		if(!understood_languages[language])
-			understood_languages[language] = list()
-		understood_languages[language] |= source
+/datum/language_holder/proc/grant_language(language, language_flags = ALL, source = LANGUAGE_MIND)
+	if(language_flags & UNDERSTOOD_LANGUAGE)
+		LAZYORASSOCLIST(understood_languages, language, source)
 		. = TRUE
-	if(spoken)
-		if(!spoken_languages[language])
-			spoken_languages[language] = list()
-		spoken_languages[language] |= source
+	if(language_flags & SPOKEN_LANGUAGE)
+		LAZYORASSOCLIST(spoken_languages, language, source)
 		. = TRUE
 
+	return .
+
 /// Grants every language to understood and spoken, and gives omnitongue.
-/datum/language_holder/proc/grant_all_languages(understood = TRUE, spoken = TRUE, grant_omnitongue = TRUE, source = LANGUAGE_MIND)
+/datum/language_holder/proc/grant_all_languages(language_flags = ALL, grant_omnitongue = TRUE, source = LANGUAGE_MIND)
 	for(var/language in GLOB.all_languages)
 		if(language == /datum/language/metalanguage)
 			continue // metalanguage shouldn't be given by this method
-		grant_language(language, understood, spoken, source)
-	if(grant_omnitongue)	// Overrides tongue limitations.
+		grant_language(language, language_flags, source)
+	if(grant_omnitongue) // Overrides tongue limitations.
 		omnitongue = TRUE
 	return TRUE
 
 /// Removes a single language or source, removing all sources returns the pre-removal state of the language.
-/datum/language_holder/proc/remove_language(language, understood = TRUE, spoken = TRUE, source = LANGUAGE_ALL)
-	if(understood && understood_languages[language])
+/datum/language_holder/proc/remove_language(language, language_flags = ALL, source = LANGUAGE_ALL)
+	if(language_flags & UNDERSTOOD_LANGUAGE)
 		if(source == LANGUAGE_ALL)
-			understood_languages -= language
+			LAZYREMOVE(understood_languages, language)
 		else
-			understood_languages[language] -= source
-			if(!length(understood_languages[language]))
-				understood_languages -= language
+			LAZYREMOVEASSOC(understood_languages, language, source)
 		. = TRUE
 
-	if(spoken && spoken_languages[language])
+	if(language_flags & SPOKEN_LANGUAGE)
 		if(source == LANGUAGE_ALL)
-			spoken_languages -= language
+			LAZYREMOVE(spoken_languages, language)
 		else
-			spoken_languages[language] -= source
-			if(!length(spoken_languages[language]))
-				spoken_languages -= language
+			LAZYREMOVEASSOC(spoken_languages, language, source)
 		. = TRUE
+
+	return .
 
 /// Removes every language and optionally sets omnitongue false. If a non default source is supplied, only removes that source.
 /datum/language_holder/proc/remove_all_languages(source = LANGUAGE_ALL, remove_omnitongue = FALSE)
 	for(var/language in GLOB.all_languages)
 		if(language == /datum/language/metalanguage) // this language is important. Don't remove it by remove_all
 			continue
-		remove_language(language, TRUE, TRUE, source)
+		remove_language(language, ALL, source)
 	if(remove_omnitongue)
 		omnitongue = FALSE
 	return TRUE
@@ -128,39 +125,41 @@ Key procs
 /datum/language_holder/proc/add_blocked_language(languages, source = LANGUAGE_MIND)
 	if(!islist(languages))
 		languages = list(languages)
+
 	for(var/language in languages)
-		if(!blocked_languages[language])
-			blocked_languages[language] = list()
-		blocked_languages[language] |= source
+		LAZYORASSOCLIST(blocked_languages, language, source)
 	return TRUE
 
 /// Removes a single language or list of languages from the blocked language list.
 /datum/language_holder/proc/remove_blocked_language(languages, source = LANGUAGE_MIND)
 	if(!islist(languages))
 		languages = list(languages)
+
 	for(var/language in languages)
-		if(blocked_languages[language])
-			if(source == LANGUAGE_ALL)
-				blocked_languages -= language
-			else
-				blocked_languages[language] -= source
-				if(!length(blocked_languages[language]))
-					blocked_languages -= language
+		if(source == LANGUAGE_ALL)
+			LAZYREMOVE(blocked_languages, language)
+		else
+			LAZYREMOVEASSOC(blocked_languages, language, source)
+
 	return TRUE
 
-/// Checks if you have the language. If spoken is true, only checks if you can speak the language.
-/datum/language_holder/proc/has_language(language, spoken = FALSE)
+/// Checks if you have the language passed.
+/datum/language_holder/proc/has_language(language, flag_to_check = UNDERSTOOD_LANGUAGE)
 	if(language in blocked_languages)
 		return FALSE
-	if(spoken)
-		return language in spoken_languages
-	return language in understood_languages
+
+	var/list/langs_to_check = list()
+	if(flag_to_check & SPOKEN_LANGUAGE)
+		langs_to_check |= spoken_languages
+	if(flag_to_check & UNDERSTOOD_LANGUAGE)
+		langs_to_check |= understood_languages
+
+	return language in langs_to_check
 
 /// Checks if you can speak the language. Tongue limitations should be supplied as an argument.
 /datum/language_holder/proc/can_speak_language(language)
-	var/atom/movable/our_atom = get_atom()
-	var/can_speak_language_path = omnitongue || our_atom.could_speak_language(language)
-	return (can_speak_language_path && has_language(language, TRUE))
+	var/can_speak_language_path = omnitongue || owner.could_speak_language(language)
+	return (can_speak_language_path && has_language(language, SPOKEN_LANGUAGE))
 
 /// Returns selected language if it can be spoken, or decides, sets and returns a new selected language if possible.
 /datum/language_holder/proc/get_selected_language()
@@ -193,40 +192,15 @@ Key procs
 		language_menu = new (src)
 	language_menu.ui_interact(user)
 
-/// Gets the atom, since we some times need to check if the tongue has limitations.
-/datum/language_holder/proc/get_atom()
-	if(owner)
-		if(istype(owner, /datum/mind))
-			var/datum/mind/M = owner
-			return M.current
-		return owner
-	return FALSE
-
-/// Empties out the atom specific languages and updates them according to the supplied atoms language holder.
-/datum/language_holder/proc/update_atom_languages(atom/movable/thing)
-	var/datum/language_holder/from_atom = thing.get_language_holder(FALSE)	//Gets the atoms language holder
-	if(from_atom == src)	//This could happen if called on an atom without a mind.
-		return FALSE
-	for(var/language in understood_languages)
-		remove_language(language, TRUE, FALSE, LANGUAGE_ATOM)
-	for(var/language in spoken_languages)
-		remove_language(language, FALSE, TRUE, LANGUAGE_ATOM)
-	for(var/language in blocked_languages)
-		remove_blocked_language(language, LANGUAGE_ATOM)
-
-	copy_languages(from_atom, blocked=TRUE) // full-copy
-	get_selected_language()
-	return TRUE
-
 /// Copies all languages from the supplied atom/language holder. Source should be overridden when you
 /// do not want the language overwritten by later atom updates or want to avoid blocked languages.
 /datum/language_holder/proc/copy_languages(var/datum/language_holder/from_holder, source_override=FALSE, spoken=TRUE, understood=TRUE, blocked=FALSE)
 	if(understood)
 		for(var/language in from_holder.understood_languages)
-			grant_language(language, TRUE, FALSE, source_override || from_holder.understood_languages[language]) // if you don't have 'source_override' argument, source from 'from_holder' will be used.
+			grant_language(language, UNDERSTOOD_LANGUAGE, source_override || from_holder.understood_languages[language]) // if you don't have 'source_override' argument, source from 'from_holder' will be used.
 	if(spoken)
 		for(var/language in from_holder.spoken_languages)
-			grant_language(language, FALSE, TRUE, source_override || from_holder.spoken_languages[language])
+			grant_language(language, SPOKEN_LANGUAGE, source_override || from_holder.spoken_languages[language])
 	if(blocked)
 		// blocked is set to FALSE by default because there's no reason to copy blocked languages in standard situations.
 		// 'blocked=TRUE' is recommanded when 'source_override=FALSE' because it means full-copy
@@ -234,55 +208,117 @@ Key procs
 			add_blocked_language(language, source_override || from_holder.blocked_languages[language])
 	return TRUE
 
+/// Transfers all mind languages to the supplied language holder.
+/datum/language_holder/proc/transfer_mind_languages(datum/language_holder/to_holder)
+	for(var/language in understood_languages)
+		if(LANGUAGE_MIND in understood_languages[language])
+			remove_language(language, UNDERSTOOD_LANGUAGE, LANGUAGE_MIND)
+			to_holder.grant_language(language, UNDERSTOOD_LANGUAGE, LANGUAGE_MIND)
+	for(var/language in spoken_languages)
+		if(LANGUAGE_MIND in spoken_languages[language])
+			remove_language(language, SPOKEN_LANGUAGE, LANGUAGE_MIND)
+			to_holder.grant_language(language, SPOKEN_LANGUAGE, LANGUAGE_MIND)
+	for(var/language in blocked_languages)
+		if(LANGUAGE_MIND in blocked_languages[language])
+			remove_blocked_language(language, LANGUAGE_MIND)
+			to_holder.add_blocked_language(language, LANGUAGE_MIND)
 
-//************************************************
-//*        Specific language holders              *
-//*      Use atom language sources only.           *
-//************************************************/
+	if(owner)
+		get_selected_language()
+	if(to_holder.owner)
+		to_holder.get_selected_language()
 
+/// A global assoc list containing prototypes of all language holders
+/// [Language holder typepath] to [language holder instance]
+/// Used for easy reference of what can speak what without needing to constantly recreate language holders.
+GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
+
+/// Inits the global list of language holder prototypes.
+/proc/init_language_holder_prototypes()
+	var/list/prototypes = list()
+	for(var/holdertype in typesof(/datum/language_holder))
+		prototypes[holdertype] = new holdertype()
+
+	return prototypes
+
+/*
+ * Specific language holders presets
+ *
+ * Prefer to use [LANGUGAE_ATOM]. Atom languages will stick through species changes but not mindswaps.
+ */
 
 /datum/language_holder/alien
-	understood_languages = list(/datum/language/xenocommon = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/xenocommon = list(LANGUAGE_ATOM))
-	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/xenocommon = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/xenocommon = list(LANGUAGE_ATOM)
+	)
+	blocked_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/apid
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/apidite = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/apidite = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/apidite = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/apidite = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/clockmob
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/ratvar = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/ratvar = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/ratvar = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/ratvar = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/construct
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/narsie = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/narsie = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/narsie = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/narsie = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/drone
 	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM))
+			/datum/language/machine = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate
-	blocked_languages = list()
+	blocked_languages = null
+
+/datum/language_holder/human_basic
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/jelly
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/slime = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/slime = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/slime = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/slime = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/oozeling
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/slime = list(LANGUAGE_ATOM))
+			/datum/language/slime = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/slime = list(LANGUAGE_ATOM))
+		/datum/language/slime = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lightbringer
 	understood_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))
@@ -290,10 +326,14 @@ Key procs
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/draconic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/draconic = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/lizard/ash
 	understood_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
@@ -301,19 +341,29 @@ Key procs
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/monkey
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/monkey = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/monkey = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/monkey = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/monkey = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/mushroom
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/mushroom = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/mushroom = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/mushroom = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/mushroom = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/slime
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/slime = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/slime = list(LANGUAGE_ATOM),
+	)
 	spoken_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))
 
 /datum/language_holder/swarmer
@@ -328,7 +378,7 @@ Key procs
 
 /datum/language_holder/spider
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/buzzwords = list(LANGUAGE_ATOM))
+			/datum/language/buzzwords = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/buzzwords = list(LANGUAGE_ATOM))
 
 /datum/language_holder/venus
@@ -337,95 +387,143 @@ Key procs
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/synthetic
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/uncommon = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM),
-								/datum/language/draconic = list(LANGUAGE_ATOM),
-								/datum/language/moffic = list(LANGUAGE_ATOM),
-								/datum/language/calcic = list(LANGUAGE_ATOM),
-								/datum/language/voltaic = list(LANGUAGE_ATOM),
-								/datum/language/apidite = list(LANGUAGE_ATOM),
-								/datum/language/sonus = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/uncommon = list(LANGUAGE_ATOM),
-							/datum/language/machine = list(LANGUAGE_ATOM),
-							/datum/language/draconic = list(LANGUAGE_ATOM),
-							/datum/language/moffic = list(LANGUAGE_ATOM),
-							/datum/language/calcic = list(LANGUAGE_ATOM),
-							/datum/language/voltaic = list(LANGUAGE_ATOM),
-							/datum/language/apidite = list(LANGUAGE_ATOM),
-							/datum/language/sonus = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+		/datum/language/machine = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+		/datum/language/moffic = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM),
+		/datum/language/voltaic = list(LANGUAGE_ATOM),
+		/datum/language/apidite = list(LANGUAGE_ATOM),
+		/datum/language/sonus = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+		/datum/language/machine = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+		/datum/language/moffic = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM),
+		/datum/language/voltaic = list(LANGUAGE_ATOM),
+		/datum/language/apidite = list(LANGUAGE_ATOM),
+		/datum/language/sonus = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/moth
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/moffic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/moffic = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/moffic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/moffic = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/skeleton
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/calcic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/calcic = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/ethereal
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/voltaic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/voltaic = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/voltaic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/voltaic = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/golem
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/terrum = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/terrum = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/terrum = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/terrum = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/golem/bone
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/terrum = list(LANGUAGE_ATOM),
-								/datum/language/calcic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/terrum = list(LANGUAGE_ATOM),
-							/datum/language/calcic = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/terrum = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/terrum = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/golem/runic
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/terrum = list(LANGUAGE_ATOM),
-								/datum/language/narsie = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/terrum = list(LANGUAGE_ATOM),
-							/datum/language/narsie = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/terrum = list(LANGUAGE_ATOM),
+		/datum/language/narsie = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/terrum = list(LANGUAGE_ATOM),
+		/datum/language/narsie = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/fly
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/buzzwords = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/buzzwords = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/buzzwords = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/buzzwords = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/diona
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/sylvan = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/sylvan = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/sylvan = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/sylvan = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/shadowpeople
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/shadowtongue = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/shadowtongue = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/shadowtongue = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/shadowtongue = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/psyphoza
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/sonus = list(LANGUAGE_ATOM),
-								/datum/language/sylvan = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/sonus = list(LANGUAGE_ATOM),
-							/datum/language/sylvan = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/sonus = list(LANGUAGE_ATOM),
+		/datum/language/sylvan = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/sonus = list(LANGUAGE_ATOM),
+		/datum/language/sylvan = list(LANGUAGE_ATOM)
+	)
 
 /datum/language_holder/empty
-	understood_languages = list()
-	spoken_languages = list()
+	understood_languages = null
+	spoken_languages = null
+
+/datum/language_holder/universal
+	understood_languages = null
+	spoken_languages = null
 
 /datum/language_holder/universal/New()
-	..()
+	. = ..()
 	grant_all_languages()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -582,7 +582,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/shared_storage/blue)
 	if(!user.can_read(src))
 		return FALSE
 	to_chat(user, "You flip through the pages of the book, quickly and conveniently learning every language in existence. Somewhat less conveniently, the aging book crumbles to dust in the process. Whoops.")
-	user.grant_all_languages()
+	user.grant_all_languages(source = LANGUAGE_BABEL)
 	new /obj/effect/decal/cleanable/ash(get_turf(user))
 	qdel(src)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -32,7 +32,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/skinned_type
 	var/list/no_equip = list()	// slots the race can't equip stuff to
 	var/nojumpsuit = 0	// this is sorta... weird. it basically lets you equip stuff that usually needs jumpsuits without one, like belts and pockets and ids
-	var/species_language_holder = /datum/language_holder
+	/// What languages this species can understand and say.
+	/// Use a [language holder datum][/datum/language_holder] typepath in this var.
+	/// Should never be null.
+	var/datum/language_holder/species_language_holder = /datum/language_holder/human_basic
 	/**
 	  * Visible CURRENT bodyparts that are unique to a species.
 	  * DO NOT USE THIS AS A LIST OF ALL POSSIBLE BODYPARTS AS IT WILL FUCK
@@ -481,6 +484,16 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	C.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/species, multiplicative_slowdown=speedmod)
 
+	// All languages associated with this language holder are added with source [LANGUAGE_SPECIES]
+	// rather than source [LANGUAGE_ATOM], so we can track what to remove if our species changes again
+	var/datum/language_holder/gaining_holder = GLOB.prototype_language_holders[species_language_holder]
+	for(var/language in gaining_holder.understood_languages)
+		C.grant_language(language, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
+	for(var/language in gaining_holder.spoken_languages)
+		C.grant_language(language, SPOKEN_LANGUAGE, LANGUAGE_SPECIES)
+	for(var/language in gaining_holder.blocked_languages)
+		C.add_blocked_language(language, LANGUAGE_SPECIES)
+
 	SEND_SIGNAL(C, COMSIG_SPECIES_GAIN, src, old_species)
 
 
@@ -511,6 +524,16 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		for(var/i in inherent_factions)
 			C.faction -= i
 	C.remove_movespeed_modifier(/datum/movespeed_modifier/species)
+
+	// Removes all languages previously associated with [LANGUAGE_SPECIES], gaining our new species will add new ones back
+	var/datum/language_holder/losing_holder = GLOB.prototype_language_holders[species_language_holder]
+	for(var/language in losing_holder.understood_languages)
+		C.remove_language(language, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
+	for(var/language in losing_holder.spoken_languages)
+		C.remove_language(language, SPOKEN_LANGUAGE, LANGUAGE_SPECIES)
+	for(var/language in losing_holder.blocked_languages)
+		C.remove_blocked_language(language, LANGUAGE_SPECIES)
+
 	SEND_SIGNAL(C, COMSIG_SPECIES_LOSS, src)
 
 /datum/species/proc/handle_hair(mob/living/carbon/human/H, forced_colour)
@@ -2930,21 +2953,23 @@ GLOBAL_LIST_EMPTY(features_by_species)
  * Returns a list containing perks, or an empty list.
  */
 /datum/species/proc/create_pref_language_perk()
-	var/list/to_add = list()
 
 	// Grab galactic common as a path, for comparisons
 	var/datum/language/common_language = /datum/language/common
 
 	// Now let's find all the languages they can speak that aren't common
 	var/list/bonus_languages = list()
-	var/datum/language_holder/temp_holder = new species_language_holder()
-	for(var/datum/language/language_type as anything in temp_holder.spoken_languages)
+	var/datum/language_holder/basic_holder = GLOB.prototype_language_holders[species_language_holder]
+	for(var/datum/language/language_type as anything in basic_holder.spoken_languages)
 		if(ispath(language_type, common_language))
 			continue
 		bonus_languages += initial(language_type.name)
 
-	// If we have any languages we can speak: create a perk for them all
-	if(length(bonus_languages))
+	if(!length(bonus_languages))
+		return // You're boring
+
+	var/list/to_add = list()
+	if(common_language in basic_holder.spoken_languages)
 		to_add += list(list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "comment",
@@ -2952,7 +2977,13 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			SPECIES_PERK_DESC = "Alongside [initial(common_language.name)], [plural_form] gain the ability to speak [english_list(bonus_languages)].",
 		))
 
-	qdel(temp_holder)
+	else
+		to_add += list(list(
+			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+			SPECIES_PERK_ICON = "comment",
+			SPECIES_PERK_NAME = "Foreign Speaker",
+			SPECIES_PERK_DESC = "[plural_form] may not speak [initial(common_language.name)], but they can speak [english_list(bonus_languages)].",
+		))
 
 	return to_add
 

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -42,12 +42,12 @@
 /mob/living/carbon/human/set_drugginess(amount)
 	..()
 	if(!amount)
-		remove_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_DRUGGY)
+		remove_language(/datum/language/beachbum, source = LANGUAGE_DRUGGY)
 
 /mob/living/carbon/human/adjust_drugginess(amount)
 	..()
 	if(!dna.check_mutation(STONER))
 		if(druggy)
-			grant_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_DRUGGY)
+			grant_language(/datum/language/beachbum, source = LANGUAGE_DRUGGY)
 		else
-			remove_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_DRUGGY)
+			remove_language(/datum/language/beachbum, source = LANGUAGE_DRUGGY)

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -18,10 +18,10 @@
 		return FALSE
 	return ..()
 
-/mob/living/carbon/could_speak_language(datum/language/dt)
-	if(CHECK_BITFIELD(initial(dt.flags), TONGUELESS_SPEECH))
+/mob/living/carbon/could_speak_language(datum/language/language_path)
+	if(CHECK_BITFIELD(initial(language_path.flags), TONGUELESS_SPEECH))
 		return TRUE
-	var/obj/item/organ/tongue/T = getorganslot(ORGAN_SLOT_TONGUE)
-	if(T)
-		return T.could_speak_language(dt)
+	var/obj/item/organ/tongue/spoken_with = getorganslot(ORGAN_SLOT_TONGUE)
+	if(spoken_with)
+		return spoken_with.could_speak_language(language_path)
 	return FALSE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -123,10 +123,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		return TRUE
 
 	if(!language) // get_message_mods() proc finds a language key, and add the language to LANGUAGE_EXTENSION
-		language = message_mods[LANGUAGE_EXTENSION]
-
-	if(!language) // there's no language argument and LANGUAGE_EXTENSION has no language. failsafe.
-		language = get_selected_language()
+		language = message_mods[LANGUAGE_EXTENSION] || get_selected_language()
 
 	// if you add a new language that works like everyone doesn't understand (i.e. anti-metalanguage), add an additional condition after this
 	// i.e.) if(!language) language = /datum/language/nobody_understands
@@ -433,12 +430,3 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /mob/living/whisper(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	say("#[message]", bubble_type, spans, sanitize, language, ignore_spam, forced)
-
-/mob/living/get_language_holder(shadow=TRUE)
-	if(mind && shadow)
-		// Mind language holders shadow mob holders.
-		. = mind.get_language_holder()
-		if(.)
-			return .
-
-	. = ..()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -180,7 +180,7 @@
 				sec.remove_hud_from(src)
 		if("universal_translator")
 			if(!languages_granted)
-				grant_all_languages(TRUE, TRUE, TRUE, LANGUAGE_SOFTWARE)
+				grant_all_languages(source = LANGUAGE_SOFTWARE)
 				languages_granted = TRUE
 		if("wipe_core")
 			var/confirm = alert(src, "Are you certain you want to wipe yourself?", "Personality Wipe", "Yes", "No")

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -244,7 +244,7 @@
 		M.maxHealth = round(M.maxHealth * 1.3)
 		M.health = M.maxHealth
 	if(transformeffects & SLIME_EFFECT_PINK)
-		M.grant_language(/datum/language/common, TRUE, TRUE)
+		M.grant_language(/datum/language/common)
 		var/datum/language_holder/LH = M.get_language_holder()
 		LH.selected_language = /datum/language/common
 	if(transformeffects & SLIME_EFFECT_BLUESPACE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1247,12 +1247,11 @@
 	fully_replace_character_name(real_name, new_name)
 
 ///Show the language menu for this mob
-/mob/verb/open_language_menu()
+/mob/verb/open_language_menu_verb()
 	set name = "Open Language Menu"
 	set category = "IC"
 
-	var/datum/language_holder/H = get_language_holder()
-	H.open_language_menu(usr)
+	get_language_holder().open_language_menu(usr)
 
 ///Adjust the nutrition of a mob
 /mob/proc/adjust_nutrition(var/change) //Honestly FUCK the oldcoders for putting nutrition on /mob someone else can move it up because holy hell I'd have to fix SO many typechecks

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2191,12 +2191,12 @@
 
 /datum/reagent/consumable/ratlight/on_mob_metabolize(mob/living/L)
 	L.add_blocked_language(subtypesof(/datum/language/) - /datum/language/ratvar, LANGUAGE_REAGENT)
-	L.grant_language(/datum/language/ratvar, TRUE, TRUE, LANGUAGE_REAGENT)
+	L.grant_language(/datum/language/ratvar, source = LANGUAGE_REAGENT)
 	..()
 
 /datum/reagent/consumable/ratlight/on_mob_end_metabolize(mob/living/L)
 	L.remove_blocked_language(subtypesof(/datum/language/), LANGUAGE_REAGENT)
-	L.remove_language(/datum/language/ratvar, TRUE, TRUE, LANGUAGE_REAGENT)
+	L.remove_language(/datum/language/ratvar, source = LANGUAGE_REAGENT)
 	L.set_light(-1)
 
 	..()

--- a/code/modules/research/xenobiology/crossbreeding/transformative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/transformative.dm
@@ -128,7 +128,7 @@ transformative extracts:
 
 /obj/item/slimecross/transformative/pink/do_effect(mob/living/simple_animal/slime/S)
 	..()
-	S.grant_language(/datum/language/common, TRUE, TRUE)
+	S.grant_language(/datum/language/common)
 	var/datum/language_holder/LH = S.get_language_holder()
 	LH.selected_language = /datum/language/common
 

--- a/code/modules/tgui/states/language_menu.dm
+++ b/code/modules/tgui/states/language_menu.dm
@@ -12,6 +12,6 @@ GLOBAL_DATUM_INIT(language_menu_state, /datum/ui_state/language_menu, new)
 	if(check_rights_for(user.client, R_ADMIN))
 		. = UI_INTERACTIVE
 	else if(istype(src_object, /datum/language_menu))
-		var/datum/language_menu/LM = src_object
-		if(LM.language_holder.get_atom() == user)
+		var/datum/language_menu/my_languages = src_object
+		if(my_languages.language_holder.owner == user)
 			. = UI_INTERACTIVE

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -40,6 +40,7 @@
 #include "heretic_rituals.dm"
 #include "icon_smoothing_unit_test.dm"
 #include "keybinding_init.dm"
+#include "language_transfer.dm"
 #include "merge_type.dm"
 #include "metabolizing.dm"
 #include "missing_icons.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There exists two language holders for the mob and the mind, this PR removes the mind language holder and offloads its handling to the mob language holder.

As a result of the centralization, we no longer need to call `update_atom_languages` to ensure the list and mob are matching. 

We also no longer delete and recreate the mob's language holder every time during transform, its handled like you'd expect any other persistent mob list to be.

Ports:
- https://github.com/tgstation/tgstation/pull/56047
- https://github.com/tgstation/tgstation/pull/72080
- https://github.com/tgstation/tgstation/pull/76612

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We can `source` regular language holders during grant and removal, so why do we need it both on mob and on mind? 

Its a big headache trying to debug it in game as one will sometimes not apply to the other during varedit, or adding a new language to one but blocked_language still persisting.

If we need to inherit languages to a new mob or whatever just do it on `/mind/proc/transfer_to` like all other stuff we want to persist.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Human with admin perms

![Screenshot 2024-12-02 174227](https://github.com/user-attachments/assets/d2b1207f-8d1d-413a-9980-4ff94af8966f)

IPC with no perms

![Screenshot 2024-12-02 174559](https://github.com/user-attachments/assets/cf4b5bd0-418a-4a22-9bdd-804d362b9e08)

Blocked language removal

https://github.com/user-attachments/assets/8da18f0a-84f3-4778-9c43-021a9c6d2052

Multilingual still works (set to draconic)

https://github.com/user-attachments/assets/f53e322b-3926-4b9c-9551-566455357b9a

Holopara inherits language

![Screenshot 2024-12-02 211343](https://github.com/user-attachments/assets/c7c0454c-0394-411a-b225-63f6f600f5a4)


</details>

## Changelog
:cl: rkz, MrMelbert, Cyberboss
refactor: refactored language holders, species changes will no longer delete all known languages
refactor: refactored tongue language lists to kill typecache nonsense and handle subtypes sanely
code: unit tests language transfers
code: fix config errors before /world/New()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
