### PR TITLE
Fixes food buff duration

### DIFF
--- a/code/datums/status_effects/food/_food_effect.dm
+++ b/code/datums/status_effects/food/_food_effect.dm
@@ -8,12 +8,12 @@
 	var/strength
 
 /datum/status_effect/food/on_creation(mob/living/new_owner, timeout = 1, strength = 1)
-	. = ..()
 	src.strength = strength
 	if(isnum(timeout))
 		duration *= timeout
 	if(istype(linked_alert, /atom/movable/screen/alert/status_effect/food))
 		linked_alert.icon_state = "[linked_alert.base_icon_state]_[strength]"
+	. = ..()
 
 /atom/movable/screen/alert/status_effect/food
 	name = "Hand-crafted meal"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

I gotta love it when i test X and it turns out Y was not working correctly because of Y being hidden behind an edge case of X

Food buffs over strength 1 were getting the `world time * timeout `instead of `duration * timeout`

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

![image](https://github.com/user-attachments/assets/dc0d6f8f-cee1-4539-bdc3-4b0fa6a8b09a)


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/f12bdc06-543c-4127-a894-177355d2de09

</details>

## Changelog
:cl: XeonMations
fix: Fixed food buff durations being way too long.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
