### PR TITLE
Removes Meteor Shield Sats Deploy Time

### DIFF
--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -139,7 +139,7 @@
 
 /obj/item/meteor_shield/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/deployable, /obj/machinery/satellite/meteor_shield, time_to_deploy = 10 SECONDS)
+	AddComponent(/datum/component/deployable, /obj/machinery/satellite/meteor_shield, time_to_deploy = 5 SECONDS)
 
 /obj/machinery/satellite/meteor_shield
 	name = "\improper Meteor Shield Satellite"

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -139,7 +139,7 @@
 
 /obj/item/meteor_shield/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/deployable, /obj/machinery/satellite/meteor_shield, time_to_deploy = 5 SECONDS)
+	AddComponent(/datum/component/deployable, /obj/machinery/satellite/meteor_shield, time_to_deploy = 0)
 
 /obj/machinery/satellite/meteor_shield
 	name = "\improper Meteor Shield Satellite"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shield Satellites took forever to deploy, at 10 seconds, where you had to be stationary and doing nothing else. This was incredibly long, and always made the task of setting up the shields feel like a big chore (because of the dead time).

~~This PR halves the deploy time from 10 seconds to 5, which is still long, but not as unbearably long.~~

This PR removes the deploy time.

## Why It's Good For The Game

Deploying the satellites is already a fairly slow process, between acquiring the satellites and getting to location. Taking 10 seconds per satellite to deploy eats up a lot of time.

As most shifts will only order satellites during an impending meteor strike, at most there will be 14 satellites available to defend the station with, which will still leave gaps in the defense to help force a round to an end, even if it isn't massive damage.

14 satellites * 10 second deploy time = 2 minutes 20 seconds. This is nearly a quarter of the time before meteors hit if you only have one person deploying satellites. 


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/5ae8ecfb-3838-46f9-ab0c-a3d9112af871


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Through Bluespace Magic, NT Engineering has removed the Shield Satellite's Deploy time.
/:cl:
