### PR TITLE
AI Hologram menu changes + bugfix

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -629,19 +629,21 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 
 	if(incapacitated())
 		return
+	var/mob/user = src
 	var/input
-	switch(alert("Would you like to select a hologram based on a crew member, an animal, or switch to a unique avatar?",,"Crew Member","Unique","Animal"))
+	var/list/hologram_choice = list("Crew Member","Unique","Animal")
+	switch(tgui_alert(user, "Would you like to select a hologram based on a crew member, an animal, or switch to a unique avatar?", "Choices", hologram_choice))
 		if("Crew Member")
 			var/list/personnel_list = list()
 
-			for(var/datum/record/crew/record in GLOB.manifest.locked)//Look in data core locked.
+			for(var/datum/record/locked/record in GLOB.manifest.locked)//Look in data core locked.
 				personnel_list["[record.name]: [record.rank]"] = record.character_appearance//Pull names, rank, and image.
 
 			if(!length(personnel_list))
 				alert("No suitable records found. Aborting.")
 				return
-			if(personnel_list.len)
-				input = input("Select a crew member:") as null|anything in sort_list(personnel_list)
+			if(length(personnel_list))
+				input = tgui_input_list(user, "Select a crew member", "AI Hologram Selection", sort_list(personnel_list))
 				var/mutable_appearance/character_icon = personnel_list[input]
 				if(character_icon)
 					qdel(holo_icon)//Clear old icon so we're not storing it in memory.
@@ -667,7 +669,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 			"spider" = 'icons/mob/animal.dmi'
 			)
 
-			input = input("Please select a hologram:") as null|anything in sort_list(icon_list)
+			input = tgui_input_list(user, "Please select a hologram:", "Animal Choice", sort_list(icon_list))
 			if(input)
 				qdel(holo_icon)
 				switch(input)
@@ -687,7 +689,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 				"horror" = 'icons/mob/ai.dmi'
 				)
 
-			input = input("Please select a hologram:") as null|anything in sort_list(icon_list)
+			input = tgui_input_list(user, "Please select a hologram", "Hologram Choice", sort_list(icon_list))
 			if(input)
 				qdel(holo_icon)
 				switch(input)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

i did an oopsie in the TGUI records PR and it was attempting to get crew records in crew.locked file. AI's should now be able to select a crew member as a hologram.

I also TGUI-ified the menus to make it look nicer.

## Why It's Good For The Game

Bugfix good. Menu update good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/47673505-8daa-43ce-98d1-ad58317fb252

</details>

## Changelog
:cl: XeonMations
fix: Fixed AIs being unable to select a crew member as a hologram.
refactor: TGUI-ified the AI hologram selection menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
