### PR TITLE
Fixes reagent grinder juicing

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -275,10 +275,9 @@
 			juice_item(juiced_item, user)
 
 /obj/machinery/reagentgrinder/proc/juice_item(obj/item/juiced_item, mob/user) //Juicing results can be found in respective object definitions
-	if(juiced_item.on_juice(src) == -1)
+	if(!juiced_item.juice(beaker, user))
 		to_chat(usr, "<span class='danger'>[src] shorts out as it tries to juice up [juiced_item], and transfers it back to storage.</span>")
 		return
-	beaker.reagents.add_reagent_list(juiced_item.juice_results)
 	remove_object(juiced_item)
 
 /obj/machinery/reagentgrinder/proc/grind(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes an issue with reagent grinders not being able to juice things.

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/11987

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

bugfix good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/b841a357-aec0-4649-9efc-e464ff4c7bbc



</details>

## Changelog
:cl: XeonMations
fix: Fixed reagent grinders being unable to juice things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
