### PR TITLE
Fixes Rabbits Eggs Spawning as Errors.

### DIFF
--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -39,7 +39,7 @@
 	speak_language = /datum/language/metalanguage // everyone should understand happy easter
 	emote_hear = list("hops.")
 	emote_see = list("hops around","bounces up and down")
-	egg_type = /obj/item/suprise_egg
+	egg_type = /obj/item/surprise_egg
 	food_type = /obj/item/food/grown/carrot
 	eggsleft = 10
 	eggsFertile = FALSE
@@ -122,12 +122,12 @@
 	//righthand_file = 'icons/mob/inhands/items/food_righthand.dmi'
 	obj_flags = UNIQUE_RENAME
 
-/obj/item/suprise_egg/loaded/Initialize(mapload)
+/obj/item/surprise_egg/loaded/Initialize(mapload)
 	. = ..()
 	var/eggcolor = pick("blue","green","mime","orange","purple","rainbow","red","yellow")
 	icon_state = "egg-[eggcolor]"
 
-/obj/item/suprise_egg/proc/dispensePrize(turf/where)
+/obj/item/surprise_egg/proc/dispensePrize(turf/where)
 	var/static/list/prize_list = list(
 		/obj/item/clothing/head/costume/bunnyhead,
 		/obj/item/clothing/suit/bunnysuit,
@@ -151,7 +151,7 @@
 	new won(where)
 	new/obj/item/food/chocolateegg(where)
 
-/obj/item/suprise_egg/attack_self(mob/user)
+/obj/item/surprise_egg/attack_self(mob/user)
 	..()
 	to_chat(user, "<span class='notice'>You unwrap [src] and find a prize inside!</span>")
 	dispensePrize(get_turf(user))

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -602,7 +602,7 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 
 /datum/holiday/easter/celebrate()
 	GLOB.maintenance_loot += list(
-		/obj/item/suprise_egg = 15,
+		/obj/item/surprise_egg = 15,
 		/obj/item/storage/basket/easter = 15)
 
 /datum/holiday/easter/greet()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes a typo in holiday code which was causing easter eggs to show up without a name or sprite (the big red source ERROR).


This could be the solution to #11988 , since easter bunnies are in the pool of mobs that spawn from the life ritual, and are therefore spawning errors, but more research would be needed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->Placeholder graphics that commonly appear ingame should not be happening.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://github.com/user-attachments/assets/ac13398d-b5bf-4972-b6eb-6610227a89ee)

</details>

## Changelog
:cl: h42

fix: Easter bunnies place down easter eggs instead of errors again.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
