### PR TITLE
Fixes snowflaked turf armor

### DIFF
--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -9,6 +9,7 @@
 	density = TRUE
 	max_integrity = 900
 	damage_deflection = 21
+	armor_type = /datum/armor/r_wall_armor
 
 	var/d_state = INTACT
 	hardness = 10
@@ -21,8 +22,16 @@
 		pipe_astar_cost = 50 \
 	)
 
-/turf/closed/wall/r_wall/get_armour_list()
-	return list(MELEE = 30,  BULLET = 30, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 100, RAD = 100, FIRE = 80, ACID = 70, STAMINA = 0, BLEED = 0)
+/datum/armor/r_wall_armor
+	melee = 30
+	bullet = 30
+	laser = 20
+	energy = 20
+	bomb = 10
+	bio = 100
+	rad = 100
+	fire = 80
+	acid = 70
 
 /turf/closed/wall/r_wall/deconstruction_hints(mob/user)
 	switch(d_state)

--- a/code/game/turfs/turf_integrity.dm
+++ b/code/game/turfs/turf_integrity.dm
@@ -7,8 +7,6 @@
 /turf
 	/// Can this turf be hit by players?
 	var/can_hit = TRUE
-	/// Has armour been generated yet?
-	var/armor_generated
 	/// The integrity that the turf starts at, defaulting to max_integrity
 	var/integrity
 	/// The maximum integrity that the turf has

--- a/code/game/turfs/turf_integrity.dm
+++ b/code/game/turfs/turf_integrity.dm
@@ -38,15 +38,6 @@
 		else
 			. += "<span class='warning'>It doesn't look like you can damage this...</span>"
 
-/// Override this proc to return the armour list
-/turf/proc/get_armour_list()
-	return null
-
-/turf/proc/generate_armor()
-	armor_generated = TRUE
-	var/armour_val = get_armour_list()
-	armor = armour_val
-
 /turf/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	if(QDELETED(src))
 		CRASH("[src] taking damage after deletion")
@@ -71,15 +62,10 @@
 /turf/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration = 0)
 	if(damage_flag == MELEE && damage_amount < damage_deflection)
 		return 0
-	switch(damage_type)
-		if(BRUTE)
-		if(BURN)
-		else
-			return 0
+	if(damage_type != BRUTE && damage_type != BURN)
+		return 0
 	var/armor_protection = 0
 	if(damage_flag)
-		if (!armor_generated)
-			generate_armor()
 		armor_protection = get_armor_rating(damage_flag)
 	if(armor_protection) //Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
 		armor_protection = clamp(armor_protection - armour_penetration, min(armor_protection, 0), 100)

--- a/code/game/turfs/turf_integrity.dm
+++ b/code/game/turfs/turf_integrity.dm
@@ -56,19 +56,6 @@
 	else
 		after_damage(damage_amount, damage_type, damage_flag)
 
-//returns the damage value of the attack after processing the obj's various armor protections
-/turf/run_atom_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration = 0)
-	if(damage_flag == MELEE && damage_amount < damage_deflection)
-		return 0
-	if(damage_type != BRUTE && damage_type != BURN)
-		return 0
-	var/armor_protection = 0
-	if(damage_flag)
-		armor_protection = get_armor_rating(damage_flag)
-	if(armor_protection) //Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
-		armor_protection = clamp(armor_protection - armour_penetration, min(armor_protection, 0), 100)
-	return round(damage_amount * (100 - armor_protection)*0.01, DAMAGE_PRECISION)
-
 /turf/proc/after_damage(damage_amount, damage_type, damage_flag)
 	return
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -355,7 +355,7 @@
 			if(!added_durability_header)
 				readout += "\n<b>DURABILITY (I-X)</b>"
 				added_damage_header = TRUE
-			readout += "\n[armor_to_protection_name(durability_key)] [armor_to_protection_class(durability_key)]"
+			readout += "\n[armor_to_protection_name(durability_key)] [armor_to_protection_class(rating)]"
 
 		if(flags_cover & HEADCOVERSMOUTH)
 			readout += "<br /><b>COVERAGE</b>"

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -59,8 +59,12 @@
 
 /obj/vehicle/sealed/mecha/working/ripley/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate,3,/obj/item/stack/sheet/animalhide/goliath_hide,list(MELEE = 10,  BULLET = 5, LASER = 5))
+	AddComponent(/datum/component/armor_plate, 3 ,/obj/item/stack/sheet/animalhide/goliath_hide, /datum/armor/armor_plate_ripley_goliath)
 
+/datum/armor/armor_plate_ripley_goliath
+	melee = 10
+	bullet = 5
+	laser = 5
 
 /obj/vehicle/sealed/mecha/working/ripley/Destroy()
 	for(var/atom/movable/A in cargo)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Simplifies turf armor. 

- Fixed ripley armor list(should be datum)

- Fixed armor value readout

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For some reason there were turf procs that could be overridden to get a turfs armor.

Instead of just redefining armor...?

Bizarre. Im counting it as a relic from before atom_integrity and armor subtypes. Now we can simply set and forget the armor on typepath instead of worrying whether its "generated" or not.

Big benefit is that one less turf armor proc is snowflaked!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Reinforced wall (54 hits to destroy)

![Screenshot 2024-12-07 164312](https://github.com/user-attachments/assets/5cfd49d1-9435-491b-95f3-28f2e408ab05)



Armorless iron wall varedited to have the same integrity values as rwalls (38 hits to destroy)

![Screenshot 2024-12-07 164432](https://github.com/user-attachments/assets/052e5e2f-cb5a-45ea-b0d6-56d5bb18a544)



</details>

## Changelog
:cl:
refactor: genericizes how turfs handle armor
fix: fix ripley goliath armor runtime
fix: fix armor tag examination runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
