### PR TITLE
Adds a flat beecoin source for admins.

### DIFF
--- a/code/__DEFINES/metacoin.dm
+++ b/code/__DEFINES/metacoin.dm
@@ -1,10 +1,12 @@
 /// Rewarded when you complete a crew objective
-#define METACOIN_CO_REWARD				40
+#define METACOIN_CO_REWARD 40
 /// Rewarded when you escape on the shuttle
-#define METACOIN_ESCAPE_REWARD           30
+#define METACOIN_ESCAPE_REWARD 30
 /// Rewarded when you survive the round
-#define METACOIN_SURVIVE_REWARD          20
+#define METACOIN_SURVIVE_REWARD 20
 /// Rewarded when you don't survive the round, but stick around till the end
-#define METACOIN_NOTSURVIVE_REWARD       10
+#define METACOIN_NOTSURVIVE_REWARD 10
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD  4
+/// Rewarded when you reach roundend as admin, to make up for not playing. 
+#define METACOIN_ROUNDEND_ADMIN 250

--- a/code/__DEFINES/metacoin.dm
+++ b/code/__DEFINES/metacoin.dm
@@ -9,4 +9,4 @@
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD  4
 /// Rewarded when you reach roundend as admin, to make up for not playing. 
-#define METACOIN_ROUNDEND_ADMIN 250
+#define METACOIN_ROUNDEND_ADMIN 30

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -18,6 +18,9 @@
 		else
 			inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
 
+	if(check_rights_for(src, R_ADMIN))
+		inc_metabalance(METACOIN_ROUNDEND_ADMIN, reason="Thanks for adminning! This should offset the cost for not playing.")
+
 /client/proc/process_greentext()
 	src.give_award(/datum/award/achievement/misc/greentext, src.mob)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A client having the `R_ADMIN` permissions at roundend will give a flat 250 beecoins.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Basically, the only way we have metacoin increases for clients is through the roundend counter or achievements.

The first of which *only* considers playtime as a character in-round. The detriment of this is that choosing to administrate a round over playing ingame is actively a detriment to getting cool stuff as admin in the beeshop. 

My solution isn't the perfect solution, but I think the value reaches about around where normal playing is at round conclusion  (~200 beecoins).

I brought this up in an admin meeting and was told that it was a code issue, so here I am.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2024-12-07 184350](https://github.com/user-attachments/assets/762df7f2-18bc-4e8e-a7a8-2c21515ad66d)


</details>

## Changelog
:cl:
server: admins get a flat beecoin amount at roundend, around what players get for surviving a station and escaping to centcom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
