### PR TITLE
Keycard authenticators now authenticate keycards

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -22,6 +22,8 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	var/datum/callback/ev
 	var/event = ""
 	var/obj/machinery/keycard_auth/event_source
+	///Triggering ID card relayed to auth devices to make sure two keycards are used.
+	var/obj/item/card/id/triggering_card
 	var/mob/triggerer = null
 	var/waiting = 0
 
@@ -67,24 +69,31 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 /obj/machinery/keycard_auth/ui_act(action, params)
 	if(..() || waiting || !allowed(usr))
 		return
+	var/obj/item/card/swipe_id = usr.get_idcard()
+	if(!swipe_id || !istype(swipe_id))
+		to_chat(usr, "<span class='warning'>No ID card detected.</span>")
+		return
 	switch(action)
 		if("red_alert")
 			if(!event_source)
-				sendEvent(KEYCARD_RED_ALERT)
+				sendEvent(KEYCARD_RED_ALERT, swipe_id)
 				. = TRUE
 		if("emergency_maint")
 			if(!event_source)
-				sendEvent(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
+				sendEvent(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS, swipe_id)
 				. = TRUE
 		if("auth_swipe")
 			if(event_source)
+				if(swipe_id == event_source.triggering_card)
+					to_chat(usr, "<span class='warning'>Invalid ID. Confirmation ID must not equal trigger ID.</span>")
+					return
 				event_source.trigger_event(usr)
 				event_source = null
 				update_appearance()
 				. = TRUE
 		if("bsa_unlock")
 			if(!event_source)
-				sendEvent(KEYCARD_BSA_UNLOCK)
+				sendEvent(KEYCARD_BSA_UNLOCK, swipe_id)
 				. = TRUE
 
 /obj/machinery/keycard_auth/update_appearance(updates)
@@ -102,8 +111,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 		. += mutable_appearance(icon, "auth_on")
 		. += emissive_appearance(icon, "auth_on", alpha = src.alpha)
 
-/obj/machinery/keycard_auth/proc/sendEvent(event_type)
+/obj/machinery/keycard_auth/proc/sendEvent(event_type, obj/item/card/id/swipe_id)
 	triggerer = usr
+	triggering_card = swipe_id //Shouldn't need qdel registering due to very short time before this var resets.
 	event = event_type
 	waiting = 1
 	GLOB.keycard_events.fireEvent("triggerEvent", src)
@@ -111,6 +121,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 
 /obj/machinery/keycard_auth/proc/eventSent()
 	triggerer = null
+	triggering_card = null
 	event = ""
 	waiting = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Keycard auth devices currently do not check whether the target using them has an ID card, despite being card auth devices (implying some physical component to the authentication).
They also do not ensure the two keycards being used are not the same, which allows a single user to perform this activity.

This PR makes keycard authenticators require an ID to swipe (This affects Silicons since they fall into the "has access but does not have IDs" category. They shouldn't really have access to these as opposed to humanoid crew, which is the main point of this requirement).

Additionally, the IDs used for triggering & confirming the requested action must be different. This is a "soft" requirement in a way, as it does not prevent you from making two IDs and switching between them while also managing to reach both devices, intended as a weak point while also not being as easy to achieve as the original bypassing methods.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Keycard Authentication Devices should authenticate keycards.
Their main intent was to create a two-step auth process akin to submarine movies, but at this time can easily be bypassed via either silicons (who are not humanoid nor command and thus NT wouldn't trust with these), or via quick movement methods / two auths being near eachother.
This rectifies the former, while also making it somewhat more difficult to "solo auth", incentivizing command cooperation.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

<details>

<summary>Silicon response</summary>

![image](https://github.com/user-attachments/assets/6601afb0-4c37-4d14-ac6f-50ca78340070)

</details>

<details>
<summary>Evil captain trying to solo auth</summary>

![image](https://github.com/user-attachments/assets/6b757246-c10a-4507-82bc-7473df5afc38)

</details>

</details>

## Changelog
:cl:
balance: keycard authentication devices require an ID to use.
balance: IDs used to initiate / confirm keycard auth events must not be the same ID.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
