### PR TITLE
Fixes MetaStation Medical Bay Door Button

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -75378,18 +75378,19 @@
 /area/medical/surgery)
 "wXv" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/newscaster{
+	pixel_y = -31
+	},
+/obj/item/kirbyplants/random,
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer";
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = -24
+	pixel_y = -24;
+	req_access_txt = "5"
 	},
-/obj/machinery/newscaster{
-	pixel_y = -31
-	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wXy" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds medical bay access restrictions to the Medical Bay Door Button in the medical bay on MetaStation

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People shouldn't be able to get into the Medical Bay by hopping over the counter and clicking a button.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/05958b28-61f0-452b-bf8f-c8f771901808



</details>

## Changelog
:cl:
fix: MetaStation Medical Bay Door Button (trademarked) Now uses proper access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
