### PR TITLE
Fixes lavaland syndicate station's explosives being able to be picked up

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -403,6 +403,7 @@
 /obj/item/bombcore/large/syndicate_base
 	installed = TRUE
 	anchored = TRUE
+	invisibility = INVISIBILITY_OBSERVER
 
 /obj/item/bombcore/miniature
 	name = "small bomb core"

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -399,6 +399,11 @@
 	range_light = 20
 	range_flame = 20
 
+// Special bomb core for inside the lavaland syndicate base walls. Players should not be able to interact with this.
+/obj/item/bombcore/large/syndicate_base
+	installed = TRUE
+	anchored = TRUE
+
 /obj/item/bombcore/miniature
 	name = "small bomb core"
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -352,16 +352,22 @@
 	icon_state = "map-overspace"
 	fixed_underlay = list("space"=1)
 
+/////////////////////Lavaland Base Syndicate Explosive Walls /////////////////////
+
 /turf/closed/wall/mineral/plastitanium/explosive
-	var/obj/item/bombcore/large/bombcore
+	var/obj/item/bombcore/large/syndicate_base/bombcore
 
 /turf/closed/wall/mineral/plastitanium/explosive/Initialize(mapload)
 	. = ..()
-	bombcore = new(get_turf(src))
-	bombcore.installed = TRUE
+	bombcore = new /obj/item/bombcore/large/syndicate_base(get_turf(src))
+	bombcore.forceMove(src)
 
 /turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
 	bombcore.detonate()
+
+/turf/closed/wall/mineral/plastitanium/explosive/Destroy()
+	qdel(bombcore)
+	..()
 
 //have to copypaste this code
 /turf/closed/wall/mineral/plastitanium/interior/copyTurf(turf/T)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -359,8 +359,7 @@
 
 /turf/closed/wall/mineral/plastitanium/explosive/Initialize(mapload)
 	. = ..()
-	bombcore = new /obj/item/bombcore/large/syndicate_base(get_turf(src))
-	bombcore.forceMove(src)
+	bombcore = new /obj/item/bombcore/large/syndicate_base(src)
 
 /turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
 	bombcore.detonate()

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -359,7 +359,8 @@
 
 /turf/closed/wall/mineral/plastitanium/explosive/Initialize(mapload)
 	. = ..()
-	bombcore = new /obj/item/bombcore/large/syndicate_base(src)
+	bombcore = new /obj/item/bombcore/large/syndicate_base(get_turf(src))
+	bombcore.forceMove(src)
 
 /turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
 	bombcore.detonate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes the actual explosives a subtype, as well as making it so they cant be picked up.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

no free explosives for you, lavaland

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



https://github.com/user-attachments/assets/271b84c4-99f2-42d8-b66a-886a1d4f6833


https://github.com/user-attachments/assets/db75f466-2aba-4d04-847f-116186391569





</details>

## Changelog
:cl: XeonMations
fix: The syndicate lavaland base's explosives are no longer able to be picked up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
