### PR TITLE
Fixes reagent grinder juicing. Again.

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -47,7 +47,7 @@
 #warn PROFILE_MAPLOAD_INIT_ATOM creates very large profiles, do not leave this on!
 #endif
 
-//#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 /// If this is uncommented, we set up the ref tracker to be used in a live environment
 /// And to log events to [log_dir]/harddels.log

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -47,7 +47,7 @@
 #warn PROFILE_MAPLOAD_INIT_ATOM creates very large profiles, do not leave this on!
 #endif
 
-#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
+//#define UNIT_TESTS			//If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 
 /// If this is uncommented, we set up the ref tracker to be used in a live environment
 /// And to log events to [log_dir]/harddels.log

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -23,7 +23,7 @@
 	icon_state = "apple"
 	bite_consumption_mod = 100 // Always eat apples in one bite
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/applejuice = 0)
+	juice_results = /datum/reagent/consumable/applejuice
 	tastes = list("apple" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/hcider
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -23,7 +23,7 @@
 	trash_type = /obj/item/grown/bananapeel
 	bite_consumption_mod = 3
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/banana = 0)
+	juice_results = /datum/reagent/consumable/banana
 	distill_reagent = /datum/reagent/consumable/ethanol/bananahonk
 	dying_key = DYE_REGISTRY_BANANA
 
@@ -33,7 +33,7 @@
 	var/obj/item/grown/bananapeel/peel = .
 	if(istype(peel))
 		peel.grind_results = list(/datum/reagent/medicine/coagulant/banana_peel = seed.potency * 0.2)
-		peel.juice_results = list(/datum/reagent/medicine/coagulant/banana_peel = seed.potency * 0.2)
+		peel.juice_results = /datum/reagent/medicine/coagulant/banana_peel
 */
 
 /obj/item/food/grown/banana/suicide_act(mob/user)

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -24,7 +24,7 @@
 	icon_state = "berrypile"
 	gender = PLURAL
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/berryjuice = 0)
+	juice_results = /datum/reagent/consumable/berryjuice
 	tastes = list("berry" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/gin
 
@@ -47,7 +47,7 @@
 	icon_state = "poisonberrypile"
 	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
-	juice_results = list(/datum/reagent/consumable/poisonberryjuice = 0)
+	juice_results = /datum/reagent/consumable/poisonberryjuice
 	tastes = list("poison-berry" = 1)
 	distill_reagent = null
 	wine_power = 35
@@ -74,7 +74,7 @@
 	icon_state = "deathberrypile"
 	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
-	juice_results = list(/datum/reagent/consumable/poisonberryjuice = 0)
+	juice_results = /datum/reagent/consumable/poisonberryjuice
 	tastes = list("death-berry" = 1)
 	distill_reagent = null
 	wine_power = 50
@@ -217,7 +217,7 @@
 	icon_state = "grapes"
 	bite_consumption_mod = 2
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/grapejuice = 0)
+	juice_results = /datum/reagent/consumable/grapejuice
 	tastes = list("grape" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/wine
 

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -29,7 +29,7 @@
 	name = "lime"
 	desc = "It's so sour, your face will twist."
 	icon_state = "lime"
-	juice_results = list(/datum/reagent/consumable/limejuice = 0)
+	juice_results = /datum/reagent/consumable/limejuice
 
 // Orange
 /obj/item/seeds/orange
@@ -55,7 +55,7 @@
 	name = "orange"
 	desc = "It's a tangy fruit."
 	icon_state = "orange"
-	juice_results = list(/datum/reagent/consumable/orangejuice = 0)
+	juice_results = /datum/reagent/consumable/orangejuice
 	distill_reagent = /datum/reagent/consumable/ethanol/triple_sec
 
 // Lemon
@@ -81,7 +81,7 @@
 	name = "lemon"
 	desc = "When life gives you lemons, make lemonade."
 	icon_state = "lemon"
-	juice_results = list(/datum/reagent/consumable/lemonjuice = 0)
+	juice_results = /datum/reagent/consumable/lemonjuice
 
 // Combustible lemon
 /obj/item/seeds/firelemon //combustible lemon is too long so firelemon
@@ -175,7 +175,7 @@
 	desc = "You can hardly wrap your head around this thing."
 	icon_state = "orang"
 	bite_consumption_mod = 2
-	juice_results = list(/datum/reagent/consumable/orangejuice = 0)
+	juice_results = /datum/reagent/consumable/orangejuice
 	distill_reagent = /datum/reagent/consumable/ethanol/triple_sec
 	tastes = list("polygons" = 1, "oranges" = 1)
 	discovery_points = 300

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -79,7 +79,7 @@
 	bite_consumption_mod = 2
 	trash_type = /obj/item/food/grown/bungopit
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/bungojuice = 0)
+	juice_results = /datum/reagent/consumable/bungojuice
 	tastes = list("bungo" = 2, "tropical fruitiness" = 1)
 	distill_reagent = null
 	discovery_points = 300

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -24,7 +24,7 @@
 	trash_type = /obj/item/grown/corncob
 	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
-	juice_results = list(/datum/reagent/consumable/corn_starch = 0)
+	juice_results = /datum/reagent/consumable/corn_starch
 	tastes = list("corn" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/whiskey
 	discovery_points = 300

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -29,7 +29,7 @@
 	bite_consumption_mod = 2
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/watermelonjuice = 0)
+	juice_results = /datum/reagent/consumable/watermelonjuice
 	wine_power = 40
 
 /obj/item/food/grown/watermelon/make_processable()

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -29,7 +29,7 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL
 	foodtypes = FRUIT | PINEAPPLE
-	juice_results = list(/datum/reagent/consumable/pineapplejuice = 0)
+	juice_results = /datum/reagent/consumable/pineapplejuice
 	tastes = list("pineapple" = 1)
 	wine_power = 40
 

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -25,7 +25,7 @@
 	icon_state = "potato"
 	bite_consumption_mod = 100
 	foodtypes = VEGETABLES
-	juice_results = list(/datum/reagent/consumable/potato_juice = 0)
+	juice_results = /datum/reagent/consumable/potato_juice
 	distill_reagent = /datum/reagent/consumable/ethanol/vodka
 
 /obj/item/food/grown/potato/wedges

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -23,7 +23,7 @@
 	icon_state = "pumpkin"
 	bite_consumption_mod = 2
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/pumpkinjuice = 0)
+	juice_results = /datum/reagent/consumable/pumpkinjuice
 	wine_power = 20
 
 /obj/item/food/grown/pumpkin/attackby(obj/item/W as obj, mob/user as mob, params)
@@ -54,6 +54,6 @@
 	icon_state = "blumpkin"
 	bite_consumption_mod = 3
 	foodtypes = FRUIT
-	juice_results = list(/datum/reagent/consumable/blumpkinjuice = 0)
+	juice_results = /datum/reagent/consumable/blumpkinjuice
 	wine_power = 50
 	discovery_points = 300

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -22,7 +22,7 @@
 	filling_color = "#FFA500"
 	bite_consumption_mod = 2
 	foodtypes = VEGETABLES
-	juice_results = list(/datum/reagent/consumable/carrotjuice = 0)
+	juice_results = /datum/reagent/consumable/carrotjuice
 	wine_power = 30
 
 /obj/item/food/grown/carrot/attackby(obj/item/I, mob/user, params)
@@ -53,7 +53,7 @@
 	desc = "Closely related to carrots."
 	icon_state = "parsnip"
 	foodtypes = VEGETABLES
-	juice_results = list(/datum/reagent/consumable/parsnipjuice = 0)
+	juice_results = /datum/reagent/consumable/parsnipjuice
 	wine_power = 35
 	discovery_points = 300
 

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -22,7 +22,7 @@
 	splat_type = /obj/effect/decal/cleanable/food/tomato_smudge
 	foodtypes = FRUIT
 	grind_results = list(/datum/reagent/consumable/ketchup = 0)
-	juice_results = list(/datum/reagent/consumable/tomatojuice = 0)
+	juice_results = /datum/reagent/consumable/tomatojuice
 	distill_reagent = /datum/reagent/consumable/enzyme
 
 // Blood Tomato

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
@@ -357,7 +357,7 @@
 	tool_behaviour = null
 	fake_seed = null
 	grind_results = list(/datum/reagent/consumable/chlorophyll = 20)
-	juice_results = list(/datum/reagent/consumable/chlorophyll = 20)
+	juice_results = /datum/reagent/consumable/chlorophyll
 
 /obj/item/clothing/head/mob_holder/nymph/Initialize(mapload, mob/living/M, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags)
 	if(M.mind)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -52,6 +52,7 @@
 #include "quirks.dm"
 #include "random_ruin_mapsize.dm"
 #include "rcd.dm"
+#include "reagent_grinder.dm"
 #include "reagent_id_typos.dm"
 #include "reagent_recipe_collisions.dm"
 #include "security_levels.dm"

--- a/code/modules/unit_tests/reagent_grinder.dm
+++ b/code/modules/unit_tests/reagent_grinder.dm
@@ -1,0 +1,57 @@
+/**
+ * Unit test to check for if reagent grinders process correctly.
+ *
+ * Accepts each item that has grind_results not null OR has an assigned juice_results variable
+ * Grinds/Juices it
+ * Checks if the output is what we expect from grinding/juicing that item
+ *
+ */
+
+/datum/unit_test/reagent_grinder
+
+/datum/unit_test/reagent_grinder/Run()
+	message_admins("Running Reagent Grinder Test")
+	grind_items()
+	juice_items()
+
+
+/datum/unit_test/reagent_grinder/proc/grind_items()
+	var/list/item_list = subtypesof(/obj/item)
+	for(var/item as anything in item_list)
+		message_admins("GRINDING: [item_list]")
+	for(var/obj/item/item as anything in item_list)
+		item = new()
+		if(!item.grind_results && !item.juice_results && !item.is_grindable())
+			QDEL_NULL(item)
+			return
+		message_admins("Now grinding: [item]")
+		var/obj/machinery/reagentgrinder/grinder = allocate(/obj/machinery/reagentgrinder)
+
+		message_admins("Moved [item] into grinder")
+		item.forceMove(grinder)
+		grinder.holdingitems[item] = TRUE
+		grinder.grind()
+		message_admins("[item] grinded with the following ingredients in beaker: [grinder.beaker.reagents], expecting [item.grind_results]")
+		TEST_ASSERT((grinder.beaker.reagents != item.grind_results), "No reagents in beaker after attempted grinding in [item], supposed to have [item.grind_results]!")
+		QDEL_NULL(item)
+
+/datum/unit_test/reagent_grinder/proc/juice_items()
+	var/list/item_list = subtypesof(/obj/item)
+	for(var/item as anything in item_list)
+		message_admins("JUICING: [item_list]")
+	for(var/obj/item/item as anything in item_list)
+		item = new()
+		if(!item.grind_results && !item.juice_results && !item.is_grindable())
+			QDEL_NULL(item)
+			return
+
+		message_admins("Now juicing: [item]")
+		var/obj/machinery/reagentgrinder/grinder = allocate(/obj/machinery/reagentgrinder)
+
+		message_admins("Moved [item] into juicer")
+		item.forceMove(grinder)
+		grinder.holdingitems[item] = TRUE
+		grinder.juice()
+		message_admins("[item] juiced with the following ingredients in beaker: [grinder.beaker.reagents], expecting [item.juice_results]")
+		TEST_ASSERT((grinder.beaker.reagents != item.juice_results), "No reagents in beaker after attempted juicing in [item], supposed to have [item.juice_results]!")
+		QDEL_NULL(item)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Turns out juice_typepaths were all lists instead of the proper datums they were supposed to be after https://github.com/BeeStation/BeeStation-Hornet/pull/11994. Oops. This fixes that.

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/12028

Also adds a reagent_grinder unit test to check that they are working correctly.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

You should be able to juice a banana.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/5ba11276-e586-4a9c-9c2c-405c1020b955



</details>

## Changelog
:cl: XeonMations
fix: You can now juice things once more in a reagent grinder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
