### PR TITLE
Adds /obj/effect/warped_rune to the supply shuttle blacklist.

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/swapper,
 		/obj/item/mail,
 		/obj/docking_port,
-		/obj/effect/warped_rune, // no teleporting to cc for you
+		/obj/effect/warped_rune // no teleporting to cc for you
 	)))
 
 /obj/docking_port/mobile/supply

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -26,7 +26,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/hilbertshotel,
 		/obj/item/swapper,
 		/obj/item/mail,
-		/obj/docking_port
+		/obj/docking_port,
+		/obj/effect/warped_rune, // no teleporting to cc for you
 	)))
 
 /obj/docking_port/mobile/supply


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the title, this PR adds /obj/effect/warped_rune to the supply shuttle blacklist. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Previously, you could spawn a rainbow slime rune on the supply shuttle, send it to centcom, then bypass the cordons with bluespace. bugs are bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/390ffac8-291e-4c59-9a45-9b971e770e34



</details>

## Changelog
:cl:
fix: you can no longer get to centcom with warped runes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
