### PR TITLE
Makes EMP'd robotic limbs no longer hardstun you

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -453,21 +453,20 @@
 	if(. & EMP_PROTECT_CONTENTS)
 		return
 	var/informed = FALSE
-	for(var/obj/item/bodypart/L in src.bodyparts)
-		if(!IS_ORGANIC_LIMB(L))
+	for(var/obj/item/bodypart/bodypart in src.bodyparts)
+		if(!IS_ORGANIC_LIMB(bodypart))
 			if(!informed)
-				to_chat(src, "<span class='userdanger'>You feel a sharp pain as your robotic limbs overload.</span>")
+				to_chat(src, "<span class='userdanger'>You feel a sharp pain as [bodypart] overloads!</span>")
 				informed = TRUE
 			switch(severity)
-				if(1)
-					L.receive_damage(0,10)
-					Paralyze(200)
-				if(2)
-					L.receive_damage(0,5)
-					Paralyze(100)
-			if(HAS_TRAIT(L, TRAIT_EASYDISMEMBER) && L.body_zone != "chest")
+				if(EMP_HEAVY)
+					bodypart.receive_damage(0,10) //Burns, heavy.
+				if(EMP_LIGHT)
+					bodypart.receive_damage(0,5) //Burns, light.
+			bodypart.receive_damage(stamina = 120) //Disable the limb since we got EMP'd
+			if(HAS_TRAIT(bodypart, TRAIT_EASYDISMEMBER) && bodypart.body_zone != "chest")
 				if(prob(20))
-					L.dismember(BRUTE)
+					bodypart.dismember(BRUTE)
 
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc
 	var/list/damaged = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Changed some code to make EMP's deal maximum stamina damage to a limb, since i was unable to figure out a way to disable a limb for the 50 seconds a heavy EMP used to make you hardstunned for.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

You should not be able to be hardstunned for 50 seconds from one heavy EMP purely because of you having one robotic arm.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/afbba457-dc94-4d59-9a6b-2eb49e7b01eb

</details>

## Changelog
:cl: XeonMations
balance: Getting yourself EMP'd with a robotic limb will no longer hardstun you, instead it will disable the limb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
