### PR TITLE
Fixes Split Personality brain trauma having the ability to RR the original mind of the body

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -60,7 +60,7 @@
 
 
 /datum/brain_trauma/severe/split_personality/proc/switch_personalities(reset_to_owner = FALSE)
-	if(QDELETED(owner) || owner.stat == DEAD || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
+	if(QDELETED(owner) || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
 		return
 
 	var/mob/living/split_personality/current_backseat

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -51,6 +51,12 @@
 		switch_personalities()
 	..()
 
+/datum/brain_trauma/severe/split_personality/on_death()
+	if(current_controller != OWNER)
+		switch_personalities(TRUE)
+	..()
+
+
 /datum/brain_trauma/severe/split_personality/on_lose()
 	if(current_controller != OWNER) //it would be funny to cure a guy only to be left with the other personality, but it seems too cruel
 		switch_personalities(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Split personalities used to be able to throw the original mind out of the round by taking over the body when the trauma was fixed. Now the trauma is removed

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Being RR'd due to a brain trauma is bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Dying removes the personality trauma

https://github.com/user-attachments/assets/9eb93efb-66e0-4d60-aca3-6ecbeedb2046

Removing the trauma when the non-original is in the body correctly places the right mind in the body (Props to Erika and Bronte for helping me test this)


https://github.com/user-attachments/assets/d43eaebf-881d-4286-99e5-754dd81ce6bb



</details>

## Changelog
:cl: XeonMations, ManiacalAnxiety, therealdoooc213
fix: Split personalities can no longer throw out their original body's mind out of their own body permenantly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
