### PR TITLE
you can no longer put food in iv drips (1984)

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -15,7 +15,6 @@
 		/obj/item/reagent_containers/blood,
 		/obj/item/reagent_containers/chem_bag,
 		/obj/item/reagent_containers/cup,
-		/obj/item/food, //Fuck it. You want to stab an IV into that 100u blood tomato? Be my guest.
 		/obj/item/reagent_containers/cup
 		)
 	)
@@ -108,7 +107,7 @@
 
 
 /obj/machinery/iv_drip/attackby(obj/item/W, mob/user, params)
-	if(is_type_in_typecache(W, drip_containers) || IS_EDIBLE(W))
+	if(is_type_in_typecache(W, drip_containers))
 		if(beaker)
 			to_chat(user, "<span class='warning'>There is already a reagent container loaded!</span>")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

you can no longer put food in iv drips

i don't consider this a bug fix because there was a code comment on it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it causes runtime errors and makes zero sense as to why i can put a cake into a IV drip

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/5811dcf9-c11b-480c-a677-2bfd4c61f369



</details>

## Changelog
:cl:
tweak: you can no longer put food in iv drips
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
