### PR TITLE
fixes mobs buckled to the operating table not being forced to lay down

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -585,9 +585,9 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/table)
 	smoothing_flags = NONE
 	smoothing_groups = null
 	canSmoothWith = null
-	can_buckle = 1
-	buckle_lying = NO_BUCKLE_LYING
-	buckle_requires_restraints = 1
+	can_buckle = TRUE
+	buckle_lying = 90
+	buckle_requires_restraints = TRUE
 	var/mob/living/carbon/human/patient = null
 	var/obj/machinery/computer/operating/computer = null
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -587,7 +587,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/table)
 	canSmoothWith = null
 	can_buckle = TRUE
 	buckle_lying = 90
-	buckle_requires_restraints = TRUE
 	var/mob/living/carbon/human/patient = null
 	var/obj/machinery/computer/operating/computer = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes mobs buckled to the operating table not being forced to lay down
one line fix
Closes #11953

## Why It's Good For The Game

this is just really weird behavior

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/d5f7cb2b-87fa-4f7b-b698-2cfbf7e112a0



</details>

## Changelog
:cl:
fix: fixed mobs buckled to the operating table not being forced to lay down
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
