### PR TITLE
Fixes a Hard Del in regenerate_organs

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 					oldorgan = null
 			else
 				oldorgan.Remove(C, special = TRUE)
-				required_organs -= oldorgan
+				required_organs -= oldorgan.type
 				QDEL_NULL(oldorgan) //we cannot just tab this out because we need to skip the deleting if it is a decoy brain.
 
 		if(oldorgan)
@@ -339,7 +339,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		else if(should_have && !(initial(neworgan.zone) in excluded_zones))
 			used_neworgan = TRUE
 			neworgan.Insert(C, TRUE, FALSE)
-			required_organs |= neworgan
+			required_organs |= neworgan.type
 
 		if(!used_neworgan)
 			qdel(neworgan)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a hard delete caused by [regenerate_organs](https://github.com/BeeStation/BeeStation-Hornet/blob/c10d71b849710a17394dc7a22b0e94d968d1a257/code/modules/mob/living/carbon/human/species.dm#L325-L370) where references are mistakenly passed to a list that takes typepaths. So the fix I applied was ensuring just that; passing the types of the organs rather than the organs themselves.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The less hard deletes, the less performance loss and probability of more problems arising

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

A patient at first
![image](https://github.com/user-attachments/assets/d55d9bcb-ea37-407a-bc10-88e18d2683fd)

After liberating them of their organs (surgical saw my beloved)
![image](https://github.com/user-attachments/assets/3550dedd-05fb-48ec-bfb7-a64f903868ec)

No Hard Deletes in the queue 10 minutes after gibbing them
![image](https://github.com/user-attachments/assets/c787cde5-cdd7-42f8-ae7f-7f27fddab35f)

</details>

## Changelog
:cl:
fix: Fixed an improperly handled list "required_organs" in species code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
