### PR TITLE
Fixes the button size of nuclear bomb interfaces

### DIFF
--- a/tgui/packages/tgui/interfaces/NuclearBomb.js
+++ b/tgui/packages/tgui/interfaces/NuclearBomb.js
@@ -29,7 +29,7 @@ const NukeKeypad = (props, context) => {
                 textAlign="center"
                 fontSize="40px"
                 lineHeight="50px"
-                width="55px"
+                width="40px"
                 className={classes(['NuclearBomb__Button', 'NuclearBomb__Button--keypad', 'NuclearBomb__Button--' + key])}
                 onClick={() => act('keypad', { digit: key })}
               />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Honestly I'm not even sure why this happened looking between our code and TG's, they're nearly identical UIs and yet one is properly sized when loaded and the other isn't. It seems like tweaking this thing by 15 pixels solves the issue of the interface clipping over it's bounds to the sides, which is warned about potentially needing to be done in the code comment above the whole thing.

This is how it looks currently, for reference:

<details>
<summary>Current Annoying UI Look</summary>

![image](https://github.com/user-attachments/assets/50f48417-6877-4d80-b856-a99dd82bdab9)

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This looks a lot better than before when the buttons were clipping into each other.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Fixed UI Look</summary>

![image](https://github.com/user-attachments/assets/0b4019ac-f05f-4533-8cf0-5e7f42e5378c)

</details>

## Changelog
:cl:
fix: The keypad buttons on nuke interfaces no longer clip into the other buttons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
