### PR TITLE
Adds in radio fuzzing in maintenance

### DIFF
--- a/code/__DEFINES/jamming_defines.dm
+++ b/code/__DEFINES/jamming_defines.dm
@@ -14,6 +14,7 @@
 #define JAMMER_PROTECTION_WIRELESS 1		//Wireless networking
 #define JAMMER_PROTECTION_AI_SHELL 2		//AI shell protection
 #define JAMMER_PROTECTION_SILICON_COMMS 1	//Silicon comms
+#define JAMMER_PROTECTION_PDA_MESSAGE 0		//PDA messages
 
 // Signal jamming
 /// Not jammed

--- a/code/__DEFINES/jamming_defines.dm
+++ b/code/__DEFINES/jamming_defines.dm
@@ -4,7 +4,7 @@
 #define JAMMER_LEVEL_NONE -1			//Jams nothing
 #define RADIO_JAMMER_ABDUCTOR_LEVEL 1	//Power of the abductor radio jammer
 #define RADIO_JAMMER_TRAITOR_LEVEL 3	//Power of the traitor radio jammer
-#define RADIO_JAMMER_MAINTENANCE_LEVEL 1	// Maintenance jams some signals with minor jamming
+#define RADIO_JAMMER_MAINTENANCE_LEVEL 0	// Maintenance jams some signals with minor jamming
 
 //Radio jammer protection level
 #define JAMMER_PROTECTION_RADIO_BASIC 0		//Basic comms channels

--- a/code/__DEFINES/jamming_defines.dm
+++ b/code/__DEFINES/jamming_defines.dm
@@ -1,8 +1,10 @@
 
 //Radio jammer levels
 //They will jam any signals that have the same or lower protection value
+#define JAMMER_LEVEL_NONE -1			//Jams nothing
 #define RADIO_JAMMER_ABDUCTOR_LEVEL 1	//Power of the abductor radio jammer
 #define RADIO_JAMMER_TRAITOR_LEVEL 3	//Power of the traitor radio jammer
+#define RADIO_JAMMER_MAINTENANCE_LEVEL 1	// Maintenance jams some signals with minor jamming
 
 //Radio jammer protection level
 #define JAMMER_PROTECTION_RADIO_BASIC 0		//Basic comms channels
@@ -12,3 +14,11 @@
 #define JAMMER_PROTECTION_WIRELESS 1		//Wireless networking
 #define JAMMER_PROTECTION_AI_SHELL 2		//AI shell protection
 #define JAMMER_PROTECTION_SILICON_COMMS 1	//Silicon comms
+
+// Signal jamming
+/// Not jammed
+#define JAM_NONE 0
+/// Some jamming effects, but not completely disabling the device
+#define JAM_MINOR 1
+/// Fully jammed, cannot function
+#define JAM_FULL 2

--- a/code/datums/components/jam_receiver.dm
+++ b/code/datums/components/jam_receiver.dm
@@ -63,7 +63,7 @@
 
 /datum/component/jam_receiver/proc/check_jammed()
 	var/atom/atom_parent = parent
-	var/new_state = atom_parent.is_jammed(intensity_resist)
+	var/new_state = atom_parent.is_jammed(intensity_resist) == JAM_FULL
 	set_jammed(new_state)
 
 /datum/component/jam_receiver/proc/set_jammed(new_state)

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -165,7 +165,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	min_ambience_cooldown = 20 SECONDS
 	max_ambience_cooldown = 35 SECONDS
 	sound_environment = SOUND_AREA_TUNNEL_ENCLOSED
-	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	mood_bonus = -1
 	mood_message = "<span class='warning'>It's kind of cramped in here!\n</span>"
 	// assistants are associated with maints, jani closet is in maints, engis have to go into maints often
@@ -177,6 +176,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lights_always_start_on = TRUE
 	color_correction = /datum/client_colour/area_color/cold_ish
 	camera_networks = list(CAMERA_NETWORK_STATION)
+	area_jamming_level = RADIO_JAMMER_MAINTENANCE_LEVEL
 
 /area/maintenance/get_area_textures()
 	return GLOB.turf_texture_maint

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -140,6 +140,8 @@
 	/// What networks should cameras in this area belong to?
 	var/list/camera_networks = list()
 
+	var/area_jamming_level = JAMMER_LEVEL_NONE
+
 /**
   * A list of teleport locations
   *

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -497,7 +497,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/camera)
 		return FALSE
 	if(machine_stat & EMPED)
 		return FALSE
-	if(is_jammed(JAMMER_PROTECTION_CAMERAS))
+	if(is_jammed(JAMMER_PROTECTION_CAMERAS) == JAM_FULL)
 		return FALSE
 	return TRUE
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -99,7 +99,7 @@
 			track_time -= 1 SECONDS
 		// Check for sensor beacon
 		var/nanite_sensors = HAS_TRAIT(human_target, TRAIT_SUIT_SENSORS)
-		if(!human_target.is_jammed(JAMMER_PROTECTION_SENSOR_NETWORK) && (nanite_sensors || HAS_TRAIT(human_target, TRAIT_NANITE_SENSORS)))
+		if(target.is_jammed(JAMMER_PROTECTION_SENSOR_NETWORK) == JAM_NONE && (nanite_sensors || HAS_TRAIT(human_target, TRAIT_NANITE_SENSORS)))
 			// Check for a uniform if not using nanites
 			// If the GPS is on, track instantly
 			var/obj/item/clothing/under/uniform = human_target.w_uniform

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -252,7 +252,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			continue
 
 		// Radio transmitters are jammed
-		if(tracked_human.is_jammed(JAMMER_PROTECTION_SENSOR_NETWORK))
+		var/jam_state = tracked_human.is_jammed(JAMMER_PROTECTION_SENSOR_NETWORK)
+		if(jam_state == JAM_FULL)
 			continue
 
 		// The entry for this human
@@ -271,19 +272,19 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				entry["ijob"] = jobs[I.hud_state]
 
 		// Binary living/dead status
-		if (nanite_sensors || uniform.sensor_mode >= SENSOR_LIVING)
+		if ((nanite_sensors || uniform.sensor_mode >= SENSOR_LIVING))
 			entry["life_status"] = !tracked_human.stat
 
 		// Damage
-		if (nanite_sensors || uniform.sensor_mode >= SENSOR_VITALS)
-			entry["oxydam"] = round(tracked_human.getOxyLoss(), 1)
-			entry["toxdam"] = round(tracked_human.getToxLoss(), 1)
-			entry["burndam"] = round(tracked_human.getFireLoss(), 1)
-			entry["brutedam"] = round(tracked_human.getBruteLoss(), 1)
+		if ((nanite_sensors || uniform.sensor_mode >= SENSOR_VITALS))
+			entry["oxydam"] = jam_state == JAM_NONE ? round(tracked_human.getOxyLoss(), 1) : rand(0, 40)
+			entry["toxdam"] = jam_state == JAM_NONE ? round(tracked_human.getToxLoss(), 1) : rand(0, 40)
+			entry["burndam"] = jam_state == JAM_NONE ? round(tracked_human.getFireLoss(), 1) : rand(0, 40)
+			entry["brutedam"] = jam_state == JAM_NONE ? round(tracked_human.getBruteLoss(), 1) : rand(0, 40)
 
 		// Area
 		if (pos && (nanite_sensors || uniform.sensor_mode >= SENSOR_COORDS))
-			entry["area"] = get_area_name(tracked_human, TRUE)
+			entry["area"] = jam_state == JAM_NONE ? get_area_name(tracked_human, TRUE) : scramble_message_replace_chars(get_area_name(tracked_human, TRUE), 80)
 
 		// Trackability
 		entry["can_track"] = tracked_human.can_track()

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -277,10 +277,10 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		// Damage
 		if ((nanite_sensors || uniform.sensor_mode >= SENSOR_VITALS))
-			entry["oxydam"] = jam_state == JAM_NONE ? round(tracked_human.getOxyLoss(), 1) : rand(0, 40)
-			entry["toxdam"] = jam_state == JAM_NONE ? round(tracked_human.getToxLoss(), 1) : rand(0, 40)
-			entry["burndam"] = jam_state == JAM_NONE ? round(tracked_human.getFireLoss(), 1) : rand(0, 40)
-			entry["brutedam"] = jam_state == JAM_NONE ? round(tracked_human.getBruteLoss(), 1) : rand(0, 40)
+			entry["oxydam"] = round(tracked_human.getOxyLoss(), 1) + (jam_state != JAM_NONE && rand(-5, 5))
+			entry["toxdam"] = round(tracked_human.getToxLoss(), 1) + (jam_state != JAM_NONE && rand(-5, 5))
+			entry["burndam"] = round(tracked_human.getFireLoss(), 1) + (jam_state != JAM_NONE && rand(-5, 5))
+			entry["brutedam"] = round(tracked_human.getBruteLoss(), 1) + (jam_state != JAM_NONE && rand(-5, 5))
 
 		// Area
 		if (pos && (nanite_sensors || uniform.sensor_mode >= SENSOR_COORDS))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -246,7 +246,7 @@
 		return
 
 	//Check radio signal jamming
-	if(is_jammed(JAMMER_PROTECTION_WIRELESS) != JAM_FULL)
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		return
 
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -246,7 +246,7 @@
 		return
 
 	//Check radio signal jamming
-	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS) != JAM_FULL)
 		return
 
 
@@ -455,14 +455,14 @@
 /obj/machinery/door/airlock/proc/canAIControl(mob/user)
 	if(protected_door)
 		return FALSE
-	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		return FALSE
 	return ((aiControlDisabled != 1) && !isAllPowerCut())
 
 /obj/machinery/door/airlock/proc/canAIHack()
 	if(protected_door)
 		return FALSE
-	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		return FALSE
 	return ((aiControlDisabled==1) && (!hackProof) && (!isAllPowerCut()));
 
@@ -779,7 +779,7 @@
 	if(detonated)
 		to_chat(user, "<span class='warning'>Unable to interface. Airlock control panel damaged.</span>")
 		return
-	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		to_chat(user, "<span class='warning'>Unable to interface. Remote communications not responding.</span>")
 		return
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -385,7 +385,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/door/window)
 		return
 
 	//Check radio signal jamming
-	if(is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		return
 
 	// Check packet access level.

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 /obj/machinery/telecomms/proc/ntnet_receive(datum/source, datum/netdata/data)
 
 	//Check radio signal jamming
-	if(is_jammed(JAMMER_PROTECTION_WIRELESS) || machine_stat & (BROKEN|NOPOWER|MAINT|EMPED))
+	if(is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL || machine_stat & (BROKEN|NOPOWER|MAINT|EMPED))
 		return
 
 	switch(data.data["type"])

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -299,8 +299,11 @@
 		channel = null
 
 	// Nearby active jammers prevent the message from transmitting
-	if(is_jammed(freq == FREQ_CENTCOM || freq == FREQ_SYNDICATE ? JAMMER_PROTECTION_RADIO_ADVANCED : JAMMER_PROTECTION_RADIO_BASIC))
+	var/jam_level = is_jammed(freq == FREQ_CENTCOM || freq == FREQ_SYNDICATE ? JAMMER_PROTECTION_RADIO_ADVANCED : JAMMER_PROTECTION_RADIO_BASIC)
+	if(jam_level == JAM_FULL)
 		return
+	if (jam_level == JAM_MINOR)
+		message = Gibberish(message, TRUE)
 
 	// Determine the identity information which will be attached to the signal.
 	var/atom/movable/virtualspeaker/speaker = new(null, talking_movable, src)
@@ -369,7 +372,7 @@
 
 	if (input_frequency == FREQ_SYNDICATE && !syndie)
 		return FALSE
-
+	
 	// allow checks: are we listening on that frequency?
 	if (input_frequency == frequency)
 		return TRUE

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -290,12 +290,15 @@ effective or pretty fucking useless.
 ///Parameters:
 /// - Protection level: The amount of protection that the atom has. See jamming_defines.dm
 /atom/proc/is_jammed(protection_level)
+	. = JAM_NONE
 	var/turf/position = get_turf(src)
+	var/area/location = position.loc
+	if (protection_level <= location.area_jamming_level)
+		. = JAM_MINOR
 	for(var/datum/component/radio_jamming/jammer as anything in GLOB.active_jammers)
 		//Check to see if the jammer is strong enough to block this signal
 		if (protection_level > jammer.intensity)
 			continue
 		var/turf/jammer_turf = get_turf(jammer.parent)
 		if(position?.get_virtual_z_level() == jammer_turf.get_virtual_z_level() && (get_dist(position, jammer_turf) <= jammer.range))
-			return TRUE
-	return FALSE
+			return JAM_FULL

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -80,7 +80,7 @@
 	. = ..()
 	if(!active)
 		return
-	if(!target || (!isnull(jamming_resistance) && src.is_jammed(jamming_resistance)))
+	if(!target || (!isnull(jamming_resistance) && src.is_jammed(jamming_resistance) != JAM_NONE))
 		. += "pinon[alert ? "alert" : ""]null[icon_suffix]"
 		return
 	var/turf/here = get_turf(src)
@@ -163,7 +163,7 @@
 	if(!here || !there)
 		return FALSE
 
-	if(there.is_jammed(jam_level))
+	if(there.is_jammed(jam_level) != JAM_NONE)
 		return FALSE
 
 	if(!powerful_z_check) // z-check will be only limited within the same area (i.e. multi-floor'ed station)

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -118,7 +118,7 @@
 		z_level_direction = ""
 
 	// getting xy result
-	if(get_dist_euclidian(here,there) <= minimum_range || (target.is_jammed(jamming_resistance) != JAM_NONE) && get_dist_euclidian(here,there) < minimum_range + 25))
+	if(get_dist_euclidian(here,there) <= minimum_range || (target.is_jammed(jamming_resistance) != JAM_NONE) && get_dist_euclidian(here,there) < minimum_range + 25)
 		pin_xy_result = "direct"
 	else
 		setDir(get_dir(here, there))

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -80,7 +80,7 @@
 	. = ..()
 	if(!active)
 		return
-	if(!target || (!isnull(jamming_resistance) && src.is_jammed(jamming_resistance) != JAM_NONE)
+	if(!target || (!isnull(jamming_resistance) && src.is_jammed(jamming_resistance) != JAM_NONE))
 		. += "pinon[alert ? "alert" : ""]null[icon_suffix]"
 		return
 	var/turf/here = get_turf(src)

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -80,7 +80,7 @@
 	. = ..()
 	if(!active)
 		return
-	if(!target || (!isnull(jamming_resistance) && src.is_jammed(jamming_resistance) != JAM_NONE))
+	if(!target || (!isnull(jamming_resistance) && (src.is_jammed(jamming_resistance) != JAM_NONE || target.is_jammed(jamming_resistance) != JAM_NONE)))
 		. += "pinon[alert ? "alert" : ""]null[icon_suffix]"
 		return
 	var/turf/here = get_turf(src)

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -80,7 +80,7 @@
 	. = ..()
 	if(!active)
 		return
-	if(!target || (!isnull(jamming_resistance) && (src.is_jammed(jamming_resistance) != JAM_NONE || target.is_jammed(jamming_resistance) != JAM_NONE)))
+	if(!target || (!isnull(jamming_resistance) && src.is_jammed(jamming_resistance) != JAM_NONE)
 		. += "pinon[alert ? "alert" : ""]null[icon_suffix]"
 		return
 	var/turf/here = get_turf(src)
@@ -118,7 +118,7 @@
 		z_level_direction = ""
 
 	// getting xy result
-	if(get_dist_euclidian(here,there) <= minimum_range)
+	if(get_dist_euclidian(here,there) <= minimum_range || (target.is_jammed(jamming_resistance) != JAM_NONE) && get_dist_euclidian(here,there) < minimum_range + 25))
 		pin_xy_result = "direct"
 	else
 		setDir(get_dir(here, there))
@@ -163,7 +163,7 @@
 	if(!here || !there)
 		return FALSE
 
-	if(there.is_jammed(jam_level) != JAM_NONE)
+	if(there.is_jammed(jam_level) == JAM_FULL)
 		return FALSE
 
 	if(!powerful_z_check) // z-check will be only limited within the same area (i.e. multi-floor'ed station)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -330,7 +330,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 	if ((ai.get_virtual_z_level() != target.get_virtual_z_level()) && !is_station_level(ai.z))
 		return FALSE
 
-	if(A.is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(A.is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		return FALSE
 
 	if (istype(loc, /obj/item/aicard))
@@ -994,7 +994,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 	if (!target || target.stat || target.deployed || !(!target.connected_ai ||(target.connected_ai == src)) || (target.ratvar && !is_servant_of_ratvar(src)))
 		return
 
-	if(target.is_jammed(JAMMER_PROTECTION_AI_SHELL))
+	if(target.is_jammed(JAMMER_PROTECTION_AI_SHELL) == JAM_FULL)
 		to_chat(src, "<span class='warning robot'>Unable to establish communication link with target.</span>")
 		return
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -8,7 +8,7 @@
 	handle_robot_cell()
 
 /mob/living/silicon/robot/proc/handle_jamming()
-	if(deployed && is_jammed(JAMMER_PROTECTION_AI_SHELL))
+	if(deployed && is_jammed(JAMMER_PROTECTION_AI_SHELL) == JAM_FULL)
 		to_chat(src, "<span class='warning robot'>Remote connection with target lost.</span>")
 		undeploy()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -375,7 +375,7 @@
 	var/turf/T1 = get_turf(A)
 	if (!T0 || ! T1)
 		return FALSE
-	if(A.is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(A.is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		return FALSE
 	return ISINRANGE(T1.x, T0.x - interaction_range, T0.x + interaction_range) && ISINRANGE(T1.y, T0.y - interaction_range, T0.y + interaction_range)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,6 +1,6 @@
 /mob/living/proc/robot_talk(message)
 	//Cannot transmit wireless messages while jammed
-	if(is_jammed(JAMMER_PROTECTION_SILICON_COMMS))
+	if(is_jammed(JAMMER_PROTECTION_SILICON_COMMS) == JAM_FULL)
 		return
 	if(CHAT_FILTER_CHECK(message))
 		to_chat(usr, "<span class='warning'>Your message contains forbidden words.</span>")

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1080,7 +1080,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/proc/topic_denied(mob/user) //Access check proc for bot topics! Remember to place in a bot's individual Topic if desired.
 	//Silicons cannot remotely interfact with robots while the robot is jammed
-	if(issilicon(user) && is_jammed(JAMMER_PROTECTION_WIRELESS))
+	if(issilicon(user) && is_jammed(JAMMER_PROTECTION_WIRELESS) == JAM_FULL)
 		return TRUE
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return TRUE

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -292,11 +292,17 @@
 		return
 
 	// Check for jammers
-	var/turf/position = get_turf(computer)
-	for(var/datum/component/radio_jamming/jammer as anything in GLOB.active_jammers)
-		var/turf/jammer_turf = get_turf(jammer.parent)
-		if(position?.get_virtual_z_level() == jammer_turf.get_virtual_z_level() && (get_dist(position, jammer_turf) <= jammer.range))
-			return FALSE
+	var/jam_level = computer.is_jammed(JAMMER_PROTECTION_PDA_MESSAGE)
+
+	if (jam_level == JAM_FULL)
+		to_chat(user, "<span class='notice'>ERROR: Server isn't responding.</span>")
+		if(ringer_status)
+			playsound(computer, 'sound/machines/terminal_error.ogg', 15, TRUE)
+		return
+
+	if (jam_level == JAM_MINOR)
+		// Slightly more robust than comms, not quite as gibberish
+		message = Gibberish(message, TRUE, 30)
 
 	// Send the signal
 	var/list/string_targets = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blocks outgoing signals while in maintenance.

Any outgoing radio messages will be fuzzy, although you will still see incoming messages as normal (similarly to how signal jamming usually works, partly because radio code doesn't make it easy to fuzz messages for specific users).

The following things are jammed while in maintenance:
- Comms messages go out, but will be fuzzy and unreadable (AI comms are not affected, nor are centcom or syndicate comms)
- Recieving comms messages is unaffected
- Suit sensors have a scrambled location and health stats will be randomised by +/-5.
- AIs will be unable to track you through suit sensors
- Pinpointers have a resolution of 25 tiles if the target is in maintenance, meaning it points you to the general wearabouts but not to the exact location.

## Why It's Good For The Game

The maintenance tunnels are a scary place, they should be able to serve as a home turf for antagonists and give advantages to those antagonists who act independantly and alone. The maintenance tunnels can't come to you, you have to decide to go to them.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/40e1e558-ca6d-404c-881c-594a93a09437)

![image](https://github.com/user-attachments/assets/e4949bfe-eca7-43af-b1d5-0297e0131958)

Messages come in normally:
![image](https://github.com/user-attachments/assets/15bafbd5-c5a8-403e-93b8-8d21a12deca1)

![image](https://github.com/user-attachments/assets/c34384b9-67e7-46c8-8cbe-f9c13afc6f5f)

Crew pinpointers break when taken into maintenance:

![image](https://github.com/user-attachments/assets/40b6f54a-3128-4f01-aeae-836a6b5da8e3)

![image](https://github.com/user-attachments/assets/fd53f64b-aa55-4425-a622-9d26edea1ac6)

## Changelog
:cl:
add: Outgoing radio messages will become fuzzy if they originate from the maintenance tunnels.
add: Disruptions to the suit sensor and tracking network while the user is in maintenance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
