### PR TITLE
Ports unit test fix. Shortens CI time significantly.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -84,6 +84,13 @@ CREATION_TEST_IGNORE_SELF(/turf)
 	///Can this floor be an underlay, for turf damage
 	var/can_underlay = TRUE
 
+#if defined(UNIT_TESTS) || defined(SPACEMAN_DMM)
+	/// For the area_contents list unit test
+	/// Allows us to know our area without needing to preassign it
+	/// Sorry for the mess
+	var/area/in_contents_of
+#endif
+
 /turf/vv_edit_var(var_name, new_value)
 	var/static/list/banned_edits = list("x", "y", "z")
 	if(var_name in banned_edits)

--- a/code/modules/unit_tests/area_contents.dm
+++ b/code/modules/unit_tests/area_contents.dm
@@ -4,8 +4,6 @@
 	priority = TEST_LONGER
 
 /datum/unit_test/area_contents/Run()
-	/// assoc list of turfs -> areas
-	var/list/turf_to_area = list()
 	// First, we check that there are no entries in more then one area
 	// That or duplicate entries
 	for(var/area/space in GLOB.areas)
@@ -13,19 +11,19 @@
 			if(!isturf(position))
 				TEST_FAIL("Found a [position.type] in [space.type]'s turf listing")
 
-			var/area/existing = turf_to_area[position]
-			if(existing == space)
-				TEST_FAIL("Found a duplicate turf [position.type] inside [space.type]'s turf listing")
-			else if(existing)
-				TEST_FAIL("Found a shared turf [position.type] between [space.type] and [existing.type]'s turf listings")
+			if(position.in_contents_of)
+				var/area/existing = position.in_contents_of
+				if(existing == space)
+					TEST_FAIL("Found a duplicate turf [position.type] inside [space.type]'s turf listing")
+				else
+					TEST_FAIL("Found a shared turf [position.type] between [space.type] and [existing.type]'s turf listings")
 
 			var/area/dream_spot = position.loc
 			if(dream_spot != space)
 				TEST_FAIL("Found a turf [position.type] which is IN [dream_spot.type], but is registered as being in [space.type]")
 
-			turf_to_area[position] = space
+			position.in_contents_of = space
 
 	for(var/turf/position in ALL_TURFS())
-		if(!turf_to_area[position])
+		if(!position.in_contents_of)
 			TEST_FAIL("Found a turf [position.type] inside [position.loc.type] that is NOT stored in any area's turf listing")
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Optimizes area_contents.

Thanks Lemon.

- https://github.com/tgstation/tgstation/pull/71295

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We've had an anchor strapped to our ankle for the past 17 months in the form of this awful unit test.

You ever get all the map workflows taking forever to go down their tests?

You ever get all the mapflows finish their tests on time but you have this one straggler not MOVING AT ALL for 12 minutes and it *completely* slows down the runners for EVERYONE?

Yea no thanks. <3

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure


Its very clear.

Before
![Screenshot 2024-12-24 200024](https://github.com/user-attachments/assets/b93accc0-87d1-4f3d-9664-4f8d670539d0)

After
![Screenshot 2024-12-24 195929](https://github.com/user-attachments/assets/f195424a-3c53-45f3-8428-5eeee070d425)


Its not an exact science, but theres a tangible and empirical difference in the map times.

## Changelog
:cl: rkz, LemonInTheDark
code: optimized a slow unit test. Speedup CI a lot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
