### PR TITLE
Removes steal plasma canister objective

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -133,19 +133,6 @@
 /datum/objective_item/steal/supermatter/TargetExists()
 	return GLOB.main_supermatter_engine != null
 
-//Items with special checks!
-/datum/objective_item/steal/plasma
-	name = "28 moles of plasma (full tank). Be sure to fill up the tank with additional plasma since it doesn't start full!"
-	targetitem = /obj/item/tank
-	difficulty = 3
-	excludefromjob = list(JOB_NAME_CHIEFENGINEER,JOB_NAME_RESEARCHDIRECTOR,JOB_NAME_STATIONENGINEER,JOB_NAME_SCIENTIST,JOB_NAME_ATMOSPHERICTECHNICIAN)
-
-/datum/objective_item/steal/plasma/check_special_completion(obj/item/tank/T)
-	var/target_amount = text2num(name)
-	var/found_amount = 0
-	found_amount += T.air_contents.get_moles(GAS_PLASMA)
-	return found_amount>=target_amount
-
 /datum/objective_item/steal/functionalai
 	name = "a functional AI."
 	targetitem = /obj/item/aicard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the steal plasma canister objective.

## Why It's Good For The Game

It sucks, it's easy and it's annoying because plasma canisters don't come full.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/141529a0-617f-4152-8a88-e05d6d7c0b58)


## Changelog
:cl:
del: Removes the steal plasma canister objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
