### PR TITLE
Fixes two /me popups happening whenever you pressed M

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -95,7 +95,7 @@
 		run_cooldown_integer(user)
 		playsound(source = user, soundin = tmp_sound, vol = sound_volume, vary = vary, ignore_walls = sound_wall_ignore)
 
-	var/msg = select_message_type(user, params, intentional)
+	var/msg = select_message_type(user, message, intentional)
 	if(params && message_param)
 		msg = select_param(user, params)
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -95,7 +95,7 @@
 		run_cooldown_integer(user)
 		playsound(source = user, soundin = tmp_sound, vol = sound_volume, vary = vary, ignore_walls = sound_wall_ignore)
 
-	var/msg = select_message_type(user, intentional)
+	var/msg = select_message_type(user, params, intentional)
 	if(params && message_param)
 		msg = select_param(user, params)
 
@@ -248,8 +248,8 @@
 		message = replacetext(message, "%s", user.p_s())
 	return message
 
-/datum/emote/proc/select_message_type(mob/user, intentional)
-	. = message
+/datum/emote/proc/select_message_type(mob/user, msg, intentional)
+	. = msg
 	if(!muzzle_ignore && user.is_muzzled() && (emote_type & EMOTE_AUDIBLE))
 		return "makes a [pick("strong ", "weak ", "")]noise."
 	if(user.mind?.miming && message_mime)
@@ -270,6 +270,8 @@
 		. = message_insect
 	else if((isanimal(user) || isbasicmob(user)) && message_simple)
 		. = message_simple
+
+	return .
 
 /datum/emote/proc/select_param(mob/user, params)
 	return replacetext(message_param, "%t", params)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -512,22 +512,6 @@
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 
-	if(!params)
-		var/custom_emote = stripped_input(user, "Choose an emote to display.")
-		if(custom_emote && !check_invalid(user, custom_emote))
-			var/list/emote_list = list("Audible", "Visible", "Both")
-			var/type = tgui_input_list(user, "Is this a visible or audible emote?", "Emote Type", emote_list)
-			switch(type)
-				if("Audible")
-					emote_type |= EMOTE_AUDIBLE
-				if("Visible")
-					emote_type |= EMOTE_VISIBLE
-				if("Both")
-					emote_type |= EMOTE_VISIBLE | EMOTE_AUDIBLE
-			message = user.say_emphasis(custom_emote)
-	else
-		message = params
-
 /datum/emote/living/custom/proc/check_invalid(mob/user, input)
 	var/static/regex/stop_bad_mime = regex(@"says|exclaims|yells|asks")
 	if(stop_bad_mime.Find(input, 1, 1))

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -522,6 +522,7 @@
 /datum/emote/living/custom/run_emote(mob/user, params, type_override = null, intentional = FALSE)
 	if(params && type_override)
 		emote_type = type_override
+	message = params
 	. = ..()
 	message = null
 	emote_type = null

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -490,7 +490,7 @@
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 
 /datum/emote/living/custom
-	key = "me"
+	key = "custom"
 	key_third_person = "custom"
 	message = null
 	mob_type_blacklist_typecache = /mob/living/brain

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -490,7 +490,7 @@
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 
 /datum/emote/living/custom
-	key = "custom"
+	key = "me"
 	key_third_person = "custom"
 	message = null
 	mob_type_blacklist_typecache = /mob/living/brain


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Due to an oversight in https://github.com/BeeStation/BeeStation-Hornet/pull/11991, there was a conflict with the key registers for custom /me commands. This fixes that.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Bugfix good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/b2cdf26e-323f-4a0d-9158-48bf2bfbc81e)


https://github.com/user-attachments/assets/b055ba9d-8c07-491f-ab5a-2b0696e0696a



</details>

## Changelog
:cl: Xeonmations
fix: Fixed pressing M making two menus popup.
del: Removed a deprecated emote menu popup.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
