### PR TITLE
photobooths on maps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21812,9 +21812,9 @@
 /turf/open/floor/iron/tech,
 /area/ai_monitored/storage/eva)
 "fto" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "ftv" = (
@@ -32853,6 +32853,16 @@
 	},
 /turf/open/floor/iron,
 /area/quartermaster/sorting)
+"jLd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "jLe" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
@@ -39442,8 +39452,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "mxi" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/machinery/photobooth,
+/obj/effect/turf_decal/siding/wideplating_new,
+/turf/open/floor/iron,
 /area/maintenance/central)
 "mye" = (
 /obj/structure/sign/departments/minsky/research/research{
@@ -50909,7 +50920,12 @@
 /turf/open/floor/carpet/blue,
 /area/medical/break_room)
 "rfh" = (
-/obj/structure/grille/broken,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -94425,8 +94441,8 @@ jVq
 sCF
 eWC
 iXb
-rfh
 eWC
+mxi
 dbO
 bqy
 cBr
@@ -94681,8 +94697,8 @@ wfq
 vfO
 hem
 eWC
-hfr
-mxi
+rfh
+eWC
 bmr
 cmE
 kPV
@@ -95195,7 +95211,7 @@ kcl
 akZ
 lyg
 bjz
-hfr
+jLd
 bmr
 bmr
 wQJ

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -51833,7 +51833,7 @@
 /area/engine/atmos)
 "qJy" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/vending/coffee,
+/obj/machinery/photobooth,
 /turf/open/floor/iron,
 /area/crew_quarters/heads/hop)
 "qJS" = (
@@ -53601,13 +53601,13 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "rpj" = (
-/obj/structure/closet/secure_closet/genpop,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/camera/directional/east,
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron,
 /area/security/prison)
 "rpq" = (
@@ -71843,6 +71843,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/iron,
 /area/security/prison)
 "xmB" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -60334,10 +60334,8 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "nrk" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/photobooth,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "nrl" = (
@@ -66994,8 +66992,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/east,
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "pzW" = (

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -1025,7 +1025,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/structure/chair/fancy/bench,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -1034,6 +1033,7 @@
 	pixel_x = 1;
 	pixel_y = 32
 	},
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron,
 /area/security/prison)
 "aua" = (
@@ -29905,15 +29905,6 @@
 	},
 /area/engine/atmos)
 "oUg" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -4;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 1
@@ -29922,6 +29913,7 @@
 	pixel_x = 1;
 	pixel_y = 28
 	},
+/obj/machinery/photobooth,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/fore)
 "oUB" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -49178,8 +49178,8 @@
 /turf/open/floor/iron/dark,
 /area/bridge)
 "mwS" = (
-/obj/effect/spawner/randomvend/cola,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted,
+/obj/machinery/photobooth,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "mwT" = (
@@ -60225,7 +60225,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/red/corner,
-/obj/structure/chair/fancy/bench,
 /obj/machinery/button/door{
 	id = "BrigSideWindows";
 	name = "Brig Side entrance Shutters Control";
@@ -60240,6 +60239,7 @@
 	pixel_y = 25;
 	req_access_txt = "2"
 	},
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "pvU" = (
@@ -68177,10 +68177,10 @@
 /turf/open/floor/vault,
 /area/engine/break_room)
 "rwJ" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
+/obj/effect/spawner/randomvend/cola,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "rxc" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -52613,7 +52613,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/chair,
 /obj/item/radio/intercom{
 	freerange = 1;
 	name = "Prison intercom";
@@ -52621,7 +52620,7 @@
 	prison_radio = 1;
 	pixel_y = 25
 	},
-/obj/effect/landmark/start/assistant,
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron,
 /area/security/prison)
 "paG" = (
@@ -54410,9 +54409,6 @@
 /turf/open/floor/iron,
 /area/quartermaster/miningoffice)
 "pCf" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -54424,6 +54420,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/photobooth,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/hop)
 "pCj" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10808,13 +10808,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "bzQ" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/photobooth,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "bzR" = (
@@ -54034,20 +54029,10 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/security/checkpoint/medical)
 "plF" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 8
 	},
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron/smooth_half,
 /area/security/prison)
 "plM" = (
@@ -71318,8 +71303,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/chair/fancy/bench/right,
 /obj/effect/turf_decal/tile/dark_red,
+/obj/structure/rack,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
 /turf/open/floor/iron/smooth_corner,
 /area/security/prison)
 "vxn" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -32077,10 +32077,8 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/photobooth/security,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "kla" = (

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -5350,6 +5350,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/guideline/guideline_edge/darkblue,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bIM" = (
@@ -16130,24 +16131,13 @@
 /turf/open/floor/iron,
 /area/crew_quarters/dorms)
 "fcE" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/guideline/guideline_edge/darkblue{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/open/floor/iron/dark/side{
+	dir = 9
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/rock/jungle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hopqueue";
-	name = "HoP Queue Shutters"
-	},
-/turf/open/floor/grass/no_border,
-/area/crew_quarters/heads/hop)
+/area/hallway/primary/fore)
 "fcK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -18171,6 +18161,7 @@
 	pixel_x = 23;
 	pixel_y = -8
 	},
+/obj/machinery/photobooth,
 /turf/open/floor/iron,
 /area/crew_quarters/heads/hop)
 "fIv" = (
@@ -21661,10 +21652,10 @@
 /area/hallway/primary/central)
 "gOj" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/turf_decal/guideline/guideline_edge/darkblue,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted{
+	alpha = 180
 	},
+/turf/open/floor/iron,
 /area/hallway/primary/fore)
 "gOk" = (
 /obj/structure/sign/departments/minsky/security/command,
@@ -24666,6 +24657,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/guideline/guideline_edge_alt/_offset/darkblue{
+	dir = 10
 	},
 /turf/open/floor/iron/dark/corner{
 	dir = 4
@@ -29987,9 +29981,8 @@
 /turf/open/floor/iron/white,
 /area/medical/sleeper)
 "jCt" = (
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	alpha = 180;
-	dir = 1
+/obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted{
+	alpha = 180
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -30003,12 +29996,7 @@
 /obj/effect/turf_decal/guideline/guideline_tri/_offset/darkblue{
 	dir = 9
 	},
-/obj/effect/turf_decal/guideline/guideline_edge_alt/_offset/darkblue{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jCx" = (
 /obj/effect/turf_decal/stripes/line,
@@ -32620,9 +32608,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/guideline/guideline_tri/_offset/darkblue,
-/obj/effect/turf_decal/guideline/guideline_edge_alt/_offset/darkblue{
-	dir = 8
-	},
 /obj/effect/turf_decal/guideline/guideline_edge_alt/_offset/darkblue{
 	dir = 10
 	},
@@ -38495,9 +38480,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/directional/east,
-/obj/effect/turf_decal/guideline/guideline_edge/darkblue{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -65861,10 +65843,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/dark_blue/fourcorners/contrasted{
-	alpha = 180
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	alpha = 180;
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/guideline/guideline_edge_alt/_offset/darkblue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/hallway/primary/fore)
 "uTj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -73355,6 +73343,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/grass/no_border,
 /area/crew_quarters/heads/hop)
@@ -108762,7 +108753,7 @@ wul
 jGN
 rlg
 mqa
-rlg
+fcE
 gOj
 bIG
 lWz
@@ -109019,8 +109010,8 @@ jvB
 grE
 moP
 gOk
+sAc
 dFh
-fcE
 xvA
 gHS
 fxw


### PR DESCRIPTION
## About The Pull Request

Adds a photobooth to every maps HOPline and a security photobooth to each maps processing room.

This machine was missed during the TGUI records PR and is an important part of the records system.

## Why It's Good For The Game

This was intended but missed during the TGUI records PR

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I'll be real I'm too lazy to screenshot every one but I pretty much added one machine per spot on every map
![image](https://github.com/user-attachments/assets/38836713-3e59-4344-ab14-cc3b1509058c)
![image](https://github.com/user-attachments/assets/ec6b1ef6-aab4-4e5a-99a5-a027486f8bd4)

</details>

## Changelog
:cl:
add: Puts photobooths on all maps
/:cl: