### PR TITLE
Fixes bar dispensers having duplicate glass overlays

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -396,6 +396,7 @@
 	if(beaker)
 		try_put_in_hand(beaker, user)
 		beaker = null
+		update_appearance()
 	if(new_beaker)
 		beaker = new_beaker
 	update_appearance()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes bar dispensers having duplicate glass overlays
This could probably be done a smarter way but i am not smart and it works
One line fix
Closes #12085

## Why It's Good For The Game

bugz bad
also it technically allowed you to put infinite overlays onto a dispenser which surely can't be good

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/d9923bf5-bfec-440d-a522-25ed94cdf9de


</details>

## Changelog
:cl:
fix: Fixed bar dispensers having duplicate glass overlays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
