### PR TITLE
Makes Disablers Bulky

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -51,6 +51,7 @@
 	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 2
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/energy/disabler/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Makes disablers bulky. Made mostly due to [this PR](https://github.com/BeeStation/BeeStation-Hornet/pull/11858) that reduces disablers shot count

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

To put it as simple as can be, disabler does two incompatible things at once. It acts as a primary weapon for security, by being a 4 shot stam crit with a massive energy pool, while also being a sidearm that can be used in tandem with other weapons like shotguns by being stored in the backpack. In isolation either of these are acceptable, but when combined they are problematic. 

Think about it objectively. If today someone were to try to add a weapon to security that they can carry at any alert level, keep concealed in a bag, that only requires 4 shots to stamcrit, that has enough energy to stamcrit 6 people, they would be laughed out of the room.

You might ask why the size and not the ammo count or the damage? The answer is precedent. The damage and ammo count are not insane compared to other weapons, it's roughly equivalent to existing e-guns. The size is not. The only comparable weapons are the X-01 and the service pistols, both of which are head of staff exclusive items.

The problem with disablers being large items is that it encourages security to keep two primary weapons on them. When you offer this opportunity, players jump at it for obvious reasons. Look no further than the tonfa. It was proposed as an **alternative** to the baton, but instead of being an alternative it is used in _addition_ to the baton. You can keep a tonfa and a baton in your sec belt, so why not do it? It's not the players fault for taking the obviously superior path. Just the same, armory weapons are not an alternative to disablers they are an addition to them. You can freely load yourself up with all the lethal weaponry you want knowing that since your disabler fits in your bag, you're prepared for any situation that you have to take someone in non-lethally. God forbid someone realizes you can dual wield disablers.

Isn't being able to deal with threats lethally and non-lethally a good thing? Yes! That's why energy guns and non-lethal ballistics ammo exist! Use those!
 
This is getting rather long so I'll cut it short here, I'm willing to throw verbal fisticuffs with anyone about this. If people really don't like disablers being bulky I can go with idea #2 where their damage and shot count is reduced, but size is preserved, leaning into the sidearm rather than primary weapon classification.

TLDR: Disablers being large instead of bulky is outside the norm and encourages unsportsmanlike conduct
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2024-12-29 090918](https://github.com/user-attachments/assets/3059cf3c-9f5b-4986-ba8a-f7e0887d2e8d)
![Screenshot 2024-12-29 090913](https://github.com/user-attachments/assets/b6dfcf4a-bd11-4c28-af55-cb6d60c6272d)


</details>

## Changelog
:cl:
balance: Disablers are now bulky and no longer fit in backpacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
