### PR TITLE
 Tear of Veil is now a soundtrack datum thing-i-ma-jig.

### DIFF
--- a/code/datums/soundtrack.dm
+++ b/code/datums/soundtrack.dm
@@ -39,3 +39,11 @@ GLOBAL_LIST_EMPTY(soundtrack_this_round) // A running list of soundtrack songs t
 	file = 'sound/soundtrack/mind_crawler.ogg'
 	length = (2 MINUTES) + (50 SECONDS)
 	station_only = TRUE
+
+/datum/soundtrack_song/tearofveil
+	title = "Tear of Veil"
+	artist = "Bolgarich"
+	album = "None!" //so it doesnt show up on credits as ()
+	url = "https://www.youtube.com/watch?v=NqNHKfTAvcw"
+	file = 'sound/soundtrack/tearofveil.ogg'
+	length = (2 MINUTES) + (52 SECONDS)

--- a/code/modules/antagonists/cult/narsie.dm
+++ b/code/modules/antagonists/cult/narsie.dm
@@ -63,7 +63,7 @@
 /obj/eldritch/narsie/proc/greeting_message()
 	send_to_playing_players("<span class='narsie'>NAR'SIE HAS RISEN</span>")
 	sound_to_playing_players('sound/creatures/narsie_rises.ogg')
-	sound_to_playing_players('sound/soundtrack/tearofveil.ogg')
+	play_soundtrack_music(/datum/soundtrack_song/tearofveil)
 	var/area/area = get_area(src)
 	if(area)
 		var/mutable_appearance/alert_overlay = mutable_appearance('icons/effects/cult_effects.dmi', "ghostalertsie")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds "Tear of Veil" by Bolgarich to soundtrack.dm, allowing it to be played and making it appear in credits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it should appear there, lets admins play the cool music

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.


https://github.com/user-attachments/assets/e22a658e-c343-44f3-ac7f-a017fab7d937





</details>

## Changelog
:cl:
tweak: "Tear of Veil" is now in Play Soundtrack Music.
tweak: Nar'sie now uses play_soundtrack_music instead of sound_to_playing_players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
