### PR TITLE
Reworks nukeop telecrystals, lowers required pop for war TC

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,6 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 5 MINUTES
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 30
 #define CHALLENGE_SHUTTLE_DELAY 35 MINUTES	//35 minutes, giving nukies at least 20 minutes to enact their assault.
 
 /obj/item/nuclear_challenge

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,4 +1,3 @@
-#define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 5 MINUTES
 #define CHALLENGE_MIN_PLAYERS 30
 #define CHALLENGE_SHUTTLE_DELAY 35 MINUTES	//35 minutes, giving nukies at least 20 minutes to enact their assault.
@@ -81,29 +80,9 @@
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
 
-	if(!check_pop())
-		qdel(src)
-		return
-
-	var/tc_to_distribute = CHALLENGE_TELECRYSTALS
-	var/tc_per_nukie = round(tc_to_distribute / (length(orphans)+length(uplinks)))
-	for (var/datum/component/uplink/uplink in uplinks)
-		uplink.telecrystals += tc_per_nukie
-		tc_to_distribute -= tc_per_nukie
-
-
-	for (var/mob/living/L in orphans)
-		var/TC = new /obj/item/stack/sheet/telecrystal(L.drop_location(), tc_per_nukie)
-		to_chat(L, "<span class='warning'>Your uplink could not be found so your share of the team's bonus telecrystals has been bluespaced to your [L.put_in_hands(TC) ? "hands" : "feet"].</span>")
-		tc_to_distribute -= tc_per_nukie
-
-	if (tc_to_distribute > 0) // What shall we do with the remainder...
-		for (var/mob/living/simple_animal/hostile/carp/cayenne/C in GLOB.mob_living_list)
-			if (C.stat != DEAD)
-				var/obj/item/stack/sheet/telecrystal/TC = new(C.drop_location(), tc_to_distribute)
-				TC.throw_at(get_step(C, C.dir), 3, 3)
-				C.visible_message("<span class='notice'>[C] coughs up a half-digested telecrystal</span>","<span class='usernotice'>You cough up a half-digested telecrystal!</span>")
-				break
+	if(check_pop())
+		for (var/datum/component/uplink/uplink in uplinks)
+			uplink.telecrystals += GLOB.joined_player_list.len / 2
 
 	qdel(src)
 
@@ -132,7 +111,6 @@
 /obj/item/nuclear_challenge/clownops
 	uplink_type = /obj/item/uplink/clownop
 
-#undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT
 #undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -33,7 +33,7 @@
 	var/war_declaration = "[user.real_name] has declared [user.p_their()] intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop [user.p_them()]."
 
 	declaring_war = TRUE
-	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
+	var/custom_threat = tgui_alert(user, "Do you want to customize your declaration?", "Customize?", list("Yes", "No"))
 	declaring_war = FALSE
 
 	if(!check_allowed(user))
@@ -41,7 +41,7 @@
 
 	if(custom_threat == "Yes")
 		declaring_war = TRUE
-		war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
+		war_declaration = tgui_input_text(user, "Insert your custom declaration", "Declaration", war_declaration)
 		declaring_war = FALSE
 
 	if(!check_allowed(user) || !war_declaration)

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -61,7 +61,7 @@
 	if(send_to_spawnpoint)
 		move_to_spawnpoint()
 		// grant extra TC for the people who start in the nukie base ie. not the lone op
-		var/extra_tc = CEILING(GLOB.joined_player_list.len/5, 5)
+		var/extra_tc = CEILING(GLOB.joined_player_list.len / 2, 5)
 		var/datum/component/uplink/U = owner.find_syndicate_uplink()
 		if (U)
 			U.telecrystals += extra_tc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nukies now get 0.5 TC per living player (rounded to the closest multiple of 5)
If you declare war over 30 population, nuclear operatives are given an additional 0.5 TC per living player.
Syndicate reinforcements no longer get TC on war being declared

## Why It's Good For The Game

Nukies currently get a base 30 TC + 0.2 TC per living player (rounded to the closest multiple of 5). If they declare war <ins>and the pop is over 50</ins> they also get an additional 280tc that is split among the team. (56 TC per person with a team of 5)

Nuclear operatives are meant to be an elite strike force with the sole purpose of destroying the station. They should have tons of resources given the relatively small size of their team compared to the crew.

If you do end up declaring war and the population isn't **over 50** you are absolutely going to lose unless you have John /tg/ McRobust on your team. Given the 15-minute delay the infiltrator has, this gives the crew ample time to: order a buttload of guns, set up barricades in the hall, give everyone AA, and arm everyone.

Considering how often nukies fail and how **INCREDIBLY RARE* 50 pop is. I believe nukies really need a buff to make them a threat again.

## Testing Photographs and Procedure

<details>
<summary>Graphs</summary>

## Current Telecrystal distribution (with a team size of 5)

![chart_old_nowar](https://github.com/user-attachments/assets/330831da-fae5-47b0-b6d7-d139559181a8)

![chart_old_war](https://github.com/user-attachments/assets/783f7c0e-3389-4891-b791-0dd51870709c)

## Proposed Telecrystal distribution

![chart_new_nowar](https://github.com/user-attachments/assets/3daba79f-c495-4c47-8277-f9db4ff46f5c)

![chart_new_war](https://github.com/user-attachments/assets/a439cde1-1e9f-434a-9958-623784fe4458)

</details>

## Changelog
:cl:
balance: gives nukeops a TC increase per player
balance: decreased the nuke op war extra tc player minimum from 50 to 30
tweak: nuke op reinforcements aren't given the declare war tc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
