### PR TITLE
Fixes Winter Echo problems

### DIFF
--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -7336,6 +7336,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow,
 /obj/structure/lattice/catwalk/over,
+/obj/structure/fans/tiny,
 /turf/open/openspace,
 /area/hallway/primary/fore)
 "dyv" = (
@@ -12991,6 +12992,7 @@
 /turf/open/floor/iron/dark,
 /area/engine/atmos)
 "glK" = (
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/snowed/colder,
 /area/hallway/primary/fore)
 "glQ" = (
@@ -17769,6 +17771,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/cmo)
+"iKP" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "iKR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37228,6 +37234,7 @@
 "sLn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/snowed/colder,
 /area/hallway/primary/fore)
 "sLu" = (
@@ -38975,6 +38982,7 @@
 /area/science/robotics)
 "tCm" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating/snowed/colder,
 /area/hallway/primary/fore)
 "tCn" = (
@@ -260006,7 +260014,7 @@ aNl
 aNl
 eDp
 lmY
-qCv
+iKP
 rAm
 tWG
 nBs

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -15,8 +15,8 @@
 	response_disarm_simple = "push"
 	faction = list("plants")
 	speed = 1
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
 	mob_size = MOB_SIZE_LARGE
 
 	pixel_x = -16


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a row of tiny fans in the entrance of Echo so the station doesn't slowly turn blue, nerfs the insanely amount of health hostile trees have

## Why It's Good For The Game

Not having the station covered in blue due to cold air is good, trees not having just 100 health less than a space dragon is also good, specially when they can randomly spawn and hit people that just walked out of the station.

https://github.com/BeeStation/BeeStation-Hornet/issues/12039

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Added a row of tiny fans on Winter Echo to prevent cold from coming in.
balance: Hostile trees now have 100 health instead of 250
/:cl:
