### PR TITLE
Turning the disabler into a sidearm

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -32,3 +32,7 @@
 /obj/item/ammo_casing/energy/disabler/hos
 	projectile_type = /obj/projectile/beam/disabler
 	e_cost = 50
+
+/obj/item/ammo_casing/energy/disabler/weak
+	projectile_type = /obj/projectile/beam/disabler/weak
+	e_cost = 65

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -46,10 +46,10 @@
 
 /obj/item/gun/energy/disabler
 	name = "disabler"
-	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
+	desc = "A self-defense sidearm that exhausts organic targets, weakening them until they collapse."
 	icon_state = "disabler"
 	item_state = null
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/weak)
 	ammo_x_offset = 2
 
 /obj/item/gun/energy/disabler/add_seclight_point()
@@ -65,6 +65,7 @@
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
 	requires_wielding = FALSE
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler) // Why not give them the good one if they're admin spawn
 
 /obj/item/gun/energy/pulse/carbine/cyborg
 	name = "cyborg pulse carbine"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -97,6 +97,9 @@
 	damage_type = STAMINA
 	pass_flags = PASSTABLE | PASSGRILLE | PASSTRANSPARENT
 
+/obj/projectile/beam/disabler/weak
+	damage = 17 // begone pocket hand cannon
+
 /obj/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The disabler now has capabilities corresponding to its smaller size. They deal 17 stamina damage per hit, bumping a stamcrit to 6 hits and limb crits to 3 hits. Their "magazine" has been reduced from 25 to 15 shots, meaning you can somewhat reliably put two people into stamcrit before requiring a recharge. **Non-lethal modes on e-guns and other energy weapons like the X-01 are unaffected**. [Alternative to my other PR because somehow people think this is less annoying than making them bulky.](https://github.com/BeeStation/BeeStation-Hornet/pull/12098)

TLDR: Disablers are now budget service pistols minus the magazines and burn damage.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Disablers currently do double duty as a primary and secondary. Station guns shouldn't be powerful AND small without being unique, like the X-01 or antique laser. Disablers are powerful and small. Their size means security carries two guns on themselves since why wouldn't they, disablers are the best non lethal weapon, meaning there is no non-lethal weapons progression since disablers do the exact same damage as e-guns while being smaller, and consequently less move speed penalty and equip time. [See the other PR if you really want more in-depth reasoning.](https://github.com/BeeStation/BeeStation-Hornet/pull/12098)

Why 17 damage? A sidearm should be noticeably worse than a primary weapon. E-guns are a 4 hit to crit if non-lethal, 5 hit to crit if lethal. Add one more hit to that, you get 6 hits to crit. Why 17 and not 18 if they're both 6 hit crits? So that armor and stamina regen provide more benefit against a sidearm, as they should.

Why 15 shots? Service pistols do 12, and have a magazine. Disablers don't have magazines, but security will continue to carry more than one gun on them the second they can. So their primary gun is a "magazine" for the purposes of how many rounds they can put out. Then add a little extra compared to the pistols since they don't have burn damage too. 


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/45eaa80e-b474-4371-96eb-b63b884f979f



</details>

## Changelog
:cl:
balance: Disabler shot count 25 -> 15, damage 28 -> 17
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
