### PR TITLE
Makes War declarations a little more clear

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -20,8 +20,11 @@
 	if(!check_allowed(user))
 		return
 
+	if(!check_pop())
+		balloon_alert_to_viewers("Due to small size of the enemy, NO ADDITIONAL TC will been awarded for WAR")
+
 	declaring_war = TRUE
-	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? [check_pop()? "" : "You will not be provided with any additional equipment given the small size of the crew. "]You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time + SSticker.round_start_time)] to decide", "Declare war?", list("Yes", "No"))
+	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? [check_pop()? "" : "You will not be provided with any additional telecrystals given the small size of the crew. "]You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time + SSticker.round_start_time)] to decide", "Declare war?", list("Yes", "No"))
 	declaring_war = FALSE
 
 	if(!check_allowed(user))
@@ -34,7 +37,7 @@
 	var/war_declaration = "[user.real_name] has declared [user.p_their()] intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop [user.p_them()]."
 
 	declaring_war = TRUE
-	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
+	var/custom_threat = tgui_alert(user, "Do you want to customize your declaration?", "Customize?", list("Yes", "No"))
 	declaring_war = FALSE
 
 	if(!check_allowed(user))

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -235,7 +235,7 @@
 
 /datum/antagonist/nukeop/leader/proc/ask_name()
 	var/randomname = pick(GLOB.last_names)
-	var/newname = stripped_input(owner.current,"You are the nuke operative [title]. Please choose a last name for your family.", "Name change",randomname)
+	var/newname = tgui_input_text(owner.current, "You are the nuke operative [title]. Please choose a last name for your family.", "Name change", randomname)
 	if (!newname)
 		newname = randomname
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes the war declaration query a little more clear, saying that nukies will NOT get extra TC when declaring war below a certain pop, rather than "equipment".

Additionally, a balloon alert will appear above the head of the nukie to all observers, so incase the leader doesn't read it, the others should get the memo.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This has occurred already where the nuclear leader either didn't read the message entirely, or was confused by the wording, which is fair enough given how vague it is. 
Only when the station pop has reached a certain threshold can nukies declared war, which was the result of Jix's pr several months ago.

This should clear it up and prevent any mishaps in the future.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/4333dfb0-ebf2-48ba-b342-53241924ffe7



</details>

## Changelog
:cl:
fix: adds a more clear alert letting nukies know that declaring war below pop will not give them extra war TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
