### PR TITLE
Fixes non-traitor smuggler satchels being "free" inventory space

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(minor_mapping)
 
 	while(turfs.len && amount > 0)
 		var/turf/T = pick_n_take(turfs)
-		var/obj/item/storage/backpack/satchel/flat/F = new(T)
+		var/obj/item/storage/backpack/satchel/flat/fake/F = new(T)
 
 		SEND_SIGNAL(F, COMSIG_OBJ_HIDE, T.underfloor_accessibility)
 		amount--

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -375,6 +375,9 @@
 	item_state = "satchel-flat"
 	w_class = WEIGHT_CLASS_NORMAL //Can fit in backpacks itself.
 
+/obj/item/storage/backpack/satchel/flat/fake
+	w_class = WEIGHT_CLASS_BULKY
+
 /obj/item/storage/backpack/satchel/flat/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE, INVISIBILITY_OBSERVER, use_anchor = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The randomly spawned smugglers satchels increase in size from normal to bulky items, meaning you can't put them in your backpack. The traitor one still fits in your backpack and is "free" extra inventory space.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

If you're dedicated with trays, you can find multiple satchels in a shift and use them to get more inventory space than you should have, letting you carry multiple large items in your backpack instead of the one you are supposed to. Minorly problematic. This clever guy, who shall remain nameless, was using it to keep a disabler, ion carbine, and a baton and some other miscellaneous stuff in their bag with room to spare. 

![Screenshot 2025-01-04 170234](https://github.com/user-attachments/assets/ae660b31-56f2-4107-b471-f0d998f9e3e4)

![Screenshot 2025-01-04 170229](https://github.com/user-attachments/assets/a457c2c2-cef8-4fca-867e-c69baabfb375)

![Screenshot 2025-01-04 170222](https://github.com/user-attachments/assets/15c0852f-b5ee-41b2-9a67-e7c81af0dfba)


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>




https://github.com/user-attachments/assets/dbddb18b-841c-47ae-a9b3-65404ff25918




</details>

## Changelog
:cl:
fix: RNG smuggler satchels no longer can be used to expand inventory space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
