### PR TITLE
Changing crews armblade wepons

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -1034,7 +1034,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "hydraulic_blade"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	force = 18
+	force = 20
 	block_upgrade_walk = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	sharpness = SHARP_DISMEMBER

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -176,7 +176,7 @@
 /obj/item/melee/arm_blade/nanite
 	name = "metallic armblade"
 	desc = "Nanites have formed this extremely sharp blade around your arm. Owie."
-	force = 15
+	force = 20
 	sharpness = SHARP_DISMEMBER
 	icon = 'icons/obj/nanite.dmi'
 	icon_state = "nanite_blade"

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -8,7 +8,7 @@ Slimecrossing Weapons
 /obj/item/melee/arm_blade/slime
 	name = "slimy boneblade"
 	desc = "What remains of the bones in your arm. Incredibly sharp, and painful for both you and your opponents."
-	force = 15
+	force = 20
 	sharpness = SHARP_DISMEMBER
 	force_string = "painful"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I changed damage of crew accessible armblades to 20 from 15, 15, 18 for nanite program, burning green extract and implant respectively  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
(Starting note, my thoughs will be mostly about nanite and green extract blades, hydraulic just got swept up in it)
I recently code dived to see what crew accessible armblades do, and in a proces learned that both nanite and burning green ones have 15 force. 15 force is fairly special number, because it is the designated dangerous tool number. In this category we have items like: bone saw, butchers cleaver, jaws of life on crowbar mode, medical drill, and most commonly used and widely permitted for any job welder (when turned on). 
This means that armblades each of with is on the end of their respective tech trees and require a lot of work to achieve (maxed out nanite research and illegal tech, xenobio up to green crosbreeds, explores finding both combat implants and armblade research disks + research up to that point). Additionally each of those blades requires a sacrifice to have (all the normal nanite problems + if armblade is here chain explosion might be to, it quite literally takes your arm away permanently, takes a lot of resources and valuable arm implant slot). Compared to just printing welder from any autolathe and having similar power using it seems unfair towards those armblades. They have one purpose, being good in combat, and they are on par with nearly free item with none of the downsides. To add insult to injury laser scalpel, fairly basic power tool for both sci and medbay deals 17 damage also with nearly 0 downsides. A cheap and relatively low tech tool is better at one thing they are supposed to be good at. 
That's why i think they need a buff. The actual number in my opinion should be somewhere between 18 (so they have a edge in the one thing they are supposed to be good at) and 20 (In my mind limit of what not unique like fire axe crew mele weapons should do). 
This would still place them lower than antagonist weapons (e-sword is lowest here and it deals 25 if i remember correctly) but stronger than just random tools you can make anywhere.
Tldr: They need a buff to be better than a welder.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
As far as i understand coding, it couldn't break anything
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Changed damage of nanite armblade 15 -> 20
balance: Changed damage of burning green extract armblade 15 -> 20
balance: Changed damage of hydraulic armblade 18 -> 20
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
