### PR TITLE
Fixes writing on photos character limited being 128 instead of the intended 256 

### DIFF
--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -60,7 +60,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/photo)
 			to_chat(user, "<span class='notice'>You scribble illegibly on [src]!</span>")
 			return
 
-		var/txt = stripped_input(user, "What would you like to write on the back?", "Photo Writing", max_length=128)
+		var/txt = stripped_input(user, "What would you like to write on the back? 256 characters max.", "Photo Writing", max_length=256)
 
 		if(txt && user.canUseTopic(src, BE_CLOSE))
 			scribble = txt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Depending if you modified the picture when it was taken, or wrote on it afterwards there would be a different character limit.

## Why It's Good For The Game

bugs bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/cd0fdf01-cd5c-44c7-b48d-cfe01c80f6b9



</details>

## Changelog
:cl:
fix: writing a caption after taking a picture has now the correct 256 character limit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
