### PR TITLE
Fixes giving emote, adds individual giving

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -284,16 +284,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(L.mobility_flags & MOBILITY_MOVE)
 		return L.resist_fire() //I just want to start a flame in your hearrrrrrtttttt.
 
-/**
- * Handles assigning most of the variables for the alert that pops up when an item is offered
- *
- * Handles setting the name, description and icon of the alert and tracking the person giving
- * and the item being offered, also registers a signal that removes the alert from anyone who moves away from the giver
- * Arguments:
- * * taker - The person receiving the alert
- * * offerer - The person giving the alert and item
- * * receiving - The item being given by the giver
- */
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"
@@ -301,6 +291,16 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	var/mob/living/carbon/taker
 	var/obj/item/receiving
 
+/**
+ * Handles assigning most of the variables for the alert that pops up when an item is offered
+ *
+ * Handles setting the name, description and icon of the alert and tracking the person giving
+ * and the item being offered, also registers a signal that removes the alert from anyone who moves away from the offerer
+ * Arguments:
+ * * taker - The person receiving the alert
+ * * offerer - The person giving the alert and item
+ * * receiving - The item being given by the offerer
+ */
 /atom/movable/screen/alert/give/proc/setup(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	name = "[offerer] is offering [receiving]"
 	desc = "[offerer] is offering [receiving]. Click this alert to take it."
@@ -310,7 +310,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	src.receiving = receiving
 	src.offerer = offerer
 	src.taker = taker
-	RegisterSignal(taker, COMSIG_MOVABLE_MOVED, PROC_REF(check_in_range))
 
 /atom/movable/screen/alert/give/Click(location, control, params)
 	. = ..()
@@ -325,14 +324,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		qdel(src)
 		return
 	taker.take(offerer, receiving)
-
-/// Simply checks if the other person is still in range
-/atom/movable/screen/alert/give/proc/check_in_range(atom/taker)
-	SIGNAL_HANDLER
-
-	if(!offerer.CanReach(taker))
-		balloon_alert(owner, "You moved out of range of [offerer]!")
-		owner.clear_alert("[offerer]")
 
 /// Gives the player the option to succumb while in critical condition
 /atom/movable/screen/alert/succumb

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -288,8 +288,12 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"
 	var/mob/living/carbon/offerer
-	var/mob/living/carbon/taker
 	var/obj/item/receiving
+
+/atom/movable/screen/alert/give/Destroy()
+	offerer = null
+	receiving = null
+	return ..()
 
 /**
  * Handles assigning most of the variables for the alert that pops up when an item is offered
@@ -309,7 +313,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	add_overlay(receiving)
 	src.receiving = receiving
 	src.offerer = offerer
-	src.taker = taker
 
 /atom/movable/screen/alert/give/Click(location, control, params)
 	. = ..()
@@ -319,10 +322,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /// An overrideable proc used simply to hand over the item when claimed, this is a proc so that high-fives can override them since nothing is actually transferred
 /atom/movable/screen/alert/give/proc/handle_transfer()
-	var/mob/living/carbon/taker = owner || src.taker
-	if(!taker)
-		qdel(src)
-		return
+	var/mob/living/carbon/taker = owner
 	taker.take(offerer, receiving)
 
 /// Gives the player the option to succumb while in critical condition

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -69,6 +69,12 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 					return TRUE
 	return ..()
 
+/mob/living/carbon/CtrlShiftClick(mob/user)
+	..()
+	if(iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		carbon_user.give(src)
+
 /mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	var/hurt = TRUE
 	if(!throwingdatum || throwingdatum.force <= MOVE_FORCE_WEAK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Refactors give code and adds clearing for both the alert and status effect. Individual players can now be given to with ctrl+shift+click

The state of the taker is now considered, which should also lessen edgecases.

Ports:
- https://github.com/tgstation/tgstation/pull/65441

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There is currently an issue where a player taking an item from a giver does not clear the taker from the candidates list, leading to the alert staying there sending warning until relogging.

This should fix a few harddels as well as some of the edgecases that have stayed in *give for the past few years.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/71676f62-5b02-4494-af7e-be5a1fcf43e4



</details>

## Changelog
:cl: rkz, cacogen
add: players can be individually given items by shift+ctrl+clicking them
fix: fixes harddels and give alert not clearing
fix: Dead, crit, and sleeping people cannot take offered items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
