### PR TITLE
Fixes dragon's wall tearing permanently breaking if the wall is destroyed before the timer is finished

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -133,6 +133,7 @@
 		tearing_wall = TRUE
 		if(do_after(src, timetotear, target = thewall))
 			if(istype(thewall, /turf/open))
+				tearing_wall = FALSE
 				return
 			thewall.dismantle_wall(1)
 			playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the game's current state, if a dragon starts to tear a wall down and an external measure destroys the wall before the doafter timer is finished, the dragon won't be able to tear walls down again for the rest of the round. This pr fixes it.

## Why It's Good For The Game

Although rare, this bug is pretty nasty and almost ended one of my dragon rounds a bit ago.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

### Current version

https://github.com/user-attachments/assets/9cb2ba9e-407a-449a-9871-19c570969200

### Fixed version

https://github.com/user-attachments/assets/4a55c622-4bc5-42ac-b8ae-446076aed7c6

</details>

## Changelog
:cl:
fix: fixed dragon's wall tearing permanently breaking if the wall is destroyed before the timer is finished
/:cl:
