### PR TITLE
Remove pref for admin login

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -767,7 +767,7 @@
 		if(logout && CONFIG_GET(flag/announce_admin_logout))
 			string = pick(
 				"Admin logout: [key_name(src)]")
-		else if(!logout && CONFIG_GET(flag/announce_admin_login) && prefs?.read_player_preference(/datum/preference/toggle/announce_login))
+		else if(!logout && CONFIG_GET(flag/announce_admin_login))
 			string = pick(
 				"Admin login: [key_name(src)]")
 		if(string)

--- a/code/modules/client/preferences/entries/player/admin.dm
+++ b/code/modules/client/preferences/entries/player/admin.dm
@@ -40,15 +40,6 @@
 
 	return is_admin(preferences.parent)
 
-/datum/preference/toggle/announce_login
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	db_key = "announce_login"
-	preference_type = PREFERENCE_PLAYER
-	default_value = FALSE
-
-/datum/preference/toggle/announce_login/is_accessible(datum/preferences/preferences, ignore_page)
-	return ..() && is_admin(preferences.parent)
-
 /datum/preference/toggle/combohud_lighting
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	db_key = "combohud_lighting"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -15,14 +15,6 @@ export const brief_outfit: Feature<string> = {
   component: FeatureDropdownInput,
 };
 
-export const announce_login: FeatureToggle = {
-  name: 'Announce Login',
-  category: 'ADMIN',
-  subcategory: 'Misc',
-  description: 'Whether you will announce whenever you login to fellow admins or not.',
-  component: CheckboxInput,
-};
-
 export const combohud_lighting: FeatureToggle = {
   name: 'Combo HUD Lighting',
   category: 'ADMIN',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This removes the pref and code associated with the preference that lets an admin change whether their arrival is announced or not in the admin log.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There really is no reason for admins not to be announced in the admin log. 

Ive had admins join and I've missed them for a long time because I forgot to check staffwho midround. Its even weirder that this preference is default to off.

I ask for other admins opinions and didn't receive any dissenting opinions.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2025-01-26 113146](https://github.com/user-attachments/assets/c39daa8a-7858-463c-8561-ca73b5718e54)


</details>

## Changelog
:cl:
admin: removed admin preference to announce login. Admin arrivals will always be announced in admin logs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
