### PR TITLE
Implements greater job role requirements for consistently misused roles

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -61,9 +61,11 @@
 
 	var/outfit = null
 
+	/// Minutes of experience-time required to play in this job. 
 	var/exp_requirements = 0
-
+	/// Experience required to play this job
 	var/exp_type = ""
+	/// Department experience required to play this job
 	var/exp_type_department = ""
 
 	///The amount of good boy points playing this role will earn you towards a higher chance to roll antagonist next round can be overridden by antag_rep.txt config

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -8,7 +8,7 @@
 	total_positions = 3
 	spawn_positions = 2
 	selection_color = "#fff5cc"
-	exp_requirements = 120
+	exp_requirements = 180 //High grief percentage
 	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/atmospheric_technician

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -8,8 +8,9 @@
 	total_positions = 3
 	spawn_positions = 2
 	selection_color = "#fff5cc"
-	exp_requirements = 180 //High grief percentage
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 120 //High grief percentage
+	exp_type = EXP_TYPE_ENGINEERING
+	exp_type_department = EXP_TYPE_ENGINEERING
 
 	outfit = /datum/outfit/job/atmospheric_technician
 

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -9,6 +9,7 @@
 	spawn_positions = 2
 	selection_color = "#bbe291"
 	exp_requirements = 120 //High grief percentage
+	exp_type = EXP_TYPE_SERVICE
 	exp_type_department = EXP_TYPE_SERVICE
 	outfit = /datum/outfit/job/botanist
 

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -9,6 +9,7 @@
 	spawn_positions = 2
 	selection_color = "#bbe291"
 	exp_requirements = 120 //High grief percentage
+	exp_type_department = EXP_TYPE_SERVICE
 	outfit = /datum/outfit/job/botanist
 
 	base_access = list(ACCESS_HYDROPONICS, ACCESS_MORGUE, ACCESS_MINERAL_STOREROOM)

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -8,7 +8,7 @@
 	total_positions = 3
 	spawn_positions = 2
 	selection_color = "#bbe291"
-
+	exp_requirements = 180 //High grief percentage
 	outfit = /datum/outfit/job/botanist
 
 	base_access = list(ACCESS_HYDROPONICS, ACCESS_MORGUE, ACCESS_MINERAL_STOREROOM)

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -8,7 +8,7 @@
 	total_positions = 3
 	spawn_positions = 2
 	selection_color = "#bbe291"
-	exp_requirements = 180 //High grief percentage
+	exp_requirements = 120 //High grief percentage
 	outfit = /datum/outfit/job/botanist
 
 	base_access = list(ACCESS_HYDROPONICS, ACCESS_MORGUE, ACCESS_MINERAL_STOREROOM)

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -8,7 +8,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	selection_color = "#dddddd"
-
+	exp_requirements = 120
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/chaplain
 
 	base_access = list(ACCESS_CHAPEL_OFFICE, ACCESS_CREMATORIUM, ACCESS_MORGUE, ACCESS_THEATRE)

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -9,7 +9,6 @@
 	spawn_positions = 1
 	selection_color = "#dddddd"
 	exp_requirements = 120
-	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/chaplain
 
 	base_access = list(ACCESS_CHAPEL_OFFICE, ACCESS_CREMATORIUM, ACCESS_MORGUE, ACCESS_THEATRE)

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -8,7 +8,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	selection_color = "#d4ebf2"
-	exp_requirements = 120
+	exp_requirements = 180 //High grief percentage
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/chemist
 

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -8,8 +8,9 @@
 	total_positions = 2
 	spawn_positions = 2
 	selection_color = "#d4ebf2"
-	exp_requirements = 180 //High grief percentage
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 120 //High grief percentage
+	exp_type = EXP_TYPE_MEDICAL
+	exp_type_department = EXP_TYPE_MEDICAL
 	outfit = /datum/outfit/job/chemist
 
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_CHEMISTRY, ACCESS_MECH_MEDICAL, ACCESS_MINERAL_STOREROOM)

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -8,7 +8,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	selection_color = "#dddddd"
-
+	exp_requirements = 60 //medium grief percentage
 	outfit = /datum/outfit/job/curator
 
 	base_access = list(ACCESS_LIBRARY, ACCESS_AUX_BASE, ACCESS_MINING_STATION)

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -10,7 +10,7 @@
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
-	exp_requirements = 120
+	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW
 	random_spawns_possible = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds increased exp_requirements for several job roles that have been utilized by bad actors for their high potential to grief. 

My increase in values is mostly empirical based on who I have had to ban or seen players complain about.

Old values and new values are as follows:
- Chaplain, 120 minutes up from 0. Highest use from griefers in addition to cremator making crew recovery impossible. Nullrod often a non-issue on normal pop, but can devastate lowpop.
- Botanist, 120 minutes up from 0. Second highest use from griefers. 
- Curator, 60 minutes up from 0. Increase for same reason as chaplain, lowpop vulnerability.

Increased times:
- Chemist, value unchanged from 120, but requires specifically medical experience to unlock
- Cyborg, 120 to 180. Cyborgs are roundstart posibrains in shells. Players trying out silicon roles should either take posibrain ghostroles or get borged. There is inherently more trust between roundstart silicons and the AI, vs Posi & borged crew

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

My reasons for each role requirement is included in the body. 

Although I think these measures aren't particularly good as the roles effected are good teaching roles, the state of grief has put players into an untenable position. 

Just today nearly the entire crew was wiped out by a chaplain, with very few bodies recoverable with the cremator.

While I think this situation is unfortunate, the clearest way forward in my head is removing 0hr players ability to have instant access to cremators and target roles that are consistently misused by griefers. Primarily Chaplain and Botanist.

Playing a round or two as another role for new players should not be a significant detriment.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/8eef1fc9-3c4b-4063-875f-8c47cb96cb52)


</details>

## Changelog
:cl:
tweak: chaplains now have a exp_requirement of 120 minutes, up from 0
tweak: botanists now have a exp_requirement of 120 minutes, up from 0
tweak: curators now have a exp_requirement of 60 minutes, up from 0
tweak: cyborgs now have a exp_requirement of 180 minutes, up from 120
tweak: chemists need explicitly medical experience, and atmosians need explicitly engineering experience.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
