### PR TITLE
Fix stat size reset condition

### DIFF
--- a/tgui/packages/tgui-panel/Panel.jsx
+++ b/tgui/packages/tgui-panel/Panel.jsx
@@ -27,6 +27,7 @@ export const Panel = (props) => {
   const audio = useAudio();
   const settings = useSettings();
   const game = useGame();
+  const dispatch = useDispatch();
   if (process.env.NODE_ENV !== 'production') {
     const { useDebug, KitchenSink } = require('tgui/debug');
     const debug = useDebug();
@@ -46,7 +47,7 @@ export const Panel = (props) => {
   }
 
   const [number, setNumber] = useLocalState('number', settings.statSize);
-  const dispatch = useDispatch();
+
   const resizeFunction = (value) => {
     dispatch(
       updateSettings({
@@ -149,8 +150,7 @@ export const Panel = (props) => {
 
 const HoboPanel = (props) => {
   const settings = useSettings();
-  const audio = useAudio();
-  const game = useGame();
+  const dispatch = useDispatch();
   if (process.env.NODE_ENV !== 'production') {
     const { useDebug, KitchenSink } = require('tgui/debug');
     const debug = useDebug();
@@ -170,7 +170,7 @@ const HoboPanel = (props) => {
   }
 
   const [number, setNumber] = useLocalState('number', settings.statSize);
-  const dispatch = useDispatch();
+
   const resizeFunction = (value) => {
     dispatch(
       updateSettings({


### PR DESCRIPTION
## About The Pull Request

Fixes a mistake in #12189 that meant resetting the stat size would always fail. `dispatch` is undefined prior.

## Why It's Good For The Game

Actually fixes existing clients. I'm not sure if this is an issue on prod, but I ran into it while doing the React migration and this was the only thing that fixed it.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

N/A, tested in my React PR.

</details>

## Changelog
:cl:
fix: Clients with persistent invisible chat windows should now properly have their chat size reset to be visible again.
/:cl: