### PR TITLE
Lazarus injector fix and update

### DIFF
--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -1,7 +1,7 @@
 /**********************Lazarus Injector**********************/
 /obj/item/lazarus_injector
 	name = "lazarus injector"
-	desc = "An injector with a cocktail of nanomachines and chemicals, this device can seemingly raise animals from the dead. Testing has shown inconsistent results and the animals these devices are used on occasionally turn against the person using them."
+	desc = "An injector with a cocktail of nanomachines and chemicals, this device can seemingly raise animals from the dead. Testing has shown inconsistent results and the animals with especially strong wills occasionally turn against the person using them."
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "lazarus_hypo"
 	item_state = "hypo"
@@ -33,8 +33,11 @@
 						return
 					M.revive(full_heal = 1, admin_revive = 1)
 					M.AIStatus = AI_OFF // don't let them attack people randomly after revived
-					M.notify_ghost_cloning("Your body is revived by [user] with a lazarus injector!", source=M)
-					to_chat(M, span_userdanger("You are not brainwashed or enslaved in any way to [user], act according to whatever makes the most sense for what you are."))
+
+					//Try to notify the ghost that they are being revived, but also that they are not loyal to the reviver
+					var/mob/ghostmob = M.notify_ghost_cloning("Your body is revived by [user] with a lazarus injector!", source=M)
+					if(ghostmob)
+						to_chat(ghostmob, span_userdanger("You are not brainwashed or enslaved in any way to [user], act according to whatever makes the most sense for what you are."))
 					log_game("[key_name(user)] has revived a player mob [key_name(target)] with a lazarus injector")
 
 				else // only do this to mindless mobs
@@ -55,9 +58,9 @@
 									var/mob/dead/observer/C = pick(candidates)
 									H.key = C.key
 									H.sentience_act()
-									to_chat(H, span_userdanger("In a striking moment of clarity you have gained greater intellect. You realize that you have been given new life by [user], but you can't seem to remember the circumstances of your death. What you do with your newfound intellect is for you to decide, but you have no sense of loyalty toward [user] or your own kind."))
+									to_chat(H, span_userdanger("In a striking moment of clarity you have gained greater intellect. You feel no strong sense of loyalty to anyone or anything, you simply feel... free"))
 
-				user.visible_message(span_notice("[user] injects [M] with [src], reviving it. [M]"))
+				user.visible_message(span_notice("[user] injects [M] with [src], reviving it."))
 				SSblackbox.record_feedback("tally", "lazarus_injector", 1, M.type)
 				playsound(src,'sound/effects/refill.ogg',50,1)
 				icon_state = "lazarus_empty"

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -37,7 +37,7 @@
 					//Try to notify the ghost that they are being revived, but also that they are not loyal to the reviver
 					var/mob/ghostmob = M.notify_ghost_cloning("Your body is revived by [user] with a lazarus injector!", source=M)
 					if(ghostmob)
-						to_chat(ghostmob, span_userdanger("You are not brainwashed or enslaved in any way to [user], act according to whatever makes the most sense for what you are."))
+						to_chat(ghostmob, span_userdanger("Lazarus does not change your loyalties or force obedience to [user] if you weren't already under their control."))
 					log_game("[key_name(user)] has revived a player mob [key_name(target)] with a lazarus injector")
 
 				else // only do this to mindless mobs

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -1,7 +1,7 @@
 /**********************Lazarus Injector**********************/
 /obj/item/lazarus_injector
 	name = "lazarus injector"
-	desc = "An injector with a cocktail of nanomachines and chemicals, this device can seemingly raise animals from the dead. Testing has shown inconsistent results and the animals with especially strong wills occasionally turn against the person using them."
+	desc = "An injector with a cocktail of nanomachines and chemicals, this device can seemingly raise animals from the dead. Testing has shown inconsistent results and the animals with especially strong wills may attack the person reviving them."
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "lazarus_hypo"
 	item_state = "hypo"

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -31,7 +31,7 @@
 					if(M.suiciding || M.ishellbound())
 						user.visible_message(span_notice("[user] injects [M] with [src], but nothing happened."))
 						return
-					M.revive(full_heal = 1, admin_revive = 1)
+					process_revival(M)
 					M.AIStatus = AI_OFF // don't let them attack people randomly after revived
 
 					//Try to notify the ghost that they are being revived, but also that they are not loyal to the reviver
@@ -41,7 +41,7 @@
 					log_game("[key_name(user)] has revived a player mob [key_name(target)] with a lazarus injector")
 
 				else // only do this to mindless mobs
-					M.revive(full_heal = 1, admin_revive = 1)
+					process_revival(M)
 					if(ishostile(target))
 						var/mob/living/simple_animal/hostile/H = M
 						H.faction = list(FACTION_NEUTRAL, "[REF(user)]") //Neutral includes crew and entirely passive mobs
@@ -78,6 +78,11 @@
 		return
 	if(!malfunctioning)
 		malfunctioning = 1
+
+/obj/item/lazarus_injector/proc/process_revival(mob/living/simple_animal/target)
+			target.do_jitter_animation(10)
+			addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, do_jitter_animation), 10), 5 SECONDS)
+			addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, revive), TRUE, TRUE), 10 SECONDS)
 
 /obj/item/lazarus_injector/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR both fixes and updates the lazarus injector:
* When used on non-sentient mobs, they will now (usually*) actually be loyal to the person who revived them again. This means actively seeking out and fighting other aggressive mobs while ignoring crew and passive mobs. Depending on exactly how the item is used, they can make for guards, or a suicidal distraction against megafauna. If a miner gets their hands on a medHUD and enough medical supplies, they may even choose to maintain a menagerie of creatures to fight for them, but good luck getting them to go where you want.
* When used on sentient mobs, the lazarus injector now very clearly states to the revived mob that they are NOT brainwashed or enslaved and should still act according to their own will. This should help eliminate confusion as to whether the revived mobs are expected to be loyal when sentient or not. 
* When examined, the lazarus injector now states that it has inconsistent results and that animals with especially strong wills may attack. 
* (usually*) The lazarus injector now has a 10% chance to make any non-sentient mob it revives into a sentient mob, in cases where this occurs, the mob is NOT directed to be loyal to anything or anyone and may attack. 

**Unchanged:** Malfunctioning lazarus (hit with EMP) will not roll for random sentience and will produce a non-sentient mob that is exclusively friendly to the person who revived them, but not toward anyone or anything else. They will still attack other crew and passive mobs as well as their own kind. Malfunctioning lazarus still have no effect on already sentient mobs. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

* Fixing lazarus behavior that has been broken for a while is good.
* Removing confusion from how already sentient mobs should behave is also good
* Giving the lazarus a chance to create a sentient mob that can choose its own future just seems like a fun thing to include. If violence is chosen the amount of damage any of the eligible mobs can do is not terribly high, and if they decide to aid the miner it should cause no balance issues that the shockingly powerful minebots (200 HP, armor, rapid ranged attacks) don't already present. It also fits somewhat with the flavor of the item to fail on "strong willed" targets. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

### Faction changing successfully, factions unchanged for non-hostile mobs also tested but not shown
![image](https://github.com/user-attachments/assets/88e9c001-c5b9-49a2-b562-8ab125b9c299)
![image](https://github.com/user-attachments/assets/26dd37b7-0f28-407c-ae61-bdf0527068e1)

### Non-sentient goliath is now demonstrably friendly toward crabs despite killing the other before revival
![image](https://github.com/user-attachments/assets/0e9828ca-51a3-4c41-90d9-f8ed447bc187)

### Non-sentient goliath will now fight other goliaths
![image](https://github.com/user-attachments/assets/938efb93-d8ea-4877-93ea-0621a18d42f3)

### Random sentience test and message (It was shortened after this screenshot)
![image](https://github.com/user-attachments/assets/d82b5b07-d78b-4335-94cf-70093c7f6b91)

### Testing the revival of an already sentient mob, and the message they get
![image](https://github.com/user-attachments/assets/a949fb4c-1e9a-44a8-9606-147857b0140b)

</details>

## Changelog
:cl:
fix: Lazarus injectors will now work as originally intended on non-sentient mobs. This means that lazarus revived mobs will be passive to crew and other passive mobs, friendly toward the person that revived them, and actively hostile to other hostile mobs.
tweak: Lazarus injectors will continue to work as they always have on already sentient mobs, and the intent is now clearly stated in-game to those mobs when they are revived. Lazarus is not a brainwashing tool and does not force loyalty or obedience in the creatures it revives if they are smart enough to think for themselves
tweak: Lazarus injectors now have a 10% chance of making any mob revived by one sentient, with its own free will to choose violence, servitude or anything in between.
tweak: The examine text of lazarus injectors now includes a warning that creatures with "especially strong wills" are known to turn against the user. This is in reference to both already sentient mobs and the newly added chance to create a sentient mob. 
tweak: Lazarus now takes ten seconds to take effect, with the mob it is used on jittering a bit before actually being revived.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
