### PR TITLE
Fixes monkey crash

### DIFF
--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -1,5 +1,3 @@
-/mob/living/carbon/monkey
-
 /mob/living/carbon/monkey/handle_mutations_and_radiation()
 	if(radiation)
 		if(radiation > RAD_MOB_KNOCKDOWN && prob(RAD_MOB_KNOCKDOWN_PROB))

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -13,7 +13,8 @@
 	type_of_meat = /obj/item/food/meat/slab/monkey
 	gib_type = /obj/effect/decal/cleanable/blood/gibs
 	unique_name = TRUE
-	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+	// Managed by the limb overlay system
+	blocks_emissive = FALSE
 	bodyparts = list(
 		/obj/item/bodypart/chest/monkey,
 		/obj/item/bodypart/head/monkey,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #12135

## About The Pull Request

Fixes the 515 monkey crash caused by alt-clicking monkeys.

I believe that this issue relates to the fact that monkey has a null icon, so when creating the emissive blocker it somehow reaches an edge case in the byond web panel icon rendering.

## Why It's Good For The Game

1/2 bugs required for 515 as the recommended client.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/459b4944-c181-49c7-b7f4-9b4cf80a2420)

![image](https://github.com/user-attachments/assets/ab5cbea6-6541-4c58-a01e-65175d7cf989)

The emissive blocker isn't needed since I refactored it to work based on limbs for carbons (so that limbs could be emissive).

## Changelog
:cl:
fix: Fixes a crash bug caused by alt-clicking on a monkey with a 515 client.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
