### PR TITLE
Resolves the fullscreen warning issue before we forget

### DIFF
--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -5,7 +5,7 @@
 	default_value = FALSE
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
-#if (MIN_COMPILER_VERSION > 515 || MIN_COMPILER_BUILD > 1630)
+#if (MIN_COMPILER_VERSION <= 515 || MIN_COMPILER_BUILD <= 1630)
 	if (value)
 		// Delete the menu
 		winset(client, "mainwindow", "menu=\"\"")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -5,7 +5,7 @@
 	default_value = FALSE
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
-#if (MIN_COMPILER_VERSION <= 515 || MIN_COMPILER_BUILD <= 1630)
+#if (client.byond_version <= 515 || client.byond_build <= 1630)
 	if (value)
 		// Delete the menu
 		winset(client, "mainwindow", "menu=\"\"")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -5,41 +5,40 @@
 	default_value = FALSE
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
-#if (client.byond_version <= 515 || client.byond_build <= 1630)
-	if (value)
-		// Delete the menu
-		winset(client, "mainwindow", "menu=\"\"")
-		// Switch to the cool status bar
-		winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
-		winset(client, "status_bar_wide", "is-visible=false")
-		// Switch to fullscreen mode
-		winset(client, "mainwindow","titlebar=false")
-		winset(client, "mainwindow","can-resize=false")
-		// Set it to minimized first because otherwise it doesn't enter fullscreen properly
-		// This line is important, and the game won't properly enter fullscreen mode otherwise
-		winset(client, "mainwindow","is-minimized=true")
-		winset(client, "mainwindow","is-maximized=true")
-		// Set the main window's size
-		winset(client, null, "split.size=mainwindow.size")
-		// Fit the viewport
-		INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
+	if(client.byond_version <= 515 || client.byond_build <= 1630)
+		if (value)
+			// Delete the menu
+			winset(client, "mainwindow", "menu=\"\"")
+			// Switch to the cool status bar
+			winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
+			winset(client, "status_bar_wide", "is-visible=false")
+			// Switch to fullscreen mode
+			winset(client, "mainwindow","titlebar=false")
+			winset(client, "mainwindow","can-resize=false")
+			// Set it to minimized first because otherwise it doesn't enter fullscreen properly
+			// This line is important, and the game won't properly enter fullscreen mode otherwise
+			winset(client, "mainwindow","is-minimized=true")
+			winset(client, "mainwindow","is-maximized=true")
+			// Set the main window's size
+			winset(client, null, "split.size=mainwindow.size")
+			// Fit the viewport
+			INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
+		else
+			// Restore the menu
+			winset(client, "mainwindow", "menu=\"menu\"")
+			// Switch to the lame status bar
+			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
+			winset(client, "status_bar", "is-visible=false")
+			winset(client, "status_bar_wide", "is-visible=true")
+			// Exit fullscreen mode
+			winset(client, "mainwindow","titlebar=true")
+			winset(client, "mainwindow","can-resize=true")
+			winset(client, "mainwindow","is-maximized=true")
+			// Fix the mapsize, turning off statusbar doesn't update scaling
+			INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
 	else
-		// Restore the menu
-		winset(client, "mainwindow", "menu=\"menu\"")
-		// Switch to the lame status bar
-		winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
-		winset(client, "status_bar", "is-visible=false")
-		winset(client, "status_bar_wide", "is-visible=true")
-		// Exit fullscreen mode
-		winset(client, "mainwindow","titlebar=true")
-		winset(client, "mainwindow","can-resize=true")
-		winset(client, "mainwindow","is-maximized=true")
-		// Fix the mapsize, turning off statusbar doesn't update scaling
-		INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
-#else
-	winset(client, "mainwindow", "menu=;is-fullscreen=[value ? "true" : "false"]")
-	INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
-#endif
+		winset(client, "mainwindow", "menu=;is-fullscreen=[value ? "true" : "false"]")
+		INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -1,7 +1,3 @@
-#if (MIN_COMPILER_VERSION > 515 && MIN_COMPILER_BUILD > 1630)
-#warn ATTENTION!! ONCE 515.1631 IS REQUIRED REPLACE WITH winset(client, "mainwindow", "menu=;is-fullscreen=true"). This means no double maximise calls to make sure window fits, and supresses titlebar, can-resize and is-maximized here making those redundant both implementations are functionally "windowed borderless"
-#endif
-
 /datum/preference/toggle/fullscreen
 	db_key = "fullscreen"
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
@@ -9,6 +5,7 @@
 	default_value = FALSE
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
+#if (MIN_COMPILER_VERSION > 515 || MIN_COMPILER_BUILD > 1630)
 	if (value)
 		// Delete the menu
 		winset(client, "mainwindow", "menu=\"\"")
@@ -39,6 +36,10 @@
 		winset(client, "mainwindow","is-maximized=true")
 		// Fix the mapsize, turning off statusbar doesn't update scaling
 		INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
+#else
+	winset(client, "mainwindow", "menu=;is-fullscreen=[value ? "true" : "false"]")
+	INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
+#endif
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -37,8 +37,15 @@
 			// Fix the mapsize, turning off statusbar doesn't update scaling
 			INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
 	else
-		winset(client, "mainwindow", "menu=;is-fullscreen=[value ? "true" : "false"]")
-		winset(client, "status_bar_wide", "is-visible=[value ? "false" : "true"]")
+		if(value)
+			winset(client, "mainwindow", "menu=;is-fullscreen=true")
+			winset(client, "status_bar_wide", "is-visible=false")
+			winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
+		else
+			winset(client, "mainwindow", "menu=;is-fullscreen=false")
+			winset(client, "status_bar_wide", "is-visible=true")
+			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
+			winset(client, "status_bar", "is-visible=false")
 		INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -38,6 +38,7 @@
 			INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
 	else
 		winset(client, "mainwindow", "menu=;is-fullscreen=[value ? "true" : "false"]")
+		winset(client, "status_bar_wide", "is-visible=[value ? "false" : "true"]")
 		INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

In https://github.com/BeeStation/BeeStation-Hornet/pull/12210 , we had wrongly set the warning to only trigger if we're on 516 and above XXX.1630, which will be in the far future when we will have forgotten this. Fixing this now is good so we dont have it break later.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Bug is bad. Bug is fix.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/220e929b-837a-4d26-a313-82a30f2c78bf

</details>

## Changelog
:cl: XeonMations
code: Changed some more fullscreen code, should work better on 515 clients now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
