### PR TITLE
Fixes admin-mentor ooc not being hot pink

### DIFF
--- a/code/modules/mentor/mentorsay.dm
+++ b/code/modules/mentor/mentorsay.dm
@@ -15,7 +15,7 @@
 
 	log_mentor("MSAY: [key_name(src)] : [msg]")
 	if(check_rights_for(src, R_ADMIN,0))
-		msg = "<b>[span_mentorsay("<font color ='#8A2BE2'>[span_prefix("MENTOR:")]")] <EM>[key_name(src, 0, 0)]</EM>: [span_message("[msg]")]</font></b>"
+		msg = "<b>[span_mentorsay("<font color ='#FF69B4'>[span_prefix("MENTOR:")]")] <EM>[key_name(src, 0, 0)]</EM>: [span_message("[msg]")]</font></b>"
 	else
 		msg = "<b>[span_mentorsay("[span_prefix("MENTOR:")]")] <EM>[key_name(src, 0, 0)]</EM>: [span_message("[msg]")]</font></b>"
 	for(var/client/client in GLOB.admins | GLOB.mentors)


### PR DESCRIPTION
## About The Pull Request

I'm assuming that somehow the color and the mentorsay span "mixed" before the span update to create hot pink. I just went ahead and changed the color to #FF69B4

## Why It's Good For The Game

fix

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/0ab87bdf-d5fd-4774-9ed6-50d269d4bb4d)

</details>

## Changelog
:cl:
fix: fixed admin-mentor ooc not being hot pink
/:cl:
