### PR TITLE
Adjusts swarmer capabilities

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -758,11 +758,8 @@
 /datum/dynamic_ruleset/midround/from_ghosts/swarmer/ready(forced = FALSE)
 	if(!..())
 		return FALSE
-	if(isnull(GLOB.the_gateway))
-		log_game("DYNAMIC: [ruletype] ruleset [name] execute failed due to no valid spawn locations (no gateway on map).")
-		return FALSE
-	if(!GLOB.the_gateway.active)
-		log_game("DYNAMIC: [ruletype] ruleset [name] execute failed due to no valid spawn locations (no ACTIVE gateway on map).")
+	if(!length(GLOB.xeno_spawn))
+		log_game("DYNAMIC: [ruletype] ruleset [name] execute failed due to no valid spawn locations")
 		return FALSE
 	return TRUE
 
@@ -770,8 +767,7 @@
 	var/datum/mind/player_mind = new /datum/mind(applicant.key)
 	player_mind.active = TRUE
 
-	var/mob/living/simple_animal/hostile/swarmer/S = new (get_turf(GLOB.the_gateway))
-	player_mind.transfer_to(S)
+	var/mob/living/simple_animal/hostile/swarmer/S = new (pick(GLOB.xeno_spawn))
 
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Swarmer by the midround ruleset.")
 	log_game("DYNAMIC: [key_name(S)] was spawned as a Swarmer by the midround ruleset.")

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -768,6 +768,7 @@
 	player_mind.active = TRUE
 
 	var/mob/living/simple_animal/hostile/swarmer/S = new (pick(GLOB.xeno_spawn))
+	player_mind.transfer_to(S)
 
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Swarmer by the midround ruleset.")
 	log_game("DYNAMIC: [key_name(S)] was spawned as a Swarmer by the midround ruleset.")

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -12,7 +12,7 @@
 	icon = 'icons/mob/swarmer.dmi'
 	icon_state = "swarmer_unactivated"
 	short_desc = "You are a swarmer!"
-	flavour_text = "Consume resources and replicate until there are no more resources left. Ensure that this location is fit for invasion at a later date; do not perform actions that would render it dangerous or inhospitable. Biological resources will be harvested at a later date; do not harm them."
+	flavour_text = "Consume resources and replicate until there are no more resources left. Ensure that this location is fit for invasion at a later date; do not perform actions that would render it dangerous or inhospitable. Biological resources will be harvested at a later date; dispatch those that get in your way without harming them."
 	density = FALSE
 	anchored = FALSE
 
@@ -835,7 +835,7 @@
 	completed = TRUE
 
 /datum/objective/do_not_harm_organisms
-	explanation_text = "Biological resources will be harvested at a later date; do not harm them."
+	explanation_text = "Biological resources will be harvested at a later date; dispatch those that get in your way without harming them."
 	completed = TRUE
 
 /datum/team/swarmer/roundend_report()

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -58,8 +58,8 @@
 	initial_language_holder = /datum/language_holder/swarmer
 	bubble_icon = "swarmer"
 	mob_biotypes = list(MOB_ROBOTIC)
-	health = 40
-	maxHealth = 40
+	health = 65
+	maxHealth = 65
 	status_flags = CANPUSH
 	icon_state = "swarmer"
 	icon_living = "swarmer"
@@ -70,7 +70,7 @@
 	maxbodytemp = 500
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
-	melee_damage = 15
+	melee_damage = 45
 	melee_damage_type = STAMINA
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD)
@@ -86,10 +86,9 @@
 	AIStatus = AI_OFF
 	pass_flags = PASSTABLE
 	mob_size = MOB_SIZE_TINY
-	ventcrawler = VENTCRAWLER_ALWAYS
 	ranged = 1
 	projectiletype = /obj/projectile/beam/disabler
-	ranged_cooldown_time = 20
+	ranged_cooldown_time = 10
 	projectilesound = 'sound/weapons/taser2.ogg'
 	loot = list(/obj/effect/decal/cleanable/robot_debris, /obj/item/stack/ore/bluespace_crystal)
 	del_on_death = TRUE

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -70,7 +70,7 @@
 	maxbodytemp = 500
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
-	melee_damage = 45
+	melee_damage = 35
 	melee_damage_type = STAMINA
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD)

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -620,7 +620,7 @@
 	if(locate(/obj/structure/swarmer/trap) in loc)
 		to_chat(src, span_warning("There is already a trap here. Aborting."))
 		return
-	Fabricate(/obj/structure/swarmer/trap, 5)
+	Fabricate(/obj/structure/swarmer/trap, 2)
 
 
 /mob/living/simple_animal/hostile/swarmer/proc/CreateBarricade()
@@ -634,7 +634,7 @@
 		to_chat(src, span_warning("We do not have the resources for this!"))
 		return
 	if(do_after(src, 1 SECONDS))
-		Fabricate(/obj/structure/swarmer/blockade, 5)
+		Fabricate(/obj/structure/swarmer/blockade, 2)
 
 
 /obj/structure/swarmer/blockade
@@ -663,7 +663,7 @@
 		return
 	if(do_after(src, 10 SECONDS))
 		var/createtype = SwarmerTypeToCreate()
-		if(createtype && Fabricate(createtype, 50))
+		if(createtype && Fabricate(createtype, 20))
 			playsound(loc,'sound/items/poster_being_created.ogg',50, 1, -1)
 
 

--- a/code/modules/antagonists/swarmer/swarmer_event.dm
+++ b/code/modules/antagonists/swarmer/swarmer_event.dm
@@ -8,7 +8,7 @@
 	dynamic_should_hijack = TRUE
 
 /datum/round_event_control/spawn_swarmer/preRunEvent()
-	if(!GLOB.the_gateway)
+	if(!GLOB.xeno_spawn)
 		return EVENT_CANT_RUN // We don't return CANT_RUN if the gateway is off because this disqualifies the event from EVER running again.
 	..()
 
@@ -17,17 +17,13 @@
 /datum/round_event/spawn_swarmer/start()
 	if(find_swarmer())
 		return FALSE // There already is active swarmers
-	if(isnull(GLOB.the_gateway))
-		return FALSE // There is no gateway
-	if(!GLOB.the_gateway.powered() || !GLOB.the_gateway.active)
-		return FALSE // The gateway
-	new /obj/effect/mob_spawn/swarmer(get_step(GLOB.the_gateway, SOUTH))
+	new /obj/effect/mob_spawn/swarmer(pick(GLOB.xeno_spawn))
 	if(prob(25)) //25% chance to announce it to the crew
 		announce_swarmer()
 
 /proc/announce_swarmer()
 	var/swarmer_report = span_bigbold("[command_name()] High-Priority Update")
-	swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come through."
+	swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station. We recommend immediate investigation, as something foreign may have infiltrated the station."
 	print_command_report(swarmer_report, announce=TRUE)
 
 /datum/round_event/spawn_swarmer/proc/find_swarmer()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -101,6 +101,8 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	faction = list(FACTION_SWARMER, FACTION_MINING)
 	weather_immunities = list("ash") //wouldn't be fun otherwise
 	AIStatus = AI_ON
+	ranged_cooldown_time = 20
+	melee_damage = 15
 
 /mob/living/simple_animal/hostile/swarmer/ai/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* **Swarmers can no longer vent crawl**
* Swarmers now have 85 HP, up from 40. This allows them to survive three lethal laser shots with 5 HP
* Swarmers now deal 35 stamina damage with melee attacks, up from 15
* Swarmer disabler speed is now doubled, but this is still only half the speed of an actual disabler so it still takes two swarmers to equal one security officer with a disabler
* Swarmer traps and walls now cost 2 resources instead of 5
* Swarmer replication costs 20 resources instead of 50 (it still takes 10 straight seconds of standing still to do and they can't exactly scurry to a totally isolated location to do it anymore)

Removing the ability to vent crawl means they can no longer evade destruction indefinitely, and can also not nearly as easily go straight for the ore silo. These changes will make them individually more powerful for combat, encourage them to actually stick together as a swarm, but also make them a much more manageable and detectable threat for the station to deal with when they have been discovered. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Swarmers are individually weak, but nearly impossible to catch and eradicate all of them. They are not fun to track down since players have to feel around blindly until they stumble into them, and then kill them before they manage to scurry back into a vent again. This also removes the ability for them to go straight for the ore silo before crew even know swarmers are present on the station in most cases. 

The buffs to combat capability are necessary since they are no longer able to run away, but since they can't flee this also means crew may frequently face multiple swarmers clumped together so I didn't want to go overboard on the buffs either. This may want a testmerge before going live

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

New disabler speed:

![dreamseeker_y58qEdwzMz](https://github.com/user-attachments/assets/a3bc3493-9cc1-46e9-95fb-79e76af9080c)

AoE Shock trap w/ new sounds

https://github.com/user-attachments/assets/bcfe54b9-4ce3-4b21-b236-4d49e4334e9f

AoE shock trap test when destroyed by force

https://github.com/user-attachments/assets/b5894ba9-915f-40ab-bd20-f9d231b19e81

Spawning through dynamic works fine

![image](https://github.com/user-attachments/assets/dbeccce5-696c-4ecd-b6a9-286261814bd2)





## Changelog
:cl:
balance: swarmers may no longer ventcrawl, and will also spawn in a random location instead of at the gateway. Without ventcrawling, the event as a whole should be more of a stand-off and defense than a bunch of constantly scurrying roaches.
tweak: swarmers now have 65 HP
tweak: swarmer ranged attack is now half the speed of security's disablers
tweak: swarmer melee attacks now do 35 stamina damage
tweak: swarmer replication now costs 20 resources
tweak: swarmer traps and walls now cost 2 resources to place
tweak: swarmer traps now trigger in an AoE when destroyed and their visuals and sound effects have been updated. The AoE has a greater effect on cyborgs than previously as well, due to their immunity to stamina damage.
tweak: swarmer objective text has been slightly modified to clarify they can attack crew as long as they don't harm them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
