### PR TITLE
Swarmer cost fixes + traps work on mechs

### DIFF
--- a/code/_onclick/hud/swarmer.dm
+++ b/code/_onclick/hud/swarmer.dm
@@ -5,8 +5,8 @@
 
 /atom/movable/screen/swarmer/FabricateTrap
 	icon_state = "ui_trap"
-	name = "Create trap (Costs 5 Resources)"
-	desc = "Creates a trap that will nonlethally shock any non-swarmer that attempts to cross it. (Costs 5 resources)"
+	name = "Create trap (Costs 2 Resources)"
+	desc = "Creates a trap that will nonlethally shock any non-swarmer that attempts to cross it. (Costs 2 resources)"
 
 /atom/movable/screen/swarmer/FabricateTrap/Click()
 	if(isswarmer(usr))
@@ -15,8 +15,8 @@
 
 /atom/movable/screen/swarmer/Barricade
 	icon_state = "ui_barricade"
-	name = "Create barricade (Costs 5 Resources)"
-	desc = "Creates a destructible barricade that will stop any non swarmer from passing it. Also allows disabler beams to pass through. (Costs 5 resources)"
+	name = "Create barricade (Costs 2 Resources)"
+	desc = "Creates a destructible barricade that will stop any non swarmer from passing it. Also allows disabler beams to pass through. (Costs 2 resources)"
 
 /atom/movable/screen/swarmer/Barricade/Click()
 	if(isswarmer(usr))
@@ -25,8 +25,8 @@
 
 /atom/movable/screen/swarmer/Replicate
 	icon_state = "ui_replicate"
-	name = "Replicate (Costs 50 Resources)"
-	desc = "Creates another of our kind."
+	name = "Replicate (Costs 20 Resources)"
+	desc = "Creates another of our kind. (Costs 20 resources)"
 
 /atom/movable/screen/swarmer/Replicate/Click()
 	if(isswarmer(usr))

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -613,6 +613,9 @@
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer) && !L.incorporeal_move)
 			shock_area()
 			qdel(src)
+	else if(ismecha(AM))
+		shock_area()
+		qdel(src)
 
 /obj/structure/swarmer/trap/proc/shock_area()
 	new /obj/effect/temp_visual/shock_trap_activate(get_turf(src))
@@ -625,6 +628,11 @@
 			L.flash_act()
 			L.adjustFireLoss(65) //This is the only way swarmers can deal with cyborgs in any capacity so it is especially harsh
 			L.Paralyze(100)
+	var/list/obj/object_targets = oview(1, src)
+	for(var/obj/vehicle/sealed/mecha/mechs in object_targets)
+		mechs.emp_act(1)
+		mechs.take_damage(35, BURN, ENERGY, 1) //Makes them take the same amount of damage as cyborgs when combined with the EMP
+		COOLDOWN_START(mechs, cooldown_vehicle_move, 3 SECONDS) //"Stuns" the mech for the duration of equipment disable, overriding their normal step cooldown
 
 /obj/effect/temp_visual/shock_trap_activate
 	randomdir = FALSE

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -649,6 +649,9 @@
 	if(locate(/obj/structure/swarmer/trap) in loc)
 		to_chat(src, span_warning("There is already a trap here. Aborting."))
 		return
+	if(resources < 2)
+		to_chat(src, span_warning("We do not have the resources for this!"))
+		return
 	if(do_after(src, 2 SECONDS))
 		Fabricate(/obj/structure/swarmer/trap, 2)
 
@@ -660,7 +663,7 @@
 	if(locate(/obj/structure/swarmer/blockade) in loc)
 		to_chat(src, span_warning("There is already a blockade here. Aborting."))
 		return
-	if(resources < 5)
+	if(resources < 2)
 		to_chat(src, span_warning("We do not have the resources for this!"))
 		return
 	if(do_after(src, 1 SECONDS))
@@ -685,7 +688,7 @@
 	set category = "Swarmer"
 	set desc = "Creates a shell for a new swarmer. Swarmers will self activate."
 	to_chat(src, span_info("We are attempting to replicate ourselves. We will need to stand still until the process is complete."))
-	if(resources < 50)
+	if(resources < 20)
 		to_chat(src, span_warning("We do not have the resources for this!"))
 		return
 	if(!isturf(loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Swarmer replication is now actually usable at 20 resources, instead of requiring 50+ to be stored. This does not change the cost of the ability, just the point at which it becomes available to use. 

Swarmer walls have had their error message adjusted in the same vein - it can now be used with only 2 resources, in line with the cost. 

Swarmer traps now have a warning if you try to place one without enough resources instead of performing the build only to fail. 

Swarmer traps now cause mechs to take the same damage as cyborgs do, and also ensures the mechs can trigger traps too. Mechs will be disabled for three seconds instead of ten however. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes good.

Mechs pose a similar or greater threat than cyborgs do, and are similar in makeup so it only makes sense that they would be similarly affected. This allows them to put up a modest fight against mechs now in much the same way as they can cyborgs. Mechs are far more likely to be equipped with the necessary ranged tools to deal with the traps so they will remain a powerful foe for swarmers to overcome though. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

https://github.com/user-attachments/assets/915a64e4-e30d-4271-b19d-e5e178034bf5

## Changelog
:cl:
tweak: Mechs are now affected by swarmer traps, however they will only be stunned for three seconds instead of ten.
fix: Adjusts swarmer abilities so that they are available in accordance to the recently updated costs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
