### PR TITLE
Fixes admin transforms transferring the wrong minds

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -43,13 +43,12 @@
 
 	return ..()
 
-/datum/dna/proc/transfer_identity(mob/living/carbon/destination, transfer_SE = FALSE)
+/datum/dna/proc/transfer_identity(mob/living/carbon/destination, transfer_SE = FALSE, transfer_species = TRUE)
 	if(!istype(destination))
 		return
 	destination.dna.unique_enzymes = unique_enzymes
 	destination.dna.uni_identity = uni_identity
 	destination.dna.blood_type = blood_type
-	destination.set_species(species.type, icon_update=0)
 	destination.dna.features = features.Copy()
 	destination.dna.real_name = real_name
 	destination.dna.temporary_mutations = temporary_mutations.Copy()
@@ -59,6 +58,8 @@
 		for(var/datum/mutation/M as() in mutations)
 			if(!istype(M, RACEMUT))
 				destination.dna.add_mutation(M, M.class)
+	if(transfer_species)
+		destination.set_species(species.type, icon_update=0)
 
 /datum/dna/proc/copy_dna(datum/dna/new_dna)
 	new_dna.unique_enzymes = unique_enzymes

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -51,7 +51,13 @@
 		new_human.dna.update_dna_identity()
 		new_human.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
 
-	if(mind && isliving(desired_mob))
+	//Ghosts have copys of their minds, but if an admin put somebody else in their og body, the mind will have a new mind.key
+	//	and transfer_to will transfer the wrong person since it uses mind.key
+	if(mind && isliving(desired_mob) && (!isobserver(src) || mind.current == src || QDELETED(mind.current)))
+		if (ckey(mind.key) != ckey)
+			//we could actually prevent the bug from happening here, but then nobody would know to look for the stack trace we are about to print.
+			stack_trace("DEBUG: The bug where mob transfers or transforms sometimes kick unrelated people out of mobs has happened again. mob [src]([type])\ref[src] owned by [ckey] is being changed into a [new_type] but has a mind owned by [ckey(mind.key)].")
+
 		mind.transfer_to(desired_mob, 1) // second argument to force key move to new mob
 	else
 		desired_mob.key = key

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -22,39 +22,40 @@
 		to_chat(usr, span_danger("Cannot convert into a new_player mob type."))
 		return
 
-	var/mob/M
+	var/mob/desired_mob
 	if(isturf(location))
-		M = new new_type( location )
+		desired_mob = new new_type(location)
 	else
-		M = new new_type( src.loc )
+		desired_mob = new new_type(src.loc)
 
-	if(!M || !ismob(M))
+	if(!desired_mob || !ismob(desired_mob))
 		to_chat(usr, "Type path is not a mob (new_type = [new_type]) in change_mob_type(). Contact a coder.")
-		qdel(M)
+		qdel(desired_mob)
 		return
 
 	if( istext(new_name) )
-		M.name = new_name
-		M.real_name = new_name
+		desired_mob.name = new_name
+		desired_mob.real_name = new_name
 	else
-		M.name = src.name
-		M.real_name = src.real_name
+		desired_mob.name = src.name
+		desired_mob.real_name = src.real_name
 
-	if(has_dna() && M.has_dna())
-		var/mob/living/carbon/C = src
-		var/mob/living/carbon/D = M
-		C.dna.transfer_identity(D)
-		D.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
-	else if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		client.prefs.apply_prefs_to(H, icon_updates = TRUE)
-		H.dna.update_dna_identity()
+	if(has_dna() && desired_mob.has_dna())
+		var/mob/living/carbon/old_mob = src
+		var/mob/living/carbon/new_mob = desired_mob
+		old_mob.dna.transfer_identity(new_mob, transfer_species = FALSE)
+		new_mob.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
+	else if(ishuman(desired_mob) && (!ismonkey(desired_mob)))
+		var/mob/living/carbon/human/new_human = desired_mob
+		client.prefs.apply_prefs_to(new_human, icon_updates = TRUE)
+		new_human.dna.update_dna_identity()
+		new_human.updateappearance(mutcolor_update=1, mutations_overlay_update=1)
 
-	if(mind && isliving(M))
-		mind.transfer_to(M, 1) // second argument to force key move to new mob
+	if(mind && isliving(desired_mob))
+		mind.transfer_to(desired_mob, 1) // second argument to force key move to new mob
 	else
-		M.key = key
+		desired_mob.key = key
 
 	if(delete_old_mob)
 		QDEL_IN(src, 1)
-	return M
+	return desired_mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes admin transforms sending the wrong client

Ports:
- https://github.com/tgstation/tgstation/pull/69481
- https://github.com/tgstation/tgstation/pull/70500

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was a nightmare on a nukie round where I had to juggle people who needed to leave with ghosts.

The issue is that if you admin transfer someone, it associates a new ghost key or some nonsense. It gets fucky when you try to ghost poll that mob later on. Idk read the tg pr this shit is awful

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/777a5c45-e328-45d1-a384-4dae9e01abe5



</details>

## Changelog
:cl: rkz, mso,  itseasytosee
fix: fixes admin transforms sending the wrong mind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
