### PR TITLE
Changes the color of AI laws in the roundend report to something more legible

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -490,6 +490,6 @@
 
 	for(var/law in supplied)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[number]:" : ""] <font color='#547DFE'>[law]</font>"
+			data += "[show_numbers ? "[number]:" : ""] <font color='#CC9900'>[law]</font>"
 			number++
 	return data

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -490,6 +490,6 @@
 
 	for(var/law in supplied)
 		if (length(law) > 0)
-			data += "[show_numbers ? "[number]:" : ""] <font color='#990099'>[law]</font>"
+			data += "[show_numbers ? "[number]:" : ""] <font color='#547DFE'>[law]</font>"
 			number++
 	return data


### PR DESCRIPTION
## About The Pull Request
One line change, changes the color of custom AI laws from #990099 to #CC9900. All other colors remain untouched.

## Why It's Good For The Game
It annoys me personally that screenshots of the roundend report and in the dark mode panel are so hard to read, and colors that both work well on grey and white are hard to find.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/e3d0254c-a06e-4870-b56b-7b734d0a8a45)
![image](https://github.com/user-attachments/assets/58edb173-710e-4d03-adaa-b6092ecb6803)
![image](https://github.com/user-attachments/assets/a43bf44d-5beb-4474-bdb4-fa20b434c675)

</details>

## Changelog
:cl: RDS88
tweak: Custom AI laws are now more readable on the end-of-round report. You don't need to squint to figure out why it was trying to door-crush you anymore
/:cl:
