### PR TITLE
Fixes stat crashes

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -405,7 +405,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 	var/list/tab_data = ..()
 	var/obj/item/organ/alien/plasmavessel/vessel = getorgan(/obj/item/organ/alien/plasmavessel)
 	if(vessel)
-		tab_data += "Plasma Stored: [vessel.stored_plasma]/[vessel.max_plasma]"
+		tab_data["Plasma Stored"] = "[vessel.stored_plasma]/[vessel.max_plasma]"
 	if(locate(/obj/item/assembly/health) in src)
 		tab_data["Health"] = GENERATE_STAT_TEXT("[health]")
 	return tab_data

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -405,7 +405,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 	var/list/tab_data = ..()
 	var/obj/item/organ/alien/plasmavessel/vessel = getorgan(/obj/item/organ/alien/plasmavessel)
 	if(vessel)
-		tab_data["Plasma Stored"] = "[vessel.stored_plasma]/[vessel.max_plasma]"
+		tab_data["Plasma Stored"] = GENERATE_STAT_TEXT("[vessel.stored_plasma]/[vessel.max_plasma]")
 	if(locate(/obj/item/assembly/health) in src)
 		tab_data["Health"] = GENERATE_STAT_TEXT("[health]")
 	return tab_data

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/nymph.dm
@@ -78,7 +78,6 @@
 	. = ..()
 	if(!is_drone)
 		update_progression()
-	get_stat_tab_status()
 	if(stat != CONSCIOUS)
 		remove_status_effect(STATUS_EFFECT_PLANTHEALING)
 	var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing

--- a/tgui/packages/tgui-panel/stat/StatStatus.js
+++ b/tgui/packages/tgui-panel/stat/StatStatus.js
@@ -6,14 +6,6 @@ import { StatText } from './StatText';
 export const StatStatus = (props) => {
   const stat = useSelector(selectStatPanel);
   const dispatch = useDispatch();
-  let statPanelData = [];
-  if (stat.infomationUpdate) {
-    for (const [key, value] of Object.entries(stat.infomationUpdate)) {
-      if (key === stat.selectedTab) {
-        statPanelData = value;
-      }
-    }
-  }
   return (
     <Flex direction="column">
       {stat.dead_popup ? (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stat will no longer crash when you are a xenomorph.

## Why It's Good For The Game

N/A

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/d1249ad2-6be4-4172-9f0b-b44f84e30064)

## Changelog
:cl:
fix: Fixes the stat panel crashing when you have a plasma vessel in your mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
