### PR TITLE
Fix: ahelp and mhelp verb buttons give the TGUI prompt now

### DIFF
--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -14,7 +14,7 @@
 	. = ..()
 	if(.)
 		return
-	user.get_adminhelp()
+	user.adminhelp()
 	return TRUE
 
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -34,14 +34,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/help_tickets/admin, new)
 	deltimer(adminhelptimerid)
 	adminhelptimerid = 0
 
-// Used for methods where input via arg doesn't work
-/client/proc/get_adminhelp()
-	var/msg = tgui_input_text(src, "Please describe your problem concisely and an admin will help as soon as they're able. Include the names of the people you are ahelping against if applicable.", "Adminhelp contents", multiline = TRUE, encode = FALSE) // we don't encode/sanitize here bc it's done for us later
-	adminhelp(msg)
-
-/client/verb/adminhelp(msg as message)
+/client/verb/adminhelp()
 	set category = "Admin"
 	set name = "Adminhelp"
+	var/msg
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
@@ -54,7 +50,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/help_tickets/admin, new)
 	if(handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
 
-	msg = trim(msg)
+	msg = trim(tgui_input_text(src, "Please describe your problem concisely and an admin will help as soon as they're able. Include the names of the people you are ahelping against if applicable.", "Adminhelp contents", multiline = TRUE, encode = FALSE))
 
 	if(!msg)
 		return

--- a/code/modules/admin/verbs/mentorhelp.dm
+++ b/code/modules/admin/verbs/mentorhelp.dm
@@ -31,14 +31,10 @@ GLOBAL_DATUM_INIT(mhelp_tickets, /datum/help_tickets/mentor, new)
 	deltimer(mentorhelptimerid)
 	mentorhelptimerid = 0
 
-/// Used for methods where input via arg doesn't work
-/client/proc/get_mentorhelp()
-	var/msg = tgui_input_text(src, "Please describe your problem concisely and a mentor will help as soon as they're able. Remember: Mentors cannot see you or what you're doing. Describe the problem in full detail.", "Mentorhelp contents", multiline = TRUE, encode = FALSE) // we don't encode/sanitize here bc it's done for us later
-	mentorhelp(msg)
-
-/client/verb/mentorhelp(msg as message)
+/client/verb/mentorhelp()
 	set category = "Mentor"
 	set name = "Mentorhelp"
+	var/msg
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
@@ -51,7 +47,7 @@ GLOBAL_DATUM_INIT(mhelp_tickets, /datum/help_tickets/mentor, new)
 	if(handle_spam_prevention(msg, MUTE_MHELP))
 		return
 
-	msg = trim(msg)
+	msg = trim(tgui_input_text(src, "Please describe your problem concisely and a mentor will help as soon as they're able. Remember: Mentors cannot see you or what you're doing. Describe the problem in full detail.", "Mentorhelp contents", multiline = TRUE, encode = FALSE))
 
 	if(!msg)
 		return


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TGUI versions of the ahelp and mhelp were already coded in but were inaccessible (except for when using the F1 hotkey for ahelp) due to the verb button asking for a text prompt that took priority. 

## Why It's Good For The Game

This fix is known to break the ability to type the contents of an ahelp or mhelp into the command bar, but Bacon mentioned it might be a better trade off, especially since there is some imporant info in the TGUI prompts that get currently overlooked. Also TGUI is always nicer looking than the boring white text boxes labeled "mentorhelp "Text""

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

mentorhelp verb button works now:

<img width="1280" alt="dreamseeker_2GzCMTRzKF" src="https://github.com/user-attachments/assets/85146487-8c86-4158-8339-daaf7d917165" />

(the actual mentorhelp is unnafected)

<img width="189" alt="dreamseeker_QNKQbeb3g1" src="https://github.com/user-attachments/assets/8de8eb4b-e2b0-4e60-9b70-26b4116279a4" />



adminhelp verb button also works now:

<img width="1280" alt="dreamseeker_ROoXGGSBGJ" src="https://github.com/user-attachments/assets/a25f6cbc-5166-412c-b506-a299ed3b5f97" />

(and showing the ahelp still works)

<img width="276" alt="dreamseeker_GMV1896GRI" src="https://github.com/user-attachments/assets/5050b810-2d07-4adc-a823-fe7d0dae7c6c" />

The F1 hotkey still works as well. The verbs are still there admined or deadmined.


</details>

## Changelog
:cl:
tweak: TGUIfies Adminhelp and Mentorhelp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
