### PR TITLE
Fixes advanced wirebrush behavior

### DIFF
--- a/code/game/objects/items/tools/wirebrush.dm
+++ b/code/game/objects/items/tools/wirebrush.dm
@@ -44,15 +44,13 @@
 		return
 
 	if(prob(crit_fail_prob))
-		to_chat(user, span_danger("You feel a sharp pain as your entire body grows oddly warm."))
-		user.radiation += crit_fail_rads
+		to_chat(user, span_danger("You feel a sharp pain as \the [src] grows oddly warm."))
+		user.rad_act(crit_fail_rads)
 		if(user.radiation > crit_fail_rads_threshold) // If you ignore the warning signs you get punished
 			user.emote("vomit")
 			user.adjustToxLoss(crit_fail_damage, forced=TRUE)
 			user.adjustOxyLoss(crit_fail_damage, forced=TRUE)
 		return
 
-	user.radiation += radiation_on_use
-
-	if(prob(25))
+	if(user.rad_act(radiation_on_use) && prob(25))
 		user.emote("cough")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes a logic issue with advanced wirebrush code, making it no longer ignore radiation protection before dealing radiation damage.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

We should not have items that ignore radiation protection when giving radiation damage.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/7dc29d15-abf9-4d47-aa4f-3f92dc753768




After removing radsuit and using the brush:

![image](https://github.com/user-attachments/assets/f2f13af7-e067-4428-9c53-4a009d6fd62b)


</details>

## Changelog
:cl: XeonMations
fix: Advanced wirebrushes no longer ignore radiation protection before dealing damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
