### PR TITLE
Fixes roundstart bolted door lights

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -524,7 +524,7 @@
 	else
 		return FALSE
 
-/obj/machinery/door/airlock/update_icon(state=0, override=0)
+/obj/machinery/door/airlock/update_icon(updates=ALL, state=0, override=0)
 	cut_overlays() // Needed without it you get like 300 unres indicator overlayers over time
 	if(operating && !override)
 		return
@@ -686,17 +686,17 @@
 /obj/machinery/door/airlock/do_animate(animation)
 	switch(animation)
 		if("opening")
-			update_icon(AIRLOCK_OPENING)
+			update_icon(state=AIRLOCK_OPENING)
 		if("closing")
-			update_icon(AIRLOCK_CLOSING)
+			update_icon(state=AIRLOCK_CLOSING)
 		if("deny")
 			if(!machine_stat)
-				update_icon(AIRLOCK_DENY)
+				update_icon(state=AIRLOCK_DENY)
 				playsound(src,doorDeni,50,0,3)
 				addtimer(CALLBACK(src, PROC_REF(finish_close_animation)), 6)
 
 /obj/machinery/door/airlock/proc/finish_close_animation()
-	update_icon(AIRLOCK_CLOSED)
+	update_icon(state=AIRLOCK_CLOSED)
 
 /obj/machinery/door/airlock/examine(mob/user)
 	. = ..()
@@ -1163,7 +1163,7 @@
 			return FALSE
 	if(charge && !detonated)
 		panel_open = TRUE
-		update_icon(AIRLOCK_OPENING)
+		update_icon(state=AIRLOCK_OPENING)
 		visible_message(span_warning("[src]'s panel is blown off in a spray of deadly shrapnel!"))
 		charge.forceMove(drop_location())
 		EX_ACT(charge, EXPLODE_DEVASTATE)
@@ -1190,7 +1190,7 @@
 	ui_update()
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_OPEN, forced)
 	operating = TRUE
-	update_icon(AIRLOCK_OPENING, 1)
+	update_icon(state=AIRLOCK_OPENING, override=TRUE)
 	sleep(1)
 	set_opacity(0)
 	update_freelook_sight()
@@ -1200,7 +1200,7 @@
 	air_update_turf(TRUE, FALSE)
 	sleep(1)
 	layer = OPEN_DOOR_LAYER
-	update_icon(AIRLOCK_OPEN, 1)
+	update_icon(state=AIRLOCK_OPEN, override=TRUE)
 	operating = FALSE
 	ui_update()
 	if(delayed_close_requested)
@@ -1237,7 +1237,7 @@
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_CLOSE, forced)
 	ui_update()
 	operating = TRUE
-	update_icon(AIRLOCK_CLOSING, 1)
+	update_icon(state=AIRLOCK_CLOSING, override=TRUE)
 	layer = CLOSED_DOOR_LAYER
 	if(air_tight)
 		set_density(TRUE)
@@ -1255,7 +1255,7 @@
 		set_opacity(1)
 	update_freelook_sight()
 	sleep(1)
-	update_icon(AIRLOCK_CLOSED, 1)
+	update_icon(state=AIRLOCK_CLOSED, override=TRUE)
 	operating = FALSE
 	delayed_close_requested = FALSE
 	ui_update()
@@ -1320,7 +1320,7 @@
 /obj/machinery/door/airlock/on_emag(mob/user)
 	..()
 	operating = TRUE
-	update_icon(AIRLOCK_EMAG, 1)
+	update_icon(state=AIRLOCK_EMAG, override=TRUE)
 	addtimer(CALLBACK(src, PROC_REF(after_emag)), 6)
 
 /obj/machinery/door/airlock/proc/after_emag()
@@ -1328,7 +1328,7 @@
 		return
 	operating = FALSE
 	if(!open())
-		update_icon(AIRLOCK_CLOSED, 1)
+		update_icon(state=AIRLOCK_CLOSED, override=TRUE)
 	bolt()
 	loseMainPower(TRUE)
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -125,7 +125,7 @@
 	attack(user,user)
 	return FIRELOSS
 
-/obj/item/assembly/flash/update_icon(flash = FALSE)
+/obj/item/assembly/flash/update_icon(updates=ALL, flash = FALSE)
 	cut_overlays()
 	attached_overlays = list()
 	if(!bulb)
@@ -224,7 +224,7 @@
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
 	set_light_on(TRUE)
 	addtimer(CALLBACK(src, PROC_REF(flash_end)), FLASH_LIGHT_DURATION, TIMER_OVERRIDE|TIMER_UNIQUE)
-	update_icon(TRUE)
+	update_icon(flash=TRUE)
 	if(user && !clown_check(user))
 		return FALSE
 	return TRUE
@@ -293,7 +293,7 @@
 	else if(issilicon(M))
 		var/mob/living/silicon/robot/R = M
 		log_combat(user, R, "flashed", src)
-		update_icon(1)
+		update_icon(flash=TRUE)
 		R.flash_act(affect_silicon = 1, type = /atom/movable/screen/fullscreen/flash/static)
 		if(R.last_flashed + FLASHED_COOLDOWN < world.time)
 			R.last_flashed = world.time
@@ -396,7 +396,7 @@
 	overheat = TRUE
 	addtimer(CALLBACK(src, PROC_REF(cooldown)), flashcd)
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
-	update_icon(1)
+	update_icon(flash=TRUE)
 	return TRUE
 
 

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -441,11 +441,11 @@
 
 /obj/item/clothing/glasses/blindfold/white/visual_equipped(mob/living/carbon/human/user, slot)
 	if(ishuman(user) && slot == ITEM_SLOT_EYES)
-		update_icon(user)
+		update_icon(user=user)
 		user.update_inv_glasses() //Color might have been changed by update_icon.
 	..()
 
-/obj/item/clothing/glasses/blindfold/white/update_icon(mob/living/carbon/human/user)
+/obj/item/clothing/glasses/blindfold/white/update_icon(updates=ALL, mob/living/carbon/human/user)
 	if(ishuman(user) && !colored_before)
 		add_atom_colour("#[user.eye_color]", FIXED_COLOUR_PRIORITY)
 		colored_before = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

While refactoring update_appearance, #8063 added an argument, "updates", to /atom/proc/update_icon. However, this argument wasn't added to the child proc /obj/machinery/door/airlock/update_icon, which already had two arguments before the change. As a result, when an airlock had its update_icon proc called from a place expecting it to run the default one (for example, /obj/machinery/proc/power_change), the "updates" argument, containing bitflags for parts of an atom's appearance to be updated, would be mistakenly passed as the "state" argument, representing an airlock's opening state. 

A visible effect of this error was that at roundstart, bolted airlocks did not have the appropriate lights applied to them, and looked unbolted.

This PR solves this issue by simply adding the "updates" argument to the child proc, despite it having no effect on its execution. 
As a preventive measure, the same was done for other children of update_icon that had arguments, namely /obj/item/assembly/flash/update_icon (flash) and /obj/item/clothing/glasses/blindfold/white/update_icon (the blindfold worn by blind humans).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Bugfix, and bug prevention. Bolted doors should have lights on at roundstart, and child procs should not have unique arguments without also inheriting the parent proc's arguments.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/a58539ff-1cda-437d-aacb-d7df4b383e04

![noruntimes](https://github.com/user-attachments/assets/88b89903-413f-4012-b7c4-1f60738a6b33)

</details>

## Changelog
:cl: beelover
fix: airlocks bolted at roundstart now have the appropriate lights on
code: added the updates argument to some children of the update_icon proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
