### PR TITLE
Reduces default ghost role cooldown to 60 seconds

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -610,7 +610,7 @@ AUTOTRANSFER_DECAY_START 24000
 AUTOTRANSFER_DECAY_AMOUNT 0.025
 
 ## Ghost role cooldown time after death (In deciseconds)
-GHOST_ROLE_COOLDOWN 3000
+GHOST_ROLE_COOLDOWN 600
 
 ## Enable/disable roundstart station traits
 #STATION_TRAITS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces default ghost role cooldown to 60 seconds

## Why It's Good For The Game

We have a lot of ghost roles where they are very weak and die quickly. There are a lot othat depend on rapid respawns. It makes sense to lower the cooldown to 60 seconds, since it's just more fun to be able to get back in quickly but there should still be something to stop you just spam sacrificing lives.

## Testing Photographs and Procedure
N/A: Configuration Change.

## Changelog
:cl:
tweak: The recommended ghost role cooldown has been reduced to 60 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
