### PR TITLE
fixes the overlapped item reclaimer

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36064,6 +36064,9 @@
 	pixel_x = 3;
 	pixel_y = 8
 	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "kVR" = (
@@ -63364,9 +63367,6 @@
 /turf/open/floor/iron,
 /area/quartermaster/storage)
 "wby" = (
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the item reclaiming console on boxstation so it is visible and usable.

## Why It's Good For The Game

This was an oversight in the box genpop overhaul

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/9d97a08c-9f56-40ca-be22-c062899b904c)


</details>

## Changelog
:cl:
tweak: moves the boxstation prison camp reclaimer console to be accessible and visible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
