### PR TITLE
Combat mode hotkeys & Unified looking/moving

### DIFF
--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -38,7 +38,7 @@
 	return TRUE
 
 /datum/keybinding/living/toggle_combat_mode
-	keys = list("`")
+	keys = list("F")
 	name = "toggle_combat_mode"
 	full_name = "Toggle Combat Mode"
 	description = "Toggles combat mode. Like Help/Harm but cooler."
@@ -81,7 +81,7 @@
 	user_mob.set_combat_mode(FALSE, silent = FALSE)
 
 /datum/keybinding/living/look_up
-	keys = list("L")
+	keys = list()
 	name = "look up"
 	full_name = "Look Up"
 	description = "Look up at the next z-level. Only works if below any nearby open space within a 3x3 square."
@@ -104,7 +104,7 @@
 	return TRUE
 
 /datum/keybinding/living/look_down
-	keys = list(";")
+	keys = list()
 	name = "look down"
 	full_name = "Look Down"
 	description = "Look down at the previous z-level. Only works if above any nearby open space within a 3x3 square."

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -103,10 +103,10 @@
 	return TRUE
 
 /datum/keybinding/mob/move_up
-	keys = list("F")
+	keys = list()
 	name = "move up"
 	full_name = "Move Up"
-	description = "Try moving upwards."
+	description = "Attempts to move upwards."
 	keybind_signal = COMSIG_KB_MOB_MOVEUP_DOWN
 
 /datum/keybinding/mob/move_up/down(client/user)
@@ -128,10 +128,10 @@
 	return TRUE
 
 /datum/keybinding/mob/move_down
-	keys = list("C")
+	keys = list()
 	name = "move down"
 	full_name = "Move Down"
-	description = "Try moving downwards."
+	description = "Attempts to move downards."
 	keybind_signal = COMSIG_KB_MOB_MOVEDOWN_DOWN
 
 /datum/keybinding/mob/move_down/down(client/user)
@@ -141,6 +141,58 @@
 	if(isliving(user.mob))
 		var/mob/living/L = user.mob
 		L.zMove(DOWN, TRUE)
+	else if(isobserver(user.mob))
+		var/turf/original = get_turf(user.mob)
+		if(!istype(original))
+			return
+		var/turf/new_turf = get_step_multiz(original, DOWN)
+		if(!istype(new_turf))
+			to_chat(user.mob, span_warning("There is nothing below you!"))
+			return
+		user.mob.Move(new_turf, DOWN)
+	return TRUE
+
+/datum/keybinding/mob/move_look_up
+	keys = list("CtrlF", "Northeast") // Northeast: Page-up
+	name = "move or look up"
+	full_name = "Move/Look Up"
+	description = "Move upwards if you are capable, otherwise looks up instead."
+	keybind_signal = COMSIG_KB_MOB_MOVEUP_DOWN
+
+/datum/keybinding/mob/move_look_up/down(client/user)
+	. = ..()
+	if(.)
+		return
+	if(isliving(user.mob))
+		var/mob/living/L = user.mob
+		if (!L.zMove(UP, FALSE))
+			L.look_up()
+	else if(isobserver(user.mob))
+		var/turf/original = get_turf(user.mob)
+		if(!istype(original))
+			return
+		var/turf/new_turf = get_step_multiz(original, UP)
+		if(!istype(new_turf))
+			to_chat(user.mob, span_warning("There is nothing above you!"))
+			return
+		user.mob.Move(new_turf, UP)
+	return TRUE
+
+/datum/keybinding/mob/move_look_down
+	keys = list("CtrlC", "Southeast") // Southeast: Page-down
+	name = "move or look down"
+	full_name = "Move/Look Down"
+	description = "Move downwards if you are capable, otherwise looks down instead."
+	keybind_signal = COMSIG_KB_MOB_MOVEDOWN_DOWN
+
+/datum/keybinding/mob/move_look_down/down(client/user)
+	. = ..()
+	if(.)
+		return
+	if(isliving(user.mob))
+		var/mob/living/L = user.mob
+		if (!L.zMove(DOWN, FALSE))
+			L.look_down()
 	else if(isobserver(user.mob))
 		var/turf/original = get_turf(user.mob)
 		if(!istype(original))

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -124,6 +124,20 @@
 	message = "drools"
 	emote_type = EMOTE_VISIBLE
 
+/datum/emote/living/jump
+	key = "jump"
+	key_third_person = "jumps"
+	message = "jumps"
+	emote_type = EMOTE_VISIBLE
+	cooldown = 2 SECONDS
+
+/datum/emote/living/jump/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!isliving(user))
+		return
+	var/mob/living/living = user
+	living.do_jump_animation()
+
 /datum/emote/living/faint
 	key = "faint"
 	key_third_person = "faints"

--- a/code/modules/multiz/movement/mob/living_zmove.dm
+++ b/code/modules/multiz/movement/mob/living_zmove.dm
@@ -1,4 +1,3 @@
-#define MOVETYPE_NONE_JUMP -1
 #define MOVETYPE_NONE 0
 #define MOVETYPE_CLIMB 1
 #define MOVETYPE_FLY 2
@@ -30,7 +29,7 @@
 		return MOVETYPE_JETPACK
 	else if(can_climb)
 		return MOVETYPE_CLIMB
-	return upwards ? MOVETYPE_NONE_JUMP : MOVETYPE_NONE
+	return MOVETYPE_NONE
 
 /// Attempts a zMove up or down, provides feedback if unable to do so.
 /mob/living/zMove(dir, feedback = FALSE, feedback_to = src)
@@ -60,11 +59,6 @@
 		if(MOVETYPE_NONE)
 			if(feedback)
 				to_chat(feedback_to, span_warning("Something is blocking you!"))
-			return FALSE
-		if(MOVETYPE_NONE_JUMP)
-			visible_message(span_warning("[src] jumps into the air, as if [p_they()] expected to float... Gravity pulls [p_them()] back down quickly."), span_warning("You try jumping into the space above you. Gravity pulls you back down quickly."))
-			do_jump_animation()
-			adjustStaminaLoss(10, forced = TRUE)
 			return FALSE
 		if(MOVETYPE_JAUNT)
 			move_verb = "moving"
@@ -171,5 +165,3 @@
 #undef MOVETYPE_JETPACK
 #undef MOVETYPE_FLOAT
 #undef MOVETYPE_JAUNT
-
-#undef MOVETYPE_NONE_JUMP

--- a/code/modules/multiz/movement/mob/living_zmove.dm
+++ b/code/modules/multiz/movement/mob/living_zmove.dm
@@ -37,7 +37,7 @@
 		return FALSE
 	if(remote_control)
 		remote_control.relaymove(src, dir)
-		return
+		return TRUE
 	var/turf/source = get_turf(src)
 	var/turf/target = get_step_multiz(src, dir)
 	if(!target)
@@ -47,10 +47,12 @@
 	if(istype(loc, /obj/effect/dummy/phased_mob)) // I despise this
 		var/obj/effect/dummy/phased_mob/L = loc
 		L.relaymove(src, dir)
-		return
+		// Return true if we changed position
+		return source != get_turf(L)
 	if(istype(buckled))
 		buckled.relaymove(src, dir)
-		return
+		// Return true if we changed position
+		return source != get_turf(L)
 	var/move_verb = "floating"
 	var/delay = 1 SECONDS
 	var/upwards = dir == UP
@@ -77,7 +79,8 @@
 			delay = 1 SECONDS
 		else
 			move_verb = "(unknown move type, call a coder!) moving"
-	return start_travel_z(src, upwards, move_verb, delay, allow_movement = (move_type != MOVETYPE_CLIMB))
+	start_travel_z(src, upwards, move_verb, delay, allow_movement = (move_type != MOVETYPE_CLIMB))
+	return TRUE
 
 /// Actually starts a zMove, doing movement animations
 /mob/living/proc/start_travel_z(mob/user, upwards = TRUE, move_verb = "floating", delay = 3 SECONDS, allow_movement = TRUE)

--- a/code/modules/multiz/movement/mob/living_zmove.dm
+++ b/code/modules/multiz/movement/mob/living_zmove.dm
@@ -52,7 +52,7 @@
 	if(istype(buckled))
 		buckled.relaymove(src, dir)
 		// Return true if we changed position
-		return source != get_turf(L)
+		return source != get_turf(src)
 	var/move_verb = "floating"
 	var/delay = 1 SECONDS
 	var/upwards = dir == UP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #12294

## About The Pull Request

Changes our hotkey schema to match up with TG's.

- F is the new button to toggle combat mode
- Ctrl+F or Page Up is the move/look up hotkey.
- Ctrl-C or Page Down is the move/look down hotkey.
- The move/look hotkey will attempt to move you in that direction, but will look otherwise. Most of the time someone can either move, or look and its rare for you to need both at the same time.
- Removes the jump animation from move up, and replaces it with a jump emote

## Why It's Good For The Game

Matching up with TG is good since it smooths out the process for people who want to play multiple servers, and F just is much easier to use than `. There is no reason such an underused key like moving up should take up the prime real estate of the left hand keys. I put them on both ctrl-F so that people who learnt it can have a close option but also copied TG's page up hotkey for the action (though not all keyboards have that key).

Removes jumping from the move up hotkey since it looks stupid and will play when you use the move/look up hotkey.

## Testing Photographs and Procedure

Move/Look:

![image](https://github.com/user-attachments/assets/8649f532-b26c-4164-a26c-320720935fa9)

![image](https://github.com/user-attachments/assets/1b0f398b-a9a1-4a5b-a440-4a0c5df51efc)

![image](https://github.com/user-attachments/assets/f189ded0-5bad-4537-9fe0-3eb04664a4c4)

Combat mode:

F works as a toggle

![image](https://github.com/user-attachments/assets/ef9ae189-692e-4008-8d93-759be5c04987)


## Changelog
:cl:
tweak: Toggle combat mode is now bound to the F key by default.
tweak: A new keybind has been added to move up or look up if you can't move, which is bound to page up/down, or ctrlF/ctrlC.
tweak: Unbound look up and move up hotkeys by default.
tweak: Removes jumping from the move up hotkey.
add: Adds a jump emote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
