### PR TITLE
Right click no longer picks up items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -565,6 +565,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		user.dropItemToGround(src)
 		return TRUE
 
+/obj/item/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	// Do not pickup items on a right click action
+	if (. == SECONDARY_ATTACK_CALL_NORMAL)
+		. = SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/item/proc/allow_attack_hand_drop(mob/user)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If right click performs no action, it defaults to calling the standard left click action. For most things, this is fine, but since items have various different right click interactions it can cause a lot of inconsistent behaviours:
- Right click on backpacks will open their inventory
- Right click on a floor tile will give you a prompt to select how many you want
- Right click on other items will pick it up

## Why It's Good For The Game

If you are right clicking, then you probably want to either experiment with right click, or you are trying to right click something else. You wouldn't actually want to pick up an item on right click.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/cefb3365-77a2-491e-9743-544e5b7d8b1f)

Tested on these random 5 items laying around on the testing map. Right click still works on backpacks, but won't pickup those other items.

## Changelog
:cl:
tweak: Right click no longer picks up items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
