### PR TITLE
Fixes right click actions not working on items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -569,7 +569,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	. = ..()
 	// Do not pickup items on a right click action
 	if (. == SECONDARY_ATTACK_CALL_NORMAL)
-		. = SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		. = SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/proc/allow_attack_hand_drop(mob/user)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The wrong return value was being used, which was cancelling item attack chains in the parent calls. The correct method continues but then cancels when it reaches the left click action.

## Why It's Good For The Game

Bug fix.

## Testing Photographs and Procedure

Affects the following items:
- Jumpsuits
- Stacks
- Pipes

Here is testing of those:

![image](https://github.com/user-attachments/assets/32c4b733-462a-4cef-9455-2422faf5cd47)

![image](https://github.com/user-attachments/assets/cf444a56-2ec6-4334-aa06-3f02371f9349)

![image](https://github.com/user-attachments/assets/48b1b9af-41da-42a3-abde-7715a35532a1)


Testing of item pickup:

![image](https://github.com/user-attachments/assets/f95aa043-1db1-42f2-a696-55fc6aa90b8b)


## Changelog
:cl:
fix: Fixes right click item interactions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
