### PR TITLE
Fixes ctrl-click not ending pulls while in combat mode

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -399,7 +399,11 @@
 
 	if(istype(AM) && Adjacent(AM))
 		start_pulling(AM)
-	else if(!combat_mode) //Don;'t cancel pulls if misclicking in combat mode.
+	else
+		// If we click on a turf adjacent to a target while we have them in an aggro-grab
+		// then we won't cancel the grab
+		if (ismob(pulling) && grab_state >= GRAB_AGGRESSIVE && isturf(AM) && Adjacent(AM, pulling))
+			return
 		stop_pulling()
 
 /mob/living/stop_pulling()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -402,7 +402,7 @@
 	else
 		// If we click on a turf adjacent to a target while we have them in an aggro-grab
 		// then we won't cancel the grab
-		if (ismob(pulling) && grab_state >= GRAB_AGGRESSIVE && isturf(AM) && Adjacent(AM, pulling))
+		if (ismob(pulling) && grab_state >= GRAB_AGGRESSIVE && isturf(AM) && get_dist(AM, pulling) <= 1)
 			return
 		stop_pulling()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #12303

Previously, enabling combat mode prevented the use of ctrl-click anywhere on the screen to stop pulling an atom. This changes the conditions required to ignore the ctrl-click to the following intersected conditions:
- The pulling thing must be a mode
- The grab state must be an aggro grab or higher
- The clicked atom must be a turf, and not an object
- The clicked turf must be adjacent to the mob that you are pulling

## Why It's Good For The Game

Having inconsistent behaviour between combat mode and non-combat mode can be annoying, however we still might want to have some slight limits on when you can stop pulling to prevent accidentally unpulling during combat.

## Testing Photographs and Procedure


https://github.com/user-attachments/assets/b28604ad-9895-435a-b1a1-fe8418aff81d



## Changelog
:cl:
fix: Fixes an issue where ctrl-click wouldn't stop pulling items while in combat mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
