### PR TITLE
Readability changes to chat

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -108,11 +108,11 @@ h1.alert, h2.alert		{color: #000000;}
 .green					{color: #03ff39;}
 .nicegreen					{color: #14a833;}
 .shadowling				{color: #3b2769;}
-.cult					{color: #960000;}
-.cultlarge				{color: #960000; font-weight: bold; font-size: 3;}
-.narsie					{color: #960000; font-weight: bold; font-size: 15;}
-.narsiesmall			{color: #960000; font-weight: bold; font-size: 6;}
-.narsiesmaller			{color: #960000; font-weight: bold; font-size: 3;}
+.cult					{color: #973e3b;}
+.cultlarge				{color: #973e3b; font-weight: bold; font-size: 3;}
+.narsie					{color: #973e3b; font-weight: bold; font-size: 15;}
+.narsiesmall			{color: #973e3b; font-weight: bold; font-size: 6;}
+.narsiesmaller			{color: #973e3b; font-weight: bold; font-size: 3;}
 .colossus				{color: #7F282A; font-size: 5;}
 .hierophant				{color: #660099; font-weight: bold; font-style: italic;}
 .hierophant_warning		{color: #660099; font-style: italic;}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -505,7 +505,7 @@ em {
   color: #b88646;
 }
 .servradio {
-  color: #4e7a1f;
+  color: #6ca729;
 }
 .syndradio {
   color: #8f4a4b;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -424,10 +424,10 @@ em {
 }
 
 .adminsay {
-  color: #b6c653;
+  color: #ff4500;
 }
 .admin {
-  color: #243fa3;
+  color: #5975da;
   font-weight: bold;
 }
 
@@ -466,12 +466,10 @@ em {
 }
 
 .deadsay {
-  color: #b866ff;
+  color: #e2c1ff;
 }
 .binarysay {
-  color: #20c20e;
-  background-color: #000000;
-  display: block;
+  color: #1e90ff;
 }
 .binarysay a {
   color: #00ff00;
@@ -490,7 +488,7 @@ em {
   color: #7ed4c2;
 }
 .comradio {
-  color: #5177ff;
+  color: #fcdf03;
 }
 .secradio {
   color: #dd3535;
@@ -658,41 +656,41 @@ em {
   color: #8e8a99;
 }
 .cult {
-  color: #aa1c1c;
+  color: #973e3b;
 }
 
 .cultitalic {
-  color: #aa1c1c;
+  color: #973e3b;
   font-style: italic;
 }
 .cultbold {
-  color: #aa1c1c;
+  color: #973e3b;
   font-style: italic;
   font-weight: bold;
 }
 .cultboldtalic {
-  color: #aa1c1c;
+  color: #973e3b;
   font-weight: bold;
   font-size: 24px;
 }
 
 .cultlarge {
-  color: #aa1c1c;
+  color: #973e3b;
   font-weight: bold;
   font-size: 24px;
 }
 .narsie {
-  color: #aa1c1c;
+  color: #973e3b;
   font-weight: bold;
   font-size: 120px;
 }
 .narsiesmall {
-  color: #aa1c1c;
+  color: #973e3b;
   font-weight: bold;
   font-size: 48px;
 }
 .narsiesmaller {
-  color: #aa1c1c;
+  color: #973e3b;
   font-weight: bold;
   font-size: 24px;
 }
@@ -1342,7 +1340,7 @@ em {
   color: #855d85;
 }
 .cultmobsay {
-  color: #aa1c1c;
+  color: #973e3b;
 }
 .slimemobsay {
   color: #00ced1;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -469,7 +469,9 @@ em {
   color: #e2c1ff;
 }
 .binarysay {
-  color: #1e90ff;
+  color: #20c20e;
+  background-color: #000000;
+  display: block;
 }
 .binarysay a {
   color: #00ff00;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -658,41 +658,41 @@ h2.alert {
   color: #3b2769;
 }
 .cult {
-  color: #960000;
+  color: #973e3b;
 }
 
 .cultitalic {
-  color: #960000;
+  color: #973e3b;
   font-style: italic;
 }
 .cultbold {
-  color: #960000;
+  color: #973e3b;
   font-style: italic;
   font-weight: bold;
 }
 .cultboldtalic {
-  color: #960000;
+  color: #973e3b;
   font-weight: bold;
   font-size: 24px;
 }
 
 .cultlarge {
-  color: #960000;
+  color: #973e3b;
   font-weight: bold;
   font-size: 24px;
 }
 .narsie {
-  color: #960000;
+  color: #973e3b;
   font-weight: bold;
   font-size: 120px;
 }
 .narsiesmall {
-  color: #960000;
+  color: #973e3b;
   font-weight: bold;
   font-size: 48px;
 }
 .narsiesmaller {
-  color: #960000;
+  color: #973e3b;
   font-weight: bold;
   font-size: 24px;
 }
@@ -1347,7 +1347,7 @@ h2.alert {
   color: #543354;
 }
 .cultmobsay {
-  color: #960000;
+  color: #973e3b;
 }
 .slimemobsay {
   color: #00ced1;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Changes the following chat colors, allowing for better readability:

* Cult related colors are more distinct on both themes.
* Command for the dark chat theme is gold colored similarly to it's light version.
* Admin and adminsay are more readable on the dark theme.
* Deadsay is pink and easier on the eyes on the dark theme.
* Service's radio comms is much lighter on the dark theme.

I initially had binary chat changes done in which it's background was removed and the color changed to light blue, but on second thought I figured the ones we already have isn't that bad thanks to the font changes. You may want to check the first linked pr below if you want to see TG's take on it.

TG port.
https://github.com/tgstation/tgstation/pull/48613
https://github.com/tgstation/tgstation/pull/53043

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Half of the game is the chat, so let's make it a bit better to read.

* Cult: Cult chat was a bit too red which made it a bit hard to distinguish from warnings sometimes, which can make it easier to ignore compared to normal.
* Command: Consistency with the lighter theme and that the shade of blue didn't really blend well with the dark background if at all, lightening it up would only make it harder to distinguish from medical's. There may be objections to the shift towards gold but it may be a good reminder that command chatter tends to be important and probably shouldn't be hard to miss.
* Admins: This is horrible.
![image](https://github.com/user-attachments/assets/25e9d245-da97-4c50-a539-f0cf11da103e)
* Deadchat: Easier on the eyes for dark theme users.
* Service: Service was just horrid to read in dark theme.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_BbDWqgpX57](https://github.com/user-attachments/assets/c643e1e5-9d96-438f-9cf3-f65b33b8b8d0)

![dreamseeker_7nnGEAAjHY](https://github.com/user-attachments/assets/c263fbfe-9174-4446-8ba8-b2ade357e12f)

![dreamseeker_6LJVtBtkq1](https://github.com/user-attachments/assets/d00ac7dc-0f01-4bc3-9cef-34c805db5b5b)

![image](https://github.com/user-attachments/assets/0f84eb8d-a767-4a97-a4f9-37bfcc28cec2)

Very unlikely to happen but not impossible, still easy to distinguish.

![image](https://github.com/user-attachments/assets/4378dd19-cd3d-4819-93f9-5b052f620d7a)


</details>

## Changelog
:cl: TheSmallBlue, MarioWizard119, stylemistake ported by Hardly
tweak: Makes cult chat look more distinct from warnings
tweak: Makes dark chat theme's command chat gold to keep it consistent with the light theme's
tweak: Deadsay is now pink on the dark chat theme
admin: Better colors for some of admin logs and says
tweak: Service is easier on the eyes for the dark chat theme.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
