### PR TITLE
Whiteship revamps: NT Personal Trader & Syndicate Probe

### DIFF
--- a/_maps/shuttles/whiteship/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship/whiteship_box.dmm
@@ -262,9 +262,9 @@
 /area/shuttle/abandoned/engine)
 "aV" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/light/small/built,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "aW" = (
@@ -509,11 +509,11 @@
 /obj/structure/closet/firecloset{
 	anchored = 1
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -1477,7 +1477,6 @@
 /obj/machinery/light/small/built{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -1491,6 +1490,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bridge)
 "dw" = (
@@ -1875,11 +1875,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/bin,
 /obj/item/trash/pistachios,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/item/trash/can,
 /obj/item/light/bulb/broken,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/crew)
 "Tm" = (

--- a/_maps/shuttles/whiteship/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship/whiteship_cere.dmm
@@ -220,6 +220,7 @@
 	},
 /obj/effect/mapping_helpers/crate_shelf_loader,
 /obj/structure/closet/crate,
+/obj/structure/closet/crate/medical,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "aB" = (
@@ -369,6 +370,9 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Probe Access"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/pod,
 /area/shuttle/abandoned)
 "aP" = (
@@ -403,10 +407,6 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
-	},
-/obj/effect/decal/cleanable/ash{
-	pixel_y = -13;
-	pixel_x = 18
 	},
 /obj/item/ammo_casing/c10mm{
 	dir = 9;
@@ -492,9 +492,7 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "bubblegumfoot"
-	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
 "ba" = (
@@ -600,6 +598,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
 	dir = 5
 	},
+/obj/item/storage/pod{
+	pixel_x = 5;
+	pixel_y = -28
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "jS" = (
@@ -616,6 +618,7 @@
 	},
 /obj/effect/turf_decal/stripes/closeup,
 /obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/pod,
 /area/shuttle/abandoned)
 "lt" = (
@@ -686,10 +689,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "vt" = (
-/obj/item/storage/pod{
-	pixel_x = 5;
-	pixel_y = -28
-	},
+/obj/structure/closet/syndicate/personal,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "xb" = (
@@ -703,7 +703,7 @@
 	name = "tactical chair"
 	},
 /obj/effect/turf_decal/trimline/dark_red,
-/obj/effect/mob_spawn/human/corpse/syndicatecommando,
+/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
 /turf/open/floor/iron/ridged/steel{
 	color = "#808080"
 	},
@@ -742,7 +742,7 @@
 "zU" = (
 /obj/structure/table/reinforced,
 /obj/item/screwdriver/nuke{
-	pixel_y = -11;
+	pixel_y = -17;
 	pixel_x = 2
 	},
 /obj/item/clothing/suit/armor/reactive/table{
@@ -755,7 +755,7 @@
 	default_raw_text = "These screws are so damn locked up that at this rate my plastitanium screwdriver is going to break before I figure out how this vest ticks. Damn you and your cheap rust prone designs Nanotrasen! Fuck!"
 	},
 /obj/item/stack/cable_coil/cut/red{
-	pixel_y = 13;
+	pixel_y = 18;
 	pixel_x = -2
 	},
 /obj/machinery/light{
@@ -813,6 +813,9 @@
 /obj/machinery/door/airlock/external{
 	name = "Probe Port Airlock"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/pod,
 /area/shuttle/abandoned)
 "Nd" = (
@@ -831,6 +834,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Probe Access"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/pod,
 /area/shuttle/abandoned)
 "QF" = (
@@ -857,10 +861,10 @@
 	pixel_x = -24
 	},
 /obj/structure/crate_shelf,
-/obj/effect/mapping_helpers/crate_shelf_loader,
 /obj/effect/turf_decal/siding/dark/end,
 /obj/structure/closet/crate,
-/obj/structure/closet/crate,
+/obj/effect/mapping_helpers/crate_shelf_loader,
+/obj/structure/closet/crate/science,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "VX" = (
@@ -906,7 +910,7 @@ ad
 aj
 ab
 aF
-aF
+aN
 aN
 aa
 aa
@@ -1102,7 +1106,7 @@ ad
 aj
 ab
 aN
-aN
+ab
 Hm
 ay
 aN

--- a/_maps/shuttles/whiteship/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship/whiteship_cere.dmm
@@ -207,7 +207,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/crate_shelf_loader,
-/obj/structure/closet/crate,
+/obj/effect/mapping_helpers/crate_shelf_loader,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "aA" = (
@@ -592,9 +592,7 @@
 	},
 /obj/structure/crate_shelf,
 /obj/effect/turf_decal/siding/dark/end,
-/obj/structure/closet/crate,
 /obj/effect/mapping_helpers/crate_shelf_loader,
-/obj/structure/closet/crate/science,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "lt" = (
@@ -842,8 +840,8 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/crate_shelf_loader,
-/obj/structure/closet/crate,
-/obj/structure/closet/crate/medical,
+/obj/effect/mapping_helpers/crate_shelf_loader,
+/obj/effect/mapping_helpers/crate_shelf_loader,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "VX" = (

--- a/_maps/shuttles/whiteship/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship/whiteship_cere.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/shuttle/abandoned)
 "ad" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -12,33 +12,50 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "ae" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned)
-"af" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
+/obj/effect/turf_decal/edges/techfloor{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/yellow,
+/obj/effect/turf_decal/edges/techfloor,
+/turf/open/floor/iron/tech/grid,
+/area/shuttle/abandoned)
+"af" = (
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 6
+	},
+/obj/machinery/computer/camera_advanced/syndie{
+	dir = 1
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "ag" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/syndicate{
+	pixel_y = 10
+	},
+/obj/item/weldingtool/mini{
+	pixel_y = -1;
+	pixel_x = -3
+	},
+/obj/item/multitool{
+	pixel_x = 9;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/abandoned)
 "ah" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/edges/techfloor,
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/turf/open/floor/iron/tech/grid,
 /area/shuttle/abandoned)
 "ai" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/iron/stairs{
+	dir = 4
+	},
 /area/shuttle/abandoned)
 "aj" = (
 /obj/structure/shuttle/engine/heater{
@@ -48,355 +65,544 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "ak" = (
-/obj/structure/mecha_wreckage/ripley,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mech_bay_recharge_floor,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/shuttle/abandoned)
 "al" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "am" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "trails_2"
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "an" = (
-/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
-/turf/open/floor/mech_bay_recharge_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "ao" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 4
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/catwalk_floor,
 /area/shuttle/abandoned)
 "ap" = (
 /obj/machinery/computer/mech_bay_power_console{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/abandoned)
 "aq" = (
-/obj/machinery/door/airlock/titanium{
-	name = "mech Bay"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
 	},
-/turf/open/floor/mineral/titanium/yellow,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 15;
+	pixel_y = -6
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "ar" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "trails_1"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "as" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 6
 	},
-/obj/structure/closet/crate{
-	name = "spare equipment crate"
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/obj/item/pen{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/folder/syndicate/red{
+	pixel_y = 8;
+	pixel_x = 8
+	},
+/obj/item/stamp/syndicate{
+	pixel_x = 8
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "at" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/shuttle/abandoned)
 "au" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
 "av" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate{
-	name = "spare equipment crate";
-	opened = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "aw" = (
-/obj/effect/turf_decal/delivery{
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"ax" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"ay" = (
+/obj/structure/table/reinforced,
+/obj/item/taperecorder{
+	pixel_y = 6;
+	pixel_x = 7
+	},
+/obj/item/blackbox{
+	pixel_y = 2;
+	pixel_x = -9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"az" = (
+/obj/effect/turf_decal/bot_red/left,
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/siding/dark/end{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/crate_shelf_loader,
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"aA" = (
+/obj/structure/crate_shelf,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/crate_shelf_loader,
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"aB" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned)
+"aC" = (
+/obj/structure/filingcabinet,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"aD" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned)
-"ax" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/structure/closet/crate{
-	name = "spare equipment crate";
-	opened = 1
-	},
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/storage/toolbox/emergency/old,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned)
-"ay" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"az" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "cerewhiteleft";
-	name = "Cargo Blast Door Toggle";
-	pixel_x = -24
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned)
-"aA" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned)
-"aB" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/structure/closet/crate{
-	name = "spare equipment crate";
-	opened = 1
-	},
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned)
-"aC" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/abandoned)
-"aD" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
-	},
-/obj/structure/closet/crate{
-	name = "spare equipment crate"
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "aE" = (
-/obj/effect/turf_decal/delivery{
+/obj/structure/filingcabinet/medical{
+	pixel_x = -8
+	},
+/obj/structure/filingcabinet/security{
+	pixel_x = 8
+	},
+/obj/effect/turf_decal/siding/dark/end{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "cerewhiteright";
-	name = "Cargo Blast Door Toggle";
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "aF" = (
 /obj/machinery/door/poddoor{
 	id = "cerewhiteleft"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
 "aG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
 "aH" = (
-/obj/machinery/door/poddoor{
-	id = "cerewhiteright"
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 6
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/machinery/vending/toyliberationstation,
+/obj/item/toy/plush/nukeplushie{
+	pixel_y = 20;
+	pixel_x = 11
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
 "aI" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/structure/closet/crate{
-	name = "spare equipment crate"
-	},
-/obj/item/storage/toolbox/mechanical/old,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "aJ" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate{
-	name = "spare equipment crate";
-	opened = 1
+/obj/machinery/computer/monitor/secret{
+	dir = 8
 	},
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium/yellow,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "aK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "trails_1"
+	},
+/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
 "aL" = (
-/obj/effect/turf_decal/delivery{
-	dir = 1
+/obj/structure/fluff/hedge,
+/obj/structure/railing{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium/yellow,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "aM" = (
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/yellow,
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/item/wrench,
+/turf/open/floor/catwalk_floor,
 /area/shuttle/abandoned)
 "aN" = (
-/obj/machinery/door/airlock/titanium{
-	name = "cockpit"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/turf/closed/wall/r_wall/syndicate,
 /area/shuttle/abandoned)
 "aO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/tank_dispenser/oxygen{
-	pixel_x = -1;
-	pixel_y = 2
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/machinery/door/airlock/hatch{
+	name = "Probe Access"
 	},
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/pod,
 /area/shuttle/abandoned)
 "aP" = (
-/obj/structure/table,
-/obj/item/gps{
-	gpstag = "NTCONST1";
-	pixel_x = -1;
-	pixel_y = 2
+/obj/machinery/light/small/directional/north{
+	bulb_colour = "#A10606"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/turf_decal/bot_red/left,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/iron/ridged/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "aQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/hatch{
+	name = "Probe Cockpit"
+	},
+/turf/open/floor/pod,
 /area/shuttle/abandoned)
 "aR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_y = -13;
+	pixel_x = 18
+	},
+/obj/item/ammo_casing/c10mm{
+	dir = 9;
+	pixel_y = 11
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = 13;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "aS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "aT" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/storage/firstaid/regular,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 1
+	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "aU" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "aV" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	name = "tactical swivel chair";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "aW" = (
-/obj/structure/chair/fancy/shuttle,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned)
-"aX" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned)
-"aZ" = (
-/obj/structure/table,
-/obj/item/phone{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/abandoned)
-"ba" = (
-/obj/machinery/computer/shuttle_flight/white_ship{
+/obj/effect/turf_decal/edges/techfloor,
+/obj/effect/turf_decal/edges/techfloor{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/iron/tech/grid,
+/area/shuttle/abandoned)
+"aX" = (
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbl1"
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"aZ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned)
+"ba" = (
+/obj/structure/mecha_wreckage/gygax,
+/turf/open/floor/mech_bay_recharge_floor{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "bb" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -1;
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/titanium/blue,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/cigbutt{
+	pixel_x = 9;
+	pixel_y = 16
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "bV" = (
-/obj/machinery/door/airlock/titanium{
-	name = "mech Bay External Airlock"
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/shuttle/abandoned)
+"db" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"fP" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/syndicate/ranged/shotgun/space/stormtrooper,
+/obj/item/ammo_casing/shotgun/buckshot{
+	pixel_x = -19;
+	pixel_y = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/shuttle/abandoned)
+"hb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden{
+	dir = 4
+	},
+/obj/item/ammo_casing/shotgun/buckshot{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing/shotgun/buckshot{
+	pixel_x = 9;
+	pixel_y = -14
+	},
+/turf/open/floor/catwalk_floor,
+/area/shuttle/abandoned)
+"iM" = (
+/obj/structure/crate_shelf,
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark/end,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"iQ" = (
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	syndicate_network = 1;
+	allow_exotic_faxes = 1;
+	name = "Donk Co. Fax Machine"
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"jd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"jS" = (
 /obj/docking_port/mobile{
 	dir = 2;
 	dwidth = 8;
@@ -408,7 +614,286 @@
 	port_direction = 8;
 	width = 13
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/pod,
+/area/shuttle/abandoned)
+"lt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/abandoned)
+"me" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"rF" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/obj/item/multitool{
+	pixel_x = 7
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"sb" = (
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 1
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"sX" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/syndicate/directional/south,
+/turf/open/floor/iron/ridged/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"te" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/chair/foldable{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/shuttle/abandoned)
+"uh" = (
+/obj/structure/filingcabinet,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 2
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"vt" = (
+/obj/item/storage/pod{
+	pixel_x = 5;
+	pixel_y = -28
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"xb" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/abandoned)
+"xV" = (
+/obj/structure/chair/fancy/shuttle{
+	name = "tactical chair"
+	},
+/obj/effect/turf_decal/trimline/dark_red,
+/obj/effect/mob_spawn/human/corpse/syndicatecommando,
+/turf/open/floor/iron/ridged/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"xZ" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"zt" = (
+/obj/structure/filingcabinet{
+	pixel_x = 8
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 2
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"zL" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/robot_debris/down,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"zU" = (
+/obj/structure/table/reinforced,
+/obj/item/screwdriver/nuke{
+	pixel_y = -11;
+	pixel_x = 2
+	},
+/obj/item/clothing/suit/armor/reactive/table{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/paper/crumpled{
+	pixel_x = 9;
+	pixel_y = 6;
+	default_raw_text = "These screws are so damn locked up that at this rate my plastitanium screwdriver is going to break before I figure out how this vest ticks. Damn you and your cheap rust prone designs Nanotrasen! Fuck!"
+	},
+/obj/item/stack/cable_coil/cut/red{
+	pixel_y = 13;
+	pixel_x = -2
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/abandoned)
+"Ao" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "trails_2"
+	},
+/obj/item/ammo_casing/shotgun/buckshot{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned)
+"DA" = (
+/obj/effect/turf_decal/edges/techfloor/corners,
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"Hm" = (
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/edges/techfloor,
+/obj/structure/chair/office{
+	name = "tactical swivel chair"
+	},
+/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
+/turf/open/floor/iron/tech/grid,
+/area/shuttle/abandoned)
+"Ld" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/shuttle/abandoned)
+"Ly" = (
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Probe Port Airlock"
+	},
+/turf/open/floor/pod,
+/area/shuttle/abandoned)
+"Nd" = (
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/robot_debris/up,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"Ou" = (
+/obj/effect/turf_decal/stripes/closeup,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/machinery/door/airlock/hatch{
+	name = "Probe Access"
+	},
+/turf/open/floor/pod,
+/area/shuttle/abandoned)
+"QF" = (
+/obj/effect/turf_decal/edges/techfloor,
+/obj/machinery/computer/shuttle_flight/white_ship{
+	dir = 1
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"SI" = (
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
+	},
+/turf/open/floor/iron/ridged/steel{
+	color = "#808080"
+	},
+/area/shuttle/abandoned)
+"Vi" = (
+/obj/machinery/button/door{
+	id = "cerewhiteleft";
+	name = "Cargo Blast Door Toggle";
+	pixel_x = -24
+	},
+/obj/structure/crate_shelf,
+/obj/effect/mapping_helpers/crate_shelf_loader,
+/obj/effect/turf_decal/siding/dark/end,
+/obj/structure/closet/crate,
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/abandoned)
+"VX" = (
+/turf/open/floor/iron/stairs{
+	dir = 8
+	},
+/area/shuttle/abandoned)
+"Wj" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "splatter1"
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned)
+"YW" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/hidden,
+/turf/open/floor/iron/dark,
+/area/shuttle/abandoned)
+"ZC" = (
+/obj/effect/turf_decal/edges/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/edges/techfloor,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/turf/open/floor/iron/tech/grid,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
@@ -416,13 +901,13 @@ aa
 aa
 aa
 aa
+aa
 ad
 aj
-ay
+ab
 aF
 aF
-ay
-aa
+aN
 aa
 aa
 aa
@@ -431,199 +916,199 @@ aa
 "}
 (2,1,1) = {"
 aa
+aa
+aa
 ad
 aj
 ab
+aN
 ab
+aW
+vt
 ab
-ay
-ah
-ah
-ay
-ab
-ab
-ab
+aN
+aa
 aa
 aa
 aa
 "}
 (3,1,1) = {"
-ab
-ab
-ab
-ab
-ab
-ab
-az
-aG
-aG
-aI
-aM
-ab
-ab
-ab
-ab
 aa
-"}
-(4,1,1) = {"
-ab
-ae
-ak
-ao
-ab
-as
-aA
-am
-ah
-aA
-ab
-ab
-ab
-aV
-ab
-aa
-"}
-(5,1,1) = {"
-ab
-af
-ag
-ag
-ab
-at
-aA
-am
-aG
-aJ
-ab
-aP
-aU
-aS
-ab
-ab
-"}
-(6,1,1) = {"
-ab
-ag
-al
-al
-aq
-au
-aB
-am
-aG
-aK
-aN
-aQ
-aR
-aQ
-aZ
-ar
-"}
-(7,1,1) = {"
-bV
-ah
-am
-am
-ar
-ah
-ah
-am
-aG
-aG
-ar
-aR
-aQ
-aW
-ba
-ar
-"}
-(8,1,1) = {"
-ab
-ag
-ag
-ag
-aq
-av
-au
-aG
-aG
-aG
-aN
-aS
-aS
-aR
-bb
-ar
-"}
-(9,1,1) = {"
-ab
-af
-ag
-ag
-ab
-aw
-aC
-am
-am
-aL
-ab
-aT
-aU
-aR
-ab
-ab
-"}
-(10,1,1) = {"
-ab
-ai
-an
-ap
-ab
-ax
-aD
-am
-am
-av
-ab
-ab
-ab
-aX
-ab
-aa
-"}
-(11,1,1) = {"
-ab
-ab
-ab
-ab
-ab
-ab
-aE
-am
-aG
-au
-aO
-ab
-ab
-ab
-ab
-aa
-"}
-(12,1,1) = {"
 aa
 ad
 aj
 ab
-ab
-ab
-ay
-aG
-ah
-ay
-ab
-ab
-ab
+aN
+az
+Vi
+aW
+aI
+aM
+aN
 aa
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+aa
+aN
+aN
+aN
+aN
+aN
+xZ
+ax
+ah
+jd
+ab
+ab
+Ly
+aN
+aN
+aa
+"}
+(5,1,1) = {"
+aa
+aN
+xb
+ba
+ap
+aN
+aA
+iM
+ai
+aJ
+aN
+aP
+ao
+SI
+aN
+aa
+"}
+(6,1,1) = {"
+Ld
+aN
+al
+Nd
+aq
+av
+aB
+Ao
+aZ
+aK
+Ou
+hb
+fP
+sX
+aN
+aa
+"}
+(7,1,1) = {"
+bV
+jS
+an
+am
+ar
+aO
+Wj
+at
+ak
+YW
+ab
+aN
+aQ
+aN
+aN
+aN
+"}
+(8,1,1) = {"
+te
+aN
+zL
+aV
+me
+av
+au
+aG
+aG
+aH
+aN
+aw
+aS
+aR
+bb
+av
+"}
+(9,1,1) = {"
+aa
+aN
+ag
+zU
+lt
+aN
+aC
+uh
+VX
+aL
+aN
+aT
+aU
+xV
+QF
+av
+"}
+(10,1,1) = {"
+aa
+aN
+aN
+aN
+aN
+aN
+aD
+an
+ZC
+db
+aN
+sb
+DA
+aX
+af
+av
+"}
+(11,1,1) = {"
+aa
+aa
+ad
+aj
+ab
+aN
+aE
+zt
+ae
+rF
+aN
+iQ
+as
+ab
+av
+aN
+"}
+(12,1,1) = {"
+aa
+aa
+aa
+ad
+aj
+ab
+aN
+aN
+Hm
+ay
+aN
+aN
+aN
+aN
 aa
 aa
 "}
@@ -632,13 +1117,13 @@ aa
 aa
 aa
 aa
+aa
 ad
 aj
-ay
-aH
-aH
-ay
-aa
+ab
+av
+av
+aN
 aa
 aa
 aa

--- a/_maps/shuttles/whiteship/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship/whiteship_cere.dmm
@@ -211,17 +211,17 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "aA" = (
-/obj/structure/crate_shelf,
-/obj/structure/railing{
+/obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/dark/end{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/crate_shelf_loader,
-/obj/structure/closet/crate,
-/obj/structure/closet/crate/medical,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark,
 /area/shuttle/abandoned)
 "aB" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -365,15 +365,14 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/abandoned)
 "aO" = (
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
-/obj/machinery/door/airlock/hatch{
-	name = "Probe Access"
+/obj/structure/chair/fancy/shuttle{
+	name = "tactical chair"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/turf_decal/trimline/dark_red,
+/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
+/turf/open/floor/iron/ridged/steel{
+	color = "#808080"
 	},
-/turf/open/floor/pod,
 /area/shuttle/abandoned)
 "aP" = (
 /obj/machinery/light/small/directional/north{
@@ -400,25 +399,6 @@
 	name = "Probe Cockpit"
 	},
 /turf/open/floor/pod,
-/area/shuttle/abandoned)
-"aR" = (
-/obj/effect/turf_decal/edges/techfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 4
-	},
-/obj/item/ammo_casing/c10mm{
-	dir = 9;
-	pixel_y = 11
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_x = 13;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/grid/steel{
-	color = "#808080"
-	},
 /area/shuttle/abandoned)
 "aS" = (
 /obj/effect/turf_decal/edges/techfloor{
@@ -483,17 +463,17 @@
 	},
 /area/shuttle/abandoned)
 "aZ" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 8
+/obj/item/storage/pod{
+	pixel_x = 5;
+	pixel_y = -28
 	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "ba" = (
 /obj/structure/mecha_wreckage/gygax,
@@ -529,8 +509,21 @@
 	},
 /area/shuttle/abandoned)
 "bV" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/docking_port/mobile{
+	dir = 2;
+	dwidth = 8;
+	dynamic_id = 1;
+	height = 16;
+	id = "whiteship";
+	launch_status = 0;
+	name = "NT Recovery White-Ship";
+	port_direction = 8;
+	width = 13
+	},
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/pod,
 /area/shuttle/abandoned)
 "db" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
@@ -592,34 +585,17 @@
 	},
 /area/shuttle/abandoned)
 "jd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/button/door{
+	id = "cerewhiteleft";
+	name = "Cargo Blast Door Toggle";
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden{
-	dir = 5
-	},
-/obj/item/storage/pod{
-	pixel_x = 5;
-	pixel_y = -28
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/abandoned)
-"jS" = (
-/obj/docking_port/mobile{
-	dir = 2;
-	dwidth = 8;
-	dynamic_id = 1;
-	height = 16;
-	id = "whiteship";
-	launch_status = 0;
-	name = "NT Recovery White-Ship";
-	port_direction = 8;
-	width = 13
-	},
-/obj/effect/turf_decal/stripes/closeup,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/pod,
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/siding/dark/end,
+/obj/structure/closet/crate,
+/obj/effect/mapping_helpers/crate_shelf_loader,
+/obj/structure/closet/crate/science,
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "lt" = (
 /obj/structure/table/reinforced,
@@ -669,14 +645,23 @@
 	},
 /area/shuttle/abandoned)
 "te" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/chair/foldable{
+/obj/effect/turf_decal/edges/techfloor{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 5
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
 	},
-/turf/open/space/basic,
+/obj/item/ammo_casing/c10mm{
+	dir = 9;
+	pixel_y = 11
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = 13;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/grid/steel{
+	color = "#808080"
+	},
 /area/shuttle/abandoned)
 "uh" = (
 /obj/structure/filingcabinet,
@@ -689,8 +674,28 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "vt" = (
-/obj/structure/closet/syndicate/personal,
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/table/reinforced,
+/obj/item/screwdriver/nuke{
+	pixel_y = -17;
+	pixel_x = 2
+	},
+/obj/item/clothing/suit/armor/reactive/table{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/paper/crumpled{
+	pixel_x = 9;
+	pixel_y = 6;
+	default_raw_text = "These screws are so damn locked up that at this rate my plastitanium screwdriver is going to break before I figure out how this vest ticks. Damn you and your cheap rust prone designs Nanotrasen! Fuck!"
+	},
+/obj/item/stack/cable_coil/cut/red{
+	pixel_y = 18;
+	pixel_x = -2
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/abandoned)
 "xb" = (
 /obj/machinery/mech_bay_recharge_port{
@@ -699,14 +704,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/abandoned)
 "xV" = (
-/obj/structure/chair/fancy/shuttle{
-	name = "tactical chair"
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/hidden,
+/obj/machinery/door/airlock/hatch{
+	name = "Probe Access"
 	},
-/obj/effect/turf_decal/trimline/dark_red,
-/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-/turf/open/floor/iron/ridged/steel{
-	color = "#808080"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
+/turf/open/floor/pod,
 /area/shuttle/abandoned)
 "xZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -740,28 +746,16 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "zU" = (
-/obj/structure/table/reinforced,
-/obj/item/screwdriver/nuke{
-	pixel_y = -17;
-	pixel_x = 2
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
 	},
-/obj/item/clothing/suit/armor/reactive/table{
-	pixel_x = -4;
-	pixel_y = 1
+/obj/machinery/door/airlock/external{
+	name = "Probe Port Airlock"
 	},
-/obj/item/paper/crumpled{
-	pixel_x = 9;
-	pixel_y = 6;
-	default_raw_text = "These screws are so damn locked up that at this rate my plastitanium screwdriver is going to break before I figure out how this vest ticks. Damn you and your cheap rust prone designs Nanotrasen! Fuck!"
-	},
-/obj/item/stack/cable_coil/cut/red{
-	pixel_y = 18;
-	pixel_x = -2
-	},
-/obj/machinery/light{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/pod,
 /area/shuttle/abandoned)
 "Ao" = (
 /obj/effect/turf_decal/siding/dark{
@@ -800,32 +794,6 @@
 /turf/open/floor/iron/tech/grid,
 /area/shuttle/abandoned)
 "Ld" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/shuttle/abandoned)
-"Ly" = (
-/obj/effect/turf_decal/stripes/closeup{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Probe Port Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/pod,
-/area/shuttle/abandoned)
-"Nd" = (
-/obj/effect/turf_decal/siding/dark/end{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/abandoned)
-"Ou" = (
 /obj/effect/turf_decal/stripes/closeup,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -836,6 +804,17 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/pod,
+/area/shuttle/abandoned)
+"Ly" = (
+/obj/structure/closet/syndicate/personal,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/abandoned)
+"Nd" = (
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/robot_debris/up,
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "QF" = (
 /obj/effect/turf_decal/edges/techfloor,
@@ -855,16 +834,16 @@
 	},
 /area/shuttle/abandoned)
 "Vi" = (
-/obj/machinery/button/door{
-	id = "cerewhiteleft";
-	name = "Cargo Blast Door Toggle";
-	pixel_x = -24
-	},
 /obj/structure/crate_shelf,
-/obj/effect/turf_decal/siding/dark/end,
-/obj/structure/closet/crate,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/end{
+	dir = 1
+	},
 /obj/effect/mapping_helpers/crate_shelf_loader,
-/obj/structure/closet/crate/science,
+/obj/structure/closet/crate,
+/obj/structure/closet/crate/medical,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/abandoned)
 "VX" = (
@@ -905,7 +884,6 @@ aa
 aa
 aa
 aa
-aa
 ad
 aj
 ab
@@ -917,9 +895,9 @@ aa
 aa
 aa
 aa
+aa
 "}
 (2,1,1) = {"
-aa
 aa
 aa
 ad
@@ -928,9 +906,10 @@ ab
 aN
 ab
 aW
-vt
+Ly
 ab
 aN
+aa
 aa
 aa
 aa
@@ -938,13 +917,12 @@ aa
 "}
 (3,1,1) = {"
 aa
-aa
 ad
 aj
 ab
 aN
 az
-Vi
+jd
 aW
 aI
 aM
@@ -953,9 +931,9 @@ aa
 aa
 aa
 aa
+aa
 "}
 (4,1,1) = {"
-aa
 aN
 aN
 aN
@@ -964,22 +942,22 @@ aN
 xZ
 ax
 ah
-jd
+aZ
 ab
 ab
-Ly
+zU
 aN
 aN
+aa
 aa
 "}
 (5,1,1) = {"
-aa
 aN
 xb
 ba
 ap
 aN
-aA
+Vi
 iM
 ai
 aJ
@@ -989,9 +967,9 @@ ao
 SI
 aN
 aa
+aa
 "}
 (6,1,1) = {"
-Ld
 aN
 al
 Nd
@@ -999,22 +977,22 @@ aq
 av
 aB
 Ao
-aZ
+aA
 aK
-Ou
+Ld
 hb
 fP
 sX
 aN
 aa
+aa
 "}
 (7,1,1) = {"
 bV
-jS
 an
 am
 ar
-aO
+xV
 Wj
 at
 ak
@@ -1025,9 +1003,9 @@ aQ
 aN
 aN
 aN
+aa
 "}
 (8,1,1) = {"
-te
 aN
 zL
 aV
@@ -1040,15 +1018,15 @@ aH
 aN
 aw
 aS
-aR
+te
 bb
 av
+aa
 "}
 (9,1,1) = {"
-aa
 aN
 ag
-zU
+vt
 lt
 aN
 aC
@@ -1058,12 +1036,12 @@ aL
 aN
 aT
 aU
-xV
+aO
 QF
 av
+aa
 "}
 (10,1,1) = {"
-aa
 aN
 aN
 aN
@@ -1079,9 +1057,9 @@ DA
 aX
 af
 av
+aa
 "}
 (11,1,1) = {"
-aa
 aa
 ad
 aj
@@ -1097,9 +1075,9 @@ as
 ab
 av
 aN
+aa
 "}
 (12,1,1) = {"
-aa
 aa
 aa
 ad
@@ -1115,9 +1093,9 @@ aN
 aN
 aa
 aa
+aa
 "}
 (13,1,1) = {"
-aa
 aa
 aa
 aa
@@ -1128,6 +1106,7 @@ ab
 av
 av
 aN
+aa
 aa
 aa
 aa

--- a/_maps/shuttles/whiteship/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship/whiteship_delta.dmm
@@ -318,6 +318,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "bl" = (
@@ -330,8 +332,6 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/structure/spider/stickyweb,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "bm" = (
@@ -818,6 +818,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cO" = (
@@ -825,8 +827,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cR" = (

--- a/_maps/shuttles/whiteship/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship/whiteship_delta.dmm
@@ -312,8 +312,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/all_access,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -332,6 +330,8 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/structure/spider/stickyweb,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "bm" = (
@@ -811,8 +811,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/all_access,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -827,6 +825,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/mapping_helpers/airalarm/all_access,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cR" = (
@@ -1280,8 +1280,8 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/shuttle/abandoned/medbay)
 "dP" = (
@@ -1982,11 +1982,11 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
 "GD" = (
@@ -2088,7 +2088,6 @@
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bar)
 "NM" = (
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/secure_closet/freezer{
@@ -2104,6 +2103,7 @@
 /obj/item/food/sandwich,
 /obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bar)
 "Qd" = (

--- a/_maps/shuttles/whiteship/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship/whiteship_meta.dmm
@@ -366,13 +366,13 @@
 /area/shuttle/abandoned/engine)
 "bi" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/light/small/built,
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "bj" = (
@@ -856,11 +856,11 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "cQ" = (
@@ -883,11 +883,11 @@
 /area/shuttle/abandoned/cargo)
 "cU" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/processor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bar)
 "cV" = (
@@ -1400,7 +1400,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
@@ -1410,6 +1409,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/engine)
 "eZ" = (
@@ -1906,7 +1906,6 @@
 "vC" = (
 /obj/machinery/light/small/built,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/white/line,
@@ -1920,6 +1919,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/bar)
 "vN" = (

--- a/_maps/shuttles/whiteship/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship/whiteship_pubby.dmm
@@ -6,112 +6,145 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
 "c" = (
-/obj/structure/shuttle/engine/propulsion/burst{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/closed/wall/mineral/titanium,
+/obj/machinery/power/smes/engineering{
+	charge = 1e+006
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "d" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shuttle Airlock"
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "e" = (
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "f" = (
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/pod,
 /area/shuttle/abandoned)
 "g" = (
 /obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
+	dir = 4
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "h" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/gun/medbeam,
-/turf/open/floor/plating/abductor,
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned)
 "i" = (
-/obj/structure/chair/fancy/shuttle,
-/turf/open/floor/plating/abductor,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned)
 "j" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/machinery/recharger,
-/obj/item/gun/energy/laser/retro,
-/turf/open/floor/plating/abductor,
+/obj/structure/rack,
+/obj/item/clothing/suit/space/hardsuit/mining,
+/obj/item/tank/internals/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned)
 "k" = (
-/obj/structure/shuttle/engine/propulsion/burst{
+/obj/structure/shuttle/engine/heater{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
 "l" = (
-/obj/structure/chair/fancy/shuttle{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/abductor,
+/obj/effect/decal/cleanable/xenoblood/xgibs/larva/body,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned)
 "m" = (
-/obj/machinery/computer/shuttle_flight/white_ship,
-/turf/open/floor/plating/abductor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/mob/living/simple_animal/hostile/alien/sentinel,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned)
 "n" = (
-/obj/structure/chair/fancy/shuttle{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/abandoned)
-"p" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/table/glass,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/hardsuit/engine/elite,
-/turf/open/floor/plating/abductor,
-/area/shuttle/abandoned)
-"q" = (
-/obj/structure/chair/fancy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/abandoned)
-"r" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/table/glass,
-/obj/item/clothing/shoes/magboots,
-/turf/open/floor/plating/abductor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/shuttle/abandoned)
-"s" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/closed/wall/mineral/titanium,
+"p" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned)
-"v" = (
+"q" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Shuttle Airlock"
 	},
+/obj/effect/turf_decal/stripes/closeup,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/turf/open/floor/pod,
+/area/shuttle/abandoned)
+"r" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"s" = (
+/obj/structure/bed,
+/obj/item/bedsheet/qm,
+/obj/item/gun/ballistic/automatic/pistol/m1911{
+	pixel_y = -8;
+	pixel_x = 3
+	},
+/obj/effect/mob_spawn/human/corpse/cargo_tech,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned)
+"v" = (
+/obj/machinery/door/airlock/external,
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 4;
@@ -123,105 +156,260 @@
 	port_direction = 4;
 	width = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/pod,
+/area/shuttle/abandoned)
+"x" = (
+/obj/structure/aquarium,
+/obj/item/fish_feed{
+	pixel_x = 10;
+	pixel_y = 19
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned)
+"y" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned)
+"z" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/shuttle/abandoned)
+"D" = (
+/obj/machinery/computer/shuttle_flight/white_ship,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned)
+"G" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/item/kirbyplants{
+	icon_state = "plant-17";
+	pixel_x = 10;
+	pixel_y = 20
+	},
+/obj/item/plate,
+/obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice{
+	pixel_x = -8;
+	pixel_y = 17
+	},
+/obj/item/food/badrecipe{
+	pixel_y = 3
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned)
+"H" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
+/area/shuttle/abandoned)
+"P" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/closeup{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/shuttle/abandoned)
+"R" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/item/paper_bin{
+	pixel_x = -6
+	},
+/obj/item/pen{
+	pixel_x = -6
+	},
+/obj/machinery/light/small,
+/obj/item/storage/bag/money{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned)
+"U" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/structure/chair/fancy/shuttle{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned)
+"X" = (
+/obj/structure/table,
+/obj/item/storage/fish_case/random{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/storage/box/aquarium_props{
+	pixel_y = -1;
+	pixel_x = -5
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/toy/figure/qm{
+	pixel_x = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/shuttle/abandoned)
+"Z" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/closet/secure_closet/freezer{
+	locked = 0;
+	name = "fridge"
+	},
+/obj/item/storage/box/donkpockets/donkpocketpizza,
+/obj/item/food/tofu/prison,
+/obj/item/food/tofu/prison,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
 a
 a
 b
-g
 d
-g
+d
+d
 b
 a
 a
 "}
 (2,1,1) = {"
 a
-b
-b
-e
-f
-e
-b
-b
+a
+r
+D
+U
+R
+r
+a
 a
 "}
 (3,1,1) = {"
+a
 b
-b
-e
-e
-f
-e
-e
-b
-b
+r
+r
+P
+r
+r
+r
+a
 "}
 (4,1,1) = {"
-c
-e
-e
+b
+r
+Z
 h
 l
-p
-e
-e
-s
+b
+X
+r
+b
 "}
 (5,1,1) = {"
 d
-f
-f
+p
+H
 i
 m
 q
-f
-f
+y
+x
 d
 "}
 (6,1,1) = {"
-c
-e
-e
+b
+r
+G
 j
 n
-r
-e
-e
+b
 s
+r
+b
 "}
 (7,1,1) = {"
-b
-b
-e
-e
+k
+r
+r
+r
 f
-e
-e
-b
-b
+r
+r
+r
+k
 "}
 (8,1,1) = {"
-a
-b
-b
+g
+k
+r
+c
+z
 e
-f
-e
-b
-b
-a
+r
+k
+g
 "}
 (9,1,1) = {"
 a
-a
+g
+r
 b
-k
 v
-k
 b
-a
+r
+g
 a
 "}

--- a/_maps/shuttles/whiteship/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship/whiteship_pubby.dmm
@@ -101,6 +101,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /mob/living/simple_animal/hostile/alien/sentinel,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/iron/smooth,
 /area/shuttle/abandoned)
 "n" = (
@@ -344,7 +345,7 @@ r
 P
 r
 r
-r
+b
 a
 "}
 (4,1,1) = {"
@@ -370,7 +371,7 @@ x
 d
 "}
 (6,1,1) = {"
-b
+r
 r
 G
 j
@@ -378,7 +379,7 @@ n
 b
 s
 r
-b
+r
 "}
 (7,1,1) = {"
 k

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -570,11 +570,11 @@
 
 /datum/map_template/shuttle/whiteship/pubby
 	suffix = "pubby"
-	name = "NT White UFO"
+	name = "NT Personal Trader"
 
 /datum/map_template/shuttle/whiteship/cere
 	suffix = "cere"
-	name = "NT Construction Vessel"
+	name = "Syndicate Probe Ship"
 
 /datum/map_template/shuttle/whiteship/delta
 	suffix = "delta"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks the two worst/most outdated looking whiteships to be closer to modern standards and more useful for adminbus (seeing as they dont spawn naturally currently)

## Why It's Good For The Game

The old ones looked ass and this was more fun than outright removing them

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Pubby Whiteship -> NT Personal Trader
OLD

![pubbyold](https://github.com/user-attachments/assets/a970a01d-0359-4526-b515-67fc5efab90f)

NEW

![pubby](https://github.com/user-attachments/assets/194a6d52-5842-45ba-ad38-67c6f1350368)

Cere Whiteship -> Syndicate Probe
OLD

![cereold](https://github.com/user-attachments/assets/670b7025-c169-46e1-bdff-7361dabaf931)

NEW

![cere](https://github.com/user-attachments/assets/0c84da05-5377-4972-b7f7-52cc8d26e547)

</details>

## Changelog
:cl:
tweak: Revamps the cere and pubby whiteships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
