### PR TITLE
[TESTMERGE ONLY] Restores heap, fixing pathfinding

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -298,6 +298,7 @@
 #include "code\__HELPERS\game.dm"
 #include "code\__HELPERS\global_lists.dm"
 #include "code\__HELPERS\guid.dm"
+#include "code\__HELPERS\heap.dm"
 #include "code\__HELPERS\icon_smoothing.dm"
 #include "code\__HELPERS\icons.dm"
 #include "code\__HELPERS\jobs.dm"

--- a/code/__HELPERS/heap.dm
+++ b/code/__HELPERS/heap.dm
@@ -1,0 +1,80 @@
+//////////////////////
+//datum/heap object
+//////////////////////
+
+/datum/heap
+	var/list/L
+	var/cmp
+
+/datum/heap/New(compare)
+	L = new()
+	cmp = compare
+
+/datum/heap/Destroy(force, ...)
+	for(var/i in L) // because this is before the list helpers are loaded
+		qdel(i)
+	L = null
+	return ..()
+
+/datum/heap/proc/is_empty()
+	return !length(L)
+
+//insert and place at its position a new node in the heap
+/datum/heap/proc/insert(atom/A)
+
+	L.Add(A)
+	swim(length(L))
+
+//removes and returns the first element of the heap
+//(i.e the max or the min dependant on the comparison function)
+/datum/heap/proc/pop()
+	if(!length(L))
+		return 0
+	. = L[1]
+
+	L[1] = L[length(L)]
+	L.Cut(length(L))
+	if(length(L))
+		sink(1)
+
+//Get a node up to its right position in the heap
+/datum/heap/proc/swim(index)
+	var/parent = round(index * 0.5)
+
+	while(parent > 0 && (call(cmp)(L[index],L[parent]) > 0))
+		L.Swap(index,parent)
+		index = parent
+		parent = round(index * 0.5)
+
+//Get a node down to its right position in the heap
+/datum/heap/proc/sink(index)
+	var/g_child = get_greater_child(index)
+
+	while(g_child > 0 && (call(cmp)(L[index],L[g_child]) < 0))
+		L.Swap(index,g_child)
+		index = g_child
+		g_child = get_greater_child(index)
+
+//Returns the greater (relative to the comparison proc) of a node children
+//or 0 if there's no child
+/datum/heap/proc/get_greater_child(index)
+	if(index * 2 > length(L))
+		return 0
+
+	if(index * 2 + 1 > length(L))
+		return index * 2
+
+	if(call(cmp)(L[index * 2],L[index * 2 + 1]) < 0)
+		return index * 2 + 1
+	else
+		return index * 2
+
+//Replaces a given node so it verify the heap condition
+/datum/heap/proc/resort(atom/A)
+	var/index = L.Find(A)
+
+	swim(index)
+	sink(index)
+
+/datum/heap/proc/List()
+	. = L.Copy()

--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -90,7 +90,9 @@
 	heuristic = get_dist(tile, node_goal)
 	f_value = number_tiles + heuristic
 
-HEAP_TYPE(/datum/path_heap, f_value)
+/// TODO: Macro this to reduce proc overhead
+/proc/HeapPathWeightCompare(datum/jps_node/a, datum/jps_node/b)
+	return b.f_value - a.f_value
 
 /// The datum used to handle the JPS pathfinding, completely self-contained
 /datum/pathfind
@@ -101,7 +103,7 @@ HEAP_TYPE(/datum/path_heap, f_value)
 	/// The turf we're trying to path to (note that this won't track a moving target)
 	var/turf/end
 	/// The open list/stack we pop nodes out from (TODO: make this a normal list and macro-ize the heap operations to reduce proc overhead)
-	var/datum/path_heap/open
+	var/datum/heap/open
 	///An assoc list that serves as the closed list & tracks what turfs came from where. Key is the turf, and the value is what turf it came from
 	var/list/sources
 	/// The list we compile at the end if successful to pass back
@@ -122,7 +124,7 @@ HEAP_TYPE(/datum/path_heap, f_value)
 /datum/pathfind/New(atom/movable/caller, atom/goal, id, max_distance, mintargetdist, simulated_only, avoid, avoid_mobs)
 	src.caller = caller
 	end = get_turf(goal)
-	open = new /datum/path_heap
+	open = new /datum/heap(/proc/HeapPathWeightCompare)
 	sources = new()
 	src.id = id
 	src.max_distance = max_distance


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#11759 made the heap into macros, this is good.

It also broke pathfinding for everything after DSnav was merged. This doesnt make much sense because it didnt really go anywhere close to heap.

So... this just restores heap for the afflicted call, and only that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

something with the heap got fucked, leading to the pathfinder not finding optimal paths... ever.

The amount of processing this needed added some substantial lag, and made bots/navigation completely unusable.

I don't understand the intricities of the heap, but I do know the revert button. 

That button fixed it on local, and its a hell of a better solution than a full revert. This isn't a permanent solution, but I'd like to see how it performs on live

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/a5bac931-42b6-4027-81d3-ef677d2a0d35



</details>

## Changelog
:cl:
fix: fixes heap on pathfinding, making it choose optimized routes again. Navigate verb and bots work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
