### PR TITLE
Circuit Expansion: Variable Length Index + Concatenate and New String Trim and Switch Case components

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -4394,6 +4394,7 @@
 #include "code\modules\wiremod\components\utility\iterator.dm"
 #include "code\modules\wiremod\components\utility\router.dm"
 #include "code\modules\wiremod\components\utility\setter.dm"
+#include "code\modules\wiremod\components\utility\switchcase.dm"
 #include "code\modules\wiremod\components\utility\typecast.dm"
 #include "code\modules\wiremod\core\admin_panel.dm"
 #include "code\modules\wiremod\core\component.dm"

--- a/beestation.dme
+++ b/beestation.dme
@@ -4387,6 +4387,7 @@
 #include "code\modules\wiremod\components\string\textcase.dm"
 #include "code\modules\wiremod\components\string\tonumber.dm"
 #include "code\modules\wiremod\components\string\tostring.dm"
+#include "code\modules\wiremod\components\string\trim.dm"
 #include "code\modules\wiremod\components\utility\clock.dm"
 #include "code\modules\wiremod\components\utility\delay.dm"
 #include "code\modules\wiremod\components\utility\getter.dm"

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -137,6 +137,12 @@
 	build_path = /obj/item/circuit_component/length
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_LIST_COMPONENTS, WIREMOD_STRING_COMPONENTS)
 
+/datum/design/component/trim
+	name = "String Trim Component"
+	id = "comp_trim"
+	build_path = /obj/item/circuit_component/trim
+	category = list(WIREMOD_CIRCUITRY, WIREMOD_STRING_COMPONENTS)
+
 /datum/design/component/light
 	name = "Light Component"
 	id = "comp_light"

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -101,6 +101,14 @@
 	build_path = /obj/item/circuit_component/iterator
 	category = list(WIREMOD_CIRCUITRY, WIREMOD_LOGIC_COMPONENTS)
 
+
+/datum/design/component/switch_case
+	name = "Switch Case"
+	id = "comp_switch_case"
+	build_path = /obj/item/circuit_component/switch_case
+	category = list(WIREMOD_CIRCUITRY, WIREMOD_LOGIC_COMPONENTS)
+
+
 /datum/design/component/delay
 	name = "Delay Component"
 	id = "comp_delay"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -217,6 +217,7 @@
 		"comp_speech",
 		"comp_split",
 		"comp_string_contains",
+		"comp_switch_case",
 		"comp_tempsensor",
 		"comp_textcase",
 		"comp_tonumber",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -221,6 +221,7 @@
 		"comp_textcase",
 		"comp_tonumber",
 		"comp_tostring",
+		"comp_trim",
 		"comp_typecast",
 		"compact_remote_shell",
 		"component_printer",

--- a/code/modules/wiremod/components/list/index.dm
+++ b/code/modules/wiremod/components/list/index.dm
@@ -9,29 +9,96 @@
 
 	/// The input port
 	var/datum/port/input/list_port
-	var/datum/port/input/index_port
 
+	/// The Input indices
+	var/list/datum/port/input/index_ports = list()
 	/// The result from the output
-	var/datum/port/output/output
+	var/list/datum/port/output/indexed_outputs = list()
+
+	var/length = 0
+
+	var/default_list_size = 1
+
+	var/min_size = 1
+	var/max_size = 20
+
+	ui_buttons = list(
+		"plus" = "increase",
+		"minus" = "decrease"
+	)
+
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
-/obj/item/circuit_component/index/populate_ports()
-	index_port = add_input_port("Index", PORT_TYPE_ANY)
-	list_port = add_input_port("List", PORT_TYPE_LIST)
+/obj/item/circuit_component/index/save_data_to_list(list/component_data)
+	. = ..()
+	component_data["length"] = length
 
-	output = add_output_port("Value", PORT_TYPE_ANY)
+/obj/item/circuit_component/index/load_data_from_list(list/component_data)
+	set_list_size(component_data["length"])
+
+	return ..()
+
+/obj/item/circuit_component/index/proc/set_list_size(new_size)
+	if(new_size <= 0)
+		for(var/datum/port/input/port in index_ports)
+			remove_input_port(port)
+		for(var/datum/port/output/port in indexed_outputs)
+			remove_output_port(port)
+		index_ports = list()
+		indexed_outputs = list()
+		length = 0
+		return
+
+	while(length > new_size)
+		var/index = length(index_ports)
+		var/entry_port = index_ports[index]
+		index_ports -= entry_port
+		remove_input_port(entry_port)
+
+		index = length(indexed_outputs)
+		var/output_port = indexed_outputs[index]
+		indexed_outputs -= output_port
+		remove_output_port(output_port)
+
+		length--
+
+	while(length < new_size)
+		length++
+		var/index = length(input_ports)
+		if(list_port)
+			index -= 1
+		if(trigger_input)
+			index -= 1
+
+		index_ports += add_input_port("Index [index+1]", PORT_TYPE_NUMBER)
+		indexed_outputs += add_output_port("Value [index+1]", PORT_TYPE_ANY)
+
+/obj/item/circuit_component/index/populate_ports()
+	list_port = add_input_port("List", PORT_TYPE_LIST)
+	set_list_size(default_list_size)
+
+/obj/item/circuit_component/index/ui_perform_action(mob/user, action)
+	switch(action)
+		if("increase")
+			set_list_size(min(length + 1, max_size))
+		if("decrease")
+			set_list_size(max(length - 1, min_size))
 
 /obj/item/circuit_component/index/input_received(datum/port/input/port)
 
-	var/index = index_port.value
-	var/list/list_input = list_port.value
+	for(var/i in 1 to length(index_ports))
+		var/datum/port/input/index_port = index_ports[i]
+		var/datum/port/output/output_port = indexed_outputs[i]
 
-	if(!islist(list_input))
-		output.set_output(null)
-		return
+		var/index = index_port.value
+		var/list/list_input = list_port.value
 
-	if(isnum(index) && (index < 1 || index > length(list_input)))
-		output.set_output(null)
-		return
+		if(!islist(list_input))
+			output_port.set_output(null)
+			continue
 
-	output.set_output(list_input[index])
+		if(isnum(index) && (index < 1 || index > length(list_input)))
+			output_port.set_output(null)
+			continue
+
+		output_port.set_output(list_input[index])

--- a/code/modules/wiremod/components/string/concat.dm
+++ b/code/modules/wiremod/components/string/concat.dm
@@ -7,7 +7,7 @@
 	display_name = "Concatenate"
 	desc = "A component that combines strings."
 
-	/// The inputs used to create the list
+	/// The inputs to concatenate
 	var/list/datum/port/input/entry_ports = list()
 
 	/// The result from the output

--- a/code/modules/wiremod/components/string/concat.dm
+++ b/code/modules/wiremod/components/string/concat.dm
@@ -7,26 +7,35 @@
 	display_name = "Concatenate"
 	desc = "A component that combines strings."
 
-	/// The amount of input ports to have
-	var/input_port_amount = 4
-
-	var/list/datum/port/input/concat_ports = list()
+	/// The inputs used to create the list
+	var/list/datum/port/input/entry_ports = list()
 
 	/// The result from the output
 	var/datum/port/output/output
+
+	/// The amount of input ports to have
+	var/length = 0
+
+	var/default_list_size = 4
+
+	var/min_size = 1
+	var/max_size = 20
+
+	ui_buttons = list(
+		"plus" = "increase",
+		"minus" = "decrease"
+	)
+
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 /obj/item/circuit_component/concat/populate_ports()
-	for(var/port_id in 1 to input_port_amount)
-		var/letter = ascii2text(text2ascii("A") + (port_id-1))
-		concat_ports += add_input_port(letter, PORT_TYPE_STRING)
-
+	set_list_size(default_list_size)
 	output = add_output_port("Output", PORT_TYPE_STRING)
 
 /obj/item/circuit_component/concat/input_received(datum/port/input/port)
 
 	var/result = ""
-	for(var/datum/port/input/input_port as anything in concat_ports)
+	for(var/datum/port/input/input_port as anything in entry_ports)
 		var/value = input_port.value
 		if(isnull(value))
 			continue
@@ -35,3 +44,39 @@
 
 	output.set_output(result)
 
+/obj/item/circuit_component/concat/save_data_to_list(list/component_data)
+	. = ..()
+	component_data["length"] = length
+
+/obj/item/circuit_component/concat/load_data_from_list(list/component_data)
+	set_list_size(component_data["length"])
+	return ..()
+
+/obj/item/circuit_component/concat/proc/set_list_size(new_size)
+	if(new_size <= 0)
+		for(var/datum/port/input/port in entry_ports)
+			remove_input_port(port)
+		entry_ports = list()
+		length = 0
+		return
+
+	while(length > new_size)
+		var/index = length(entry_ports)
+		var/entry_port = entry_ports[index]
+		entry_ports -= entry_port
+		remove_input_port(entry_port)
+		length--
+
+	while(length < new_size)
+		length++
+		var/index = length(input_ports)
+		if(trigger_input)
+			index -= 1
+		entry_ports += add_input_port("Index [index+1]", PORT_TYPE_STRING)
+
+/obj/item/circuit_component/concat/ui_perform_action(mob/user, action)
+	switch(action)
+		if("increase")
+			set_list_size(min(length + 1, max_size))
+		if("decrease")
+			set_list_size(max(length - 1, min_size))

--- a/code/modules/wiremod/components/string/trim.dm
+++ b/code/modules/wiremod/components/string/trim.dm
@@ -1,0 +1,45 @@
+/**
+ * # String Trim Component
+ *
+ * Trims From Left or Right End of Strings
+ */
+/obj/item/circuit_component/trim
+	display_name = "String Trim"
+	desc = "A component that trims strings. Use a Negative Left Value to trim characters off the total length or a positive value to set the string length to a specific length."
+
+	//Trims characters off the left hand side of the string.
+	var/datum/port/input/left_trim_input
+
+	var/datum/port/input/string_input
+
+	//Positive Values trims string to a total length (i.e. "string" with 3 = "str" )
+	//Negative Values trims characters off the end (i.e. "string" with -1 = "strin" )
+	var/datum/port/input/right_trim_input
+
+	/// The result from the output
+	var/datum/port/output/string_output
+
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+/obj/item/circuit_component/trim/populate_ports()
+
+	left_trim_input = add_input_port("Left Trim", PORT_TYPE_NUMBER)
+	string_input = add_input_port("Input", PORT_TYPE_STRING)
+	right_trim_input = add_input_port("Right Trim", PORT_TYPE_NUMBER)
+
+	string_output = add_output_port("Output", PORT_TYPE_STRING)
+
+/obj/item/circuit_component/trim/input_received(datum/port/input/port)
+
+	var/left_trim_sanity = left_trim_input.value >= 1 ? left_trim_input.value : 1 /// Sanity Check. Must be greater than 1.
+
+	var/right_trim_sanity = right_trim_input.value
+
+	//We add one to make it more clear to use. copytext uses the end as length+1, which results in having to set a string length of 2, to get one character out of the string.
+	if(right_trim_sanity > 0)
+		right_trim_sanity ++
+
+	var/result = copytext(string_input.value, left_trim_sanity, right_trim_sanity)
+
+	string_output.set_output(result)
+

--- a/code/modules/wiremod/components/string/trim.dm
+++ b/code/modules/wiremod/components/string/trim.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/trim
 	display_name = "String Trim"
-	desc = "A component that trims strings. Use a Negative Left Value to trim characters off the total length or a positive value to set the string length to a specific length."
+	desc = "A component that trims strings. Use a Negative Right Value to trim characters off the total length or a positive value to set the string length to a specific length."
 
 	//Trims characters off the left hand side of the string.
 	var/datum/port/input/left_trim_input
@@ -35,7 +35,7 @@
 
 	var/right_trim_sanity = right_trim_input.value
 
-	//We add one to make it more clear to use. copytext uses the end as length+1, which results in having to set a string length of 2, to get one character out of the string.
+	//We add one to make it easier to use. copytext uses the end as length+1, which results in having to set a string length of 2, to get one character out of the string.
 	if(right_trim_sanity > 0)
 		right_trim_sanity ++
 

--- a/code/modules/wiremod/components/utility/switchcase.dm
+++ b/code/modules/wiremod/components/utility/switchcase.dm
@@ -1,0 +1,101 @@
+/**
+ * # Switch Case
+ *
+ * A multi-comparison component which compares an input to a variable list of inputs, routing the signal to a matching value.
+ */
+/obj/item/circuit_component/switch_case
+	display_name = "Switch Case"
+	desc = "A component that compares an input to an array of values, outputting a signal to the matching index, or a default port if no value matches."
+
+	/// The values to check against
+	var/list/datum/port/input/case_ports = list()
+	/// List of the output signals
+	var/list/datum/port/output/output_signals = list()
+
+	/// The input to compare against
+	var/datum/port/input/input_port
+	/// If no values matches, output the signal here
+	var/datum/port/output/default_port
+
+	/// The amount of input ports to have
+	var/length = 0
+
+	var/default_list_size = 4
+
+	var/min_size = 1
+	var/max_size = 20
+
+	ui_buttons = list(
+		"plus" = "increase",
+		"minus" = "decrease"
+	)
+
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
+
+/obj/item/circuit_component/switch_case/populate_ports()
+	input_port = add_input_port("Switch", PORT_TYPE_NUMBER)
+	default_port = add_output_port("Default Output", PORT_TYPE_SIGNAL)
+	set_list_size(default_list_size)
+
+/obj/item/circuit_component/switch_case/input_received(datum/port/input/port)
+
+	for(var/i in 1 to length(case_ports))
+		var/datum/port/input/case = case_ports[i]
+		var/datum/port/output/output_signal = output_signals[i]
+		var/value = case.value
+		if(isnull(value))
+			continue
+		/// If we match the input signal, trigger the matching output signal, and then exit.
+		if(value == input_port.value)
+			output_signal.set_output(COMPONENT_SIGNAL)
+			return
+
+	/// We got through all the cases without equalling, so set the default port
+	default_port.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/switch_case/save_data_to_list(list/component_data)
+	. = ..()
+	component_data["length"] = length
+
+/obj/item/circuit_component/switch_case/load_data_from_list(list/component_data)
+	set_list_size(component_data["length"])
+	return ..()
+
+/obj/item/circuit_component/switch_case/proc/set_list_size(new_size)
+	if(new_size <= 0)
+		for(var/datum/port/input/port in case_ports)
+			remove_input_port(port)
+		for(var/datum/port/output/port in output_signals)
+			remove_output_port(port)
+		case_ports = list()
+		output_signals = list()
+		length = 0
+		return
+
+	while(length > new_size)
+		var/index = length(case_ports)
+		var/entry_port = case_ports[index]
+		case_ports -= entry_port
+		remove_input_port(entry_port)
+
+		index = length(output_signals)
+		var/output_port = output_signals[index]
+		output_signals -= output_port
+		remove_output_port(output_port)
+
+		length--
+
+	while(length < new_size)
+		length++
+		var/index = length(case_ports)
+
+		case_ports += add_input_port("Case [index+1]", PORT_TYPE_NUMBER)
+		output_signals += add_output_port("Output [index+1]", PORT_TYPE_SIGNAL)
+
+
+/obj/item/circuit_component/switch_case/ui_perform_action(mob/user, action)
+	switch(action)
+		if("increase")
+			set_list_size(min(length + 1, max_size))
+		if("decrease")
+			set_list_size(max(length - 1, min_size))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds two new components to Wiremod Circuits and improves the functionality of two existing circuits.
The Index List component and Concatenate String components now behave like the list literal component and can be expanded or contracted up to 20 inputs wide to reduce the tedious print + inserting that happens.

These changes are based off the list literal component, which has the variable adding / subtracting buttons for more inputs.

In addition, two new components were created: String Trim and Switch Case

String trim allows for trimming characters from the right and left of the string. The Right trim can either set the total string length, or trim a specific number of characters off the end of the list if a negative value is passed in. My comment describes it much better.
```
//Positive Values trims string to a total length (i.e. "string" with 3 = "str" )
//Negative Values trims characters off the end (i.e. "string" with -1 = "strin" )
```
The switch case component is a comparison on steroids. It takes in one input value and an array of number inputs. If the input value matches one of the inputs, it triggers the matching signal. This allows for building state machines where a branch of signals is triggered if the input matches a specific value. This has been needed badly, because otherwise you have to chain a bunch of comparisons together, which is annoying to print and insert.

## Why It's Good For The Game

Variable Length Components:
Less repetitive printing and inserting == more time for more interesting circuits and their interactions with the round.

New Circuits:
The additional circuits make it easier for more complicated behaviors in circuit logic, allowing for more interesting circuits for people to mess around with,  without having to print a billion other components to make a logic structure which is a basic function in almost all programming languages.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>String Trim</summary>

String Trim Test Circuit (String Limits adjusted for the outputs)

![String Trim Component Circuit](https://github.com/user-attachments/assets/a39772ba-293c-47a0-a867-39dfe8c1f1da)

String Trim from 0 to 0

![String Trim 1 0](https://github.com/user-attachments/assets/f0fd90bc-a505-448c-95c1-148ef740a400)

String Trim from 1 to -1 (1 char from end)

![String Trim 1 -1](https://github.com/user-attachments/assets/80646b69-5124-45b4-9878-817e04358407)

String Trim from 1 to (1 to 3)

![String Trim 1 1 to 3](https://github.com/user-attachments/assets/548f18b1-63e7-4b46-af5d-c9ee104668cf)

</details>

<details>
<summary>Switch Case</summary>

Test Circuit

![Switch Case Test Circuit](https://github.com/user-attachments/assets/01f59725-142c-40e1-89a6-91de6e68f68e)

Switch Case Test Output

![Switch Case Output](https://github.com/user-attachments/assets/89179050-d01d-4f88-affb-d71dfe763468)

Cases 4 and 5 will not trigger. 4 because it's a duplicate value of case 1 which triggered first, and 5 because it is null.

</details>

<details>
<summary>Variable Array Index and String Concatenate</summary>

![Adjustable Index Test Circuit](https://github.com/user-attachments/assets/738225fc-5756-40f4-afd1-1466859196cd)

Indexing from Index 1 to 5 (produces 5 to 1 because list literal has reversed values)
![Adjustable Index Test Output Ordered](https://github.com/user-attachments/assets/54dfa8b5-733f-40b0-b816-4b2c9e3b47dc)

Indexing from Index 5 to 1 (produces 1 to 5 because list literal has reversed values)

![Adjustable Index Test Output Reversed](https://github.com/user-attachments/assets/a5c202ed-9341-44a7-b680-c7e53a23dfb8)

</details>





## Changelog
:cl:
add: Added a Wiremod Switch Case component
add: Added a Wiremod String Trim Component
tweak: Wiremod String Concatenate component now has variable number of inputs
tweak: Wiremod Index List component now has variable number of inputs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
