### PR TITLE
Quirks no longer cost or give points

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -398,7 +398,8 @@ GLOBAL_LIST_INIT(available_random_trauma_list, list(
 
 // Roundstart trait system
 
-#define MAX_QUIRKS 6 //! The maximum amount of quirks one character can have at roundstart
+//The maximum amount of positive quirks one character can have at roundstart, and I hope whoever originally named this simply MAX_QUIRKS stubs their toe
+#define MAX_POSITIVE_QUIRKS 2
 
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY	5

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -399,7 +399,7 @@ GLOBAL_LIST_INIT(available_random_trauma_list, list(
 // Roundstart trait system
 
 //The maximum amount of positive quirks one character can have at roundstart, and I hope whoever originally named this simply MAX_QUIRKS stubs their toe
-#define MAX_POSITIVE_QUIRKS 2
+#define MAX_POSITIVE_QUIRKS 3
 
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY	5

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -101,8 +101,8 @@
 	return sorttext(B.id, A.id)
 
 /proc/cmp_quirk_asc(datum/quirk/A, datum/quirk/B)
-	var/a_sign = SIGN(initial(A.value) * -1)
-	var/b_sign = SIGN(initial(B.value) * -1)
+	var/a_sign = SIGN(initial(A.quirk_value) * -1)
+	var/b_sign = SIGN(initial(B.quirk_value) * -1)
 
 	// Neutral traits go last.
 	if(a_sign == 0)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -18,8 +18,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Jolly","Depression","Apathetic","Hypersensitive"),
 		list("Ageusia","Vegetarian","Deviant Tastes"),
 		list("Ananas Affinity","Ananas Aversion"),
-		list("Alcohol Tolerance","Light Drinker"),
-		list("Social Anxiety","Mute"),
+		list("Alcohol Tolerance","Light Drinker","Drunken Resilience")
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()
@@ -39,7 +38,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 	for(var/datum/quirk/T as() in quirk_list)
 		quirks[initial(T.name)] = T
-		quirk_points[initial(T.name)] = initial(T.value)
+		quirk_points[initial(T.name)] = initial(T.quirk_value)
 
 /datum/controller/subsystem/processing/quirks/proc/AssignQuirks(datum/mind/user, client/cli, spawn_effects)
 	var/bad_quirk_checker = 0
@@ -48,7 +47,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		var/datum/quirk/Q = quirks[V]
 		if(Q)
 			user.add_quirk(Q, spawn_effects)
-			bad_quirk_checker += initial(Q.value)
+			bad_quirk_checker += initial(Q.quirk_value)
 		else
 			stack_trace("Invalid quirk \"[V]\" in client [cli.ckey] preferences. the game has reset their quirks automatically.")
 			bad_quirks += V
@@ -65,7 +64,6 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 /datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks)
 	var/list/new_quirks = list()
 	var/list/positive_quirks = list()
-	var/balance = 0
 
 	var/list/all_quirks = get_quirks()
 
@@ -94,26 +92,13 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		if (blacklisted)
 			continue
 
-		var/value = initial(quirk.value)
-		if (value > 0)
-			if (positive_quirks.len == MAX_QUIRKS)
+		if (quirk.quirk_value > 0)
+			if (length(positive_quirks) == MAX_POSITIVE_QUIRKS)
 				continue
 
-			positive_quirks[quirk_name] = value
+			positive_quirks[quirk_name] = quirk.quirk_value
 
-		balance += value
 		new_quirks += quirk_name
-
-	if (balance > 0)
-		var/balance_left_to_remove = balance
-
-		for (var/positive_quirk in positive_quirks)
-			var/value = positive_quirks[positive_quirk]
-			balance_left_to_remove -= value
-			new_quirks -= positive_quirk
-
-			if (balance_left_to_remove <= 0)
-				break
 
 	// It is guaranteed that if no quirks are invalid, you can simply check through `==`
 	if (new_quirks.len == quirks.len)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -18,7 +18,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Jolly","Depression","Apathetic","Hypersensitive"),
 		list("Ageusia","Vegetarian","Deviant Tastes"),
 		list("Ananas Affinity","Ananas Aversion"),
-		list("Alcohol Tolerance","Light Drinker","Drunken Resilience")
+		list("Alcohol Tolerance","Light Drinker"),
+		list("Light Drinker","Drunken Resilience")
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -92,11 +92,14 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		if (blacklisted)
 			continue
 
-		if (quirk.quirk_value > 0)
+		//I don't fully understand why declaring this is necessary, but when I tried to simplify it to just calling quirk.quirk_value it runtimes with a null value??
+		var/initial_value = initial(quirk.quirk_value)
+
+		if (initial_value > 0)
 			if (length(positive_quirks) == MAX_POSITIVE_QUIRKS)
 				continue
 
-			positive_quirks[quirk_name] = quirk.quirk_value
+			positive_quirks[quirk_name] = initial_value
 
 		new_quirks += quirk_name
 

--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -6,7 +6,8 @@
 	/// The icon to show in the preferences menu.
 	/// This references a tgui icon, so it can be FontAwesome or a tgfont (with a tg- prefix).
 	var/icon
-	var/value = 0
+	///Positive if the quirk is beneficial to gameplay, negative if the quirk is restrictive/harmful, 0 if the quirk has no substantial impact on gameplay
+	var/quirk_value = 0
 	var/list/restricted_mobtypes = list(/mob/living/carbon/human) //specifies valid mobtypes, have a good reason to change this
 	var/list/restricted_species //specifies valid species, use /datum/species/
 	var/species_whitelist = TRUE //whether restricted_species is a whitelist or a blacklist
@@ -135,13 +136,13 @@
 	for(var/datum/quirk/candidate as anything in mind.quirks)
 		switch(category)
 			if(CAT_QUIRK_MAJOR_DISABILITY)
-				if(candidate.value >= -4)
+				if(candidate.quirk_value >= -4)
 					continue
 			if(CAT_QUIRK_MINOR_DISABILITY)
-				if(!ISINRANGE(candidate.value, -4, -1))
+				if(!ISINRANGE(candidate.quirk_value, -4, -1))
 					continue
 			if(CAT_QUIRK_NOTES)
-				if(candidate.value < 0)
+				if(candidate.quirk_value < 0)
 					continue
 		dat += medical ? candidate.medical_record_text : candidate.name
 

--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -1,10 +1,10 @@
-//predominantly negative traits
+//These traits primarily present a disadvantage to the players, some worse than others.
 
 /datum/quirk/badback
 	name = "Bad Back"
 	desc = "Thanks to your poor posture, backpacks and other bags never sit right on your back. More evently weighted objects are fine, though."
 	icon = "hiking"
-	value = -2
+	quirk_value = -1
 	mood_quirk = TRUE
 	medical_record_text = "Patient scans indicate severe and chronic back pain."
 	gain_text = span_danger("Your back REALLY hurts!")
@@ -22,7 +22,7 @@
 	name = "Blood Deficiency"
 	desc = "Your body can't produce enough blood to sustain itself."
 	icon = "tint"
-	value = -2
+	quirk_value = -1
 	gain_text = span_danger("You feel your vigor slowly fading away.")
 	lose_text = span_notice("You feel vigorous again.")
 	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
@@ -39,7 +39,7 @@
 	name = "Blind"
 	desc = "You are completely blind, nothing can counteract this."
 	icon = "eye-slash"
-	value = -4
+	quirk_value = -1
 	gain_text = span_danger("You can't see anything.")
 	lose_text = span_notice("You miraculously gain back your vision.")
 	medical_record_text = "Patient has permanent blindness."
@@ -61,8 +61,8 @@
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Thankfully, you start with a bottle of mannitol pills."
 	icon = "brain"
+	quirk_value = -1
 	mob_trait = TRAIT_BRAIN_TUMOR
-	value = -3
 	gain_text = span_danger("You feel smooth.")
 	lose_text = span_notice("You feel wrinkled again.")
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
@@ -106,7 +106,7 @@
 	name = "Deaf"
 	desc = "You are incurably deaf."
 	icon = "deaf"
-	value = -2
+	quirk_value = -1
 	mob_trait = TRAIT_DEAF
 	gain_text = span_danger("You can't hear anything.")
 	lose_text = span_notice("You're able to hear again!")
@@ -116,8 +116,8 @@
 	name = "Depression"
 	desc = "You sometimes just hate life."
 	icon = "frown"
+	quirk_value = -1
 	mob_trait = TRAIT_DEPRESSION
-	value = -1
 	gain_text = span_danger("You start feeling depressed.")
 	lose_text = span_notice("You no longer feel depressed.") //if only it were that easy!
 	medical_record_text = "Patient has a severe mood disorder causing them to experience sudden moments of sadness."
@@ -132,7 +132,7 @@
 	name = "Family Heirloom"
 	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
 	icon = "toolbox"
-	value = -1
+	quirk_value = -1
 	mood_quirk = TRUE
 	process = TRUE
 	medical_record_text = "Patient demonstrates an unnatural attachment to a family heirloom."
@@ -260,7 +260,7 @@
 	name = "Frail"
 	desc = "Your bones might as well be made of glass! Your limbs can take less damage before they become disabled."
 	icon = "skull"
-	value = -2
+	quirk_value = -1
 	mob_trait = TRAIT_EASYLIMBDISABLE
 	gain_text = span_danger("You feel frail.")
 	lose_text = span_notice("You feel sturdy again.")
@@ -270,7 +270,7 @@
 	name = "Foreigner"
 	desc = "You're not from around here. You don't know Galactic Common!"
 	icon = "question-circle"
-	value = -1
+	quirk_value = -1
 	gain_text = span_notice("The words being spoken around you don't make any sense.")
 	lose_text = span_notice("You've developed fluency in Galactic Common.")
 	medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
@@ -291,7 +291,7 @@
 	name = "Heavy Sleeper"
 	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up."
 	icon = "bed"
-	value = -1
+	quirk_value = -1
 	mob_trait = TRAIT_HEAVY_SLEEPER
 	gain_text = span_danger("You feel sleepy.")
 	lose_text = span_notice("You feel awake again.")
@@ -301,26 +301,16 @@
 	name = "Hypersensitive"
 	desc = "Bad things affect your mood more than they should."
 	icon = "flushed"
-	value = -1
+	quirk_value = -1
 	gain_text = span_danger("You seem to make a big deal out of everything.")
 	lose_text = span_notice("You don't seem to make a big deal out of everything anymore.")
 	medical_record_text = "Patient demonstrates a high level of emotional volatility."
-
-/datum/quirk/light_drinker
-	name = "Light Drinker"
-	desc = "You just can't handle your drinks and get drunk very quickly."
-	icon = "cocktail"
-	value = -1
-	mob_trait = TRAIT_LIGHT_DRINKER
-	gain_text = span_notice("Just the thought of drinking alcohol makes your head spin.")
-	lose_text = span_danger("You're no longer severely affected by alcohol.")
-	medical_record_text = "Patient demonstrates a low tolerance for alcohol."
 
 /datum/quirk/nearsighted //t. errorage
 	name = "Nearsighted"
 	desc = "You are nearsighted without prescription glasses, but spawn with a pair."
 	icon = "glasses"
-	value = -1
+	quirk_value = -1
 	gain_text = span_danger("Things far away from you start looking blurry.")
 	lose_text = span_notice("You start seeing faraway things normally again.")
 	medical_record_text = "Patient requires prescription glasses in order to counteract nearsightedness."
@@ -342,7 +332,7 @@
 	name = "Nyctophobia"
 	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
 	icon = "lightbulb"
-	value = -1
+	quirk_value = -1
 	process = TRUE
 	medical_record_text = "Patient demonstrates a fear of the dark."
 
@@ -363,7 +353,7 @@
 	name = "Pacifist"
 	desc = "The thought of violence makes you sick. So much so, in fact, that you can't hurt anyone."
 	icon = "peace"
-	value = -2
+	quirk_value = -1
 	mob_trait = TRAIT_PACIFISM
 	gain_text = span_danger("You feel repulsed by the thought of violence!")
 	lose_text = span_notice("You think you can defend yourself again.")
@@ -373,7 +363,7 @@
 	name = "Paraplegic"
 	desc = "Your legs do not function. Nothing will ever fix this. But hey, free wheelchair!"
 	icon = "wheelchair"
-	value = -3
+	quirk_value = -1
 	medical_record_text = "Patient has an untreatable impairment in motor function in the lower extremities."
 	trauma_type = /datum/brain_trauma/severe/paralysis/paraplegic/
 
@@ -401,7 +391,7 @@
 	name = "Poor Aim"
 	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."
 	icon = "bullseye"
-	value = -1
+	quirk_value = -1
 	mob_trait = TRAIT_POOR_AIM
 	medical_record_text = "Patient possesses a strong tremor in both hands."
 
@@ -409,7 +399,7 @@
 	name = "Prosopagnosia"
 	desc = "You have a mental disorder that prevents you from being able to recognize faces at all."
 	icon = "user-secret"
-	value = -1
+	quirk_value = -1
 	mob_trait = TRAIT_PROSOPAGNOSIA
 	medical_record_text = "Patient suffers from prosopagnosia and cannot recognize faces."
 
@@ -417,7 +407,7 @@
 	name = "Prosthetic Limb"
 	desc = "An accident caused you to lose one of your limbs. Because of this, you now have a random prosthetic!"
 	icon = "tg-prosthetic-leg"
-	value = -1
+	quirk_value = -1
 	var/slot_string = "limb"
 
 /datum/quirk/prosthetic_limb/on_spawn()
@@ -451,7 +441,7 @@
 	name = "Pushover"
 	desc = "Your first instinct is always to let people push you around. Resisting out of grabs will take conscious effort."
 	icon = "handshake"
-	value = -2
+	quirk_value = -1
 	mob_trait = TRAIT_GRABWEAKNESS
 	gain_text = span_danger("You feel like a pushover.")
 	lose_text = span_notice("You feel like standing up for yourself.")
@@ -461,7 +451,7 @@
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. This is NOT a license to grief."
 	icon = "grin-tongue-wink"
-	value = -2
+	quirk_value = -1
 	//no mob trait because it's handled uniquely
 	gain_text = span_userdanger("...")
 	lose_text = span_notice("You feel in tune with the world again.")
@@ -488,7 +478,7 @@
 	name = "Social Anxiety"
 	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
 	icon = "comment-slash"
-	value = -1
+	quirk_value = -1
 	gain_text = span_danger("You start worrying about what you're saying.")
 	lose_text = span_notice("You feel comfortable with talking again.") //if only it were that easy!
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
@@ -520,7 +510,7 @@
 	name = "Junkie"
 	desc = "You can't get enough of hard drugs."
 	icon = "pills"
-	value = -2
+	quirk_value = -1
 	gain_text = span_danger("You suddenly feel the craving for drugs.")
 	lose_text = span_notice("You feel like you should kick your drug habit.")
 	medical_record_text = "Patient has a history of hard drugs."
@@ -590,7 +580,7 @@
 	name = "Smoker"
 	desc = "Sometimes you just really want a smoke. Probably not great for your lungs."
 	icon = "smoking"
-	value = -1
+	quirk_value = -1
 	gain_text = span_danger("You could really go for a smoke right about now.")
 	lose_text = span_notice("You feel like you should quit smoking.")
 	medical_record_text = "Patient is a current smoker."
@@ -623,7 +613,7 @@
 	name = "Alcoholic"
 	desc = "You can't stand being sober."
 	icon = "angry"
-	value = -1
+	quirk_value = -1
 	gain_text = span_danger("You could really go for a drink right about now.")
 	lose_text = span_notice("You feel like you should quit drinking.")
 	medical_record_text = "Patient is an alcohol abuser."
@@ -686,7 +676,7 @@
 	name = "Unstable"
 	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"
 	icon = "cloud-rain"
-	value = -2
+	quirk_value = -1
 	mob_trait = TRAIT_UNSTABLE
 	gain_text = span_danger("There's a lot on your mind right now.")
 	lose_text = span_notice("Your mind finally feels calm.")
@@ -696,7 +686,7 @@
 	name = "Phobia"
 	desc = "Because of a traumatic event in your past you have developed a strong phobia."
 	icon = "spider"
-	value = -2
+	quirk_value = -1
 	gain_text = null // these are handled by the trauma itself
 	lose_text = null
 	medical_record_text = "Patient suffers from a deeply-rooted phobia."

--- a/code/datums/traits/neutral_quirk.dm
+++ b/code/datums/traits/neutral_quirk.dm
@@ -1,11 +1,18 @@
-//traits with no real impact that can be taken freely
-//MAKE SURE THESE DO NOT MAJORLY IMPACT GAMEPLAY. those should be positive or negative traits.
+//Traits that provide only flavor, and do not impose a noteworthy disadvantage to the player
+
+/datum/quirk/alcohol_tolerance
+	name = "Alcohol Tolerance"
+	desc = "You become drunk more slowly and suffer fewer drawbacks from alcohol."
+	icon = "beer"
+	mob_trait = TRAIT_ALCOHOL_TOLERANCE
+	gain_text = span_notice("You feel like you could drink a whole keg!")
+	lose_text = span_danger("You don't feel as resistant to alcohol anymore. Somehow.")
+	medical_record_text = "Patient demonstrates a high tolerance for alcohol."
 
 /datum/quirk/no_taste
 	name = "Ageusia"
 	desc = "You can't taste anything! Toxic food will still poison you."
 	icon = "meh-blank"
-	value = 0
 	mob_trait = TRAIT_AGEUSIA
 	gain_text = span_notice("You can't taste anything!")
 	lose_text = span_notice("You can taste again!")
@@ -15,7 +22,6 @@
 	name = "Vegetarian"
 	desc = "You find the idea of eating meat morally and physically repulsive."
 	icon = "carrot"
-	value = 0
 	gain_text = span_notice("You feel repulsion at the idea of eating meat.")
 	lose_text = span_notice("You feel like eating meat isn't that bad.")
 	medical_record_text = "Patient reports a vegetarian diet."
@@ -39,7 +45,6 @@
 	name = "Ananas Affinity"
 	desc = "You find yourself greatly enjoying fruits of the ananas genus. You can't seem to ever get enough of their sweet goodness!"
 	icon = "thumbs-up"
-	value = 0
 	gain_text = span_notice("You feel an intense craving for pineapple.")
 	lose_text = span_notice("Your feelings towards pineapples seem to return to a lukewarm state.")
 	medical_record_text = "Patient demonstrates a pathological love of pineapple."
@@ -58,7 +63,6 @@
 	name = "Ananas Aversion"
 	desc = "You find yourself greatly detesting fruits of the ananas genus. Serious, how the hell can anyone say these things are good? And what kind of madman would even dare putting it on a pizza!?"
 	icon = "thumbs-down"
-	value = 0
 	gain_text = span_notice("You find yourself pondering what kind of idiot actually enjoys pineapples.")
 	lose_text = span_notice("Your feelings towards pineapples seem to return to a lukewarm state.")
 	medical_record_text = "Patient demonstrates a pathological hate of pineapple."
@@ -77,7 +81,6 @@
 	name = "Deviant Tastes"
 	desc = "You dislike food that most people enjoy, and find delicious what they don't."
 	icon = "grin-tongue-squint"
-	value = 0
 	gain_text = span_notice("You start craving something that tastes strange.")
 	lose_text = span_notice("You feel like eating normal food again.")
 	medical_record_text = "Patient demonstrates irregular nutrition preferences."
@@ -95,11 +98,19 @@
 	T?.liked_food = initial(T?.liked_food)
 	T?.disliked_food = initial(T?.disliked_food)
 
+/datum/quirk/light_drinker
+	name = "Light Drinker"
+	desc = "You just can't handle your drinks and get drunk very quickly."
+	icon = "cocktail"
+	mob_trait = TRAIT_LIGHT_DRINKER
+	gain_text = span_notice("Just the thought of drinking alcohol makes your head spin.")
+	lose_text = span_danger("You're no longer severely affected by alcohol.")
+	medical_record_text = "Patient demonstrates a low tolerance for alcohol."
+
 /datum/quirk/monochromatic
 	name = "Monochromacy"
 	desc = "You suffer from full colorblindness, and perceive nearly the entire world in blacks and whites."
 	icon = "adjust"
-	value = 0
 	medical_record_text = "Patient is afflicted with almost complete color blindness."
 
 /datum/quirk/monochromatic/add()
@@ -117,8 +128,25 @@
 	name = "Mute"
 	desc = "You are unable to speak."
 	icon = "volume-mute"
-	value = 0
 	mob_trait = TRAIT_MUTE
 	gain_text = span_danger("You feel unable to talk.")
 	lose_text = span_notice("You feel able to talk again.")
 	medical_record_text = "Patient is unable to speak."
+
+/datum/quirk/plushielover
+	name = "Plushie Lover"
+	desc = "You love your squishy friends so much. You start with a plushie delivery beacon."
+	icon = "heart"
+	mob_trait = TRAIT_PLUSHIELOVER
+	gain_text = span_notice("You can't wait to hug a plushie!.")
+	lose_text = span_danger("You don't feel that passion for plushies anymore.")
+	medical_record_text = "Patient demonstrated a high affinity for plushies."
+
+/datum/quirk/plushielover/on_spawn()
+	var/mob/living/carbon/human/H = quirk_target
+	var/obj/item/choice_beacon/radial/plushie/B = new(get_turf(H))
+	var/list/slots = list (
+		"backpack" = ITEM_SLOT_BACKPACK,
+		"hands" = ITEM_SLOT_HANDS,
+	)
+	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)

--- a/code/datums/traits/neutral_quirk.dm
+++ b/code/datums/traits/neutral_quirk.dm
@@ -124,6 +124,24 @@
 /datum/quirk/monochromatic/remove()
 	quirk_target.remove_client_colour(/datum/client_colour/monochrome)
 
+/datum/quirk/musician
+	name = "Musician"
+	desc = "You can tune handheld musical instruments to play melodies that clear certain negative effects and soothe the soul. You start with a delivery beacon."
+	icon = "guitar"
+	mob_trait = TRAIT_MUSICIAN
+	gain_text = span_notice("You know everything about musical instruments.")
+	lose_text = span_danger("You forget how musical instruments work.")
+	medical_record_text = "Patient brain scans show a highly-developed auditory pathway."
+
+/datum/quirk/musician/on_spawn()
+	var/mob/living/carbon/human/H = quirk_target
+	var/obj/item/choice_beacon/radial/music/B = new(get_turf(H))
+	var/list/slots = list (
+		"backpack" = ITEM_SLOT_BACKPACK,
+		"hands" = ITEM_SLOT_HANDS,
+	)
+	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)
+
 /datum/quirk/mute
 	name = "Mute"
 	desc = "You are unable to speak."
@@ -150,3 +168,29 @@
 		"hands" = ITEM_SLOT_HANDS,
 	)
 	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)
+
+/datum/quirk/spiritual
+	name = "Spiritual"
+	desc = "You hold a spiritual belief, whether in God, nature or the arcane rules of the universe. You gain comfort from the presence of holy people, and believe that your prayers are more special than others."
+	icon = "bible"
+	mob_trait = TRAIT_SPIRITUAL
+	gain_text = span_notice("You have faith in a higher power.")
+	lose_text = span_danger("You lose faith!")
+	process = TRUE
+	medical_record_text = "Patient reports a belief in a higher power."
+
+/datum/quirk/spiritual/on_spawn()
+	var/mob/living/carbon/human/H = quirk_target
+	H.equip_to_slot_or_del(new /obj/item/storage/fancy/candle_box(H), ITEM_SLOT_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/storage/box/matches(H), ITEM_SLOT_BACKPACK)
+
+/datum/quirk/spiritual/on_process()
+	var/comforted = FALSE
+	for(var/mob/living/carbon/human/H in oview(5, quirk_target))
+		if(H.mind?.holy_role && H.stat == CONSCIOUS)
+			comforted = TRUE
+			break
+	if(comforted)
+		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "religious_comfort", /datum/mood_event/religiously_comforted)
+	else
+		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "religious_comfort")

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -73,25 +73,6 @@
 	lose_text = span_danger("You start tromping around like a barbarian.")
 	medical_record_text = "Patient's dexterity belies a strong capacity for stealth."
 
-/datum/quirk/musician
-	name = "Musician"
-	desc = "You can tune handheld musical instruments to play melodies that clear certain negative effects and soothe the soul. You start with a delivery beacon."
-	icon = "guitar"
-	quirk_value = 1
-	mob_trait = TRAIT_MUSICIAN
-	gain_text = span_notice("You know everything about musical instruments.")
-	lose_text = span_danger("You forget how musical instruments work.")
-	medical_record_text = "Patient brain scans show a highly-developed auditory pathway."
-
-/datum/quirk/musician/on_spawn()
-	var/mob/living/carbon/human/H = quirk_target
-	var/obj/item/choice_beacon/radial/music/B = new(get_turf(H))
-	var/list/slots = list (
-		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS,
-	)
-	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)
-
 /datum/quirk/linguist
 	name = "Linguist"
 	desc = "Although you don't know every language, your intense interest in languages allows you to recognise the features of most languages."
@@ -195,33 +176,6 @@
 	quirk_value = 1
 	mob_trait = TRAIT_SKITTISH
 	medical_record_text = "Patient demonstrates a high aversion to danger and has described hiding in containers out of fear."
-
-/datum/quirk/spiritual
-	name = "Spiritual"
-	desc = "You hold a spiritual belief, whether in God, nature or the arcane rules of the universe. You gain comfort from the presence of holy people, and believe that your prayers are more special than others."
-	icon = "bible"
-	quirk_value = 1
-	mob_trait = TRAIT_SPIRITUAL
-	gain_text = span_notice("You have faith in a higher power.")
-	lose_text = span_danger("You lose faith!")
-	process = TRUE
-	medical_record_text = "Patient reports a belief in a higher power."
-
-/datum/quirk/spiritual/on_spawn()
-	var/mob/living/carbon/human/H = quirk_target
-	H.equip_to_slot_or_del(new /obj/item/storage/fancy/candle_box(H), ITEM_SLOT_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/storage/box/matches(H), ITEM_SLOT_BACKPACK)
-
-/datum/quirk/spiritual/on_process()
-	var/comforted = FALSE
-	for(var/mob/living/carbon/human/H in oview(5, quirk_target))
-		if(H.mind?.holy_role && H.stat == CONSCIOUS)
-			comforted = TRUE
-			break
-	if(comforted)
-		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "religious_comfort", /datum/mood_event/religiously_comforted)
-	else
-		SEND_SIGNAL(quirk_target, COMSIG_CLEAR_MOOD_EVENT, "religious_comfort")
 
 /datum/quirk/tagger
 	name = "Tagger"

--- a/code/datums/traits/positive_quirk.dm
+++ b/code/datums/traits/positive_quirk.dm
@@ -1,21 +1,10 @@
-//predominantly positive traits
-//this file is named weirdly so that positive traits are listed above negative ones
-
-/datum/quirk/alcohol_tolerance
-	name = "Alcohol Tolerance"
-	desc = "You become drunk more slowly and suffer fewer drawbacks from alcohol."
-	icon = "beer"
-	value = 1
-	mob_trait = TRAIT_ALCOHOL_TOLERANCE
-	gain_text = span_notice("You feel like you could drink a whole keg!")
-	lose_text = span_danger("You don't feel as resistant to alcohol anymore. Somehow.")
-	medical_record_text = "Patient demonstrates a high tolerance for alcohol."
+//This file contains quirks that provide a gameplay advantage. Players are limited to a maximum of two of these quirks
 
 /datum/quirk/apathetic
 	name = "Apathetic"
 	desc = "You are used to the awful things that happen here, bad events affect your mood less."
 	icon = "meh"
-	value = 1
+	quirk_value = 1
 	mood_quirk = TRUE
 	medical_record_text = "Patient was administered the Apathy Evaluation Scale but did not bother to complete it."
 
@@ -23,7 +12,7 @@
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."
 	icon = "wine-bottle"
-	value = 2
+	quirk_value = 1
 	mob_trait = TRAIT_DRUNK_HEALING
 	gain_text = span_notice("You feel like a drink would do you good.")
 	lose_text = span_danger("You no longer feel like drinking would ease your pain.")
@@ -33,7 +22,7 @@
 	name = "Empath"
 	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
 	icon = "smile-beam"
-	value = 2
+	quirk_value = 1
 	mob_trait = TRAIT_EMPATH
 	gain_text = span_notice("You feel in tune with those around you.")
 	lose_text = span_danger("You feel isolated from others.")
@@ -43,7 +32,7 @@
 	name = "Freerunning"
 	desc = "You're great at quick moves! You can climb tables more quickly."
 	icon = "running"
-	value = 2
+	quirk_value = 1
 	mob_trait = TRAIT_FREERUNNING
 	gain_text = span_notice("You feel lithe on your feet!")
 	lose_text = span_danger("You feel clumsy again.")
@@ -53,7 +42,7 @@
 	name = "Friendly"
 	desc = "You give the best hugs, especially when you're in the right mood."
 	icon = "hands-helping"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_FRIENDLY
 	gain_text = span_notice("You want to hug someone.")
 	lose_text = span_danger("You no longer feel compelled to hug others.")
@@ -64,7 +53,7 @@
 	name = "Jolly"
 	desc = "You sometimes just feel happy, for no reason at all."
 	icon = "grin"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_JOLLY
 	mood_quirk = TRUE
 	process = TRUE
@@ -78,7 +67,7 @@
 	name = "Light Step"
 	desc = "You walk with a gentle step; stepping on sharp objects is quieter, less painful and you won't leave footprints behind you. Also, your hands and clothes will not get messed in case of stepping in blood."
 	icon = "shoe-prints"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_LIGHT_STEP
 	gain_text = span_notice("You walk with a little more litheness.")
 	lose_text = span_danger("You start tromping around like a barbarian.")
@@ -88,7 +77,7 @@
 	name = "Musician"
 	desc = "You can tune handheld musical instruments to play melodies that clear certain negative effects and soothe the soul. You start with a delivery beacon."
 	icon = "guitar"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_MUSICIAN
 	gain_text = span_notice("You know everything about musical instruments.")
 	lose_text = span_danger("You forget how musical instruments work.")
@@ -107,7 +96,7 @@
 	name = "Linguist"
 	desc = "Although you don't know every language, your intense interest in languages allows you to recognise the features of most languages."
 	icon = "language"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_LINGUIST
 	gain_text = span_notice("You can recognise the linguistic features of every language.")
 	lose_text = span_danger("You can no longer recognise linguistic features for each language.")
@@ -117,7 +106,7 @@
 	name = "Multilingual"
 	desc = "You spent a portion of your life learning to understand an additional language. You may or may not be able to speak it based on your anatomy."
 	icon = "comments"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_MULTILINGUAL
 	gain_text = span_notice("You have learned to understand an additional language.")
 	lose_text = span_danger("You have forgotten how to understand a language.")
@@ -155,7 +144,7 @@
 	name = "Night Vision"
 	desc = "You can see slightly more clearly in full darkness than most people."
 	icon = "eye"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_NIGHT_VISION_WEAK
 	gain_text = span_notice("The shadows seem a little less dark.")
 	lose_text = span_danger("Everything seems a little darker.")
@@ -172,7 +161,7 @@
 	name = "Psychic Photographer"
 	desc = "You have a special camera that can capture a photo of ghosts. Your experience in photography shortens the delay between each shot."
 	icon = "camera"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_PHOTOGRAPHER
 	gain_text = span_notice("You know everything about photography.")
 	lose_text = span_danger("You forget how photo cameras work.")
@@ -195,7 +184,7 @@
 	name = "Self-Aware"
 	desc = "You know your body well, and can accurately assess the extent of your wounds."
 	icon = "bone"
-	value = 2
+	quirk_value = 1
 	mob_trait = TRAIT_SELF_AWARE
 	medical_record_text = "Patient demonstrates an uncanny knack for self-diagnosis."
 
@@ -203,7 +192,7 @@
 	name = "Skittish"
 	desc = "You can conceal yourself in danger. Ctrl-shift-click a closed locker to jump into it, as long as you have access."
 	icon = "trash"
-	value = 2
+	quirk_value = 1
 	mob_trait = TRAIT_SKITTISH
 	medical_record_text = "Patient demonstrates a high aversion to danger and has described hiding in containers out of fear."
 
@@ -211,7 +200,7 @@
 	name = "Spiritual"
 	desc = "You hold a spiritual belief, whether in God, nature or the arcane rules of the universe. You gain comfort from the presence of holy people, and believe that your prayers are more special than others."
 	icon = "bible"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_SPIRITUAL
 	gain_text = span_notice("You have faith in a higher power.")
 	lose_text = span_danger("You lose faith!")
@@ -238,7 +227,7 @@
 	name = "Tagger"
 	desc = "You're an experienced artist. While drawing graffiti, you can get twice as many uses out of drawing supplies."
 	icon = "spray-can"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_TAGGER
 	gain_text = span_notice("You know how to tag walls efficiently.")
 	lose_text = span_danger("You forget how to tag walls properly.")
@@ -255,7 +244,7 @@
 	name = "Voracious"
 	desc = "Nothing gets between you and your food. You eat faster and can binge on junk food! Being fat suits you just fine."
 	icon = "drumstick-bite"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_VORACIOUS
 	gain_text = span_notice("You feel HONGRY.")
 	lose_text = span_danger("You no longer feel HONGRY.")
@@ -265,7 +254,7 @@
 	name = "NEET"
 	desc = "For some reason you qualified for social welfare."
 	icon = "money-check-alt"
-	value = 1
+	quirk_value = 1
 	mob_trait = TRAIT_NEET
 	gain_text = span_notice("You feel useless to society.")
 	lose_text = span_danger("You no longer feel useless to society.")
@@ -284,7 +273,7 @@
 	name = "Skater Bro"
 	desc = "You're a little too into old-earth skater culture! You're much more used to riding and falling off skateboards, needing less stamina to do kickflips and taking less damage upon bumping into something."
 	icon = "hand-middle-finger"
-	value = 2
+	quirk_value = 1
 	mob_trait = TRAIT_PROSKATER
 	gain_text = span_notice("You feel like hitting a sick grind!")
 	lose_text = span_danger("You no longer feel like you're in touch with the youth.")
@@ -293,22 +282,3 @@
 /datum/quirk/proskater/on_spawn()
 	var/mob/living/carbon/human/H = quirk_target
 	H.equip_to_slot_or_del(new /obj/item/melee/skateboard/pro(H), ITEM_SLOT_BACKPACK)
-
-/datum/quirk/plushielover
-	name = "Plushie Lover"
-	desc = "You love your squishy friends so much. You start with a plushie delivery beacon."
-	icon = "heart"
-	value = 1
-	mob_trait = TRAIT_PLUSHIELOVER
-	gain_text = span_notice("You can't wait to hug a plushie!.")
-	lose_text = span_danger("You don't feel that passion for plushies anymore.")
-	medical_record_text = "Patient demonstrated a high affinity for plushies."
-
-/datum/quirk/plushielover/on_spawn()
-	var/mob/living/carbon/human/H = quirk_target
-	var/obj/item/choice_beacon/radial/plushie/B = new(get_turf(H))
-	var/list/slots = list (
-		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS,
-	)
-	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -40,12 +40,12 @@
 			"description" = initial(quirk.desc),
 			"icon" = initial(quirk.icon),
 			"name" = quirk_name,
-			"value" = initial(quirk.value),
+			"value" = initial(quirk.quirk_value),
 			"path" = quirk
 		)
 
 	return list(
-		"max_positive_quirks" = MAX_QUIRKS,
+		"max_positive_quirks" = MAX_POSITIVE_QUIRKS,
 		"quirk_info" = quirk_info,
 		"quirk_blacklist" = SSquirks.quirk_blacklist,
 	)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -231,7 +231,6 @@ export const QuirksPage = (props) => {
                           quirkName,
                           {
                             ...quirk,
-                            failTooltip: getReasonToNotAdd(quirkName),
                           },
                         ];
                       })}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -82,7 +82,6 @@ const QuirkList = (props: {
                       <Stack.Item grow basis="content">
                         <b>{quirk.name}</b>
                       </Stack.Item>
-
                     </Stack>
                   </Stack.Item>
 
@@ -157,7 +156,6 @@ export const QuirksPage = (props) => {
           if (selectedQuirk.value > 0) {
             positiveQuirks += 1;
           }
-
         }
 
         const getReasonToNotAdd = (quirkName: string) => {
@@ -192,7 +190,6 @@ export const QuirksPage = (props) => {
           <Stack align="center" fill>
             <Stack.Item basis="50%">
               <Stack vertical fill align="center">
-
                 <Stack.Item>
                   <Box as="b" fontSize="1.6em">
                     Available Quirks
@@ -227,25 +224,24 @@ export const QuirksPage = (props) => {
                 </Stack.Item>
               </Stack>
             </Stack.Item>
-              <Stack vertical fill align="center">
-                <Stack.Item>
-                  <Box fontSize="1.3em">Positive Quirks</Box>
-                </Stack.Item>
+            <Stack vertical fill align="center">
+              <Stack.Item>
+                <Box fontSize="1.3em">Positive Quirks</Box>
+              </Stack.Item>
 
-                <Stack.Item>
-                  <StatDisplay>
-                    {positiveQuirks} / {maxPositiveQuirks}
-                  </StatDisplay>
-                </Stack.Item>
+              <Stack.Item>
+                <StatDisplay>
+                  {positiveQuirks} / {maxPositiveQuirks}
+                </StatDisplay>
+              </Stack.Item>
 
-                <Stack.Item>
-                  <Icon name="exchange-alt" size={1.5} ml={2} mr={2} />
-                </Stack.Item>
-              </Stack>
+              <Stack.Item>
+                <Icon name="exchange-alt" size={1.5} ml={2} mr={2} />
+              </Stack.Item>
+            </Stack>
 
             <Stack.Item basis="50%">
               <Stack vertical fill align="center">
-
                 <Stack.Item>
                   <Box as="b" fontSize="1.6em">
                     Current Quirks
@@ -255,7 +251,6 @@ export const QuirksPage = (props) => {
                 <Stack.Item grow width="100%">
                   <QuirkList
                     onClick={(quirkName, quirk) => {
-
                       setSelectedQuirks(selectedQuirks.filter((otherQuirk) => quirkName !== otherQuirk));
 
                       act('remove_quirk', { quirk: quirk.name });

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -83,9 +83,6 @@ const QuirkList = (props: {
                         <b>{quirk.name}</b>
                       </Stack.Item>
 
-                      <Stack.Item>
-                        <b>{quirk.value}</b>
-                      </Stack.Item>
                     </Stack>
                   </Stack.Item>
 
@@ -145,7 +142,7 @@ export const QuirksPage = (props) => {
           if (quirkA.value === quirkB.value) {
             return quirkA.name > quirkB.name ? 1 : -1;
           } else {
-            return quirkA.value - quirkB.value;
+            return quirkB.value - quirkA.value;
           }
         });
 
@@ -195,15 +192,6 @@ export const QuirksPage = (props) => {
           <Stack align="center" fill>
             <Stack.Item basis="50%">
               <Stack vertical fill align="center">
-                <Stack.Item>
-                  <Box fontSize="1.3em">Positive Quirks</Box>
-                </Stack.Item>
-
-                <Stack.Item>
-                  <StatDisplay>
-                    {positiveQuirks} / {maxPositiveQuirks}
-                  </StatDisplay>
-                </Stack.Item>
 
                 <Stack.Item>
                   <Box as="b" fontSize="1.6em">
@@ -231,6 +219,7 @@ export const QuirksPage = (props) => {
                           quirkName,
                           {
                             ...quirk,
+                            failTooltip: getReasonToNotAdd(quirkName),
                           },
                         ];
                       })}
@@ -238,10 +227,21 @@ export const QuirksPage = (props) => {
                 </Stack.Item>
               </Stack>
             </Stack.Item>
+              <Stack vertical fill align="center">
+                <Stack.Item>
+                  <Box fontSize="1.3em">Positive Quirks</Box>
+                </Stack.Item>
 
-            <Stack.Item>
-              <Icon name="exchange-alt" size={1.5} ml={2} mr={2} />
-            </Stack.Item>
+                <Stack.Item>
+                  <StatDisplay>
+                    {positiveQuirks} / {maxPositiveQuirks}
+                  </StatDisplay>
+                </Stack.Item>
+
+                <Stack.Item>
+                  <Icon name="exchange-alt" size={1.5} ml={2} mr={2} />
+                </Stack.Item>
+              </Stack>
 
             <Stack.Item basis="50%">
               <Stack vertical fill align="center">
@@ -269,6 +269,7 @@ export const QuirksPage = (props) => {
                           quirkName,
                           {
                             ...quirk,
+                            failTooltip: getReasonToNotAdd(quirkName),
                           },
                         ];
                       })}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -149,7 +149,6 @@ export const QuirksPage = (props) => {
           }
         });
 
-        let balance = 0;
         let positiveQuirks = 0;
 
         for (const selectedQuirkName of selectedQuirks) {
@@ -162,7 +161,6 @@ export const QuirksPage = (props) => {
             positiveQuirks += 1;
           }
 
-          balance += selectedQuirk.value;
         }
 
         const getReasonToNotAdd = (quirkName: string) => {
@@ -171,8 +169,6 @@ export const QuirksPage = (props) => {
           if (quirk.value > 0) {
             if (positiveQuirks >= maxPositiveQuirks) {
               return "You can't have any more positive quirks!";
-            } else if (balance + quirk.value > 0) {
-              return 'You need a negative quirk to balance this out!';
             }
           }
 
@@ -190,16 +186,6 @@ export const QuirksPage = (props) => {
                 return `This is incompatible with ${incompatibleQuirk}!`;
               }
             }
-          }
-
-          return undefined;
-        };
-
-        const getReasonToNotRemove = (quirkName: string) => {
-          const quirk = quirkInfo[quirkName];
-
-          if (balance - quirk.value > 0) {
-            return 'You need to remove a positive quirk first!';
           }
 
           return undefined;
@@ -260,13 +246,6 @@ export const QuirksPage = (props) => {
 
             <Stack.Item basis="50%">
               <Stack vertical fill align="center">
-                <Stack.Item>
-                  <Box fontSize="1.3em">Quirk Balance</Box>
-                </Stack.Item>
-
-                <Stack.Item>
-                  <StatDisplay>{balance}</StatDisplay>
-                </Stack.Item>
 
                 <Stack.Item>
                   <Box as="b" fontSize="1.6em">
@@ -277,9 +256,6 @@ export const QuirksPage = (props) => {
                 <Stack.Item grow width="100%">
                   <QuirkList
                     onClick={(quirkName, quirk) => {
-                      if (getReasonToNotRemove(quirkName) !== undefined) {
-                        return;
-                      }
 
                       setSelectedQuirks(selectedQuirks.filter((otherQuirk) => quirkName !== otherQuirk));
 
@@ -294,7 +270,6 @@ export const QuirksPage = (props) => {
                           quirkName,
                           {
                             ...quirk,
-                            failTooltip: getReasonToNotRemove(quirkName),
                           },
                         ];
                       })}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This removes the point values (at least player facing) from quirks and removes the need to balance positive and negative quirks. Players may now choose positive quirks without being forced into negative quirks, but each character has a finite limit of three positive quirks they can take instead

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The system of counterbalancing good and bad quirks only pushes players to take character traits they have no intention of interacting with, and frequently making choices that best enable them to ignore the downsides they've chosen entirely. Quirks should be something that players choose based on what they want to build their character around, and the current system is only stifling to that. 

This entirely removes "Powergaming" from quirk choice. Everyone gets the same number of positive quirks regardless of how many negatives they chose, and players will only take negative quirks they actually want to be a part of their character and that they intend to interact with. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/2c206434-418b-431b-a4d2-ba767e6d505f)

![image](https://github.com/user-attachments/assets/014734ce-9798-48f5-b23c-2db3f9d4882e)

## Changelog
:cl:
balance: Quirks no longer require balancing of good and bad. All characters are now able to choose three positive quirks, even if they take no negative quirks. Nothing increases or decreases this amount, and negative quirks exist only for those who wish to actually interact with them as part of their character.
tweak: Drunken Resilience may no longer be combined with Light Drinker, get to chugging if you want that whiskey to numb the pain.
tweak: Alcohol tolerance, light drinker, plushie lover, musician and spiritual have all been moved to neutral traits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
