### PR TITLE
Readds IPC mutation toxin

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -653,6 +653,14 @@
 	race = /datum/species/oozeling
 	taste_description = "burning ooze"
 
+/datum/reagent/mutationtoxin/ipc
+	name = "IPC Mutation Toxin"
+	description = "A metallic toxin"
+	color = "#5EFF3B"
+	chem_flags = CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY
+	race = /datum/species/ipc
+	taste_description = "copper wire"
+
 //BLACKLISTED RACES
 /datum/reagent/mutationtoxin/skeleton
 	name = "Skeleton Mutation Toxin"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -884,13 +884,13 @@
 	results = list(/datum/reagent/mutationtoxin/oozeling = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/medicine/calomel = 10, /datum/reagent/toxin/bad_food = 30, /datum/reagent/stable_plasma = 5)
 
+//////////////Mutation toxins made out of advanced toxin/////////////
+
 /datum/chemical_reaction/mutationtoxin/ipc
 	name = /datum/reagent/mutationtoxin/ipc
 	id = /datum/reagent/mutationtoxin/ipc
 	results = list(/datum/reagent/mutationtoxin/ipc = 5)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/teslium = 20)
-
-//////////////Mutation toxins made out of advanced toxin/////////////
+	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/teslium = 20)
 
 /datum/chemical_reaction/mutationtoxin/skeleton
 	name = /datum/reagent/mutationtoxin/skeleton

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -884,6 +884,12 @@
 	results = list(/datum/reagent/mutationtoxin/oozeling = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/medicine/calomel = 10, /datum/reagent/toxin/bad_food = 30, /datum/reagent/stable_plasma = 5)
 
+/datum/chemical_reaction/mutationtoxin/ipc
+	name = /datum/reagent/mutationtoxin/ipc
+	id = /datum/reagent/mutationtoxin/ipc
+	results = list(/datum/reagent/mutationtoxin/ipc = 5)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/teslium = 20)
+
 //////////////Mutation toxins made out of advanced toxin/////////////
 
 /datum/chemical_reaction/mutationtoxin/skeleton


### PR DESCRIPTION
## About The Pull Request
This PR readds IPC mutation toxin to the game, as well as a recipe for it (5u basic **mutation** toxin, 20u teslium)

## Why It's Good For The Game
This used to exist, but was removed by #5611 for what entirely seems to be personal preference? It was removed alongside super soldier mutation toxin, which I understand, but it works fine. It's not even a way to trap people species-wise, since IPCs can still use and benefit from mutation toxins just fine.

It's good for the game because it might be useful in gimmicks, and it's weird to me that IPCs are a roundstart race without a mutation toxin when things like skeletons and shadowpeople have them.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/5138ebaa-4333-4448-a0df-ee2eb3196221)
I did, in fact, become an IPC, and all visual effects and actions worked as normal.

</details>

## Changelog
:cl:
add: IPC mutation toxin, again!
/:cl:

