### PR TITLE
Fixes death message

### DIFF
--- a/code/controllers/configuration/entries/policies.dm
+++ b/code/controllers/configuration/entries/policies.dm
@@ -5,5 +5,4 @@
 	config_entry_value = span_boldannounce("Even if you take the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.")
 
 /datum/config_entry/string/death_message
-	config_entry_value = span_deathmessage(span_bigbold("You have died!")) + "<br/>\
-		Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab.<br/> " + span_boldred("You do not remember the circumstances leading up to your death!")
+	config_entry_value = "<span class='death_message'><span class='big bold'>You have died!</span><br/>Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the "Do Not Resuscitate" verb in the ghost tab.<br/><span class = 'bold purple'>You do not remember the circumstances leading up to your death!</span></span>"

--- a/code/controllers/configuration/entries/policies.dm
+++ b/code/controllers/configuration/entries/policies.dm
@@ -5,4 +5,4 @@
 	config_entry_value = span_boldannounce("Even if you take the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.")
 
 /datum/config_entry/string/death_message
-	config_entry_value = "<span class='death_message'><span class='big bold'>You have died!</span><br/>Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the "Do Not Resuscitate" verb in the ghost tab.<br/><span class = 'bold purple'>You do not remember the circumstances leading up to your death!</span></span>"
+	config_entry_value = "<span class='death_message'><span class='big bold'>You have died!</span><br/>Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab.<br/><span class = 'bold purple'>You do not remember the circumstances leading up to your death!</span></span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the death message.

## Why It's Good For The Game

For advanced HTML, the span macros do more harm than good. This is one such example of them doing just that.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/67e06678-6b4d-4934-ba15-9b259731776b)

## Changelog
:cl:
fix: Fixes death message default setting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
