### PR TITLE
Adding possibility of fixing walls and fixing gridle on right click

### DIFF
--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -132,6 +132,7 @@
 				balloon_alert(user, "You fix some dents on the wall.")
 				cut_overlay(dent_decals)
 				dent_decals.Cut()
+			integrity = max_integrity
 			return TRUE
 
 	return FALSE

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -70,7 +70,7 @@
 				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 				new /obj/structure/lattice/catwalk/over(src)
 				return
-	if(istype(C, /obj/item/stack/sheet/iron) && attachment_holes)
+	if(istype(C, /obj/item/stack/sheet/iron) && attachment_holes && LEFT_CLICK)
 		if(broken || burnt)
 			to_chat(user, span_warning("Repair the plating first!"))
 			return

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -70,7 +70,8 @@
 				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 				new /obj/structure/lattice/catwalk/over(src)
 				return
-	if(istype(C, /obj/item/stack/sheet/iron) && attachment_holes && LEFT_CLICK)
+	var/is_left_cliking = LAZYACCESS(params2list(params), LEFT_CLICK)
+	if(istype(C, /obj/item/stack/sheet/iron) && attachment_holes && is_left_cliking)
 		if(broken || burnt)
 			to_chat(user, span_warning("Repair the plating first!"))
 			return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2298,7 +2298,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	glass_name = "glass of ants"
 	glass_desc = "Bottoms up...?"
 	/// How much damage the ants are going to be doing (rises with each tick the ants are in someone's body)
-	var/ant_damage = 0
+	var/ant_damage = 0 // Not actual damage, only way to check how long they were inside
 	/// Tells the debuff how many ants we are being covered with.
 	var/amount_left = 0
 	/// List of possible common statements to scream when eating ants


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I added possibility of actually fixing the walls instead of just deleting dents
I removed reinforcing floors with metal from right click since its now makes girders for walls instead
(added comment to something that confused me in past, never again)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixes are good, I think this counts
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

![Zrzut ekranu (74)](https://github.com/user-attachments/assets/9c5beb43-3f7e-47e2-a125-1c0efcc5bfc4)

![Zrzut ekranu (75)](https://github.com/user-attachments/assets/5fb7bf5c-e252-47e9-ae75-2a4660503ff3)

![Zrzut ekranu (76)](https://github.com/user-attachments/assets/a55ec9fd-5c5a-4d30-87bf-68f19976585c)

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Welding a damaged wall now heals it's values rather than only it's appearance
fix: Rclicking untiled floors no longer reinforces them, as it overrode the behavior of Rclicking with iron sheets to build girders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
