### PR TITLE
Don't start an extra database for no reason in CI

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -21,14 +21,6 @@ jobs:
   run_integration_tests:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
       - name: Restore BYOND cache


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/DaedalusDock/daedalusdock/pull/1220

So, turns out, `run_integration_tests` sets up a random mysql container... and then ignores it and uses the pre-installed database on the `ubuntu-latest` image.

Yeahhh. That's a huge waste of time.

Credit to @francinum for figuring this out

## Why It's Good For The Game

Saves time running integration tests, which is always nice.

## Testing Photographs and Procedure

just look at the CI run for this PR

## Changelog

Only affects CI, no in-game changes whatsoever