### PR TITLE
Major changes to ion weaponry + EMPs against cybernetics in carbons

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1039,7 +1039,7 @@
 
 /datum/status_effect/spanish
 	id = "spanish"
-	duration = 120 SECONDS
+	duration = 25 SECONDS
 	alert_type = null
 
 /datum/status_effect/spanish/on_apply(mob/living/new_owner, ...)
@@ -1057,7 +1057,7 @@
 /datum/status_effect/ipc/emp
 	id = "ipc_emp"
 	examine_text = span_warning("SUBJECTPRONOUN is buzzing and twitching!")
-	duration = 120 SECONDS
+	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/emp
 	status_type = STATUS_EFFECT_REFRESH
 /atom/movable/screen/alert/status_effect/emp

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1060,6 +1060,7 @@
 	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/emp
 	status_type = STATUS_EFFECT_REFRESH
+
 /atom/movable/screen/alert/status_effect/emp
 	name = "Electro-Magnetic Pulse"
 	desc = "You've been hit with an EMP! You're malfunctioning!"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -255,9 +255,8 @@
 					H.revive(0)
 
 /obj/item/organ/brain/positron/emp_act(severity)
-	if(prob(30/severity))
-		owner.apply_status_effect(STATUS_EFFECT_IPC_EMP)
-		to_chat(owner, span_warning("Alert: Posibrain function disrupted."))
+	owner.apply_status_effect(STATUS_EFFECT_IPC_EMP)
+	to_chat(owner, span_warning("Alert: Posibrain function disrupted."))
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -255,13 +255,9 @@
 					H.revive(0)
 
 /obj/item/organ/brain/positron/emp_act(severity)
-	switch(severity)
-		if(1)
-			owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 75)
-			to_chat(owner, span_warning("Alert: Posibrain heavily damaged."))
-		if(2)
-			owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 25)
-			to_chat(owner, span_warning("Alert: Posibrain damaged."))
+	if(prob(30/severity)) //25% for light, 50% for heavy
+		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		to_chat(owner, span_warning("Alert: Posibrain damaged."))
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -255,9 +255,9 @@
 					H.revive(0)
 
 /obj/item/organ/brain/positron/emp_act(severity)
-	if(prob(30/severity)) //25% for light, 50% for heavy
-		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-		to_chat(owner, span_warning("Alert: Posibrain damaged."))
+	if(prob(30/severity))
+		owner.apply_status_effect(STATUS_EFFECT_IPC_EMP)
+		to_chat(owner, span_warning("Alert: Posibrain function disrupted."))
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -448,14 +448,13 @@
 			if(!informed)
 				to_chat(src, span_userdanger("You feel a sharp pain as [bodypart] overloads!"))
 				informed = TRUE
-			switch(severity)
-				if(EMP_HEAVY)
-					bodypart.receive_damage(0,10) //Burns, heavy.
-				if(EMP_LIGHT)
-					bodypart.receive_damage(0,5) //Burns, light.
-			bodypart.receive_damage(stamina = 120) //Disable the limb since we got EMP'd
+			if(prob(30/severity)) //Random chance to disable and burn limbs
+				bodypart.receive_damage(burn = 5)
+				bodypart.receive_damage(stamina = 120) //Disable the limb since we got EMP'd
+			else
+				bodypart.receive_damage(stamina = 10) //Progressive stamina damage to ensure a consistent takedown within a reasonable number of hits, regardless of RNG
 			if(HAS_TRAIT(bodypart, TRAIT_EASYDISMEMBER) && bodypart.body_zone != "chest")
-				if(prob(20))
+				if(prob(5))
 					bodypart.dismember(BRUTE)
 
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -36,8 +36,12 @@
 			if(we_breath)
 				adjustOxyLoss(8)
 				Unconscious(80)
-			// Tissues die without blood circulation
-			adjustBruteLoss(2)
+
+			// Tissues die without blood circulation, machines burn without coolant circulation
+			if (HAS_TRAIT(src, TRAIT_BLOOD_COOLANT))
+				adjustFireLoss(1)
+			else
+				adjustBruteLoss(2)
 
 		//Body temperature stability and damage
 		dna.species.handle_body_temperature(src)

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -3,6 +3,9 @@
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
+/obj/item/ammo_casing/energy/ion/weak
+	projectile_type = /obj/projectile/ion/weak
+
 /obj/item/ammo_casing/energy/declone
 	projectile_type = /obj/projectile/energy/declone
 	select_name = "declone"

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -2,9 +2,11 @@
 	projectile_type = /obj/projectile/ion
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
+	e_cost = 80
 
 /obj/item/ammo_casing/energy/ion/weak
 	projectile_type = /obj/projectile/ion/weak
+	e_cost = 60
 
 /obj/item/ammo_casing/energy/declone
 	projectile_type = /obj/projectile/energy/declone

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -7,9 +7,10 @@
 	w_class = WEIGHT_CLASS_HUGE
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
-	ammo_type = list(/obj/item/ammo_casing/energy/ion)
+	ammo_type = list(/obj/item/ammo_casing/energy/ion) //Heavy EMP, 15 shots
 	ammo_x_offset = 3
 	fire_rate = 1.5
+	gun_charge = 1200
 
 /obj/item/gun/energy/ionrifle/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
@@ -26,9 +27,10 @@
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BELT
 	pin = null
-	ammo_type = list(/obj/item/ammo_casing/energy/ion/weak)
+	ammo_type = list(/obj/item/ammo_casing/energy/ion/weak) //Light EMP, 24 shots
 	ammo_x_offset = 2
 	fire_rate = 2.5
+	full_auto = TRUE
 
 /obj/item/gun/energy/ionrifle/carbine/add_seclight_point()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -9,6 +9,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/ion)
 	ammo_x_offset = 3
+	fire_rate = 1.5
 
 /obj/item/gun/energy/ionrifle/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
@@ -19,13 +20,15 @@
 
 /obj/item/gun/energy/ionrifle/carbine
 	name = "ion carbine"
-	desc = "The MK.II Prototype Ion Projector is a lightweight carbine version of the larger ion rifle, built to be ergonomic and efficient."
+	desc = "The MK.II Prototype Ion Projector is much faster, built to be ergonomic and efficient, but packs less of a punch per shot."
 	icon_state = "ioncarbine"
 	worn_icon_state = "ioncarbine"
-	w_class = WEIGHT_CLASS_LARGE
+	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BELT
 	pin = null
+	ammo_type = list(/obj/item/ammo_casing/energy/ion/weak)
 	ammo_x_offset = 2
+	fire_rate = 2.5
 
 /obj/item/gun/energy/ionrifle/carbine/add_seclight_point()
 	. = ..()

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -9,12 +9,12 @@
 
 /obj/projectile/ion/on_hit(atom/target, blocked = FALSE)
 	..()
-	empulse(target, 1, 1)
+	target.emp_act(EMP_LIGHT)
 	return BULLET_ACT_HIT
 
 /obj/projectile/ion/weak
 
 /obj/projectile/ion/weak/on_hit(atom/target, blocked = FALSE)
 	..()
-	empulse(target, 0, 0)
+	target.emp_act(EMP_HEAVY)
 	return BULLET_ACT_HIT

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -170,10 +170,12 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(prob(15/severity) && owner)
+	if(prob(80/severity) && owner)
 		to_chat(owner, span_warning("The electro magnetic pulse causes [src] to malfunction!"))
 		// give the owner an idea about why his implant is glitching
 		Retract()
+		owner.drop_all_held_items()
+		Extend(pick(contents))
 
 /obj/item/organ/cyberimp/arm/proc/Retract()
 	if(!active_item || (active_item in src))
@@ -247,22 +249,6 @@
 				Extend(choice)
 	else
 		Retract()
-
-
-/obj/item/organ/cyberimp/arm/gun/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	if(prob(30/severity) && owner && !(organ_flags & ORGAN_FAILING))
-		Retract()
-		owner.visible_message(span_danger("A loud bang comes from [owner]\'s [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm!"))
-		playsound(get_turf(owner), 'sound/weapons/flashbang.ogg', 100, 1)
-		to_chat(owner, span_userdanger("You feel an explosion erupt inside your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm as your implant breaks!"))
-		owner.adjust_fire_stacks(20)
-		owner.IgniteMob()
-		owner.adjustFireLoss(25)
-		organ_flags |= ORGAN_FAILING
-
 
 /obj/item/organ/cyberimp/arm/gun/laser
 	name = "arm-mounted laser implant"

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -11,19 +11,25 @@
 	icon_state = "chest_implant"
 	implant_color = "#00AA00"
 	var/hunger_threshold = NUTRITION_LEVEL_STARVING
-	var/synthesizing = 0
-	var/poison_amount = 5
+	var/synthesizing = FALSE
+	var/malfunctioning = FALSE
 	slot = ORGAN_SLOT_STOMACH_AID
 
 /obj/item/organ/cyberimp/chest/nutriment/on_life()
 	if(synthesizing)
 		return
 
-	if(owner.nutrition <= hunger_threshold)
+	if(malfunctioning && owner.nutrition >= hunger_threshold)
+		synthesizing = TRUE
+		to_chat(owner, span_warning("You feel like your insides are burning."))
+		owner.adjust_nutrition(-50)
+		addtimer(CALLBACK(src, PROC_REF(synth_cool)), 2 MINUTES)
+
+	else if(owner.nutrition <= hunger_threshold)
 		synthesizing = TRUE
 		to_chat(owner, span_notice("You feel less hungry..."))
 		owner.adjust_nutrition(50)
-		addtimer(CALLBACK(src, PROC_REF(synth_cool)), 50)
+		addtimer(CALLBACK(src, PROC_REF(synth_cool)), 5 SECONDS)
 
 /obj/item/organ/cyberimp/chest/nutriment/proc/synth_cool()
 	synthesizing = FALSE
@@ -32,9 +38,8 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	owner.reagents.add_reagent(/datum/reagent/toxin/bad_food, poison_amount / severity)
-	to_chat(owner, span_warning("You feel like your insides are burning."))
-
+	if(prob(30/severity))
+		malfunctioning = TRUE
 
 /obj/item/organ/cyberimp/chest/nutriment/plus
 	name = "Nutriment pump implant PLUS"
@@ -42,7 +47,6 @@
 	icon_state = "chest_implant"
 	implant_color = "#006607"
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY
-	poison_amount = 10
 
 /obj/item/organ/cyberimp/chest/reviver
 	name = "Reviver implant"
@@ -92,26 +96,10 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-
-	if(reviving)
-		revive_cost += 200
-	else
-		reviver_cooldown += 20 SECONDS
-
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		if(H.stat != DEAD && prob(50 / severity) && H.can_heartattack())
-			H.set_heartattack(TRUE)
-			to_chat(H, span_userdanger("You feel a horrible agony in your chest!"))
-			addtimer(CALLBACK(src, PROC_REF(undo_heart_attack)), 600 / severity)
-
-/obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()
-	var/mob/living/carbon/human/H = owner
-	if(!istype(H))
-		return
-	H.set_heartattack(FALSE)
-	if(H.stat == CONSCIOUS)
-		to_chat(H, span_notice("You feel your heart beating again!"))
+	if(prob(30/severity))
+		to_chat(owner, span_userdanger("You feel a sharp pain in your chest, your reviver implant seems to have shorted out!"))
+		owner.Knockdown((3 SECONDS))
+		Destroy()
 
 /obj/item/organ/cyberimp/chest/reviver/syndicate
 	syndicate_implant = TRUE

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -1,3 +1,8 @@
+/obj/item/organ/cyberimp/eyes/emp_act(severity)
+	if(prob(30/severity)) //They same effect as having cybernetic eyes
+		to_chat(owner, span_warning("Static obfuscates your vision!"))
+		owner.flash_act(visual = 1)
+
 /obj/item/organ/cyberimp/eyes/hud
 	name = "cybernetic hud"
 	desc = "artificial photoreceptors with specialized functionality"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -34,9 +34,11 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	var/stun_amount = 200/severity
-	owner.Stun(stun_amount)
-	to_chat(owner, span_warning("Your body seizes up!"))
+	if(prob(30/severity))
+		owner.drop_all_held_items()
+		owner.Knockdown((6 SECONDS)/severity)
+		owner.Jitter((4 SECONDS)/severity)
+		to_chat(owner, span_warning("Your body seizes up!"))
 
 
 /obj/item/organ/cyberimp/brain/anti_drop
@@ -57,7 +59,7 @@
 		var/list/hold_list = owner.get_empty_held_indexes()
 		if(LAZYLEN(hold_list) == owner.held_items.len)
 			to_chat(owner, span_notice("You are not holding any items, your hands relax..."))
-			active = 0
+			active = FALSE
 			stored_items = list()
 		else
 			for(var/obj/item/I in stored_items)
@@ -69,19 +71,9 @@
 
 
 /obj/item/organ/cyberimp/brain/anti_drop/emp_act(severity)
-	. = ..()
-	if(!owner || . & EMP_PROTECT_SELF)
-		return
-	var/range = severity ? 10 : 5
-	var/atom/A
 	if(active)
 		release_items()
-	for(var/obj/item/I in stored_items)
-		A = pick(oview(range))
-		I.throw_at(A, range, 2)
-		to_chat(owner, span_warning("Your [owner.get_held_index_name(owner.get_held_index_of_item(I))] spasms and throws the [I.name]!"))
-	stored_items = list()
-
+	..()
 
 /obj/item/organ/cyberimp/brain/anti_drop/proc/release_items()
 	for(var/obj/item/I in stored_items)
@@ -129,16 +121,6 @@
 		owner.SetKnockdown(0)
 		owner.SetImmobilized(0)
 		owner.SetParalyzed(0)
-
-/obj/item/organ/cyberimp/brain/anti_stun/emp_act(severity)
-	. = ..()
-	if((organ_flags & ORGAN_FAILING) || . & EMP_PROTECT_SELF)
-		return
-	organ_flags |= ORGAN_FAILING
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 90 / severity)
-
-/obj/item/organ/cyberimp/brain/anti_stun/proc/reboot()
-	organ_flags &= ~ORGAN_FAILING
 
 /obj/item/organ/cyberimp/brain/anti_stun/syndicate
 	syndicate_implant = TRUE

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -155,19 +155,12 @@
 	organ_flags = ORGAN_SYNTHETIC
 
 /obj/item/organ/ears/robot/emp_act(severity)
-	switch(severity)
-		if(1)
-			owner.Jitter(30)
-			owner.Dizzy(30)
-			owner.Knockdown(200)
-			to_chat(owner, span_warning("Alert: Audio sensors malfunctioning"))
-			owner.apply_status_effect(STATUS_EFFECT_IPC_EMP)
-		if(2)
-			owner.Jitter(15)
-			owner.Dizzy(15)
-			owner.Knockdown(100)
-			to_chat(owner, span_warning("Alert: Audio sensors malfunctioning"))
-			owner.apply_status_effect(STATUS_EFFECT_IPC_EMP)
+	. = ..()
+	if(prob(30/severity))
+		owner.Jitter(30/severity)
+		owner.Dizzy(30/severity)
+		to_chat(owner, span_warning("Alert: Audio sensors malfunctioning"))
+
 
 /obj/item/organ/ears/diona
 	name = "trichomes"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -142,10 +142,9 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	if(prob(10 * severity))
-		return
-	to_chat(owner, span_warning("Static obfuscates your vision!"))
-	owner.flash_act(visual = 1)
+	if(prob(30/severity))
+		to_chat(owner, span_warning("Static obfuscates your vision!"))
+		owner.flash_act(visual = 1)
 
 /obj/item/organ/eyes/robotic/xray
 	name = "\improper X-ray eyes"

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -194,11 +194,13 @@
 	var/rid = /datum/reagent/medicine/epinephrine
 	var/ramount = 10
 
-/obj/item/organ/heart/cybernetic/emp_act()
+/obj/item/organ/heart/cybernetic/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	Stop()
+	if(prob(30/severity))
+		Stop()
+		addtimer(CALLBACK(src, PROC_REF(Restart)), 10 SECONDS)
 
 /obj/item/organ/heart/cybernetic/on_life()
 	. = ..()
@@ -222,11 +224,6 @@
 /obj/item/organ/heart/cybernetic/ipc
 	desc = "An electronic device that appears to mimic the functions of an organic heart."
 	dose_available = FALSE
-
-/obj/item/organ/heart/cybernetic/ipc/emp_act()
-	. = ..()
-	to_chat(owner, span_warning("Alert: Cybernetic heart failed one heartbeat"))
-	addtimer(CALLBACK(src, PROC_REF(Restart)), 10 SECONDS)
 
 /obj/item/organ/heart/freedom
 	name = "heart of freedom"

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -112,11 +112,8 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	switch(severity)
-		if(1)
-			damage+=100
-		if(2)
-			damage+=50
+	if(prob(30/severity))
+		damage += (30/severity)
 
 /obj/item/organ/liver/cybernetic/upgraded/ipc
 	name = "substance processor"

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -130,12 +130,9 @@
 	status = ORGAN_ROBOTIC
 
 /obj/item/organ/liver/cybernetic/upgraded/ipc/emp_act(severity)
-	to_chat(owner, span_warning("Alert: Your Substance Processor has been damaged. An internal chemical leak is affecting performance."))
-	switch(severity)
-		if(1)
-			owner.toxloss += 15
-		if(2)
-			owner.toxloss += 5
+	if(prob(30/severity))
+		to_chat(owner, span_warning("Alert: Your Substance Processor has been damaged. An internal chemical leak is affecting performance."))
+		owner.adjustToxLoss(8/severity)
 
 /obj/item/organ/liver/diona
 	name = "liverwort"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -392,11 +392,12 @@
 	safe_breath_min = 13
 	safe_breath_max = 100
 
-/obj/item/organ/lungs/cybernetic/emp_act()
+/obj/item/organ/lungs/cybernetic/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	owner.losebreath = 20
+	if(prob(30/severity))
+		owner.losebreath += 10
 
 
 /obj/item/organ/lungs/cybernetic/upgraded

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -196,8 +196,6 @@
 	desc = "A basic device designed to mimic the functions of a human stomach"
 	organ_flags = ORGAN_SYNTHETIC
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
-	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
-	COOLDOWN_DECLARE(severe_cooldown)
 
 /obj/item/organ/stomach/cybernetic/upgraded
 	name = "cybernetic stomach"
@@ -205,17 +203,13 @@
 	desc = "An electronic device designed to mimic the functions of a human stomach. Handles disgusting food a bit better."
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	disgust_metabolism = 2
-	emp_vulnerability = 40
 
 /obj/item/organ/stomach/cybernetic/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
+	if(prob(30/severity))
 		owner.vomit(stun = FALSE)
-		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
-	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
-		organ_flags |= ORGAN_FAILING //Starts organ failure - gonna need replacing soon.
 
 /obj/item/organ/stomach/diona
 	name = "nutrient vessel"

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -144,13 +144,8 @@
 		owner.nutrition = (charge/max_charge)*NUTRITION_LEVEL_FULL
 
 /obj/item/organ/stomach/battery/emp_act(severity)
-	switch(severity)
-		if(1)
-			adjust_charge(-0.5 * max_charge)
-			applyOrganDamage(30)
-		if(2)
-			adjust_charge(-0.25 * max_charge)
-			applyOrganDamage(15)
+	. = ..()
+	adjust_charge((-0.3 * max_charge) / severity)
 
 /obj/item/organ/stomach/battery/ipc
 	name = "micro-cell"

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -298,9 +298,10 @@
 	return ..() + /datum/language/machine + /datum/language/voltaic
 
 /obj/item/organ/tongue/robot/emp_act(severity)
-	owner.emote("scream")
-	owner.apply_status_effect(STATUS_EFFECT_SPANISH)
-	owner.apply_status_effect(STATUS_EFFECT_IPC_EMP)
+	if(prob(30/severity))
+		owner.emote("scream")
+		owner.apply_status_effect(STATUS_EFFECT_SPANISH)
+
 
 /obj/item/organ/tongue/robot/handle_speech(datum/source, list/speech_args)
 	speech_args[SPEECH_SPANS] |= SPAN_ROBOT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All cases where two numbers displayed like this (15%/30%) or (4/8) are cases where the larger number is for heavy EMP, and the smaller number is for light EMP. 

### Cybernetic organs + IPCs
* **IPC brains** no longer take any direct damage from EMP, and are now the source of the generic status effect that warns an IPC they have been exposed to an EMP, instead of the ears and tongue both applying it. The associated status effect now lasts for only ten seconds instead of two minutes.
* **IPC tongues** now have a (15%/30%) chance of being affected by EMP, and the duration of being forced into galactic uncommon has been reduced to only 25 seconds instead of two full minutes. 
* **Cybernetic stomachs** have a (15%/30%) chance to cause the owner to vomit, without hardstun.
* **IPC stomachs (power cells)** are guaranteed to lose (15%/30%) of their max charge, down from (25%/75%)
* **Cybernetic livers** have a (15%/30%) chance of taking (15/30) damage
* **IPC livers specifically** have a (15%/30%) chance of triggering (4/8) toxin damage which is a small amount, but also especially annoying for them to deal with compared to other races.
* **All robotic eyes (IPC included)** have a (15%/30%) chance of being flashed, ignoring flash protection
* **IPC ears** have a (15%/30%) chance of triggering jitters and dizziness for (1.5/3) seconds. 
* **Robotic limbs (IPC included)** have a (15%/30%) chance of taking 5 burn damage and 120 stamina damage, and failing this chance are guaranteed to take 10 stamina damage
* **Cybernetic hearts (IPC included)** now have a (15%/30%) chance of being stopped when hit with an EMP, but will restart 10 seconds later making the heart attack temporary. The heart attack will still cause substantial oxyloss and some brute damage for organics, or some burn damage for IPCs (Heart attack code specific to the coolant trait was added for this effect on IPCs)

### Non-organ implants
* **Toolset and other arm implants** now have a (15%/30%) chance to retract the current tool, drop all held items, and then extend a random tool. The energy gun arm implant no longer explodes, it is simply affected by EMP like any other energy gun. 
* **Nutriment pumps** no longer fill the user with badfood, instead having a (15%/30%) chance of malfunctioning permanently and causing the owner of the implant to become hungrier once every two minutes for as long as they're *above* the hunger threshold of the implant.
* **Reviver implants** now have a (15%/30%) chance of malfunctioning so bad the device is destroyed. This destruction has no additional effect on the owner beyond a flavor message about feeling a sharp pain in their chest.
* **HUD implants** now have a (15%/30%) chance to flash the owner
* **All brain implants** now have a (15%/30%) chance to cause a (3/6) second knockdown and some jitters, as well as forcibly causing all items to be dropped. "Brain implants" include the anti-drop implant and anti-stun implant. 

### Ion Rifle (Heavy EMP)
* No longer has an AoE effect on its projectile, only direct hits will EMP
* Now has a reduced fire rate, down to 1.5 from 2.5
* Now has an increased magazine capacity, up to 15 from 10

### Ion Carbine (Light EMP)
* No longer has an AoE effect on its projectile, only direct hits will EMP
* Has an unchanged fire rate, **but is now fully automatic** which will effectively increase fire rate slightly
* Now has an increased magazine capacity, up to 24 from 10
* Is now a **huge** item, meaning it can no longer fit inside of bags.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

### IPC and Cybernetic changes
Excessively debilitating effects that serve as an unbeatable hard-counter are not fun or engaging gameplay mechanics. Players never have any interest in cybernetic organs because they are effectively signing their own death warrant in too many circumstances. Each of the adjusted effects are still debilitating, especially for a substantially enhanced person (or fully cybernetic such as IPC) but they are no longer guaranteed to be instantly game-over'd when faced with one.

### AoE removal from guns

EMP already exists in AoE form, and it's also already pretty damn accessible. Every lathe can produce the iron and uranium (provided miners exist) to create an EMP grenade. Guns with the ability to sustain repeated fire should not be capable of AoE, especially when those guns are intended to be a direct counterplay. 

Removing the AoE makes them much worse, but still effective at taking down the various targets they are intended to, and with a lot less collateral damage in the process... at least as long as you hit what you're aiming for. 

### Other changes to the ion guns

While removing the AoE was probably enough on its own, I also wanted to push both guns into unique directions. With the removal of AoE as well as the substantial nerf to their efficacy per shot to humanoid targets, I felt both guns needed increased capacity to still be worth choosing over ordinary lethals. The roundstart available ion rifle is the weaker choice overall, but packs more punch per shot. The carbine sports higher DPS, but requires trigger control despite having a larger magazine or else  it will empty much faster. Carbine was made huge because it is not a class of gun that should be able to fit in bags given the power it currently, and still sports. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

*Please note that I miss some of these shots*

![dreamseeker_PWE2cEvTto](https://github.com/user-attachments/assets/dc0e27e6-5a61-4302-a4ae-9457440f6e92)

## Changelog
:cl:
balance: EMPs are now significantly less lethal to players with cybernetic implants, organs and limbs including IPCs. Most cybernetics have a maximum of a 30% chance to be affected by an EMP now, but it will be rolled separately for each limb/organ/implant so that the more you have the more likely you are to be affected in some way. This means IPCs will still be relatively weak to EMP, but crew can upgrade in moderation without fear of an EMP hitting them too hard.
balance: Ion rifles and carbines have lost their AoE effect on the projectiles and now require a direct hit to trigger an EMP
tweak: Ion rifles have had their firing rate reduced from 2.5 shots per second to 1.5 shots per second
tweak: Ion rifles have had their capacity increased from 10 shots with a full charge to 15
tweak: Ion carbines are now fully automatic at 2.5 shots per second (this is the same fire rate they already had)
tweak: Ion carbines have a new capacity of 24, up from 10
tweak: Ion carbines no longer fit into bags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
