### PR TITLE
Fixes zombie organs not progressing

### DIFF
--- a/code/modules/admin/verbs/manipulate_organs.dm
+++ b/code/modules/admin/verbs/manipulate_organs.dm
@@ -1,8 +1,8 @@
 /client/proc/manipulate_organs(mob/living/carbon/C in world)
 	set name = "Manipulate Organs"
 	set category = "Debug"
-	var/operation = input("Select organ operation.", "Organ Manipulation", "cancel") as null|anything in list("add organ", "add implant", "drop organ/implant", "remove organ/implant", "cancel")
-	if (!operation)
+	var/operation = tgui_input_list(usr, "Select organ operation", "Organ Manipulation", list("add organ", "add implant", "drop organ/implant", "remove organ/implant"))
+	if (isnull(operation))
 		return
 
 	var/list/organs = list()
@@ -12,8 +12,10 @@
 				var/dat = replacetext("[path]", "/obj/item/organ/", ":")
 				organs[dat] = path
 
-			var/obj/item/organ/organ = input("Select organ type:", "Organ Manipulation", null) as null|anything in organs
-			if(!organ)
+			var/obj/item/organ/organ = tgui_input_list(usr, "Select organ type", "Organ Manipulation", organs)
+			if(isnull(organ))
+				return
+			if(isnull(organs[organ]))
 				return
 			organ = organs[organ]
 			organ = new organ
@@ -26,8 +28,10 @@
 				var/dat = replacetext("[path]", "/obj/item/implant/", ":")
 				organs[dat] = path
 
-			var/obj/item/implant/organ = input("Select implant type:", "Organ Manipulation", null) as null|anything in organs
-			if(!organ)
+			var/obj/item/implant/organ = tgui_input_list(usr, "Select implant type", "Organ Manipulation", organs)
+			if(isnull(organ))
+				return
+			if(isnull(organs[organ]))
 				return
 			organ = organs[organ]
 			organ = new organ
@@ -36,20 +40,18 @@
 			message_admins("[key_name_admin(usr)] has added implant [organ.type] to [ADMIN_LOOKUPFLW(C)]")
 
 		if("drop organ/implant", "remove organ/implant")
-			for(var/X in C.internal_organs)
-				var/obj/item/organ/I = X
+			for(var/obj/item/organ/I as anything in C.internal_organs)
 				organs["[I.name] ([I.type])"] = I
 
-			for(var/X in C.implants)
-				var/obj/item/implant/I = X
+			for(var/obj/item/organ/I as anything in C.implants)
 				organs["[I.name] ([I.type])"] = I
 
-			var/obj/item/organ = input("Select organ/implant:", "Organ Manipulation", null) as null|anything in organs
-			if(!organ)
+			var/obj/item/organ = tgui_input_list(usr, "Select organ/implant", "Organ Manipulation", organs)
+			if(isnull(organ))
+				return
+			if(isnull(organs[organ]))
 				return
 			organ = organs[organ]
-			if(!organ)
-				return
 			var/obj/item/organ/O
 			var/obj/item/implant/I
 

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -45,7 +45,7 @@
 		return
 	if(!(src in owner.internal_organs))
 		Remove(owner, TRUE)
-	if(owner.mob_biotypes & MOB_INORGANIC)//does not process in inorganic things
+	if(MOB_INORGANIC in owner.mob_biotypes)//does not process in inorganic things
 		return
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
 		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1 * delta_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Zombie organs were early returning during process() because of an incorrect biotype check that assumed biotypes were bitflags. They are not. 

This incorrect operator usage made the conditional true on humans everytime process() was called. Brain damage and checking if the mob was a zombie would never progress. This fixes that.

Additionally the organ manipulator is now tgui.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Zombies work again

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/99361b15-cfd0-4289-8f55-93d453a94099



</details>

## Changelog
:cl:
fix: zombie tumors work again
code: tgui'd VV dropdown organ manipulator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
