### PR TITLE
Clarifies anomaly core bounties

### DIFF
--- a/code/modules/cargo/bounties/core.dm
+++ b/code/modules/cargo/bounties/core.dm
@@ -1,47 +1,47 @@
 /datum/bounty/item/core/New()
 	..()
-	description = "The admiral heard that a [name] core help you grow your beard, fetch a [name] core immediately! Ship it to receive a large payment."
+	description = "The admiral heard that a [name] anomaly core can help you grow your beard, fetch a [name] core immediately! We'll reward you handsomely."
 	required_count = 1
 
 /datum/bounty/item/core/mark_high_priority(scale_reward)
 	return ..(max(scale_reward * 0.7, 1.2))
 
 /datum/bounty/item/core/bleed
-	name = "Bleed"
+	name = "Blood Anomaly Core"
 	reward = 25000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/blood)
 
 /datum/bounty/item/core/bluespace
-	name = "Bluespace"
+	name = "Bluespace Anomaly Core"
 	reward = 45000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/bluespace)
 
 /datum/bounty/item/core/delimber
-	name = "Delimber"
+	name = "Delimber Anomaly Core"
 	reward = 30000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/bioscrambler)
 
 /datum/bounty/item/core/flux
-	name = "Flux"
+	name = "Flux Anomaly Core"
 	reward = 20000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/flux)
 
 /datum/bounty/item/core/pyro
-	name = "Pyro"
+	name = "Pyro Anomaly Core"
 	reward = 25000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/pyro)
 
 /datum/bounty/item/core/vortex
-	name = "Vortex"
+	name = "Vortex Anomaly Core"
 	reward = 50000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/vortex)
 
 /datum/bounty/item/core/gravity
-	name = "Gravity"
+	name = "Gravity Anomaly Core"
 	reward = 20000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/grav)
 
 /datum/bounty/item/core/hallucination
-	name = "Hallucination"
+	name = "Hallucination Anomaly Core"
 	reward = 15000
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/hallucination)


### PR DESCRIPTION
## About The Pull Request
This changes the name of the anomaly core bounties from [name] to [name] anomaly core. Mechanically, they remain unchanged.

## Why It's Good For The Game
I've seen a lot of people ask what a "bleed" or a "delimber" is, unaware that it means that type of anomaly core. This should hopefully make that more clear.

## Testing Photographs and Procedure
Must we really?

## Changelog
:cl:
tweak: Clarified the anomaly core bounties! It should be more clear exactly what central wants now.
/:cl: