### PR TITLE
Adds a color intensity variable to reagents, now you can dye your mixes

### DIFF
--- a/code/modules/reagents/chemistry/colors.dm
+++ b/code/modules/reagents/chemistry/colors.dm
@@ -7,7 +7,7 @@
 	var/vol_temp
 
 	for(var/datum/reagent/R in reagent_list)
-		vol_temp = R.volume
+		vol_temp = R.volume * R.color_intensity
 		vol_counter += vol_temp
 
 		if(!mixcolor)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -44,6 +44,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/volume = 0
 	/// color it looks in containers etc
 	var/color = "#000000" // rgb: 0, 0, 0
+	/// intensity of color provided, dyes or things that should work like a dye will more strongly affect the final color of a reagent
+	var/color_intensity = 1
 	// default = I am not sure this shit + CHEMICAL_NOT_SYNTH
 	var/chem_flags = CHEMICAL_NOT_DEFINED
 	///how fast the reagent is metabolized by the mob

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1390,6 +1390,7 @@
 	description = "A powder that is used for coloring things."
 	reagent_state = SOLID
 	color = "#FFFFFF" // rgb: 207, 54, 0
+	color_intensity = 50
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY
 	taste_description = "the back of class"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's pretty much all in the title. 
* This adds a color intensity multiplier to reagents which defaults to 1.  
* Colorful reagent powders (including crayon) have this multiplier set to 50 so that they can be used as dyes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Reagent colors are a nice detail that can enable experienced players to distinguish reagents on sight. Being able to dye your reagents can be a robust way to disguise what you're really mixing. It will also pair especially nicely with #12388 as players will be able to color their concoctions more deliberately. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Bottle on the left contains one crayon
Bottle on the right contains 29u of Kelotane at the start
What I am doing is swapping 1u back and forth between the two bottles

![dreamseeker_BGBjT6XGal](https://github.com/user-attachments/assets/50e92185-2d81-438a-844c-62bfd87db935)


## Changelog
:cl:
tweak: Colorful reagents now have 50x color intensity in reagent containers. This means you can use crayon powder to dye your ugly brown medicine into a bright cherry red. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
