### PR TITLE
"Fixes" clown clumsiness for antagonists (except changelings)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -385,7 +385,6 @@
 			var/datum/antagonist/rev/head/new_head = new antag_datum()
 			new_head.give_flash = TRUE
 			new_head.give_hud = TRUE
-			new_head.remove_clumsy = TRUE
 			M.add_antag_datum(new_head,revolution)
 		else
 			assigned -= M

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -106,7 +106,6 @@
 		var/datum/antagonist/rev/head/new_head = new()
 		new_head.give_flash = TRUE
 		new_head.give_hud = TRUE
-		new_head.remove_clumsy = TRUE
 		rev_mind.add_antag_datum(new_head,revolution)
 		GLOB.pre_setup_antags -= rev_mind
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -75,7 +75,6 @@
 	var/mob/living/carbon/C = owner.current
 	if(!istype(C))
 		return
-	handle_clown_mutation(C, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 	. += cult_give_item(/obj/item/melee/cultblade/dagger, C)
 	if(metal)
 		. += cult_give_item(/obj/item/stack/sheet/runed_metal/ten, C)

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -189,7 +189,6 @@
 
 /datum/antagonist/heretic/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/our_mob = mob_override || owner.current
-	handle_clown_mutation(our_mob, "Ancient knowledge described to you has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 	our_mob.faction |= FACTION_HERETIC
 	RegisterSignals(our_mob, list(COMSIG_MOB_PRE_SPELL_CAST, COMSIG_MOB_SPELL_ACTIVATED), PROC_REF(on_spell_cast))
 	RegisterSignal(our_mob, COMSIG_MOB_ITEM_AFTERATTACK, PROC_REF(on_item_afterattack))
@@ -198,7 +197,6 @@
 
 /datum/antagonist/heretic/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/our_mob = mob_override || owner.current
-	handle_clown_mutation(our_mob, removing = FALSE)
 	our_mob.faction -= FACTION_HERETIC
 	UnregisterSignal(our_mob, list(COMSIG_MOB_PRE_SPELL_CAST, COMSIG_MOB_SPELL_ACTIVATED, COMSIG_MOB_ITEM_AFTERATTACK, COMSIG_MOB_LOGIN))
 	update_heretic_icons_removed()

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -108,7 +108,6 @@
 /datum/antagonist/rev/head/admin_add(datum/mind/new_owner,mob/admin)
 	give_flash = TRUE
 	give_hud = TRUE
-	remove_clumsy = TRUE
 	new_owner.add_antag_datum(src)
 	message_admins("[key_name_admin(admin)] has head-rev'ed [key_name_admin(new_owner)].")
 	log_admin("[key_name(admin)] has head-rev'ed [key_name(new_owner)].")
@@ -134,14 +133,11 @@
 	//This is probably overkill but making these impact state annoys me
 	var/old_give_flash = give_flash
 	var/old_give_hud = give_hud
-	var/old_remove_clumsy = remove_clumsy
 	give_flash = TRUE
 	give_hud = FALSE
-	remove_clumsy = FALSE
 	equip_rev()
 	give_flash = old_give_flash
 	give_hud = old_give_hud
-	remove_clumsy = old_remove_clumsy
 
 /datum/antagonist/rev/head/proc/admin_repair_flash(mob/admin)
 	var/list/L = owner.current.get_contents()
@@ -162,7 +158,6 @@
 	hud_type = "rev_head"
 	banning_key = ROLE_REV_HEAD
 	required_living_playtime = 4
-	var/remove_clumsy = FALSE
 	var/give_flash = FALSE
 	var/give_hud = TRUE
 
@@ -247,9 +242,6 @@
 	var/mob/living/carbon/H = owner.current
 	if(!ishuman(H) && !ismonkey(H))
 		return
-
-	if(remove_clumsy)
-		handle_clown_mutation(H, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 
 	if(give_flash)
 		var/obj/item/assembly/flash/handheld/T = new(H)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -27,12 +27,6 @@
 	finalize_traitor()
 	..()
 
-/datum/antagonist/traitor/apply_innate_effects()
-	handle_clown_mutation(owner.current, silent ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
-
-/datum/antagonist/traitor/remove_innate_effects()
-	handle_clown_mutation(owner.current, removing=FALSE)
-
 /datum/antagonist/traitor/on_removal()
 	//Remove malf powers.
 	if(traitor_kind == TRAITOR_AI && owner.current && isAI(owner.current))

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -299,7 +299,7 @@
 	clumsy_check = 0
 
 /obj/item/gun/ballistic/revolver/reverse/can_trigger_gun(mob/living/user)
-	if((HAS_TRAIT(user, TRAIT_CLUMSY)) || (user.mind && user.mind.assigned_role == JOB_NAME_CLOWN))
+	if((HAS_TRAIT(user, TRAIT_CLUMSY)))
 		return ..()
 	if(process_fire(user, user, FALSE, null, BODY_ZONE_HEAD))
 		user.visible_message(span_warning("[user] somehow manages to shoot [user.p_them()]self in the face!"), span_userdanger("You somehow shoot yourself in the face! How the hell?!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #12397
This removes the code that takes the honkmother's blessing away from clowns that happen to be antagonists. All antagonist clowns except for changelings (which aren't actually a clown) will retain clumsiness and all of the hilarity that results from it.

This PR also removes the check for clown job from the reverse revolver

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Clowns should be silly even when they're antagonists, and this isn't very silly. 
This also enables clowns to use taeclowndo boots again, since those require clumsiness to use now

**_This is not a true "fix" as the removal of clumsiness was apparently intended_** This is an abstract solution to an issue I created. Alternatives include removing taeclowndo from explorer mission clowns and/or removing the clumsiness restriction from the taeclowndo shoes which enables them to be used by anyone even if they aren't clown oriented at all. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

## Reverse revolver shown

![dreamseeker_zg2zfPoFhn](https://github.com/user-attachments/assets/da758803-8da2-4be8-9c9f-564050440eec)


## Changelog
:cl:
tweak: Antagonist clowns are now clumsy again, except for changelings. This additionally means taeclowndo shoes are usable by traitorous clowns again
code: Removed a mostly redundant check from reverse revolver. It only checks for clumsiness now, not the clown job
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
