### PR TITLE
Fixes two issues with taeclowndo

### DIFF
--- a/code/modules/clothing/shoes/taeclowndo.dm
+++ b/code/modules/clothing/shoes/taeclowndo.dm
@@ -8,4 +8,4 @@
 
 //we only want to grant the powers to true clowns, not those fakers that remove their clumsiness
 /obj/item/clothing/shoes/clown_shoes/taeclowndo/item_action_slot_check(slot, mob/user)
-	return slot == ITEM_SLOT_FEET && HAS_TRAIT(user, TRAIT_CLUMSY)
+	return slot == ITEM_SLOT_FEET && (HAS_TRAIT(user, TRAIT_CLUMSY) || (user.mind && user.mind.assigned_role == JOB_NAME_CLOWN))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -182,6 +182,8 @@
 
 	implants = list(/obj/item/implant/sad_trombone)
 
+/datum/outfit/vip_target/clown/pre_equip(mob/living/carbon/human/H)
+	H.dna.add_mutation(CLOWNMUT)
+
 /datum/outfit/vip_target/clown/post_equip(mob/living/carbon/human/H)
 	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names))
-	H.dna.add_mutation(CLOWNMUT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #12397
Fixes assassination target clowns not seeing the taeclowndo abilities without taking the shoes off and on first. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Clowns should be able to use their special antag shoes without jumping through extra hoops. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/30281cf3-ca9b-4657-8486-97d40679ca9e)

![image](https://github.com/user-attachments/assets/6ee4e479-757a-4920-a4a9-49107aec3a94)


## Changelog
:cl:
fix: Taeclowndo shoes now work as expected again. Clown antagonists can use them without being clumsy, and assassination target clowns can use them without taking the shoes off and on again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
