### PR TITLE
Removes the ability to fire two guns at the same time

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -45,7 +45,7 @@
 	var/firing_burst = 0				//Prevent the weapon from firing again while already firing
 	var/semicd = 0						//cooldown handler
 	var/weapon_weight = WEAPON_LIGHT
-	var/dual_wield_spread = 24			//additional spread when dual wielding
+	var/single_hand_spread = 24			//additional spread when holding a gun with only one hand
 	var/spread = 0						//Spread induced by the gun itself.
 	var/spread_multiplier = 1			//Multiplier for shotgun spread
 	var/requires_wielding = TRUE
@@ -357,7 +357,7 @@
 
 		//If you're not holding it with both hands, suffer aim penalty
 		else
-			bonus_spread += dual_wield_spread
+			bonus_spread += single_hand_spread
 
 	var/zone_override = null
 	if(aimed == GUN_AIMED_POINTBLANK)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -348,22 +348,16 @@
 					user.dropItemToGround(src, TRUE)
 				return
 
-	if(weapon_weight == WEAPON_HEAVY && !is_wielded)
-		balloon_alert(user, "You need both hands free to fire [src]!")
-		return
-
-	//DUAL (or more!) WIELDING
 	var/bonus_spread = 0
-	var/loop_counter = 0
-	if(ishuman(user) && user.combat_mode)
-		var/mob/living/carbon/human/H = user
-		for(var/obj/item/gun/G in H.held_items)
-			if(G == src || G.weapon_weight >= WEAPON_MEDIUM || weapon_weight >= WEAPON_MEDIUM)
-				continue
-			else if(G.can_trigger_gun(user))
-				bonus_spread += dual_wield_spread
-				loop_counter++
-				addtimer(CALLBACK(G, TYPE_PROC_REF(/obj/item/gun, process_fire), target, user, TRUE, params, null, bonus_spread, flag), loop_counter)
+
+	if(!is_wielded)
+		if(weapon_weight == WEAPON_HEAVY)
+			balloon_alert(user, "You need both hands free to fire [src]!")
+			return
+
+		//If you're not holding it with both hands, suffer aim penalty
+		else
+			bonus_spread += dual_wield_spread
 
 	var/zone_override = null
 	if(aimed == GUN_AIMED_POINTBLANK)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -374,7 +374,7 @@
 	name = "lever action shotgun"
 	desc = "A really old shotgun with five shell capacity. This one can fit in a backpack."
 	w_class = WEIGHT_CLASS_LARGE
-	dual_wield_spread = 0
+	single_hand_spread = 0
 	fire_sound_volume = 60    //tried on 90 my eardrums said goodbye
 	item_state = "leveraction"
 	icon_state = "leveraction"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -8,7 +8,7 @@
 	modifystate = 1
 	ammo_x_offset = 3
 	weapon_weight = WEAPON_MEDIUM
-	dual_wield_spread = 60
+	single_hand_spread = 60
 
 /obj/item/gun/energy/e_gun/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This removes the ability to fire a gun in your inactive hand

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Guns are no longer the most powerful "melee" weapon in the game. The dramatically reduced accuracy for dual wielding was supposed to make it largely non-viable, but all it actually did in practice was require the guns to be used in melee range. 

When used in melee range, dual wield lasers lasers do 40 damage per attack at a rate of 2.5 attacks per second. Disablers do 56 stamina damage at this same rate. PKAs can do up to 80 damage in a single burst, or extremely rapidly fire off 40s. None of these are intended balance numbers for these weapons, even if they require melee range to perform at this level. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![dreamseeker_1v25aKkD2Z](https://github.com/user-attachments/assets/f7b0bc8e-3d46-4c5a-98d7-12ae6923b935)

## Changelog
:cl:
del: Ranged weapons will no longer fire from the inactive hand in combat mode. You can still dual wield guns, but they will no longer fire simultaneously. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
