### PR TITLE
Fixes "You have one or more outdated quirks"

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -42,17 +42,15 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		quirk_points[initial(T.name)] = initial(T.quirk_value)
 
 /datum/controller/subsystem/processing/quirks/proc/AssignQuirks(datum/mind/user, client/cli, spawn_effects)
-	var/bad_quirk_checker = 0
 	var/list/bad_quirks = list()
 	for(var/V in cli.prefs.all_quirks)
 		var/datum/quirk/Q = quirks[V]
 		if(Q)
 			user.add_quirk(Q, spawn_effects)
-			bad_quirk_checker += initial(Q.quirk_value)
 		else
 			stack_trace("Invalid quirk \"[V]\" in client [cli.ckey] preferences. the game has reset their quirks automatically.")
 			bad_quirks += V
-	if(bad_quirk_checker > 0 || length(bad_quirks)) // negative & zero value = calculation good / positive quirk value = something's wrong
+	if(length(bad_quirks)) // negative & zero value = calculation good / positive quirk value = something's wrong
 		cli.prefs.all_quirks = list()
 		// save the new cleared quirks.
 		cli.prefs.mark_undatumized_dirty_character()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently players who have more positive than negative quirks saved to the database receive an error and have their saved quirks wiped every round, despite being allowed to play with those quirks and save them. This PR fixes the extra safety check that wipes any quirk balance with a positive total. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs are bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Not much to show here, it's a lack of a certain popup arriving on roundstart with a positive balance. Again I'm not even certain I can trigger this without a database, but it looks like I should have been able to in my initial testing despite not doing so. 

![dreamseeker_uECLoVKOIT](https://github.com/user-attachments/assets/4299916b-e54f-4a31-ae2d-bf56d9d97cda)


## Changelog
:cl:
fix: Quirks should no longer randomly reset with a false error message!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
