### PR TITLE
Debug tool improvement: Makes mapping range debug verbs more obvious

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -67,6 +67,7 @@ GLOBAL_PROTECT(admin_verbs_debug_mapping)
 /obj/effect/debugging/marker
 	icon = 'icons/turf/areas.dmi'
 	icon_state = "yellow"
+	plane = ABOVE_LIGHTING_PLANE
 
 /obj/effect/debugging/marker/Move()
 	return 0
@@ -81,10 +82,16 @@ GLOBAL_PROTECT(admin_verbs_debug_mapping)
 			on = TRUE
 		T.maptext = null
 
+	for(var/obj/effect/debugging/marker/M in world)
+		qdel(M)
+
 	if(!on)
 		var/list/seen = list()
 		for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 			for(var/turf/T in C.can_see())
+				var/obj/effect/debugging/marker/F = new/obj/effect/debugging/marker(T)
+				if (!(T in C.can_see()))
+					qdel(F)
 				seen[T]++
 		for(var/turf/T in seen)
 			T.maptext = MAPTEXT("[seen[T]]")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added `plane = ABOVE_LIGHTING_PLANE` to `/obj/effect/debugging/marker`.
Also adds these debug markers to the camera range display instead of just the intercom.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Improving ingame debug tools is nice :)
Adding the plane change to the debug markers makes them visible even in dark and over things like airlocks and windows (not a thing previously).
Also the previous camera range display was... bad.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

What it looked like before:
<img width="827" alt="dreamseeker_rIjg1ELj12" src="https://github.com/user-attachments/assets/3fbe655d-27b8-4d90-aa66-88902f678775" />

What it looks like now:
<img width="827" alt="dreamseeker_GRmXHuzcGY" src="https://github.com/user-attachments/assets/064d80c2-24bd-4469-89cd-3490d197755a" />

It's now better for actually finding the holes in camera coverage:
<img width="827" alt="dreamseeker_m3z2vtEF78" src="https://github.com/user-attachments/assets/b9b41512-f76e-4e7a-9546-a07f65f6080b" />


</details>

## Changelog
:cl:
tweak: (debug tool) mapping range verbs are more obvious now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
