### PR TITLE
Tweak: "Required votes to leave" never drops to 0

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -33,7 +33,8 @@ SUBSYSTEM_DEF(autotransfer)
 		if(decay_start)
 			decay_count++
 
-		required_votes_to_leave = length(GLOB.clients) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count)
+		required_votes_to_leave = max(length(GLOB.clients) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count), 1)
+
 		if(connected_votes_to_leave >= required_votes_to_leave)
 			if(SSshuttle.canEvac() == TRUE) //This must include the == TRUE because all returns for this proc have a value, we specifically want to check for TRUE
 				SSshuttle.requestEvac(null, "Crew Transfer Requested.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On live right now, the decay for people required to vote to leave reaches 0 at around the 3 hour mark, this PR adds a minimum.
Added a max() proc to required_votes_to_leave, so it never goes past 1.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

While the change to the crew votes was overall good, being forced to call the shuttle when **NO ONE** wants it, is a bit silly. This way we still get down to just a single person wanting to go home, but if everyone wants to stay, let them!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

a couple of minutes in:
![image](https://github.com/user-attachments/assets/4405fce6-ad71-46ce-ae48-b75d0d02a044)

post 20 minutes in (the vote is at 0/1 properly):
![image](https://github.com/user-attachments/assets/7e564ecc-1c0e-45d3-b73a-21c856bb3423)

~~I'm not waiting for 3 hours to test this, if you have a way for me to test it faster, let me know!~~
I waited for 3 hours and 15 minutes to test this:
![image](https://github.com/user-attachments/assets/f720c466-40b5-49bc-b880-09ffe9bfa85d)


</details>

## Changelog
:cl: Gilgax
tweak: Crew transfer shuttle is no longer mandatory at the 3 hour mark.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
