### PR TITLE
Adjusts deadchat color to more closely match the previous purple

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -466,7 +466,7 @@ em {
 }
 
 .deadsay {
-  color: #b866ff;
+  color: #c482ff;
 }
 .binarysay {
   color: #20c20e;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -466,7 +466,7 @@ em {
 }
 
 .deadsay {
-  color: #e2c1ff;
+  color: #b866ff;
 }
 .binarysay {
   color: #20c20e;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The pink from #12325 looks so washed out and doesnt mesh well with the other colors.
![image](https://github.com/user-attachments/assets/597f4c33-b06f-4cd5-8ecc-168beac1e1fa)
![image](https://github.com/user-attachments/assets/1ea0736c-a065-4c3d-ac14-28b9a66f5e17)
![image](https://github.com/user-attachments/assets/61676369-0581-4482-bb36-8ba054fa9116)

So, this adjusts the color to one more similar to the previous color, while keeping readability

## Why It's Good For The Game

Players were attached to the old style dark purple. 

This adjusts it back to a color similar to that, while still trying to keep progress made in being readable.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/cb1550c2-8d68-4726-a506-7d5a0d255c3a)

Old:
![image](https://github.com/user-attachments/assets/7825b003-04c1-41bc-b733-5588002aa491)

Current:
![image](https://github.com/user-attachments/assets/4fafb708-e5fa-4340-b827-41cc2def6576)


New:
![image](https://github.com/user-attachments/assets/5ecea144-0618-46c6-aa83-910bfdb021b5)

</details>

## Changelog
:cl:
tweak: Tweaks dead chat color from washed out pink to a more legible purple. Maintains WCAG text legibility compliance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
