### PR TITLE
Runtime fix: You can throw people again

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -178,8 +178,13 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 	var/sound/throwsound = 'sound/weapons/throw.ogg'
 	playsound(src, throwsound, min(8*min(get_dist(loc,target),thrown_thing.throw_range), 50), vary = TRUE, extrarange = -1)
 	log_message("has thrown [thrown_thing].", LOG_ATTACK)
-	visible_message(span_danger("[src] [held_item.throw_verb ? held_item.throw_verb : verb_text] [thrown_thing]."), \
-						span_danger("You [held_item.throw_verb ? held_item.throw_verb : verb_text] [thrown_thing]."))
+
+	if (!held_item)
+		visible_message(span_danger("[src] [verb_text] [thrown_thing]."), \
+							span_danger("You [verb_text] [thrown_thing]."))
+	else
+		visible_message(span_danger("[src] [held_item.throw_verb ? held_item.throw_verb : verb_text] [thrown_thing]."), \
+							span_danger("You [held_item.throw_verb ? held_item.throw_verb : verb_text] [thrown_thing]."))
 	log_message("has thrown [thrown_thing]", LOG_ATTACK)
 
 	newtonian_move(get_dir(target, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #12424

The messages when throwing something asked for `held_item.throw_verb`, but would throw a runtime if you weren't holding something (like in the case you're agressive grabbing someone with empty hands). This PR adds an if to catch that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Runtime bad, fix good! 👍 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

After throwing person:
<img width="866" alt="dreamseeker_txpyjrSbAw" src="https://github.com/user-attachments/assets/aba41412-bfde-4572-8fa3-5cd2023c8731" />

Also threw an item to see it didn't bork:
<img width="723" alt="dreamseeker_ZAsnpYrBuI" src="https://github.com/user-attachments/assets/a3dd8653-6237-4f85-a4db-900c924fa0dc" />

</details>

## Changelog
:cl: Gilgax
fix: You can throw people again!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
