### PR TITLE
Furnishes metastation's brig a bit

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1033,7 +1033,12 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "ajz" = (
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/security/warden)
 "ajD" = (
 /turf/closed/wall,
@@ -1748,7 +1753,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_corner,
 /area/security/warden)
 "aqa" = (
 /turf/closed/wall/r_wall,
@@ -1918,7 +1926,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "arc" = (
 /obj/structure/cable/yellow{
@@ -1927,7 +1935,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "arl" = (
 /obj/effect/spawner/room/threexthree,
@@ -2007,7 +2015,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
 /area/security/warden)
 "asq" = (
 /obj/effect/landmark/start/warden,
@@ -2021,7 +2034,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "asr" = (
 /obj/machinery/computer/crew{
@@ -2030,7 +2046,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "asQ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -15904,7 +15923,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "chi" = (
 /obj/structure/table,
@@ -19766,7 +19788,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "cQV" = (
 /obj/item/flashlight/lantern{
@@ -29359,7 +29381,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/warden,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/security/warden)
 "fYI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -31108,7 +31133,8 @@
 	name = "Outer Window"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "gKE" = (
 /obj/machinery/door/airlock/external{
@@ -31826,7 +31852,12 @@
 /area/science/xenobiology)
 "gXh" = (
 /obj/machinery/computer/holodeck/prison,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
 /area/security/warden)
 "gXq" = (
 /turf/open/space/basic,
@@ -32323,9 +32354,6 @@
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/dark_red/anticorner{
-	dir = 8
 	},
 /turf/open/floor/iron/smooth_corner{
 	dir = 4
@@ -35306,7 +35334,11 @@
 	},
 /obj/structure/closet/secure_closet/warden,
 /obj/item/gun/energy/laser,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/red,
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "ika" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -35548,7 +35580,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "ioT" = (
 /obj/structure/window/reinforced,
@@ -36275,7 +36307,13 @@
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/security/warden)
 "iCT" = (
 /obj/structure/disposalpipe/segment{
@@ -37143,7 +37181,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "iSU" = (
 /obj/structure/sign/departments/medbay/alt,
@@ -41766,7 +41804,8 @@
 /obj/item/folder/red,
 /obj/item/poster/random_official,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "kGJ" = (
 /obj/structure/cable/yellow{
@@ -45489,7 +45528,10 @@
 /obj/machinery/computer/records/security{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "mcV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
@@ -46492,7 +46534,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "mxH" = (
 /obj/structure/cable/yellow{
@@ -49054,7 +49099,10 @@
 /obj/machinery/light_switch{
 	pixel_y = -26
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "nrZ" = (
 /obj/structure/cable/yellow{
@@ -52955,7 +53003,10 @@
 	pixel_x = 10;
 	pixel_y = 3
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "oIj" = (
 /obj/structure/disposalpipe/segment{
@@ -53583,7 +53634,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/rnd/production/techfab/department/security,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "oUz" = (
 /obj/structure/disposalpipe/segment{
@@ -57356,7 +57410,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth_large,
 /area/security/warden)
 "qru" = (
 /obj/structure/cable{
@@ -62149,7 +62203,10 @@
 	pixel_x = 29;
 	pixel_y = -28
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/anticorner,
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/security/warden)
 "seq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -74223,7 +74280,10 @@
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_y = 2
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "wxT" = (
 /obj/structure/disposalpipe/segment{
@@ -76130,7 +76190,10 @@
 /obj/item/wirecutters{
 	pixel_y = 2
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
 /area/security/warden)
 "xgR" = (
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55249,9 +55249,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "pBf" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3644,16 +3644,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/storage_wing)
-"aGd" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
-	},
-/area/security/main)
 "aGf" = (
 /obj/effect/turf_decal/pool{
 	dir = 8
@@ -20497,6 +20487,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
+"daz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "daO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -37990,6 +37989,17 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
+"jlY" = (
+/obj/structure/table,
+/obj/item/paper/guides/jobs/security/labor_camp{
+	pixel_x = 5
+	},
+/obj/item/radio/off{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "jmN" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -44103,6 +44113,23 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/tcommsat/server)
+"lCs" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "lCt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -50093,6 +50120,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
+"nLa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "nLe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50345,15 +50381,13 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "nPB" = (
-/obj/structure/table,
-/obj/item/paper/guides/jobs/security/labor_camp{
-	pixel_x = 5
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Labor - Starboard"
 	},
-/obj/item/radio/off{
-	pixel_x = -7;
-	pixel_y = 7
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "nPH" = (
 /obj/structure/cable/yellow{
@@ -52104,10 +52138,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/checker,
 /area/crew_quarters/kitchen)
-"otk" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
 "otF" = (
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -54242,8 +54272,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "piK" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/dark/smooth_corner,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "pkb" = (
 /obj/machinery/computer/rdservercontrol,
@@ -55201,12 +55236,7 @@
 /turf/open/floor/wood,
 /area/library)
 "pAS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "pBf" = (
@@ -58938,13 +58968,12 @@
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/hor)
 "qTJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/security/main)
 "qTN" = (
 /obj/machinery/computer/teleporter,
@@ -59952,6 +59981,21 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"rno" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "rnD" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating,
@@ -61255,6 +61299,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"rPe" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "rPl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61548,14 +61596,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"rTk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/security/main)
 "rTo" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61708,9 +61748,15 @@
 /turf/open/floor/iron,
 /area/engine/engineering)
 "rVA" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "rVC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61919,10 +61965,6 @@
 	},
 /turf/open/floor/carpet/grimy,
 /area/hallway/primary/central)
-"rYP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
 "rZd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
@@ -68097,21 +68139,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/bridge)
-"uiQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
 "uiY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68480,9 +68507,7 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "uqY" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "ura" = (
@@ -69339,13 +69364,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "uHs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/security/main)
 "uHy" = (
 /obj/structure/cable/yellow{
@@ -71711,15 +71731,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"vzw" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Labor - Starboard"
-	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
-	},
-/area/security/main)
 "vzH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -73367,6 +73378,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"wew" = (
+/obj/effect/turf_decal/tile/red/half,
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "wex" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room";
@@ -75887,21 +75907,10 @@
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
 "xac" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
+/obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "xad" = (
 /obj/machinery/light_switch{
@@ -111857,7 +111866,7 @@ lMJ
 aaa
 aiD
 pyl
-pAS
+daz
 vCS
 ajD
 ajD
@@ -112369,7 +112378,7 @@ aaa
 iRB
 gKE
 kKh
-uiQ
+rno
 ucb
 tyL
 hsZ
@@ -112627,12 +112636,12 @@ lMJ
 ajD
 ajo
 aqa
-xac
+lCs
 jkx
 fjg
 xUL
 nnt
-qTJ
+nLa
 wsD
 aqa
 aje
@@ -112886,10 +112895,10 @@ aaa
 aiD
 xtg
 cYA
-nPB
-otk
-uqY
-uHs
+jlY
+pAS
+xac
+piK
 cBe
 aqa
 aje
@@ -113145,7 +113154,7 @@ jtU
 jkx
 anQ
 cNb
-rYP
+uqY
 xkm
 gNz
 aqa
@@ -113398,12 +113407,12 @@ lMJ
 gKE
 sxb
 fvX
-piK
-kqh
-vzw
-aGd
+uHs
+wew
+nPB
+rVA
 vgT
-rTk
+qTJ
 pmt
 aqa
 fFI
@@ -114430,7 +114439,7 @@ jRV
 ieV
 acP
 acP
-rVA
+rPe
 aqa
 wrp
 aqa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -57127,6 +57127,9 @@
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
 /turf/open/floor/iron/smooth_half,
 /area/security/prison)
 "qlJ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29821,28 +29821,28 @@
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
 /obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/head/cone{
-	pixel_x = -4;
+	pixel_x = -10;
 	pixel_y = 4
 	},
 /obj/machinery/light/small,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/cone{
+	pixel_x = -10;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/techmaint,
 /area/security/main)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20487,15 +20487,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"daz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
 "daO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -26925,6 +26916,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"fhS" = (
+/obj/structure/table,
+/obj/item/paper/guides/jobs/security/labor_camp{
+	pixel_x = 5
+	},
+/obj/item/radio/off{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "fic" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -27014,10 +27016,12 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "fjg" = (
-/obj/machinery/computer/shuttle_flight/labor{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/security/main)
 "fjD" = (
 /obj/structure/disposalpipe/segment{
@@ -32354,6 +32358,9 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
+/obj/effect/turf_decal/tile/dark_red/anticorner{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth_corner{
 	dir = 4
 	},
@@ -32963,7 +32970,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/security/main)
 "htc" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -37118,17 +37130,20 @@
 	},
 /area/security/brig)
 "iRB" = (
-/obj/structure/lattice,
-/obj/docking_port/stationary{
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock";
+	req_one_access_txt = "1;4"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "iRC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
@@ -37989,17 +38004,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
-"jlY" = (
-/obj/structure/table,
-/obj/item/paper/guides/jobs/security/labor_camp{
-	pixel_x = 5
-	},
-/obj/item/radio/off{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
 "jmN" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -40932,6 +40936,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/locker)
+"kqA" = (
+/obj/machinery/computer/prisoner/gulag_teleporter_computer,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "kqX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -43872,7 +43880,12 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/security/main)
 "lxS" = (
 /obj/structure/rack,
@@ -44113,23 +44126,6 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/tcommsat/server)
-"lCs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/security/main)
 "lCt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -49299,7 +49295,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
 /area/security/main)
 "nvp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -49710,6 +49711,10 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science)
+"nDs" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "nDy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50120,15 +50125,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
-"nLa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
 "nLe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50381,12 +50377,20 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "nPB" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Security - Labor - Starboard"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/smooth_half{
+/obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
 	},
 /area/security/main)
 "nPH" = (
@@ -50766,6 +50770,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"nWC" = (
+/obj/machinery/computer/shuttle_flight/labor{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "nWN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54272,13 +54282,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "piK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Labor - Starboard"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "pkb" = (
 /obj/machinery/computer/rdservercontrol,
@@ -55236,7 +55246,12 @@
 /turf/open/floor/wood,
 /area/library)
 "pAS" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "pBf" = (
@@ -58200,6 +58215,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/fitness/recreation)
+"qFX" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "qFY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -58968,12 +58993,13 @@
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/hor)
 "qTJ" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "qTN" = (
 /obj/machinery/computer/teleporter,
@@ -59981,21 +60007,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"rno" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
 "rnD" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating,
@@ -61299,10 +61310,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"rPe" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
 "rPl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61748,14 +61755,8 @@
 /turf/open/floor/iron,
 /area/engine/engineering)
 "rVA" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/security/main)
 "rVC" = (
 /obj/structure/cable/yellow{
@@ -66111,6 +66112,15 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"tyE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "tyH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -66711,6 +66721,12 @@
 /obj/item/clothing/under/misc/assistantformal,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"tJU" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "tKB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plating,
@@ -69364,8 +69380,13 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "uHs" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/dark/smooth_corner,
+/obj/effect/turf_decal/tile/red/half,
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/security/main)
 "uHy" = (
 /obj/structure/cable/yellow{
@@ -73378,15 +73399,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"wew" = (
-/obj/effect/turf_decal/tile/red/half,
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
-	},
-/area/security/main)
 "wex" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room";
@@ -75907,11 +75919,17 @@
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
 "xac" = (
-/obj/structure/chair/office{
-	dir = 1
+/obj/structure/lattice,
+/obj/docking_port/stationary{
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_home";
+	name = "fore bay 1";
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 9
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
+/turf/open/space/basic,
+/area/space/nearstation)
 "xad" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -78838,15 +78856,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/storage/satellite)
 "xWQ" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_half{
+/obj/effect/turf_decal/tile/red/anticorner{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/smooth_corner,
 /area/security/main)
 "xWX" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -111866,7 +111882,7 @@ lMJ
 aaa
 aiD
 pyl
-daz
+qTJ
 vCS
 ajD
 ajD
@@ -112375,10 +112391,10 @@ aaa
 aaa
 aaa
 aaa
-iRB
+xac
 gKE
 kKh
-rno
+iRB
 ucb
 tyL
 hsZ
@@ -112636,12 +112652,12 @@ lMJ
 ajD
 ajo
 aqa
-lCs
+nPB
 jkx
-fjg
+nWC
 xUL
 nnt
-nLa
+tyE
 wsD
 aqa
 aje
@@ -112895,10 +112911,10 @@ aaa
 aiD
 xtg
 cYA
-jlY
+fhS
+kqA
+tJU
 pAS
-xac
-piK
 cBe
 aqa
 aje
@@ -113407,12 +113423,12 @@ lMJ
 gKE
 sxb
 fvX
-uHs
-wew
-nPB
 rVA
+uHs
+piK
+qFX
 vgT
-qTJ
+fjg
 pmt
 aqa
 fFI
@@ -114439,7 +114455,7 @@ jRV
 ieV
 acP
 acP
-rPe
+nDs
 aqa
 wrp
 aqa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -415,7 +415,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/main)
 "acN" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - Mix"
@@ -1024,7 +1024,7 @@
 "ajo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/main)
 "ajx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -1457,8 +1457,10 @@
 /obj/structure/table,
 /obj/item/paper/guides/jobs/security/labor_camp,
 /obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "anS" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -2251,11 +2253,14 @@
 /turf/open/floor/carpet/grimy,
 /area/tcommsat/computer)
 "auo" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/brig)
 "aup" = (
 /obj/effect/spawner/room/tenxten,
 /turf/open/floor/plating,
@@ -2725,8 +2730,8 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner,
+/area/security/main)
 "aAi" = (
 /obj/item/computer_hardware/hard_drive/role/engineering{
 	pixel_x = 4;
@@ -14842,6 +14847,7 @@
 	req_access_txt = "3"
 	},
 /obj/effect/loot_jobscale/armoury/riot_shield,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "bVW" = (
@@ -17676,7 +17682,7 @@
 /area/hallway/primary/aft)
 "cvW" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
+	name = "Labor Camp";
 	req_one_access_txt = "1;4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -17692,8 +17698,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "cvX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18108,8 +18121,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/security/main)
 "cBg" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery,
@@ -19139,9 +19154,13 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "cNf" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -19698,6 +19717,7 @@
 /obj/item/storage/box/breacherslug,
 /obj/item/storage/box/breacherslug,
 /obj/effect/loot_jobscale/armoury/riot_shotgun,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "cQQ" = (
@@ -20173,7 +20193,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Fore Primary Hallway Cells"
+	c_tag = "Fore Primary Hallway 2"
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -20397,8 +20417,8 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "cYJ" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -21269,8 +21289,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "dgJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -23023,8 +23043,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "dEV" = (
 /obj/structure/cable/yellow{
@@ -23540,6 +23560,15 @@
 	},
 /turf/open/floor/iron,
 /area/engine/engineering)
+"dPv" = (
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/brig)
 "dPw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -24600,9 +24629,11 @@
 /area/maintenance/aft/secondary)
 "emp" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_corner,
+/area/security/main)
 "emC" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/structure/sign/warning/fire{
@@ -25050,8 +25081,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "etX" = (
 /obj/structure/disposalpipe/segment{
@@ -25137,10 +25168,14 @@
 "exg" = (
 /obj/structure/table,
 /obj/item/paper_bin{
-	pixel_x = -3;
+	pixel_x = -6;
 	pixel_y = 7
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "exs" = (
@@ -26214,13 +26249,10 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "eUt" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -26954,15 +26986,19 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "fjg" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "fjD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27533,6 +27569,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "ftJ" = (
@@ -27548,6 +27587,17 @@
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/prison,
 /area/security/prison)
+"fub" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half,
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/brig)
 "fue" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -27614,7 +27664,7 @@
 "fvX" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
+	req_one_access_txt = "1;4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -27623,8 +27673,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "fvZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -28596,6 +28647,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "fML" = (
@@ -29280,6 +29332,7 @@
 /obj/machinery/computer/warrant{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "fYf" = (
@@ -29760,6 +29813,10 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "ghA" = (
@@ -29882,6 +29939,9 @@
 	name = "Interrogation Intercom";
 	pixel_y = -31
 	},
+/obj/item/food/popcorn{
+	pixel_x = 8
+	},
 /turf/open/floor/carpet/royalblack,
 /area/security/main)
 "gka" = (
@@ -29937,7 +29997,9 @@
 "gkV" = (
 /obj/structure/table,
 /obj/item/folder/red,
-/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs{
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "glr" = (
@@ -30218,6 +30280,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"grq" = (
+/obj/effect/turf_decal/tile/red/fourcorners/contrasted,
+/obj/machinery/camera/directional/east,
+/turf/open/floor/prison,
+/area/security/prison)
 "grs" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -30618,6 +30685,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/maintenance/aft)
+"gBP" = (
+/obj/machinery/door/window/eastleft{
+	name = "Infirmary"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/brig)
 "gBY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -31040,11 +31113,11 @@
 "gKE" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
+	req_one_access_txt = "1;4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/main)
 "gLj" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -31146,8 +31219,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "gNH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -31886,11 +31964,6 @@
 /turf/open/floor/iron,
 /area/quartermaster/office)
 "hbB" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Infirmary"
-	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
@@ -32076,10 +32149,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red/half{
+/obj/effect/turf_decal/tile/red/anticorner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_half,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/security/brig)
 "hfF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -32643,14 +32718,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "hoI" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "hoT" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/extinguisher,
@@ -32730,13 +32807,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "hqG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/tile/red/anticorner{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/security/brig)
 "hqK" = (
 /obj/structure/grille/broken,
@@ -32857,8 +32933,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "htc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -35647,6 +35723,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/item/beacon/nettingportal,
 /obj/effect/loot_jobscale/armoury/dragnet,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "irf" = (
@@ -35676,6 +35753,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/techmaint,
 /area/security/main)
@@ -35847,6 +35927,7 @@
 "ivh" = (
 /obj/structure/rack,
 /obj/effect/loot_jobscale/armoury/energy_gun,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "ivo" = (
@@ -35897,7 +35978,7 @@
 	},
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/techmaint,
+/turf/open/floor/iron/textured_large,
 /area/security/main)
 "iwT" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -37799,8 +37880,8 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "jkx" = (
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "jkz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -38228,11 +38309,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/red/anticorner{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/security/main)
 "jut" = (
 /obj/machinery/computer/cargo/request{
 	dir = 4
@@ -38258,6 +38341,7 @@
 	dir = 4;
 	light_color = "#e8eaff"
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "juU" = (
@@ -38506,8 +38590,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "jzU" = (
 /obj/effect/turf_decal/plaque{
@@ -38576,7 +38660,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/security/brig)
 "jAJ" = (
 /obj/structure/disposalpipe/trunk{
@@ -38815,6 +38900,12 @@
 	id_tag = "prisonereducation";
 	name = "Prison Acess";
 	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -39590,7 +39681,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/camera/directional/south,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "jUc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
@@ -39851,7 +39946,7 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/effect/spawner/lootdrop/armory_contraband,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/bot_red/left,
 /turf/open/floor/iron/tech/grid,
 /area/ai_monitored/security/armory)
 "jZO" = (
@@ -40655,9 +40750,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/anticorner,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/security/main)
 "koB" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable/yellow{
@@ -41434,9 +41531,11 @@
 /area/hallway/secondary/entry)
 "kCX" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "kDC" = (
 /obj/machinery/power/shieldwallgen,
 /obj/structure/window/reinforced{
@@ -41584,6 +41683,7 @@
 	},
 /obj/effect/loot_jobscale/armoury/riot_suit,
 /obj/effect/loot_jobscale/armoury/riot_helmet,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "kFB" = (
@@ -41871,7 +41971,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/main)
 "kKj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
@@ -42561,6 +42661,7 @@
 	pixel_x = -1;
 	pixel_y = 11
 	},
+/obj/machinery/camera/directional/east,
 /turf/open/floor/prison,
 /area/security/prison)
 "lad" = (
@@ -42587,8 +42688,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "laO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -43145,16 +43249,23 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "loH" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_one_access_txt = "1;4"
-	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp";
+	req_one_access_txt = "1;4"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "loK" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -43215,9 +43326,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/machinery/camera{
-	dir = 10
 	},
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /turf/open/floor/prison,
@@ -43612,7 +43720,8 @@
 /area/engine/engineering)
 "lwp" = (
 /obj/machinery/camera{
-	dir = 9
+	dir = 9;
+	c_tag = "Fore Primary Hallway 3"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -43691,8 +43800,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "lxS" = (
 /obj/structure/rack,
 /obj/machinery/firealarm{
@@ -43896,6 +44005,21 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/hos)
+"lBF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/obj/machinery/door/window/eastright{
+	name = "Infirmary"
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/brig)
 "lBQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -44976,9 +45100,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lTw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/brig_physician,
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
@@ -45006,8 +45127,8 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "lTL" = (
 /obj/structure/sink{
 	dir = 8;
@@ -45111,7 +45232,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/security/brig)
 "lWP" = (
 /obj/structure/filingcabinet,
@@ -45489,10 +45615,18 @@
 /area/hydroponics/garden)
 "mgc" = (
 /obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/radio/off,
+/obj/item/radio/off{
+	pixel_x = -9
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 12
+	},
+/obj/item/radio/off,
+/obj/item/radio/off{
+	pixel_x = 9
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
@@ -45855,8 +45989,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/security/main)
 "moZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48028,8 +48164,11 @@
 	dir = 1;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "mYS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -48690,8 +48829,8 @@
 /area/medical/patients_rooms)
 "nnt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "nnH" = (
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 23
@@ -49066,8 +49205,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "nvp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -49864,6 +50003,13 @@
 /obj/machinery/fax/service,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"nKq" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/plaque,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/brig)
 "nKu" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Chapel - Port"
@@ -50717,7 +50863,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/security/brig)
 "nZE" = (
 /obj/structure/cable/yellow,
@@ -50861,6 +51012,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "ocx" = (
@@ -51232,8 +51387,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "ojf" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -52440,6 +52595,7 @@
 "oBP" = (
 /obj/structure/rack,
 /obj/effect/loot_jobscale/armoury/laser_gun,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "oBZ" = (
@@ -54022,14 +54178,14 @@
 "piK" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
+	req_one_access_txt = "1;4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/main)
 "pkb" = (
 /obj/machinery/computer/rdservercontrol,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -54189,8 +54345,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "pmD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -54290,6 +54449,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"pnt" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/tile/red/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/security/main)
 "pou" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54419,6 +54587,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -54816,11 +54988,13 @@
 	pixel_y = 24
 	},
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/red/half{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "pyq" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -54862,6 +55036,7 @@
 	dir = 4
 	},
 /obj/effect/loot_jobscale/armoury/disabler,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "pzn" = (
@@ -55246,8 +55421,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/security/main)
 "pHJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -58693,8 +58870,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "qTN" = (
 /obj/machinery/computer/teleporter,
 /obj/machinery/firealarm{
@@ -60684,21 +60863,21 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "rIb" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - EVA Storage"
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "rId" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61446,7 +61625,7 @@
 "rVA" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
+	req_one_access_txt = "1;4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -61458,8 +61637,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "rVC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -62870,6 +63050,10 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"suR" = (
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "suT" = (
 /obj/structure/closet/crate,
 /obj/item/coin/silver,
@@ -62949,7 +63133,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/main)
 "sxu" = (
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
 /obj/structure/cable/yellow{
@@ -63618,7 +63802,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "sKK" = (
 /obj/structure/closet{
@@ -64525,7 +64712,7 @@
 "tdx" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
-/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/bot_red/right,
 /turf/open/floor/iron/tech/grid,
 /area/ai_monitored/security/armory)
 "teA" = (
@@ -64710,7 +64897,9 @@
 "tgp" = (
 /obj/structure/table,
 /obj/item/folder/red,
-/obj/item/storage/fancy/cigarettes,
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = -7
+	},
 /obj/item/clothing/mask/gas/sechailer,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
@@ -64823,6 +65012,7 @@
 /obj/structure/rack,
 /obj/effect/loot_jobscale/armoury/bulletproof_vest,
 /obj/effect/loot_jobscale/armoury/bulletproof_helmet,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "tiS" = (
@@ -64982,13 +65172,10 @@
 /turf/open/floor/iron/dark,
 /area/chapel/main)
 "tkK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "tkT" = (
 /obj/effect/turf_decal/stripes/line{
@@ -65838,8 +66025,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "tyV" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -66687,7 +66874,9 @@
 /area/hallway/secondary/command)
 "tOL" = (
 /obj/structure/table,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	pixel_y = 5
+	},
 /obj/item/pen,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/structure/disposalpipe/segment,
@@ -67360,11 +67549,13 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/security/main)
 "uck" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
@@ -68194,15 +68385,14 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "uqY" = (
-/obj/effect/turf_decal/tile/red/half,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "ura" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
@@ -68272,6 +68462,7 @@
 	c_tag = "Security - Gear Room"
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "usJ" = (
@@ -69060,8 +69251,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "uHy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -70453,15 +70644,14 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "vhl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
@@ -71624,8 +71814,8 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "vCX" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -72008,6 +72198,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/techmaint,
 /area/security/main)
 "vJS" = (
@@ -72335,11 +72526,10 @@
 "vNT" = (
 /obj/structure/table,
 /obj/item/folder/red,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/item/clothing/mask/gas/sechailer,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -73706,6 +73896,15 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/aft)
+"wrp" = (
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "wrv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
@@ -73756,8 +73955,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/main)
 "wsV" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -74571,7 +74770,7 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_edge,
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "wIf" = (
 /obj/structure/cable/yellow{
@@ -75395,7 +75594,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/security/brig)
 "wWC" = (
 /obj/structure/cable/yellow{
@@ -75592,8 +75792,10 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "xad" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -75830,9 +76032,6 @@
 /area/hallway/primary/central)
 "xfg" = (
 /obj/machinery/light/small,
-/obj/machinery/door/window/westleft{
-	name = "Infirmary"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -76207,14 +76406,12 @@
 /turf/open/floor/iron,
 /area/maintenance/department/medical/central)
 "xkm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark/smooth_corner,
+/area/security/main)
 "xkr" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -76751,11 +76948,13 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red/half{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "xts" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
@@ -76884,6 +77083,9 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "xuR" = (
@@ -76930,8 +77132,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "xwi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -77084,8 +77286,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/dark/smooth_corner,
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/security/brig)
 "xzl" = (
 /obj/effect/turf_decal/bot_white,
@@ -77160,6 +77364,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"xzZ" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Fore Primary Hallway 1"
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xAf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/circuit/green,
@@ -77397,6 +77608,7 @@
 /obj/structure/rack,
 /obj/item/storage/box/sec_barricades,
 /obj/item/survivalcapsule/capsule_checkpoint,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ai_monitored/security/armory)
 "xER" = (
@@ -77549,7 +77761,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "xHE" = (
 /obj/structure/disposalpipe/segment{
@@ -78240,10 +78455,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "xSa" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/techmaint,
-/area/security/main)
+/obj/effect/turf_decal/tile/red/anticorner{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/smooth_corner,
+/area/security/brig)
 "xSc" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -78412,8 +78629,8 @@
 /obj/item/razor{
 	pixel_x = -6
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "xUQ" = (
 /obj/item/cigbutt,
 /turf/open/floor/iron,
@@ -78503,8 +78720,10 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/security/brig)
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "xWX" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
@@ -103576,7 +103795,7 @@ tTJ
 cXj
 thM
 sbU
-etl
+kcV
 sWw
 aHx
 aaa
@@ -103824,7 +104043,7 @@ pUJ
 ias
 cxT
 qLS
-dAL
+grq
 pZF
 dAL
 dAL
@@ -104334,12 +104553,12 @@ sKS
 idh
 iRA
 obN
-obN
+dPv
 oaG
 uFw
 ryP
 ybU
-obN
+hqG
 aax
 xef
 aXr
@@ -104586,7 +104805,7 @@ aaZ
 aaZ
 aaZ
 ajm
-ryP
+loN
 uyb
 yix
 fcV
@@ -104842,8 +105061,8 @@ lMJ
 lMJ
 lMJ
 ajm
-ybL
-ryP
+xSa
+fvA
 jAH
 xzg
 obn
@@ -104851,7 +105070,7 @@ uHE
 erL
 fnD
 iji
-obn
+fub
 xlX
 sKv
 aax
@@ -105099,9 +105318,9 @@ lMJ
 ajm
 ajm
 ajm
-ybL
-ryP
-uyb
+auo
+gBP
+lBF
 ahx
 ahx
 ahx
@@ -107944,7 +108163,7 @@ gXh
 fYF
 sek
 dkO
-auo
+sbU
 oHJ
 nsp
 aHD
@@ -108190,7 +108409,7 @@ xiV
 iKp
 iwF
 usB
-xSa
+noD
 ghr
 ajD
 vHe
@@ -108201,9 +108420,9 @@ ahB
 kGn
 ahB
 adY
-aDC
+sbU
 tSN
-aDC
+xzZ
 aHE
 aIN
 foy
@@ -108458,9 +108677,9 @@ jMB
 rjy
 xsN
 svW
-aDC
+sbU
 tSN
-aDC
+suR
 aHE
 xCN
 vLn
@@ -108709,15 +108928,15 @@ jut
 ajD
 ajD
 egA
-oVG
+nKq
 tkK
 aiq
 rHN
 wHO
 gtX
-aDC
+sbU
 tSN
-aDC
+suR
 aHE
 vEi
 nwX
@@ -111005,7 +111224,7 @@ aaa
 aaa
 lMJ
 aaa
-ahx
+ajD
 adZ
 adZ
 agm
@@ -111268,7 +111487,7 @@ rVA
 jkx
 moM
 hoI
-bTb
+aiD
 ezU
 qZr
 qTf
@@ -111519,17 +111738,17 @@ aaa
 aaa
 aaa
 lMJ
-ahx
+ajD
 ajo
-ajm
+aqa
 pyl
 jkx
 vCS
-ahx
-ahx
-ahx
+ajD
+ajD
+ajD
 cvW
-ajm
+aqa
 aoJ
 aqa
 llw
@@ -111778,7 +111997,7 @@ aaa
 lMJ
 aaa
 aaa
-bTb
+aiD
 lTC
 xwd
 moM
@@ -111786,7 +112005,7 @@ xac
 xWQ
 pHo
 oiM
-ajm
+aqa
 aoK
 aqa
 yfv
@@ -112033,9 +112252,9 @@ aaa
 aaa
 aaa
 lMJ
-ahx
+ajD
 ajo
-ajm
+aqa
 ucb
 tyL
 hsZ
@@ -112043,7 +112262,7 @@ lxO
 nvn
 dgD
 aAf
-ajm
+aqa
 amF
 ajD
 yfv
@@ -112300,7 +112519,7 @@ nnt
 uHs
 jkx
 wsD
-ajm
+aqa
 aje
 ajD
 imY
@@ -112547,17 +112766,17 @@ aaa
 aaa
 aaa
 lMJ
-ahx
-ahx
-ahx
+ajD
+ajD
+ajD
 xtg
 cYA
 xUL
 jkx
-hqG
+uqY
 jkx
 cBe
-ajm
+aqa
 aje
 ajD
 lHe
@@ -112806,7 +113025,7 @@ aaa
 lMJ
 aaa
 lMJ
-ajm
+aqa
 jtU
 qTJ
 anQ
@@ -112814,7 +113033,7 @@ cNb
 uqY
 xkm
 gNz
-ajm
+aqa
 ygR
 ajD
 ajD
@@ -113063,15 +113282,15 @@ aaa
 lMJ
 gXq
 wLz
-ajm
-ajm
-ajm
-ahx
-ahx
+aqa
+aqa
+aqa
+ajD
+ajD
 vgT
-ahx
+ajD
 pmt
-ajm
+aqa
 fFI
 cPz
 sEC
@@ -113323,12 +113542,12 @@ wLz
 bdU
 uKH
 iMM
-ajm
+aqa
 emp
 fjg
-ahx
+ajD
 laG
-ajm
+aqa
 hxW
 agq
 agq
@@ -113580,10 +113799,10 @@ wLz
 fLl
 hsl
 sEA
-ajm
+aqa
 kCX
 rIb
-ahx
+ajD
 mYL
 acF
 viw
@@ -113837,12 +114056,12 @@ wLz
 kIF
 jRV
 ieV
-ajm
-emp
+aqa
+pnt
 koh
-ahx
-jkx
-ajm
+ajD
+xuf
+aqa
 wdT
 agq
 aje
@@ -114094,12 +114313,12 @@ wLz
 pAS
 nPB
 pAS
-ajm
-ajm
-ajm
-ajm
-jkx
-ajm
+aqa
+aqa
+aqa
+aqa
+wrp
+aqa
 dbu
 agq
 aje
@@ -114354,9 +114573,9 @@ tjG
 acP
 afs
 lTL
-ajm
+aqa
 loH
-ajm
+aqa
 vtN
 acP
 arB

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -77270,7 +77270,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = s;
+	name = "Security EVA Storage";
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/door/firedoor,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -407,7 +407,6 @@
 	name = "Security Maintenance";
 	req_one_access_txt = "1;4"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -1273,7 +1272,8 @@
 /area/maintenance/port)
 "alD" = (
 /obj/machinery/camera{
-	dir = 10
+	dir = 10;
+	c_tag = "Security - Prison - Port"
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/crayons,
@@ -1456,15 +1456,10 @@
 /turf/open/floor/iron/dark,
 /area/aisat)
 "anQ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Atmospherics Tank - N2O"
-	},
-/obj/structure/table,
-/obj/item/paper/guides/jobs/security/labor_camp,
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/smooth_half{
+/obj/machinery/computer/security/labor{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "anS" = (
 /turf/open/floor/plating/airless,
@@ -2749,6 +2744,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/security/main)
 "aAi" = (
@@ -3648,6 +3644,16 @@
 	},
 /turf/open/floor/plating,
 /area/construction/storage_wing)
+"aGd" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "aGf" = (
 /obj/effect/turf_decal/pool{
 	dir = 8
@@ -18139,13 +18145,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/directional/south,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Labor - Aft"
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
-	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "cBg" = (
 /obj/machinery/recharge_station,
@@ -19172,16 +19179,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cNb" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/obj/machinery/gulag_teleporter,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "cNf" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -20436,9 +20435,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYA" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
+/obj/structure/chair/office,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "cYJ" = (
@@ -21304,13 +21301,15 @@
 /turf/open/space,
 /area/space/nearstation)
 "dgD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "dgJ" = (
@@ -21443,7 +21442,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/camera/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Prison - Solitary"
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "dhy" = (
@@ -22168,6 +22169,12 @@
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
 	req_one_access_txt = "1;4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -27008,18 +27015,10 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "fjg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/computer/shuttle_flight/labor{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "fjD" = (
 /obj/structure/disposalpipe/segment{
@@ -30307,7 +30306,9 @@
 /area/hallway/secondary/exit/departure_lounge)
 "grq" = (
 /obj/effect/turf_decal/tile/red/fourcorners/contrasted,
-/obj/machinery/camera/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Prison - Starboard"
+	},
 /turf/open/floor/prison,
 /area/security/prison)
 "grs" = (
@@ -31245,12 +31246,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "gNH" = (
 /obj/structure/cable/yellow{
@@ -31597,7 +31597,7 @@
 	},
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera/directional/north{
-	c_tag = "Evidence Storage"
+	c_tag = "Security - Evidence Storage"
 	},
 /obj/item/storage/secure/safe{
 	name = "evidence safe";
@@ -32527,7 +32527,7 @@
 /area/medical/break_room)
 "hkO" = (
 /obj/machinery/camera/motion/directional/south{
-	c_tag = "Armory - External"
+	c_tag = "Security - Armory - External"
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -32746,10 +32746,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "hoI" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red/anticorner{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - E.V.A. Storage";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_corner{
@@ -32961,6 +32963,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "htc" = (
@@ -34247,6 +34250,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/main)
 "hQF" = (
@@ -36472,6 +36481,7 @@
 /obj/item/folder/red,
 /obj/item/assembly/flash/handheld,
 /obj/item/book/manual/wiki/sopsecurity,
+/obj/item/clothing/head/helmet/toggleable/justice/escape,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "iFc" = (
@@ -37109,6 +37119,7 @@
 	},
 /area/security/brig)
 "iRB" = (
+/obj/structure/lattice,
 /obj/docking_port/stationary{
 	dwidth = 2;
 	height = 5;
@@ -37117,7 +37128,6 @@
 	roundstart_template = /datum/map_template/shuttle/labour/box;
 	width = 9
 	},
-/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "iRC" = (
@@ -38341,17 +38351,15 @@
 /turf/open/floor/iron,
 /area/maintenance/aft)
 "jtU" = (
-/obj/machinery/computer/security/labor{
-	dir = 8
-	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red/anticorner{
-	dir = 4
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
+	dir = 1
 	},
 /area/security/main)
 "jut" = (
@@ -38991,7 +38999,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Brig - Hallway - Entrance"
+	c_tag = "Security - Hallway - Entrance"
 	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
@@ -39719,7 +39727,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/camera/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Hallway - Port"
+	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
@@ -40785,14 +40795,10 @@
 /turf/open/floor/iron,
 /area/quartermaster/miningoffice)
 "koh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/red/anticorner,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 1
-	},
-/area/security/main)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cigbutt,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "koB" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable/yellow{
@@ -41568,12 +41574,25 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kCX" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
+/obj/item/toy/plush/slimeplushie/pink{
+	pixel_x = -8;
+	pixel_y = 12
 	},
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/main)
+/obj/structure/table/wood,
+/obj/item/toy/plush/moth/brown{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/toy/plush/moth/poison{
+	pixel_y = -5;
+	pixel_x = -7
+	},
+/obj/item/toy/figure/clown{
+	pixel_x = 9;
+	pixel_y = -6
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "kDC" = (
 /obj/machinery/power/shieldwallgen,
 /obj/structure/window/reinforced{
@@ -42700,7 +42719,9 @@
 	pixel_x = -1;
 	pixel_y = 11
 	},
-/obj/machinery/camera/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Prison - Fore"
+	},
 /turf/open/floor/prison,
 /area/security/prison)
 "lad" = (
@@ -43288,9 +43309,6 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "loH" = (
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -43838,6 +43856,11 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
@@ -45159,14 +45182,10 @@
 /turf/open/floor/iron,
 /area/crew_quarters/dorms)
 "lTC" = (
-/obj/structure/chair,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_half,
+/turf/closed/wall,
 /area/security/main)
 "lTL" = (
 /obj/structure/sink{
@@ -46028,11 +46047,12 @@
 /turf/open/floor/iron/grid/steel,
 /area/medical/patients_rooms)
 "moM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/tile/red/half{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
 	},
 /area/security/main)
 "moZ" = (
@@ -49115,6 +49135,7 @@
 	dir = 4
 	},
 /obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "nsj" = (
@@ -49247,12 +49268,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "nvp" = (
@@ -49811,7 +49830,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Head of Security's Office"
+	c_tag = "Security - Head of Security's Office"
 	},
 /turf/open/floor/iron/dark,
 /area/crew_quarters/heads/hos)
@@ -50326,27 +50345,16 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "nPB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cryogenic Lounge"
+/obj/structure/table,
+/obj/item/paper/guides/jobs/security/labor_camp{
+	pixel_x = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/item/radio/off{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/crew_quarters/cryopods)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "nPH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52096,6 +52104,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /turf/open/floor/iron/checker,
 /area/crew_quarters/kitchen)
+"otk" = (
+/obj/machinery/computer/prisoner/gulag_teleporter_computer,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "otF" = (
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -54230,15 +54242,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "piK" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/security/main)
 "pkb" = (
 /obj/machinery/computer/rdservercontrol,
@@ -54399,10 +54404,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red/half{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_half,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/security/main)
 "pmD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -54504,14 +54511,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "pnt" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/tile/red/anticorner{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/toy/redbutton{
+	pixel_y = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
-	},
-/area/security/main)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "pou" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -55038,16 +55044,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pyl" = (
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "pyq" = (
 /obj/item/radio/intercom{
@@ -55197,9 +55201,14 @@
 /turf/open/floor/wood,
 /area/library)
 "pAS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/crew_quarters/cryopods)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "pBf" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
@@ -55807,6 +55816,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/security/main)
 "pOk" = (
@@ -58923,13 +58938,13 @@
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/hor)
 "qTJ" = (
-/obj/machinery/computer/shuttle_flight/labor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
 	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "qTN" = (
 /obj/machinery/computer/teleporter,
@@ -59041,7 +59056,9 @@
 /area/maintenance/disposal/incinerator)
 "qVZ" = (
 /obj/structure/closet/secure_closet/genpop,
-/obj/machinery/camera/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Prison - Entrance"
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -59281,6 +59298,9 @@
 	},
 /obj/effect/turf_decal/tile/red/anticorner{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
@@ -60923,18 +60943,11 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
 "rIb" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - EVA Storage"
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_half,
-/area/security/main)
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "rId" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61184,17 +61197,24 @@
 /turf/open/floor/iron/grid/steel,
 /area/medical/virology)
 "rOa" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenic Lounge"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
@@ -61528,6 +61548,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"rTk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/security/main)
 "rTo" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61680,23 +61708,9 @@
 /turf/open/floor/iron,
 /area/engine/engineering)
 "rVA" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock";
-	req_one_access_txt = "1;4"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/main)
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
 "rVC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61905,6 +61919,10 @@
 	},
 /turf/open/floor/carpet/grimy,
 /area/hallway/primary/central)
+"rYP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "rZd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2{
@@ -63480,7 +63498,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/camera/directional/south{
-	c_tag = "Brig - Hallway - Starboard"
+	c_tag = "Security - Hallway - Starboard"
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/brig)
@@ -66085,6 +66103,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "tyV" = (
@@ -67604,17 +67625,16 @@
 /turf/open/floor/iron/dark,
 /area/aisat)
 "ucb" = (
-/obj/structure/chair,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 1
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -31
 	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "uck" = (
 /obj/effect/landmark/xeno_spawn,
@@ -68077,6 +68097,21 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
 /area/bridge)
+"uiQ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock";
+	req_one_access_txt = "1;4"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/main)
 "uiY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68445,11 +68480,8 @@
 /turf/open/floor/plating,
 /area/medical/surgery)
 "uqY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 8
+/obj/structure/chair/office{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
@@ -69292,7 +69324,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/camera/motion/directional/south{
-	c_tag = "Armory - Internal"
+	c_tag = "Security - Armory - Internal"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/ai_monitored/security/armory)
@@ -69307,9 +69339,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "uHs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
@@ -70699,18 +70733,13 @@
 /turf/open/floor/iron/dark,
 /area/bridge)
 "vgT" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security E.V.A. Storage";
-	req_access_txt = "3"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "vhl" = (
 /obj/effect/turf_decal/stripes/line,
@@ -71682,6 +71711,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vzw" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Labor - Starboard"
+	},
+/obj/effect/turf_decal/tile/red/half,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/main)
 "vzH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -71870,9 +71908,6 @@
 "vCS" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
-	},
-/obj/structure/chair{
-	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
@@ -73229,7 +73264,12 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/prison)
 "wbW" = (
 /obj/structure/table,
@@ -74008,13 +74048,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "wsV" = (
@@ -75847,16 +75887,20 @@
 /turf/open/floor/iron,
 /area/crew_quarters/fitness/recreation)
 "xac" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/gulag_teleporter,
-/obj/effect/turf_decal/tile/red/half{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_half{
-	dir = 1
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
 	},
 /area/security/main)
 "xad" = (
@@ -76176,7 +76220,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/directional/north{
-	c_tag = "Warden's Office"
+	c_tag = "Security - Warden's Office"
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -76472,11 +76516,10 @@
 /turf/open/floor/iron,
 /area/maintenance/department/medical/central)
 "xkm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/dark/smooth_corner,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "xkr" = (
 /obj/machinery/smartfridge/extract/preloaded,
@@ -77011,15 +77054,13 @@
 /turf/open/floor/iron,
 /area/engine/gravity_generator)
 "xtg" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/main)
 "xts" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
@@ -77195,9 +77236,17 @@
 /turf/open/floor/iron,
 /area/engine/engineering)
 "xwd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = s;
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/main)
 "xwi" = (
@@ -77765,7 +77814,7 @@
 /area/science/shuttledock)
 "xGs" = (
 /obj/machinery/camera/directional/south{
-	c_tag = "Brig - Infirmary"
+	c_tag = "Security - Infirmary"
 	},
 /obj/effect/turf_decal/tile/red/half,
 /obj/structure/bodycontainer/morgue{
@@ -78780,11 +78829,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/storage/satellite)
 "xWQ" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
@@ -111290,7 +111339,7 @@ aaa
 aaa
 lMJ
 aaa
-ajD
+aaa
 adZ
 adZ
 agm
@@ -111546,11 +111595,11 @@ aaa
 aaa
 lMJ
 lMJ
-iRB
-piK
-kKh
-rVA
-jkx
+lMJ
+aaa
+aaa
+aqa
+emp
 moM
 hoI
 aiD
@@ -111804,15 +111853,15 @@ aaa
 aaa
 aaa
 lMJ
-ajD
-ajo
-aqa
+lMJ
+aaa
+aiD
 pyl
-jkx
+pAS
 vCS
 ajD
 ajD
-ajD
+atX
 cvW
 aqa
 aoJ
@@ -112061,13 +112110,13 @@ aaa
 aaa
 aaa
 lMJ
-aaa
-aaa
-aiD
+ajD
+ajD
+aqa
 lTC
 xwd
-moM
-xac
+ajD
+ajD
 xWQ
 pHo
 oiM
@@ -112317,10 +112366,10 @@ aaa
 aaa
 aaa
 aaa
-lMJ
-ajD
-ajo
-aqa
+iRB
+gKE
+kKh
+uiQ
 ucb
 tyL
 hsZ
@@ -112575,15 +112624,15 @@ aaa
 aaa
 aaa
 lMJ
-gKE
-sxb
-fvX
+ajD
+ajo
+aqa
+xac
 jkx
-jkx
-jkx
+fjg
+xUL
 nnt
-uHs
-jkx
+qTJ
 wsD
 aqa
 aje
@@ -112832,15 +112881,15 @@ aaa
 aaa
 aaa
 lMJ
-ajD
-ajD
-ajD
+aaa
+aaa
+aiD
 xtg
 cYA
-xUL
-jkx
+nPB
+otk
 uqY
-jkx
+uHs
 cBe
 aqa
 aje
@@ -113089,14 +113138,14 @@ aaa
 aaa
 aaa
 lMJ
-aaa
-lMJ
+ajD
+ajo
 aqa
 jtU
-qTJ
+jkx
 anQ
 cNb
-uqY
+rYP
 xkm
 gNz
 aqa
@@ -113346,15 +113395,15 @@ aaa
 aaa
 aaa
 lMJ
-gXq
-wLz
-aqa
-aqa
-aqa
-ajD
-ajD
+gKE
+sxb
+fvX
+piK
+kqh
+vzw
+aGd
 vgT
-ajD
+rTk
 pmt
 aqa
 fFI
@@ -113365,7 +113414,7 @@ jJU
 sEC
 sEC
 sEC
-xAM
+vXq
 vEY
 nDI
 axC
@@ -113603,15 +113652,15 @@ aaa
 aaa
 aaa
 aaf
-aaa
-wLz
-bdU
-uKH
-iMM
-aqa
-emp
-fjg
 ajD
+ajD
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
+aqa
 laG
 aqa
 hxW
@@ -113862,13 +113911,13 @@ aaa
 aaf
 aaa
 wLz
-fLl
-hsl
-sEA
-aqa
+bdU
+uKH
+iMM
+acP
 kCX
 rIb
-ajD
+aqa
 mYL
 acF
 viw
@@ -114119,13 +114168,13 @@ aaa
 aaf
 aaa
 wLz
-kIF
-jRV
-ieV
-aqa
+fLl
+hsl
+sEA
+acP
 pnt
 koh
-ajD
+aqa
 xuf
 aqa
 wdT
@@ -114374,14 +114423,14 @@ aaf
 aaf
 aaf
 aaf
-gXq
+lMJ
 wLz
-pAS
-nPB
-pAS
-aqa
-aqa
-aqa
+kIF
+jRV
+ieV
+acP
+acP
+rVA
 aqa
 wrp
 aqa
@@ -114632,10 +114681,10 @@ aaa
 aaa
 aaf
 aaa
+acP
 acQ
-wXb
 rOa
-tjG
+acQ
 acP
 afs
 lTL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mapping change to Metastation's brig:
* Labor camp reworked: Area is now part of the security office instead of the brig, including APC and access (people who lost access to it, only lost it from the dorms side and they couldn't access the airlocks to the shuttle or the console anyway). This also includes moving stuff around made it look nicer, added missing wall mounts and lockers, removed Labor one way access (now matches most other stations).
* Re-added the cool fake wall maints room behind the bathroom (totally just random maint stuff, I swear).
* A few decal and tiling changes
* Brig phys office directional windows/windoors are now outside it instead of inside it
* A nice plant outside the brig phys office :)
* Cameras to previous blindspots
* A lot of camera renames ("Security - [Room] - [Placement]")
* Added random fun items around (weewoo helmet that kilo has, popcorn in the interrogation watch room).
* An intercom on an intercom blindspot
* An airalarm on the left side of the brig
* A lightswitch on the labor shuttle area and a lightswitch on the prision entrance (it used to not have any)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Spruces up a security office that felt barren, adds missing cameras to cover up odd/annoying blind spots for the AI, plus extra missing furnishing that was needed.
This is mostly a PR to get used to strongdmm2 to be honest, hopefully more (and better) mapping PRs to come.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Before</summary>

<img width="761" alt="dreamseeker_PZvuNnJ7UY" src="https://github.com/user-attachments/assets/172f8267-5743-4f86-8c29-f386693f0113" />

</details>

<details>
<summary>After</summary>

![dreamseeker_GJNt7B8Mzw](https://github.com/user-attachments/assets/2236dae6-3b71-4d5c-98a4-b0ab97a6e88c)


Close up of the labor shuttle area:
<img width="786" alt="dreamseeker_71iAOdp9pd" src="https://github.com/user-attachments/assets/4e3233f8-c642-4b91-8c48-5fc3034f4f19" />
<img width="553" alt="StrongDMM_CrDo4qZS6V" src="https://github.com/user-attachments/assets/4d1af80c-3904-4336-8b39-06d076d2dfe1" />

Warden's office:
![image](https://github.com/user-attachments/assets/b6fd971b-979f-419e-86be-a38cfb456921)

The maints room:
<img width="507" alt="dreamseeker_bd3c0d3Mtq" src="https://github.com/user-attachments/assets/7b64cfc6-cf9c-4d29-b354-22862ce69bbf" />

As for testing, I walked around as a sec off and all the doors/air seemed fine. I tried to enter the labor area as an assistant and couldn't, all the vents and scrubbers were online, and I spawned myself in as the AI and saw no wierd gaps in camera coverage.

</details>

## Changelog
:cl: Gilgax
tweak: Spruced up Metastation's brig a bit (Decals, missing furnishing/cameras, brought back the hidden bathroom maints room, etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
