### PR TITLE
Monkey AI removable via lobotomy, transferable with the brain

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -44,6 +44,10 @@
 		C.update_hair()
 		return
 
+	if(ai_controller && !special)	//are we a monkey brain?
+		ai_controller.PossessPawn(C)	//Posession code was designed to handle everything
+		ai_controller = null
+
 	if(brainmob)
 		if(C.key)
 			C.ghostize()
@@ -69,6 +73,11 @@
 		var/datum/brain_trauma/BT = X
 		BT.on_lose(TRUE)
 		BT.owner = null
+
+	if(C.ai_controller && !special)	//special is called in humanisation/dehumanisation
+		C.ai_controller.set_ai_status(AI_STATUS_OFF)
+		src.ai_controller = C.ai_controller	//AI is stored in the brain but doesn't control it.
+		C.ai_controller.UnpossessPawn(FALSE)	//The body no longer has AI.
 
 	if((!gc_destroyed || (owner && !owner.gc_destroyed)) && !no_id_transfer)
 		if(C.mind)

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -45,6 +45,8 @@
 			"[user] successfully lobotomizes [target]!",
 			"[user] completes the surgery on [target]'s brain.")
 	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
+	if(target.ai_controller)
+		target.ai_controller.Destroy()	//we just cut a piece of an already simple mind, there is no turning back.
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		unbrainwash(target)
 	switch(rand(0, 3))//Now let's see what hopefully-not-important part of the brain we cut off


### PR DESCRIPTION

## About The Pull Request

You can now perform lobotomy on humans and monkeys to permanently get rid of their AI controller.
When you remove the brain (or the head entirely), and put it in another body, the AI controller is stored in the brain and is transferred with it. 

## Why It's Good For The Game

There were instances where player's brains were transferred into a humanised monkey's body, and the resulting chimera was both player-controllable, and a subject of monkey AI.
Although I am unsure whether this is the case today, there still was a leftover issue of the monkey mind permanently residing in the body itself, despite the brain being swapped for someone else's, which ruined the immersion.
This PR covers this situation.

Also, the ability to lobotomise a monkey to get rid of it's violent/distracting behavior would be rather immersive, and gathered some support.
![image](https://github.com/user-attachments/assets/5fc25fb2-ccd5-4741-84da-12b77bdd003f)


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
https://www.youtube.com/watch?v=wU5n2cG7huU

## Changelog
:cl:
add: You can now lobotomise monkeys and humanised monkeys to get rid of their behaviour.
tweak: AI controllers are now transferrable by removing/implanting the brain or head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
