### PR TITLE
Makes getting fat harder

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1437,14 +1437,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	//The fucking TRAIT_FAT mutation is the dumbest shit ever. It makes the code so difficult to work with
 	if(HAS_TRAIT_FROM(H, TRAIT_FAT, OBESITY))//I share your pain, past coder.
-		if(H.overeatduration < 100)
+		if(H.overeatduration < 200)
 			to_chat(H, span_notice("You feel fit again!"))
 			REMOVE_TRAIT(H, TRAIT_FAT, OBESITY)
 			H.remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
 			H.update_inv_w_uniform()
 			H.update_inv_wear_suit()
 	else
-		if(H.overeatduration >= 100)
+		if(H.overeatduration >= 200)
 			to_chat(H, span_danger("You suddenly feel blubbery!"))
 			ADD_TRAIT(H, TRAIT_FAT, OBESITY)
 			H.add_movespeed_modifier(/datum/movespeed_modifier/obesity)

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -1,5 +1,5 @@
 /datum/movespeed_modifier/obesity
-	multiplicative_slowdown = 1.5
+	multiplicative_slowdown = 1.65
 
 /datum/movespeed_modifier/monkey_reagent_speedmod
 	variable = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/12391

Doubles the necessary amount of ``overeatduration`` to become fat but makes you slightly slower when fat

## Why It's Good For The Game

You become fat TOO fast, it takes a single whole meal to make you chubby and it last forever, is not fun at all to deal with.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I could eat 2 sandwiches with no problem and then ate a burger and became fat 👍 

![image](https://github.com/user-attachments/assets/454c782d-5bc7-4421-93e8-abd949d8f8da)

</details>

## Changelog
:cl: ClownMoff
balance: It now takes twice the effort to become fat, but you are slightly slower when obese
/:cl:
