### PR TITLE
Removed decomposition of nitryl

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -108,14 +108,6 @@
 /// The amount of thermal energy consumed when a mole of NITRYL is formed from tritium, nitrogen, and BZ.
 #define NITRYL_FORMATION_ENERGY 100000
 
-/// The maximum temperature NITRYL can decompose into nitrogen and hydrogen at.
-#define NITRYL_DECOMPOSITION_MAX_TEMP (T0C + 70) //Pretty warm, explicitly not fire temps. Time bombs are cool, but not that cool. If it makes you feel any better it's close.
-/// A scaling divisor for the rate of NITRYL decomposition relative to mix temperature.
-#define NITRYL_DECOMPOSITION_TEMP_DIVISOR (FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 8)
-/// The amount of energy released when a mole of NITRYL decomposes into nitrogen and hydrogen.
-#define NITRYL_DECOMPOSITION_ENERGY 30000
-
-
 // Stimulum:
 #define STIMULUM_HEAT_SCALE 100000
 #define STIMULUM_FIRST_RISE 0.65

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -506,51 +506,6 @@
 		air.temperature = max(((temperature * old_heat_capacity - energy_used) / new_heat_capacity), TCMB) //the air cools down when reacting
 	return REACTING
 
-
-/**
- * Nitryl Decomposition:
- *
- * The decomposition of nitryl.
- * Exothermic.
- * Requires oxygen as catalyst.
- */
-/datum/gas_reaction/nitryl_decomposition
-	priority_group = PRIORITY_PRE_FORMATION
-	name = "Nitryl Decomposition"
-	id = "nitryl_decomp"
-	desc = "Decomposition of nitryl when exposed to oxygen under normal temperatures."
-
-/datum/gas_reaction/nitryl_decomposition/init_reqs()
-	requirements = list(
-		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
-		/datum/gas/nitryl = MINIMUM_MOLE_COUNT,
-		"MAX_TEMP" = NITRYL_DECOMPOSITION_MAX_TEMP,
-	)
-
-/datum/gas_reaction/nitryl_decomposition/react(datum/gas_mixture/air)
-	var/list/cached_gases = air.gases
-	var/temperature = air.temperature
-
-	//This reaction is aggressively slow. like, a tenth of a mole per fire slow. Keep that in mind
-	var/heat_efficiency = min(temperature / NITRYL_DECOMPOSITION_TEMP_DIVISOR, cached_gases[/datum/gas/nitryl][MOLES])
-
-	if (heat_efficiency <= 0 || (cached_gases[/datum/gas/nitryl][MOLES] - heat_efficiency < 0)) //Shouldn't produce gas from nothing.
-		return NO_REACTION
-
-	var/old_heat_capacity = air.heat_capacity()
-	air.assert_gases(/datum/gas/nitrogen)
-	cached_gases[/datum/gas/nitryl][MOLES] -= heat_efficiency
-	cached_gases[/datum/gas/nitrogen][MOLES] += heat_efficiency
-
-	SET_REACTION_RESULTS(heat_efficiency)
-	var/energy_released = heat_efficiency * NITRYL_DECOMPOSITION_ENERGY
-	var/new_heat_capacity = air.heat_capacity()
-	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
-		air.temperature = max(((temperature * old_heat_capacity + energy_released) / new_heat_capacity), TCMB) //the air heats up when reacting
-	return REACTING
-
-
-
 /datum/gas_reaction/stimformation //Stimulum formation follows a strange pattern of how effective it will be at a given temperature, having some multiple peaks and some large dropoffs. Exo and endo thermic.
 	priority_group = PRIORITY_FORMATION
 	name = "Stimulum formation"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed decomposition of nitryl in room temperature and presence of oxygen
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Apparently Linda had that build in, it makes using nitryl for air mix with oxygen more or less impossible, since it decomposes and heats up the air tank in the process. 
Its still possible to make air mix but you need pluxonium with just increases skill threshold for making it a lot, since making pluxonium isn't easy. I don't see why we should gate keep nitryl behind spending 20 hours understanding atmos especially since we weren't doing it before.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Nitryl not decomposing
![Zrzut ekranu (92)](https://github.com/user-attachments/assets/6611386c-80d0-4ba9-be1a-e301e12d15ab)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
del: Removed nitryl decomposing in room temperature (added by linda)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
