### PR TITLE
Paper doesn't move around during mapload

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -69,8 +69,9 @@
 
 /obj/item/paper/Initialize(mapload)
 	. = ..()
-	pixel_y = rand(-8, 8)
-	pixel_x = rand(-9, 9)
+	if (!mapload)
+		pixel_y = rand(-8, 8)
+		pixel_x = rand(-9, 9)
 
 	if(default_raw_text)
 		add_raw_text(default_raw_text)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a mapload check to the random pixel shift on the paper init.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mappers rejoice as you can place paper in specific locations on a tile instead of having it end up somewhere random!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Spawned in on Meta, went to two pieces of paper that were always moving when mapping a security refurbish and they're both centered now:
<img width="103" alt="dreamseeker_J54APBF0Xz" src="https://github.com/user-attachments/assets/419716a1-ea2d-4b6f-b6ac-ac8de983fc86" />
<img width="83" alt="dreamseeker_8NUFN3xbkQ" src="https://github.com/user-attachments/assets/c9e91d1f-99f4-449d-b6a1-6450afbd37d3" />


</details>

## Changelog
:cl: Gilgax
tweak: Paper doesn't move around during mapload
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
