### PR TITLE
Camera Network Changes (some network areas changed, Removed AI "jump to network")

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1727,6 +1727,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "eva"
 	ambience_index = AMBIENCE_DANGER
 	color_correction = /datum/client_colour/area_color/cold_ish
+	camera_networks = list(CAMERA_NETWORK_STATION)
 
 /area/ai_monitored/storage/satellite
 	name = "AI Satellite Maint"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -1266,7 +1266,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/processing
 	name = "Labor Shuttle Dock"
 	icon_state = "sec_prison"
-	camera_networks = list(CAMERA_NETWORK_PRISON)
+	camera_networks = list(CAMERA_NETWORK_PRISON, CAMERA_NETWORK_LABOR)
 
 /area/security/processing/cremation
 	name = "Security Crematorium"

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -68,11 +68,13 @@
 
 /area/mine/laborcamp
 	name = "Labor Camp"
+	camera_networks = list(CAMERA_NETWORK_LABOR)
 
 /area/mine/laborcamp/security
 	name = "Labor Camp Security"
 	icon_state = "security"
 	ambience_index = AMBIENCE_DANGER
+	camera_networks = list(CAMERA_NETWORK_LABOR)
 
 //This is a placeholder for the lavaland sci area. Whoever is here after me, I have made you some additional areas to work with.
 //You are free to rename these and change their icons. My job is done here.

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -8,10 +8,13 @@
 	var/list/T = list()
 
 	for (var/obj/machinery/camera/C in L)
-		var/list/tempnetwork = C.network&src.network
-		if (tempnetwork.len)
+		if(!(is_station_level(C.z) || is_mining_level(C.z)))
+			continue
+		if(!C.can_use())
+			continue
+		var/list/ainetworkall = C
+		if (ainetworkall)
 			T["[C.c_tag][(C.can_use() ? null : " (Deactivated)")]"] = C
-
 	return T
 
 /mob/living/silicon/ai/proc/show_camera_list()

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -10,11 +10,9 @@
 	for (var/obj/machinery/camera/C in L)
 		if(!(is_station_level(C.z) || is_mining_level(C.z)))
 			continue
-		if(!C.can_use())
-			continue
-		var/list/ainetworkall = C
-		if (ainetworkall)
+		if (L.len)
 			T["[C.c_tag][(C.can_use() ? null : " (Deactivated)")]"] = C
+
 	return T
 
 /mob/living/silicon/ai/proc/show_camera_list()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -168,7 +168,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 
 	if(isturf(loc))
 		add_verb(list(
-			/mob/living/silicon/ai/proc/ai_network_change,
+//			/mob/living/silicon/ai/proc/ai_network_change,
 			/mob/living/silicon/ai/proc/ai_hologram_change,
 			/mob/living/silicon/ai/proc/botcall,
 			/mob/living/silicon/ai/proc/control_integrated_radio,
@@ -584,6 +584,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 //Replaces /mob/living/silicon/ai/verb/change_network() in ai.dm & camera.dm
 //Adds in /mob/living/silicon/ai/proc/ai_network_change() instead
 //Addition by Mord_Sith to define AI's network change ability
+/*
 /mob/living/silicon/ai/proc/ai_network_change()
 	set category = "AI Commands"
 	set name = "Jump To Network"
@@ -624,7 +625,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 				break
 	to_chat(src, span_notice("Switched to the \"[uppertext(network)]\" camera network."))
 //End of code by Mord_Sith
-
+*/
 //I am the icon meister. Bow fefore me.	//>fefore
 /mob/living/silicon/ai/proc/ai_hologram_change()
 	set name = "Change Hologram"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -179,7 +179,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 	GLOB.shuttle_caller_list += src
 
 	builtInCamera = new (src)
-	builtInCamera.network = list(CAMERA_NETWORK_STATION)
+	builtInCamera.network = list()
 
 	ADD_TRAIT(src, TRAIT_PULL_BLOCKED, ROUNDSTART_TRAIT)
 	ADD_TRAIT(src, TRAIT_HANDS_BLOCKED, ROUNDSTART_TRAIT)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -581,51 +581,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 	SIGNAL_HANDLER
 	queueAlarm("--- [alarm_type] alarm in [source_area.name] has been cleared.", alarm_type, 0)
 
-//Replaces /mob/living/silicon/ai/verb/change_network() in ai.dm & camera.dm
-//Adds in /mob/living/silicon/ai/proc/ai_network_change() instead
-//Addition by Mord_Sith to define AI's network change ability
-/*
-/mob/living/silicon/ai/proc/ai_network_change()
-	set category = "AI Commands"
-	set name = "Jump To Network"
-	unset_machine()
-	var/cameralist[0]
-
-	if(incapacitated())
-		return
-
-	var/mob/living/silicon/ai/U = usr
-
-	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-		if(!(is_station_level(C.z) || is_mining_level(C.z)))
-			continue
-		if(!C.can_use())
-			continue
-
-		for(var/i in C.network)
-			if (i == CAMERA_NETWORK_RESEARCH || i == CAMERA_NETWORK_TOXINS_TEST || i == CAMERA_NETWORK_PRISON)
-				continue
-			cameralist[i] = i
-	var/old_network = network
-	network = input(U, "Which network would you like to view?") as null|anything in sort_list(cameralist)
-	if(ai_tracking_target)
-		ai_stop_tracking()
-	if(!U.eyeobj)
-		U.view_core()
-		return
-
-	if(isnull(network))
-		network = old_network // If nothing is selected
-	else
-		for(var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-			if(!C.can_use())
-				continue
-			if(network in C.network)
-				U.eyeobj.setLoc(get_turf(C))
-				break
-	to_chat(src, span_notice("Switched to the \"[uppertext(network)]\" camera network."))
-//End of code by Mord_Sith
-*/
 //I am the icon meister. Bow fefore me.	//>fefore
 /mob/living/silicon/ai/proc/ai_hologram_change()
 	set name = "Change Hologram"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -168,7 +168,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/silicon/ai)
 
 	if(isturf(loc))
 		add_verb(list(
-//			/mob/living/silicon/ai/proc/ai_network_change,
 			/mob/living/silicon/ai/proc/ai_hologram_change,
 			/mob/living/silicon/ai/proc/botcall,
 			/mob/living/silicon/ai/proc/control_integrated_radio,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Fixes #11835 (AI internal camera no longer has a network so it doesn't display on camera consoles).
2. Fixes labor camera console (`CAMERA_NETWORK_LABOR` was not used in any area, was added to laborcamp, laborcamp/security and processing (the labor shuttle dock on station)).
3. EVA storage now shows up on normal camera network instead of the AI sattelite network.
4. Removes the "Jump to network" function for AI. AIs "Show Camera List" button now shows all cameras on station and LL level no matter their network (note: AI could always see through them, just couldn't jump to them)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1, 2, and 3 are just bug fixes. The AI x-ray camera shouldn't be visible to all networks, the labor camera console was just empty and EVA storage is not on the minisat in anymap.
For 4, I personally have noticed that the jump to network feature is just clunky, you'll often want to go to look at lavaland, or want to quickly teleport to telecomms and you couldn't because it wasn't on your selected network. (for Lavaland, as far as I know, a lot of AI mains just used the camera tracking on Frank). This does not change what cameras are visible to the AI, you could always see through every camera as long as you were on its Z-level, this also doesn't mess with secret networked cameras since AI's could just jump to them before anyway, and finally it doesn't work to try and find off station cameras like on off station shuttles, ruins or anything due to the check for LL or station z-level.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<details>
<summary>1. AI internal camera</summary>
Spawned in as AI, ghosted, went to sec camera console, AI chambers aren't there:

<img width="471" alt="dreamseeker_ttvRQuBOxa" src="https://github.com/user-attachments/assets/569b2719-eafe-4b73-ab6e-5d2a1371b523" />

Also, the AI can still see just fine (disabled all cameras nearby and AI could still see):

![image](https://github.com/user-attachments/assets/e9182683-b9f9-45f0-b09c-ef2c3d08dd57)

</details>
<details>
<summary>2. Labor dock camera console</summary>

![image](https://github.com/user-attachments/assets/8e649c2f-e272-48be-abf3-0c9ea233d206)

</details>

<details>
<summary>3. EVA storage network</summary>

Opened the normal security camera console (it was there) and the minisat monitor screen (it was no longe there):

![image](https://github.com/user-attachments/assets/bf83768c-1173-4eb7-9e51-df5f54eeabd0)

![image](https://github.com/user-attachments/assets/a47844a1-57a8-4e5e-b8b0-36b6552cdcd4)

</details>

<details>
<summary>4. AI network changes</summary>

Clicking the button (ignore the run time, that's from spawning in with the debug suit):
![image](https://github.com/user-attachments/assets/6c4ba471-a12a-4635-8132-a55723471e8f)
Labor is present and teleport works:
![image](https://github.com/user-attachments/assets/658f732a-60cc-496c-acca-f5be84e5c950)
![image](https://github.com/user-attachments/assets/a2a1c97b-0ecc-4dfb-bf22-dc114b3fe802)
Thunderdome cameras aren't present:
![image](https://github.com/user-attachments/assets/94219d7a-a9c9-434d-999f-0317f49c12af)
Jump to network verb is gone:
![image](https://github.com/user-attachments/assets/93be7518-910a-41e2-9ad1-0c0092844f80)
![image](https://github.com/user-attachments/assets/07804ffa-c6a3-4f73-98dd-b196fad52cb5)
Deactivated cameras show up and can be teleported to (still can't through them):
![image](https://github.com/user-attachments/assets/4b896b87-01c4-474d-b80e-2303a208d5c4)

</details>

## Changelog
:cl: Gilgax
fix: AI internal camera no longer has a network so it doesn't display on camera consoles
fix: Labor camera console now actually show labor area cameras on it
tweak: EVA storage now shows up on normal camera network instead of the AI sattelite network.
tweak: Removes the "Jump to network" function for AI. AIs "Show Camera List" button now shows all cameras on station and LL level no matter their network (note: AI could always see through them, just couldn't jump to them)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
