### PR TITLE
Fixes revenant telepathy is made to be TG version, now as ours. Also minour tweak to telepathy

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -166,7 +166,7 @@
 	telepathy_span = "revennotice"
 	bold_telepathy_span = "revenboldnotice"
 
-	antimagic_flags = MAGIC_RESISTANCE_HOLY|MAGIC_RESISTANCE_MIND
+	use_runechat_telepathy = TRUE
 
 /datum/action/spell/aoe/revenant
 	background_icon_state = "bg_revenant"

--- a/code/modules/spells/spell_types/list_targets/telepathy.dm
+++ b/code/modules/spells/spell_types/list_targets/telepathy.dm
@@ -6,7 +6,7 @@
 	requires_target = TRUE
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
-	antimagic_flags = MAGIC_RESISTANCE_MIND
+	antimagic_flags = NONE
 
 	/// The message we send to the next person via telepathy.
 	var/message
@@ -14,6 +14,8 @@
 	var/telepathy_span = "notice"
 	/// The bolded span surrounding the telepathy message
 	var/bold_telepathy_span = "boldnotice"
+	/// Only dedicated for revenants
+	var/use_runechat_telepathy = FALSE
 
 /datum/action/spell/telepathy/pre_cast(mob/user, atom/target)
 	. = ..()
@@ -33,13 +35,18 @@
 
 /datum/action/spell/telepathy/on_cast(mob/living/user, mob/living/target)
 	. = ..()
+	message = user.treat_message_min(message)
 	log_directed_talk(owner, target, message, LOG_SAY, name)
 
 	var/formatted_message = "<span class='[telepathy_span]'>[message]</span>"
 
 	to_chat(owner, "<span class='[bold_telepathy_span]'>You transmit to [target]:</span> [formatted_message]")
-	if(!target.can_block_magic(antimagic_flags)) //hear no evil
-		to_chat(target, "<span class='[bold_telepathy_span]'>You hear something behind you talking...</span> [formatted_message]")
+	to_chat(target, "<span class='[bold_telepathy_span]'>You hear something behind you talking...</span> [formatted_message]")
+	if(use_runechat_telepathy)
+		owner.create_private_chat_message(message="...[message]",
+									message_language = /datum/language/metalanguage,
+									hearers=list(owner, target))
+	else
 		target.balloon_alert(target, "You hear a voice in your head...")
 	for(var/mob/dead/ghost as anything in GLOB.dead_mob_list)
 		if(!isobserver(ghost))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Caused by https://github.com/BeeStation/BeeStation-Hornet/pull/11527
* Revenant telepathy now shows runechat. Old telepathy doesn't. (but it reports you hear something at least.)
* Telepathy is no longer antimagic protected

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
also, telepathy is an RP tool. Being unusable by antimagic seems not necessary.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://github.com/user-attachments/assets/2b61e394-a08d-43f1-83e2-6eaf3071a558)


## Changelog
:cl:
tweak: Telepathy is no longer blocked by antimagic protection. Telepathy will be always relayed to the target.
fix: Revenant telepathy now shows the runechat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
