### PR TITLE
Fixed shield generator error generating immortality

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -78,7 +78,7 @@
 	anchored = FALSE
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	req_access = list(ACCESS_ENGINE)
-	max_integrity = 100
+	max_integrity = 200
 	var/active = FALSE
 	var/list/deployed_shields
 	var/locked = FALSE
@@ -120,6 +120,7 @@
 /obj/machinery/shieldgen/deconstruct(disassembled = TRUE)
 	atom_break()
 	locked = pick(0,1)
+	return ..()
 
 /obj/machinery/shieldgen/interact(mob/user)
 	. = ..()
@@ -132,7 +133,7 @@
 		to_chat(user, span_warning("The panel must be closed before operating this machine!"))
 		return
 
-	if (active)
+	if(active)
 		user.visible_message("[user] deactivated \the [src].", \
 			span_notice("You deactivate \the [src]."), \
 			span_italics("You hear heavy droning fade out."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When destroyed (at least by plasma fire) hull breath shield generators kept themselves alive by generating infinite errors. I took that Incredible power away from them. Also doubled their health since now they actually can die (it was half of standard machine, now its one standard machine)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
BUG FIX = GOOD
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Not screaming infinite errors at me
![Zrzut ekranu (94)](https://github.com/user-attachments/assets/5fb46937-852f-4591-9108-48dd1adbcc4b)


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Took away shield generators ability to stay alive through pure spite despite having negative health (and doubled their health to compensate)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
