### PR TITLE
Lowers the amount of TOTAL scientist slots by 1, lowers the amount of SPAWN engineer slots by 2 on lowpop stations

### DIFF
--- a/_maps/map_files/KiloStation/map_adjustment_kilo.dm
+++ b/_maps/map_files/KiloStation/map_adjustment_kilo.dm
@@ -1,0 +1,9 @@
+/*
+			< ATTENTION >
+	If you need to add more map_adjustment, check 'map_adjustment_include.dm'
+	These 'map_adjustment.dm' files shouldn't be included in 'dme'
+*/
+
+/datum/map_adjustment/echo_station/job_change()
+	change_job_position(JOB_NAME_SCIENTIST, 3)
+	change_job_position(JOB_NAME_STATIONENGINEER, 4)

--- a/beestation.dme
+++ b/beestation.dme
@@ -15,6 +15,7 @@
 // BEGIN_INCLUDE
 #include "__odlint.dm"
 #include "_maps\_basemap.dm"
+#include "_maps\map_files\KiloStation\map_adjustment_kilo.dm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_debugger.dm"

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -5,7 +5,7 @@
 	department_head = list(JOB_NAME_RESEARCHDIRECTOR)
 	supervisors = "the research director"
 	faction = "Station"
-	total_positions = 5
+	total_positions = 4
 	spawn_positions = 3
 	selection_color = "#ffeeff"
 	exp_requirements = 120

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -5,8 +5,8 @@
 	department_head = list(JOB_NAME_CHIEFENGINEER)
 	supervisors = "the chief engineer"
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 2
+	total_positions = 5
+	spawn_positions = 3
 	selection_color = "#fff5cc"
 	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -5,8 +5,8 @@
 	department_head = list(JOB_NAME_CHIEFENGINEER)
 	supervisors = "the chief engineer"
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 3
+	spawn_positions = 2
 	selection_color = "#fff5cc"
 	exp_requirements = 120
 	exp_type = EXP_TYPE_CREW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers the amount of scientist and engineers slots

## Why It's Good For The Game

What do you need all of those slots for?? CE and RD are basically Engineer+ and Scientist+. It helps a little those lowpop shifts with 8 people in science and 4 in engineering and the rest of the departments lacking personnel. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Is it really needed?

</details>

## Changelog
:cl: ClownMoff
tweak: [All stations except KiloStation and EchoStation] Reduced amount of total scientist slots from 5 to 4
tweak: [All stations except KiloStation] Reduced amount of SPAWN station engineers slots from 5 to 3, still can latejoin 2 slots more
tweak: [KiloStation] Reduced amount of TOTAL scientist spawns to 3
tweak: [KiloStation] Reduced amount of TOTAL station engineers to 4
/:cl: