### PR TITLE
Auto-transfer system no longer factors in players who are still in the lobby

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(autotransfer)
 	var/decay_count = 0
 	var/connected_votes_to_leave = 0
 	var/required_votes_to_leave = 0
+	///Total players currently in the game, dead or observing. Explicitly excludes lobby players
+	var/active_playercount = 0
 
 /datum/controller/subsystem/autotransfer/Initialize()
 	reminder_time = REALTIMEOFDAY + CONFIG_GET(number/autotransfer_decay_start)
@@ -25,15 +27,20 @@ SUBSYSTEM_DEF(autotransfer)
 	// Alternatively this could just hook into client/new and client/destroy, but
 	// it doesn't matter that much if we lose count for a bit
 	connected_votes_to_leave = 0
+	active_playercount = 0
+
 	for(var/client/c in GLOB.clients)
+		if(isnewplayer(c.mob))
+			continue //We don't count them or their votes
 		if (c.player_details.voted_to_leave)
 			connected_votes_to_leave ++
+		active_playercount ++
 
 	if(REALTIMEOFDAY > checkvotes_time)
 		if(decay_start)
 			decay_count++
 
-		required_votes_to_leave = max(length(GLOB.clients) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count), 1)
+		required_votes_to_leave = max(active_playercount * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count), 1)
 
 		if(connected_votes_to_leave >= required_votes_to_leave)
 			if(SSshuttle.canEvac() == TRUE) //This must include the == TRUE because all returns for this proc have a value, we specifically want to check for TRUE

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -344,7 +344,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set category = "OOC"
 	set desc = "Votes to end the round"
 
-	if(player_details.voted_to_leave)
+	if(isnewplayer(mob))
+		to_chat(src, "<font color='purple'>You cannot vote from the lobby.</font>")
+	else if(player_details.voted_to_leave)
 		player_details.voted_to_leave = FALSE
 		SSautotransfer.connected_votes_to_leave--
 		to_chat(src, "<font color='purple'>You are no longer voting for the current round to end.</font>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This updates the auto-transfer system to exclude players sitting at the lobby, likely to be afk. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The votes to leave should not be higher just because of players sitting AFK in the lobby who potentially forgot to close the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

From the lobby there are no players connected in the count
![image](https://github.com/user-attachments/assets/4bda20ae-6518-44f0-9535-d9908ff7b3a9)

But if I join and vote to leave the system works normally
![image](https://github.com/user-attachments/assets/cba8a487-cf4d-4a9a-8a2e-e3ea823b5ba6)


## Changelog
:cl:
tweak: The auto-transfer vote system no longer factors in players who are sitting in the lobby when calculating the required votes to leave. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
