### PR TITLE
Fix to admin alert level blocking other keycard actions

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -82,23 +82,24 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 			if(!event_source)
 				sendEvent(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS, swipe_id)
 				. = TRUE
+		if("bsa_unlock")
+			if(!event_source)
+				sendEvent(KEYCARD_BSA_UNLOCK, swipe_id)
+				. = TRUE
 		if("auth_swipe")
 			if(event_source)
 				if(swipe_id == event_source.triggering_card)
 					to_chat(usr, span_warning("Invalid ID. Confirmation ID must not equal trigger ID."))
 					return
 				var/current_sec_level = SSsecurity_level.get_current_level_as_number()
-				if(current_sec_level > SEC_LEVEL_RED)
+				if(current_sec_level > SEC_LEVEL_RED && event == KEYCARD_RED_ALERT)
 					to_chat(usr, span_warning("Alert cannot be manually lowered from the current security level!"))
 					return
 				event_source.trigger_event(usr)
 				event_source = null
 				update_appearance()
 				. = TRUE
-		if("bsa_unlock")
-			if(!event_source)
-				sendEvent(KEYCARD_BSA_UNLOCK, swipe_id)
-				. = TRUE
+
 
 /obj/machinery/keycard_auth/update_appearance(updates)
 	. = ..()
@@ -120,8 +121,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 	triggering_card = swipe_id //Shouldn't need qdel registering due to very short time before this var resets.
 	event = event_type
 	waiting = 1
-	GLOB.keycard_events.fireEvent("triggerEvent", src)
-	addtimer(CALLBACK(src, PROC_REF(eventSent)), 20)
+	GLOB.keycard_events.fireEvent("triggerEvent", src, event)
+	addtimer(CALLBACK(src, PROC_REF(eventSent)), 5 SECONDS)
 
 /obj/machinery/keycard_auth/proc/eventSent()
 	triggerer = null
@@ -129,13 +130,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 	event = ""
 	waiting = 0
 
-/obj/machinery/keycard_auth/proc/triggerEvent(source)
+/obj/machinery/keycard_auth/proc/triggerEvent(source, event_trigered)
 	event_source = source
+	event = event_trigered
 	update_appearance()
-	addtimer(CALLBACK(src, PROC_REF(eventTriggered)), 20)
+	addtimer(CALLBACK(src, PROC_REF(eventTriggered)), 5 SECONDS)
 
 /obj/machinery/keycard_auth/proc/eventTriggered()
 	event_source = null
+	event = ""
 	update_appearance()
 
 /obj/machinery/keycard_auth/proc/trigger_event(confirmer)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix to https://github.com/BeeStation/BeeStation-Hornet/issues/12435 and emergency maint acces since it had the same problem
Also increased time to authentication from 2 to 5 seconds
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs = bad
Anyone who ever had to authorise anything with autentication device knows how incredibly anoing it is because the time to click properly is so low and UI doesn't update fast enough if you don't click it again. 5 seconds should be low enough that its really hard for one person to do both (and he would need 2 command IDs) while not being so incredibly finicky to do properly
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Changing to red is impossible but bluaspace gun can be activated
![Zrzut ekranu (102)](https://github.com/user-attachments/assets/cdad887c-7cd1-45f9-bb24-1dd753dcff9e)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Key card device now gives you 5 seconds instead of 2 to authorise
fix: Alert levels above red no longer block activating BSA and emergency main access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
