### PR TITLE
Fixes rolling paper not having any papers inside

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -327,6 +327,7 @@
 	icon_state = "cig_paper_pack"
 	base_icon_state = "cig_paper_pack"
 	contents_tag = "rolling paper"
+	spawn_count = 10
 	spawn_type = /obj/item/rollingpaper
 
 /obj/item/storage/fancy/rollingpapers/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes rolling paper packet not having papers inside.
Likely broken by #11894 

## Why It's Good For The Game

Not being able to make rollies - bad? I want to smoke my weed!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/ec848890-918a-411f-a9e9-18f23857b2da)


</details>

## Changelog
:cl:
fix: Rolling paper packs now have rolling paper again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
