### PR TITLE
Reenables the GPS

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -66,7 +66,7 @@
 	suit_type = /obj/item/clothing/suit/space/eva
 	helmet_type = /obj/item/clothing/head/helmet/space/eva
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/gps
+	storage_type = /obj/item/gps/off
 
 /obj/machinery/suit_storage_unit/captain
 	suit_type = /obj/item/clothing/suit/space/hardsuit/swat/captain
@@ -86,12 +86,12 @@
 /obj/machinery/suit_storage_unit/security
 	suit_type = /obj/item/clothing/suit/space/hardsuit/security
 	mask_type = /obj/item/clothing/mask/gas/sechailer
-	storage_type = /obj/item/gps/security
+	storage_type = /obj/item/gps/security/off
 
 /obj/machinery/suit_storage_unit/hos
 	suit_type = /obj/item/clothing/suit/space/hardsuit/security/head_of_security
 	mask_type = /obj/item/clothing/mask/gas/sechailer
-	storage_type = /obj/item/gps/security
+	storage_type = /obj/item/gps/security/off
 
 /obj/machinery/suit_storage_unit/atmos
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/atmos
@@ -101,27 +101,27 @@
 /obj/machinery/suit_storage_unit/mining
 	suit_type = /obj/item/clothing/suit/hooded/explorer
 	mask_type = /obj/item/clothing/mask/gas/explorer
-	storage_type = /obj/item/gps/mining
+	storage_type = /obj/item/gps/mining/off
 
 /obj/machinery/suit_storage_unit/mining/eva
 	suit_type = /obj/item/clothing/suit/space/hardsuit/mining
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/gps/mining
+	storage_type = /obj/item/gps/mining/off
 
 /obj/machinery/suit_storage_unit/exploration
 	suit_type = /obj/item/clothing/suit/space/hardsuit/exploration
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/gps/mining/exploration
+	storage_type = /obj/item/gps/mining/exploration/off
 
 /obj/machinery/suit_storage_unit/cmo
 	suit_type = /obj/item/clothing/suit/space/hardsuit/medical/cmo
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/gps
+	storage_type = /obj/item/gps/off
 
 /obj/machinery/suit_storage_unit/rd
 	suit_type = /obj/item/clothing/suit/space/hardsuit/research_director
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/gps
+	storage_type = /obj/item/gps/off
 
 /obj/machinery/suit_storage_unit/syndicate
 	suit_type = /obj/item/clothing/suit/space/hardsuit/syndi
@@ -159,7 +159,7 @@
 	helmet_type = /obj/item/clothing/head/helmet/space/hunter
 	suit_type = /obj/item/clothing/suit/space/hunter
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/gps
+	storage_type = /obj/item/gps/off
 
 /obj/machinery/suit_storage_unit/open
 	state_open = TRUE

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -10,6 +10,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	obj_flags = UNIQUE_RENAME
 	var/gpstag
+	var/start_on = TRUE
 
 /obj/item/gps/Initialize(mapload)
 	. = ..()
@@ -17,28 +18,49 @@
 
 /// Adds the GPS component to this item.
 /obj/item/gps/proc/add_gps_component()
-	AddComponent(/datum/component/gps/item, gpstag, FALSE)
+	AddComponent(/datum/component/gps/item, gpstag, start_on)
+
+/obj/item/gps/off
+	start_on = FALSE
+
 
 /obj/item/gps/science
 	icon_state = "gps-n"
 	gpstag = "SCI0"
 
+/obj/item/gps/science/off
+	start_on = FALSE
+
 /obj/item/gps/engineering
 	icon_state = "gps-e"
 	gpstag = "ENG0"
+
+/obj/item/gps/engineering/off
+	start_on = FALSE
+
 
 /obj/item/gps/mining
 	icon_state = "gps-m"
 	gpstag = "MINE0"
 	desc = "A positioning system helpful for rescuing trapped or injured miners, keeping one on you at all times while mining might just save your life."
 
+/obj/item/gps/mining/off
+	start_on = FALSE
+
 /obj/item/gps/mining/exploration
 	gpstag = "EXP0"
 	desc = "A positioning system used for long-ranged tracking of important beacons."
 
+/obj/item/gps/mining/exploration/off
+	start_on = FALSE
+
 /obj/item/gps/security
 	icon_state = "gps-s"
 	gpstag = "SEC0"
+
+/obj/item/gps/security/off
+	start_on = FALSE
+
 
 /obj/item/gps/cyborg
 	icon_state = "gps-b"

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -85,7 +85,7 @@
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	back = /obj/item/storage/backpack
-	r_hand = /obj/item/gps
+	r_hand = /obj/item/gps/off
 
 /datum/outfit/vip_target/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

GPS devices were stealth-nerfed in #10479 by making the default state of GPS Off.
This PR creates a subtype of GPS that starts off, and adds it to the suit storages.

## Why It's Good For The Game

While with the introduction of a GPS device into most suit storages, making them start off made sense as to not clutter the signal list, this resulted in GPS signals at most points of interest being off as well. Thus making it even harder to find the whiteship, MacSpace and other ruins.
By fixing the changes, the space is once again more lively.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

GPS not pointing to the suit storages, but GPS devices that were previously off are now visible.
![image](https://github.com/user-attachments/assets/fc59bfac-0396-440e-bfa6-dffd1de2746b)

</details>

## Changelog
:cl:
fix: GPS devices once again start on by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
