### PR TITLE
Fixes the captain's spare ID safe being unlocked at roundstart

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -242,7 +242,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/storage/secure/safe/caps_spare, 32)
 		/obj/item/card/id/))
 	l_code = SSjob.spare_id_safe_code
 	l_set = TRUE
-	atom_storage.locked = FALSE
+	atom_storage.locked = TRUE
 	update_appearance()
 
 /obj/item/storage/secure/safe/caps_spare/PopulateContents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/12477

The captain's spare ID safe should be locked at the start of the round.

The PR https://github.com/BeeStation/BeeStation-Hornet/pull/11894 moved storages from components to datums and that is where the safe was accidentally set to be unlocked, from what I can tell. 
It was merged last week which matches with when the issue first appeared.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

The captain's spare ID safe should be locked roundstart.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![grafik](https://github.com/user-attachments/assets/028157dd-9c08-4c27-b3e1-7554b76bcb1e)

</details>

## Changelog
:cl:
fix: Fixes the captain's spare ID safe being unlocked at roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
