### PR TITLE
Move `/world/Genesis` to the top of the dme

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1,6 +1,11 @@
 // DM Environment file for beestation.dme.
 // All manual changes should be made outside the BEGIN_ and END_ blocks.
 // New source code should be placed in .dm files: choose File/New --> Code File.
+
+// This should always be the VERY FIRST THING. No exceptions. Read the file for more info, but basically, this needs to be here so that we can ensure specific code is always the very first thing to execute.
+#include "code\genesis_call.dme"
+// Again, DO NOT MOVE IT OR ALLOW ANY OTHER #include TO PRECEDE THE ONE ABOVE.
+
 // BEGIN_INTERNALS
 // END_INTERNALS
 
@@ -4459,7 +4464,6 @@
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
 #include "code\~overrides\quickstart.dm"
-#include "code\~~genesis_call\genesis_call.dm"
 #include "interface\interface.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"

--- a/code/genesis_call.dme
+++ b/code/genesis_call.dme
@@ -15,10 +15,10 @@
  * THE GENESIS CALL
  *
  * THE VERY FIRST LINE OF DM CODE TO EXECUTE
- * Ong this must be done after !!!EVERYTHING!!! else
+ * Ong this must be done before !!!EVERYTHING!!! else
  * NO IFS ANDS OR BUTS
  * it's a hack, not an example of any sort, and DEFINITELY should NOT be emulated
- * IT JUST HAS TO BE LAST!!!!!!
+ * IT JUST HAS TO BE FIRST!!!!!!
  * If you want to do something in the initialization pipeline
  * FIRST RTFM IN /code/game/world.dm
  * AND THEN NEVER RETURN TO THIS PLACE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/90255

okay so genesis actually needs to be first.

i did a bit of an experiment to see exactly what's called first.

`/world/proc/genesis_test` was just a `world.log << "[x]"` wrapper in this test

top of the dme:
```dm
/world/proc/_a2()
    var/static/_ = world.genesis_test("a2")

/world/proc/_z2()
    var/static/_ = world.genesis_test("z2")
```

bottom of the dme:
```dm
/world/proc/_a1()
    var/static/_ = world.genesis_test("a1")

/world/proc/_z1()
    var/static/_ = world.genesis_test("z1")
```

here's the output:
```
Welcome BYOND! (5.0 Public Version 516.1659)
genesis testa2
genesis testz2
genesis testa1
genesis testz1
World loaded at 01:38:36!
```

so yeah, seems being included FIRST is correct.
to avoid any sort of potential accidental sorting/moving/priority shenanigans, genesis itself is now in a `.dme` file, that is included just below the header of the dme, before `// BEGIN_INTERNALS`

## Changelog

No user-facing changes. Or even noticeable by most coders.
