### PR TITLE
Changes service experience requirements to collect playtime from the service department

### DIFF
--- a/code/controllers/subsystem/department.dm
+++ b/code/controllers/subsystem/department.dm
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(department)
 		EXP_TYPE_SUPPLY = 	SSdepartment.get_jobs_by_dept_id(DEPT_NAME_CARGO),
 		EXP_TYPE_SECURITY = SSdepartment.get_jobs_by_dept_id(DEPT_NAME_SECURITY),
 		EXP_TYPE_SILICON = 	SSdepartment.get_jobs_by_dept_id(DEPT_NAME_SILICON),
-		EXP_TYPE_SERVICE = 	SSdepartment.get_jobs_by_dept_id(DEPT_NAME_CIVILIAN)
+		EXP_TYPE_SERVICE = 	SSdepartment.get_jobs_by_dept_id(DEPT_NAME_SERVICE)
 	)
 
 	return SS_INIT_SUCCESS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Resolves #12509 
Makes service exp count service exp instead of civilian exp.

## Why It's Good For The Game

Bugs bad.

## Testing Photographs and Procedure

~~I am not sure how to test this. I don't have a DB set up, and the fix seems straightforward enough.~~
Trust me bro

## Changelog
:cl:
fix: Fixed botanist player hours requiring civilian exp despite saying it requires service exp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
