### PR TITLE
Spines can be Fixed via Cloning

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -282,6 +282,7 @@
 				H.gain_trauma(cloned_trauma, BT.resilience)
 
 		H.set_cloned_appearance()
+		H.cure_trauma_type(/datum/brain_trauma/severe/paralysis/paraplegic, TRAUMA_RESILIENCE_ABSOLUTE)
 
 		H.set_suicide(FALSE)
 


### PR DESCRIPTION
## About The Pull Request
Makes cloning remove the paraplegic trait, even on those who joined paraplegic.

## Why It's Good For The Game
Makes it possible for those being foolish with the tackle an option to fixing their fucked up spine.

Adds a reason as to why people who are paraplegic as they would oppose being cloned.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/7a0acab6-286a-42ce-840a-8164ea913e94)

</details>

## Changelog
:cl:
balance: Cloning fixes Paraplegic
/:cl:
