### PR TITLE
Fixes lavaland armour not being nerfed while on station

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -579,7 +579,7 @@ BLIND     // can't see anything
 	var/turf/T = get_turf(src)
 	if(!T || !(d_type in high_pressure_multiplier_types))
 		return
-	if (is_mining_level(T.z))
+	if (!is_mining_level(T.z))
 		return . * high_pressure_multiplier
 
 #undef SENSORS_OFF

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -572,17 +572,15 @@ BLIND     // can't see anything
 	if(prob(0.2))
 		to_chat(L, span_warning("The damaged threads on your [src.name] chafe!"))
 
-/*
 /obj/item/clothing/get_armor_rating(d_type)
 	. = ..()
 	if(high_pressure_multiplier == 1)
 		return
-	var/turf/T = get_turf(usr)
+	var/turf/T = get_turf(src)
 	if(!T || !(d_type in high_pressure_multiplier_types))
 		return
-	if(!lavaland_equipment_pressure_check(T))
-		. *= high_pressure_multiplier
-*/
+	if (is_mining_level(T.z))
+		return . * high_pressure_multiplier
 
 #undef SENSORS_OFF
 #undef SENSORS_BINARY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lavaland armour has regained its armour reduction penalty while being used on station.

I decided to base this on z-level and not pressure as I heard some concerns about this needing to be removed due to it being a hot proc, although I believe that the execution time to call count ratio is relatively low.

## Why It's Good For The Game

You should not be able to gain 70 armour while on station because you have something from lavaland, which operates on an entirely different balance scheme to the station.

## Testing Photographs and Procedure

Station:

![image](https://github.com/user-attachments/assets/57f48c0f-2980-4bb7-9c9f-c657d5e95401)

![image](https://github.com/user-attachments/assets/c76d6264-047b-4224-8844-4d3f9b9b7623)

Lavaland:

![image](https://github.com/user-attachments/assets/96274e9c-b12c-4bcf-9553-ab5a5e6b359b)

## Changelog
:cl:
fix: Fixes lavaland armours not having armour penalties while away from lavaland.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
