### PR TITLE
Pizza bombs no longer have a chance to explode instantly when EMPed

### DIFF
--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -39,6 +39,9 @@
 		pizza = new pizza
 	update_icon()
 
+/obj/item/pizzabox/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 
 /obj/item/pizzabox/Destroy()
 	unprocess()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds the EMP protection element to pizza boxes, meaning pizza bombs no longer have a chance to explode instantly when EMPed.

ided pr because i found this out the hard way earlier today and got gibbed 5 minutes into the round

## Why It's Good For The Game

Pizza boxes spawn in one of the syndi kit tactical sets along with EMPs. If you actually use those EMPs without dumping the pizza box somewhere, you have a chance to be instantly gibbed. I'd wager that's not a good thing.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/0f6751e9-e2a9-447d-b364-8e67f1df89cb)

</details>

## Changelog
:cl:
balance: pizza bombs no longer have a chance to detonate instantly when EMPed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
