### PR TITLE
Fines now get enforced mechanically, and users will be informed of arrest warrants

### DIFF
--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -317,7 +317,7 @@
 	user.investigate_log("New Citation: <strong>[input_name]</strong> Fine: [fine_amount] | Added to [name] by [key_name(user)]", INVESTIGATE_RECORDS)
 
 	// Attach to the citation
-	addtimer(CALLBACK(src, PROC_REF(escalate_citation), WEAKREF(new_citation), WEAKREF(crime_console)), 30 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(escalate_citation), WEAKREF(new_citation), WEAKREF(crime_console)), 15 MINUTES)
 	return TRUE
 
 /datum/record/crew/proc/escalate_citation(datum/weakref/r_citation, datum/weakref/r_crime_console)
@@ -328,7 +328,7 @@
 	if (citation.paid >= citation.fine)
 		return
 	citation.valid = FALSE
-	add_crime(citation.author, "112: Fine Avoidance.", 0, "Failed to pay citation valued at [citation.fine - citation.paid] credits which was issued for [citation.name].", crime_console)
+	add_crime(citation.author, "112: Fine Avoidance", 0, "Failed to pay citation valued at [citation.fine - citation.paid] credits which was issued for [citation.name].", crime_console)
 
 /// Handles editing a crime on a particular record. Also includes citations.
 /datum/record/crew/proc/edit_crime(mob/user, name, description, crime_ref)

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -305,7 +305,7 @@
 		crimes += new_crime
 		wanted_status = WANTED_ARREST
 		user.investigate_log("New Crime: <strong>[input_name]</strong> | Added to [name] by [key_name(user)]", INVESTIGATE_RECORDS)
-		new_crime.alert_owner(user, crime_console, name, "A warrant for your arrest has been filed for [input_name]. Please appear before security immediately.")
+		new_crime.alert_owner(user, crime_console, name, "A warrant for your arrest has been filed. Please appear before security immediately to discuss this matter. Failure to comply may result in increased punitive action.")
 
 		update_matching_security_huds(name)
 		return TRUE

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -285,13 +285,13 @@
 /// Handles adding a crime to a particular record.
 /datum/record/crew/proc/add_crime(mob/user, crime_name, fine_amount, details, crime_console)
 	var/input_name = trim(crime_name, MAX_CRIME_NAME_LEN)
-	if(!input_name)
+	if(!input_name && user)
 		to_chat(user, span_warning("You must enter a name for the crime."))
 		playsound(src, 'sound/machines/terminal_error.ogg', 75, TRUE)
 		return FALSE
 
 	var/max = CONFIG_GET(number/maxfine)
-	if(fine_amount > max)
+	if(fine_amount > max && user)
 		to_chat(user, span_warning("The maximum fine is [max] credits."))
 		playsound(src, 'sound/machines/terminal_error.ogg', 75, TRUE)
 		return FALSE
@@ -305,6 +305,7 @@
 		crimes += new_crime
 		wanted_status = WANTED_ARREST
 		user.investigate_log("New Crime: <strong>[input_name]</strong> | Added to [name] by [key_name(user)]", INVESTIGATE_RECORDS)
+		user.alert_owner(user, crime_console, name, "A warrant for your arrest has been filed for [input_name]. Please appear before security immediately.")
 
 		update_matching_security_huds(name)
 		return TRUE
@@ -312,10 +313,22 @@
 	var/datum/crime_record/citation/new_citation = new(name = input_name, details = input_details, author = user, fine = fine_amount)
 
 	citations += new_citation
-	new_citation.alert_owner(user, crime_console, name, "You have been issued a [fine_amount]cr citation for [input_name]. Fines are payable at Security.")
+	new_citation.alert_owner(user, crime_console, name, "You have been issued a [fine_amount]cr citation for [input_name]. Fines are payable at Security. You have 15 minutes to pay this amount.")
 	user.investigate_log("New Citation: <strong>[input_name]</strong> Fine: [fine_amount] | Added to [name] by [key_name(user)]", INVESTIGATE_RECORDS)
 
+	// Attach to the citation
+	addtimer(CALLBACK(src, PROC_REF(escalate_citation), WEAKREF(new_citation), WEAKREF(crime_console)), 30 SECONDS)
 	return TRUE
+
+/datum/record/crew/proc/escalate_citation(datum/weakref/r_citation, datum/weakref/r_crime_console)
+	var/datum/crime_record/citation/citation = r_citation.resolve()
+	if (!citation)
+		return
+	var/crime_console = r_crime_console.resolve()
+	if (citation.paid >= citation.fine)
+		return
+	citation.valid = FALSE
+	add_crime(citation.author, citation.name, 0, "112 Minor: Failed to pay citation valued at [citation.fine - citation.paid] credits.", crime_console)
 
 /// Handles editing a crime on a particular record. Also includes citations.
 /datum/record/crew/proc/edit_crime(mob/user, name, description, crime_ref)

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -325,7 +325,7 @@
 	if (!citation)
 		return
 	var/crime_console = r_crime_console.resolve()
-	if (citation.paid >= citation.fine)
+	if (citation.paid >= citation.fine || !citation.valid)
 		return
 	citation.valid = FALSE
 	add_crime(citation.author, "112: Fine Avoidance", 0, "Failed to pay citation valued at [citation.fine - citation.paid] credits which was issued for [citation.name].", crime_console)

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -305,7 +305,7 @@
 		crimes += new_crime
 		wanted_status = WANTED_ARREST
 		user.investigate_log("New Crime: <strong>[input_name]</strong> | Added to [name] by [key_name(user)]", INVESTIGATE_RECORDS)
-		user.alert_owner(user, crime_console, name, "A warrant for your arrest has been filed for [input_name]. Please appear before security immediately.")
+		new_crime.alert_owner(user, crime_console, name, "A warrant for your arrest has been filed for [input_name]. Please appear before security immediately.")
 
 		update_matching_security_huds(name)
 		return TRUE
@@ -328,7 +328,7 @@
 	if (citation.paid >= citation.fine)
 		return
 	citation.valid = FALSE
-	add_crime(citation.author, citation.name, 0, "112 Minor: Failed to pay citation valued at [citation.fine - citation.paid] credits.", crime_console)
+	add_crime(citation.author, "112: Fine Avoidance.", 0, "Failed to pay citation valued at [citation.fine - citation.paid] credits which was issued for [citation.name].", crime_console)
 
 /// Handles editing a crime on a particular record. Also includes citations.
 /datum/record/crew/proc/edit_crime(mob/user, name, description, crime_ref)

--- a/code/datums/records/sub_records/crime_record.dm
+++ b/code/datums/records/sub_records/crime_record.dm
@@ -49,7 +49,7 @@
 	return TRUE
 
 /// Sends a citation alert message to the target's PDA.
-/datum/crime_record/citation/proc/alert_owner(mob/sender, atom/source, target_name, message)
+/datum/crime_record/proc/alert_owner(mob/sender, atom/source, target_name, message)
 	for(var/obj/item/modular_computer/tablet in GLOB.TabletMessengers)
 		if(tablet.saved_identification != target_name)
 			continue

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -324,25 +324,15 @@
 					var/fine = tgui_input_number(human_user, "Citation fine", "Security HUD", 50, max_fine, 5)
 					if(!fine || !target_record || !citation_name || !allowed_access || !isnum(fine) || fine > max_fine || fine <= 0 || !human_user.canUseHUD() || !HAS_TRAIT(human_user, TRAIT_SECURITY_HUD))
 						return
-
-					var/datum/crime_record/citation/new_citation = new(name = citation_name, author = allowed_access, fine = fine)
-
-					target_record.citations += new_citation
-					new_citation.alert_owner(usr, src, target_record.name, "You have been fined [fine] credits for '[citation_name]'. Fines may be paid at security.")
-					investigate_log("New Citation: <strong>[citation_name]</strong> Fine: [fine] | Added to [target_record.name] by [key_name(human_user)]", INVESTIGATE_RECORDS)
+					target_record.add_crime(usr, citation_name, fine, null, src)
 					return
 
 				if(href_list["add_crime"])
 					var/crime_name = tgui_input_text(human_user, "Crime name", "Security HUD", max_length = MAX_MESSAGE_LEN)
 					if(!target_record || !crime_name || !allowed_access || !human_user.canUseHUD() || !HAS_TRAIT(human_user, TRAIT_SECURITY_HUD))
 						return
-
-					var/datum/crime_record/new_crime = new(name = crime_name, author = allowed_access)
-
-					target_record.crimes += new_crime
-					investigate_log("New Crime: <strong>[crime_name]</strong> | Added to [target_record.name] by [key_name(human_user)]", INVESTIGATE_RECORDS)
+					target_record.add_crime(human_user, crime_name, 0, null, src)
 					to_chat(human_user, span_notice("Successfully added a crime."))
-
 					return
 
 				if(href_list["add_note"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- When you get issued a fine, a timer starts. If the fine is not paid within 15 minutes, then you will have an arrest warrant automatically issued.
- You will now be informed when an arrest warrant is filed against you, similar to citations.
- SecHuds now use add_crime rather than a copy paste of its code.

## Why It's Good For The Game

Its good to communicate to players that security is now going to be hot on their heels and gives players some advanced notice to prevent awkward encounters with security where both sides just stop in a staring match since they feel a bit awkward by getting the jump on the other player unfairly. Of course you can manually set someone to arrest without issuing a crime, but this is more there so that as security you have an easy IC way to give your target notice to make arresting them a bit easier (and hey, they might even show up at security).

Fines being enforced is obviously good, since right now they get issued and then forgotten about. If you forget about it as the reciever, then you are going to prison.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/3b1cab61-a3cc-4a2b-9252-ce93b9e8046a)

Note that I updated the text to not include the reason for the arrest warrant being created. The new test reads: `A warrant for your arrest has been filed. Please appear before security immediately to discuss this matter. Failure to comply may result in increased punitive action.`.

![image](https://github.com/user-attachments/assets/068d093d-0f0e-4723-95c3-2108cb67ba51)

![image](https://github.com/user-attachments/assets/fb9fc31e-b398-4335-9ea4-e1f25e973e7a)

![image](https://github.com/user-attachments/assets/ba9a9c57-bb79-40f0-9d20-56c9762e56f6)


## Changelog
:cl:
tweak: When a crime is added to a player's record which sets them to arrest, the player will be notified and asked to appear before security.
tweak: Not paying a fine within 15 minutes results in an automatic arrest warrant being created for fine avoidance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
