### PR TITLE
Unit tests inhands

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -2071,7 +2071,7 @@
 /obj/item/stack/cable_coil{
 	amount = 2;
 	icon_state = "coil_red2";
-	item_state = "coil_red"
+	inhand_icon_state = "coil_red"
 	},
 /obj/structure/alien/weeds{
 	color = "#4BAE56";

--- a/_maps/arenas/clockwork.dmm
+++ b/_maps/arenas/clockwork.dmm
@@ -54,7 +54,7 @@
 	desc = "A very REAL ratvarian spear.";
 	icon = 'icons/obj/clockwork_objects.dmi';
 	icon_state = "ratvarian_spear";
-	item_state = "ratvarian_spear";
+	inhand_icon_state = "ratvarian_spear";
 	lefthand_file = 'icons/mob/inhands/antag/clockwork_lefthand.dmi';
 	name = "toy spear";
 	righthand_file = 'icons/mob/inhands/antag/clockwork_righthand.dmi'

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -37331,7 +37331,7 @@
 /obj/item/melee/baseball_bat{
 	desc = "Don't tell anyone you put any points into dex, though.";
 	icon_state = "swordon";
-	item_state = "swordon";
+	inhand_icon_state = "swordon";
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi';
 	name = "moonlight greatsword";
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -52985,7 +52985,7 @@
 /obj/item/melee/baseball_bat{
 	desc = "Don't tell anyone you put any points into dex, though.";
 	icon_state = "swordon";
-	item_state = "swordon";
+	inhand_icon_state = "swordon";
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi';
 	name = "moonlight greatsword";
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'

--- a/code/_globalvars/religion.dm
+++ b/code/_globalvars/religion.dm
@@ -8,4 +8,4 @@ GLOBAL_LIST_EMPTY(religion_sect_datums)
 //bible
 GLOBAL_VAR(bible_name)
 GLOBAL_VAR(bible_icon_state)
-GLOBAL_VAR(bible_item_state)
+GLOBAL_VAR(bible_inhand_icon_state)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -82,7 +82,7 @@
 	icon = 'icons/obj/magic.dmi'//Needs sprites
 	icon_state = "2"
 	item_flags = NOBLUDGEON | ABSTRACT | DROPDEL | ISWEAPON
-	//item_state = null
+	//inhand_icon_state = null
 	w_class = WEIGHT_CLASS_GIGANTIC
 
 	plane = ABOVE_HUD_PLANE

--- a/code/controllers/subsystem/persistent_paintings.dm
+++ b/code/controllers/subsystem/persistent_paintings.dm
@@ -93,7 +93,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 	/// A list of /datum/paintings saved or ready to be saved this round.
 	var/list/paintings = list()
 
-/datum/controller/subsystem/persistent_paintings/Initialize(start_timeofday)
+/datum/controller/subsystem/persistent_paintings/Initialize()
 	var/json_file = file("data/paintings.json")
 	if(fexists(json_file))
 		var/list/raw_data = update_format(json_decode(file2text(json_file)))
@@ -105,7 +105,7 @@ SUBSYSTEM_DEF(persistent_paintings)
 	for(var/obj/structure/sign/painting/painting_frame as anything in painting_frames)
 		painting_frame.load_persistent()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /**
  * Generates painting data ready to be consumed by ui.

--- a/code/datums/components/transforming.dm
+++ b/code/datums/components/transforming.dm
@@ -192,8 +192,8 @@
 	source.hitsound = hitsound_on
 	source.w_class = w_class_on
 	source.icon_state = "[source.icon_state]_on"
-	if(inhand_icon_change && source.item_state)
-		source.item_state = "[source.item_state]_on"
+	if(inhand_icon_change && source.inhand_icon_state)
+		source.inhand_icon_state = "[source.inhand_icon_state]_on"
 	source.update_inhand_icon()
 
 /*
@@ -223,7 +223,7 @@
 	source.hitsound = initial(source.hitsound)
 	source.w_class = initial(source.w_class)
 	source.icon_state = initial(source.icon_state)
-	source.item_state = initial(source.item_state)
+	source.inhand_icon_state = initial(source.inhand_icon_state)
 	if(ismob(source.loc))
 		var/mob/loc_mob = source.loc
 		loc_mob.update_inv_hands()

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -185,7 +185,7 @@
 	name = "krav maga gloves"
 	desc = "These gloves can teach you to perform Krav Maga using nanochips."
 	icon_state = "fightgloves"
-	item_state = "fightgloves"
+	inhand_icon_state = "fightgloves"
 	worn_icon_state = "fightgloves"
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
@@ -208,7 +208,7 @@
 	name = "combat gloves plus"
 	desc = "These tactical gloves are fireproof and shock resistant, and using nanochip technology it teaches you the powers of krav maga."
 	icon_state = "cgloves"
-	item_state = "combatgloves"
+	inhand_icon_state = "combatgloves"
 	worn_icon_state = "combatgloves"
 	siemens_coefficient = 0
 	strip_delay = 80

--- a/code/datums/mutations/acidooze.dm
+++ b/code/datums/mutations/acidooze.dm
@@ -24,7 +24,7 @@
 	desc = "Keep away from children, paperwork, and children doing paperwork."
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "bloodhand_left"
-	item_state = "fleshtostone"
+	inhand_icon_state = "fleshtostone"
 	var/static/base_acid_volume = 15
 	var/static/base_blood_cost = 20
 	var/static/icon_left = "bloodhand_left"

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -14,7 +14,7 @@
 	name = "\improper shock touch"
 	desc = "This is kind of like when you rub your feet on a shag rug so you can zap your friends, only a lot less safe."
 	icon_state = "zapper"
-	item_state = "zapper"
+	inhand_icon_state = "zapper"
 
 /datum/action/spell/touch/shock
 	name = "Shock Touch"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1329,6 +1329,7 @@
 	switch(var_name)
 		if(NAMEOF(src, color))
 			add_atom_colour(color, ADMIN_COLOUR_PRIORITY)
+			update_appearance()
 
 /**
   * Return the markup to for the dropdown list for the VV panel for this atom

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -151,7 +151,7 @@
 		C.flags_cover = chosen_prof.flags_cover_list[slot]
 		C.lefthand_file = chosen_prof.lefthand_file_list[slot]
 		C.righthand_file = chosen_prof.righthand_file_list[slot]
-		C.item_state = chosen_prof.item_state_list[slot]
+		C.inhand_icon_state = chosen_prof.inhand_icon_state_list[slot]
 		C.worn_icon = chosen_prof.worn_icon_list[slot]
 		C.worn_icon_state = chosen_prof.worn_icon_state_list[slot]
 

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -3,7 +3,7 @@
 	desc = "A seemingly innocent sunflower...with a twist. A <i>slippery</i> twist."
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "sunflower"
-	item_state = "sunflower"
+	inhand_icon_state = "sunflower"
 	amount_per_transfer_from_this = 3
 	spray_range = 1
 	stream_range = 1
@@ -163,7 +163,7 @@
 	name = "bananium energy shield"
 	desc = "A shield that stops most melee attacks, protects user from almost all energy projectiles, and can be thrown to slip opponents."
 	icon_state = "bananaeshield"
-	item_state = "bananaeshield"
+	inhand_icon_state = "bananaeshield"
 	throw_speed = 1
 	force = 0
 	throwforce = 0

--- a/code/game/gamemodes/legacy_gang_outfits.dm
+++ b/code/game/gamemodes/legacy_gang_outfits.dm
@@ -161,7 +161,7 @@
 /obj/item/storage/belt/military/gang
 	name = "badass belt"
 	icon_state = "gangbelt"
-	item_state = "gang"
+	inhand_icon_state = "gang"
 	desc = "The belt buckle simply reads 'BAMF'."
 
 /obj/item/clothing/mask/gskull

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -288,7 +288,7 @@
 	desc = "A powerful secondary explosive of syndicate design and unknown composition, it should be stable under normal conditions..."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "bombcore"
-	item_state = "eshield0"
+	inhand_icon_state = "eshield0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
@@ -531,7 +531,7 @@
 	desc = "Your standard issue bomb synchronizing button. Five second safety delay to prevent 'accidents'."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "bigred"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -287,7 +287,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 
 	add_atom_colour(initial(target_type.color), FIXED_COLOUR_PRIORITY)
 	icon_state = initial(target_type.icon_state)
-	item_state = initial(target_type.item_state)
+	inhand_icon_state = initial(target_type.inhand_icon_state)
 	worn_icon_state = initial(target_type.worn_icon_state)
 	inhand_x_dimension = initial(target_type.inhand_x_dimension)
 	inhand_y_dimension = initial(target_type.inhand_y_dimension)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -15,7 +15,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	icon = 'icons/obj/items_and_weapons.dmi'
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	/// The icon state for the icons that appear in the players hand while holding it. Gotten from /client/var/lefthand_file and /client/var/righthand_file
-	var/item_state = null
+	var/inhand_icon_state = null
 	/// The icon for holding in hand icon states for the left hand.
 	var/lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	/// The icon for holding in hand icon states for the right hand.
@@ -42,7 +42,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	//Not on /clothing because for some reason any /obj/item can technically be "worn" with enough fuckery.
 	/// If this is set, update_icons() will find on mob (WORN, NOT INHANDS) states in this file instead, primary use: badminnery/events
 	var/icon/worn_icon = null
-	//Icon state for mob worn overlays. If not set falls back to item_state, then icon_state
+	//Icon state for mob worn overlays. If not set falls back to inhand_icon_state, then icon_state
 	var/worn_icon_state
 	/// If this is set, update_icons() will force the on mob state (WORN, NOT INHANDS) onto this layer, instead of it's default
 	var/alternate_worn_layer
@@ -753,7 +753,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	// Remove any item actions we temporary gave out.
 	for(var/datum/action/action_item_has as anything in actions)
 		action_item_has.Remove(user)
-		
+
 	item_flags &= ~BEING_REMOVED
 	item_flags &= ~PICKED_UP
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -10,7 +10,7 @@ AI MODULES
 	name = "\improper AI module"
 	icon = 'icons/obj/module.dmi'
 	icon_state = "std_mod"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	desc = "An AI Module for programming laws to an AI."

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -784,7 +784,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 
 /obj/item/construction/rcd/borg/syndicate
 	icon_state = "ircd"
-	item_state = "ircd"
+	inhand_icon_state = "ircd"
 	energyfactor = 66
 
 /obj/item/construction/rcd/loaded
@@ -793,7 +793,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 /obj/item/construction/rcd/combat
 	name = "industrial RCD"
 	icon_state = "ircd"
-	item_state = "ircd"
+	inhand_icon_state = "ircd"
 	max_matter = 500
 	matter = 500
 	canRturf = TRUE
@@ -804,7 +804,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	desc = "Highly compressed matter for the RCD."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "rcd"
-	item_state = "rcdammo"
+	inhand_icon_state = "rcdammo"
 	w_class = WEIGHT_CLASS_TINY
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -825,7 +825,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	delay_mod = 0.6
 	ranged = TRUE
 	icon_state = "arcd"
-	item_state = "oldrcd"
+	inhand_icon_state = "oldrcd"
 	has_ammobar = FALSE
 	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
 

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -3,7 +3,7 @@
 	desc = "A device used to rapidly deploy cable. It has screws on the side which can be removed to slide off the cables. Do not use without insulation!"
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcl-0"
-	item_state = "rcl-0"
+	inhand_icon_state = "rcl-0"
 	var/obj/structure/cable/last
 	var/obj/item/stack/cable_coil/loaded
 	opacity = FALSE
@@ -116,21 +116,21 @@
 /obj/item/rcl/update_icon_state()
 	if(!loaded)
 		icon_state = "rcl-0"
-		item_state = "rcl-0"
+		inhand_icon_state = "rcl-0"
 		return ..()
 	switch(loaded.amount)
 		if(61 to INFINITY)
 			icon_state = "rcl-30"
-			item_state = "rcl"
+			inhand_icon_state = "rcl"
 		if(31 to 60)
 			icon_state = "rcl-20"
-			item_state = "rcl"
+			inhand_icon_state = "rcl"
 		if(1 to 30)
 			icon_state = "rcl-10"
-			item_state = "rcl"
+			inhand_icon_state = "rcl"
 		else
 			icon_state = "rcl-0"
-			item_state = "rcl-0"
+			inhand_icon_state = "rcl-0"
 	return ..()
 
 /obj/item/rcl/proc/is_empty(mob/user, loud = 1)
@@ -335,15 +335,15 @@
 /obj/item/rcl/ghetto/update_icon_state()
 	if(!loaded)
 		icon_state = "rclg-0"
-		item_state = "rclg-0"
+		inhand_icon_state = "rclg-0"
 		return ..()
 	switch(loaded.amount)
 		if(1 to INFINITY)
 			icon_state = "rclg-1"
-			item_state = "rcl"
+			inhand_icon_state = "rcl"
 		else
 			icon_state = "rclg-1"
-			item_state = "rclg-1"
+			inhand_icon_state = "rclg-1"
 	return ..()
 
 /datum/action/item_action/rcl_col

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -9,7 +9,7 @@
 	desc = "An advanced autopainter preprogrammed with several paintjobs for airlocks. Use it on an airlock during or after construction to change the paintjob. Alt-Click to remove the ink cartridge."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "paint_sprayer"
-	item_state = "paint_sprayer"
+	inhand_icon_state = "paint_sprayer"
 	worn_icon_state = "painter"
 	w_class = WEIGHT_CLASS_SMALL
 
@@ -188,7 +188,7 @@
 	desc = "An airlock painter, reprogramed to use a different style of paint in order to apply decals for floor tiles as well, in addition to repainting doors. Decals break when the floor tiles are removed. Alt-Click to remove the ink cartridge."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "decal_sprayer"
-	item_state = "decal_sprayer"
+	inhand_icon_state = "decal_sprayer"
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=50)
 	initial_ink_type = /obj/item/toner/large
 	/// The current direction of the decal being printed

--- a/code/game/objects/items/bedsheets.dm
+++ b/code/game/objects/items/bedsheets.dm
@@ -9,7 +9,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/bedsheet_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/bedsheet_righthand.dmi'
 	icon_state = "sheetwhite"
-	item_state = "sheetwhite"
+	inhand_icon_state = "sheetwhite"
 	slot_flags = ITEM_SLOT_NECK
 	layer = MOB_LAYER
 	throwforce = 0
@@ -61,89 +61,89 @@
 
 /obj/item/bedsheet/blue
 	icon_state = "sheetblue"
-	item_state = "sheetblue"
+	inhand_icon_state = "sheetblue"
 	dream_messages = list("blue")
 
 /obj/item/bedsheet/green
 	icon_state = "sheetgreen"
-	item_state = "sheetgreen"
+	inhand_icon_state = "sheetgreen"
 	dream_messages = list("green")
 
 /obj/item/bedsheet/grey
 	icon_state = "sheetgrey"
-	item_state = "sheetgrey"
+	inhand_icon_state = "sheetgrey"
 	dream_messages = list("grey")
 
 /obj/item/bedsheet/orange
 	icon_state = "sheetorange"
-	item_state = "sheetorange"
+	inhand_icon_state = "sheetorange"
 	dream_messages = list("orange")
 
 /obj/item/bedsheet/purple
 	icon_state = "sheetpurple"
-	item_state = "sheetpurple"
+	inhand_icon_state = "sheetpurple"
 	dream_messages = list("purple")
 
 /obj/item/bedsheet/red
 	icon_state = "sheetred"
-	item_state = "sheetred"
+	inhand_icon_state = "sheetred"
 	dream_messages = list("red")
 
 /obj/item/bedsheet/yellow
 	icon_state = "sheetyellow"
-	item_state = "sheetyellow"
+	inhand_icon_state = "sheetyellow"
 	dream_messages = list("yellow")
 
 /obj/item/bedsheet/brown
 	icon_state = "sheetbrown"
-	item_state = "sheetbrown"
+	inhand_icon_state = "sheetbrown"
 	dream_messages = list("brown")
 
 /obj/item/bedsheet/black
 	icon_state = "sheetblack"
-	item_state = "sheetblack"
+	inhand_icon_state = "sheetblack"
 	dream_messages = list("black")
 
 /obj/item/bedsheet/patriot
 	name = "patriotic bedsheet"
 	desc = "You've never felt more free than when sleeping on this."
 	icon_state = "sheetUSA"
-	item_state = "sheetUSA"
+	inhand_icon_state = "sheetUSA"
 	dream_messages = list("America", "freedom", "fireworks", "bald eagles")
 
 /obj/item/bedsheet/rainbow
 	name = "rainbow bedsheet"
 	desc = "A multicolored blanket. It's actually several different sheets cut up and sewn together."
 	icon_state = "sheetrainbow"
-	item_state = "sheetrainbow"
+	inhand_icon_state = "sheetrainbow"
 	dream_messages = list("red", "orange", "yellow", "green", "blue", "purple", "a rainbow")
 
 /obj/item/bedsheet/mime
 	name = "mime's blanket"
 	desc = "A very soothing striped blanket.  All the noise just seems to fade out when you're under the covers in this."
 	icon_state = "sheetmime"
-	item_state = "sheetmime"
+	inhand_icon_state = "sheetmime"
 	dream_messages = list("silence", "gestures", "a pale face", "a gaping mouth", "the mime")
 
 /obj/item/bedsheet/clown
 	name = "clown's blanket"
 	desc = "A rainbow blanket with a clown mask woven in. It smells faintly of bananas."
 	icon_state = "sheetclown"
-	item_state = "sheetrainbow"
+	inhand_icon_state = "sheetrainbow"
 	dream_messages = list("honk", "laughter", "a prank", "a joke", "a smiling face", "the clown")
 
 /obj/item/bedsheet/captain
 	name = "captain's bedsheet"
 	desc = "It has a Nanotrasen symbol on it, and was woven with a revolutionary new kind of thread guaranteed to have 0.01% permeability for most non-chemical substances, popular among most modern captains."
 	icon_state = "sheetcaptain"
-	item_state = "sheetcaptain"
+	inhand_icon_state = "sheetcaptain"
 	dream_messages = list("authority", "a golden ID", "sunglasses", "a green disc", "an antique gun", "the captain")
 
 /obj/item/bedsheet/rd
 	name = "research director's bedsheet"
 	desc = "It appears to have a beaker emblem, and is made out of fire-resistant material, although it probably won't protect you in the event of fires you're familiar with every day."
 	icon_state = "sheetrd"
-	item_state = "sheetrd"
+	inhand_icon_state = "sheetrd"
 	dream_messages = list("authority", "a silvery ID", "a bomb", "a mech", "a facehugger", "maniacal laughter", "the research director")
 
 // for Free Golems.
@@ -156,98 +156,98 @@
 	name = "medical blanket"
 	desc = "It's a sterilized* blanket commonly used in the Medbay.  <i>*Sterilization is voided if a virologist is present onboard the station.</i>"
 	icon_state = "sheetmedical"
-	item_state = "sheetmedical"
+	inhand_icon_state = "sheetmedical"
 	dream_messages = list("healing", "life", "surgery", "a doctor")
 
 /obj/item/bedsheet/cmo
 	name = "chief medical officer's bedsheet"
 	desc = "It's a sterilized blanket that has a cross emblem. There's some cat fur on it, likely from Runtime."
 	icon_state = "sheetcmo"
-	item_state = "sheetcmo"
+	inhand_icon_state = "sheetcmo"
 	dream_messages = list("authority", "a silvery ID", "healing", "life", "surgery", "a cat", "the chief medical officer")
 
 /obj/item/bedsheet/hos
 	name = "head of security's bedsheet"
 	desc = "It is decorated with a shield emblem. While crime doesn't sleep, you do, but you are still THE LAW!"
 	icon_state = "sheethos"
-	item_state = "sheethos"
+	inhand_icon_state = "sheethos"
 	dream_messages = list("authority", "a silvery ID", "handcuffs", "a baton", "a flashbang", "sunglasses", "the head of security")
 
 /obj/item/bedsheet/hop
 	name = "head of personnel's bedsheet"
 	desc = "It is decorated with a key emblem. For those rare moments when you can rest and cuddle with Ian without someone screaming for you over the radio."
 	icon_state = "sheethop"
-	item_state = "sheethop"
+	inhand_icon_state = "sheethop"
 	dream_messages = list("authority", "a silvery ID", "obligation", "a computer", "an ID", "a corgi", "the head of personnel")
 
 /obj/item/bedsheet/ce
 	name = "chief engineer's bedsheet"
 	desc = "It is decorated with a wrench emblem. It's highly reflective and stain resistant, so you don't need to worry about ruining it with oil."
 	icon_state = "sheetce"
-	item_state = "sheetce"
+	inhand_icon_state = "sheetce"
 	dream_messages = list("authority", "a silvery ID", "the engine", "power tools", "an APC", "a parrot", "the chief engineer")
 
 /obj/item/bedsheet/qm
 	name = "quartermaster's bedsheet"
 	desc = "It is decorated with a crate emblem in silver lining.  It's rather tough, and just the thing to lie on after a hard day of pushing paper."
 	icon_state = "sheetqm"
-	item_state = "sheetqm"
+	inhand_icon_state = "sheetqm"
 	dream_messages = list("a grey ID", "a shuttle", "a crate", "a sloth", "the quartermaster")
 
 /obj/item/bedsheet/magician
 	name = "magician's cape"
 	desc = "A magician never reveals his secrets."
 	icon_state = "sheetmagician"
-	item_state = "sheetmagician"
+	inhand_icon_state = "sheetmagician"
 	dream_messages = list("trickery", "crime", "a gullible mark", "an angry wizard", "pixie dust")
 
 /obj/item/bedsheet/centcom
 	name = "\improper CentCom bedsheet"
 	desc = "Woven with advanced nanothread for warmth as well as being very decorated, essential for all officials."
 	icon_state = "sheetcentcom"
-	item_state = "sheetcentcom"
+	inhand_icon_state = "sheetcentcom"
 	dream_messages = list("a unique ID", "authority", "artillery", "an ending")
 
 /obj/item/bedsheet/syndie
 	name = "syndicate bedsheet"
 	desc = "It has a syndicate emblem and it has an aura of evil."
 	icon_state = "sheetsyndie"
-	item_state = "sheetsyndie"
+	inhand_icon_state = "sheetsyndie"
 	dream_messages = list("a green disc", "a red crystal", "a glowing blade", "a wire-covered ID")
 
 /obj/item/bedsheet/cult
 	name = "cultist's bedsheet"
 	desc = "You might dream of Nar'Sie if you sleep with this. It seems rather tattered and glows of an eldritch presence."
 	icon_state = "sheetcult"
-	item_state = "sheetcult"
+	inhand_icon_state = "sheetcult"
 	dream_messages = list("a tome", "a floating red crystal", "a glowing sword", "a bloody symbol", "a massive humanoid figure")
 
 /obj/item/bedsheet/wiz
 	name = "wizard's bedsheet"
 	desc = "A special fabric enchanted with magic so you can have an enchanted night. It even glows!"
 	icon_state = "sheetwiz"
-	item_state = "sheetwiz"
+	inhand_icon_state = "sheetwiz"
 	dream_messages = list("a book", "an explosion", "lightning", "a staff", "a skeleton", "a robe", "magic")
 
 /obj/item/bedsheet/nanotrasen
 	name = "\improper Nanotrasen bedsheet"
 	desc = "It has the Nanotrasen logo on it and has an aura of duty."
 	icon_state = "sheetNT"
-	item_state = "sheetNT"
+	inhand_icon_state = "sheetNT"
 	dream_messages = list("authority", "an ending")
 
 /obj/item/bedsheet/ian
 	name = "Ian's bedsheet"
 	desc = "The HoP's beloved pet, now in bedsheet format."
 	icon_state = "sheetian"
-	item_state = "sheetian"
+	inhand_icon_state = "sheetian"
 	dream_messages = list("a dog", "a corgi", "woof", "bark", "arf")
 
 /obj/item/bedsheet/cosmos
 	name = "cosmic space bedsheet"
 	desc = "Made from the dreams of those who wonder at the stars."
 	icon_state = "sheetcosmos"
-	item_state = "sheetcosmos"
+	inhand_icon_state = "sheetcosmos"
 	dream_messages = list("the infinite cosmos", "Hans Zimmer music", "a flight through space", "the galaxy", "being fabulous", "shooting stars")
 	light_power = 2
 	light_range = 1.4
@@ -306,88 +306,88 @@
 
 /obj/item/bedsheet/double/blue
 	icon_state = "double_sheetblue"
-	item_state = "sheetblue"
+	inhand_icon_state = "sheetblue"
 	dream_messages = list("blue")
 
 /obj/item/bedsheet/double/green
 	icon_state = "double_sheetgreen"
-	item_state = "sheetgreen"
+	inhand_icon_state = "sheetgreen"
 	dream_messages = list("green")
 
 /obj/item/bedsheet/double/grey
 	icon_state = "double_sheetgrey"
-	item_state = "sheetgrey"
+	inhand_icon_state = "sheetgrey"
 	dream_messages = list("grey")
 
 /obj/item/bedsheet/double/orange
 	icon_state = "double_sheetorange"
-	item_state = "sheetorange"
+	inhand_icon_state = "sheetorange"
 	dream_messages = list("orange")
 
 /obj/item/bedsheet/double/purple
 	icon_state = "double_sheetpurple"
-	item_state = "sheetpurple"
+	inhand_icon_state = "sheetpurple"
 	dream_messages = list("purple")
 
 /obj/item/bedsheet/double/red
 	icon_state = "double_sheetred"
-	item_state = "sheetred"
+	inhand_icon_state = "sheetred"
 	dream_messages = list("red")
 
 /obj/item/bedsheet/double/yellow
 	icon_state = "double_sheetyellow"
-	item_state = "sheetyellow"
+	inhand_icon_state = "sheetyellow"
 	dream_messages = list("yellow")
 
 /obj/item/bedsheet/double/brown
 	icon_state = "double_sheetbrown"
-	item_state = "sheetbrown"
+	inhand_icon_state = "sheetbrown"
 	dream_messages = list("brown")
 
 /obj/item/bedsheet/double/black
 	icon_state = "double_sheetblack"
-	item_state = "sheetblack"
+	inhand_icon_state = "sheetblack"
 	dream_messages = list("black")
 
 /obj/item/bedsheet/double/patriot
 	name = "double patriotic bedsheet"
 	icon_state = "double_sheetUSA"
-	item_state = "sheetUSA"
+	inhand_icon_state = "sheetUSA"
 	dream_messages = list("America", "freedom", "fireworks", "bald eagles")
 	desc = "You've never felt more free than when sleeping on this."
 
 /obj/item/bedsheet/double/rainbow
 	name = "double rainbow bedsheet"
 	icon_state = "double_sheetrainbow"
-	item_state = "sheetrainbow"
+	inhand_icon_state = "sheetrainbow"
 	dream_messages = list("red", "orange", "yellow", "green", "blue", "purple", "a rainbow")
 	desc = "A multicolored blanket. It's actually several different sheets cut up and sewn together."
 
 /obj/item/bedsheet/double/mime
 	name = "double mime's blanket"
 	icon_state = "double_sheetmime"
-	item_state = "sheetmime"
+	inhand_icon_state = "sheetmime"
 	dream_messages = list("silence", "gestures", "a pale face", "a gaping mouth", "the mime")
 	desc = "A very soothing striped blanket.  All the noise just seems to fade out when you're under the covers in this."
 
 /obj/item/bedsheet/double/clown
 	name = "double clown's blanket"
 	icon_state = "double_sheetclown"
-	item_state = "sheetrainbow"
+	inhand_icon_state = "sheetrainbow"
 	dream_messages = list("honk", "laughter", "a prank", "a joke", "a smiling face", "the clown")
 	desc = "A rainbow blanket with a clown mask woven in. It smells faintly of bananas."
 
 /obj/item/bedsheet/double/captain
 	name = "double captain's bedsheet"
 	icon_state = "double_sheetcaptain"
-	item_state = "sheetcaptain"
+	inhand_icon_state = "sheetcaptain"
 	dream_messages = list("authority", "a golden ID", "sunglasses", "a green disc", "an antique gun", "the captain")
 	desc = "It has a Nanotrasen symbol on it, and was woven with a revolutionary new kind of thread guaranteed to have 0.01% permeability for most non-chemical substances, popular among most modern captains."
 
 /obj/item/bedsheet/double/rd
 	name = "double research director's bedsheet"
 	icon_state = "double_sheetrd"
-	item_state = "sheetrd"
+	inhand_icon_state = "sheetrd"
 	dream_messages = list("authority", "a silvery ID", "a bomb", "a mech", "a facehugger", "maniacal laughter", "the research director")
 	desc = "It appears to have a beaker emblem, and is made out of fire-resistant material, although it probably won't protect you in the event of fires you're familiar with every day."
 
@@ -400,84 +400,84 @@
 /obj/item/bedsheet/double/medical
 	name = "double medical blanket"
 	icon_state = "double_sheetmedical"
-	item_state = "sheetmedical"
+	inhand_icon_state = "sheetmedical"
 	dream_messages = list("healing", "life", "surgery", "a doctor")
 	desc = "It's a sterilized* blanket commonly used in the Medbay.  <i>*Sterilization is voided if a virologist is present onboard the station.</i>"
 
 /obj/item/bedsheet/double/cmo
 	name = "double chief medical officer's bedsheet"
 	icon_state = "double_sheetcmo"
-	item_state = "sheetcmo"
+	inhand_icon_state = "sheetcmo"
 	dream_messages = list("authority", "a silvery ID", "healing", "life", "surgery", "a cat", "the chief medical officer")
 	desc = "It's a sterilized blanket that has a cross emblem. There's some cat fur on it, likely from Runtime."
 
 /obj/item/bedsheet/double/hos
 	name = "double head of security's bedsheet"
 	icon_state = "double_sheethos"
-	item_state = "sheethos"
+	inhand_icon_state = "sheethos"
 	dream_messages = list("authority", "a silvery ID", "handcuffs", "a baton", "a flashbang", "sunglasses", "the head of security")
 	desc = "It is decorated with a shield emblem. While crime doesn't sleep, you do, but you are still THE LAW!"
 
 /obj/item/bedsheet/double/hop
 	name = "double head of personnel's bedsheet"
 	icon_state = "double_sheethop"
-	item_state = "sheethop"
+	inhand_icon_state = "sheethop"
 	dream_messages = list("authority", "a silvery ID", "obligation", "a computer", "an ID", "a corgi", "the head of personnel")
 	desc = "It is decorated with a key emblem. For those rare moments when you can rest and cuddle with Ian without someone screaming for you over the radio."
 
 /obj/item/bedsheet/double/ce
 	name = "double chief engineer's bedsheet"
 	icon_state = "double_sheetce"
-	item_state = "sheetce"
+	inhand_icon_state = "sheetce"
 	dream_messages = list("authority", "a silvery ID", "the engine", "power tools", "an APC", "a parrot", "the chief engineer")
 	desc = "It is decorated with a wrench emblem. It's highly reflective and stain resistant, so you don't need to worry about ruining it with oil."
 
 /obj/item/bedsheet/double/qm
 	name = "double quartermaster's bedsheet"
 	icon_state = "double_sheetqm"
-	item_state = "sheetqm"
+	inhand_icon_state = "sheetqm"
 	dream_messages = list("a grey ID", "a shuttle", "a crate", "a sloth", "the quartermaster")
 	desc = "It is decorated with a crate emblem in silver lining.  It's rather tough, and just the thing to lie on after a hard day of pushing paper."
 
 /obj/item/bedsheet/double/centcom
 	name = "\improper double CentCom bedsheet"
 	icon_state = "double_sheetcentcom"
-	item_state = "sheetcentcom"
+	inhand_icon_state = "sheetcentcom"
 	dream_messages = list("a unique ID", "authority", "artillery", "an ending")
 	desc = "Woven with advanced nanothread for warmth as well as being very decorated, essential for all officials."
 
 /obj/item/bedsheet/double/syndie
 	name = "double syndicate bedsheet"
 	icon_state = "double_sheetsyndie"
-	item_state = "sheetsyndie"
+	inhand_icon_state = "sheetsyndie"
 	dream_messages = list("a green disc", "a red crystal", "a glowing blade", "a wire-covered ID")
 	desc = "It has a syndicate emblem and it has an aura of evil."
 
 /obj/item/bedsheet/double/cult
 	name = "double cultist's bedsheet"
 	icon_state = "double_sheetcult"
-	item_state = "sheetcult"
+	inhand_icon_state = "sheetcult"
 	dream_messages = list("a tome", "a floating red crystal", "a glowing sword", "a bloody symbol", "a massive humanoid figure")
 	desc = "You might dream of Nar'Sie if you sleep with this. It seems rather tattered and glows of an eldritch presence."
 
 /obj/item/bedsheet/double/wiz
 	name = "double wizard's bedsheet"
 	icon_state = "double_sheetwiz"
-	item_state = "sheetwiz"
+	inhand_icon_state = "sheetwiz"
 	dream_messages = list("a book", "an explosion", "lightning", "a staff", "a skeleton", "a robe", "magic")
 	desc = "A special fabric enchanted with magic so you can have an enchanted night. It even glows!"
 
 /obj/item/bedsheet/double/nanotrasen
 	name = "\improper double Nanotrasen bedsheet"
 	icon_state = "double_sheetNT"
-	item_state = "sheetNT"
+	inhand_icon_state = "sheetNT"
 	dream_messages = list("authority", "an ending")
 	desc = "It has the Nanotrasen logo on it and has an aura of duty."
 
 /obj/item/bedsheet/double/ian
 	name = "double Ian's bedsheet"
 	icon_state = "double_sheetian"
-	item_state = "sheetian"
+	inhand_icon_state = "sheetian"
 	dream_messages = list("a dog", "a corgi", "woof", "bark", "arf")
 	desc = "The HoP's beloved pet, now in bedsheet format."
 
@@ -485,7 +485,7 @@
 /obj/item/bedsheet/double/cosmos
 	name = "double cosmic space bedsheet"
 	icon_state = "double_sheetcosmos"
-	item_state = "sheetcosmos"
+	inhand_icon_state = "sheetcosmos"
 	dream_messages = list("the infinite cosmos", "Hans Zimmer music", "a flight through space", "the galaxy", "being fabulous", "shooting stars")
 	desc = "Made from the dreams of those who wonder at the stars."
 	light_power = 2.1

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -1,7 +1,7 @@
 /obj/item/binoculars
 	name = "binoculars"
 	desc = "Used for long-distance surveillance."
-	item_state = "binoculars"
+	inhand_icon_state = "binoculars"
 	icon_state = "binoculars"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
@@ -30,7 +30,7 @@
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(unwield))
 	listeningTo = user
 	user.visible_message(span_notice("[user] holds [src] up to [user.p_their()] eyes."), span_notice("You hold [src] up to your eyes."))
-	item_state = "binoculars_wielded"
+	inhand_icon_state = "binoculars_wielded"
 	user.regenerate_icons()
 	if(!user?.client)
 		return
@@ -60,7 +60,7 @@
 		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
 		listeningTo = null
 	user.visible_message(span_notice("[user] lowers [src]."), span_notice("You lower [src]."))
-	item_state = "binoculars"
+	inhand_icon_state = "binoculars"
 	user.regenerate_icons()
 	if(user && user.client)
 		user.regenerate_icons()

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -5,7 +5,7 @@
 		humankind. The jewelry he kept for himself."
 	icon = 'icons/obj/candle.dmi'
 	icon_state = "candle1"
-	item_state = "candle1"
+	inhand_icon_state = "candle1"
 	w_class = WEIGHT_CLASS_TINY
 	light_color = LIGHT_COLOR_FIRE
 	heat = 1000

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -32,7 +32,7 @@
 	var/function = "storage"
 	var/data = "null"
 	var/special = null
-	item_state = "card-id"
+	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	var/detail_color = COLOR_ASSEMBLY_ORANGE
@@ -64,7 +64,7 @@
 	desc = "It is an ID card, the magnetic strip is exposed and attached to some circuitry."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
-	item_state = "card-id"
+	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON | ISWEAPON
@@ -147,7 +147,7 @@
 	desc = "It is an ID card, the magnetic strip is exposed and attached to some circuitry. Closer inspection shows that this card is a poorly made replica, with a \"DonkCo\" logo stamped on the back."
 	name = "cryptographic sequencer"
 	icon_state = "emag"
-	item_state = "card-id"
+	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 
@@ -159,7 +159,7 @@
 	name = "identification card"
 	desc = "A card used to provide ID and determine access across the station."
 	icon_state = "id"
-	item_state = "card-id"
+	inhand_icon_state = "card-id"
 	worn_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
@@ -438,7 +438,7 @@ update_label("John Doe", "Clowny")
 	name = "silver identification card"
 	desc = "A silver ID card, issued to positions which require honour and dedication."
 	icon_state = "silver"
-	item_state = "silver_id"
+	inhand_icon_state = "silver_id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	hud_state = JOB_HUD_RAWCENTCOM
@@ -454,7 +454,7 @@ update_label("John Doe", "Clowny")
 	name = "gold identification card"
 	desc = "A golden ID card. issued to positions which wield power and might."
 	icon_state = "gold"
-	item_state = "gold_id"
+	inhand_icon_state = "gold_id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	hud_state = JOB_HUD_RAWCOMMAND
@@ -679,7 +679,7 @@ update_label("John Doe", "Clowny")
 	name = "captain's spare ID"
 	desc = "The spare ID of the High Lord himself."
 	icon_state = "gold"
-	item_state = "gold_id"
+	inhand_icon_state = "gold_id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	registered_name = JOB_NAME_CAPTAIN
@@ -793,7 +793,7 @@ update_label("John Doe", "Clowny")
 	name = "prisoner ID card"
 	desc = "You are a number, you are not a free man."
 	icon_state = "orange"
-	item_state = "orange-id"
+	inhand_icon_state = "orange-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	var/goal = 0 //How far from freedom?

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -103,7 +103,7 @@
 	icon = 'icons/obj/banner.dmi'
 	name_type = "planet"
 	icon_state = "banner"
-	item_state = "banner"
+	inhand_icon_state = "banner"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	desc = "A cunning device used to claim ownership of planets."

--- a/code/game/objects/items/chrono_eraser.dm
+++ b/code/game/objects/items/chrono_eraser.dm
@@ -5,7 +5,7 @@
 	desc = "The result of outlawed time-bluespace research, this device is capable of wiping a being from the timestream. They never are, they never were, they never will be."
 	icon = 'icons/obj/chronos.dmi'
 	icon_state = "chronobackpack"
-	item_state = "backpack"
+	inhand_icon_state = "backpack"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -38,7 +38,7 @@
 	desc = "It's as if they never existed in the first place."
 	icon = 'icons/obj/chronos.dmi'
 	icon_state = "chronogun"
-	item_state = "chronogun"
+	inhand_icon_state = "chronogun"
 	w_class = WEIGHT_CLASS_NORMAL
 	item_flags = DROPDEL | ISWEAPON
 	ammo_type = list(/obj/item/ammo_casing/energy/chrono_beam)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -48,7 +48,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		damtype = BURN
 		force = 3
 		hitsound = 'sound/items/welder.ogg'
-		item_state = "cigon"
+		inhand_icon_state = "cigon"
 		name = "lit [initial(name)]"
 		desc = "A [initial(name)]. This one is lit."
 		attack_verb_continuous = list("burns", "sings")
@@ -63,7 +63,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		damtype = BRUTE
 		force = initial(force)
 		icon_state = "match_burnt"
-		item_state = "cigoff"
+		inhand_icon_state = "cigoff"
 		name = "burnt [initial(name)]"
 		desc = "A [initial(name)]. This one has seen better days."
 		attack_verb_continuous = list("flicks")
@@ -127,7 +127,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A roll of tobacco and nicotine."
 	icon_state = "cigoff"
 	throw_speed = 0.5
-	item_state = "cigoff"
+	inhand_icon_state = "cigoff"
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	grind_results = list()
@@ -230,7 +230,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return
 	if(!(flags_1 & INITIALIZED_1))
 		icon_state = icon_on
-		item_state = icon_on
+		inhand_icon_state = icon_on
 		return
 
 	lit = TRUE
@@ -253,7 +253,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	DISABLE_BITFIELD(reagents.flags, NO_REACT)
 	reagents.handle_reactions()
 	icon_state = icon_on
-	item_state = icon_on
+	inhand_icon_state = icon_on
 	if(flavor_text)
 		T.visible_message(flavor_text)
 	START_PROCESSING(SSobj, src)
@@ -276,7 +276,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	damtype = BRUTE
 	force = 0
 	icon_state = icon_off
-	item_state = icon_off
+	inhand_icon_state = icon_off
 	STOP_PROCESSING(SSobj, src)
 	ENABLE_BITFIELD(reagents.flags, NO_REACT)
 	lit = FALSE
@@ -431,7 +431,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "spliffoff"
 	type_butt = /obj/item/cigbutt/roach
 	throw_speed = 0.5
-	item_state = "spliffoff"
+	inhand_icon_state = "spliffoff"
 	smoketime = 4 * 60
 	chem_volume = 50
 	list_reagents = null
@@ -476,7 +476,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigaroff" //make sure to add positional sprites in icons/obj/cigarettes.dmi if you add more.
 	type_butt = /obj/item/cigbutt/cigarbutt
 	throw_speed = 0.5
-	item_state = "cigaroff"
+	inhand_icon_state = "cigaroff"
 	smoketime = 11 * 60
 	chem_volume = 40
 	list_reagents = list(/datum/reagent/drug/nicotine = 25)
@@ -522,7 +522,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "smoking pipe"
 	desc = "A pipe, for smoking. Probably made of meerschaum or something."
 	icon_state = "pipeoff"
-	item_state = "pipeoff"
+	inhand_icon_state = "pipeoff"
 	icon_on = "pipeon"  //Note - these are in masks.dmi
 	icon_off = "pipeoff"
 	smoketime = 0
@@ -550,7 +550,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			to_chat(M, span_notice("Your [name] goes out."))
 			lit = 0
 			icon_state = icon_off
-			item_state = icon_off
+			inhand_icon_state = icon_off
 			M.update_inv_wear_mask()
 			packeditem = 0
 			name = "empty [initial(name)]"
@@ -593,7 +593,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		user.visible_message(span_notice("[user] puts out [src]."), span_notice("You put out [src]."))
 		lit = 0
 		icon_state = icon_off
-		item_state = icon_off
+		inhand_icon_state = icon_off
 		STOP_PROCESSING(SSobj, src)
 		return
 	if(!lit && smoketime > 0)
@@ -609,7 +609,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "corn cob pipe"
 	desc = "A nicotine delivery system popularized by folksy backwoodsmen and kept popular in the modern age and beyond by space hipsters. Can be loaded with objects."
 	icon_state = "cobpipeoff"
-	item_state = "cobpipeoff"
+	inhand_icon_state = "cobpipeoff"
 	icon_on = "cobpipeon"  //Note - these are in masks.dmi
 	icon_off = "cobpipeoff"
 	smoketime = 0
@@ -623,7 +623,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "The zippo."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "zippo"
-	item_state = "zippo"
+	inhand_icon_state = "zippo"
 	worn_icon_state = "lighter"
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = CONDUCT_1
@@ -867,7 +867,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A classy and highly sophisticated electronic cigarette, for classy and dignified gentlemen. A warning label reads \"Warning: Do not fill with flammable materials.\""//<<< i'd vape to that.
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "red_vape"
-	item_state = null
+	inhand_icon_state = null
 	w_class = WEIGHT_CLASS_TINY
 	item_flags = ISWEAPON
 	var/chem_volume = 100
@@ -892,7 +892,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/clothing/mask/vape)
 		if(!param_color)
 			param_color = pick("red","blue","black","white","green","purple","yellow","orange")
 		icon_state = "[param_color]_vape"
-		item_state = "[param_color]_vape"
+		inhand_icon_state = "[param_color]_vape"
 
 /obj/item/clothing/mask/vape/attackby(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_SCREWDRIVER)

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -7,7 +7,7 @@
 	name = "circuit board"
 	icon = 'icons/obj/module.dmi'
 	icon_state = "id_mod"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	custom_materials = list(/datum/material/glass=1000)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -139,7 +139,7 @@
 	desc = "A horn off of a bicycle."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "bike_horn"
-	item_state = "bike_horn"
+	inhand_icon_state = "bike_horn"
 	worn_icon_state = "horn"
 	lefthand_file = 'icons/mob/inhands/equipment/horns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/horns_righthand.dmi'
@@ -186,7 +186,7 @@
 	name = "golden bike horn"
 	desc = "Golden? Clearly, it's made with bananium! Honk!"
 	icon_state = "gold_horn"
-	item_state = "gold_horn"
+	inhand_icon_state = "gold_horn"
 	worn_icon_state = "horn_gold"
 	var/flip_cooldown = 0
 

--- a/code/game/objects/items/colorizers/colorizer.dm
+++ b/code/game/objects/items/colorizers/colorizer.dm
@@ -10,7 +10,7 @@
 	var/list/forbidden_targets = list()
 	var/apply_icon = null
 	var/apply_icon_state = null
-	var/apply_item_state = null
+	var/apply_inhand_icon_state = null
 	var/apply_righthand_file = null
 	var/apply_lefthand_file = null
 
@@ -43,8 +43,8 @@
 
 	var/obj/item/target_item = to_be_colored
 	if(istype(target_item))
-		if(apply_item_state)
-			target_item.item_state = apply_item_state
+		if(apply_inhand_icon_state)
+			target_item.inhand_icon_state = apply_inhand_icon_state
 		if(apply_righthand_file)
 			target_item.righthand_file = apply_righthand_file
 		if(apply_lefthand_file)

--- a/code/game/objects/items/combat/shield_belt.dm
+++ b/code/game/objects/items/combat/shield_belt.dm
@@ -7,7 +7,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	icon = 'icons/obj/clothing/belts.dmi'
 	icon_state = "shield_belt"
-	item_state = "security"
+	inhand_icon_state = "security"
 	worn_icon_state = "shield_belt"
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -4,7 +4,7 @@
 
 /obj/item/door_remote
 	icon_state = "gangtool-white"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	icon = 'icons/obj/device.dmi'

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -580,7 +580,7 @@
 	paint_color = null
 	drawtype = "splatter"
 
-	item_state = "spraycan"
+	inhand_icon_state = "spraycan"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	desc = "A metallic container containing tasty paint."

--- a/code/game/objects/items/debug_items.dm
+++ b/code/game/objects/items/debug_items.dm
@@ -152,7 +152,7 @@
 /obj/item/construction/rcd/arcd/debug
 	name = "\improper CentCom Admin RCD"
 	icon_state = "ircd"
-	item_state = "ircd"
+	inhand_icon_state = "ircd"
 	w_class = WEIGHT_CLASS_TINY
 	max_matter = INFINITY
 	matter = INFINITY
@@ -236,7 +236,7 @@
 	name = "bag of portable hole"
 	desc = "A backpack that opens into a localized pocket of nullspace."
 	icon_state = "holdingpack"
-	item_state = "holdingpack"
+	inhand_icon_state = "holdingpack"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	item_flags = NO_MAT_REDEMPTION
 	armor_type = /datum/armor/backpack_debug

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -6,7 +6,7 @@
 	desc = "A device that delivers powerful shocks to detachable paddles that resuscitate incapacitated patients."
 	icon = 'icons/obj/defib.dmi'
 	icon_state = "defibunit"
-	item_state = "defibunit"
+	inhand_icon_state = "defibunit"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
@@ -253,7 +253,7 @@
 	name = "compact defibrillator"
 	desc = "A belt-equipped defibrillator that can be rapidly deployed."
 	icon_state = "defibcompact"
-	item_state = "defibcompact"
+	inhand_icon_state = "defibcompact"
 	worn_icon_state = "defibcompact"
 	w_class = WEIGHT_CLASS_LARGE
 	slot_flags = ITEM_SLOT_BELT
@@ -299,7 +299,7 @@
 	desc = "A pair of plastic-gripped paddles with flat metal surfaces that are used to deliver powerful electric shocks."
 	icon = 'icons/obj/defib.dmi'
 	icon_state = "defibpaddles0"
-	item_state = "defibpaddles0"
+	inhand_icon_state = "defibpaddles0"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 
@@ -390,7 +390,7 @@
 /obj/item/shockpaddles/update_icon_state()
 	var/wielded = ISWIELDED(src)
 	icon_state = "[base_icon_state][wielded]"
-	item_state = icon_state
+	inhand_icon_state = icon_state
 	if(cooldown)
 		icon_state = "[base_icon_state][wielded]_cooldown"
 	return ..()
@@ -697,7 +697,7 @@
 	name = "cyborg defibrillator paddles"
 	icon = 'icons/obj/defib.dmi'
 	icon_state = "defibpaddles0"
-	item_state = "defibpaddles0"
+	inhand_icon_state = "defibpaddles0"
 	req_defib = FALSE
 
 /obj/item/shockpaddles/cyborg/attack(mob/M, mob/user)
@@ -718,7 +718,7 @@
 	combat = TRUE
 	icon = 'icons/obj/defib.dmi'
 	icon_state = "defibpaddles0"
-	item_state = "defibpaddles0"
+	inhand_icon_state = "defibpaddles0"
 
 /obj/item/shockpaddles/syndicate/cyborg
 	req_defib = FALSE

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -3,7 +3,7 @@
 	desc = "A storage device for AIs. Patent pending."
 	icon = 'icons/obj/aicards.dmi'
 	icon_state = "aicard" // aicard-full
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/devices/anomaly_neutralizer.dm
+++ b/code/game/objects/items/devices/anomaly_neutralizer.dm
@@ -3,7 +3,7 @@
 	desc = "A one-use device capable of instantly neutralizing anomalous and otherworldly entities."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "memorizer2"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -3,7 +3,7 @@
 	desc = "A beacon used by a teleporter."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "beacon"
-	item_state = "beacon"
+	inhand_icon_state = "beacon"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	var/enabled = TRUE

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -11,7 +11,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state	= "camera_bug"
 	w_class		= WEIGHT_CLASS_TINY
-	item_state	= "camera_bug"
+	inhand_icon_state	= "camera_bug"
 	throw_speed	= 4
 	throw_range	= 20
 	item_flags = NOBLUDGEON

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -5,7 +5,7 @@
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON
 	slot_flags = ITEM_SLOT_BELT
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -3,7 +3,7 @@
 	desc = "An illegally modified BSRPED, capable of reducing the size of most items."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "compression_c"
-	item_state = "RPED"
+	inhand_icon_state = "RPED"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/devices/desynchronizer.dm
+++ b/code/game/objects/items/devices/desynchronizer.dm
@@ -3,7 +3,7 @@
 	desc = "An experimental device that can temporarily desynchronize the user from spacetime, effectively making them disappear while it's active."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "desynchronizer"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NOBLUDGEON
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'

--- a/code/game/objects/items/devices/doorCharge.dm
+++ b/code/game/objects/items/devices/doorCharge.dm
@@ -2,7 +2,7 @@
 	name = "airlock charge"
 	desc = null //Different examine for traitors
 	icon = 'icons/obj/device.dmi'
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	icon_state = "doorCharge"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -4,7 +4,7 @@
 	custom_price = 10
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "flashlight"
-	item_state = "flashlight"
+	inhand_icon_state = "flashlight"
 	worn_icon_state = "flashlight"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
@@ -180,7 +180,7 @@
 	name = "penlight"
 	desc = "A pen-sized light, used by medical staff. It can also be used to create a hologram to alert people of incoming medical assistance."
 	icon_state = "penlight"
-	item_state = ""
+	inhand_icon_state = ""
 	worn_icon_state = "pen"
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = CONDUCT_1
@@ -218,7 +218,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	name = "seclite"
 	desc = "A robust flashlight used by security."
 	icon_state = "seclite"
-	item_state = "seclite"
+	inhand_icon_state = "seclite"
 	worn_icon_state = "seclite"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -231,7 +231,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	name = "desk lamp"
 	desc = "A desk lamp with an adjustable mount."
 	icon_state = "lamp"
-	item_state = "lamp"
+	inhand_icon_state = "lamp"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 10
@@ -247,7 +247,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 /obj/item/flashlight/lamp/green
 	desc = "A classic green-shaded desk lamp."
 	icon_state = "lampgreen"
-	item_state = "lampgreen"
+	inhand_icon_state = "lampgreen"
 
 
 
@@ -264,7 +264,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	name = "banana lamp"
 	desc = "Only a clown would think to make a ghetto banana-shaped lamp. Even has a goofy pullstring."
 	icon_state = "bananalamp"
-	item_state = "bananalamp"
+	inhand_icon_state = "bananalamp"
 
 // FLARES
 
@@ -274,7 +274,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	w_class = WEIGHT_CLASS_SMALL
 	light_range = 7 // Pretty bright.
 	icon_state = "flare"
-	item_state = "flare"
+	inhand_icon_state = "flare"
 	actions_types = list()
 	/// How many seconds of fuel we have left
 	var/fuel = 0
@@ -351,7 +351,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	w_class = WEIGHT_CLASS_BULKY
 	light_range = 4
 	icon_state = "torch"
-	item_state = "torch"
+	inhand_icon_state = "torch"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	light_color = LIGHT_COLOR_ORANGE
@@ -361,7 +361,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 /obj/item/flashlight/lantern
 	name = "lantern"
 	icon_state = "lantern"
-	item_state = "lantern"
+	inhand_icon_state = "lantern"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	desc = "A mining lantern."
@@ -377,7 +377,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	name = "suspicious lantern"
 	desc = "A suspicious looking lantern."
 	icon_state = "syndilantern"
-	item_state = "syndilantern"
+	inhand_icon_state = "syndilantern"
 	light_range = 10
 
 /obj/item/flashlight/slime
@@ -386,7 +386,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	desc = "Extract from a yellow slime. It emits a strong light when squeezed."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "slime"
-	item_state = "slime"
+	inhand_icon_state = "slime"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = null
@@ -457,7 +457,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 	color = LIGHT_COLOR_GREEN
 	icon_state = "glowstick"
 	base_icon_state = "glowstick"
-	item_state = "glowstick"
+	inhand_icon_state = "glowstick"
 	grind_results = list(/datum/reagent/phenol = 15, /datum/reagent/hydrogen = 10, /datum/reagent/oxygen = 5) //Meth-in-a-stick
 	var/burn_pickup = FALSE	//If true, fuel will only decrease after being picked up or used in hand (Useful for mapping)
 	var/fuel = 0 // How many seconds of fuel we have left
@@ -495,7 +495,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/temp_visual/medical_holosign)
 
 /obj/item/flashlight/glowstick/update_icon_state()
 	icon_state = "[base_icon_state][(fuel <= 0) ? "-empty" : ""]"
-	item_state = "[base_icon_state][((fuel > 0) && on) ? "-on" : ""]"
+	inhand_icon_state = "[base_icon_state][((fuel > 0) && on) ? "-on" : ""]"
 	return ..()
 
 /obj/item/flashlight/glowstick/update_overlays()
@@ -621,7 +621,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/flashlight/spotlight)
 	name = "flashdark"
 	desc = "A strange device manufactured with mysterious elements that somehow emits darkness. Or maybe it just sucks in light? Nobody knows for sure."
 	icon_state = "flashdark"
-	item_state = "flashdark"
+	inhand_icon_state = "flashdark"
 	light_system = STATIC_LIGHT //The overlay light component is not yet ready to produce darkness.
 	light_range = 0
 	///Variable to preserve old lighting behavior in flashlights, to handle darkness.

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -6,7 +6,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NOBLUDGEON
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -9,7 +9,7 @@
 	desc = "A handheld device used for detecting and measuring radiation pulses."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "geiger_off"
-	item_state = "multitool"
+	inhand_icon_state = "multitool"
 	worn_icon_state = "geiger_counter"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -4,7 +4,7 @@
 	desc = "Helping lost spacemen find their way through the planets since 2016."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "gps-c"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -3,7 +3,7 @@
 	desc = "Don't shine it in your eyes!"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "pointer"
-	item_state = "pen"
+	inhand_icon_state = "pen"
 	worn_icon_state = "pen"
 	var/pointer_icon_state
 	flags_1 = CONDUCT_1
@@ -82,7 +82,7 @@
 		to_chat(user, "<span class='warning'>Your fingers can't press the button!</span>")
 		return
 	add_fingerprint(user)
-	
+
 	//nothing happens if the battery is drained
 	if(recharge_locked)
 		to_chat(user, span_notice("You point [src] at [target], but it's still charging."))

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -43,7 +43,7 @@
 	desc = "A device to automatically replace lights. Refill with broken or working light bulbs, or sheets of glass."
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "lightreplacer0"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "light_replacer"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -3,7 +3,7 @@
 	desc = "A device used to project your voice. Loudly."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "megaphone"
-	item_state = "megaphone"
+	inhand_icon_state = "megaphone"
 	lefthand_file = 'icons/mob/inhands/misc/megaphone_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/megaphone_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
@@ -48,23 +48,23 @@
 /obj/item/megaphone/sec
 	name = "security megaphone"
 	icon_state = "megaphone-sec"
-	item_state = "megaphone-sec"
+	inhand_icon_state = "megaphone-sec"
 
 /obj/item/megaphone/command
 	name = "command megaphone"
 	icon_state = "megaphone-command"
-	item_state = "megaphone-command"
+	inhand_icon_state = "megaphone-command"
 
 /obj/item/megaphone/cargo
 	name = "supply megaphone"
 	icon_state = "megaphone-cargo"
-	item_state = "megaphone-cargo"
+	inhand_icon_state = "megaphone-cargo"
 
 /obj/item/megaphone/clown
 	name = "clown's megaphone"
 	desc = "Something that should not exist."
 	icon_state = "megaphone-clown"
-	item_state = "megaphone-clown"
+	inhand_icon_state = "megaphone-clown"
 	voicespan = list(SPAN_CLOWN)
 
 /obj/item/megaphone/nospam

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -15,7 +15,7 @@
 	desc = "Used for pulsing wires to test which to cut. Not recommended by doctors."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "multitool"
-	item_state = "multitool"
+	inhand_icon_state = "multitool"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	force = 5

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -2,7 +2,7 @@
 	name = "personal AI device"
 	icon = 'icons/obj/aicards.dmi'
 	icon_state = "pai"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -2,7 +2,7 @@
 	name = "pipe painter"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler1"
-	item_state = "flight"
+	inhand_icon_state = "flight"
 	item_flags = NOBLUDGEON
 	var/paint_color = "grey"
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -9,7 +9,7 @@
 	desc = "A nulling power sink which drains energy from electrical systems."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "powersink0"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/devices/pressureplates.dm
+++ b/code/game/objects/items/devices/pressureplates.dm
@@ -3,7 +3,7 @@
 	name = "pressure plate"
 	desc = "An electronic device that triggers when stepped on."
 	icon = 'icons/obj/device.dmi'
-	item_state = "flash"
+	inhand_icon_state = "flash"
 	icon_state = "pressureplate"
 	var/trigger_mob = TRUE
 	var/trigger_item = FALSE

--- a/code/game/objects/items/devices/quantum_keycard.dm
+++ b/code/game/objects/items/devices/quantum_keycard.dm
@@ -3,7 +3,7 @@
 	desc = "A keycard able to link to a quantum pad's particle signature, allowing other quantum pads to travel there instead of their linked pad."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "quantum_keycard"
-	item_state = "card-id"
+	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -3,7 +3,7 @@
 	desc = "Dance my monkeys! DANCE!!!"
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "electropack0"
-	item_state = "electropack"
+	inhand_icon_state = "electropack"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	name = "radio headset"
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys."
 	icon_state = "headset"
-	item_state = "headset"
+	inhand_icon_state = "headset"
 	worn_icon_state = "headset"
 	custom_materials = list(/datum/material/iron=75)
 	subspace_transmission = TRUE
@@ -87,7 +87,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	name = "syndicate headset"
 	desc = "A syndicate headset that can be used to hear all radio frequencies. Protects ears from flashbangs."
 	icon_state = "syndie_headset"
-	item_state = "syndie_headset"
+	inhand_icon_state = "syndie_headset"
 	bang_protect = 1
 
 /obj/item/radio/headset/syndicate/alt/leader

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/radio.dmi'
 	name = "station bounced radio"
 	icon_state = "walkietalkie"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	worn_icon_state = "radio"
 	desc = "A basic handheld radio that communicates with local telecommunication networks."
 	dog_fashion = /datum/dog_fashion/back

--- a/code/game/objects/items/devices/reverse_bear_trap.dm
+++ b/code/game/objects/items/devices/reverse_bear_trap.dm
@@ -8,7 +8,7 @@
 	resistance_flags = FIRE_PROOF | UNACIDABLE
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
-	item_state = "rack_parts"
+	inhand_icon_state = "rack_parts"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	item_flags = ISWEAPON

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -25,7 +25,7 @@ GENE SCANNER
 	var/client/viewing
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
@@ -143,7 +143,7 @@ GENE SCANNER
 	name = "health analyzer"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "health"
-	item_state = "healthanalyzer"
+	inhand_icon_state = "healthanalyzer"
 	worn_icon_state = "healthanalyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
@@ -639,7 +639,7 @@ GENE SCANNER
 	custom_price = 10
 	icon = 'icons/obj/device.dmi'
 	icon_state = "analyzer"
-	item_state = "analyzer"
+	inhand_icon_state = "analyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	drop_sound = 'sound/items/handling/weldingtool_drop.ogg'
@@ -826,7 +826,7 @@ GENE SCANNER
 	desc = "A device that analyzes a slime's internal composition and measures its stats."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "adv_spectrometer"
-	item_state = "analyzer"
+	inhand_icon_state = "analyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
@@ -933,7 +933,7 @@ GENE SCANNER
 	name = "nanite scanner"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "nanite_scanner"
-	item_state = "nanite_remote"
+	inhand_icon_state = "nanite_remote"
 	worn_icon_state = "healthanalyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
@@ -961,7 +961,7 @@ GENE SCANNER
 	name = "genetic sequence scanner"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gene"
-	item_state = "healthanalyzer"
+	inhand_icon_state = "healthanalyzer"
 	worn_icon_state = "healthanalyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'

--- a/code/game/objects/items/devices/sensor_device.dm
+++ b/code/game/objects/items/devices/sensor_device.dm
@@ -3,7 +3,7 @@
 	desc = "A miniature machine that tracks suit sensors across the station."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "scanner"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -8,7 +8,7 @@
 	desc = "A device that is able to create sounds."
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "radio"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	w_class = WEIGHT_CLASS_TINY
 	siemens_coefficient = 1
 

--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -3,7 +3,7 @@
 	desc = "An experimental device that is able to swap the locations of two entities by switching their particles' spin values. Must be linked to another device to function."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "swapper"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NOBLUDGEON
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -3,7 +3,7 @@
 	desc = "A device that can record to cassette tapes, and play them. It automatically translates the content in playback."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "taperecorder_empty"
-	item_state = "analyzer"
+	inhand_icon_state = "analyzer"
 	worn_icon_state = "analyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -373,7 +373,7 @@
 	desc = "A magnetic tape that can hold up to ten minutes of content on either side."
 	icon_state = "tape_white"
 	icon = 'icons/obj/device.dmi'
-	item_state = "analyzer"
+	inhand_icon_state = "analyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -25,7 +25,7 @@ effective or pretty fucking useless.
 	throw_speed = 3
 	throw_range = 7
 	flags_1 = CONDUCT_1
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 
@@ -187,7 +187,7 @@ effective or pretty fucking useless.
 	desc = "Makes you invisible for short periods of time. Recharges in darkness."
 	icon = 'icons/obj/clothing/belts.dmi'
 	icon_state = "utilitybelt"
-	item_state = "utility"
+	inhand_icon_state = "utility"
 	worn_icon_state = "utility"
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb_continuous = list("whips", "lashes", "disciplines")
@@ -254,7 +254,7 @@ effective or pretty fucking useless.
 	lefthand_file = 'icons/mob/inhands/misc/bedsheet_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/bedsheet_righthand.dmi'
 	icon_state = "sheetmagician"
-	item_state = "sheetmagician"
+	inhand_icon_state = "sheetmagician"
 	worn_icon_state = "sheetblack"
 	slot_flags = ITEM_SLOT_NECK
 	layer = MOB_LAYER

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -2,7 +2,7 @@
 	icon = 'icons/obj/assemblies.dmi'
 	name = "tank transfer valve"
 	icon_state = "valve_1"
-	item_state = "ttv"
+	inhand_icon_state = "ttv"
 	lefthand_file = 'icons/mob/inhands/weapons/bombs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/bombs_righthand.dmi'
 	desc = "Regulates the transfer of air between two tanks."

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -3,7 +3,7 @@
 	desc = "\"Top Secret\" documents."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "docs_generic"
-	item_state = "paper"
+	inhand_icon_state = "paper"
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	throw_range = 1

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -3,7 +3,7 @@
 	desc = "A traditional red fire extinguisher."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "fire_extinguisher0"
-	item_state = "fire_extinguisher"
+	inhand_icon_state = "fire_extinguisher"
 	hitsound = 'sound/weapons/smash.ogg'
 	flags_1 = CONDUCT_1
 	throwforce = 10
@@ -31,7 +31,7 @@
 	name = "pocket fire extinguisher"
 	desc = "A light and compact fibreglass-framed model fire extinguisher."
 	icon_state = "miniFE0"
-	item_state = "miniFE"
+	inhand_icon_state = "miniFE"
 	hitsound = null	//it is much lighter, after all.
 	flags_1 = null //doesn't CONDUCT_1
 	throwforce = 2
@@ -54,7 +54,7 @@
 	name = "advanced fire extinguisher"
 	desc = "Used to stop thermonuclear fires from spreading inside your engine."
 	icon_state = "foam_extinguisher0"
-	item_state = "foam_extinguisher"
+	inhand_icon_state = "foam_extinguisher"
 	dog_fashion = null
 	chem = /datum/reagent/firefighting_foam
 	tanktype = /obj/structure/reagent_dispensers/foamtank

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -3,7 +3,7 @@
 	desc = "You are a firestarter!"
 	icon = 'icons/obj/flamethrower.dmi'
 	icon_state = "flamethrowerbase"
-	item_state = "flamethrower_0"
+	inhand_icon_state = "flamethrower_0"
 	lefthand_file = 'icons/mob/inhands/weapons/flamethrower_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/flamethrower_righthand.dmi'
 	flags_1 = CONDUCT_1
@@ -60,7 +60,7 @@
 
 
 /obj/item/flamethrower/update_icon_state()
-	item_state = "flamethrower_[lit]"
+	inhand_icon_state = "flamethrower_[lit]"
 	return ..()
 
 /obj/item/flamethrower/update_overlays()

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -293,7 +293,7 @@
 	desc = "Bon appetit!"
 	icon = 'icons/obj/food/burgerbread.dmi'
 	icon_state = "baguette"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon_state = "baguette"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 8,
@@ -323,7 +323,7 @@
 	desc = "Alas, it is limited."
 	icon = 'icons/obj/food/burgerbread.dmi'
 	icon_state = "garlicbread"
-	item_state = null
+	inhand_icon_state = null
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 10,
 		/datum/reagent/consumable/nutriment/vitamin = 6,

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -22,7 +22,7 @@
 	desc = "An egg!"
 	icon = 'icons/obj/food/egg.dmi'
 	icon_state = "egg"
-	item_state = "egg"
+	inhand_icon_state = "egg"
 	food_reagents = list(
 		/datum/reagent/consumable/eggyolk = 2, /datum/reagent/consumable/eggwhite = 4
 	)

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -172,7 +172,7 @@
 	name = "Powercrepe"
 	desc = "With great power, comes great crepes.  It looks like a pancake filled with jelly but packs quite a punch."
 	icon_state = "powercrepe"
-	item_state = "powercrepe"
+	inhand_icon_state = "powercrepe"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 10,
 		/datum/reagent/consumable/nutriment/vitamin = 5,

--- a/code/game/objects/items/food/pancakes.dm
+++ b/code/game/objects/items/food/pancakes.dm
@@ -3,7 +3,7 @@
 	desc = "A fluffy pancake. The softer, superior relative of the waffle."
 	icon = 'icons/obj/food/pancakes.dmi'
 	icon_state = "pancakes_1"
-	item_state = null
+	inhand_icon_state = null
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 4,
 		/datum/reagent/consumable/nutriment/vitamin = 2

--- a/code/game/objects/items/food/sweets.dm
+++ b/code/game/objects/items/food/sweets.dm
@@ -182,7 +182,7 @@
 	desc = "A delicious lollipop. Makes for a great Valentine's present."
 	icon = 'icons/obj/lollipop.dmi'
 	icon_state = "lollipop_stick"
-	item_state = null
+	inhand_icon_state = null
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 1,
 		/datum/reagent/consumable/nutriment/vitamin = 1,
@@ -303,7 +303,7 @@
 	name = "Swirl lollipop"
 	desc = "A massive rainbow swirlled lollipop. Said to contain extra sugar."
 	icon_state = "swirl_lollipop"
-	item_state = "swirl_lollipop"
+	inhand_icon_state = "swirl_lollipop"
 	food_reagents = list(
 		/datum/reagent/consumable/sugar = 30,
 		/datum/reagent/drug/happiness = 5, //swirl lollipops make everyone happy!

--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 	desc = "PRESENTS!!!! yippie!"
 	icon = 'icons/obj/storage/wrapping.dmi'
 	icon_state = "giftdeliverypackage3"
-	item_state = "gift"
+	inhand_icon_state = "gift"
 	resistance_flags = FLAMMABLE
 
 	var/obj/item/contains_type
@@ -105,7 +105,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 		var/list/gift_types_list = subtypesof(/obj/item)
 		for(var/V in gift_types_list)
 			var/obj/item/I = V
-			if((!initial(I.icon_state)) || (!initial(I.item_state)) || (initial(I.item_flags) & ABSTRACT))
+			if((!initial(I.icon_state)) || (!initial(I.inhand_icon_state)) || (initial(I.item_flags) & ABSTRACT))
 				gift_types_list -= V
 		GLOB.possible_gifts = gift_types_list
 	var/gift_type = pick(GLOB.possible_gifts)

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -10,7 +10,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "grenade"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	worn_icon_state = "grenade"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'

--- a/code/game/objects/items/grenades/antigravity.dm
+++ b/code/game/objects/items/grenades/antigravity.dm
@@ -1,7 +1,7 @@
 /obj/item/grenade/antigravity
 	name = "antigravity grenade"
 	icon_state = "emp"
-	item_state = "emp"
+	inhand_icon_state = "emp"
 
 	var/range = 7
 	var/forced_value = 0

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -2,7 +2,7 @@
 	name = "chemical grenade"
 	desc = "A custom made grenade."
 	icon_state = "chemg"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	w_class = WEIGHT_CLASS_SMALL
 	force = 2
 	var/stage = GRENADE_EMPTY

--- a/code/game/objects/items/grenades/discogrenade.dm
+++ b/code/game/objects/items/grenades/discogrenade.dm
@@ -10,7 +10,7 @@
 	name = "Ethereal Disco Grenade"
 	desc = "An unethical micro-party that will make all non-Ethereal beings dance to its beat!"
 	icon_state = "disco"
-	item_state = "disco"
+	inhand_icon_state = "disco"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/list/messages = list("This party is great!", "Wooo!!!", "Party!", "Check out these moves!", "Hey, want to dance with me?")
@@ -40,7 +40,7 @@
 	name = "Micro Disco"
 	desc = "A massive disco contained in a tiny package!"
 	icon_state = "disco"
-	item_state = "disco"
+	inhand_icon_state = "disco"
 	var/spawn_new = TRUE
 	var/timerID
 	var/lightcolor

--- a/code/game/objects/items/grenades/emgrenade.dm
+++ b/code/game/objects/items/grenades/emgrenade.dm
@@ -2,7 +2,7 @@
 	name = "classic EMP grenade"
 	desc = "It is designed to wreak havoc on electronic systems."
 	icon_state = "emp"
-	item_state = "emp"
+	inhand_icon_state = "emp"
 
 /obj/item/grenade/empgrenade/prime(mob/living/lanced_by)
 	. = ..()

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -1,7 +1,7 @@
 /obj/item/grenade/flashbang
 	name = "flashbang"
 	icon_state = "flashbang"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 7 //how many tiles away the mob will be stunned.
@@ -62,7 +62,7 @@
 /obj/item/grenade/stingbang
 	name = "stingbang"
 	icon_state = "timeg"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/flashbang_range = 1 //how many tiles away the mob will be stunned.
@@ -129,7 +129,7 @@
 	name = "rotfrag grenade"
 	desc = "A grenade that generates more shrapnel the more you rotate it in your hand after pulling the pin. This one releases shrapnel shards."
 	icon_state = "timeg"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	var/rots_per_mag = 3 /// how many times we need to "rotate" the charge in hand per extra tile of magnitude

--- a/code/game/objects/items/grenades/ghettobomb.dm
+++ b/code/game/objects/items/grenades/ghettobomb.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "improvised_grenade"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	icon_state_preview = "chemg" // a black stick is bad to recognise as a preview
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -2,7 +2,7 @@
 	name = "plastic explosive"
 	desc = "Used to put holes in specific areas without too much extra hole."
 	icon_state = "plastic-explosive0"
-	item_state = "plastic-explosive"
+	inhand_icon_state = "plastic-explosive"
 	lefthand_file = 'icons/mob/inhands/weapons/bombs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/bombs_righthand.dmi'
 	item_flags = NOBLUDGEON
@@ -23,7 +23,7 @@
 
 /obj/item/grenade/plastic/Initialize(mapload)
 	. = ..()
-	plastic_overlay = mutable_appearance(icon, "[item_state]2", HIGH_OBJ_LAYER)
+	plastic_overlay = mutable_appearance(icon, "[inhand_icon_state]2", HIGH_OBJ_LAYER)
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
@@ -179,9 +179,9 @@
 
 /obj/item/grenade/plastic/update_icon()
 	if(nadeassembly)
-		icon_state = "[item_state]1"
+		icon_state = "[inhand_icon_state]1"
 	else
-		icon_state = "[item_state]0"
+		icon_state = "[inhand_icon_state]0"
 
 //////////////////////////
 ///// The Explosives /////
@@ -256,7 +256,7 @@
 	name = "X4"
 	desc = "A shaped high-explosive breaching charge. Designed to ensure user safety and wall nonsafety."
 	icon_state = "plasticx40"
-	item_state = "plasticx4"
+	inhand_icon_state = "plasticx4"
 	gender = PLURAL
 	directional = TRUE
 	boom_sizes = list(0, 2, 5)

--- a/code/game/objects/items/grenades/smokebomb.dm
+++ b/code/game/objects/items/grenades/smokebomb.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "smokewhite"
 	det_time = 20
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	slot_flags = ITEM_SLOT_BELT
 	var/datum/effect_system/smoke_spread/bad/smoke
 

--- a/code/game/objects/items/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/grenades/spawnergrenade.dm
@@ -3,7 +3,7 @@
 	name = "delivery grenade"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "delivery"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
 
@@ -53,7 +53,7 @@
 	name = "C.L.U.W.N.E."
 	desc = "A sleek device often given to clowns on their 10th birthdays for protection. You can hear faint scratching coming from within."
 	icon_state = "clown_ball"
-	item_state = "clown_ball"
+	inhand_icon_state = "clown_ball"
 	spawner_type = list(/mob/living/simple_animal/hostile/retaliate/clown/fleshclown, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk, /mob/living/simple_animal/hostile/retaliate/clown/longface, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus, /mob/living/simple_animal/hostile/retaliate/clown/mutant/blob, /mob/living/simple_animal/hostile/retaliate/clown/banana, /mob/living/simple_animal/hostile/retaliate/clown/honkling, /mob/living/simple_animal/hostile/retaliate/clown/lube)
 	deliveryamt = 1
 
@@ -61,6 +61,6 @@
 	name = "stuffed C.L.U.W.N.E."
 	desc = "A sleek device often given to clowns on their 10th birthdays for protection. While a typical C.L.U.W.N.E only holds one creature, sometimes foolish young clowns try to cram more in, often to disasterous effect."
 	icon_state = "clown_broken"
-	item_state = "clown_broken"
+	inhand_icon_state = "clown_broken"
 	spawner_type = /mob/living/simple_animal/hostile/retaliate/clown/mutant
 	deliveryamt = 5

--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -3,7 +3,7 @@
 	name = "syndicate minibomb"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "syndicate"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	ex_heavy = 2
 	ex_light = 4
 	ex_flame = 2
@@ -52,7 +52,7 @@
 	name = "gluon frag grenade"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "bluefrag"
-	item_state = "flashbang"
+	inhand_icon_state = "flashbang"
 	var/freeze_range = 4
 	var/rad_damage = 350
 	var/stamina_damage = 30

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -14,7 +14,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "handcuff"
-	item_state = "handcuff"
+	inhand_icon_state = "handcuff"
 	worn_icon_state = "handcuff"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -92,7 +92,7 @@
 	name = "cable restraints"
 	desc = "Looks like some cables tied together. Could be used to tie something up."
 	icon_state = "cuff"
-	item_state = "coil"
+	inhand_icon_state = "coil"
 	color = "#ff0000"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -129,7 +129,7 @@
 	desc = "A pair of restraints fashioned from long strands of flesh."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sinewcuff"
-	item_state = "sinewcuff"
+	inhand_icon_state = "sinewcuff"
 	custom_materials = null
 	color = null
 
@@ -186,7 +186,7 @@
 /obj/item/restraints/handcuffs/cable/zipties/used
 	desc = "A pair of broken zipties."
 	icon_state = "cuff_used"
-	item_state = "cuff"
+	inhand_icon_state = "cuff"
 
 /obj/item/restraints/handcuffs/cable/zipties/used/attack()
 	return
@@ -327,7 +327,7 @@
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
 	icon_state = "bola"
-	item_state = "bola"
+	inhand_icon_state = "bola"
 	lefthand_file = 'icons/mob/inhands/weapons/thrown_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/thrown_righthand.dmi'
 	breakouttime = 20//easy to apply, easy to break out of
@@ -366,7 +366,7 @@
 	name = "reinforced bola"
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
-	item_state = "bola_r"
+	inhand_icon_state = "bola_r"
 	breakouttime = 70
 	knockdown = 20
 
@@ -374,14 +374,14 @@
 	name = "watcher Bola"
 	desc = "A Bola made from the stretchy sinew of fallen watchers."
 	icon_state = "bola_watcher"
-	item_state = "bola_watcher"
+	inhand_icon_state = "bola_watcher"
 	breakouttime = 45
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"
 	desc = "A specialized hard-light bola designed to ensnare fleeing criminals and aid in arrests."
 	icon_state = "ebola"
-	item_state = "ebola"
+	inhand_icon_state = "ebola"
 	hitsound = 'sound/weapons/taserhit.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 	breakouttime = 60
@@ -401,7 +401,7 @@
 	name = "gonbola"
 	desc = "Hey, if you have to be hugged in the legs by anything, it might as well be this little guy."
 	icon_state = "gonbola"
-	item_state = "bola_r"
+	inhand_icon_state = "bola_r"
 	breakouttime = 300
 	slowdown = 0
 	var/datum/status_effect/gonbola_pacify/effectReference

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -8,7 +8,7 @@
 	name = "artistic toolbox"
 	desc = "A toolbox painted bright green. Looking at it makes you feel uneasy."
 	icon_state = "his_grace"
-	item_state = "artistic_toolbox"
+	inhand_icon_state = "artistic_toolbox"
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	icon = 'icons/obj/items_and_weapons.dmi'
@@ -252,7 +252,7 @@
 	force_bonus += ascend_bonus
 	desc = "A legendary toolbox and a distant artifact from The Age of Three Powers. On its three latches engraved are the words \"The Sun\", \"The Moon\", and \"The Stars\". The entire toolbox has the words \"The World\" engraved into its sides."
 	icon_state = "his_grace_ascended"
-	item_state = "toolbox_gold"
+	inhand_icon_state = "toolbox_gold"
 	ascended = TRUE
 	playsound(src, 'sound/effects/his_grace_ascend.ogg', 100)
 	if(istype(master))

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -3,7 +3,7 @@
 	desc = "A handy-dandy holographic projector that displays a janitorial sign."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "signmaker"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	force = 0

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -82,7 +82,7 @@
 	name = "student robe"
 	desc = "The uniform of a bygone institute of learning."
 	icon_state = "studentuni"
-	item_state = "studentuni"
+	inhand_icon_state = "studentuni"
 	body_parts_covered = ARMS|CHEST
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
@@ -146,7 +146,7 @@
 	name = "null rod"
 	desc = "A rod of pure obsidian; its very presence disrupts and dampens the powers of Nar'Sie and Ratvar's followers."
 	icon_state = "nullrod"
-	item_state = "nullrod"
+	inhand_icon_state = "nullrod"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	block_upgrade_walk = 1
@@ -280,7 +280,7 @@
 
 /obj/item/nullrod/godhand
 	icon_state = "disintegrate"
-	item_state = "disintegrate"
+	inhand_icon_state = "disintegrate"
 	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
 	name = "god hand"
@@ -299,7 +299,7 @@
 
 /obj/item/nullrod/staff
 	icon_state = "godstaff-red"
-	item_state = "godstaff-red"
+	inhand_icon_state = "godstaff-red"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	name = "red holy staff"
@@ -320,14 +320,14 @@
 /obj/item/nullrod/staff/blue
 	name = "blue holy staff"
 	icon_state = "godstaff-blue"
-	item_state = "godstaff-blue"
+	inhand_icon_state = "godstaff-blue"
 	shield_icon = "shield-old"
 
 /obj/item/nullrod/claymore
 	name = "holy claymore"
 	desc = "A weapon fit for a crusade!"
 	icon_state = "claymore"
-	item_state = "claymore"
+	inhand_icon_state = "claymore"
 	worn_icon_state = "claymore"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -346,7 +346,7 @@
 	name = "dark blade"
 	desc = "Spread the glory of the dark gods!"
 	icon_state = "cultblade"
-	item_state = "cultblade"
+	inhand_icon_state = "cultblade"
 	worn_icon_state = "cultblade"
 	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
@@ -359,7 +359,7 @@
 	name = "sacred chainsaw sword"
 	desc = "Suffer not a heretic to live."
 	icon_state = "chainswordon"
-	item_state = "chainswordon"
+	inhand_icon_state = "chainswordon"
 	worn_icon_state = "chainswordon"
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
@@ -372,7 +372,7 @@
 	name = "force weapon"
 	desc = "The blade glows with the power of faith. Or possibly a battery."
 	icon_state = "swordon"
-	item_state = "swordon"
+	inhand_icon_state = "swordon"
 	worn_icon_state = "swordon"
 	slot_flags = ITEM_SLOT_BELT
 
@@ -380,7 +380,7 @@
 	name = "\improper Hanzo steel"
 	desc = "Capable of cutting clean through a holy claymore."
 	icon_state = "katana"
-	item_state = "katana"
+	inhand_icon_state = "katana"
 	worn_icon_state = "katana"
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
@@ -390,7 +390,7 @@
 	name = "extradimensional blade"
 	desc = "Once the harbinger of an interdimensional war, its sharpness fluctuates wildly."
 	icon_state = "multiverse"
-	item_state = "multiverse"
+	inhand_icon_state = "multiverse"
 	worn_icon_state = "multiverse"
 	slot_flags = ITEM_SLOT_BACK
 
@@ -403,7 +403,7 @@
 	desc = "If you strike me down, I shall become more robust than you can possibly imagine."
 	icon = 'icons/obj/transforming_energy.dmi'
 	icon_state = "e_sword_on_blue"
-	item_state = "e_sword_on_blue"
+	inhand_icon_state = "e_sword_on_blue"
 	worn_icon_state = "swordblue"
 	slot_flags = ITEM_SLOT_BELT
 	hitsound = 'sound/weapons/blade1.ogg'
@@ -412,21 +412,21 @@
 	name = "dark energy sword"
 	desc = "Woefully ineffective when used on steep terrain." //Anakin used his BLUE lightsaber in episode IV, FOOL
 	icon_state = "e_sword_on_red"
-	item_state = "e_sword_on_red"
+	inhand_icon_state = "e_sword_on_red"
 	worn_icon_state = "swordred"
 
 /obj/item/nullrod/claymore/saber/pirate
 	name = "nautical energy sword"
 	desc = "Convincing HR that your religion involved piracy was no mean feat."
 	icon_state = "e_cutlass_on"
-	item_state = "e_cutlass_on"
+	inhand_icon_state = "e_cutlass_on"
 	worn_icon_state = "swordred"
 
 /obj/item/nullrod/sord
 	name = "\improper UNREAL SORD"
 	desc = "This thing is so unspeakably HOLY you are having a hard time even holding it."
 	icon_state = "sord"
-	item_state = "sord"
+	inhand_icon_state = "sord"
 	worn_icon_state = "sord"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -450,7 +450,7 @@
 	name = "reaper scythe"
 	desc = "Ask not for whom the bell tolls..."
 	icon_state = "scythe1"
-	item_state = "scythe1"
+	inhand_icon_state = "scythe1"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -472,7 +472,7 @@
 	name = "high frequency blade"
 	desc = "Bad references are the DNA of the soul."
 	icon_state = "hfrequency0"
-	item_state = "hfrequency1"
+	inhand_icon_state = "hfrequency1"
 	worn_icon_state = "hfrequency0"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -484,7 +484,7 @@
 	name = "dormant spellblade"
 	desc = "The blade grants the wielder nearly limitless power...if they can figure out how to turn it on, that is."
 	icon_state = "spellblade"
-	item_state = "spellblade"
+	inhand_icon_state = "spellblade"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	worn_icon_state = "spellblade"
@@ -495,7 +495,7 @@
 	name = "possessed blade"
 	desc = "When the station falls into chaos, it's nice to have a friend by your side."
 	icon_state = "talking_sword"
-	item_state = "talking_sword"
+	inhand_icon_state = "talking_sword"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	worn_icon_state = "talking_sword"
@@ -547,7 +547,7 @@
 	name = "possessed chainsaw sword"
 	desc = "Suffer not a heretic to live."
 	icon_state = "chainswordon"
-	item_state = "chainswordon"
+	inhand_icon_state = "chainswordon"
 	worn_icon_state = "chainswordon"
 	chaplain_spawnable = FALSE
 	force = 30
@@ -562,7 +562,7 @@
 	name = "relic war hammer"
 	desc = "This war hammer cost the chaplain forty thousand space dollars."
 	icon_state = "hammeron"
-	item_state = "hammeron"
+	inhand_icon_state = "hammeron"
 	worn_icon_state = "hammeron"
 	lefthand_file = 'icons/mob/inhands/weapons/hammers_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/hammers_righthand.dmi'
@@ -576,7 +576,7 @@
 	name = "chainsaw hand"
 	desc = "Good? Bad? You're the guy with the chainsaw hand."
 	icon_state = "chainsaw_on"
-	item_state = "mounted_chainsaw"
+	inhand_icon_state = "mounted_chainsaw"
 	lefthand_file = 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
@@ -602,7 +602,7 @@
 	desc = "Used for absolutely hilarious sacrifices."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "clownrender"
-	item_state = "cultdagger"
+	inhand_icon_state = "cultdagger"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	worn_icon_state = "render"
@@ -640,7 +640,7 @@
 	name = "holy whip"
 	desc = "What a terrible night to be on Space Station 13."
 	icon_state = "chain"
-	item_state = "chain"
+	inhand_icon_state = "chain"
 	worn_icon_state = "whip"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
@@ -653,7 +653,7 @@
 	name = "atheist's fedora"
 	desc = "The brim of the hat is as sharp as your wit. The edge would hurt almost as much as disproving the existence of God."
 	icon_state = "fedora"
-	item_state = "fedora"
+	inhand_icon_state = "fedora"
 	slot_flags = ITEM_SLOT_HEAD
 	icon = 'icons/obj/clothing/head/hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/hats.dmi'
@@ -671,7 +671,7 @@
 	desc = "Particularly twisted deities grant gifts of dubious value."
 	icon = 'icons/obj/changeling_items.dmi'
 	icon_state = "arm_blade"
-	item_state = "arm_blade"
+	inhand_icon_state = "arm_blade"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	slot_flags = null
@@ -689,14 +689,14 @@
 /obj/item/nullrod/armblade/tentacle
 	name = "unholy blessing"
 	icon_state = "tentacle"
-	item_state = "tentacle"
+	inhand_icon_state = "tentacle"
 
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"
 	desc = "An adorable stuffed toy that resembles the god of all carp. The teeth look pretty sharp. Activate it to receive the blessing of Carp-Sie."
 	icon = 'icons/obj/plushes.dmi'
 	icon_state = "carpplush"
-	item_state = "carp_plushie"
+	inhand_icon_state = "carp_plushie"
 	worn_icon_state = "nullrod"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
@@ -726,7 +726,7 @@
 	attack_verb_simple = list("smash", "slam", "whack", "thwack")
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "bostaff0"
-	item_state = "bostaff0"
+	inhand_icon_state = "bostaff0"
 	worn_icon_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
@@ -735,7 +735,7 @@
 	name = "arrhythmic knife"
 	desc = "They say fear is the true mind killer, but stabbing them in the head works too. Honour compels you to not sheathe it once drawn."
 	icon_state = "crysknife"
-	item_state = "crysknife"
+	inhand_icon_state = "crysknife"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
@@ -783,7 +783,7 @@
 	desc = "A tutorial in mummification is carved into the staff. You could probably craft the wraps if you had some cloth."
 	icon = 'icons/obj/guns/magic.dmi'
 	icon_state = "pharoah_sceptre"
-	item_state = "pharoah_sceptre"
+	inhand_icon_state = "pharoah_sceptre"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	worn_icon_state = "pharoah_sceptre"
@@ -797,7 +797,7 @@
 	desc = "A tool so powerful even you cannot perfectly use it."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hypertool"
-	item_state = "hypertool"
+	inhand_icon_state = "hypertool"
 	worn_icon_state = "hypertool"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -812,7 +812,7 @@
 	name = "ancient spear"
 	desc = "An ancient spear made of brass, I mean gold, I mean bronze. It looks highly mechanical."
 	icon_state = "ratvarian_spear"
-	item_state = "ratvarian_spear"
+	inhand_icon_state = "ratvarian_spear"
 	lefthand_file = 'icons/mob/inhands/antag/clockwork_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/clockwork_righthand.dmi'
 	icon = 'icons/obj/clockwork_objects.dmi'
@@ -830,7 +830,7 @@
 	desc = "A strange, transparent knife which constantly shifts color. This one glitters with a holy aura."
 	icon = 'icons/obj/knives.dmi'
 	icon_state = "rainbowknife"
-	item_state = "rainbowknife"
+	inhand_icon_state = "rainbowknife"
 	force = 15
 	throwforce = 15
 	damtype = BRUTE

--- a/code/game/objects/items/implants/implantcase.dm
+++ b/code/game/objects/items/implants/implantcase.dm
@@ -3,7 +3,7 @@
 	desc = "A glass case containing an implant."
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "implantcase-0"
-	item_state = "implantcase"
+	inhand_icon_state = "implantcase"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	throw_speed = 2

--- a/code/game/objects/items/implants/implanter.dm
+++ b/code/game/objects/items/implants/implanter.dm
@@ -3,7 +3,7 @@
 	desc = "A sterile automatic implant injector."
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "implanter0"
-	item_state = "syringe_0"
+	inhand_icon_state = "syringe_0"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	throw_speed = 3

--- a/code/game/objects/items/implants/implantpad.dm
+++ b/code/game/objects/items/implants/implantpad.dm
@@ -3,7 +3,7 @@
 	desc = "Used to modify implants."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "implantpad-0"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	throw_speed = 3

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -3,7 +3,7 @@
 	desc = "A tool for inductively charging internal power cells. It is ruggedized for frequent use."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "inducer-engi"
-	item_state = "inducer-engi"
+	inhand_icon_state = "inducer-engi"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	force = 7
@@ -200,7 +200,7 @@
 /obj/item/inducer/sci
 	name = "inducer"
 	icon_state = "inducer-sci"
-	item_state = "inducer-sci"
+	inhand_icon_state = "inducer-sci"
 	desc = "A tool for inductively charging internal power cells. This one has a science color scheme, and is less potent than its engineering counterpart."
 	cell_type = null
 	powertransfer = 500

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -5,7 +5,7 @@
 	icon_state = "knife"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
-	item_state = "knife"
+	inhand_icon_state = "knife"
 	worn_icon_state = "knife"
 	desc = "The original knife, it is said that all other knives are only copies of this one."
 	flags_1 = CONDUCT_1
@@ -66,7 +66,7 @@
 /obj/item/knife/butcher
 	name = "butcher's cleaver"
 	icon_state = "butch"
-	item_state = "butch"
+	inhand_icon_state = "butch"
 	desc = "A huge thing used for chopping and chopping up meat. This includes clowns and clown by-products."
 	flags_1 = CONDUCT_1
 	force = 15
@@ -81,7 +81,7 @@
 /obj/item/knife/hunting
 	name = "hunting knife"
 	desc = "Despite its name, it's mainly used for cutting meat from dead prey rather than actual hunting."
-	item_state = "huntingknife"
+	inhand_icon_state = "huntingknife"
 	icon_state = "huntingknife"
 	icon = 'icons/obj/knives.dmi'
 	force = 12
@@ -142,7 +142,7 @@
 
 /obj/item/knife/combat/bone
 	name = "bone dagger"
-	item_state = "bone_dagger"
+	inhand_icon_state = "bone_dagger"
 	icon_state = "bone_dagger"
 	icon = 'icons/obj/knives.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
@@ -164,7 +164,7 @@
 	desc = "A crude knife fashioned by wrapping some cable around a glass shard. It looks like it could be thrown with some force.. and stick. Good to throw at someone chasing you"
 	icon = 'icons/obj/knives.dmi'
 	icon_state = "shank"
-	item_state = "shank"
+	inhand_icon_state = "shank"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 8 // 3 more than base glass shard
@@ -183,7 +183,7 @@
 /obj/item/knife/shiv/carrot
 	name = "carrot shiv"
 	icon_state = "carrotshiv"
-	item_state = "carrotshiv"
+	inhand_icon_state = "carrotshiv"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "Unlike other carrots, you should probably keep this far away from your eyes."

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -2,7 +2,7 @@
 	name = "latex glove"
 	desc = "Sterile and airtight."
 	icon_state = "latexballon"
-	item_state = "lgloves"
+	inhand_icon_state = "lgloves"
 	force = 0
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
@@ -15,7 +15,7 @@
 	if (icon_state == "latexballon_bursted")
 		return
 	icon_state = "latexballon_blow"
-	item_state = "latexballon"
+	inhand_icon_state = "latexballon"
 	user.update_inv_hands()
 	to_chat(user, span_notice("You blow up [src] with [tank]."))
 	air_contents = tank.remove_air_volume(3)
@@ -25,7 +25,7 @@
 		return
 	playsound(src, 'sound/weapons/gunshot.ogg', 100, 1)
 	icon_state = "latexballon_bursted"
-	item_state = "lgloves"
+	inhand_icon_state = "lgloves"
 	if(isliving(loc))
 		var/mob/living/user = src.loc
 		user.update_inv_hands()

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -95,10 +95,10 @@
 		return
 	if(HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
 		icon_state = "[base_icon_state]_on_[sword_color_icon]" // "esword_on_red"
-		item_state = icon_state
+		inhand_icon_state = icon_state
 	else
 		icon_state = base_icon_state
-		item_state = base_icon_state
+		inhand_icon_state = base_icon_state
 
 /**
  * Signal proc for [COMSIG_TRANSFORMING_ON_TRANSFORM].
@@ -133,7 +133,7 @@
 	name = "energy axe"
 	desc = "An energized battle axe."
 	icon_state = "axe"
-	item_state = "axe"
+	inhand_icon_state = "axe"
 	base_icon_state = "axe"
 	lefthand_file = 'icons/mob/inhands/weapons/axes_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/axes_righthand.dmi'
@@ -173,7 +173,7 @@
 	desc = "May the force be within you."
 	icon_state = "e_sword"
 	base_icon_state = "e_sword"
-	item_state = "e_sword"
+	inhand_icon_state = "e_sword"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	hitsound = "swing_hit"
@@ -335,7 +335,7 @@
 	name = "energy cutlass"
 	desc = "Arrrr matey."
 	icon_state = "e_cutlass"
-	item_state = "e_cutlass"
+	inhand_icon_state = "e_cutlass"
 	base_icon_state = "e_cutlass"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -379,4 +379,4 @@
 	name = "hardlight blade"
 	desc = "An extremely sharp blade made out of hard light. Packs quite a punch."
 	icon_state = "lightblade"
-	item_state = "lightblade"
+	inhand_icon_state = "lightblade"

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -13,7 +13,7 @@
 	name = "chain of command"
 	desc = "A tool used by great men to placate the frothing masses."
 	icon_state = "chain"
-	item_state = "chain"
+	inhand_icon_state = "chain"
 	worn_icon_state = "whip"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
@@ -36,7 +36,7 @@
 	desc = "A grotesque blade that on closer inspection seems made of synthetic flesh, it still feels like it would hurt very badly as a weapon."
 	icon = 'icons/obj/changeling_items.dmi'
 	icon_state = "arm_blade"
-	item_state = "arm_blade"
+	inhand_icon_state = "arm_blade"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
@@ -57,7 +57,7 @@
 	name = "officer's sabre"
 	desc = "An elegant weapon, its monomolecular edge is capable of cutting through flesh and bone with ease."
 	icon_state = "sabre"
-	item_state = "sabre"
+	inhand_icon_state = "sabre"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
@@ -145,7 +145,7 @@
 	desc = "An elegant weapon, it has an inscription on it that says:  \"La Gluten Gutter\"."
 	force = 18
 	icon_state = "rapier"
-	item_state = "rapier"
+	inhand_icon_state = "rapier"
 	lefthand_file = null
 	righthand_file = null
 	block_power = 60
@@ -171,7 +171,7 @@
 	desc = "A wooden truncheon for beating criminal scum."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "baton"
-	item_state = "classic_baton"
+	inhand_icon_state = "classic_baton"
 	worn_icon_state = "classic_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -356,7 +356,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	stamina_damage = 0
 	stun_animation = FALSE
-	item_state = null
+	inhand_icon_state = null
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = ISWEAPON
@@ -401,7 +401,7 @@
 	if(on)
 		to_chat(user, desc["local_on"])
 		icon_state = on_icon_state
-		item_state = on_item_state
+		inhand_icon_state = on_item_state
 		w_class = weight_class_on
 		force = force_on
 		attack_verb_continuous = list("smacks", "strikes", "cracks", "beats")
@@ -409,7 +409,7 @@
 	else
 		to_chat(user, desc["local_off"])
 		icon_state = off_icon_state
-		item_state = null //no sprite for concealment even when in hand
+		inhand_icon_state = null //no sprite for concealment even when in hand
 		slot_flags = ITEM_SLOT_BELT
 		w_class = WEIGHT_CLASS_SMALL
 		force = force_off
@@ -426,7 +426,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
-	item_state = null
+	inhand_icon_state = null
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = ISWEAPON
@@ -464,7 +464,7 @@
 	if(on)
 		to_chat(user, desc["local_on"])
 		icon_state = on_icon_state
-		item_state = on_item_state
+		inhand_icon_state = on_item_state
 		w_class = weight_class_on
 		force = force_on
 		attack_verb_continuous = list("smacks", "strikes", "cracks", "beats")
@@ -472,7 +472,7 @@
 	else
 		to_chat(user, desc["local_off"])
 		icon_state = off_icon_state
-		item_state = null //no sprite for concealment even when in hand
+		inhand_icon_state = null //no sprite for concealment even when in hand
 		slot_flags = ITEM_SLOT_BELT
 		w_class = WEIGHT_CLASS_SMALL
 		force = force_off
@@ -610,7 +610,7 @@
 	desc = "In a station full of bad ideas, this might just be the worst."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "supermatter_sword"
-	item_state = "supermatter_sword"
+	inhand_icon_state = "supermatter_sword"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	slot_flags = null
@@ -715,7 +715,7 @@
 	name = "curator's whip"
 	desc = "Somewhat eccentric and outdated, it still stings like hell to be hit by."
 	icon_state = "whip"
-	item_state = "chain"
+	inhand_icon_state = "chain"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	worn_icon_state = "whip"
@@ -772,7 +772,7 @@
 	desc = "A telescopic roasting stick with a miniature shield generator designed to ensure entry into various high-tech shielded cooking ovens and firepits."
 	icon = 'icons/obj/service/kitchen.dmi'
 	icon_state = "roastingstick_0"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon_state = "tele_baton"
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
@@ -820,7 +820,7 @@
 /obj/item/melee/roastingstick/proc/on_transform(obj/item/source, mob/user, active)
 	SIGNAL_HANDLER
 
-	item_state = active ? "nullrod" : null
+	inhand_icon_state = active ? "nullrod" : null
 	if(user)
 		balloon_alert(user, "[active ? "extended" : "collapsed"] [src]")
 	playsound(src, 'sound/weapons/batonextend.ogg', 50, TRUE)
@@ -892,7 +892,7 @@
 	desc = "An portable anti-gravity generator which knocks people back upon contact."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "telebaton_1"
-	item_state = "nullrod"
+	inhand_icon_state = "nullrod"
 	worn_icon_state = "tele_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -928,7 +928,7 @@
 		repeat offenses and has brought employment to lawyers for decades."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "beater"
-	item_state = "beater"
+	inhand_icon_state = "beater"
 	worn_icon_state = "classic_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -18,7 +18,7 @@
 	desc = "Hey, why are you viewing this?!! Please let CentCom know about this odd occurrence."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-blue"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	var/uses = 1
 
 /obj/item/choice_beacon/attack_self(mob/user)
@@ -401,7 +401,7 @@
 	name = "Upgrade Wand"
 	icon = 'icons/obj/guns/magic.dmi'
 	icon_state = "nothingwand"
-	item_state = "wand"
+	inhand_icon_state = "wand"
 	w_class = WEIGHT_CLASS_SMALL
 	var/used = FALSE
 

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -75,7 +75,7 @@
 	name = "advanced mop"
 	mopcap = 10
 	icon_state = "advmop"
-	item_state = "advmop"
+	inhand_icon_state = "advmop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	force = 12

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "paint_neutral"
 	var/paint_color = "FFFFFF"
-	item_state = "paintcan"
+	inhand_icon_state = "paintcan"
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FLAMMABLE
 	max_integrity = 100

--- a/code/game/objects/items/peppercloud.dm
+++ b/code/game/objects/items/peppercloud.dm
@@ -4,7 +4,7 @@
 	desc = "Manufactured by UhangInc, upon activation a pepper-cloud will be deployed slowing down and disorienting anyone who enters it."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "pepperspray"
-	item_state = "pepperspray"
+	inhand_icon_state = "pepperspray"
 	worn_icon_state = "spraybottle"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/pet_carrier.dmi'
 	base_icon_state = "pet_carrier"
 	icon_state = "pet_carrier_open"
-	item_state = "pet_carrier"
+	inhand_icon_state = "pet_carrier"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 5

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -7,7 +7,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "pinpointer"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -13,7 +13,7 @@
 	attack_verb_simple = list("bludgeon", "smash", "beat")
 	icon = 'icons/obj/pneumaticCannon.dmi'
 	icon_state = "pneumaticCannon"
-	item_state = "bulldog"
+	inhand_icon_state = "bulldog"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	armor_type = /datum/armor/item_pneumatic_cannon
@@ -313,7 +313,7 @@
 	desc = "A weapon favored by carp hunters. Fires specialized spears using magnetic energy. A savvy- or desperate- hunter may be able to find more esoteric payloads"
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "speargun"
-	item_state = "speargun"
+	inhand_icon_state = "speargun"
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
@@ -334,7 +334,7 @@
 	name = "quiver"
 	desc = "A quiver for holding magspears."
 	icon_state = "quiver"
-	item_state = "quiver"
+	inhand_icon_state = "quiver"
 
 /obj/item/storage/backpack/magspear_quiver/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -2,7 +2,7 @@
 	name = "power-fist"
 	desc = "A metal gauntlet with a piston-powered ram ontop for that extra 'ompfh' in your punch."
 	icon_state = "powerfist"
-	item_state = "powerfist"
+	inhand_icon_state = "powerfist"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -3,7 +3,7 @@
 	desc = "A banner with Nanotrasen's logo on it."
 	icon = 'icons/obj/banner.dmi'
 	icon_state = "banner"
-	item_state = "banner"
+	inhand_icon_state = "banner"
 	force = 8
 	attack_verb_continuous = list("forcefully inspires", "violently encourages", "relentlessly galvanizes")
 	attack_verb_simple = list("forcefully inspire", "violently encourage", "relentlessly galvanize")
@@ -79,7 +79,7 @@
 	name = "securistan banner"
 	desc = "The banner of Securistan, ruling the station with an iron fist."
 	icon_state = "banner_security"
-	item_state = "banner_security"
+	inhand_icon_state = "banner_security"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	job_loyalties = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_WARDEN, JOB_NAME_DETECTIVE, JOB_NAME_HEADOFSECURITY, JOB_NAME_BRIGPHYSICIAN, JOB_NAME_DEPUTY)
@@ -92,7 +92,7 @@
 	name = "meditopia banner"
 	desc = "The banner of Meditopia, generous benefactors that cure wounds and shelter the weak."
 	icon_state = "banner_medical"
-	item_state = "banner_medical"
+	inhand_icon_state = "banner_medical"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	job_loyalties = list(JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHEMIST, JOB_NAME_GENETICIST, JOB_NAME_VIROLOGIST, JOB_NAME_PARAMEDIC, JOB_NAME_CHIEFMEDICALOFFICER)
@@ -113,7 +113,7 @@
 	name = "sciencia banner"
 	desc = "The banner of Sciencia, bold and daring thaumaturges and researchers that take the path less traveled."
 	icon_state = "banner_science"
-	item_state = "banner_science"
+	inhand_icon_state = "banner_science"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	job_loyalties = list(JOB_NAME_SCIENTIST, JOB_NAME_ROBOTICIST, JOB_NAME_RESEARCHDIRECTOR)
@@ -129,7 +129,7 @@
 	name = "cargonia banner"
 	desc = "The banner of the eternal Cargonia, with the mystical power of conjuring any object into existence."
 	icon_state = "banner_cargo"
-	item_state = "banner_cargo"
+	inhand_icon_state = "banner_cargo"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	job_loyalties = list(JOB_NAME_CARGOTECHNICIAN, JOB_NAME_SHAFTMINER, JOB_NAME_QUARTERMASTER)
@@ -142,7 +142,7 @@
 	name = "engitopia banner"
 	desc = "The banner of Engitopia, wielders of limitless power."
 	icon_state = "banner_engineering"
-	item_state = "banner_engineering"
+	inhand_icon_state = "banner_engineering"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	job_loyalties = list(JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN, JOB_NAME_CHIEFENGINEER)
@@ -170,13 +170,13 @@
 /obj/item/banner/red
 	name = "red banner"
 	icon_state = "banner-red"
-	item_state = "banner-red"
+	inhand_icon_state = "banner-red"
 	desc = "A banner with the logo of the red deity."
 
 /obj/item/banner/blue
 	name = "blue banner"
 	icon_state = "banner-blue"
-	item_state = "banner-blue"
+	inhand_icon_state = "banner-blue"
 	desc = "A banner with the logo of the blue deity."
 
 /obj/item/storage/backpack/bannerpack

--- a/code/game/objects/items/scrolls.dm
+++ b/code/game/objects/items/scrolls.dm
@@ -7,7 +7,7 @@
 	var/smoke_amt = 20 //How much smoke after teleporting
 	actions_types = list(/datum/action/spell/teleport/area_teleport/wizard/scroll)
 	w_class = WEIGHT_CLASS_SMALL
-	item_state = "paper"
+	inhand_icon_state = "paper"
 	throw_speed = 3
 	throw_range = 7
 	resistance_flags = FLAMMABLE

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -124,7 +124,7 @@
 	name = "\improper Roman shield"
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
 	icon_state = "roman_shield"
-	item_state = "roman_shield"
+	inhand_icon_state = "roman_shield"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	transparent = FALSE
@@ -146,7 +146,7 @@
 	name = "wooden buckler"
 	desc = "A medieval wooden buckler."
 	icon_state = "buckler"
-	item_state = "buckler"
+	inhand_icon_state = "buckler"
 	block_level = 1
 	block_upgrade_walk = 1
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
@@ -166,7 +166,7 @@
 	name = "Goliath shield"
 	desc = "A shield made from interwoven plates of goliath hide."
 	icon_state = "goliath_shield"
-	item_state = "goliath_shield"
+	inhand_icon_state = "goliath_shield"
 	block_level = 1
 	block_upgrade_walk = 1
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
@@ -187,7 +187,7 @@
 	name = "strobe shield"
 	desc = "A shield with a built in, high intensity light capable of blinding and disorienting suspects. Takes regular handheld flashes as bulbs."
 	icon_state = "flashshield"
-	item_state = "flashshield"
+	inhand_icon_state = "flashshield"
 	var/obj/item/assembly/flash/handheld/embedded_flash
 
 /obj/item/shield/riot/flash/Initialize(mapload)
@@ -240,10 +240,10 @@
 /obj/item/shield/riot/flash/update_icon_state()
 	if(!embedded_flash || embedded_flash.burnt_out)
 		icon_state = "riot"
-		item_state = "riot"
+		inhand_icon_state = "riot"
 	else
 		icon_state = "flashshield"
-		item_state = "flashshield"
+		inhand_icon_state = "flashshield"
 	return ..()
 
 /obj/item/shield/riot/flash/examine(mob/user)
@@ -255,7 +255,7 @@
 	name = "energy combat shield"
 	desc = "An advanced hard-light shield. It can be retracted, expanded, and stored anywhere, but can't take much punishment before needing a reset"
 	icon_state = "eshield"
-	item_state = "eshield"
+	inhand_icon_state = "eshield"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY

--- a/code/game/objects/items/stacks/ores/ore.dm
+++ b/code/game/objects/items/stacks/ores/ore.dm
@@ -6,7 +6,7 @@
 	desc = "A rather dull rock for a stone."
 	icon = 'icons/obj/stacks/minerals.dmi'
 	icon_state = "ore"
-	item_state = "ore"
+	inhand_icon_state = "ore"
 	full_w_class = WEIGHT_CLASS_BULKY
 	singular_name = "ore chunk"
 	material_flags = MATERIAL_EFFECTS

--- a/code/game/objects/items/stacks/ores/ore.dm
+++ b/code/game/objects/items/stacks/ores/ore.dm
@@ -6,7 +6,7 @@
 	desc = "A rather dull rock for a stone."
 	icon = 'icons/obj/stacks/minerals.dmi'
 	icon_state = "ore"
-	inhand_icon_state = "ore"
+	inhand_icon_state = null
 	full_w_class = WEIGHT_CLASS_BULKY
 	singular_name = "ore chunk"
 	material_flags = MATERIAL_EFFECTS

--- a/code/game/objects/items/stacks/ores/ore_type.dm
+++ b/code/game/objects/items/stacks/ores/ore_type.dm
@@ -7,7 +7,6 @@
 	name = "uranium ore"
 	desc = "The fuel of the late 20th century."
 	icon_state = "uranium_ore"
-	inhand_icon_state = "uranium_ore"
 	singular_name = "uranium ore chunk"
 	points = 38
 	material_flags = NONE
@@ -25,7 +24,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/uranium)
 	name = "iron ore"
 	desc = "The most abundant material around, yet so scarce."
 	icon_state = "iron_ore"
-	inhand_icon_state = "iron_ore"
 	singular_name = "iron ore chunk"
 	points = 2
 	mats_per_unit = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT)
@@ -42,7 +40,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/iron)
 	name = "sand pile"
 	desc = "A pile of sandy quartz."
 	icon_state = "sand"
-	inhand_icon_state = "sand"
 	singular_name = "sand pile"
 	points = 2
 	mats_per_unit = list(/datum/material/glass=MINERAL_MATERIAL_AMOUNT)
@@ -96,7 +93,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/glass/basalt)
 	name = "plasma ore"
 	desc = "The fuel of our times."
 	icon_state = "plasma_ore"
-	inhand_icon_state = "plasma_ore"
 	singular_name = "plasma ore chunk"
 	points = 19
 	mats_per_unit = list(/datum/material/plasma=MINERAL_MATERIAL_AMOUNT)
@@ -117,7 +113,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/plasma)
 	name = "copper ore"
 	desc = "The base for all your electronics."
 	icon_state = "copper_ore"
-	inhand_icon_state = "Copper_ore"
 	singular_name = "Copper ore chunk"
 	points = 6
 	mats_per_unit = list(/datum/material/copper=MINERAL_MATERIAL_AMOUNT)
@@ -134,7 +129,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/copper)
 	name = "silver ore"
 	desc = "Purity in mineral form."
 	icon_state = "silver_ore"
-	inhand_icon_state = "silver_ore"
 	singular_name = "silver ore chunk"
 	points = 20
 	mats_per_unit = list(/datum/material/silver=MINERAL_MATERIAL_AMOUNT)
@@ -168,7 +162,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/gold)
 	name = "diamond ore"
 	desc = "Densly packed coal, wonder how it got here..."
 	icon_state = "diamond_ore"
-	inhand_icon_state = "diamond_ore"
 	singular_name = "diamond ore chunk"
 	points = 63
 	mats_per_unit = list(/datum/material/diamond=MINERAL_MATERIAL_AMOUNT)
@@ -184,7 +177,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/diamond)
 	name = "bananium ore"
 	desc = "Unlike bananas, this ore is rather funny."
 	icon_state = "bananium_ore"
-	inhand_icon_state = "bananium_ore"
 	singular_name = "bananium ore chunk"
 	points = 75
 	mats_per_unit = list(/datum/material/bananium=MINERAL_MATERIAL_AMOUNT)
@@ -200,7 +192,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/bananium)
 	name = "titanium ore"
 	desc = "A strong material for ship construction."
 	icon_state = "titanium_ore"
-	inhand_icon_state = "titanium_ore"
 	singular_name = "titanium ore chunk"
 	points = 38
 	mats_per_unit = list(/datum/material/titanium=MINERAL_MATERIAL_AMOUNT)
@@ -217,7 +208,6 @@ STACKSIZE_MACRO(/obj/item/stack/ore/titanium)
 	name = "slag"
 	desc = "Completely useless."
 	icon_state = "slag"
-	inhand_icon_state = "slag"
 	singular_name = "slag chunk"
 	merge_type = /obj/item/stack/ore/slag
 

--- a/code/game/objects/items/stacks/ores/ore_type.dm
+++ b/code/game/objects/items/stacks/ores/ore_type.dm
@@ -7,7 +7,7 @@
 	name = "uranium ore"
 	desc = "The fuel of the late 20th century."
 	icon_state = "uranium_ore"
-	item_state = "uranium_ore"
+	inhand_icon_state = "uranium_ore"
 	singular_name = "uranium ore chunk"
 	points = 38
 	material_flags = NONE
@@ -25,7 +25,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/uranium)
 	name = "iron ore"
 	desc = "The most abundant material around, yet so scarce."
 	icon_state = "iron_ore"
-	item_state = "iron_ore"
+	inhand_icon_state = "iron_ore"
 	singular_name = "iron ore chunk"
 	points = 2
 	mats_per_unit = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT)
@@ -42,7 +42,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/iron)
 	name = "sand pile"
 	desc = "A pile of sandy quartz."
 	icon_state = "sand"
-	item_state = "sand"
+	inhand_icon_state = "sand"
 	singular_name = "sand pile"
 	points = 2
 	mats_per_unit = list(/datum/material/glass=MINERAL_MATERIAL_AMOUNT)
@@ -96,7 +96,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/glass/basalt)
 	name = "plasma ore"
 	desc = "The fuel of our times."
 	icon_state = "plasma_ore"
-	item_state = "plasma_ore"
+	inhand_icon_state = "plasma_ore"
 	singular_name = "plasma ore chunk"
 	points = 19
 	mats_per_unit = list(/datum/material/plasma=MINERAL_MATERIAL_AMOUNT)
@@ -117,7 +117,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/plasma)
 	name = "copper ore"
 	desc = "The base for all your electronics."
 	icon_state = "copper_ore"
-	item_state = "Copper_ore"
+	inhand_icon_state = "Copper_ore"
 	singular_name = "Copper ore chunk"
 	points = 6
 	mats_per_unit = list(/datum/material/copper=MINERAL_MATERIAL_AMOUNT)
@@ -134,7 +134,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/copper)
 	name = "silver ore"
 	desc = "Purity in mineral form."
 	icon_state = "silver_ore"
-	item_state = "silver_ore"
+	inhand_icon_state = "silver_ore"
 	singular_name = "silver ore chunk"
 	points = 20
 	mats_per_unit = list(/datum/material/silver=MINERAL_MATERIAL_AMOUNT)
@@ -168,7 +168,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/gold)
 	name = "diamond ore"
 	desc = "Densly packed coal, wonder how it got here..."
 	icon_state = "diamond_ore"
-	item_state = "diamond_ore"
+	inhand_icon_state = "diamond_ore"
 	singular_name = "diamond ore chunk"
 	points = 63
 	mats_per_unit = list(/datum/material/diamond=MINERAL_MATERIAL_AMOUNT)
@@ -184,7 +184,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/diamond)
 	name = "bananium ore"
 	desc = "Unlike bananas, this ore is rather funny."
 	icon_state = "bananium_ore"
-	item_state = "bananium_ore"
+	inhand_icon_state = "bananium_ore"
 	singular_name = "bananium ore chunk"
 	points = 75
 	mats_per_unit = list(/datum/material/bananium=MINERAL_MATERIAL_AMOUNT)
@@ -200,7 +200,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/bananium)
 	name = "titanium ore"
 	desc = "A strong material for ship construction."
 	icon_state = "titanium_ore"
-	item_state = "titanium_ore"
+	inhand_icon_state = "titanium_ore"
 	singular_name = "titanium ore chunk"
 	points = 38
 	mats_per_unit = list(/datum/material/titanium=MINERAL_MATERIAL_AMOUNT)
@@ -217,7 +217,7 @@ STACKSIZE_MACRO(/obj/item/stack/ore/titanium)
 	name = "slag"
 	desc = "Completely useless."
 	icon_state = "slag"
-	item_state = "slag"
+	inhand_icon_state = "slag"
 	singular_name = "slag chunk"
 	merge_type = /obj/item/stack/ore/slag
 

--- a/code/game/objects/items/stacks/rods/rods.dm
+++ b/code/game/objects/items/stacks/rods/rods.dm
@@ -3,7 +3,7 @@
 	desc = "Some rods. Can be used for building or something."
 	singular_name = "iron rod"
 	icon_state = "rods"
-	item_state = "rods"
+	inhand_icon_state = "rods"
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 9

--- a/code/game/objects/items/stacks/sheets/mineral/exotics.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/exotics.dm
@@ -11,7 +11,7 @@ Exotic mineral Sheets
 /obj/item/stack/sheet/mineral/bananium
 	name = "bananium"
 	icon_state = "sheet-bananium"
-	item_state = "sheet-bananium"
+	inhand_icon_state = "sheet-bananium"
 	singular_name = "bananium sheet"
 	sheettype = "bananium"
 	mats_per_unit = list(/datum/material/bananium=MINERAL_MATERIAL_AMOUNT)
@@ -30,7 +30,7 @@ Exotic mineral Sheets
 /obj/item/stack/sheet/mineral/adamantine
 	name = "adamantine"
 	icon_state = "sheet-adamantine"
-	item_state = "sheet-adamantine"
+	inhand_icon_state = "sheet-adamantine"
 	singular_name = "adamantine sheet"
 	mats_per_unit = list(/datum/material/adamantine=MINERAL_MATERIAL_AMOUNT)
 	grind_results = list(/datum/reagent/liquidadamantine = 10)
@@ -46,7 +46,7 @@ Exotic mineral Sheets
 	name = "alien alloy"
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "sheet-abductor"
-	item_state = "sheet-abductor"
+	inhand_icon_state = "sheet-abductor"
 	singular_name = "alien alloy sheet"
 	sheettype = "abductor"
 	mats_per_unit = list(/datum/material/alloy/alien=MINERAL_MATERIAL_AMOUNT)

--- a/code/game/objects/items/stacks/sheets/mineral/glass.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/glass.dm
@@ -15,7 +15,7 @@
 	desc = "HOLY SHEET! That is a lot of glass."
 	singular_name = "glass sheet"
 	icon_state = "sheet-glass"
-	item_state = "sheet-glass"
+	inhand_icon_state = "sheet-glass"
 	mats_per_unit = list(/datum/material/glass=MINERAL_MATERIAL_AMOUNT)
 	armor_type = /datum/armor/sheet_glass
 	resistance_flags = ACID_PROOF
@@ -73,7 +73,7 @@
 	desc = "Glass which seems to have rods or something stuck in them."
 	singular_name = "reinforced glass sheet"
 	icon_state = "sheet-rglass"
-	item_state = "sheet-rglass"
+	inhand_icon_state = "sheet-rglass"
 	custom_materials = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT * 0.5, /datum/material/glass=MINERAL_MATERIAL_AMOUNT)
 	armor_type = /datum/armor/sheet_rglass
 	resistance_flags = ACID_PROOF
@@ -122,7 +122,7 @@
 	desc = "A glass sheet made out of a plasma-silicate alloy. It looks extremely tough and heavily fire resistant."
 	singular_name = "plasma glass sheet"
 	icon_state = "sheet-pglass"
-	item_state = "sheet-pglass"
+	inhand_icon_state = "sheet-pglass"
 	mats_per_unit = list(/datum/material/alloy/plasmaglass=MINERAL_MATERIAL_AMOUNT)
 	material_type = /datum/material/alloy/plasmaglass
 	armor_type = /datum/armor/sheet_plasmaglass
@@ -165,7 +165,7 @@
 	desc = "A glass sheet made out of a plasma-silicate alloy and a rod matrix. It looks hopelessly tough and nearly fire-proof!"
 	singular_name = "reinforced plasma glass sheet"
 	icon_state = "sheet-prglass"
-	item_state = "sheet-prglass"
+	inhand_icon_state = "sheet-prglass"
 	mats_per_unit = list(/datum/material/alloy/plasmaglass=MINERAL_MATERIAL_AMOUNT, /datum/material/iron = MINERAL_MATERIAL_AMOUNT * 0.5)
 	armor_type = /datum/armor/sheet_plasmarglass
 	resistance_flags = ACID_PROOF
@@ -191,7 +191,7 @@
 	desc = "A glass sheet made out of a titanium-silicate alloy."
 	singular_name = "titanium glass sheet"
 	icon_state = "sheet-titaniumglass"
-	item_state = "sheet-titaniumglass"
+	inhand_icon_state = "sheet-titaniumglass"
 	mats_per_unit = list(/datum/material/alloy/titaniumglass=MINERAL_MATERIAL_AMOUNT)
 	material_type = /datum/material/alloy/titaniumglass
 	armor_type = /datum/armor/sheet_titaniumglass
@@ -213,7 +213,7 @@
 	desc = "A glass sheet made out of a plasma-titanium-silicate alloy."
 	singular_name = "plastitanium glass sheet"
 	icon_state = "sheet-plastitaniumglass"
-	item_state = "sheet-plastitaniumglass"
+	inhand_icon_state = "sheet-plastitaniumglass"
 	mats_per_unit = list(/datum/material/titanium=MINERAL_MATERIAL_AMOUNT * 0.5, /datum/material/plasma=MINERAL_MATERIAL_AMOUNT * 0.5, /datum/material/glass=MINERAL_MATERIAL_AMOUNT)
 	armor_type = /datum/armor/sheet_plastitaniumglass
 	resistance_flags = ACID_PROOF
@@ -238,7 +238,7 @@
 	item_flags = ISWEAPON
 	force = 5
 	throwforce = 10
-	item_state = "shard-glass"
+	inhand_icon_state = "shard-glass"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	custom_materials = list(/datum/material/glass=MINERAL_MATERIAL_AMOUNT)

--- a/code/game/objects/items/stacks/sheets/mineral/materials.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/materials.dm
@@ -22,7 +22,7 @@ Mineral Sheets
 	desc = "This appears to be a combination of both sand and stone."
 	singular_name = "sandstone brick"
 	icon_state = "sheet-sandstone"
-	item_state = "sheet-sandstone"
+	inhand_icon_state = "sheet-sandstone"
 	throw_speed = 3
 	throw_range = 5
 	mats_per_unit = list(/datum/material/glass=MINERAL_MATERIAL_AMOUNT)
@@ -38,7 +38,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/diamond
 	name = "diamond"
 	icon_state = "sheet-diamond"
-	item_state = "sheet-diamond"
+	inhand_icon_state = "sheet-diamond"
 	singular_name = "diamond"
 	sheettype = "diamond"
 	mats_per_unit = list(/datum/material/diamond=MINERAL_MATERIAL_AMOUNT)
@@ -56,7 +56,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/uranium
 	name = "uranium"
 	icon_state = "sheet-uranium"
-	item_state = "sheet-uranium"
+	inhand_icon_state = "sheet-uranium"
 	singular_name = "uranium rod"
 	sheettype = "uranium"
 	mats_per_unit = list(/datum/material/uranium=MINERAL_MATERIAL_AMOUNT)
@@ -74,7 +74,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/plasma
 	name = "solid plasma"
 	icon_state = "sheet-plasma"
-	item_state = "sheet-plasma"
+	inhand_icon_state = "sheet-plasma"
 	singular_name = "plasma crystal"
 	sheettype = "plasma"
 	resistance_flags = FLAMMABLE
@@ -115,7 +115,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/gold
 	name = "gold"
 	icon_state = "sheet-gold"
-	item_state = "sheet-gold"
+	inhand_icon_state = "sheet-gold"
 	singular_name = "gold bar"
 	sheettype = "gold"
 	mats_per_unit = list(/datum/material/gold=MINERAL_MATERIAL_AMOUNT)
@@ -133,7 +133,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/silver
 	name = "silver"
 	icon_state = "sheet-silver"
-	item_state = "sheet-silver"
+	inhand_icon_state = "sheet-silver"
 	singular_name = "silver bar"
 	sheettype = "silver"
 	mats_per_unit = list(/datum/material/silver=MINERAL_MATERIAL_AMOUNT)
@@ -152,7 +152,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/copper
 	name = "copper"
 	icon_state = "sheet-copper"
-	item_state = "sheet-copper"
+	inhand_icon_state = "sheet-copper"
 	singular_name = "copper bar"
 	sheettype = "copper"
 	mats_per_unit = list(/datum/material/copper=MINERAL_MATERIAL_AMOUNT)
@@ -170,7 +170,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/titanium
 	name = "titanium"
 	icon_state = "sheet-titanium"
-	item_state = "sheet-titanium"
+	inhand_icon_state = "sheet-titanium"
 	singular_name = "titanium sheet"
 	force = 5
 	throwforce = 5
@@ -192,7 +192,7 @@ Mineral Sheets
 /obj/item/stack/sheet/mineral/plastitanium
 	name = "plastitanium"
 	icon_state = "sheet-plastitanium"
-	item_state = "sheet-plastitanium"
+	inhand_icon_state = "sheet-plastitanium"
 	singular_name = "plastitanium sheet"
 	force = 5
 	throwforce = 5

--- a/code/game/objects/items/stacks/sheets/mineral/metals.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/metals.dm
@@ -19,7 +19,7 @@ Metals Sheets
 	desc = "Sheets made out of iron."
 	singular_name = "iron sheet"
 	icon_state = "sheet-metal"
-	item_state = "sheet-metal"
+	inhand_icon_state = "sheet-metal"
 	mats_per_unit = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT)
 	throwforce = 10
 	flags_1 = CONDUCT_1
@@ -85,7 +85,7 @@ Metals Sheets
 	singular_name = "plasteel sheet"
 	desc = "This sheet is an alloy of iron and plasma."
 	icon_state = "sheet-plasteel"
-	item_state = "sheet-metal"
+	inhand_icon_state = "sheet-metal"
 	mats_per_unit = list(/datum/material/alloy/plasteel=MINERAL_MATERIAL_AMOUNT)
 	material_type = /datum/material/alloy/plasteel
 	throwforce = 10
@@ -114,7 +114,7 @@ Metals Sheets
 	desc = "Sheets of cold metal with shifting inscriptions writ upon them."
 	singular_name = "runed metal sheet"
 	icon_state = "sheet-runed"
-	item_state = "sheet-runed"
+	inhand_icon_state = "sheet-runed"
 	//icon = 'icons/obj/stacks/mineral.dmi'
 	sheettype = "runed"
 	merge_type = /obj/item/stack/sheet/runed_metal
@@ -145,7 +145,7 @@ Metals Sheets
 	desc = "Sheets made out of brass."
 	singular_name = "brass sheet"
 	icon_state = "sheet-brass"
-	item_state = "sheet-brass"
+	inhand_icon_state = "sheet-brass"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	throwforce = 10
 	max_amount = 50
@@ -182,7 +182,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/sheet/brass)
 	desc = "On closer inspection, what appears to be wholly-unsuitable-for-building brass is actually more structurally stable bronze."
 	singular_name = "bronze sheet"
 	icon_state = "sheet-brass"
-	item_state = "sheet-brass"
+	inhand_icon_state = "sheet-brass"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	throwforce = 10
 	max_amount = 50

--- a/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
+++ b/code/game/objects/items/stacks/sheets/miscellaneous/miscellaneous_mats.dm
@@ -14,7 +14,7 @@ Miscellaneous material sheets
 /obj/item/stack/sheet/wax
 	name = "wax"
 	icon_state = "sheet-wax"
-	item_state = "sheet-wax"
+	inhand_icon_state = "sheet-wax"
 	singular_name = "wax block"
 	force = 1
 	throwforce = 2
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 /obj/item/stack/sheet/snow
 	name = "snow"
 	icon_state = "sheet-snow"
-	item_state = "sheet-snow"
+	inhand_icon_state = "sheet-snow"
 	icon = 'icons/obj/stacks/minerals.dmi'
 	singular_name = "snow block"
 	force = 1
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	desc = "Compress dinosaur over millions of years, then refine, split and mold, and voila! You have plastic."
 	singular_name = "plastic sheet"
 	icon_state = "sheet-plastic"
-	item_state = "sheet-plastic"
+	inhand_icon_state = "sheet-plastic"
 	mats_per_unit = list(/datum/material/plastic=MINERAL_MATERIAL_AMOUNT)
 	throwforce = 7
 	merge_type = /obj/item/stack/sheet/plastic
@@ -101,7 +101,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	singular_name = "cardboard sheet"
 	icon = 'icons/obj/stacks/miscellaneous.dmi'
 	icon_state = "sheet-card"
-	item_state = "sheet-card"
+	inhand_icon_state = "sheet-card"
 	resistance_flags = FLAMMABLE
 	force = 0
 	throwforce = 0

--- a/code/game/objects/items/stacks/sheets/organic/cloths.dm
+++ b/code/game/objects/items/stacks/sheets/organic/cloths.dm
@@ -42,7 +42,7 @@ Various Cloths
 	singular_name = "cloth roll"
 	icon_state = "sheet-cloth"
 	icon = 'icons/obj/stacks/organic.dmi'
-	item_state = "sheet-cloth"
+	inhand_icon_state = "sheet-cloth"
 	resistance_flags = FLAMMABLE
 	force = 0
 	throwforce = 0
@@ -68,7 +68,7 @@ Various Cloths
 	desc = "A fabric sown from incredibly durable threads, known for its usefulness in armor production."
 	singular_name = "durathread roll"
 	icon_state = "sheet-durathread"
-	item_state = "sheet-durathread"
+	inhand_icon_state = "sheet-durathread"
 	icon = 'icons/obj/stacks/organic.dmi'
 	resistance_flags = FLAMMABLE
 	force = 0
@@ -87,7 +87,7 @@ Various Cloths
 	desc = "A long soft material. This one is made from cotton rather than spidersilk."
 	singular_name = "Silk Sheet"
 	icon_state = "sheet-silk"
-	item_state = "sheet-silk"
+	inhand_icon_state = "sheet-silk"
 	novariants = TRUE
 	merge_type = /obj/item/stack/sheet/silk
 	icon = 'icons/obj/stacks/organic.dmi'

--- a/code/game/objects/items/stacks/sheets/organic/hides.dm
+++ b/code/game/objects/items/stacks/sheets/organic/hides.dm
@@ -4,7 +4,7 @@
 	name = "hide"
 	desc = "Something went wrong."
 	icon_state = "sheet-hide"
-	item_state = "sheet-hide"
+	inhand_icon_state = "sheet-hide"
 	icon = 'icons/obj/stacks/organic.dmi'
 	novariants = TRUE
 	merge_type = /obj/item/stack/sheet/animalhide
@@ -37,7 +37,7 @@
 	desc = "The by-product of corgi farming."
 	singular_name = "corgi hide piece"
 	icon_state = "sheet-corgi"
-	item_state = "sheet-corgi"
+	inhand_icon_state = "sheet-corgi"
 	merge_type = /obj/item/stack/sheet/animalhide/corgi
 
 /obj/item/stack/sheet/animalhide/corgi/get_recipes()
@@ -50,7 +50,7 @@
 	desc = "A thin layer of mothroach hide."
 	singular_name = "mothroach hide piece"
 	icon_state = "sheet-mothroach"
-	item_state = "sheet-mothroach"
+	inhand_icon_state = "sheet-mothroach"
 	merge_type = /obj/item/stack/sheet/animalhide/mothroach
 
 /* Gondola hide */
@@ -60,7 +60,7 @@
 	desc = "The extremely valuable product of gondola hunting."
 	singular_name = "gondola hide piece"
 	icon_state = "sheet-gondola"
-	item_state = "sheet-gondola"
+	inhand_icon_state = "sheet-gondola"
 	merge_type = /obj/item/stack/sheet/animalhide/gondola
 
 /obj/item/stack/sheet/animalhide/gondola/get_recipes()
@@ -73,7 +73,7 @@
 	desc = "The by-product of cat farming."
 	singular_name = "cat hide piece"
 	icon_state = "sheet-cat"
-	item_state = "sheet-cat"
+	inhand_icon_state = "sheet-cat"
 	merge_type = /obj/item/stack/sheet/animalhide/cat
 
 /* Monkey hide */
@@ -96,7 +96,7 @@
 	desc = "Sssssss..."
 	singular_name = "lizard hide"
 	icon_state = "sheet-lizard"
-	item_state = "sheet-lizard"
+	inhand_icon_state = "sheet-lizard"
 	merge_type = /obj/item/stack/sheet/animalhide/lizard
 
 /* Xeno hide */
@@ -106,7 +106,7 @@
 	desc = "The skin of a terrible creature."
 	singular_name = "alien hide piece"
 	icon_state = "sheet-xeno"
-	item_state = "sheet-xeno"
+	inhand_icon_state = "sheet-xeno"
 
 /obj/item/stack/sheet/animalhide/xeno/get_recipes()
 	return GLOB.xeno_recipes

--- a/code/game/objects/items/stacks/sheets/organic/leather.dm
+++ b/code/game/objects/items/stacks/sheets/organic/leather.dm
@@ -5,7 +5,7 @@
 	desc = "The by-product of mob grinding."
 	singular_name = "leather piece"
 	icon_state = "sheet-leather"
-	item_state = "sheet-leather"
+	inhand_icon_state = "sheet-leather"
 	icon = 'icons/obj/stacks/organic.dmi'
 	merge_type = /obj/item/stack/sheet/leather
 
@@ -17,7 +17,7 @@
 	desc = "This hide was stripped of its hair, but still needs washing and tanning."
 	singular_name = "hairless hide piece"
 	icon_state = "sheet-hairlesshide"
-	item_state = "sheet-hairlesshide"
+	inhand_icon_state = "sheet-hairlesshide"
 	icon = 'icons/obj/stacks/organic.dmi'
 	merge_type = /obj/item/stack/sheet/leather/hairlesshide
 
@@ -26,7 +26,7 @@
 	desc = "This leather has been cleaned but still needs to be dried."
 	singular_name = "wet leather piece"
 	icon_state = "sheet-wetleather"
-	item_state = "sheet-wetleather"
+	inhand_icon_state = "sheet-wetleather"
 	icon = 'icons/obj/stacks/organic.dmi'
 	merge_type = /obj/item/stack/sheet/leather/wetleather
 	var/wetness = 30 //Reduced when exposed to high temperautres

--- a/code/game/objects/items/stacks/sheets/organic/miscellaneous_organics.dm
+++ b/code/game/objects/items/stacks/sheets/organic/miscellaneous_organics.dm
@@ -25,7 +25,7 @@
 /obj/item/stack/sheet/bone
 	name = "bones"
 	icon_state = "bone"
-	item_state = "sheet-bone"
+	inhand_icon_state = "sheet-bone"
 	icon = 'icons/obj/stacks/organic.dmi'
 	singular_name = "bone"
 	desc = "Someone's been drinking their milk."

--- a/code/game/objects/items/stacks/sheets/organic/wood.dm
+++ b/code/game/objects/items/stacks/sheets/organic/wood.dm
@@ -14,7 +14,7 @@ Woods Sheets
 	desc = "One can only guess that this is a bunch of wood."
 	singular_name = "wood plank"
 	icon_state = "sheet-wood"
-	item_state = "sheet-wood"
+	inhand_icon_state = "sheet-wood"
 	icon = 'icons/obj/stacks/organic.dmi'
 	mats_per_unit = list(/datum/material/wood=MINERAL_MATERIAL_AMOUNT)
 	sheettype = "wood"
@@ -39,7 +39,7 @@ Woods Sheets
 	desc = "Finely cut bamboo sticks."
 	singular_name = "cut bamboo"
 	icon_state = "sheet-bamboo"
-	item_state = "sheet-bamboo"
+	inhand_icon_state = "sheet-bamboo"
 	icon = 'icons/obj/stacks/organic.dmi'
 	force = 10
 	throwforce = 10
@@ -71,7 +71,7 @@ Woods Sheets
 	desc = "A thin wooden frame with paper attached."
 	singular_name = "paper frame"
 	icon_state = "sheet-paper"
-	item_state = "sheet-paper"
+	inhand_icon_state = "sheet-paper"
 	icon = 'icons/obj/stacks/organic.dmi'
 	merge_type = /obj/item/stack/sheet/paperframes
 	resistance_flags = FLAMMABLE

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -4,7 +4,7 @@
 	singular_name = "floor tile"
 	desc = "The ground you walk on."
 	icon_state = "tile"
-	item_state = "tile"
+	inhand_icon_state = "tile"
 	force = 6
 	mats_per_unit = list(/datum/material/iron=500)
 	throwforce = 10

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -29,7 +29,7 @@
 	singular_name = "plasma floor tile"
 	desc = "A tile made out of highly flammable plasma. This can only end well."
 	icon_state = "tile_plasma"
-	item_state = "tile-plasma"
+	inhand_icon_state = "tile-plasma"
 	turf_type = /turf/open/floor/mineral/plasma
 	mineralType = "plasma"
 	mats_per_unit = list(/datum/material/plasma=MINERAL_MATERIAL_AMOUNT*0.25)
@@ -40,7 +40,7 @@
 	singular_name = "uranium floor tile"
 	desc = "A tile made out of uranium. You feel a bit woozy."
 	icon_state = "tile_uranium"
-	item_state = "tile-uranium"
+	inhand_icon_state = "tile-uranium"
 	turf_type = /turf/open/floor/mineral/uranium
 	mineralType = "uranium"
 	mats_per_unit = list(/datum/material/uranium=MINERAL_MATERIAL_AMOUNT*0.25)
@@ -51,7 +51,7 @@
 	singular_name = "gold floor tile"
 	desc = "A tile made out of gold, the swag seems strong here."
 	icon_state = "tile_gold"
-	item_state = "tile-gold"
+	inhand_icon_state = "tile-gold"
 	turf_type = /turf/open/floor/mineral/gold
 	mineralType = "gold"
 	mats_per_unit = list(/datum/material/gold=MINERAL_MATERIAL_AMOUNT*0.25)
@@ -62,7 +62,7 @@
 	singular_name = "silver floor tile"
 	desc = "A tile made out of silver, the light shining from it is blinding."
 	icon_state = "tile_silver"
-	item_state = "tile-silver"
+	inhand_icon_state = "tile-silver"
 	turf_type = /turf/open/floor/mineral/silver
 	mineralType = "silver"
 	mats_per_unit = list(/datum/material/silver=MINERAL_MATERIAL_AMOUNT*0.25)
@@ -83,7 +83,7 @@
 	singular_name = "diamond floor tile"
 	desc = "A tile made out of diamond. Wow, just, wow."
 	icon_state = "tile_diamond"
-	item_state = "tile-diamond"
+	inhand_icon_state = "tile-diamond"
 	turf_type = /turf/open/floor/mineral/diamond
 	mineralType = "diamond"
 	mats_per_unit = list(/datum/material/diamond=MINERAL_MATERIAL_AMOUNT*0.25)
@@ -94,7 +94,7 @@
 	singular_name = "bananium floor tile"
 	desc = "A tile made out of bananium, HOOOOOOOOONK!"
 	icon_state = "tile_bananium"
-	item_state = "tile-bananium"
+	inhand_icon_state = "tile-bananium"
 	turf_type = /turf/open/floor/mineral/bananium
 	mineralType = "bananium"
 	mats_per_unit = list(/datum/material/bananium=MINERAL_MATERIAL_AMOUNT*0.25)
@@ -107,7 +107,7 @@
 	desc = "A tile made out of alien alloy."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "tile_abductor"
-	item_state = "tile-abductor"
+	inhand_icon_state = "tile-abductor"
 	turf_type = /turf/open/floor/mineral/abductor
 	mats_per_unit = list(/datum/material/alloy/alien=MINERAL_MATERIAL_AMOUNT*0.25)
 	mineralType = "abductor"
@@ -118,7 +118,7 @@
 	singular_name = "titanium floor tile"
 	desc = "Sleek titanium tiles, used for shuttles."
 	icon_state = "tile_titanium"
-	item_state = "tile-shuttle"
+	inhand_icon_state = "tile-shuttle"
 	turf_type = /turf/open/floor/mineral/titanium
 	mineralType = "titanium"
 	mats_per_unit = list(/datum/material/titanium=MINERAL_MATERIAL_AMOUNT*0.25)
@@ -215,7 +215,7 @@
 	singular_name = "plastitanium floor tile"
 	desc = "A tile made of plastitanium, used for very evil shuttles."
 	icon_state = "tile_plastitanium"
-	item_state = "tile-darkshuttle"
+	inhand_icon_state = "tile-darkshuttle"
 	turf_type = /turf/open/floor/mineral/plastitanium
 	mineralType = "plastitanium"
 	mats_per_unit = list(/datum/material/alloy/plastitanium=MINERAL_MATERIAL_AMOUNT*0.50)
@@ -238,7 +238,7 @@
 	singular_name = "snow tile"
 	desc = "A layer of snow."
 	icon_state = "tile_snow"
-	item_state = "tile-silver"
+	inhand_icon_state = "tile-silver"
 	turf_type = /turf/open/floor/grass/snow/safe
 	mineralType = "snow"
 	merge_type = /obj/item/stack/tile/mineral/snow
@@ -248,7 +248,7 @@
 	singular_name = "wax tile"
 	desc = "A large, flat sheet of wax."
 	icon_state = "tile_wax"
-	item_state = "tile-wax"
+	inhand_icon_state = "tile-wax"
 	turf_type = /turf/open/floor/wax
 	mineralType = "wax"
 	merge_type = /obj/item/stack/tile/mineral/wax
@@ -257,7 +257,7 @@
 	name = "brass tiles"
 	desc = "An ornante tile made out of brass."
 	icon_state = "tile_brass"
-	item_state = "tile_brass"
+	inhand_icon_state = "tile_brass"
 	turf_type = /turf/open/floor/clockwork
 	mineralType = "brass"
 	merge_type = /obj/item/stack/tile/mineral/brass
@@ -266,7 +266,7 @@
 	name = "bronze tiles"
 	desc = "An ornate tile made out of... wait this is bronze!"
 	icon_state = "tile_brass"
-	item_state = "tile_brass"
+	inhand_icon_state = "tile_brass"
 	turf_type = /turf/open/floor/bronze
 	mineralType = "bronze"
 	merge_type = /obj/item/stack/tile/mineral/bronze

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -109,7 +109,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "grass floor tile"
 	desc = "A patch of grass like they use on space golf courses."
 	icon_state = "tile_grass"
-	item_state = "tile-grass"
+	inhand_icon_state = "tile-grass"
 	turf_type = /turf/open/floor/grass
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/tile/grass
@@ -132,7 +132,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "fairygrass floor tile"
 	desc = "A patch of odd, glowing blue grass."
 	icon_state = "tile_fairygrass"
-	item_state = "tile-fairygrass"
+	inhand_icon_state = "tile-fairygrass"
 	turf_type = /turf/open/floor/grass/fairy
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/tile/fairygrass
@@ -215,7 +215,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "wood floor tile"
 	desc = "An easy to fit wood floor tile."
 	icon_state = "tile-wood"
-	item_state = "tile-wood"
+	inhand_icon_state = "tile-wood"
 	turf_type = /turf/open/floor/wood
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/tile/wood
@@ -226,7 +226,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "bamboo mat piece"
 	desc = "A piece of a bamboo mat with a decorative trim."
 	icon_state = "tile-bamboo"
-	item_state = "tile-bamboo"
+	inhand_icon_state = "tile-bamboo"
 	turf_type = /turf/open/floor/bamboo
 	merge_type = /obj/item/stack/tile/bamboo
 	resistance_flags = FLAMMABLE
@@ -237,7 +237,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "basalt floor tile"
 	desc = "Artificially made ashy soil themed on a hostile environment."
 	icon_state = "tile_basalt"
-	item_state = "tile-basalt"
+	inhand_icon_state = "tile-basalt"
 	turf_type = /turf/open/floor/grass/fakebasalt
 	merge_type = /obj/item/stack/tile/basalt
 
@@ -247,7 +247,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "carpet"
 	desc = "A piece of carpet. It is the same size as a floor tile."
 	icon_state = "tile-carpet"
-	item_state = "tile-carpet"
+	inhand_icon_state = "tile-carpet"
 	turf_type = /turf/open/floor/carpet
 	resistance_flags = FLAMMABLE
 	tableVariant = /obj/structure/table/wood/fancy
@@ -278,7 +278,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/black
 	name = "black carpet"
 	icon_state = "tile-carpet-black"
-	item_state = "tile-carpet-black"
+	inhand_icon_state = "tile-carpet-black"
 	merge_type = /obj/item/stack/tile/carpet/black
 	turf_type = /turf/open/floor/carpet/black
 	tableVariant = /obj/structure/table/wood/fancy/black
@@ -286,7 +286,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/blue
 	name = "blue carpet"
 	icon_state = "tile-carpet-blue"
-	item_state = "tile-carpet-blue"
+	inhand_icon_state = "tile-carpet-blue"
 	merge_type = /obj/item/stack/tile/carpet/blue
 	turf_type = /turf/open/floor/carpet/blue
 	tableVariant = /obj/structure/table/wood/fancy/blue
@@ -297,7 +297,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/cyan
 	name = "cyan carpet"
 	icon_state = "tile-carpet-cyan"
-	item_state = "tile-carpet-cyan"
+	inhand_icon_state = "tile-carpet-cyan"
 	merge_type = /obj/item/stack/tile/carpet/cyan
 	turf_type = /turf/open/floor/carpet/cyan
 	tableVariant = /obj/structure/table/wood/fancy/cyan
@@ -308,7 +308,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/green
 	name = "green carpet"
 	icon_state = "tile-carpet-green"
-	item_state = "tile-carpet-green"
+	inhand_icon_state = "tile-carpet-green"
 	merge_type = /obj/item/stack/tile/carpet/green
 	turf_type = /turf/open/floor/carpet/green
 	tableVariant = /obj/structure/table/wood/fancy/green
@@ -316,7 +316,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/orange
 	name = "orange carpet"
 	icon_state = "tile-carpet-orange"
-	item_state = "tile-carpet-orange"
+	inhand_icon_state = "tile-carpet-orange"
 	merge_type = /obj/item/stack/tile/carpet/orange
 	turf_type = /turf/open/floor/carpet/orange
 	tableVariant = /obj/structure/table/wood/fancy/orange
@@ -324,7 +324,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/purple
 	name = "purple carpet"
 	icon_state = "tile-carpet-purple"
-	item_state = "tile-carpet-purple"
+	inhand_icon_state = "tile-carpet-purple"
 	merge_type = /obj/item/stack/tile/carpet/purple
 	turf_type = /turf/open/floor/carpet/purple
 	tableVariant = /obj/structure/table/wood/fancy/purple
@@ -332,7 +332,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/red
 	name = "red carpet"
 	icon_state = "tile-carpet-red"
-	item_state = "tile-carpet-red"
+	inhand_icon_state = "tile-carpet-red"
 	merge_type = /obj/item/stack/tile/carpet/red
 	turf_type = /turf/open/floor/carpet/red
 	tableVariant = /obj/structure/table/wood/fancy/red
@@ -340,7 +340,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/royalblack
 	name = "royal black carpet"
 	icon_state = "tile-carpet-royalblack"
-	item_state = "tile-carpet-royalblack"
+	inhand_icon_state = "tile-carpet-royalblack"
 	merge_type = /obj/item/stack/tile/carpet/royalblack
 	turf_type = /turf/open/floor/carpet/royalblack
 	tableVariant = /obj/structure/table/wood/fancy/royalblack
@@ -348,7 +348,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 /obj/item/stack/tile/carpet/royalblue
 	name = "royal blue carpet"
 	icon_state = "tile-carpet-royalblue"
-	item_state = "tile-carpet-royalblue"
+	inhand_icon_state = "tile-carpet-royalblue"
 	merge_type = /obj/item/stack/tile/carpet/royalblue
 	turf_type = /turf/open/floor/carpet/royalblue
 	tableVariant = /obj/structure/table/wood/fancy/royalblue
@@ -358,7 +358,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "grimy carpet floor tile"
 	desc = "A piece of carpet that feels more like floor tiles, sure it feels hard to the touch for being carpet..."
 	icon_state = "tile-carpet-grimy"
-	item_state = "tile-carpet-grimy"
+	inhand_icon_state = "tile-carpet-grimy"
 	merge_type = /obj/item/stack/tile/carpet/grimy
 	turf_type = /turf/open/floor/carpet/grimy
 
@@ -419,7 +419,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "astral carpet"
 	desc = "A piece of carpet with a convincing star pattern."
 	icon_state = "tile_space"
-	item_state = "tile-space"
+	inhand_icon_state = "tile-space"
 	turf_type = /turf/open/floor/fakespace
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/tile/fakespace
@@ -432,7 +432,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "fake pit"
 	desc = "A piece of carpet with a forced perspective illusion of a pit. No way this could fool anyone!"
 	icon_state = "tile_pit"
-	item_state = "tile-basalt"
+	inhand_icon_state = "tile-basalt"
 	turf_type = /turf/open/floor/fakepit
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/tile/fakepit
@@ -446,7 +446,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "high-traction floor tile"
 	desc = "A high-traction floor tile. It feels rubbery in your hand."
 	icon_state = "tile_noslip"
-	item_state = "tile-noslip"
+	inhand_icon_state = "tile-noslip"
 	turf_type = /turf/open/floor/noslip
 	merge_type = /obj/item/stack/tile/noslip
 
@@ -507,7 +507,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "blue circuit tile"
 	desc = "A blue circuit tile."
 	icon_state = "tile_bcircuit"
-	item_state = "tile-bcircuit"
+	inhand_icon_state = "tile-bcircuit"
 	turf_type = /turf/open/floor/circuit
 	merge_type = /obj/item/stack/tile/circuit
 
@@ -516,7 +516,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "green circuit tile"
 	desc = "A green circuit tile."
 	icon_state = "tile_gcircuit"
-	item_state = "tile-gcircuit"
+	inhand_icon_state = "tile-gcircuit"
 	turf_type = /turf/open/floor/circuit/green
 	merge_type = /obj/item/stack/tile/circuit/green
 
@@ -529,7 +529,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "red circuit tile"
 	desc = "A red circuit tile."
 	icon_state = "tile_rcircuit"
-	item_state = "tile-rcircuit"
+	inhand_icon_state = "tile-rcircuit"
 	turf_type = /turf/open/floor/circuit/red
 	merge_type = /obj/item/stack/tile/circuit/red
 
@@ -543,7 +543,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "pod floor tile"
 	desc = "A grooved floor tile."
 	icon_state = "tile_pod"
-	item_state = "tile-pod"
+	inhand_icon_state = "tile-pod"
 	turf_type = /turf/open/floor/pod
 	merge_type = /obj/item/stack/tile/pod
 	tile_reskin_types = list(
@@ -650,7 +650,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	desc = "Glass window floors, to let you see... Whatever that is down there."
 	icon_state = "tile_glass"
 	turf_type = /turf/open/floor/glass
-	item_state = "tile-glass"
+	inhand_icon_state = "tile-glass"
 	merge_type = /obj/item/stack/tile/glass
 	mats_per_unit = list(/datum/material/glass=MINERAL_MATERIAL_AMOUNT * 0.25) // 4 tiles per sheet
 	replace_plating = TRUE
@@ -663,7 +663,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "reinforced glass floor tile"
 	desc = "Reinforced glass window floors. These bad boys are 50% stronger than their predecessors!"
 	icon_state = "tile_rglass"
-	item_state = "tile-rglass"
+	inhand_icon_state = "tile-rglass"
 	turf_type = /turf/open/floor/glass/reinforced
 	merge_type = /obj/item/stack/tile/rglass
 	mats_per_unit = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT * 0.125, /datum/material/glass=MINERAL_MATERIAL_AMOUNT * 0.25) // 4 tiles per sheet
@@ -760,7 +760,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/tile)
 	singular_name = "catwalk floor tile"
 	desc = "Flooring that shows its contents underneath. Engineers love it!"
 	icon_state = "maint_catwalk"
-	item_state = "tile-catwalk"
+	inhand_icon_state = "tile-catwalk"
 	turf_type = /turf/open/floor/catwalk_floor
 	merge_type = /obj/item/stack/tile/catwalk_tile //Just to be cleaner, these all stack with eachother
 	tile_reskin_types = list(

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -14,7 +14,7 @@
 	desc = "You wear this on your back and put items into it."
 	icon = 'icons/obj/storage/backpack.dmi'
 	icon_state = "backpack"
-	item_state = "backpack"
+	inhand_icon_state = "backpack"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -38,7 +38,7 @@
 	name = "bag of holding"
 	desc = "A backpack that opens into a localized pocket of bluespace."
 	icon_state = "holdingpack"
-	item_state = "holdingpack"
+	inhand_icon_state = "holdingpack"
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 	armor_type = /datum/armor/backpack_holding
@@ -52,7 +52,7 @@
 	name = "bag of honking"
 	desc = "An advanced clowning backpack for holding large quantities of pranking gear"
 	icon_state = "clownpack"
-	item_state = "clownpack"
+	inhand_icon_state = "clownpack"
 
 /obj/item/storage/backpack/holding/Initialize(mapload)
 	. = ..()
@@ -105,7 +105,7 @@
 	desc = "Space Santa uses this to deliver presents to all the nice children in space in Christmas! Wow, it's pretty big!"
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "giftbag0"
-	item_state = "giftbag"
+	inhand_icon_state = "giftbag"
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/backpack/santabag/Initialize(mapload)
@@ -138,86 +138,86 @@
 	name = "trophy rack"
 	desc = "It's useful for both carrying extra gear and proudly declaring your insanity."
 	icon_state = "cultpack"
-	item_state = "backpack"
+	inhand_icon_state = "backpack"
 
 /obj/item/storage/backpack/clown
 	name = "Giggles von Honkerton"
 	desc = "It's a backpack made by Honk! Co."
 	icon_state = "clownpack"
-	item_state = "clownpack"
+	inhand_icon_state = "clownpack"
 
 /obj/item/storage/backpack/explorer
 	name = "explorer bag"
 	desc = "A robust backpack for stashing your loot."
 	icon_state = "explorerpack"
-	item_state = "explorerpack"
+	inhand_icon_state = "explorerpack"
 
 /obj/item/storage/backpack/mime
 	name = "Parcel Parceaux"
 	desc = "A silent backpack made for those silent workers. Silence Co."
 	icon_state = "mimepack"
-	item_state = "mimepack"
+	inhand_icon_state = "mimepack"
 
 /obj/item/storage/backpack/medic
 	name = "medical backpack"
 	desc = "It's a backpack especially designed for use in a sterile environment."
 	icon_state = "medicalpack"
-	item_state = "medicalpack"
+	inhand_icon_state = "medicalpack"
 
 /obj/item/storage/backpack/security
 	name = "security backpack"
 	desc = "It's a very robust backpack."
 	icon_state = "securitypack"
-	item_state = "securitypack"
+	inhand_icon_state = "securitypack"
 
 /obj/item/storage/backpack/captain
 	name = "captain's backpack"
 	desc = "It's a special backpack made exclusively for Nanotrasen officers."
 	icon_state = "captainpack"
-	item_state = "captainpack"
+	inhand_icon_state = "captainpack"
 
 /obj/item/storage/backpack/industrial
 	name = "industrial backpack"
 	desc = "It's a tough backpack for the daily grind of station life."
 	icon_state = "engiepack"
-	item_state = "engiepack"
+	inhand_icon_state = "engiepack"
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/botany
 	name = "botany backpack"
 	desc = "It's a backpack made of all-natural fibers."
 	icon_state = "botpack"
-	item_state = "botpack"
+	inhand_icon_state = "botpack"
 
 /obj/item/storage/backpack/chemistry
 	name = "chemistry backpack"
 	desc = "A backpack specially designed to repel stains and hazardous liquids."
 	icon_state = "chempack"
-	item_state = "chempack"
+	inhand_icon_state = "chempack"
 
 /obj/item/storage/backpack/genetics
 	name = "genetics backpack"
 	desc = "A bag designed to be super tough, just in case someone hulks out on you."
 	icon_state = "genepack"
-	item_state = "genepack"
+	inhand_icon_state = "genepack"
 
 /obj/item/storage/backpack/science
 	name = "science backpack"
 	desc = "A specially designed backpack. It's fire resistant and smells vaguely of plasma."
 	icon_state = "toxpack"
-	item_state = "toxpack"
+	inhand_icon_state = "toxpack"
 
 /obj/item/storage/backpack/virology
 	name = "virology backpack"
 	desc = "A backpack made of hypo-allergenic fibers. It's designed to help prevent the spread of disease. Smells like monkey."
 	icon_state = "viropack"
-	item_state = "viropack"
+	inhand_icon_state = "viropack"
 
 /obj/item/storage/backpack/ert
 	name = "emergency response team commander backpack"
 	desc = "A spacious backpack with lots of pockets, worn by the Commander of an Emergency Response Team."
 	icon_state = "ert_commander"
-	item_state = "securitypack"
+	inhand_icon_state = "securitypack"
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/ert/Initialize(mapload)
@@ -249,31 +249,31 @@
 	name = "cak backpack"
 	desc = "A cute backpack resembling Cak."
 	icon_state = "cakpack"
-	item_state = "cakpack"
+	inhand_icon_state = "cakpack"
 
 /obj/item/storage/backpack/ian
 	name = "ian backpack"
 	desc = "A cute backpack resembling Ian."
 	icon_state = "ianpack"
-	item_state = "ianpack"
+	inhand_icon_state = "ianpack"
 
 /obj/item/storage/backpack/lisa
 	name = "lisa backpack"
 	desc = "A cute backpack resembling Lisa."
 	icon_state = "lisapack"
-	item_state = "lisapack"
+	inhand_icon_state = "lisapack"
 
 /obj/item/storage/backpack/renault
 	name = "renault backpack"
 	desc = "A cute backpack resembling Renault."
 	icon_state = "renaultpack"
-	item_state = "renaultpack"
+	inhand_icon_state = "renaultpack"
 
 /obj/item/storage/backpack/runtime
 	name = "runtime backpack"
 	desc = "A cute backpack resembling Runtime."
 	icon_state = "runtimepack"
-	item_state = "runtimepack"
+	inhand_icon_state = "runtimepack"
 
 /*
  * Satchel Types
@@ -288,7 +288,7 @@
 	name = "leather satchel"
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel"
-	item_state = "satchel"
+	inhand_icon_state = "satchel"
 
 /obj/item/storage/backpack/satchel/leather/withwallet/PopulateContents()
 	new /obj/item/storage/wallet/random(src)
@@ -300,68 +300,68 @@
 	name = "industrial satchel"
 	desc = "A tough satchel with extra pockets."
 	icon_state = "satchel-eng"
-	item_state = "satchel-eng"
+	inhand_icon_state = "satchel-eng"
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/satchel/med
 	name = "medical satchel"
 	desc = "A sterile satchel used in medical departments."
 	icon_state = "satchel-med"
-	item_state = "satchel-med"
+	inhand_icon_state = "satchel-med"
 
 /obj/item/storage/backpack/satchel/vir
 	name = "virologist satchel"
 	desc = "A sterile satchel with virologist colours."
 	icon_state = "satchel-vir"
-	item_state = "satchel-vir"
+	inhand_icon_state = "satchel-vir"
 
 /obj/item/storage/backpack/satchel/chem
 	name = "chemist satchel"
 	desc = "A sterile satchel with chemist colours."
 	icon_state = "satchel-chem"
-	item_state = "satchel-chem"
+	inhand_icon_state = "satchel-chem"
 
 /obj/item/storage/backpack/satchel/gen
 	name = "geneticist satchel"
 	desc = "A sterile satchel with geneticist colours."
 	icon_state = "satchel-gen"
-	item_state = "satchel-gen"
+	inhand_icon_state = "satchel-gen"
 
 /obj/item/storage/backpack/satchel/tox
 	name = "scientist satchel"
 	desc = "Useful for holding research materials."
 	icon_state = "satchel-tox"
-	item_state = "satchel-tox"
+	inhand_icon_state = "satchel-tox"
 
 /obj/item/storage/backpack/satchel/hyd
 	name = "botanist satchel"
 	desc = "A satchel made of all natural fibers."
 	icon_state = "satchel-hyd"
-	item_state = "satchel-hyd"
+	inhand_icon_state = "satchel-hyd"
 
 /obj/item/storage/backpack/satchel/sec
 	name = "security satchel"
 	desc = "A robust satchel for security related needs."
 	icon_state = "satchel-sec"
-	item_state = "satchel-sec"
+	inhand_icon_state = "satchel-sec"
 
 /obj/item/storage/backpack/satchel/explorer
 	name = "explorer satchel"
 	desc = "A robust satchel for stashing your loot."
 	icon_state = "satchel-explorer"
-	item_state = "satchel-explorer"
+	inhand_icon_state = "satchel-explorer"
 
 /obj/item/storage/backpack/satchel/cap
 	name = "captain's satchel"
 	desc = "An exclusive satchel for Nanotrasen officers."
 	icon_state = "satchel-cap"
-	item_state = "satchel-cap"
+	inhand_icon_state = "satchel-cap"
 
 /obj/item/storage/backpack/satchel/flat
 	name = "smuggler's satchel"
 	desc = "A very slim satchel that can easily fit into tight spaces."
 	icon_state = "satchel-flat"
-	item_state = "satchel-flat"
+	inhand_icon_state = "satchel-flat"
 	w_class = WEIGHT_CLASS_NORMAL //Can fit in backpacks itself.
 
 /obj/item/storage/backpack/satchel/flat/Initialize(mapload)
@@ -404,7 +404,7 @@
 	name = "mail bag"
 	desc = "A bag for letters, envelopes, and other postage."
 	icon_state = "mailbag"
-	item_state = "mailbag"
+	inhand_icon_state = "mailbag"
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 
 /obj/item/storage/backpack/satchel/mail/Initialize(mapload)
@@ -429,7 +429,7 @@
 	name = "duffel bag"
 	desc = "A large duffel bag for holding extra things."
 	icon_state = "duffel"
-	item_state = "duffel"
+	inhand_icon_state = "duffel"
 	slowdown = 1
 
 /obj/item/storage/backpack/duffelbag/Initialize(mapload)
@@ -440,13 +440,13 @@
 	name = "captain's duffel bag"
 	desc = "A large duffel bag for holding extra captainly goods."
 	icon_state = "duffel-captain"
-	item_state = "duffel-captain"
+	inhand_icon_state = "duffel-captain"
 
 /obj/item/storage/backpack/duffelbag/med
 	name = "medical duffel bag"
 	desc = "A large duffel bag for holding extra medical supplies."
 	icon_state = "duffel-med"
-	item_state = "duffel-med"
+	inhand_icon_state = "duffel-med"
 
 /obj/item/storage/backpack/duffelbag/med/surgery
 	name = "surgical duffel bag"
@@ -485,7 +485,7 @@
 	name = "security duffel bag"
 	desc = "A large duffel bag for holding extra security supplies and ammunition."
 	icon_state = "duffel-sec"
-	item_state = "duffel-sec"
+	inhand_icon_state = "duffel-sec"
 
 /obj/item/storage/backpack/duffelbag/sec/surgery
 	name = "surgical duffel bag"
@@ -521,14 +521,14 @@
 	name = "industrial duffel bag"
 	desc = "A large duffel bag for holding extra tools and supplies."
 	icon_state = "duffel-eng"
-	item_state = "duffel-eng"
+	inhand_icon_state = "duffel-eng"
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/duffelbag/drone
 	name = "drone duffel bag"
 	desc = "A large duffel bag for holding tools and hats."
 	icon_state = "duffel-drone"
-	item_state = "duffel-drone"
+	inhand_icon_state = "duffel-drone"
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/duffelbag/drone/PopulateContents()
@@ -544,14 +544,14 @@
 	name = "science duffel bag"
 	desc = "A large duffel bag for holding extra tools and artifacts."
 	icon_state = "duffel-drone"
-	item_state = "duffel-drone"
+	inhand_icon_state = "duffel-drone"
 	resistance_flags = FIRE_PROOF
 
 /obj/item/storage/backpack/duffelbag/clown
 	name = "clown's duffel bag"
 	desc = "A large duffel bag for holding lots of funny gags!"
 	icon_state = "duffel-clown"
-	item_state = "duffel-clown"
+	inhand_icon_state = "duffel-clown"
 
 /obj/item/storage/backpack/duffelbag/clown/cream_pie/PopulateContents()
 	for(var/i in 1 to 10)
@@ -564,7 +564,7 @@
 	name = "suspicious looking duffel bag"
 	desc = "A large duffel bag for holding extra tactical supplies."
 	icon_state = "duffel-syndie"
-	item_state = "duffel-syndieammo"
+	inhand_icon_state = "duffel-syndieammo"
 	slowdown = 0
 	resistance_flags = FIRE_PROOF
 
@@ -575,7 +575,7 @@
 /obj/item/storage/backpack/duffelbag/syndie/hitman
 	desc = "A large duffel bag for holding extra things. There is a Nanotrasen logo on the back."
 	icon_state = "duffel-syndieammo"
-	item_state = "duffel-syndieammo"
+	inhand_icon_state = "duffel-syndieammo"
 
 /obj/item/storage/backpack/duffelbag/syndie/hitman/PopulateContents()
 	new /obj/item/clothing/under/suit/black(src)
@@ -590,13 +590,13 @@
 	name = "medical duffel bag"
 	desc = "A large duffel bag for holding extra tactical medical supplies."
 	icon_state = "duffel-syndiemed"
-	item_state = "duffel-syndiemed"
+	inhand_icon_state = "duffel-syndiemed"
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery
 	name = "surgery duffel bag"
 	desc = "A suspicious looking duffel bag for holding surgery tools."
 	icon_state = "duffel-syndiemed"
-	item_state = "duffel-syndiemed"
+	inhand_icon_state = "duffel-syndiemed"
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery/PopulateContents()
 	new /obj/item/scalpel(src)
@@ -614,7 +614,7 @@
 	name = "ammunition duffel bag"
 	desc = "A large duffel bag for holding extra weapons ammunition and supplies."
 	icon_state = "duffel-syndieammo"
-	item_state = "duffel-syndieammo"
+	inhand_icon_state = "duffel-syndieammo"
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun
 	desc = "A large duffel bag, packed to the brim with Bulldog shotgun magazines."

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -36,7 +36,7 @@
 	desc = "It's the heavy-duty black polymer kind. Time to take out the trash!"
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "trashbag"
-	item_state = "trashbag"
+	inhand_icon_state = "trashbag"
 	worn_icon_state = "trashbag"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/belts.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	icon_state = "utilitybelt"
-	item_state = "utility"
+	inhand_icon_state = "utility"
 	worn_icon_state = "utility"
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
@@ -38,7 +38,7 @@
 	name = "toolbelt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
 	desc = "Holds tools."
 	icon_state = "utilitybelt"
-	item_state = "utility"
+	inhand_icon_state = "utility"
 	worn_icon_state = "utility"
 	content_overlays = TRUE
 	custom_price = 50
@@ -80,7 +80,7 @@
 	name = "botanical belt"
 	desc = "Can hold various botanical equipment."
 	icon_state = "botanical"
-	item_state = "botanical"
+	inhand_icon_state = "botanical"
 	worn_icon_state = "botanical"
 	content_overlays = TRUE
 
@@ -111,7 +111,7 @@
 	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun
 	desc = "Holds tools, looks snazzy."
 	icon_state = "utilitybelt_ce"
-	item_state = "utility_ce"
+	inhand_icon_state = "utility_ce"
 	worn_icon_state = "utility_ce"
 
 /obj/item/storage/belt/utility/chief/full
@@ -256,7 +256,7 @@
 	name = "medical belt"
 	desc = "Can hold various medical equipment."
 	icon_state = "medicalbelt"
-	item_state = "medical"
+	inhand_icon_state = "medical"
 	worn_icon_state = "medical"
 	content_overlays = TRUE
 
@@ -336,7 +336,7 @@
 	name = "security belt"
 	desc = "Can hold security gear like handcuffs and flashes."
 	icon_state = "securitybelt"
-	item_state = "security"//Could likely use a better one.
+	inhand_icon_state = "security"//Could likely use a better one.
 	worn_icon_state = "security"
 	content_overlays = TRUE
 
@@ -387,7 +387,7 @@
 	name = "security webbing"
 	desc = "Unique and versatile chest rig, can hold security gear."
 	icon_state = "securitywebbing"
-	item_state = "securitywebbing"
+	inhand_icon_state = "securitywebbing"
 	worn_icon_state = "securitywebbing"
 	content_overlays = FALSE
 	custom_premium_price = 800
@@ -396,7 +396,7 @@
 	name = "explorer's webbing"
 	desc = "A versatile chest rig, cherished by miners and hunters alike."
 	icon_state = "explorer1"
-	item_state = "explorer1"
+	inhand_icon_state = "explorer1"
 	worn_icon_state = "explorer1"
 
 /obj/item/storage/belt/mining/Initialize(mapload)
@@ -460,14 +460,14 @@
 
 /obj/item/storage/belt/mining/alt
 	icon_state = "explorer2"
-	item_state = "explorer2"
+	inhand_icon_state = "explorer2"
 	worn_icon_state = "explorer2"
 
 /obj/item/storage/belt/mining/primitive
 	name = "hunter's belt"
 	desc = "A versatile belt, woven from sinew."
 	icon_state = "ebelt"
-	item_state = "ebelt"
+	inhand_icon_state = "ebelt"
 	worn_icon_state = "ebelt"
 
 /obj/item/storage/belt/mining/primitive/Initialize(mapload)
@@ -478,7 +478,7 @@
 	name = "soul stone belt"
 	desc = "Designed for ease of access to the shards during a fight, as to not let a single enemy spirit slip away."
 	icon_state = "soulstonebelt"
-	item_state = "soulstonebelt"
+	inhand_icon_state = "soulstonebelt"
 	worn_icon_state = "soulstonebelt"
 
 /obj/item/storage/belt/soulstone/Initialize(mapload)
@@ -504,7 +504,7 @@
 	name = "championship belt"
 	desc = "Proves to the world that you are the strongest!"
 	icon_state = "championbelt"
-	item_state = "champion"
+	inhand_icon_state = "champion"
 	worn_icon_state = "champion"
 	custom_materials = list(/datum/material/gold=400)
 
@@ -519,7 +519,7 @@
 	name = "chest rig"
 	desc = "A set of tactical webbing worn by Syndicate boarding parties."
 	icon_state = "militarywebbing"
-	item_state = "militarywebbing"
+	inhand_icon_state = "militarywebbing"
 	worn_icon_state = "militarywebbing"
 	resistance_flags = FIRE_PROOF
 
@@ -577,7 +577,7 @@
 	desc = "A belt used by abductor agents."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "belt"
-	item_state = "security"
+	inhand_icon_state = "security"
 	worn_icon_state = "security"
 
 /obj/item/storage/belt/military/abductor/full/PopulateContents()
@@ -595,7 +595,7 @@
 	desc = "A belt used by abductor agents."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "belt"
-	item_state = "security"
+	inhand_icon_state = "security"
 	worn_icon_state = "security"
 
 /obj/item/storage/belt/military/abductor/med/PopulateContents()
@@ -612,21 +612,21 @@
 	name = "army belt"
 	desc = "A belt used by military forces."
 	icon_state = "grenadebeltold"
-	item_state = "security"
+	inhand_icon_state = "security"
 	worn_icon_state = "security"
 
 /obj/item/storage/belt/military/assault
 	name = "assault belt"
 	desc = "A tactical assault belt."
 	icon_state = "assaultbelt"
-	item_state = "security"
+	inhand_icon_state = "security"
 	worn_icon_state = "security"
 
 /obj/item/storage/belt/grenade
 	name = "grenadier belt"
 	desc = "A belt for holding grenades."
 	icon_state = "grenadebeltnew"
-	item_state = "security"
+	inhand_icon_state = "security"
 	worn_icon_state = "security"
 
 /obj/item/storage/belt/grenade/Initialize(mapload)
@@ -664,14 +664,14 @@
 	name = "grenadier chest rig"
 	desc = "A set of tactical webbing stocked full of grenades."
 	icon_state = "militarywebbing"
-	item_state = "militarywebbing"
+	inhand_icon_state = "militarywebbing"
 	worn_icon_state = "militarywebbing"
 
 /obj/item/storage/belt/wands
 	name = "wand belt"
 	desc = "A belt designed to hold various rods of power. A veritable fanny pack of exotic magic."
 	icon_state = "soulstonebelt"
-	item_state = "soulstonebelt"
+	inhand_icon_state = "soulstonebelt"
 	worn_icon_state = "soulstonebelt"
 
 /obj/item/storage/belt/wands/Initialize(mapload)
@@ -697,7 +697,7 @@
 	name = "janibelt"
 	desc = "A belt used to hold most janitorial supplies."
 	icon_state = "janibelt"
-	item_state = "janibelt"
+	inhand_icon_state = "janibelt"
 	worn_icon_state = "janibelt"
 
 /obj/item/storage/belt/janitor/Initialize(mapload)
@@ -731,7 +731,7 @@
 	name = "bandolier"
 	desc = "A bandolier for holding shotgun ammunition."
 	icon_state = "bandolier"
-	item_state = "bandolier"
+	inhand_icon_state = "bandolier"
 	worn_icon_state = "bandolier"
 
 /obj/item/storage/belt/bandolier/Initialize(mapload)
@@ -763,7 +763,7 @@
 	name = "leather quiver"
 	desc = "A quiver made from the hide of some animal. Used to hold arrows."
 	icon_state = "quiver"
-	item_state = "quiver"
+	inhand_icon_state = "quiver"
 	worn_icon_state = "quiver"
 
 /obj/item/storage/belt/quiver/Initialize(mapload)
@@ -781,7 +781,7 @@
 	name = "fannypack"
 	desc = "A dorky fannypack for keeping small items in."
 	icon_state = "fannypack_leather"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon_state = "fannypack_leather"
 	dying_key = DYE_REGISTRY_FANNYPACK
 	custom_price = 15
@@ -795,7 +795,7 @@
 	name = "Worn belt"
 	desc = "A weathered belt that is used for storing various gadgets"
 	icon_state = "utilitybelt" //Placeholder for now.
-	item_state = "utility"
+	inhand_icon_state = "utility"
 	worn_icon_state = "utility"
 
 /obj/item/storage/belt/fannypack/black
@@ -858,7 +858,7 @@
 	name = "sabre sheath"
 	desc = "An ornate sheath designed to hold an officer's blade."
 	icon_state = "sheath"
-	item_state = "sheath"
+	inhand_icon_state = "sheath"
 	worn_icon_state = "sheath"
 	w_class = WEIGHT_CLASS_BULKY
 
@@ -891,11 +891,11 @@
 
 /obj/item/storage/belt/sabre/update_icon_state()
 	icon_state = initial(icon_state)
-	item_state = initial(item_state)
+	inhand_icon_state = initial(inhand_icon_state)
 	worn_icon_state = initial(worn_icon_state)
 	if(contents.len)
 		icon_state += "-sabre"
-		item_state += "-sabre"
+		inhand_icon_state += "-sabre"
 		worn_icon_state += "-sabre"
 	return ..()
 
@@ -908,14 +908,14 @@
 	desc = "Bon appetit!"
 	icon = 'icons/obj/food/burgerbread.dmi'
 	icon_state = "baguette"
-	item_state = "baguette"
+	inhand_icon_state = "baguette"
 	worn_icon_state = "baguette"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 
 /obj/item/storage/belt/sabre/mime/update_icon()
 	icon_state = "baguette"
-	item_state = "baguette"
+	inhand_icon_state = "baguette"
 
 /obj/item/storage/belt/sabre/mime/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -28,7 +28,7 @@
 	desc = "Apply to head repeatedly."
 	icon = 'icons/obj/storage/book.dmi'
 	icon_state = "bible"
-	item_state = "bible"
+	inhand_icon_state = "bible"
 	lefthand_file = 'icons/mob/inhands/misc/books_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/books_righthand.dmi'
 	var/mob/affecting = null
@@ -52,7 +52,7 @@
 	if(!current_skin && H.mind.holy_role == HOLY_ROLE_HIGHPRIEST)
 		if(GLOB.bible_icon_state)//If the original has been reskinned but this one hasn't been, we make it look like the original
 			icon_state = GLOB.bible_icon_state
-			item_state = GLOB.bible_item_state
+			inhand_icon_state = GLOB.bible_inhand_icon_state
 			if(icon_state == "honk1" || icon_state == "honk2")
 				var/mob/living/carbon/C = H
 				if(C.has_dna())
@@ -110,8 +110,8 @@
 		current_skin = choice
 		icon_state = unique_reskin_icon[choice]
 		GLOB.bible_icon_state = icon_state
-		item_state = unique_reskin_icon[choice]
-		GLOB.bible_item_state = item_state
+		inhand_icon_state = unique_reskin_icon[choice]
+		GLOB.bible_inhand_icon_state = inhand_icon_state
 		if(choice == "Clown Bible" || choice == "Banana Bible")
 			var/mob/living/carbon/C = M
 			if(C.has_dna())
@@ -224,7 +224,7 @@
 			var/obj/item/storage/book/bible/B = A
 			B.name = name
 			B.icon_state = icon_state
-			B.item_state = item_state
+			B.inhand_icon_state = inhand_icon_state
 
 	else if(istype(A, /obj/item/soulstone) && !iscultist(user))
 		var/obj/item/soulstone/SS = A

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -28,7 +28,7 @@
 	icon = 'icons/obj/storage/box.dmi'
 	w_class = WEIGHT_CLASS_MEDIUM
 	icon_state = "box"
-	item_state = "syringe_kit"
+	inhand_icon_state = "syringe_kit"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	resistance_flags = FLAMMABLE
@@ -116,7 +116,7 @@
 	desc = "Unfortunately not large enough to trap the mime."
 	foldable = null
 	icon_state = "box"
-	item_state = null
+	inhand_icon_state = null
 	alpha = 0
 
 /obj/item/storage/box/mime/attack_hand(mob/user, list/modifiers)
@@ -779,7 +779,7 @@
 	desc = "A small box of Almost But Not Quite Plasma Premium Matches."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "matchbox"
-	item_state = "zippo"
+	inhand_icon_state = "zippo"
 	worn_icon_state = "lighter"
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_BELT
@@ -804,7 +804,7 @@
 	name = "box of replacement bulbs"
 	illustration = "light"
 	desc = "This box is shaped on the inside so that only light tubes and bulbs fit."
-	item_state = "syringe_kit"
+	inhand_icon_state = "syringe_kit"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	foldable = /obj/item/stack/sheet/cardboard //BubbleWrap
@@ -970,7 +970,7 @@
 	if(theme_name)
 		name = "[name] ([theme_name])"
 		desc = "A box containing supplementary ingredients for the aspiring chef. The box's theme is '[theme_name]'."
-		item_state = "syringe_kit"
+		inhand_icon_state = "syringe_kit"
 
 /obj/item/storage/box/ingredients/wildcard
 	theme_name = "wildcard"

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -116,7 +116,7 @@
 
 /obj/item/storage/fancy/egg_box
 	icon = 'icons/obj/food/containers.dmi'
-	item_state = "eggbox"
+	inhand_icon_state = "eggbox"
 	icon_state = "eggbox"
 	base_icon_state = "eggbox"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
@@ -141,7 +141,7 @@
 	icon = 'icons/obj/candle.dmi'
 	icon_state = "candlebox5"
 	base_icon_state = "candlebox"
-	item_state = "candlebox5"
+	inhand_icon_state = "candlebox5"
 	worn_icon_state = "cigpack"
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 2
@@ -161,7 +161,7 @@
 	desc = "The most popular brand of cigarettes, sponsors of the Space Olympics."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cig"
-	item_state = "cigpacket"
+	inhand_icon_state = "cigpacket"
 	base_icon_state = "cig"
 	worn_icon_state = "cigpack"
 	w_class = WEIGHT_CLASS_TINY
@@ -399,7 +399,7 @@
 	name = "heart-shaped box"
 	desc = "A heart-shaped box for holding tiny chocolates."
 	icon = 'icons/obj/food/containers.dmi'
-	item_state = "chocolatebox"
+	inhand_icon_state = "chocolatebox"
 	icon_state = "chocolatebox"
 	base_icon_state = "chocolatebox"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -15,7 +15,7 @@
 	desc = "It's an emergency medical kit for those serious boo-boos."
 	icon = 'icons/obj/storage/medkit.dmi'
 	icon_state = "firstaid"
-	item_state = "firstaid"
+	inhand_icon_state = "firstaid"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	throw_speed = 3
@@ -57,7 +57,7 @@
 /obj/item/storage/firstaid/medical
 	name = "doctor's bag"
 	icon_state = "firstaid-surgeryalt"
-	item_state = "firstaid-surgeryalt"
+	inhand_icon_state = "firstaid-surgeryalt"
 	worn_icon = 'icons/mob/clothing/belt.dmi'
 	worn_icon_state = "firstaid_surgeryalt"
 	desc = "A fancy high capacity aid kit for doctors, full of medical supplies and basic surgical equipment"
@@ -136,7 +136,7 @@
 /obj/item/storage/firstaid/medical/paramedic
 	name = "paramedics medical bag"
 	icon_state = "firstaid-surgeryalt"
-	item_state = "firstaid-surgeryalt"
+	inhand_icon_state = "firstaid-surgeryalt"
 	worn_icon = 'icons/mob/clothing/belt.dmi'
 	worn_icon_state = "firstaid_surgeryalt"
 	desc = "A not-so fancy high capacity aid kit for paramedics, filled with 'top of the line' medical supplies."
@@ -239,7 +239,7 @@
 	name = "burn treatment kit"
 	desc = "A specialized medical kit for when the toxins lab <i>-spontaneously-</i> burns down."
 	icon_state = "firstaid-burn"
-	item_state = "firstaid-burn"
+	inhand_icon_state = "firstaid-burn"
 	skin_type = MEDBOT_SKIN_BURN
 
 /obj/item/storage/firstaid/fire/suicide_act(mob/living/carbon/user)
@@ -263,7 +263,7 @@
 	name = "toxin treatment kit"
 	desc = "Used to treat toxic blood content and radiation poisoning."
 	icon_state = "firstaid-toxin"
-	item_state = "firstaid-toxin"
+	inhand_icon_state = "firstaid-toxin"
 	skin_type = MEDBOT_SKIN_TOXIN
 
 /obj/item/storage/firstaid/toxin/suicide_act(mob/living/carbon/user)
@@ -290,7 +290,7 @@
 	name = "radiation treatment kit"
 	desc = "Used to treat minor toxic blood content and major radiation poisoning."
 	icon_state = "firstaid-rad"
-	item_state = "firstaid-rad"
+	inhand_icon_state = "firstaid-rad"
 	skin_type = MEDBOT_SKIN_RADIATION
 
 /obj/item/storage/firstaid/radbgone/suicide_act(mob/living/carbon/user)
@@ -315,7 +315,7 @@
 	name = "oxygen deprivation treatment kit"
 	desc = "A box full of oxygen goodies."
 	icon_state = "firstaid-o2"
-	item_state = "firstaid-o2"
+	inhand_icon_state = "firstaid-o2"
 
 /obj/item/storage/firstaid/o2/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins hitting [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -340,7 +340,7 @@
 	name = "brute trauma treatment kit"
 	desc = "A first aid kit for when you get toolboxed."
 	icon_state = "firstaid-brute"
-	item_state = "firstaid-brute"
+	inhand_icon_state = "firstaid-brute"
 	skin_type = MEDBOT_SKIN_BRUTE
 
 /obj/item/storage/firstaid/brute/suicide_act(mob/living/carbon/user)
@@ -367,7 +367,7 @@
 	name = "advanced first aid kit"
 	desc = "An advanced kit to help deal with advanced wounds."
 	icon_state = "firstaid-advanced"
-	item_state = "firstaid-advanced"
+	inhand_icon_state = "firstaid-advanced"
 	custom_premium_price = 600
 	skin_type = MEDBOT_SKIN_ADVANCED
 
@@ -396,7 +396,7 @@
 	name = "mystery medical kit"
 	desc = "Are you feeling lucky today?"
 	icon_state = "firstaid-mystery"
-	item_state = "firstaid-mystery"
+	inhand_icon_state = "firstaid-mystery"
 	skin_type = NONE
 
 /obj/item/storage/firstaid/random/Initialize(mapload)
@@ -439,7 +439,7 @@
 	name = "combat medical kit"
 	desc = "I hope you've got insurance."
 	icon_state = "firstaid-combat"
-	item_state = "firstaid-combat"
+	inhand_icon_state = "firstaid-combat"
 	skin_type = MEDBOT_SKIN_SYNDI
 	w_class = WEIGHT_CLASS_NORMAL
 
@@ -503,7 +503,7 @@
 	name = "infiltrator medical kit"
 	desc = "(Un)fortunately for you, the Syndicate has a good medical plan."
 	icon_state = "firstaid-combat"
-	item_state = "firstaid-combat"
+	inhand_icon_state = "firstaid-combat"
 	skin_type = MEDBOT_SKIN_SYNDI
 	w_class = WEIGHT_CLASS_NORMAL
 
@@ -553,7 +553,7 @@
 	desc = "It's an airtight container for storing medication."
 	icon_state = "pill_canister_0"
 	icon = 'icons/obj/medicine_containers.dmi'
-	item_state = "contsolid"
+	inhand_icon_state = "contsolid"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -3,7 +3,7 @@
 	desc = "A locked box."
 	icon = 'icons/obj/storage/case.dmi'
 	icon_state = "lockbox+l"
-	item_state = "lockbox+l"
+	inhand_icon_state = "lockbox+l"
 	lefthand_file = 'icons/mob/inhands/equipment/case_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/case_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -30,13 +30,13 @@
 			locked = atom_storage.locked
 			if(locked)
 				icon_state = "[base_icon_state]+l"
-				item_state = "[base_icon_state]+l"
+				inhand_icon_state = "[base_icon_state]+l"
 				to_chat(user, span_danger("You lock the [src.name]!"))
 				atom_storage.close_all()
 				return
 			else
 				icon_state = "[base_icon_state]"
-				item_state = "[base_icon_state]"
+				inhand_icon_state = "[base_icon_state]"
 				to_chat(user, span_danger("You unlock the [src.name]!"))
 				return
 		else
@@ -56,7 +56,7 @@
 	atom_storage.locked = FALSE
 	desc += "It appears to be broken."
 	icon_state = "[src.base_icon_state]+b"
-	item_state = "[src.base_icon_state]+b"
+	inhand_icon_state = "[src.base_icon_state]+b"
 	user?.visible_message(span_warning("[user] breaks \the [src] with an electromagnetic card!"))
 
 /obj/item/storage/lockbox/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
@@ -82,7 +82,7 @@
 	name = "medal box"
 	desc = "A locked box used to store medals of honor."
 	icon_state = "medalbox+l"
-	item_state = "medalbox+l"
+	inhand_icon_state = "medalbox+l"
 	base_icon_state = "medalbox"
 	w_class = WEIGHT_CLASS_NORMAL
 	req_access = list(ACCESS_CAPTAIN)
@@ -119,15 +119,15 @@
 /obj/item/storage/lockbox/medal/update_icon_state()
 	if(atom_storage?.locked)
 		icon_state = "[base_icon_state]+l"
-		item_state = "[base_icon_state]+l"
+		inhand_icon_state = "[base_icon_state]+l"
 	else
 		icon_state = "[base_icon_state]"
-		item_state = "[base_icon_state]"
+		inhand_icon_state = "[base_icon_state]"
 		if(open)
 			icon_state += "open"
 		if(broken)
 			icon_state += "+b"
-			item_state = "[base_icon_state]+b"
+			inhand_icon_state = "[base_icon_state]+b"
 	return ..()
 
 /obj/item/storage/lockbox/medal/update_overlays()

--- a/code/game/objects/items/storage/paperbag.dm
+++ b/code/game/objects/items/storage/paperbag.dm
@@ -10,16 +10,16 @@
 	desc = "A sack neatly crafted out of paper."
 	icon = 'icons/obj/storage/paperbag.dmi'
 	icon_state = "paperbag_None"
-	item_state = "paperbag_None"
+	inhand_icon_state = "paperbag_None"
 	resistance_flags = FLAMMABLE
 	foldable = null
 	var/design = NODESIGN
 
 /obj/item/storage/box/papersack/update_icon_state()
 	if(contents.len == 0)
-		icon_state = "[item_state]"
+		icon_state = "[inhand_icon_state]"
 	else
-		icon_state = "[item_state]_closed"
+		icon_state = "[inhand_icon_state]_closed"
 	return ..()
 
 /obj/item/storage/box/papersack/attackby(obj/item/W, mob/user, params)
@@ -39,7 +39,7 @@
 		to_chat(usr, span_notice("You make some modifications to [src] using your pen."))
 		design = designs[choice]
 		icon_state = "paperbag_[design]"
-		item_state = "paperbag_[design]"
+		inhand_icon_state = "paperbag_[design]"
 		switch(designs[choice])
 			if(NODESIGN)
 				desc = "A sack neatly crafted out of paper."
@@ -54,12 +54,12 @@
 		return 0
 	else if(W.is_sharp())
 		if(!contents.len)
-			if(item_state == "paperbag_None")
+			if(inhand_icon_state == "paperbag_None")
 				user.show_message(span_notice("You cut eyeholes into [src]."), MSG_VISUAL)
 				new /obj/item/clothing/head/costume/papersack(user.loc)
 				qdel(src)
 				return 0
-			else if(item_state == "paperbag_SmileyFace")
+			else if(inhand_icon_state == "paperbag_SmileyFace")
 				user.show_message(span_notice("You cut eyeholes into [src] and modify the design."), MSG_VISUAL)
 				new /obj/item/clothing/head/costume/papersack/smiley(user.loc)
 				qdel(src)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -123,7 +123,7 @@
 /obj/item/storage/secure/briefcase
 	name = "secure briefcase"
 	icon_state = "sec-case"
-	item_state = "sec-case"
+	inhand_icon_state = "sec-case"
 	lefthand_file = 'icons/mob/inhands/equipment/case_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/case_righthand.dmi'
 	desc = "A large briefcase with a digital locking system."

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -3,7 +3,7 @@
 	desc = "Danger. Very robust."
 	icon = 'icons/obj/storage/toolbox.dmi'
 	icon_state = "toolbox_default"
-	item_state = "toolbox_default"
+	inhand_icon_state = "toolbox_default"
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	flags_1 = CONDUCT_1
@@ -45,7 +45,7 @@
 /obj/item/storage/toolbox/emergency
 	name = "emergency toolbox"
 	icon_state = "red"
-	item_state = "toolbox_red"
+	inhand_icon_state = "toolbox_red"
 	material_flags = NONE
 
 /obj/item/storage/toolbox/emergency/PopulateContents()
@@ -70,7 +70,7 @@
 /obj/item/storage/toolbox/mechanical
 	name = "mechanical toolbox"
 	icon_state = "blue"
-	item_state = "toolbox_blue"
+	inhand_icon_state = "toolbox_blue"
 	material_flags = NONE
 
 /obj/item/storage/toolbox/mechanical/PopulateContents()
@@ -107,7 +107,7 @@
 	name = "toolbox"
 	desc = "A old, blue toolbox, it looks robust."
 	icon_state = "oldtoolboxclean"
-	item_state = "toolbox_blue"
+	inhand_icon_state = "toolbox_blue"
 	has_latches = FALSE
 	force = 19
 	throwforce = 22
@@ -139,7 +139,7 @@
 /obj/item/storage/toolbox/electrical
 	name = "electrical toolbox"
 	icon_state = "yellow"
-	item_state = "toolbox_yellow"
+	inhand_icon_state = "toolbox_yellow"
 	material_flags = NONE
 
 /obj/item/storage/toolbox/electrical/PopulateContents()
@@ -158,7 +158,7 @@
 /obj/item/storage/toolbox/syndicate
 	name = "suspicious looking toolbox"
 	icon_state = "syndicate"
-	item_state = "toolbox_syndi"
+	inhand_icon_state = "toolbox_syndi"
 	force = 15
 	throwforce = 18
 	material_flags = NONE
@@ -179,7 +179,7 @@
 /obj/item/storage/toolbox/drone
 	name = "mechanical toolbox"
 	icon_state = "blue"
-	item_state = "toolbox_blue"
+	inhand_icon_state = "toolbox_blue"
 	material_flags = NONE
 
 /obj/item/storage/toolbox/drone/PopulateContents()
@@ -196,7 +196,7 @@
 	name = "brass box"
 	desc = "A huge brass box with several indentations in its surface."
 	icon_state = "brassbox"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon_state = null
 	has_latches = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
@@ -226,7 +226,7 @@
 	name = "artistic toolbox"
 	desc = "A toolbox painted bright green. Why anyone would store art supplies in a toolbox is beyond you, but it has plenty of extra space."
 	icon_state = "green"
-	item_state = "artistic_toolbox"
+	inhand_icon_state = "artistic_toolbox"
 	w_class = WEIGHT_CLASS_GIGANTIC //Holds more than a regular toolbox!
 	material_flags = NONE
 
@@ -252,7 +252,7 @@
 	desc = "It contains a few clips."
 	icon = 'icons/obj/storage/case.dmi'
 	icon_state = "ammobox"
-	item_state = "ammobox"
+	inhand_icon_state = "ammobox"
 	drop_sound = 'sound/items/handling/ammobox_drop.ogg'
 	pickup_sound =  'sound/items/handling/ammobox_pickup.ogg'
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -3,7 +3,7 @@
 	desc = "A stun baton for incapacitating people with. Left click to stun, right click to baton shove."
 
 	icon_state = "stunbaton"
-	item_state = "baton"
+	inhand_icon_state = "baton"
 	worn_icon_state = "classic_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -276,7 +276,7 @@
 	name = "stunprod"
 	desc = "An improvised stun baton."
 	icon_state = "stunprod"
-	item_state = "prod"
+	inhand_icon_state = "prod"
 	worn_icon_state = null
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -2,7 +2,7 @@
 	name = "jetpack (empty)"
 	desc = "A tank of compressed gas for use as propulsion in zero-gravity areas. Use with caution."
 	icon_state = "jetpack"
-	item_state = "jetpack"
+	inhand_icon_state = "jetpack"
 	lefthand_file = 'icons/mob/inhands/equipment/jetpacks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/jetpacks_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -143,7 +143,7 @@
 	name = "improvised jetpack"
 	desc = "A jetpack made from two air tanks, a fire extinguisher and some atmospherics equipment. It doesn't look like it can hold much."
 	icon_state = "jetpack-improvised"
-	item_state = "jetpack-sec"
+	inhand_icon_state = "jetpack-sec"
 	worn_icon = null
 	volume = 20 //normal jetpacks have 70 volume
 	gas_type = null //it starts empty
@@ -169,19 +169,19 @@
 	name = "void jetpack (oxygen)"
 	desc = "It works well in a void."
 	icon_state = "jetpack-void"
-	item_state =  "jetpack-void"
+	inhand_icon_state =  "jetpack-void"
 
 /obj/item/tank/jetpack/oxygen
 	name = "jetpack (oxygen)"
 	desc = "A tank of compressed oxygen for use as propulsion in zero-gravity areas. Use with caution."
 	icon_state = "jetpack"
-	item_state = "jetpack"
+	inhand_icon_state = "jetpack"
 
 /obj/item/tank/jetpack/oxygen/harness
 	name = "jet harness (oxygen)"
 	desc = "A lightweight tactical harness, used by those who don't want to be weighed down by traditional jetpacks."
 	icon_state = "jetpack-mini"
-	item_state = "jetpack-black"
+	inhand_icon_state = "jetpack-black"
 	volume = 40
 	throw_range = 7
 	w_class = WEIGHT_CLASS_LARGE
@@ -191,7 +191,7 @@
 	name = "\improper Captain's jetpack"
 	desc = "A compact, lightweight jetpack containing a high amount of compressed oxygen."
 	icon_state = "jetpack-captain"
-	item_state = "jetpack-captain"
+	inhand_icon_state = "jetpack-captain"
 	w_class = WEIGHT_CLASS_LARGE
 	volume = 90
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //steal objective items are hard to destroy.
@@ -201,13 +201,13 @@
 	name = "security jetpack (oxygen)"
 	desc = "A tank of compressed oxygen for use as propulsion in zero-gravity areas by security forces."
 	icon_state = "jetpack-sec"
-	item_state = "jetpack-sec"
+	inhand_icon_state = "jetpack-sec"
 
 /obj/item/tank/jetpack/combustion
 	name = "rocket jetpack"
 	desc = "A jetpack capable of powerful flight, strong enough to counteract the effects of gravity. Uses the high energy output of plasma combustion to generate enough thrust."
 	icon_state = "jetpack-rocket"
-	item_state =  "jetpack-rocket"
+	inhand_icon_state =  "jetpack-rocket"
 	gas_type = null
 	use_ion_trail = FALSE
 	var/gravity_joules = 10000
@@ -385,7 +385,7 @@
 	name = "jetpack (carbon dioxide)"
 	desc = "A tank of compressed carbon dioxide for use as propulsion in zero-gravity areas. Painted black to indicate that it should not be used as a source for internals."
 	icon_state = "jetpack-black"
-	item_state =  "jetpack-black"
+	inhand_icon_state =  "jetpack-black"
 	distribute_pressure = 0
 	gas_type = /datum/gas/carbon_dioxide
 
@@ -395,7 +395,7 @@
 	name = "hardsuit jetpack upgrade"
 	desc = "A modular, compact set of thrusters designed to integrate with a hardsuit. It is fueled by a tank inserted into the suit's storage compartment."
 	icon_state = "jetpack-mining"
-	item_state = "jetpack-black"
+	inhand_icon_state = "jetpack-black"
 	w_class = WEIGHT_CLASS_NORMAL
 	actions_types = list(/datum/action/item_action/toggle_jetpack, /datum/action/item_action/jetpack_stabilization)
 	volume = 1

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -52,7 +52,7 @@
 	name = "anesthetic tank"
 	desc = "A tank with an N2O/O2 gas mix."
 	icon_state = "anesthetic"
-	item_state = "an_tank"
+	inhand_icon_state = "an_tank"
 	force = 10
 
 /obj/item/tank/internals/anesthetic/populate_gas()
@@ -71,7 +71,7 @@
 	name = "air tank"
 	desc = "Mixed anyone?"
 	icon_state = "air"
-	item_state = "air"
+	inhand_icon_state = "air"
 	force = 10
 	dog_fashion = /datum/dog_fashion/back
 
@@ -121,7 +121,7 @@
 	name = "extended-capacity plasma internals tank"
 	desc = "A tank of plasma gas designed specifically for use as internals, particularly for plasma-based lifeforms. If you're not a Plasmaman, you probably shouldn't use this."
 	icon_state = "plasmaman_tank"
-	item_state = "plasmaman_tank"
+	inhand_icon_state = "plasmaman_tank"
 	worn_icon_state = "plasmaman_tank"
 	force = 10
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
@@ -139,7 +139,7 @@
 /obj/item/tank/internals/plasmaman/belt
 	name = "plasma internals belt tank"
 	icon_state = "plasmaman_tank_belt"
-	item_state = "plasmaman_tank_belt"
+	inhand_icon_state = "plasmaman_tank_belt"
 	worn_icon_state = "plasmaman_tank_belt"
 	worn_icon = null
 	slot_flags = ITEM_SLOT_BELT

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -4,7 +4,7 @@
 	desc = "A S.U.N.S.H.I.N.E. brand watertank backpack with nozzle to water plants."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "waterbackpack"
-	item_state = "waterbackpack"
+	inhand_icon_state = "waterbackpack"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -166,7 +166,7 @@
 	desc = "A mister nozzle attached to a water tank."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "mister"
-	item_state = "mister"
+	inhand_icon_state = "mister"
 	lefthand_file = 'icons/mob/inhands/equipment/mister_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mister_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -204,7 +204,7 @@
 	name = "backpack cleaner tank"
 	desc = "A janitorial cleaner backpack with nozzle to clean blood and graffiti."
 	icon_state = "waterbackpackjani"
-	item_state = "waterbackpackjani"
+	inhand_icon_state = "waterbackpackjani"
 	custom_price = 100
 
 /obj/item/watertank/janitor/Initialize(mapload)
@@ -217,7 +217,7 @@
 	desc = "A janitorial spray nozzle attached to a watertank, designed to clean up large messes."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "misterjani"
-	item_state = "misterjani"
+	inhand_icon_state = "misterjani"
 	lefthand_file = 'icons/mob/inhands/equipment/mister_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mister_righthand.dmi'
 	amount_per_transfer_from_this = 5
@@ -241,7 +241,7 @@
 	name = "backpack firefighter tank"
 	desc = "A refrigerated and pressurized backpack tank with extinguisher nozzle, intended to fight fires. Swaps between extinguisher, resin launcher and a smaller scale resin foamer."
 	icon = 'icons/obj/atmospherics/equipment.dmi'
-	item_state = "waterbackpackatmos"
+	inhand_icon_state = "waterbackpackatmos"
 	icon_state = "waterbackpackatmos"
 	worn_icon_state = "waterbackpackatmos"
 	volume = 200
@@ -279,9 +279,9 @@
 	if(noz)
 		var/obj/item/extinguisher/mini/nozzle/sprayer = noz
 		if(sprayer.toggled)
-			item_state = "[initial(item_state)]_on"
+			inhand_icon_state = "[initial(inhand_icon_state)]_on"
 		else
-			item_state = initial(item_state)
+			inhand_icon_state = initial(inhand_icon_state)
 		if(istype(loc, /mob/living/carbon))
 			var/mob/living/carbon/wearer = loc
 			if(wearer.back == src)
@@ -378,7 +378,7 @@
 	desc = "A heavy duty nozzle attached to a firefighter's backpack tank."
 	icon = 'icons/obj/atmospherics/equipment.dmi'
 	icon_state = "atmos_nozzle"
-	item_state = "nozzleatmos"
+	inhand_icon_state = "nozzleatmos"
 	lefthand_file = 'icons/mob/inhands/equipment/mister_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mister_righthand.dmi'
 	safety = 0
@@ -424,9 +424,9 @@
 /obj/item/extinguisher/mini/nozzle/update_icon(updates)
 	. = ..()
 	if(toggled)
-		item_state = "[initial(item_state)]_on"
+		inhand_icon_state = "[initial(inhand_icon_state)]_on"
 	else
-		item_state = initial(item_state)
+		inhand_icon_state = initial(inhand_icon_state)
 	if(istype(loc, /mob/living/carbon))
 		var/mob/living/carbon/wearer = loc
 		if(wearer.get_active_held_item() == src)//Someone's holding it
@@ -635,7 +635,7 @@
 	desc = "A chemical autoinjector that can be carried on your back."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "waterbackpackchem"
-	item_state = "waterbackpackchem"
+	inhand_icon_state = "waterbackpackchem"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -19,7 +19,7 @@
 	var/temp = null
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_SMALL
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	throw_speed = 3
@@ -102,7 +102,7 @@
 	desc = "A portable item using blue-space technology."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hand_tele"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	throwforce = 0
@@ -279,7 +279,7 @@
 		using the device far exceeds that of what Nanotrasen has been able to produce, mainly due to the fact that the Syndicate don't see it as an unwanted side effect."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "syndi_tele"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	throwforce = 5

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -3,7 +3,7 @@
 	desc = "A prod with a bluespace crystal on the end. The crystal doesn't look too fun to touch."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "teleprod"
-	item_state = "teleprod"
+	inhand_icon_state = "teleprod"
 	slot_flags = null
 
 /obj/item/melee/baton/cattleprod/teleprod/attack(mob/living/carbon/M, mob/living/carbon/user)//handles making things teleport when hit

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -9,7 +9,7 @@
 	desc = "Extremely radioactive. Wear goggles."
 	icon = 'icons/obj/nuke_tools.dmi'
 	icon_state = "plutonium_core"
-	item_state = "plutoniumcore"
+	inhand_icon_state = "plutoniumcore"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	layer = ABOVE_MOB_LAYER
 	var/pulse = 0
@@ -46,7 +46,7 @@
 	desc = "Solid container for radioactive objects."
 	icon = 'icons/obj/nuke_tools.dmi'
 	icon_state = "core_container_empty"
-	item_state = "tile"
+	inhand_icon_state = "tile"
 	lefthand_file = 'icons/mob/inhands/misc/sheets_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/sheets_righthand.dmi'
 	var/obj/item/nuke_core/core
@@ -89,7 +89,7 @@
 	desc = "A screwdriver with an ultra thin tip that's carefully designed to boost screwing speed."
 	icon = 'icons/obj/nuke_tools.dmi'
 	icon_state = "screwdriver_nuke"
-	item_state = "screwdriver_nuke"
+	inhand_icon_state = "screwdriver_nuke"
 	toolspeed = 0.5
 	random_color = FALSE
 	greyscale_config_inhand_left = null
@@ -124,7 +124,7 @@
 	name = "supermatter sliver"
 	desc = "A tiny, highly volatile sliver of a supermatter crystal. Do not handle without protection!"
 	icon_state = "supermatter_sliver"
-	item_state = "supermattersliver"
+	inhand_icon_state = "supermattersliver"
 	pulseicon = "supermatter_sliver_pulse"
 
 /obj/item/nuke_core/supermatter_sliver/attack_tk(mob/user) // no TK dusting memes
@@ -230,7 +230,7 @@
 
 /obj/item/hemostat/supermatter/update_icon_state()
 	icon_state = "supermatter_tongs[sliver ? "_loaded" : null]"
-	//item_state = "supermatter_tongs[sliver ? "_loaded" : null]"
+	//inhand_icon_state = "supermatter_tongs[sliver ? "_loaded" : null]"
 	return ..()
 
 /obj/item/hemostat/supermatter/afterattack(atom/O, mob/user, proximity)

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -53,7 +53,7 @@
 	name = "hand drill"
 	desc = "A simple powered hand drill. It's fitted with a screw bit."
 	icon_state = "drill"
-	item_state = "drill"
+	inhand_icon_state = "drill"
 	worn_icon_state = "drill"
 
 	force = 8 //might or might not be too high, subject to change
@@ -84,7 +84,7 @@
 	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
 	usesound = 'sound/items/jaws_pry.ogg'
 	icon_state = "jaws"
-	item_state = "jawsoflife"
+	inhand_icon_state = "jawsoflife"
 	worn_icon_state = "jawsoflife"
 
 	force = 15

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -3,7 +3,7 @@
 	desc = "You can be totally screwy with this."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "screwdriver_map"
-	item_state = "screwdriver"
+	inhand_icon_state = "screwdriver"
 	worn_icon_state = "screwdriver"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -76,7 +76,7 @@
 	desc = "A screwdriver made of brass. The handle feels freezing cold."
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	icon_state = "screwdriver_brass"
-	item_state = "screwdriver_brass"
+	inhand_icon_state = "screwdriver_brass"
 	toolspeed = 0.5
 	random_color = FALSE
 	greyscale_config_inhand_left = null
@@ -87,7 +87,7 @@
 	desc = "An ultrasonic screwdriver."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "screwdriver_a"
-	item_state = "screwdriver_nuke"
+	inhand_icon_state = "screwdriver_nuke"
 	usesound = 'sound/items/pshoom.ogg'
 	toolspeed = 0.1
 	random_color = FALSE

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -5,7 +5,7 @@
 	desc = "A standard edition welder provided by Nanotrasen."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "welder"
-	item_state = "welder"
+	inhand_icon_state = "welder"
 	worn_icon_state = "welder"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -62,9 +62,9 @@
 
 /obj/item/weldingtool/update_icon_state()
 	if(welding)
-		item_state = "[initial(item_state)]1"
+		inhand_icon_state = "[initial(inhand_icon_state)]1"
 	else
-		item_state = "[initial(item_state)]"
+		inhand_icon_state = "[initial(inhand_icon_state)]"
 	return ..()
 
 /obj/item/weldingtool/update_overlays()
@@ -399,7 +399,7 @@
 	name = "upgraded industrial welding tool"
 	desc = "An upgraded welder based of the industrial welder."
 	icon_state = "upindwelder"
-	item_state = "upindwelder"
+	inhand_icon_state = "upindwelder"
 	max_fuel = 80
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
 
@@ -407,7 +407,7 @@
 	name = "experimental welding tool"
 	desc = "An experimental welder capable of self-fuel generation and less harmful to the eyes."
 	icon_state = "exwelder"
-	item_state = "exwelder"
+	inhand_icon_state = "exwelder"
 	max_fuel = 40
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
 	var/last_gen = 0
@@ -422,7 +422,7 @@
 	desc = "A brass welder that seems to constantly refuel itself. It is faintly warm to the touch."
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	icon_state = "brasswelder"
-	item_state = "brasswelder"
+	inhand_icon_state = "brasswelder"
 	light_intensity = 1
 
 /obj/item/weldingtool/experimental/process(delta_time)

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -3,7 +3,7 @@
 	desc = "This cuts wires."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "cutters_map"
-	item_state = "cutters"
+	inhand_icon_state = "cutters"
 	worn_icon_state = "cutters"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -3,7 +3,7 @@
 	desc = "A wrench with common uses. Can be found in your hand."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "wrench"
-	item_state = "wrench"
+	inhand_icon_state = "wrench"
 	worn_icon_state = "wrench"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -68,7 +68,7 @@
 	desc = "A translucent balloon. There's nothing in it."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "waterballoon-e"
-	item_state = "balloon-empty"
+	inhand_icon_state = "balloon-empty"
 
 
 /obj/item/toy/balloon/Initialize(mapload)
@@ -132,10 +132,10 @@
 /obj/item/toy/balloon/update_icon()
 	if(src.reagents.total_volume >= 1)
 		icon_state = "waterballoon"
-		item_state = "balloon"
+		inhand_icon_state = "balloon"
 	else
 		icon_state = "waterballoon-e"
-		item_state = "balloon-empty"
+		inhand_icon_state = "balloon-empty"
 
 /obj/item/toy/syndicateballoon
 	name = "syndicate balloon"
@@ -146,7 +146,7 @@
 	force = 0
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "syndballoon"
-	item_state = "syndballoon"
+	inhand_icon_state = "syndballoon"
 	lefthand_file = 'icons/mob/inhands/antag/balloons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/balloons_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
@@ -187,7 +187,7 @@
 	desc = "Looks almost like the real thing! Ages 8 and up. Please recycle in an autolathe when you're out of caps."
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "revolver"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	worn_icon_state = "gun"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
@@ -314,7 +314,7 @@
 	. = ..()
 	var/last_part = HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) ? "_on[saber_color ? "_[saber_color]" : null]" : null
 	icon_state = "[initial(icon_state)][last_part]"
-	item_state = "[initial(item_state)][last_part]"
+	inhand_icon_state = "[initial(inhand_icon_state)][last_part]"
 
 /obj/item/toy/sword/multitool_act(mob/living/user, obj/item/tool)
 	if(hacked)
@@ -355,7 +355,7 @@
 	desc = "It says \"Sternside Changs #1 fan\" on it."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "foamblade"
-	item_state = "arm_blade"
+	inhand_icon_state = "arm_blade"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	attack_verb_continuous = list("pricks", "absorbs", "gores")
@@ -372,7 +372,7 @@
 	desc = "Despite being a cheap plastic imitation of a stunbaton, it can still be charged."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "stunbaton"
-	item_state = "baton"
+	inhand_icon_state = "baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	attack_verb_continuous = list("batongs", "stuns", "hits")
@@ -384,7 +384,7 @@
 	name = "windup toolbox"
 	desc = "A replica toolbox that rumbles when you turn the key."
 	icon_state = "his_grace"
-	item_state = "artistic_toolbox"
+	inhand_icon_state = "artistic_toolbox"
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	var/active = FALSE
@@ -466,7 +466,7 @@
 	desc = "Woefully underpowered in D20."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "katana"
-	item_state = "katana"
+	inhand_icon_state = "katana"
 	worn_icon_state = "katana"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -1299,7 +1299,7 @@
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "ball"
 	name = "beach ball"
-	item_state = "beachball"
+	inhand_icon_state = "beachball"
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
 	item_flags = NO_PIXEL_RANDOM_DROP
 
@@ -1338,7 +1338,7 @@
 	desc = "A cheap plastic replica of a dagger. Produced by THE ARM Toys, Inc."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
-	item_state = "cultdagger"
+	inhand_icon_state = "cultdagger"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
@@ -1448,7 +1448,7 @@
 /obj/item/toy/figure/assistant
 	name = "\improper Assistant action figure"
 	icon_state = "assistant"
-	item_state = "doll"
+	inhand_icon_state = "doll"
 	toysay = "Greytide world wide!"
 
 /obj/item/toy/figure/atmos
@@ -1650,7 +1650,7 @@
 	desc = "It's a dummy, dummy."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "puppet"
-	item_state = "puppet"
+	inhand_icon_state = "puppet"
 	var/doll_name = "Dummy"
 
 //Add changing looks when i feel suicidal about making 20 inhands for these.

--- a/code/game/objects/items/vending_items.dm
+++ b/code/game/objects/items/vending_items.dm
@@ -7,7 +7,7 @@
 
 	icon = 'icons/obj/vending_restock.dmi'
 	icon_state = "refill_snack"
-	item_state = "restock_unit"
+	inhand_icon_state = "restock_unit"
 	desc = "A vending machine restock cart."
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -2,7 +2,7 @@
 	icon = 'icons/obj/wallframe.dmi'
 	custom_materials = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT*2)
 	flags_1 = CONDUCT_1
-	item_state = "syringe_kit"
+	inhand_icon_state = "syringe_kit"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
@@ -83,7 +83,7 @@
 	desc = "Looks like a circuit. Probably is."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "door_electronics"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -42,7 +42,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "\improper SORD"
 	desc = "This thing is so unspeakably shitty you are having a hard time even holding it."
 	icon_state = "sord"
-	item_state = "sord"
+	inhand_icon_state = "sord"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
@@ -72,7 +72,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "claymore"
 	desc = "What are you standing around staring at this for? Get to killing!"
 	icon_state = "claymore"
-	item_state = "claymore"
+	inhand_icon_state = "claymore"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -228,7 +228,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			user.update_icons()
 			new_name = "GORE-DRENCHED CLAYMORE OF [pick("THE WHIMSICAL SLAUGHTER", "A THOUSAND SLAUGHTERED CATTLE", "GLORY AND VALHALLA", "ANNIHILATION", "OBLITERATION")]"
 			icon_state = "claymore_valhalla"
-			item_state = "cultblade"
+			inhand_icon_state = "cultblade"
 			remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 
 	name = new_name
@@ -238,7 +238,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "Bone Sword"
 	desc = "Jagged pieces of bone are tied to what looks like a goliaths femur."
 	icon_state = "bone_sword"
-	item_state = "bone_sword"
+	inhand_icon_state = "bone_sword"
 	worn_icon_state = "claymore"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -263,7 +263,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "katana"
 	desc = "Woefully underpowered in D20."
 	icon_state = "katana"
-	item_state = "katana"
+	inhand_icon_state = "katana"
 	worn_icon_state = "katana"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -302,7 +302,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "wired rod"
 	desc = "A rod with some wire wrapped around the top. It'd be easy to attach something to the top bit."
 	icon_state = "wiredrod"
-	item_state = "rods"
+	inhand_icon_state = "rods"
 	flags_1 = CONDUCT_1
 	force = 9
 	throwforce = 10
@@ -346,7 +346,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "throwing star"
 	desc = "An ancient weapon still used to this day, due to its ease of lodging itself into its victim's body parts."
 	icon_state = "throwingstar"
-	item_state = "eshield0"
+	inhand_icon_state = "eshield0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 2
@@ -488,7 +488,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A cane used by a true gentleman. Or a clown."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "cane"
-	item_state = "stick"
+	inhand_icon_state = "stick"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	block_upgrade_walk = 1
@@ -530,7 +530,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A great tool to drag someone else's drinks across the bar."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "cane"
-	item_state = "stick"
+	inhand_icon_state = "stick"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	force = 3
@@ -561,7 +561,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "mounted chainsaw template"
 	desc = "A chainsaw that has replaced your arm."
 	icon_state = "chainsaw_on"
-	item_state = "mounted_chainsaw"
+	inhand_icon_state = "mounted_chainsaw"
 	lefthand_file = 'icons/mob/inhands/weapons/chainsaw_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL | ISWEAPON
@@ -682,7 +682,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "improvised skateboard"
 	desc = "A skateboard. It can be placed on its wheels and ridden, or used as a strong weapon."
 	icon_state = "skateboard"
-	item_state = "skateboard"
+	inhand_icon_state = "skateboard"
 	block_upgrade_walk = 1
 	force = 12
 	throwforce = 4
@@ -701,7 +701,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "skateboard"
 	desc = "A RaDSTORMz brand professional skateboard. It looks sturdy and well made."
 	icon_state = "skateboard2"
-	item_state = "skateboard2"
+	inhand_icon_state = "skateboard2"
 	board_item_type = /obj/vehicle/ridden/scooter/skateboard/pro
 	custom_premium_price = 300
 
@@ -709,7 +709,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "hoverboard"
 	desc = "A blast from the past, so retro!"
 	icon_state = "hoverboard_red"
-	item_state = "hoverboard_red"
+	inhand_icon_state = "hoverboard_red"
 	board_item_type = /obj/vehicle/ridden/scooter/skateboard/hoverboard
 	custom_premium_price = 2015
 
@@ -717,7 +717,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "\improper Board Of Directors"
 	desc = "The engineering complexity of a spaceship concentrated inside of a board. Just as expensive, too."
 	icon_state = "hoverboard_nt"
-	item_state = "hoverboard_nt"
+	inhand_icon_state = "hoverboard_nt"
 	board_item_type = /obj/vehicle/ridden/scooter/skateboard/hoverboard/admin
 
 /obj/item/melee/baseball_bat
@@ -725,7 +725,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "There ain't a skull in the league that can withstand a swatter."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "baseball_bat"
-	item_state = "baseball_bat"
+	inhand_icon_state = "baseball_bat"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	block_upgrade_walk = 1
@@ -780,7 +780,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "metal baseball bat"
 	desc = "This bat is made of highly reflective, highly armored material."
 	icon_state = "baseball_bat_metal"
-	item_state = "baseball_bat_metal"
+	inhand_icon_state = "baseball_bat_metal"
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	block_level = 1
 	force = 12
@@ -800,7 +800,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "Useful for killing insects of all sizes."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "flyswatter"
-	item_state = "flyswatter"
+	inhand_icon_state = "flyswatter"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	force = 1
@@ -851,7 +851,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "slapper"
 	desc = "This is how real men fight."
 	icon_state = "latexballon"
-	item_state = "nothing"
+	inhand_icon_state = "nothing"
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | ISWEAPON
@@ -919,7 +919,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "Futuristic tech has allowed these classic spring-boxing toys to essentially act as a fully functional hand-operated hand prosthetic."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "extendohand"
-	item_state = "extendohand"
+	inhand_icon_state = "extendohand"
 	item_flags = ISWEAPON
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
@@ -944,7 +944,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "raised hand"
 	desc = "Slap my hand."
 	icon_state = "latexballon"
-	item_state = "nothing"
+	inhand_icon_state = "nothing"
 	hitsound = 'sound/weapons/punchmiss.ogg'
 	force = 0
 	throwforce = 0
@@ -970,7 +970,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "Billy club"
 	desc = "A club designed for breaching enclosed spaces, with an insulated handle-guard to prevent shocks."
 	icon_state = "billyclub"
-	item_state = "classic_baton"
+	inhand_icon_state = "classic_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	force = 12
@@ -1032,7 +1032,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "hydraulic blade"
 	desc = "Extremely sharp and dangerous weapon."
 	icon_state = "hydraulic_blade"
-	item_state = "hydraulic_blade"
+	inhand_icon_state = "hydraulic_blade"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 20

--- a/code/game/objects/structures/beds_chairs/chair_item.dm
+++ b/code/game/objects/structures/beds_chairs/chair_item.dm
@@ -5,7 +5,7 @@
 	desc = "Basic brawl essential."
 	icon = 'icons/obj/beds_chairs/chairs.dmi'
 	icon_state = "chair_toppled"
-	item_state = "chair"
+	inhand_icon_state = "chair"
 	lefthand_file = 'icons/mob/inhands/misc/chairs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/chairs_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
@@ -78,7 +78,7 @@
 	name = "fancy chair"
 	desc = "Meeting brawl essential."
 	icon_state = "chair_fancy_toppled"
-	item_state = "chair_fancy"
+	inhand_icon_state = "chair_fancy"
 	hitsound = 'sound/items/trayhit2.ogg'
 	custom_materials = list(/datum/material/iron = 3000)
 	origin_type = /obj/structure/chair/fancy
@@ -91,7 +91,7 @@
 	name = "stool"
 	desc = "The last line of defense."
 	icon_state = "stool_toppled"
-	item_state = "stool"
+	inhand_icon_state = "stool"
 	origin_type = /obj/structure/chair/stool
 	break_chance = 0 //It's too sturdy.
 
@@ -99,14 +99,14 @@
 	name = "bar stool"
 	desc = "Bar brawl essential."
 	icon_state = "bar_toppled"
-	item_state = "stool_bar"
+	inhand_icon_state = "stool_bar"
 	origin_type = /obj/structure/chair/stool/bar
 
 /obj/item/chair/stool/bamboo
 	name = "bamboo stool"
 	desc = "The apex of the bar brawl experience."
 	icon_state = "bamboo_stool_toppled"
-	item_state = "stool_bamboo"
+	inhand_icon_state = "stool_bamboo"
 	hitsound = 'sound/weapons/genhit1.ogg'
 	origin_type = /obj/structure/chair/stool/bamboo
 	custom_materials = null
@@ -119,7 +119,7 @@
 	name = "wooden chair"
 	desc = "Fancy brawl essential."
 	icon_state = "wooden_chair_toppled"
-	item_state = "woodenchair"
+	inhand_icon_state = "woodenchair"
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
 	hitsound = 'sound/weapons/genhit1.ogg'
@@ -140,7 +140,7 @@
 	name = "plastic chair"
 	desc = "Be the reclaimer of your name." //bury the light deep withiiiiiiiiiiiiiiiiin
 	icon_state = "plastic_chair_toppled"
-	item_state = "plastic_chair"
+	inhand_icon_state = "plastic_chair"
 	force = 3//have you ever been hit by a plastic chair? those aren't as bad as a metal or a wood one!
 	throwforce = 6
 	block_upgrade_walk = 1

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -206,7 +206,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 	desc = "Rubber ducky you're so fine, you make bathtime lots of fuuun. Rubber ducky I'm awfully fooooond of yooooouuuu~"	//thanks doohl
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "rubberducky"
-	item_state = "rubberducky"
+	inhand_icon_state = "rubberducky"
 	worn_icon_state = "duck"
 
 

--- a/code/modules/admin/verbs/BrokenInhands.dm
+++ b/code/modules/admin/verbs/BrokenInhands.dm
@@ -10,10 +10,10 @@
 		var/list/Rstates = IR.IconStates()
 		var/icon/J = new(O.icon)
 		var/list/istates = J.IconStates()
-		if(!Lstates.Find(O.icon_state) && !Lstates.Find(O.item_state))
+		if(!Lstates.Find(O.icon_state) && !Lstates.Find(O.inhand_icon_state))
 			if(O.icon_state)
 				text += "[O.type] WANTS IN LEFT HAND CALLED\n\"[O.icon_state]\".\n"
-		if(!Rstates.Find(O.icon_state) && !Rstates.Find(O.item_state))
+		if(!Rstates.Find(O.icon_state) && !Rstates.Find(O.inhand_icon_state))
 			if(O.icon_state)
 				text += "[O.type] WANTS IN RIGHT HAND CALLED\n\"[O.icon_state]\".\n"
 
@@ -21,9 +21,9 @@
 		if(O.icon_state)
 			if(!istates.Find(O.icon_state))
 				text += "[O.type] MISSING NORMAL ICON CALLED\n\"[O.icon_state]\" IN \"[O.icon]\"\n"
-		if(O.item_state)
-			if(!istates.Find(O.item_state))
-				text += "[O.type] MISSING NORMAL ICON CALLED\n\"[O.item_state]\" IN \"[O.icon]\"\n"
+		if(O.inhand_icon_state)
+			if(!istates.Find(O.inhand_icon_state))
+				text += "[O.type] MISSING NORMAL ICON CALLED\n\"[O.inhand_icon_state]\" IN \"[O.icon]\"\n"
 		text+="\n"
 		qdel(O)
 	if(text)

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -11,7 +11,7 @@
 	desc = "A vest outfitted with advanced stealth technology. It has two modes - combat and stealth."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "vest_stealth"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	blood_overlay_type = "armor"
 	armor_type = /datum/armor/abductor_vest
 	actions_types = list(/datum/action/item_action/hands_free/activate)
@@ -197,7 +197,7 @@
 	name = "science tool"
 	desc = "A dual-mode tool for retrieving specimens and scanning appearances. Scanning can be done through cameras."
 	icon_state = "gizmo_scan"
-	item_state = "silencer"
+	inhand_icon_state = "silencer"
 	var/mode = GIZMO_SCAN
 	var/mob/living/marked = null
 	var/obj/machinery/abductor/console/console
@@ -283,7 +283,7 @@
 	name = "abductor silencer"
 	desc = "A compact device used to shut down communications equipment."
 	icon_state = "silencer"
-	item_state = "gizmo"
+	inhand_icon_state = "gizmo"
 
 /obj/item/abductor/silencer/ComponentInitialize()
 	. = ..()
@@ -297,7 +297,7 @@
 	desc = "A dual-mode tool for directly communicating with sentient brains. It can be used to send a direct message to a target, \
 			or to send a command to a test subject with a charged gland."
 	icon_state = "mind_device_message"
-	item_state = "silencer"
+	inhand_icon_state = "silencer"
 	var/mode = MIND_DEVICE_MESSAGE
 
 /obj/item/abductor/mind_device/attack_self(mob/user)
@@ -394,7 +394,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/declone, /obj/item/ammo_casing/energy/ion, /obj/item/ammo_casing/energy/temp)
 	pin = /obj/item/firing_pin/abductor
 	icon_state = "alienpistol"
-	item_state = "alienpistol"
+	inhand_icon_state = "alienpistol"
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 	w_class = WEIGHT_CLASS_SMALL
 
@@ -438,7 +438,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	lefthand_file = 'icons/mob/inhands/antag/abductor_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/abductor_righthand.dmi'
 	icon_state = "wonderprodStun"
-	item_state = "wonderprod"
+	inhand_icon_state = "wonderprod"
 	worn_icon_state = "classic_baton"
 
 	force = 7
@@ -505,16 +505,16 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	switch(mode)
 		if(BATON_STUN)
 			icon_state = "wonderprodStun"
-			item_state = "wonderprodStun"
+			inhand_icon_state = "wonderprodStun"
 		if(BATON_SLEEP)
 			icon_state = "wonderprodSleep"
-			item_state = "wonderprodSleep"
+			inhand_icon_state = "wonderprodSleep"
 		if(BATON_CUFF)
 			icon_state = "wonderprodCuff"
-			item_state = "wonderprodCuff"
+			inhand_icon_state = "wonderprodCuff"
 		if(BATON_PROBE)
 			icon_state = "wonderprodProbe"
-			item_state = "wonderprodProbe"
+			inhand_icon_state = "wonderprodProbe"
 
 /obj/item/melee/baton/abductor/attack(mob/target, mob/living/user)
 	if(!AbductorCheck(user))
@@ -695,7 +695,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	desc = "An advanced alien headset designed to monitor communications of human space stations. Why does it have a microphone? No one knows."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "abductor_headset"
-	item_state = "abductor_headset"
+	inhand_icon_state = "abductor_headset"
 	keyslot2 = new /obj/item/encryptionkey/heads/captain
 	bang_protect = 1
 
@@ -784,7 +784,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	name = "agent headgear"
 	desc = "Abduct with style - spiky style. Prevents digital tracking."
 	icon_state = "alienhelmet"
-	item_state = "alienhelmet"
+	inhand_icon_state = "alienhelmet"
 	flash_protect = 1
 	blockTracking = TRUE
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
@@ -917,7 +917,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	name = "alien jumpsuit"
 	icon = 'icons/obj/clothing/under/syndicate.dmi'
 	icon_state = "abductor"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	worn_icon = 'icons/mob/clothing/under/syndicate.dmi'
 	armor_type = /datum/armor/under_abductor
 	can_adjust = FALSE

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -320,7 +320,7 @@
 			prof.name_list[slot] = I.name
 			prof.appearance_list[slot] = I.appearance
 			prof.flags_cover_list[slot] = I.flags_cover
-			prof.item_state_list[slot] = I.item_state
+			prof.inhand_icon_state_list[slot] = I.inhand_icon_state
 			prof.lefthand_file_list[slot] = I.lefthand_file
 			prof.righthand_file_list[slot] = I.righthand_file
 			prof.worn_icon_list[slot] = I.worn_icon
@@ -546,7 +546,7 @@
 	var/list/appearance_list = list()
 	var/list/flags_cover_list = list()
 	var/list/exists_list = list()
-	var/list/item_state_list = list()
+	var/list/inhand_icon_state_list = list()
 	var/list/lefthand_file_list = list()
 	var/list/righthand_file_list = list()
 	var/list/worn_icon_list = list()
@@ -573,7 +573,7 @@
 	newprofile.appearance_list = appearance_list.Copy()
 	newprofile.flags_cover_list = flags_cover_list.Copy()
 	newprofile.exists_list = exists_list.Copy()
-	newprofile.item_state_list = item_state_list.Copy()
+	newprofile.inhand_icon_state_list = inhand_icon_state_list.Copy()
 	newprofile.lefthand_file_list = lefthand_file_list.Copy()
 	newprofile.righthand_file_list = righthand_file_list.Copy()
 	newprofile.worn_icon_list = worn_icon_list.Copy()

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -147,7 +147,7 @@
 	desc = "A grotesque blade made out of bone and flesh that cleaves through people as a hot knife through butter."
 	icon = 'icons/obj/changeling_items.dmi'
 	icon_state = "arm_blade"
-	item_state = "arm_blade"
+	inhand_icon_state = "arm_blade"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL | ISWEAPON
@@ -219,7 +219,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/melee/arm_blade)
 	desc = "A fleshy tentacle that can stretch out and grab things or people."
 	icon = 'icons/obj/changeling_items.dmi'
 	icon_state = "tentacle"
-	item_state = "tentacle"
+	inhand_icon_state = "tentacle"
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL | NOBLUDGEON
@@ -446,7 +446,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "lingspacehelmet"
-	item_state = null
+	inhand_icon_state = null
 	desc = "A covering of armored pressure and temperature-resistant organic tissue with a glass-like chitin front."
 	item_flags = DROPDEL
 	clothing_flags = STOPSPRESSUREDAMAGE
@@ -493,7 +493,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	name = "chitinous mass"
 	desc = "A tough, hard covering of black chitin."
 	icon_state = "lingarmor"
-	item_state = null
+	inhand_icon_state = null
 	item_flags = DROPDEL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	armor_type = /datum/armor/armor_changeling
@@ -526,7 +526,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	name = "chitinous mass"
 	desc = "A tough, hard covering of black chitin with transparent chitin in front."
 	icon_state = "lingarmorhelmet"
-	item_state = null
+	inhand_icon_state = null
 	item_flags = DROPDEL
 	armor_type = /datum/armor/helmet_changeling
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEEYES|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT

--- a/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/hateful_manacles.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/slab_empowerments/hateful_manacles.dm
@@ -57,7 +57,7 @@
 	name = "replicant manacles"
 	desc = "Heavy manacles made out of freezing-cold metal. It looks like brass, but feels much more solid."
 	icon_state = "brass_manacles"
-	item_state = "brass_manacles"
+	inhand_icon_state = "brass_manacles"
 	item_flags = DROPDEL
 
 /obj/item/restraints/handcuffs/clockwork/dropped(mob/user)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -307,7 +307,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
 	icon_state = "disintegrate"
-	item_state = "disintegrate"
+	inhand_icon_state = "disintegrate"
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
 
 	w_class = WEIGHT_CLASS_HUGE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -12,7 +12,7 @@
 	desc = "A strange dagger said to be used by sinister groups for \"preparing\" a corpse before sacrificing it to their dark gods."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
-	item_state = "cultdagger"
+	inhand_icon_state = "cultdagger"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	inhand_x_dimension = 32
@@ -43,7 +43,7 @@ Striking a noncultist, however, will tear their flesh."}
 	name = "eldritch longsword"
 	desc = "A sword humming with unholy energy. It glows with a dim red light."
 	icon_state = "cultblade"
-	item_state = "cultblade"
+	inhand_icon_state = "cultblade"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
@@ -111,7 +111,7 @@ Striking a noncultist, however, will tear their flesh."}
 	name = "\improper Nar'Sien bola"
 	desc = "A strong bola, bound with dark magic that allows it to pass harmlessly through Nar'Sien cultists. Throw it to trip and slow your victim."
 	icon_state = "bola_cult"
-	item_state = "bola_cult"
+	inhand_icon_state = "bola_cult"
 	breakouttime = 60
 	knockdown = 20
 
@@ -163,7 +163,7 @@ Striking a noncultist, however, will tear their flesh."}
 	icon_state = "cultrobes"
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
-	item_state = "cultrobes"
+	inhand_icon_state = "cultrobes"
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
@@ -192,13 +192,13 @@ Striking a noncultist, however, will tear their flesh."}
 	name = "cultist hood"
 	desc = "An armored hood worn by the followers of Nar'Sie."
 	icon_state = "cult_hoodalt"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/hooded/cultrobes/alt
 	name = "cultist robes"
 	desc = "An armored set of robes worn by the followers of Nar'Sie."
 	icon_state = "cultrobesalt"
-	item_state = null
+	inhand_icon_state = null
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/alt
 
 /obj/item/clothing/suit/hooded/cultrobes/alt/ghost
@@ -211,7 +211,7 @@ Striking a noncultist, however, will tear their flesh."}
 /obj/item/clothing/head/wizard/magus
 	name = "magus helm"
 	icon_state = "magus"
-	item_state = null
+	inhand_icon_state = null
 	desc = "A helm worn by the followers of Nar'Sie."
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDEEARS|HIDEEYES|HIDESNOUT
 	armor_type = /datum/armor/wizard_magus
@@ -236,7 +236,7 @@ Striking a noncultist, however, will tear their flesh."}
 	icon_state = "magusred"
 	icon = 'icons/obj/clothing/suits/wizard.dmi'
 	worn_icon = 'icons/mob/clothing/suits/wizard.dmi'
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(/obj/item/tome, /obj/item/melee/cultblade)
 	armor_type = /datum/armor/suit_magusred
@@ -272,7 +272,7 @@ Striking a noncultist, however, will tear their flesh."}
 	name = "empowered cultist armor"
 	desc = "A set of runed armour scribbed with blood rites which shimmer in the light, reflecting projectiles."
 	icon_state = "cult_armor"
-	item_state = null
+	inhand_icon_state = null
 	w_class = WEIGHT_CLASS_BULKY
 	armor_type = /datum/armor/cultrobes_cult_shield
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie
@@ -386,7 +386,7 @@ Striking a noncultist, however, will tear their flesh."}
 	desc = "may Nar'Sie guide you through the darkness and shield you from the light."
 	name = "zealot's blindfold"
 	icon_state = "blindfold"
-	item_state = "blindfold"
+	inhand_icon_state = "blindfold"
 	flash_protect = 1
 	vision_correction = 1
 
@@ -512,7 +512,7 @@ Striking a noncultist, however, will tear their flesh."}
 	w_class = WEIGHT_CLASS_SMALL
 	light_range = 1
 	icon_state = "torch"
-	item_state = "torch"
+	inhand_icon_state = "torch"
 	color = "#ff0000"
 	on_damage = 15
 	slot_flags = null
@@ -717,7 +717,7 @@ Striking a noncultist, however, will tear their flesh."}
 	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
 	icon_state = "disintegrate"
-	item_state = "disintegrate"
+	inhand_icon_state = "disintegrate"
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	throwforce = 0

--- a/code/modules/antagonists/heretic/items/forbidden_book.dm
+++ b/code/modules/antagonists/heretic/items/forbidden_book.dm
@@ -3,7 +3,7 @@
 	name = "Codex Cicatrix"
 	desc = "This book describes the secrets of the veil between worlds."
 	icon = 'icons/obj/heretic.dmi'
-	item_state = "book"
+	inhand_icon_state = "book"
 	icon_state = "book"
 	worn_icon_state = "book"
 	w_class = WEIGHT_CLASS_SMALL
@@ -46,8 +46,8 @@
  * Plays a little animation that shows the book opening and closing.
  */
 /obj/item/codex_cicatrix/proc/open_animation()
-	icon_state = "[item_state]_open"
-	flick("[item_state]_opening", src)
+	icon_state = "[inhand_icon_state]_open"
+	flick("[inhand_icon_state]_opening", src)
 
 	addtimer(CALLBACK(src, PROC_REF(close_animation)), 5 SECONDS)
 
@@ -55,5 +55,5 @@
  * Plays a closing animation and resets the icon state.
  */
 /obj/item/codex_cicatrix/proc/close_animation()
-	icon_state = item_state
-	flick("[item_state]_closing", src)
+	icon_state = inhand_icon_state
+	flick("[inhand_icon_state]_closing", src)

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -25,7 +25,7 @@
 	name = "ominous armor"
 	desc = "A ragged, dusty set of robes. Strange eyes line the inside."
 	icon_state = "eldritch_armor"
-	item_state = null
+	inhand_icon_state = null
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	allowed = list(/obj/item/melee/sickly_blade)
@@ -85,7 +85,7 @@
 	name = "void cloak"
 	desc = "Black like tar and doesn't reflect any light. Runic symbols line the outside, with each flash you lose comprehension of what you are seeing."
 	icon_state = "void_cloak"
-	item_state = "void_cloak"
+	inhand_icon_state = "void_cloak"
 	allowed = list(/obj/item/melee/sickly_blade)
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/void
 	flags_inv = NONE

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -3,7 +3,7 @@
 	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched..."
 	icon = 'icons/obj/heretic.dmi'
 	icon_state = "eldritch_blade"
-	item_state = "eldritch_blade"
+	inhand_icon_state = "eldritch_blade"
 	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
@@ -62,7 +62,7 @@
 	desc = "This crescent blade is decrepit, wasting to rust. \
 		Yet still it bites, ripping flesh and bone with jagged, rotten teeth."
 	icon_state = "rust_blade"
-	item_state = "rust_blade"
+	inhand_icon_state = "rust_blade"
 	after_use_message = "The Rusted Hills hear your call..."
 
 /obj/item/melee/sickly_blade/ash
@@ -70,7 +70,7 @@
 	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. \
 		Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge."
 	icon_state = "ash_blade"
-	item_state = "ash_blade"
+	inhand_icon_state = "ash_blade"
 	after_use_message = "The Nightwatcher hears your call..."
 
 /obj/item/melee/sickly_blade/flesh
@@ -78,7 +78,7 @@
 	desc = "A crescent blade born from a fleshwarped creature. \
 		Keenly aware, it seeks to spread to others the suffering it has endured from its dreadful origins."
 	icon_state = "flesh_blade"
-	item_state = "flesh_blade"
+	inhand_icon_state = "flesh_blade"
 	after_use_message = "The Marshal hears your call..."
 
 /obj/item/melee/sickly_blade/void
@@ -86,5 +86,5 @@
 	desc = "Devoid of any substance, this blade reflects nothingness. \
 		It is a real depiction of purity, and chaos that ensues after its implementation."
 	icon_state = "void_blade"
-	item_state = "void_blade"
+	inhand_icon_state = "void_blade"
 	after_use_message = "The Aristocrat hears your call..."

--- a/code/modules/antagonists/heretic/items/madness_mask.dm
+++ b/code/modules/antagonists/heretic/items/madness_mask.dm
@@ -3,7 +3,7 @@
 	name = "Abyssal Mask"
 	desc = "A mask created from the suffering of existence. Looking down its eyes, you notice something gazing back at you."
 	icon_state = "mad_mask"
-	item_state = "mad_mask"
+	inhand_icon_state = "mad_mask"
 	w_class = WEIGHT_CLASS_SMALL
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -61,7 +61,7 @@
 		Causes knockdown, minor bruises, and major stamina damage. \
 		It gains additional beneficial effects as you expand your knowledge of the Mansus."
 	icon_state = "mansus_grasp"
-	item_state = "mansus_grasp"
+	inhand_icon_state = "mansus_grasp"
 
 /obj/item/melee/touch_attack/mansus_fist/Initialize(mapload)
 	. = ..()

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -4,7 +4,7 @@
 	icon_state = "shield0"
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -6,7 +6,7 @@
 	name = "Declaration of War (Challenge Mode)"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-red"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	desc = "Use to send a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -641,7 +641,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 /obj/item/disk
 	icon = 'icons/obj/module.dmi'
 	w_class = WEIGHT_CLASS_TINY
-	item_state = "card-id"
+	inhand_icon_state = "card-id"
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 	icon_state = "datadisk0"

--- a/code/modules/antagonists/role_preference/role_antagonists.dm
+++ b/code/modules/antagonists/role_preference/role_antagonists.dm
@@ -133,7 +133,7 @@
 	icon.Crop(-15, -15, 48, 48)
 
 	var/obj/item/melee/cultblade/longsword = new
-	icon.Blend(icon(longsword.lefthand_file, longsword.item_state), ICON_OVERLAY)
+	icon.Blend(icon(longsword.lefthand_file, longsword.inhand_icon_state), ICON_OVERLAY)
 	qdel(longsword)
 
 	// Move the guy back to the bottom left, 32x32.
@@ -237,7 +237,7 @@
 	icon.Crop(-15, -15, 48, 48)
 
 	var/obj/item/melee/sickly_blade/ash/blade = new
-	icon.Blend(icon(blade.lefthand_file, blade.item_state), ICON_OVERLAY)
+	icon.Blend(icon(blade.lefthand_file, blade.inhand_icon_state), ICON_OVERLAY)
 	qdel(blade)
 
 	// Move the guy back to the bottom left, 32x32.

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -8,7 +8,7 @@
 	desc = "A wicked curved blade of alien origin, recovered from the ruins of a vast city."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
-	item_state = "knife"
+	inhand_icon_state = "knife"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	force = 15
@@ -235,7 +235,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/rend)
 	desc = "A shard capable of resurrecting humans as skeleton thralls."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "necrostone"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
@@ -316,7 +316,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/rend)
 	desc = "Something creepy about it."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "voodoo"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	var/mob/living/carbon/human/target = null

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -2,7 +2,7 @@
 	name = "soulstone shard"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "soulstone"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	layer = HIGH_OBJ_LAYER

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -78,7 +78,7 @@
 	desc = "A powerful and versatile flashbulb device, with applications ranging from disorienting attackers to acting as visual receptors in robot production. \
 		It is highly effective against targets who aren't standing or are suffering from exhaustion."
 	icon_state = "flash"
-	item_state = "flashtool"
+	inhand_icon_state = "flashtool"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	throwforce = 0
@@ -367,7 +367,7 @@
 	desc = "If you see this, you're not likely to remember it any time soon."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "memorizer"
-	item_state = "nullrod"
+	inhand_icon_state = "nullrod"
 
 /obj/item/assembly/flash/handheld //this is now the regular pocket flashes
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -2,7 +2,7 @@
 	name = "Assembly"
 	icon = 'icons/obj/assemblies/new_assemblies.dmi'
 	icon_state = "holder"
-	item_state = "assembly"
+	inhand_icon_state = "assembly"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -2,7 +2,7 @@
 	name = "mousetrap"
 	desc = "A handy little spring-loaded trap for catching pesty rodents."
 	icon_state = "mousetrap"
-	item_state = "mousetrap"
+	inhand_icon_state = "mousetrap"
 	custom_materials = list(/datum/material/iron=100)
 	attachable = TRUE
 	var/armed = FALSE

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -2,7 +2,7 @@
 	name = "remote signaling device"
 	desc = "Used to remotely activate devices. Allows for syncing when using a secure signaler on another."
 	icon_state = "signaller"
-	item_state = "signaler"
+	inhand_icon_state = "signaler"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	custom_materials = list(/datum/material/iron=400, /datum/material/glass=120)
@@ -187,7 +187,7 @@
 	name = "anomaly core"
 	desc = "The neutralized core of an anomaly. It'd probably be valuable for research."
 	icon_state = "anomaly_core"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	resistance_flags = FIRE_PROOF

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -11,7 +11,7 @@
 	name = "banner"
 	icon = 'icons/obj/banner.dmi'
 	icon_state = "banner"
-	item_state = "banner"
+	inhand_icon_state = "banner"
 	lefthand_file = 'icons/mob/inhands/equipment/banners_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/banners_righthand.dmi'
 	desc = "A banner with Nanotrasen's logo on it."
@@ -106,7 +106,7 @@
 /obj/item/ctf/red
 	name = "red flag"
 	icon_state = "banner-red"
-	item_state = "banner-red"
+	inhand_icon_state = "banner-red"
 	desc = "A red banner used to play capture the flag."
 	team = RED_TEAM
 	reset_path = /obj/effect/ctf/flag_reset/red
@@ -115,7 +115,7 @@
 /obj/item/ctf/blue
 	name = "blue flag"
 	icon_state = "banner-blue"
-	item_state = "banner-blue"
+	inhand_icon_state = "banner-blue"
 	desc = "A blue banner used to play capture the flag."
 	team = BLUE_TEAM
 	reset_path = /obj/effect/ctf/flag_reset/blue

--- a/code/modules/bluespace_anchor/bluespace_anchor_deployer.dm
+++ b/code/modules/bluespace_anchor/bluespace_anchor_deployer.dm
@@ -4,7 +4,7 @@
 
 	icon = 'icons/obj/bluespace_anchor.dmi'
 	icon_state = "anchor_undeployed"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -3,7 +3,7 @@
 	desc = "A device used to check objects against Nanotrasen exports and bounty database."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "export_scanner"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	item_flags = NOBLUDGEON

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -687,5 +687,5 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/effect/pod_landingzone)
 	desc = "This disk provides a firmware update to the Express Supply Console, granting the use of Nanotrasen's Bluespace Drop Pods to the supply department."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cargodisk"
-	item_state = "card-id"
+	inhand_icon_state = "card-id"
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/cargo/supplypod_beacon.dm
+++ b/code/modules/cargo/supplypod_beacon.dm
@@ -3,7 +3,7 @@
 	desc = "A device that can be linked to an Express Supply Console for precision supply pod deliveries. Alt-click to remove link."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "supplypod_beacon"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -243,7 +243,7 @@
 			if(initial(picked_item.greyscale_config_inhand_right))
 				I.righthand_file = SSgreyscale.GetColoredIconByType(initial(picked_item.greyscale_config_inhand_right), initial(picked_item.greyscale_colors))
 		I.worn_icon_state = initial(picked_item.worn_icon_state)
-		I.item_state = initial(picked_item.item_state)
+		I.inhand_icon_state = initial(picked_item.inhand_icon_state)
 		if(!keepname)
 			I.name = initial(picked_item.name)
 		I.desc = initial(picked_item.desc)
@@ -376,7 +376,7 @@
 	desc = "A tough jumpsuit woven from alloy threads. It can take on the appearance of other jumpsuits."
 	icon = 'icons/obj/clothing/under/color.dmi'
 	worn_icon = 'icons/mob/clothing/under/color.dmi'
-	item_state = "engi_suit"
+	inhand_icon_state = "engi_suit"
 	greyscale_colors = null
 	greyscale_config = null
 	greyscale_config_inhand_left = null
@@ -386,7 +386,7 @@
 /obj/item/clothing/under/chameleon/envirosuit/ratvar
 	name = "ratvarian engineer's envirosuit"
 	desc = "A tough envirosuit woven from alloy threads. It can take on the appearance of other jumpsuits."
-	item_state = "engineer_envirosuit"
+	inhand_icon_state = "engineer_envirosuit"
 
 /obj/item/clothing/under/chameleon/Initialize(mapload)
 	. = ..()
@@ -429,7 +429,7 @@
 	icon_state = "armor"
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	blood_overlay_type = "armor"
 	resistance_flags = NONE
 	armor_type = /datum/armor/suit_chameleon
@@ -485,7 +485,7 @@
 	name = "Optical Meson Scanner"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
 	icon_state = "meson"
-	item_state = "meson"
+	inhand_icon_state = "meson"
 	resistance_flags = NONE
 	armor_type = /datum/armor/glasses_chameleon
 
@@ -540,14 +540,14 @@
 	name = "welding goggles"
 	desc = "Protects the eyes from welders; approved by the mad scientist association."
 	icon_state = "welding-g"
-	item_state = "welding-g"
+	inhand_icon_state = "welding-g"
 	flash_protect = 3
 
 /obj/item/clothing/gloves/chameleon
 	desc = "These gloves provide protection against electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
-	item_state = "ygloves"
+	inhand_icon_state = "ygloves"
 	worn_icon_state = "ygloves"
 
 	resistance_flags = NONE
@@ -604,7 +604,7 @@
 	name = "combat gloves"
 	desc = "These tactical gloves are fireproof and shock resistant."
 	icon_state = "cgloves"
-	item_state = "combatgloves"
+	inhand_icon_state = "combatgloves"
 	worn_icon_state = "combatgloves"
 	siemens_coefficient = 0
 	strip_delay = 80
@@ -685,7 +685,7 @@
 /obj/item/clothing/head/chameleon/envirohelm
 	name = "plasma envirosuit helmet"
 	desc = "A special containment helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment. It is space-worthy, and may be worn in tandem with other EVA gear."
-	item_state = "mime_envirohelm"
+	inhand_icon_state = "mime_envirohelm"
 	resistance_flags = FIRE_PROOF
 	strip_delay = 80
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | HEADINTERNALS
@@ -701,7 +701,7 @@
 	name = "ratvarian engineer's envirosuit helmet"
 	desc = "A tough envirohelm woven from alloy threads. It can take on the appearance of other headgear."
 	//icon_state = "engineer_envirohelm"
-	item_state = "engineer_envirohelm"
+	inhand_icon_state = "engineer_envirohelm"
 	flash_protect = 1
 
 /obj/item/clothing/head/chameleon/drone
@@ -760,7 +760,7 @@
 	name = "gas mask"
 	desc = "A face-covering mask that can be connected to an air supply. While good for concealing your identity, it isn't good for blocking gas flow." //More accurate
 	icon_state = "gas_alt"
-	item_state = "gas_alt"
+	inhand_icon_state = "gas_alt"
 	resistance_flags = NONE
 	armor_type = /datum/armor/mask_chameleon
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
@@ -1047,7 +1047,7 @@
 /obj/item/radio/headset/chameleon/bowman
 	name = "bowman headset"
 	icon_state = "syndie_headset"
-	item_state = "syndie_headset"
+	inhand_icon_state = "syndie_headset"
 	bang_protect = 3
 
 /obj/item/modular_computer/tablet/pda/chameleon

--- a/code/modules/clothing/ears/_ears.dm
+++ b/code/modules/clothing/ears/_ears.dm
@@ -11,7 +11,7 @@
 	name = "earmuffs"
 	desc = "Protects your hearing from loud noises, and quiet ones as well."
 	icon_state = "earmuffs"
-	item_state = "earmuffs"
+	inhand_icon_state = "earmuffs"
 	strip_delay = 15
 	equip_delay_other = 25
 	resistance_flags = FLAMMABLE
@@ -28,7 +28,7 @@
 	icon = 'icons/obj/clothing/accessories.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "headphones"
-	item_state = "headphones"
+	inhand_icon_state = "headphones"
 	slot_flags = ITEM_SLOT_EARS | ITEM_SLOT_HEAD | ITEM_SLOT_NECK //Fluff item, put it wherever you want!
 	actions_types = list(/datum/action/item_action/toggle_headphones)
 	var/headphones_on = FALSE
@@ -43,7 +43,7 @@
 
 /obj/item/clothing/ears/headphones/update_icon_state()
 	icon_state = "[initial(icon_state)]_[headphones_on? "on" : "off"]"
-	item_state = "[initial(item_state)]_[headphones_on? "on" : "off"]"
+	inhand_icon_state = "[initial(inhand_icon_state)]_[headphones_on? "on" : "off"]"
 	. = ..()
 
 /obj/item/clothing/ears/headphones/proc/toggle(owner, force_state)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -556,7 +556,7 @@
 	name = "eye of god"
 	desc = "A strange eye, said to have been torn from an omniscient creature that used to roam the wastes."
 	icon_state = "godeye"
-	inhand_icon_state = "godeye"
+	inhand_icon_state = null
 	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS
 	darkness_view = 8
 	clothing_flags = SCAN_REAGENTS | SCAN_BOOZEPOWER

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -77,7 +77,7 @@
 	name = "optical meson scanner"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting conditions."
 	icon_state = "meson"
-	item_state = "meson"
+	inhand_icon_state = "meson"
 	emissive_state = "meson_emissive"
 	darkness_view = 2
 	vision_flags = SEE_TURFS
@@ -106,7 +106,7 @@
 	name = "night vision meson scanner"
 	desc = "An optical meson scanner fitted with an amplified visible light spectrum overlay, providing greater visual clarity in darkness."
 	icon_state = "nvgmeson"
-	item_state = "nvgmeson"
+	inhand_icon_state = "nvgmeson"
 	emissive_state = "nvgmeson_emissive"
 	darkness_view = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
@@ -115,7 +115,7 @@
 /obj/item/clothing/glasses/meson/gar
 	name = "gar mesons"
 	icon_state = "garm"
-	item_state = "garm"
+	inhand_icon_state = "garm"
 	desc = "Do the impossible, see the invisible!"
 	force = 10
 	throwforce = 10
@@ -130,7 +130,7 @@
 	name = "prescription meson scanner"
 	desc = "A crude combination between a pair of prescription glasses and the electronics of a meson scanner."
 	icon_state = "prescmeson"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	emissive_state = "prehud_emissive"
 	vision_correction = 1
 
@@ -138,7 +138,7 @@
 	name = "science goggles"
 	desc = "A pair of snazzy goggles used to protect against chemical spills. Fitted with an analyzer for scanning items and reagents."
 	icon_state = "purple"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	emissive_state = "meson_emissive"
 	clothing_flags = SCAN_REAGENTS
 	actions_types = list(/datum/action/item_action/toggle_research_scanner)
@@ -173,7 +173,7 @@
 	name = "science sunglasses"
 	desc = "A pair of sunglasses outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion. Has enhanced shielding which blocks flashes."
 	icon_state = "sunhudscience"
-	item_state = "sunhudscience"
+	inhand_icon_state = "sunhudscience"
 	emissive_state = "sun_emissive"
 	flash_protect = 1
 
@@ -186,7 +186,7 @@
 	name = "night vision science goggles"
 	desc = "A pair of snazzy goggles to protect against chemical spills, AND your fear of the dark! Fitted with an analyzer for scanning items and reagents."
 	icon_state = "purplenight"
-	item_state = "purplenight"
+	inhand_icon_state = "purplenight"
 	emissive_state = "nvgmeson_emissive"
 	darkness_view = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
@@ -195,7 +195,7 @@
 	name = "night vision goggles"
 	desc = "You can totally see in the dark now!"
 	icon_state = "night"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	emissive_state = "nvg_emissive"
 	darkness_view = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
@@ -209,20 +209,20 @@
 	name = "eyepatch"
 	desc = "Yarr."
 	icon_state = "eyepatch"
-	item_state = "eyepatch"
+	inhand_icon_state = "eyepatch"
 
 /obj/item/clothing/glasses/monocle
 	name = "monocle"
 	desc = "Such a dapper eyepiece!"
 	icon_state = "monocle"
-	item_state = "headset" // lol
+	inhand_icon_state = "headset" // lol
 	vision_correction = 1
 
 /obj/item/clothing/glasses/material
 	name = "optical material scanner"
 	desc = "Very confusing glasses."
 	icon_state = "material"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	vision_flags = SEE_OBJS
 	glass_colour_type = /datum/client_colour/glass_colour/lightblue
 
@@ -230,13 +230,13 @@
 	name = "optical material scanner"
 	desc = "Used by miners to detect ores deep within the rock."
 	icon_state = "material"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	darkness_view = 0
 
 /obj/item/clothing/glasses/material/mining/gar
 	name = "gar material scanner"
 	icon_state = "garm"
-	item_state = "garm"
+	inhand_icon_state = "garm"
 	desc = "Do the impossible, see the invisible!"
 	force = 10
 	throwforce = 20
@@ -252,35 +252,35 @@
 	name = "prescription glasses"
 	desc = "Made by Nerd. Co."
 	icon_state = "glasses"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	vision_correction = 1 //corrects nearsightedness
 
 /obj/item/clothing/glasses/regular/jamjar
 	name = "jamjar glasses"
 	desc = "Also known as Virginity Protectors."
 	icon_state = "jamjar_glasses"
-	item_state = "jamjar_glasses"
+	inhand_icon_state = "jamjar_glasses"
 	vision_correction = 1
 
 /obj/item/clothing/glasses/regular/hipster
 	name = "hipster glasses"
 	desc = "Made by Uncool. Co."
 	icon_state = "hipster_glasses"
-	item_state = "hipster_glasses"
+	inhand_icon_state = "hipster_glasses"
 	vision_correction = 1
 
 /obj/item/clothing/glasses/regular/circle
 	name = "circle glasses"
 	desc = "Why would you wear something so controversial yet so brave?"
 	icon_state = "circle_glasses"
-	item_state = "circle_glasses"
+	inhand_icon_state = "circle_glasses"
 	vision_correction = 1
 
 /obj/item/clothing/glasses/sunglasses/circle_sunglasses
 	name = "circle sunglasses"
 	desc = "Shit's pimpin'"
 	icon_state = "circle_sunglasses"
-	item_state = "circle_sunglasses"
+	inhand_icon_state = "circle_sunglasses"
 
 //Here lies green glasses, so ugly they died. RIP
 
@@ -288,7 +288,7 @@
 	name = "sunglasses"
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. They do not provide flash protection."
 	icon_state = "sun"
-	item_state = "sunglasses"
+	inhand_icon_state = "sunglasses"
 	darkness_view = 1
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/gray
@@ -322,7 +322,7 @@
 	name = "black gar glasses"
 	desc = "Go beyond impossible and kick reason to the curb!  Has enhanced shielding which blocks flashes."
 	icon_state = "garb"
-	item_state = "garb"
+	inhand_icon_state = "garb"
 	force = 10
 	throwforce = 10
 	throw_speed = 4
@@ -336,7 +336,7 @@
 	name = "black giga gar glasses"
 	desc = "Believe in us humans.  Has enhanced shielding which blocks flashes."
 	icon_state = "supergarb"
-	item_state = "garb"
+	inhand_icon_state = "garb"
 	force = 12
 	throwforce = 12
 
@@ -344,7 +344,7 @@
 	name = "gar glasses"
 	desc = "Just who the hell do you think I am?!  Has enhanced shielding which blocks flashes."
 	icon_state = "gar"
-	item_state = "gar"
+	inhand_icon_state = "gar"
 	force = 10
 	throwforce = 10
 	throw_speed = 4
@@ -359,7 +359,7 @@
 	name = "giga gar glasses"
 	desc = "We evolve past the person we were a minute before. Little by little we advance with each turn. That's how a drill works!  Has enhanced shielding which blocks flashes."
 	icon_state = "supergar"
-	item_state = "gar"
+	inhand_icon_state = "gar"
 	force = 12
 	throwforce = 12
 	glass_colour_type = /datum/client_colour/glass_colour/red
@@ -368,7 +368,7 @@
 	name = "welding goggles"
 	desc = "Protects the eyes from welders; approved by the mad scientist association."
 	icon_state = "welding-g"
-	item_state = "welding-g"
+	inhand_icon_state = "welding-g"
 	actions_types = list(/datum/action/item_action/toggle)
 	custom_materials = list(/datum/material/iron = 250)
 	flash_protect = 2
@@ -384,7 +384,7 @@
 	name = "optical ecto-scanner"
 	desc = "A bulky pair of unwieldy glasses that lets you see things best left unseen. Obscures vision, but also has enhanced shielding which blocks flashes."
 	icon_state = "bustin-g"
-	item_state = "bustin-g"
+	inhand_icon_state = "bustin-g"
 	flash_protect = 2
 	tint = 2
 	glass_colour_type = /datum/client_colour/glass_colour/green
@@ -426,7 +426,7 @@
 	name = "blindfold"
 	desc = "Covers the eyes, preventing sight."
 	icon_state = "blindfold"
-	item_state = "blindfold"
+	inhand_icon_state = "blindfold"
 	flash_protect = 2
 	tint = 3
 	darkness_view = 1
@@ -436,7 +436,7 @@
 	name = "blind personnel blindfold"
 	desc = "Indicates that the wearer suffers from blindness."
 	icon_state = "blindfoldwhite"
-	item_state = "blindfoldwhite"
+	inhand_icon_state = "blindfoldwhite"
 	var/colored_before = FALSE
 
 /obj/item/clothing/glasses/blindfold/white/visual_equipped(mob/living/carbon/human/user, slot)
@@ -461,13 +461,13 @@
 
 /obj/item/clothing/glasses/sunglasses/advanced/big
 	icon_state = "bigsunglasses"
-	item_state = "bigsunglasses"
+	inhand_icon_state = "bigsunglasses"
 
 /obj/item/clothing/glasses/thermal
 	name = "optical thermal scanner"
 	desc = "Thermals in the shape of glasses."
 	icon_state = "thermal"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	vision_flags = SEE_MOBS
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	glass_colour_type = /datum/client_colour/glass_colour/red
@@ -524,39 +524,39 @@
 	name = "optical thermal eyepatch"
 	desc = "An eyepatch with built-in thermal optics."
 	icon_state = "eyepatch"
-	item_state = "eyepatch"
+	inhand_icon_state = "eyepatch"
 
 /obj/item/clothing/glasses/cold
 	name = "cold goggles"
 	desc = "A pair of goggles meant for low temperatures."
 	icon_state = "cold"
-	item_state = "cold"
+	inhand_icon_state = "cold"
 
 /obj/item/clothing/glasses/heat
 	name = "heat goggles"
 	desc = "A pair of goggles meant for high temperatures."
 	icon_state = "heat"
-	item_state = "heat"
+	inhand_icon_state = "heat"
 
 /obj/item/clothing/glasses/orange
 	name = "orange glasses"
 	desc = "A sweet pair of orange shades."
 	icon_state = "orangeglasses"
-	item_state = "orangeglasses"
+	inhand_icon_state = "orangeglasses"
 	glass_colour_type = /datum/client_colour/glass_colour/lightorange
 
 /obj/item/clothing/glasses/red
 	name = "red glasses"
 	desc = "Hey, you're looking good, senpai!"
 	icon_state = "redglasses"
-	item_state = "redglasses"
+	inhand_icon_state = "redglasses"
 	glass_colour_type = /datum/client_colour/glass_colour/red
 
 /obj/item/clothing/glasses/godeye
 	name = "eye of god"
 	desc = "A strange eye, said to have been torn from an omniscient creature that used to roam the wastes."
 	icon_state = "godeye"
-	item_state = "godeye"
+	inhand_icon_state = "godeye"
 	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS
 	darkness_view = 8
 	clothing_flags = SCAN_REAGENTS | SCAN_BOOZEPOWER
@@ -597,7 +597,7 @@
 	if(istype(W, src) && W != src && W.loc == user)
 		if(W.icon_state == "godeye")
 			W.icon_state = "doublegodeye"
-			W.item_state = "doublegodeye"
+			W.inhand_icon_state = "doublegodeye"
 			W.desc = "A pair of strange eyes, said to have been torn from an omniscient creature that used to roam the wastes. There's no real reason to have two, but that isn't stopping you."
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -10,7 +10,7 @@
 	name = "engineering scanner goggles"
 	desc = "Goggles used by engineers. The Meson Scanner mode lets you see basic structural and terrain layouts through walls, the T-ray Scanner mode lets you see underfloor objects such as cables and pipes, and the Radiation Scanner mode let's you see objects contaminated by radiation."
 	icon_state = "trayson-meson"
-	item_state = "trayson-meson"
+	inhand_icon_state = "trayson-meson"
 	actions_types = list(/datum/action/item_action/toggle_mode)
 
 	vision_flags = NONE
@@ -120,7 +120,7 @@
 	update_mob()
 
 /obj/item/clothing/glasses/meson/engine/proc/update_mob()
-	item_state = icon_state
+	inhand_icon_state = icon_state
 	if(isliving(loc))
 		var/mob/living/user = loc
 		if(user.get_item_by_slot(ITEM_SLOT_EYES) == src)
@@ -131,7 +131,7 @@
 /obj/item/clothing/glasses/meson/engine/tray //atmos techs have lived far too long without tray goggles while those damned engineers get their dual-purpose gogles all to themselves
 	name = "optical t-ray scanner"
 	icon_state = "trayson-t-ray"
-	item_state = "trayson-t-ray"
+	inhand_icon_state = "trayson-t-ray"
 	desc = "Used by engineering staff to see underfloor objects such as cables and pipes."
 	range = 2
 
@@ -145,7 +145,7 @@
 /obj/item/clothing/glasses/meson/engine/shuttle
 	name = "shuttle region scanner"
 	icon_state = "trayson-shuttle"
-	item_state = "trayson-shuttle"
+	inhand_icon_state = "trayson-shuttle"
 	desc = "Used to see the boundaries of shuttle regions."
 
 	modes = list(MODE_NONE = MODE_SHUTTLE, MODE_SHUTTLE = MODE_NONE)

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -131,7 +131,7 @@
 	desc = "An advanced medical head-up display that allows doctors to find patients in complete darkness."
 	icon_state = "healthhudnight"
 	emissive_state = "nvg_emissive"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	darkness_view = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	glass_colour_type = /datum/client_colour/glass_colour/green
@@ -172,7 +172,7 @@
 	desc = "A robotics diagnostic HUD fitted with a light amplifier."
 	icon_state = "diagnostichudnight"
 	emissive_state = "nvg_emissive"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	darkness_view = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	glass_colour_type = /datum/client_colour/glass_colour/green
@@ -182,7 +182,7 @@
 	desc = "Sunglasses with a diagnostic HUD."
 	icon_state = "sunhuddiag"
 	emissive_state = "sun_emissive"
-	item_state = "glasses"
+	inhand_icon_state = "glasses"
 	flash_protect = 1
 	tint = 1
 
@@ -287,7 +287,7 @@
 	name = "\improper HUD gar glasses"
 	desc = "GAR glasses with a HUD."
 	icon_state = "gars"
-	item_state = "garb"
+	inhand_icon_state = "garb"
 	force = 10
 	throwforce = 10
 	throw_speed = 4
@@ -301,7 +301,7 @@
 	name = "giga HUD gar glasses"
 	desc = "GIGA GAR glasses with a HUD."
 	icon_state = "supergars"
-	item_state = "garb"
+	inhand_icon_state = "garb"
 	force = 12
 	throwforce = 12
 
@@ -378,7 +378,7 @@
 	name = "Omni HUD"
 	desc = "Glasses with every function."
 	icon_state = "doublegodeye"
-	item_state = "doublegodeye"
+	inhand_icon_state = "doublegodeye"
 	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS
 	darkness_view = 8
 	flash_protect = 2

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -4,7 +4,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/clothing/gloves.dmi'
 	icon_state = "white"
-	item_state = "wgloves"
+	inhand_icon_state = "wgloves"
 	worn_icon_state = "wgloves"
 	siemens_coefficient = 0.5
 	body_parts_covered = HANDS

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -2,31 +2,31 @@
 	name = "boxing gloves"
 	desc = "Because you really needed another excuse to punch your crewmates."
 	icon_state = "boxing"
-	item_state = "boxing"
+	inhand_icon_state = "boxing"
 	worn_icon_state = "boxing"
 	equip_delay_other = 60
 	species_exception = list(/datum/species/golem) // now you too can be a golem boxing champion
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"
-	item_state = "boxinggreen"
+	inhand_icon_state = "boxinggreen"
 	worn_icon_state = "boxinggreen"
 
 /obj/item/clothing/gloves/boxing/blue
 	icon_state = "boxingblue"
-	item_state = "boxingblue"
+	inhand_icon_state = "boxingblue"
 	worn_icon_state = "boxingblue"
 
 /obj/item/clothing/gloves/boxing/yellow
 	icon_state = "boxingyellow"
-	item_state = "boxingyellow"
+	inhand_icon_state = "boxingyellow"
 	worn_icon_state = "boxingyellow"
 
 /obj/item/clothing/gloves/boxing/yellow/insulated
 	name = "budget boxing gloves"
 	desc = "Standard boxing gloves coated in a makeshift insulating coat. This can't possibly go wrong at all."
 	icon_state = "boxingyellow"
-	item_state = "boxingyellow"
+	inhand_icon_state = "boxingyellow"
 	worn_icon_state = "boxingyellow"
 	siemens_coefficient = 1	//Set to a default of 1, gets overridden in Initialize()
 

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -4,7 +4,7 @@
 	desc = "These gloves provide protection against electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
-	item_state = "ygloves"
+	inhand_icon_state = "ygloves"
 	worn_icon_state = "ygloves"
 	siemens_coefficient = 0
 	armor_type = /datum/armor/color_yellow
@@ -49,7 +49,7 @@
 	desc = "These gloves are cheap knockoffs of the coveted ones - no way this can end badly."
 	name = "budget insulated gloves"
 	icon_state = "yellow"
-	item_state = "ygloves"
+	inhand_icon_state = "ygloves"
 	worn_icon_state = "ygloves"
 	siemens_coefficient = 1 //Set to a default of 1, gets overridden in Initialize()
 	armor_type = /datum/armor/color_fyellow
@@ -76,7 +76,7 @@
 	desc = "These gloves would protect the wearer from electric shock... if the fingers were covered."
 	name = "fingerless insulated gloves"
 	icon_state = "yellowcut"
-	item_state = "ygloves"
+	inhand_icon_state = "ygloves"
 	worn_icon_state = "ygloves"
 	transfer_prints = TRUE
 
@@ -87,7 +87,7 @@
 	desc = "These gloves are fire-resistant."
 	name = "black gloves"
 	icon_state = "black"
-	item_state = "blackgloves"
+	inhand_icon_state = "blackgloves"
 	worn_icon_state = "blackgloves"
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
@@ -100,14 +100,14 @@
 	name = "orange gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "orange"
-	item_state = "orangegloves"
+	inhand_icon_state = "orangegloves"
 	worn_icon_state = "orangegloves"
 
 /obj/item/clothing/gloves/color/red
 	name = "red gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "red"
-	item_state = "redgloves"
+	inhand_icon_state = "redgloves"
 	worn_icon_state = "redgloves"
 
 /obj/item/clothing/gloves/color/red/insulated
@@ -121,63 +121,63 @@
 	name = "rainbow gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "rainbow"
-	item_state = "rainbowgloves"
+	inhand_icon_state = "rainbowgloves"
 	worn_icon_state = "rainbowgloves"
 
 /obj/item/clothing/gloves/color/blue
 	name = "blue gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "blue"
-	item_state = "bluegloves"
+	inhand_icon_state = "bluegloves"
 	worn_icon_state = "bluegloves"
 
 /obj/item/clothing/gloves/color/purple
 	name = "purple gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "purple"
-	item_state = "purplegloves"
+	inhand_icon_state = "purplegloves"
 	worn_icon_state = "purplegloves"
 
 /obj/item/clothing/gloves/color/green
 	name = "green gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "green"
-	item_state = "greengloves"
+	inhand_icon_state = "greengloves"
 	worn_icon_state = "greengloves"
 
 /obj/item/clothing/gloves/color/grey
 	name = "grey gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "gray"
-	item_state = "graygloves"
+	inhand_icon_state = "graygloves"
 	worn_icon_state = "graygloves"
 
 /obj/item/clothing/gloves/color/light_brown
 	name = "light brown gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "lightbrown"
-	item_state = "lightbrowngloves"
+	inhand_icon_state = "lightbrowngloves"
 	worn_icon_state = "lightbrowngloves"
 
 /obj/item/clothing/gloves/color/brown
 	name = "brown gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "brown"
-	item_state = "browngloves"
+	inhand_icon_state = "browngloves"
 	worn_icon_state = "browngloves"
 
 /obj/item/clothing/gloves/color/denied
 	name = "ERROR gloves"
 	desc = "With these gloves you will be like the legendary Midas. Except instead of turning to gold everthing you touch will become -REDACTED-."
 	icon_state = "denied"
-	item_state = "redgloves"
+	inhand_icon_state = "redgloves"
 	worn_icon_state = "deniedgloves"
 
 /obj/item/clothing/gloves/color/captain
 	desc = "Regal blue gloves, with a nice gold trim, a diamond anti-shock coating, and an integrated thermal barrier. Swanky."
 	name = "captain's gloves"
 	icon_state = "captain"
-	item_state = "egloves"
+	inhand_icon_state = "egloves"
 	worn_icon_state = "egloves"
 	siemens_coefficient = 0
 	cold_protection = HANDS
@@ -197,7 +197,7 @@
 	name = "latex gloves"
 	desc = "Cheap sterile gloves made from latex. Transfers minor paramedic knowledge to the user via budget nanochips."
 	icon_state = "latex"
-	item_state = "latex"
+	inhand_icon_state = "latex"
 	worn_icon_state = "latex"
 	siemens_coefficient = 0.3
 	armor_type = /datum/armor/color_latex
@@ -232,7 +232,7 @@
 	name = "nitrile gloves"
 	desc = "Pricy sterile gloves that are stronger than latex. Transfers intimate paramedic knowledge into the user via nanochips."
 	icon_state = "nitrile"
-	item_state = "nitrilegloves"
+	inhand_icon_state = "nitrilegloves"
 	worn_icon_state = "nitrilegloves"
 	transfer_prints = FALSE
 	carrytrait = TRAIT_QUICKER_CARRY
@@ -241,14 +241,14 @@
 	name = "white gloves"
 	desc = "These look pretty fancy."
 	icon_state = "white"
-	item_state = "wgloves"
+	inhand_icon_state = "wgloves"
 	worn_icon_state = "wgloves"
 
 /obj/item/clothing/gloves/color/color_yellow
 	name = "yellow gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "white"
-	item_state = "wgloves"
+	inhand_icon_state = "wgloves"
 	worn_icon_state = "wgloves"
 	color = "#ffe14d"
 
@@ -273,5 +273,5 @@
 	name = "maid arm covers"
 	desc = "Cylindrical looking tubes that go over your arm, weird."
 	icon_state = "maid_arms"
-	item_state = "maid_arms"
+	inhand_icon_state = "maid_arms"
 	worn_icon_state = "maid_arms"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -3,7 +3,7 @@
 	name = "fingerless gloves"
 	desc = "Plain black gloves without fingertips for the hard working."
 	icon_state = "fingerless"
-	item_state = "fingerless"
+	inhand_icon_state = "fingerless"
 	worn_icon_state = "fingerless"
 	transfer_prints = TRUE
 	strip_delay = 40
@@ -17,7 +17,7 @@
 	name = "botanist's leather gloves"
 	desc = "These leather gloves protect against thorns, barbs, prickles, spikes and other harmful objects of floral origin.  They're also quite warm."
 	icon_state = "leather"
-	item_state = "ggloves"
+	inhand_icon_state = "ggloves"
 	worn_icon_state = "ggloves"
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
@@ -36,7 +36,7 @@
 	name = "combat gloves"
 	desc = "These tactical gloves are fireproof and shock resistant."
 	icon_state = "cgloves"
-	item_state = "combatgloves"
+	inhand_icon_state = "combatgloves"
 	worn_icon_state = "combatgloves"
 	siemens_coefficient = 0
 	strip_delay = 80
@@ -59,7 +59,7 @@
 	name = "bone bracers"
 	desc = "For when you're expecting to get slapped on the wrist. Offers modest protection to your arms."
 	icon_state = "bracers"
-	item_state = "bracers"
+	inhand_icon_state = "bracers"
 	worn_icon_state = "bracers"
 	transfer_prints = TRUE
 	strip_delay = 40
@@ -87,7 +87,7 @@
 	name = "Gloves of the North Star"
 	desc = "Just looking at these fills you with an urge to beat the shit out of people."
 	icon_state = "rapid"
-	item_state = "rapid"
+	inhand_icon_state = "rapid"
 	worn_icon_state = "rapid"
 	transfer_prints = TRUE
 	item_flags = ISWEAPON
@@ -123,7 +123,7 @@
 	name = "white gloves"
 	desc = "These look pretty fancy."
 	icon_state = "white"
-	item_state = "wgloves"
+	inhand_icon_state = "wgloves"
 	var/range = 3
 
 /obj/item/clothing/gloves/color/white/magic/attackby(obj/item/W, mob/user, params)
@@ -154,7 +154,7 @@
 	name = "anti-tactile pinchers"
 	desc = "Used for the fine manipulation and examination of artifacts."
 	icon_state = "pincher"
-	item_state = "pincher"
+	inhand_icon_state = "pincher"
 	worn_icon_state = "pincher"
 	transfer_prints = FALSE
 	actions_types = list(/datum/action/item_action/artifact_pincher_mode)

--- a/code/modules/clothing/head/cakehat.dm
+++ b/code/modules/clothing/head/cakehat.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "hardhat0_cakehat"
-	item_state = "hardhat0_cakehat"
+	inhand_icon_state = "hardhat0_cakehat"
 	hat_type = "cakehat"
 	lefthand_file = 'icons/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing_righthand.dmi'
@@ -55,7 +55,7 @@
 	name = "energy cake"
 	desc = "You put the energy sword on your cake. Brilliant."
 	icon_state = "hardhat0_energycake"
-	item_state = "hardhat0_energycake"
+	inhand_icon_state = "hardhat0_energycake"
 	hat_type = "energycake"
 	hitsound = 'sound/weapons/tap.ogg'
 	hitsound_on = 'sound/weapons/blade1.ogg'

--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -64,7 +64,7 @@
 	icon = 'icons/obj/clothing/head/utility.dmi'
 	worn_icon = 'icons/mob/clothing/head/utility.dmi'
 	icon_state = "chef"
-	item_state = "chef"
+	inhand_icon_state = "chef"
 	dynamic_hair_suffix = ""
 	dog_fashion = /datum/dog_fashion/head/chef
 
@@ -81,7 +81,7 @@
 	icon = 'icons/obj/clothing/head/hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/hats.dmi'
 	icon_state = "tophat"
-	item_state = "that"
+	inhand_icon_state = "that"
 
 /obj/item/clothing/head/collectable/captain
 	name = "collectable captain's hat"
@@ -89,7 +89,7 @@
 	icon = 'icons/obj/clothing/head/hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/hats.dmi'
 	icon_state = "captain"
-	item_state = null
+	inhand_icon_state = null
 	dog_fashion = /datum/dog_fashion/head/captain
 
 /obj/item/clothing/head/collectable/police
@@ -116,14 +116,14 @@
 	icon = 'icons/obj/clothing/head/utility.dmi'
 	worn_icon = 'icons/mob/clothing/head/utility.dmi'
 	icon_state = "welding"
-	item_state = "welding"
+	inhand_icon_state = "welding"
 	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/collectable/slime
 	name = "collectable slime hat"
 	desc = "Just like a real brain slug!"
 	icon_state = "headslime"
-	item_state = null
+	inhand_icon_state = null
 	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/collectable/flatcap
@@ -132,20 +132,20 @@
 	icon = 'icons/obj/clothing/head/beret.dmi'
 	worn_icon = 'icons/mob/clothing/head/beret.dmi'
 	icon_state = "flat_cap"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/collectable/pirate
 	name = "collectable pirate hat"
 	desc = "You'd make a great Dread Syndie Roberts!"
 	icon_state = "pirate"
-	item_state = null
+	inhand_icon_state = null
 	dog_fashion = /datum/dog_fashion/head/pirate
 
 /obj/item/clothing/head/collectable/kitty
 	name = "collectable kitty ears"
 	desc = "The fur feels... a bit too realistic."
 	icon_state = "kitty"
-	item_state = null
+	inhand_icon_state = null
 	clothing_flags = SNUG_FIT
 	dynamic_hair_suffix = ""
 	dog_fashion = /datum/dog_fashion/head/kitty
@@ -154,7 +154,7 @@
 	name = "collectable rabbit ears"
 	desc = "Not as lucky as the feet!"
 	icon_state = "bunny"
-	item_state = null
+	inhand_icon_state = null
 	clothing_flags = SNUG_FIT
 	dynamic_hair_suffix = ""
 	dog_fashion = /datum/dog_fashion/head/rabbit
@@ -173,7 +173,7 @@
 	icon = 'icons/obj/clothing/head/utility.dmi'
 	worn_icon = 'icons/mob/clothing/head/utility.dmi'
 	icon_state = "hardhat0_yellow"
-	item_state = null
+	inhand_icon_state = null
 	clothing_flags = SNUG_FIT
 	dog_fashion = /datum/dog_fashion/head
 
@@ -200,7 +200,7 @@
 	icon = 'icons/obj/clothing/head/helmet.dmi'
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "thunderdome"
-	item_state = "thunderdome"
+	inhand_icon_state = "thunderdome"
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEHAIR
 
@@ -210,6 +210,6 @@
 	icon = 'icons/obj/clothing/head/helmet.dmi'
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "swatsyndie"
-	item_state = "swatsyndie"
+	inhand_icon_state = "swatsyndie"
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEHAIR

--- a/code/modules/clothing/head/costume.dm
+++ b/code/modules/clothing/head/costume.dm
@@ -6,7 +6,7 @@
 	name = "powdered wig"
 	desc = "A powdered wig."
 	icon_state = "pwig"
-	item_state = "pwig"
+	inhand_icon_state = "pwig"
 
 /obj/item/clothing/head/hooded/hasturhood
 	name = "hastur's hood"
@@ -23,7 +23,7 @@
 	icon = 'icons/obj/clothing/head/spacehelm.dmi'
 	worn_icon = 'icons/mob/clothing/head/spacehelm.dmi'
 	icon_state = "syndicate-helm-black-red"
-	item_state = "syndicate-helm-black-red"
+	inhand_icon_state = "syndicate-helm-black-red"
 	desc = "A plastic replica of a Syndicate agent's space helmet. You'll look just like a real murderous Syndicate agent in this! This is a toy, it is not made for use in space!"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = SNUG_FIT
@@ -32,7 +32,7 @@
 	name = "cueball helmet"
 	desc = "A large, featureless white orb meant to be worn on your head. How do you even see out of this thing?"
 	icon_state = "cueball"
-	item_state = null
+	inhand_icon_state = null
 	flags_cover = HEADCOVERSEYES|HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = SNUG_FIT
@@ -41,7 +41,7 @@
 	name = "Snowman Head"
 	desc = "A ball of white styrofoam. So festive."
 	icon_state = "snowman_h"
-	item_state = null
+	inhand_icon_state = null
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = SNUG_FIT
@@ -50,7 +50,7 @@
 	name = "witch costume wig"
 	desc = "Eeeee~heheheheheheh!"
 	icon_state = "witch"
-	item_state = null
+	inhand_icon_state = null
 	flags_inv = HIDEHAIR
 
 /obj/item/clothing/head/costume/maidheadband
@@ -62,7 +62,7 @@
 	name = "chicken suit head"
 	desc = "Bkaw!"
 	icon_state = "chickenhead"
-	item_state = "chickensuit"
+	inhand_icon_state = "chickensuit"
 	clothing_flags = SNUG_FIT
 	body_parts_covered = HEAD
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
@@ -71,14 +71,14 @@
 	name = "griffon head"
 	desc = "Why not 'eagle head'? Who knows."
 	icon_state = "griffinhat"
-	item_state = null
+	inhand_icon_state = null
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/costume/xenos
 	name = "xenos helmet"
 	icon_state = "xenos"
-	item_state = "xenos_helm"
+	inhand_icon_state = "xenos_helm"
 	desc = "A helmet made out of chitinous alien hide."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = SNUG_FIT
@@ -101,7 +101,7 @@
 	name = "cardborg helmet"
 	desc = "A helmet made out of a box."
 	icon_state = "cardborg_h"
-	item_state = "cardborg_h"
+	inhand_icon_state = "cardborg_h"
 	clothing_flags = SNUG_FIT
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
@@ -171,7 +171,7 @@
 	name = "carp helmet"
 	desc = "Spaceworthy and it looks like a space carp's head, smells like one too."
 	icon_state = "carp_helm"
-	item_state = "syndicate"
+	inhand_icon_state = "syndicate"
 	armor_type = /datum/armor/carp_hood_spaceproof
 	light_system = NO_LIGHT_SUPPORT
 	light_range = 0 //luminosity when on

--- a/code/modules/clothing/head/fedora.dm
+++ b/code/modules/clothing/head/fedora.dm
@@ -3,7 +3,7 @@
 	icon_state = "fedora"
 	icon = 'icons/obj/clothing/head/hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/hats.dmi'
-	item_state = "fedora"
+	inhand_icon_state = "fedora"
 	desc = "A really cool hat if you're a mobster. A really lame hat if you're not."
 
 /obj/item/clothing/head/fedora/Initialize(mapload)

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -6,7 +6,7 @@
 	name = "hard hat"
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight."
 	icon_state = "hardhat0_yellow"
-	item_state = null
+	inhand_icon_state = null
 	armor_type = /datum/armor/utility_hardhat
 	flags_inv = NONE
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
@@ -54,7 +54,7 @@
 	update_appearance()
 
 /obj/item/clothing/head/utility/hardhat/update_icon_state()
-	icon_state = item_state = "hardhat[on]_[hat_type]"
+	icon_state = inhand_icon_state = "hardhat[on]_[hat_type]"
 	return ..()
 
 /obj/item/clothing/head/utility/hardhat/proc/turn_on(mob/user)
@@ -65,7 +65,7 @@
 
 /obj/item/clothing/head/utility/hardhat/orange
 	icon_state = "hardhat0_orange"
-	item_state = null
+	inhand_icon_state = null
 	hat_type = "orange"
 	dog_fashion = null
 
@@ -73,7 +73,7 @@
 	name = "firefighter helmet"
 	desc = "A helmet designed to be used in very hot, high pressure areas."
 	icon_state = "hardhat0_red"
-	item_state = null
+	inhand_icon_state = null
 	hat_type = "red"
 	dog_fashion = null
 	clothing_flags = STOPSPRESSUREDAMAGE | SNUG_FIT
@@ -89,7 +89,7 @@
 	name = "white hard hat"
 	desc = "It's a hard hat, but painted white. Probably belongs to the Chief Engineer. Looks a little more solid."
 	icon_state = "hardhat0_white"
-	item_state = null
+	inhand_icon_state = null
 	hat_type = "white"
 	clothing_flags = STOPSPRESSUREDAMAGE | SNUG_FIT
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
@@ -100,7 +100,7 @@
 
 /obj/item/clothing/head/utility/hardhat/dblue
 	icon_state = "hardhat0_dblue"
-	item_state = null
+	inhand_icon_state = null
 	hat_type = "dblue"
 	dog_fashion = null
 
@@ -108,7 +108,7 @@
 	name = "atmospheric technician's firefighting helmet"
 	desc = "A firefighter's helmet, able to keep the user cool in any situation."
 	icon_state = "hardhat0_atmos"
-	item_state = "hardhat0_atmos"
+	inhand_icon_state = "hardhat0_atmos"
 	hat_type = "atmos"
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT  | HEADINTERNALS
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
@@ -169,13 +169,13 @@
 
 /obj/item/clothing/head/utility/hardhat/welding/orange
 	icon_state = "hardhat0_orange"
-	item_state = null
+	inhand_icon_state = null
 	hat_type = "orange"
 
 /obj/item/clothing/head/utility/hardhat/welding/white
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight AND welding shield!" //This bulb is not smaller
 	icon_state = "hardhat0_white"
-	item_state = "hardhat0_white"
+	inhand_icon_state = "hardhat0_white"
 	light_range = 4 //Boss always takes the best stuff
 	hat_type = "white"
 	clothing_flags = STOPSPRESSUREDAMAGE | SNUG_FIT
@@ -190,7 +190,7 @@
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "hardhat0_pumpkin"
-	item_state = null
+	inhand_icon_state = null
 	hat_type = "pumpkin"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = SNUG_FIT
@@ -209,7 +209,7 @@
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	clothing_flags = SNUG_FIT
 	icon_state = "hardhat0_reindeer"
-	item_state = null
+	inhand_icon_state = null
 	hat_type = "reindeer"
 	flags_inv = 0
 	armor_type = /datum/armor/none

--- a/code/modules/clothing/head/hat.dm
+++ b/code/modules/clothing/head/hat.dm
@@ -6,7 +6,7 @@
 	name = "\improper CentCom hat"
 	icon_state = "centcom"
 	desc = "It's good to be emperor."
-	item_state = "that"
+	inhand_icon_state = "that"
 	flags_inv = NONE
 	armor_type = /datum/armor/hats_centhat
 	strip_delay = 80
@@ -27,7 +27,7 @@
 	name = "\improper CentCom commander cap"
 	icon_state = "centcom_cap"
 	desc = "Worn by the finest of CentCom commanders. Inside the lining of the cap, lies two faint initials."
-	item_state = "that"
+	inhand_icon_state = "that"
 	flags_inv = 0
 	armor_type = /datum/armor/hats_centcom_cap
 	strip_delay = (8 SECONDS)
@@ -47,7 +47,7 @@
 	name = "striped red tophat"
 	desc = "It smells like fresh donut holes. / <i>Il sent comme des trous de beignets frais.</i>"
 	icon_state = "canada"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/costume/redcoat
 	name = "redcoat's hat"
@@ -62,7 +62,7 @@
 /obj/item/clothing/head/costume/plague
 	name = "plague doctor's hat"
 	desc = "These were once used by plague doctors. They're pretty much useless."
-	item_state = "that"
+	inhand_icon_state = "that"
 	icon_state = "plaguedoctor"
 	clothing_flags = THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT
 	armor_type = /datum/armor/costume_plague
@@ -83,14 +83,14 @@
 	name = "bowler-hat"
 	desc = "Gentleman, elite aboard!"
 	icon_state = "bowler"
-	item_state = null
+	inhand_icon_state = null
 	dynamic_hair_suffix = ""
 
 /obj/item/clothing/head/costume/bearpelt
 	name = "bear pelt hat"
 	desc = "Fuzzy."
 	icon_state = "bearpelt"
-	item_state = "bearpelt"
+	inhand_icon_state = "bearpelt"
 
 /obj/item/clothing/head/flatcap
 	name = "flat cap"
@@ -98,13 +98,13 @@
 	icon = 'icons/obj/clothing/head/beret.dmi'
 	worn_icon = 'icons/mob/clothing/head/beret.dmi'
 	icon_state = "flat_cap"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/costume/santa
 	name = "santa hat"
 	desc = "On the first day of christmas my employer gave to me!"
 	icon_state = "santahatnorm"
-	item_state = "that"
+	inhand_icon_state = "that"
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	dog_fashion = /datum/dog_fashion/head/santa
@@ -154,13 +154,13 @@
 	name = "\improper CentCom Head Intern beancap"
 	desc = "A horrifying mix of beanie and softcap in CentCom green. You'd have to be pretty desperate for power over your peers to agree to wear this."
 	icon_state = "intern_hat"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/costume/ushanka
 	name = "ushanka"
 	desc = "Perfect for winter in Siberia, da?"
 	icon_state = "ushankadown"
-	item_state = null
+	inhand_icon_state = null
 	flags_inv = HIDEEARS|HIDEHAIR
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
@@ -171,11 +171,11 @@
 /obj/item/clothing/head/costume/ushanka/attack_self(mob/user)
 	if(earflaps_down)
 		icon_state = "ushankaup"
-		item_state = "ushankaup"
+		inhand_icon_state = "ushankaup"
 		earflaps_down = FALSE
 		to_chat(user, span_notice("You raise the ear flaps on the ushanka."))
 	else
 		icon_state = initial(icon_state)
-		item_state = initial(item_state)
+		inhand_icon_state = initial(inhand_icon_state)
 		earflaps_down = TRUE
 		to_chat(user, span_notice("You lower the ear flaps on the ushanka."))

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/head/helmet.dmi'
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "helmet"
-	item_state = "helmet"
+	inhand_icon_state = "helmet"
 	armor_type = /datum/armor/head_helmet
 	flags_inv = HIDEEARS
 	cold_protection = HEAD
@@ -68,7 +68,7 @@
 	name = "bulletproof helmet"
 	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "helmetalt"
-	item_state = "helmetalt"
+	inhand_icon_state = "helmetalt"
 	armor_type = /datum/armor/helmet_alt
 
 
@@ -96,7 +96,7 @@
 	name = "blue helmet"
 	desc = "A reliable, blue tinted helmet reminding you that you <i>still</i> owe that engineer a beer."
 	icon_state = "blueshift"
-	item_state = "blueshift"
+	inhand_icon_state = "blueshift"
 	custom_premium_price = 450
 
 /obj/item/clothing/head/helmet/toggleable
@@ -137,7 +137,7 @@
 	name = "riot helmet"
 	desc = "It's a helmet specifically designed to protect against close range attacks."
 	icon_state = "riot"
-	item_state = "helmet"
+	inhand_icon_state = "helmet"
 	toggle_message = "You pull the visor down on"
 	alt_toggle_message = "You push the visor up on"
 	armor_type = /datum/armor/toggleable_riot
@@ -167,7 +167,7 @@
 	name = "helmet of justice"
 	desc = "WEEEEOOO. WEEEEEOOO. WEEEEOOOO."
 	icon_state = "justice"
-	item_state = "justice_helmet"
+	inhand_icon_state = "justice_helmet"
 	toggle_message = "You turn off the lights on"
 	alt_toggle_message = "You turn on the lights on"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
@@ -206,7 +206,7 @@
 	name = "\improper SWAT helmet"
 	desc = "An extremely robust, space-worthy helmet in a nefarious red and black stripe pattern."
 	icon_state = "swatsyndie"
-	item_state = "swatsyndie"
+	inhand_icon_state = "swatsyndie"
 	armor_type = /datum/armor/helmet_swat
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -239,14 +239,14 @@
 	name = "\improper SWAT helmet"
 	desc = "An extremely robust, space-worthy helmet with the Nanotrasen logo emblazoned on the top."
 	icon_state = "swat"
-	item_state = "swat"
+	inhand_icon_state = "swat"
 
 /obj/item/clothing/head/helmet/thunderdome
 	name = "\improper Thunderdome helmet"
 	desc = "<i>'Let the battle commence!'</i>"
 	flags_inv = HIDEEARS|HIDEHAIR
 	icon_state = "thunderdome"
-	item_state = "thunderdome"
+	inhand_icon_state = "thunderdome"
 	armor_type = /datum/armor/helmet_thunderdome
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -284,7 +284,7 @@
 	armor_type = /datum/armor/helmet_roman
 	resistance_flags = FIRE_PROOF
 	icon_state = "roman"
-	item_state = "roman"
+	inhand_icon_state = "roman"
 	strip_delay = 100
 
 
@@ -310,7 +310,7 @@
 	name = "\improper Roman legionnaire helmet"
 	desc = "An ancient helmet made of bronze and leather. Has a red crest on top of it."
 	icon_state = "roman_c"
-	item_state = "roman_c"
+	inhand_icon_state = "roman_c"
 
 /obj/item/clothing/head/helmet/roman/legionnaire/fake
 	desc = "An ancient helmet made of plastic and leather. Has a red crest on top of it."
@@ -324,7 +324,7 @@
 	name = "gladiator helmet"
 	desc = "Ave, Imperator, morituri te salutant."
 	icon_state = "gladiator"
-	item_state = "gladiator"
+	inhand_icon_state = "gladiator"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR
 	flags_cover = HEADCOVERSEYES
 
@@ -333,7 +333,7 @@
 	desc = "They have chosen their own end."
 	icon_state = "redtaghelm"
 	flags_cover = HEADCOVERSEYES
-	item_state = "redtaghelm"
+	inhand_icon_state = "redtaghelm"
 	armor_type = /datum/armor/helmet_redtaghelm
 
 
@@ -352,7 +352,7 @@
 	desc = "They'll need more men."
 	icon_state = "bluetaghelm"
 	flags_cover = HEADCOVERSEYES
-	item_state = "bluetaghelm"
+	inhand_icon_state = "bluetaghelm"
 	armor_type = /datum/armor/helmet_bluetaghelm
 
 
@@ -370,7 +370,7 @@
 	name = "medieval helmet"
 	desc = "A classic metal helmet."
 	icon_state = "knight_green"
-	item_state = "knight_green"
+	inhand_icon_state = "knight_green"
 	armor_type = /datum/armor/helmet_knight
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
@@ -390,15 +390,15 @@
 
 /obj/item/clothing/head/helmet/knight/blue
 	icon_state = "knight_blue"
-	item_state = "knight_blue"
+	inhand_icon_state = "knight_blue"
 
 /obj/item/clothing/head/helmet/knight/yellow
 	icon_state = "knight_yellow"
-	item_state = "knight_yellow"
+	inhand_icon_state = "knight_yellow"
 
 /obj/item/clothing/head/helmet/knight/red
 	icon_state = "knight_red"
-	item_state = "knight_red"
+	inhand_icon_state = "knight_red"
 
 /obj/item/clothing/head/helmet/skull
 	name = "skull helmet"
@@ -407,7 +407,7 @@
 	flags_cover = HEADCOVERSEYES
 	armor_type = /datum/armor/helmet_skull
 	icon_state = "skull"
-	item_state = "skull"
+	inhand_icon_state = "skull"
 	strip_delay = 100
 
 
@@ -426,7 +426,7 @@
 	name = "durathread helmet"
 	desc = "A helmet made from durathread, a strong material commonly used for ballistic protection."
 	icon_state = "durathread"
-	item_state = "durathread"
+	inhand_icon_state = "durathread"
 	resistance_flags = FLAMMABLE
 	armor_type = /datum/armor/helmet_durathread
 	strip_delay = 60
@@ -447,7 +447,7 @@
 	name = "russian helmet"
 	desc = "It can hold a bottle of vodka."
 	icon_state = "rus_helmet"
-	item_state = "rus_helmet"
+	inhand_icon_state = "rus_helmet"
 	armor_type = /datum/armor/helmet_rus_helmet
 
 /datum/armor/helmet_rus_helmet
@@ -470,7 +470,7 @@
 	name = "battle ushanka"
 	desc = "100% bear."
 	icon_state = "rus_ushanka"
-	item_state = "rus_ushanka"
+	inhand_icon_state = "rus_ushanka"
 	body_parts_covered = HEAD
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
@@ -496,7 +496,7 @@
 	icon = 'icons/obj/clothing/head/cowboy.dmi'
 	worn_icon = 'icons/mob/clothing/head/cowboy.dmi'
 	icon_state = "cowboy"
-	item_state = "cowboy"
+	inhand_icon_state = "cowboy"
 	worn_icon_state = "cowboy_outlaw"
 	body_parts_covered = HEAD
 	armor_type = /datum/armor/helmet_outlaw

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -7,7 +7,7 @@
 //Chef
 /obj/item/clothing/head/utility/chefhat
 	name = "chef's hat"
-	item_state = "chefhat"
+	inhand_icon_state = "chefhat"
 	icon_state = "chef"
 	desc = "The commander in chef's head wear."
 	strip_delay = 10
@@ -30,7 +30,7 @@
 	name = "captain's hat"
 	desc = "It's good being the king."
 	icon_state = "captain"
-	item_state = "that"
+	inhand_icon_state = "that"
 	flags_inv = 0
 	armor_type = /datum/armor/hats_caphat
 	strip_delay = 60
@@ -100,7 +100,7 @@
 	desc = "There's only one man who can sniff out the dirty stench of crime, and he's likely wearing this hat."
 	armor_type = /datum/armor/fedora_det_hat
 	icon_state = "detective"
-	item_state = "det_hat"
+	inhand_icon_state = "det_hat"
 	var/candy_cooldown = 0
 	dog_fashion = /datum/dog_fashion/head/detective
 
@@ -289,7 +289,7 @@
 	name = "warden's campaign hat"
 	desc = "A special armored campaign hat with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficient protection."
 	icon_state = "wardendrill"
-	item_state = null
+	inhand_icon_state = null
 	dog_fashion = null
 	var/mode = DRILL_DEFAULT
 

--- a/code/modules/clothing/head/justice.dm
+++ b/code/modules/clothing/head/justice.dm
@@ -2,23 +2,23 @@
 	name = "justice hat"
 	desc = "Fight for what's righteous!"
 	icon_state = "justicered"
-	item_state = null
+	inhand_icon_state = null
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEHAIR|HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES
 
 /obj/item/clothing/head/costume/justice/blue
 	icon_state = "justiceblue"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/costume/justice/yellow
 	icon_state = "justiceyellow"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/costume/justice/green
 	icon_state = "justicegreen"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/costume/justice/pink
 	icon_state = "justicepink"
-	item_state = null
+	inhand_icon_state = null

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/janitor.dmi'
 	worn_icon = 'icons/mob/clothing/head/utility.dmi'
 	icon_state = "cone"
-	item_state = null
+	inhand_icon_state = null
 	force = 1
 	throwforce = 3
 	throw_speed = 2

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -14,7 +14,7 @@
 	name = "welding helmet"
 	desc = "A head-mounted face cover designed to protect the wearer completely from space-arc eye."
 	icon_state = "welding"
-	item_state = "welding"
+	inhand_icon_state = "welding"
 	clothing_flags = SNUG_FIT
 	custom_materials = list(/datum/material/iron=1750, /datum/material/glass=400)
 	flash_protect = 2
@@ -42,7 +42,7 @@
 	desc = "A bunch of hair without a head attached."
 	icon = 'icons/mob/human_face.dmi'	  // default icon for all hairs
 	icon_state = "hair_vlong"
-	item_state = "pwig"
+	inhand_icon_state = "pwig"
 	flags_inv = HIDEHAIR	//Instead of being handled as a clothing item, it overrides the hair values in /datum/species/proc/handle_hair
 	slot_flags = ITEM_SLOT_HEAD
 	worn_icon = 'icons/mob/human_face.dmi'
@@ -149,14 +149,14 @@
 	name = "hat of ultimate masculinity"
 	desc = "Even the mere act of wearing this makes you want to pose menacingly."
 	icon_state = "speedwagon"
-	item_state = "speedwagon"
+	inhand_icon_state = "speedwagon"
 	worn_y_offset = 4
 
 /obj/item/clothing/head/costume/speedwagon/cursed
 	name = "ULTIMATE HAT"
 	desc = "You feel weak and pathetic in comparison to this exceptionally beautiful hat."
 	icon_state = "speedwagon"
-	item_state = "speedwagon"
+	inhand_icon_state = "speedwagon"
 	worn_y_offset = 6
 
 /obj/item/clothing/head/franks_hat
@@ -165,4 +165,4 @@
 	icon = 'icons/obj/clothing/head/cowboy.dmi'
 	worn_icon = 'icons/mob/clothing/head/cowboy.dmi'
 	icon_state = "cowboy"
-	item_state = "cowboy"
+	inhand_icon_state = "cowboy"

--- a/code/modules/clothing/head/pirate.dm
+++ b/code/modules/clothing/head/pirate.dm
@@ -2,7 +2,7 @@
 	name = "pirate hat"
 	desc = "Yarr."
 	icon_state = "pirate"
-	item_state = null
+	inhand_icon_state = null
 	dog_fashion = /datum/dog_fashion/head/pirate
 
 /obj/item/clothing/head/costume/pirate
@@ -28,11 +28,11 @@
 /obj/item/clothing/head/costume/pirate/captain
 	name = "pirate captain hat"
 	icon_state = "hgpiratecap"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/costume/pirate/bandana
 	name = "pirate bandana"
 	desc = "Yarr."
 	icon_state = "bandana"
-	item_state = null
+	inhand_icon_state = null
 	dynamic_hair_suffix = ""

--- a/code/modules/clothing/head/sombrero.dm
+++ b/code/modules/clothing/head/sombrero.dm
@@ -2,7 +2,7 @@
 	name = "sombrero"
 	icon = 'icons/obj/clothing/head/sombrero.dmi'
 	icon_state = "sombrero"
-	item_state = "sombrero"
+	inhand_icon_state = "sombrero"
 	desc = "You can practically taste the fiesta."
 	flags_inv = HIDEHAIR
 
@@ -12,7 +12,7 @@
 	name = "green sombrero"
 	desc = "As elegant as a dancing cactus."
 	icon_state = "greensombrero"
-	item_state = "greensombrero"
+	inhand_icon_state = "greensombrero"
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 	dog_fashion = null
 
@@ -20,7 +20,7 @@
 	name = "shamebrero"
 	desc = "Once it's on, it never comes off."
 	icon_state = "shamebrero"
-	item_state = "shamebrero"
+	inhand_icon_state = "shamebrero"
 	dog_fashion = null
 
 /obj/item/clothing/head/costume/sombrero/shamebrero/Initialize(mapload)

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -2,7 +2,7 @@
 	name = "tinfoil hat"
 	desc = "Thought control rays, psychotronic scanning. Don't mind that, I'm protected cause I made this hat."
 	icon_state = "foilhat"
-	item_state = null
+	inhand_icon_state = null
 	clothing_flags = EFFECT_HAT | SNUG_FIT
 	armor_type = /datum/armor/costume_foilhat
 	equip_delay_other = 140
@@ -64,7 +64,7 @@
 	icon = 'icons/obj/clothing/head/plasmaman_hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/plasmaman_head.dmi'
 	icon_state = "tinfoil_envirohelm"
-	item_state = "tinfoil_envirohelm"
+	inhand_icon_state = "tinfoil_envirohelm"
 	strip_delay = 150
 	clothing_flags = STOPSPRESSUREDAMAGE | EFFECT_HAT | SNUG_FIT | HEADINTERNALS
 	armor_type = /datum/armor/foilhat_plasmaman
@@ -94,7 +94,7 @@
 /obj/item/clothing/head/costume/foilhat/plasmaman/attack_self(mob/user)
 	on = !on
 	icon_state = "[initial(icon_state)][on ? "-light":""]"
-	item_state = icon_state
+	inhand_icon_state = icon_state
 	user.update_inv_head() //So the mob overlay updates
 
 	if(on)

--- a/code/modules/clothing/head/tophat.dm
+++ b/code/modules/clothing/head/tophat.dm
@@ -2,6 +2,6 @@
 	name = "top-hat"
 	desc = "It's an amish looking hat."
 	icon_state = "tophat"
-	item_state = "that"
+	inhand_icon_state = "that"
 	dog_fashion = /datum/dog_fashion/head
 	throwforce = 1

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -2,7 +2,7 @@
 	name = "balaclava"
 	desc = "LOADSAMONEY"
 	icon_state = "balaclava"
-	item_state = "balaclava"
+	inhand_icon_state = "balaclava"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
@@ -15,7 +15,7 @@
 	name = "Luchador Mask"
 	desc = "Worn by robust fighters, flying high to defeat their foes!"
 	icon_state = "luchag"
-	item_state = "luchag"
+	inhand_icon_state = "luchag"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
 	modifies_speech = TRUE
@@ -48,19 +48,19 @@
 	name = "Tecnicos Mask"
 	desc = "Worn by robust fighters who uphold justice and fight honorably."
 	icon_state = "luchador"
-	item_state = "luchador"
+	inhand_icon_state = "luchador"
 
 /obj/item/clothing/mask/luchador/rudos
 	name = "Rudos Mask"
 	desc = "Worn by robust fighters who are willing to do anything to win."
 	icon_state = "luchar"
-	item_state = "luchar"
+	inhand_icon_state = "luchar"
 
 /obj/item/clothing/mask/russian_balaclava
 	name = "russian balaclava"
 	desc = "Protects your face from snow."
 	icon_state = "rus_balaclava"
-	item_state = "rus_balaclava"
+	inhand_icon_state = "rus_balaclava"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -2,7 +2,7 @@
 	desc = "A close-fitting mask that can be connected to an air supply."
 	name = "breath mask"
 	icon_state = "breath"
-	item_state = "m_mask"
+	inhand_icon_state = "m_mask"
 	body_parts_covered = 0
 	clothing_flags = MASKINTERNALS
 	visor_flags = MASKINTERNALS
@@ -38,7 +38,7 @@
 	desc = "A close-fitting sterile mask that can be connected to an air supply."
 	name = "medical mask"
 	icon_state = "medical"
-	item_state = "m_mask"
+	inhand_icon_state = "m_mask"
 	armor_type = /datum/armor/breath_medical
 	equip_delay_other = 10
 

--- a/code/modules/clothing/masks/cluwne.dm
+++ b/code/modules/clothing/masks/cluwne.dm
@@ -3,7 +3,7 @@
 	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."
 	flags_cover = MASKCOVERSEYES
 	icon_state = "cluwne"
-	item_state = "cluwne"
+	inhand_icon_state = "cluwne"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	flags_1 = MASKINTERNALS
 	item_flags = ABSTRACT | DROPDEL

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -5,7 +5,7 @@
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_NORMAL
-	item_state = "gas_alt"
+	inhand_icon_state = "gas_alt"
 	gas_transfer_coefficient = 0.01
 	armor_type = /datum/armor/mask_gas
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
@@ -20,7 +20,7 @@
 	desc = "Oooh, gold and green. Fancy! This should help as you sit in your office."
 	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "gas_centcom"
-	item_state = "gas_centcom"
+	inhand_icon_state = "gas_centcom"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 // **** Welding gas mask ****
@@ -65,7 +65,7 @@
 	name = "plague doctor mask"
 	desc = "A modernised version of the classic design, this mask will not only filter out toxins but it can also be connected to an air supply."
 	icon_state = "plaguedoctor"
-	item_state = "gas_mask"
+	inhand_icon_state = "gas_mask"
 
 /obj/item/clothing/mask/gas/syndicate
 	name = "syndicate mask"
@@ -78,7 +78,7 @@
 	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."
 	clothing_flags = MASKINTERNALS
 	icon_state = "clown"
-	item_state = "clown_hat"
+	inhand_icon_state = "clown_hat"
 	dye_color = "clown"
 	w_class = WEIGHT_CLASS_SMALL
 	flags_cover = MASKCOVERSEYES
@@ -125,7 +125,7 @@
 	desc = "A feminine clown mask for the dabbling crossdressers or female entertainers."
 	clothing_flags = MASKINTERNALS
 	icon_state = "sexyclown"
-	item_state = "sexyclown"
+	inhand_icon_state = "sexyclown"
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 
@@ -134,7 +134,7 @@
 	desc = "The traditional mime's mask. It has an eerie facial posture."
 	clothing_flags = MASKINTERNALS
 	icon_state = "mime"
-	item_state = "mime"
+	inhand_icon_state = "mime"
 	w_class = WEIGHT_CLASS_SMALL
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
@@ -176,7 +176,7 @@
 	desc = "A mask used when acting as a monkey."
 	clothing_flags = MASKINTERNALS
 	icon_state = "monkeymask"
-	item_state = "monkeymask"
+	inhand_icon_state = "monkeymask"
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 
@@ -185,14 +185,14 @@
 	desc = "A traditional female mime's mask."
 	clothing_flags = MASKINTERNALS
 	icon_state = "sexymime"
-	item_state = "sexymime"
+	inhand_icon_state = "sexymime"
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 
 /obj/item/clothing/mask/gas/death_commando
 	name = "Death Commando Mask"
 	icon_state = "swat"
-	item_state = "swat"
+	inhand_icon_state = "swat"
 
 /obj/item/clothing/mask/gas/cyborg
 	name = "cyborg visor"
@@ -217,7 +217,7 @@
 	name = "tiki mask"
 	desc = "A creepy wooden mask. Surprisingly expressive for a poorly carved bit of wood."
 	icon_state = "tiki_eyebrow"
-	item_state = "tiki_eyebrow"
+	inhand_icon_state = "tiki_eyebrow"
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 1.25)
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
@@ -260,7 +260,7 @@
 /obj/item/clothing/mask/gas/old
 	desc = "A face-covering mask that can be connected to an air supply. This one appears to be one of the older models."
 	icon_state = "gas_alt_old"
-	item_state = "gas_alt_old"
+	inhand_icon_state = "gas_alt_old"
 
 /obj/item/clothing/mask/gas/old/modulator
 	name = "modified gas mask"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -6,7 +6,7 @@
 	desc = "A standard issue Security gas mask with integrated 'Compli-o-nator 3000' device. Plays over a dozen pre-recorded compliance phrases designed to get scumbags to stand still whilst you tase them. Do not tamper with the device."
 	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/adjust)
 	icon_state = "sechailer"
-	item_state = "sechailer"
+	inhand_icon_state = "sechailer"
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
@@ -30,7 +30,7 @@
 	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000."
 	actions_types = list(/datum/action/item_action/halt)
 	icon_state = "swat"
-	item_state = "swat"
+	inhand_icon_state = "swat"
 	aggressiveness = 3
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDEEYES | HIDEEARS | HIDEHAIR | HIDESNOUT
 	visor_flags_inv = 0
@@ -56,7 +56,7 @@
 	name = "spacepol mask"
 	desc = "A close-fitting tactical mask created in cooperation with a certain megacorporation, comes with an especially aggressive Compli-o-nator 3000."
 	icon_state = "spacepol"
-	item_state = "spacepol"
+	inhand_icon_state = "spacepol"
 
 /obj/item/clothing/mask/gas/sechailer/cyborg
 	name = "security hailer"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -2,7 +2,7 @@
 	name = "muzzle"
 	desc = "To stop that awful noise."
 	icon_state = "muzzle"
-	item_state = "blindfold"
+	inhand_icon_state = "blindfold"
 	flags_cover = MASKCOVERSMOUTH
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0.9
@@ -20,7 +20,7 @@
 	name = "sterile mask"
 	desc = "A sterile mask designed to help prevent the spread of diseases."
 	icon_state = "sterile"
-	item_state = "sterile"
+	inhand_icon_state = "sterile"
 	w_class = WEIGHT_CLASS_TINY
 	flags_inv = HIDEFACE|HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH
@@ -71,7 +71,7 @@
 	name = "emotion mask"
 	desc = "Express your happiness or hide your sorrows with this cultured cutout."
 	icon_state = "joy"
-	item_state = "joy"
+	inhand_icon_state = "joy"
 	flags_inv = HIDESNOUT
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
@@ -104,7 +104,7 @@
 	name = "pig mask"
 	desc = "A rubber pig mask with a builtin voice modulator."
 	icon_state = "pig"
-	item_state = "pig"
+	inhand_icon_state = "pig"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	clothing_flags = VOICEBOX_TOGGLABLE
 	w_class = WEIGHT_CLASS_SMALL
@@ -130,7 +130,7 @@
 	name = "frog mask"
 	desc = "An ancient mask carved in the shape of a frog.<br> Sanity is like gravity, all it needs is a push."
 	icon_state = "frog"
-	item_state = "frog"
+	inhand_icon_state = "frog"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
 	clothing_flags = VOICEBOX_TOGGLABLE
@@ -159,7 +159,7 @@
 /obj/item/clothing/mask/cowmask
 	name = "cow mask"
 	icon_state = "cowmask"
-	item_state = "cowmask"
+	inhand_icon_state = "cowmask"
 	clothing_flags = VOICEBOX_TOGGLABLE
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
@@ -184,7 +184,7 @@
 	name = "horse head mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a horse."
 	icon_state = "horsehead"
-	item_state = "horsehead"
+	inhand_icon_state = "horsehead"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDEEYES|HIDEEARS|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
 	clothing_flags = VOICEBOX_TOGGLABLE
@@ -209,7 +209,7 @@
 	name = "rat mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a rat."
 	icon_state = "rat"
-	item_state = "rat"
+	inhand_icon_state = "rat"
 	flags_inv = HIDEFACE|HIDESNOUT
 	flags_cover = MASKCOVERSMOUTH
 
@@ -217,63 +217,63 @@
 	name = "fox mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a fox."
 	icon_state = "fox"
-	item_state = "fox"
+	inhand_icon_state = "fox"
 
 /obj/item/clothing/mask/rat/bee
 	name = "bee mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a bee."
 	icon_state = "bee"
-	item_state = "bee"
+	inhand_icon_state = "bee"
 
 /obj/item/clothing/mask/rat/bear
 	name = "bear mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a bear."
 	icon_state = "bear"
-	item_state = "bear"
+	inhand_icon_state = "bear"
 
 /obj/item/clothing/mask/rat/bat
 	name = "bat mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a bat."
 	icon_state = "bat"
-	item_state = "bat"
+	inhand_icon_state = "bat"
 
 /obj/item/clothing/mask/rat/raven
 	name = "raven mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a raven."
 	icon_state = "raven"
-	item_state = "raven"
+	inhand_icon_state = "raven"
 
 /obj/item/clothing/mask/rat/jackal
 	name = "jackal mask"
 	desc = "A mask made of soft vinyl and latex, representing the head of a jackal."
 	icon_state = "jackal"
-	item_state = "jackal"
+	inhand_icon_state = "jackal"
 
 /obj/item/clothing/mask/rat/tribal
 	name = "tribal mask"
 	desc = "A mask carved out of wood, detailed carefully by hand."
 	icon_state = "bumba"
-	item_state = "bumba"
+	inhand_icon_state = "bumba"
 
 /obj/item/clothing/mask/mummy
 	name = "mummy mask"
 	desc = "Ancient bandages."
 	icon_state = "mummy_mask"
-	item_state = "mummy_mask"
+	inhand_icon_state = "mummy_mask"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/mask/scarecrow
 	name = "sack mask"
 	desc = "A burlap sack with eyeholes."
 	icon_state = "scarecrow_sack"
-	item_state = "scarecrow_sack"
+	inhand_icon_state = "scarecrow_sack"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/mask/gondola
 	name = "gondola mask"
 	desc = "Genuine gondola fur."
 	icon_state = "gondola"
-	item_state = "gondola"
+	inhand_icon_state = "gondola"
 	flags_inv = HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	w_class = WEIGHT_CLASS_SMALL
 	modifies_speech = TRUE

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -20,7 +20,7 @@
 	desc = "A neosilk clip-on tie."
 	icon = 'icons/obj/clothing/neck.dmi'
 	icon_state = "bluetie"
-	item_state = ""	//no inhands
+	inhand_icon_state = ""	//no inhands
 	worn_icon = 'icons/mob/clothing/neck.dmi'
 	worn_icon_state = "bluetie"
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/clothing/shoes/cluwne.dm
+++ b/code/modules/clothing/shoes/cluwne.dm
@@ -2,7 +2,7 @@
 	desc = "The prankster's standard-issue clowning shoes. Damn, they're huge!"
 	name = "clown shoes"
 	icon_state = "clown"
-	item_state = "cluwne"
+	inhand_icon_state = "cluwne"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	item_flags = DROPDEL
 	slowdown = SHOES_SLOWDOWN+1

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -2,7 +2,7 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle."
 	name = "magboots"
 	icon_state = "magboots0"
-	item_state = "magboots"
+	inhand_icon_state = "magboots"
 	var/magboot_state = "magboots"
 	var/magpulse = 0
 	var/slowdown_active = 2

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -3,7 +3,7 @@
 	name = "combat boots"
 	desc = "High speed, low drag combat boots."
 	icon_state = "jackboots"
-	item_state = "jackboots"
+	inhand_icon_state = "jackboots"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	armor_type = /datum/armor/shoes_combat
@@ -65,7 +65,7 @@
 	desc = "A pair of shiny black wooden sandals."
 	name = "black sandals"
 	icon_state = "blacksandals"
-	item_state = "blacksandals"
+	inhand_icon_state = "blacksandals"
 
 /obj/item/clothing/shoes/sandal/magic
 	name = "magical sandals"
@@ -110,7 +110,7 @@
 	desc = "The prankster's standard-issue clowning shoes. Damn, they're huge! Ctrl-click to toggle waddle dampeners."
 	name = "clown shoes"
 	icon_state = "clown"
-	item_state = "clown_shoes"
+	inhand_icon_state = "clown_shoes"
 	slowdown = SHOES_SLOWDOWN+1
 	var/datum/component/waddle
 	var/enabled_waddle = TRUE
@@ -158,7 +158,7 @@
 	name = "jackboots"
 	desc = "Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time."
 	icon_state = "sec_jackboots"
-	item_state = "sec_jackboots"
+	inhand_icon_state = "sec_jackboots"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	strip_delay = 30
@@ -182,7 +182,7 @@
 	name = "replica jackboots"
 	desc = "An unarmored replica of Nanotrasen's Security combat boots. Unlike the real deal, this pair is better fit for everyday wear rather than combat."
 	icon_state = "jackboots"
-	item_state = "jackboots"
+	inhand_icon_state = "jackboots"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 
@@ -190,7 +190,7 @@
 	name = "white replica jackboots"
 	desc = "A cheap replica of Nanotrasen's Security combat boots. Unlike the real deal, this pair is better fit for everyday wear rather than combat."
 	icon_state = "white_jackboots"
-	item_state = "white_jackboots"
+	inhand_icon_state = "white_jackboots"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 
@@ -198,7 +198,7 @@
 	name = "winter boots"
 	desc = "Boots lined with 'synthetic' animal fur."
 	icon_state = "winterboots"
-	item_state = "winterboots"
+	inhand_icon_state = "winterboots"
 	armor_type = /datum/armor/shoes_winterboots
 	cold_protection = FEET|LEGS
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
@@ -230,7 +230,7 @@
 	name = "work boots"
 	desc = "Nanotrasen-issue Engineering lace-up work boots for the especially blue-collar."
 	icon_state = "workboots"
-	item_state = "jackboots"
+	inhand_icon_state = "jackboots"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	armor_type = /datum/armor/shoes_workboots
@@ -256,7 +256,7 @@
 	name = "\improper Nar'Sien invoker boots"
 	desc = "A pair of boots worn by the followers of Nar'Sie."
 	icon_state = "cult"
-	item_state = "cult"
+	inhand_icon_state = "cult"
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
@@ -283,7 +283,7 @@
 	name = "roman sandals"
 	desc = "Sandals with buckled leather straps on it."
 	icon_state = "roman"
-	item_state = "roman"
+	inhand_icon_state = "roman"
 	strip_delay = 100
 	equip_delay_other = 100
 	armor_type = /datum/armor/shoes_roman
@@ -296,7 +296,7 @@
 	name = "griffon boots"
 	desc = "A pair of costume boots fashioned after bird talons."
 	icon_state = "griffinboots"
-	item_state = "griffinboots"
+	inhand_icon_state = "griffinboots"
 
 /obj/item/clothing/shoes/griffin/Initialize(mapload)
 	. = ..()
@@ -307,7 +307,7 @@
 	name = "jump boots"
 	desc = "A specialized pair of combat boots with a built-in propulsion system for rapid forward movement."
 	icon_state = "jetboots"
-	item_state = "jetboots"
+	inhand_icon_state = "jetboots"
 	resistance_flags = FIRE_PROOF
 	actions_types = list(/datum/action/item_action/bhop)
 	armor_type = /datum/armor/shoes_bhop
@@ -369,7 +369,7 @@
 	name = "Kindle Kicks"
 	desc = "They'll sure kindle something in you, and it's not childhood nostalgia..."
 	icon_state = "kindleKicks"
-	item_state = "kindleKicks"
+	inhand_icon_state = "kindleKicks"
 	actions_types = list(/datum/action/item_action/kindleKicks)
 	var/lightCycle = 0
 	var/active = FALSE
@@ -400,7 +400,7 @@
 	name = "russian boots"
 	desc = "Comfy shoes."
 	icon_state = "rus_shoes"
-	item_state = "rus_shoes"
+	inhand_icon_state = "rus_shoes"
 
 /obj/item/clothing/shoes/russian/Initialize(mapload)
 	. = ..()
@@ -411,4 +411,4 @@
 	name = "swag shoes"
 	desc = "They got me for my foams!"
 	icon_state = "SwagShoes"
-	item_state = "SwagShoes"
+	inhand_icon_state = "SwagShoes"

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -3,7 +3,7 @@
 	desc = "Uses patented retractable wheel technology. Never sacrifice speed for style - not that this provides much of either." //Thanks Fel
 	icon_state = "sneakers"
 	worn_icon_state = "wheelys"
-	item_state = "wheelys"
+	inhand_icon_state = "wheelys"
 	greyscale_colors = "#545454#ffffff"
 	greyscale_config = /datum/greyscale_config/sneakers_wheelys
 	actions_types = list(/datum/action/item_action/wheelys)

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/clothing/head/spacehelm.dmi'
 	worn_icon = 'icons/mob/clothing/head/spacehelm.dmi'
 	icon_state = "spaceold"
-	item_state = "space_helmet"
+	inhand_icon_state = "space_helmet"
 	desc = "A special helmet with solar UV shielding to protect your eyes from harmful rays."
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | HEADINTERNALS
 	armor_type = /datum/armor/helmet_space
@@ -113,7 +113,7 @@
 	icon_state = "spaceold"
 	icon = 'icons/obj/clothing/suits/spacesuit.dmi'
 	worn_icon = 'icons/mob/clothing/suits/spacesuit.dmi'
-	item_state = "s_suit"
+	inhand_icon_state = "s_suit"
 	w_class = WEIGHT_CLASS_BULKY
 	gas_transfer_coefficient = 0.01
 	clothing_flags = NOTCONSUMABLE | STOPSPRESSUREDAMAGE | THICKMATERIAL

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -2,7 +2,7 @@
 	name = "Chronosuit Helmet"
 	desc = "A white helmet with an opaque blue visor."
 	icon_state = "chronohelmet"
-	item_state = "chronohelmet"
+	inhand_icon_state = "chronohelmet"
 	slowdown = 1
 	armor_type = /datum/armor/space_chronos
 	resistance_flags = FIRE_PROOF | ACID_PROOF
@@ -31,7 +31,7 @@
 	name = "Chronosuit"
 	desc = "An advanced spacesuit equipped with time-bluespace teleportation and anti-compression technology."
 	icon_state = "chronosuit"
-	item_state = "chronosuit"
+	inhand_icon_state = "chronosuit"
 	actions_types = list(/datum/action/item_action/toggle_spacesuit, /datum/action/item_action/toggle)
 	armor_type = /datum/armor/space_chronos
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/clothing/head/hardsuit.dmi'
 	worn_icon = 'icons/mob/clothing/head/hardsuit.dmi'
 	icon_state = "hardsuit0-engineering"
-	item_state = "eng_helm"
+	inhand_icon_state = "eng_helm"
 	max_integrity = 300
 	armor_type = /datum/armor/space_hardsuit
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
@@ -154,7 +154,7 @@
 	icon = 'icons/obj/clothing/suits/hardsuit.dmi'
 	worn_icon = 'icons/mob/clothing/suits/hardsuit.dmi'
 	icon_state = "hardsuit-engineering"
-	item_state = "eng_hardsuit"
+	inhand_icon_state = "eng_hardsuit"
 	max_integrity = 300
 	armor_type = /datum/armor/space_hardsuit
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner, /obj/item/construction/rcd, /obj/item/pipe_dispenser)
@@ -313,7 +313,7 @@
 	name = "engineering hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
 	icon_state = "hardsuit0-engineering"
-	item_state = "eng_helm"
+	inhand_icon_state = "eng_helm"
 	armor_type = /datum/armor/hardsuit_engine
 	hardsuit_type = "engineering"
 	resistance_flags = FIRE_PROOF
@@ -336,7 +336,7 @@
 	name = "engineering hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
 	icon_state = "hardsuit-engineering"
-	item_state = "eng_hardsuit"
+	inhand_icon_state = "eng_hardsuit"
 	armor_type = /datum/armor/hardsuit_engine
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
 	resistance_flags = FIRE_PROOF
@@ -360,7 +360,7 @@
 	name = "atmospherics hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has thermal shielding."
 	icon_state = "hardsuit0-atmospherics"
-	item_state = "atmo_helm"
+	inhand_icon_state = "atmo_helm"
 	hardsuit_type = "atmospherics"
 	armor_type = /datum/armor/engine_atmos
 	heat_protection = HEAD												//Uncomment to enable firesuit protection
@@ -384,7 +384,7 @@
 	name = "atmospherics hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has thermal shielding."
 	icon_state = "hardsuit-atmospherics"
-	item_state = "atmo_hardsuit"
+	inhand_icon_state = "atmo_hardsuit"
 	armor_type = /datum/armor/engine_atmos
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -410,7 +410,7 @@
 	name = "advanced hardsuit helmet"
 	desc = "An advanced helmet designed for work in a hazardous, low pressure environment. Shines with a high polish."
 	icon_state = "hardsuit0-white"
-	item_state = "ce_helm"
+	inhand_icon_state = "ce_helm"
 	hardsuit_type = "white"
 	armor_type = /datum/armor/engine_elite
 	heat_protection = HEAD
@@ -434,7 +434,7 @@
 	icon_state = "hardsuit-white"
 	name = "advanced hardsuit"
 	desc = "An advanced suit that protects against hazardous, low pressure environments. Shines with a high polish."
-	item_state = "ce_hardsuit"
+	inhand_icon_state = "ce_hardsuit"
 	armor_type = /datum/armor/engine_elite
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -461,7 +461,7 @@
 	name = "mining hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating for wildlife encounters and dual floodlights."
 	icon_state = "hardsuit0-mining"
-	item_state = "mining_helm"
+	inhand_icon_state = "mining_helm"
 	hardsuit_type = "mining"
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
@@ -493,7 +493,7 @@
 	icon_state = "hardsuit-mining"
 	name = "mining hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters."
-	item_state = "mining_hardsuit"
+	inhand_icon_state = "mining_hardsuit"
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
 	supports_variations = DIGITIGRADE_VARIATION
@@ -526,7 +526,7 @@
 	name = "exploration hardsuit helmet"
 	desc = "An advanced space-proof hardsuit designed to protect against off-station threats."
 	icon_state = "hardsuit0-exploration"
-	item_state = "death_commando_mask"
+	inhand_icon_state = "death_commando_mask"
 	hardsuit_type = "exploration"
 	heat_protection = HEAD
 	armor_type = /datum/armor/hardsuit_exploration
@@ -567,7 +567,7 @@
 	name = "exploration hardsuit"
 	desc = "An advanced space-proof hardsuit designed to protect against off-station threats. Despite looking remarkably similar to the mining hardsuit \
 		Nanotrasen officials note that it is unique in every way and the design has not been copied in any way."
-	item_state = "exploration_hardsuit"
+	inhand_icon_state = "exploration_hardsuit"
 	armor_type = /datum/armor/hardsuit_exploration
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/bag/ore, /obj/item/pickaxe, /obj/item/gun/ballistic/rifle/leveraction/exploration, /obj/item/gun/energy/laser/repeater/explorer)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/exploration
@@ -593,7 +593,7 @@
 	name = "Cybersun hardsuit helmet"
 	desc = "A bulbous red helmet designed for scavenging in hazardous, low pressure environments. Has dual floodlights, and a 360 Degree view."
 	icon_state = "hardsuit0-cybersun"
-	item_state = "death_commando_mask"
+	inhand_icon_state = "death_commando_mask"
 	hardsuit_type = "cybersun"
 	armor_type = /datum/armor/hardsuit_cybersun
 	strip_delay = 600
@@ -620,7 +620,7 @@
 		sacrificed in favor of more effective blunt armor plates and radiation shielding."
 	armor_type = /datum/armor/hardsuit_cybersun
 	hardsuit_type = "cybersun"
-	item_state = "death_commando_mask"
+	inhand_icon_state = "death_commando_mask"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/cybersun
 	jetpack = /obj/item/tank/jetpack/suit
 
@@ -644,7 +644,7 @@
 	desc = "A dual-mode advanced helmet designed for work in special operations. It is in EVA mode. Property of Gorlex Marauders."
 	alt_desc = "A dual-mode advanced helmet designed for work in special operations. It is in combat mode. Property of Gorlex Marauders."
 	icon_state = "hardsuit1-syndi"
-	item_state = "syndie_helm"
+	inhand_icon_state = "syndie_helm"
 	hardsuit_type = "syndi"
 	armor_type = /datum/armor/hardsuit_syndi
 	on = TRUE
@@ -747,7 +747,7 @@
 	desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in EVA mode. Property of Gorlex Marauders."
 	alt_desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in combat mode. Property of Gorlex Marauders."
 	icon_state = "hardsuit1-syndi"
-	item_state = "syndie_hardsuit"
+	inhand_icon_state = "syndie_hardsuit"
 	hardsuit_type = "syndi"
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = ACID_PROOF
@@ -815,7 +815,7 @@
 /obj/item/clothing/suit/space/hardsuit/syndipreview
 	name = "blood-red hardsuit"
 	icon_state = "hardsuit1-syndi"
-	item_state = "syndie_hardsuit"
+	inhand_icon_state = "syndie_hardsuit"
 	hardsuit_type = "syndi"
 	cell = null
 	show_hud = FALSE
@@ -879,7 +879,7 @@
 	desc = "A dual-mode advanced helmet designed for any crime-fighting situation. It is in travel mode."
 	alt_desc = "A dual-mode advanced helmet designed for any crime-fighting situation. It is in combat mode."
 	icon_state = "hardsuit1-owl"
-	item_state = "s_helmet"
+	inhand_icon_state = "s_helmet"
 	hardsuit_type = "owl"
 	visor_flags_inv = 0
 	visor_flags = 0
@@ -890,7 +890,7 @@
 	desc = "A dual-mode advanced hardsuit designed for any crime-fighting situation. It is in travel mode."
 	alt_desc = "A dual-mode advanced hardsuit designed for any crime-fighting situation. It is in combat mode."
 	icon_state = "hardsuit1-owl"
-	item_state = "s_suit"
+	inhand_icon_state = "s_suit"
 	hardsuit_type = "owl"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/owl
 
@@ -900,7 +900,7 @@
 	name = "gem-encrusted hardsuit helmet"
 	desc = "A bizarre gem-encrusted helmet that radiates magical energies."
 	icon_state = "hardsuit0-wiz"
-	item_state = "wiz_helm"
+	inhand_icon_state = "wiz_helm"
 	hardsuit_type = "wiz"
 	resistance_flags = FIRE_PROOF | ACID_PROOF //No longer shall our kind be foiled by lone chemists with spray bottles!
 	armor_type = /datum/armor/hardsuit_wizard
@@ -926,7 +926,7 @@
 	icon_state = "hardsuit-wiz"
 	name = "gem-encrusted hardsuit"
 	desc = "A bizarre gem-encrusted suit that radiates magical energies."
-	item_state = "wiz_hardsuit"
+	inhand_icon_state = "wiz_hardsuit"
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	clothing_flags = CASTING_CLOTHES
@@ -971,7 +971,7 @@
 	name = "medical hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low pressure environment. Built with lightweight materials for extra comfort, but does not protect the eyes from intense light."
 	icon_state = "hardsuit0-medical"
-	item_state = "medical_helm"
+	inhand_icon_state = "medical_helm"
 	hardsuit_type = "medical"
 	flash_protect = 0
 	armor_type = /datum/armor/hardsuit_medical
@@ -995,7 +995,7 @@
 	icon_state = "hardsuit-medical"
 	name = "medical hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Built with lightweight materials for easier movement."
-	item_state = "medical_hardsuit"
+	inhand_icon_state = "medical_hardsuit"
 	supports_variations = DIGITIGRADE_VARIATION
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/firstaid, /obj/item/healthanalyzer, /obj/item/stack/medical)
 	armor_type = /datum/armor/hardsuit_medical
@@ -1075,7 +1075,7 @@
 	icon_state = "hardsuit-rd"
 	name = "prototype hardsuit"
 	desc = "A prototype suit that protects against hazardous, low pressure environments. Fitted with extensive plating for handling explosives and dangerous research materials."
-	item_state = "hardsuit-rd"
+	inhand_icon_state = "hardsuit-rd"
 	supports_variations = DIGITIGRADE_VARIATION
 	resistance_flags = ACID_PROOF | FIRE_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT //Same as an emergency firesuit. Not ideal for extended exposure.
@@ -1106,7 +1106,7 @@
 	name = "security hardsuit helmet"
 	desc = "A bulky, armored helmet designed to protect security personnel in low pressure environments."
 	icon_state = "hardsuit0-sec"
-	item_state = "sec_helm"
+	inhand_icon_state = "sec_helm"
 	hardsuit_type = "sec"
 	armor_type = /datum/armor/hardsuit_security
 
@@ -1129,7 +1129,7 @@
 	icon_state = "hardsuit-sec"
 	name = "security hardsuit"
 	desc = "A bulky, armored suit designed to protect security personnel in low pressure environments."
-	item_state = "sec_hardsuit"
+	inhand_icon_state = "sec_hardsuit"
 	supports_variations = DIGITIGRADE_VARIATION
 	armor_type = /datum/armor/hardsuit_security
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security
@@ -1203,7 +1203,7 @@
 /obj/item/clothing/head/helmet/space/hardsuit/swat
 	name = "\improper MK.II SWAT Helmet"
 	icon_state = "swat2helm"
-	item_state = "swat2helm"
+	inhand_icon_state = "swat2helm"
 	desc = "A tactical SWAT helmet MK.II."
 	armor_type = /datum/armor/hardsuit_swat
 	resistance_flags = FIRE_PROOF | ACID_PROOF
@@ -1233,7 +1233,7 @@
 	desc = "A tactical suit first developed in a joint effort by the defunct IS-ERI and Nanotrasen in 2321 for military operations. \
 		It has a minor slowdown, but offers decent protection and helps the wearer resist shoving in close quarters."
 	icon_state = "swat2"
-	item_state = "swat2"
+	inhand_icon_state = "swat2"
 	armor_type = /datum/armor/hardsuit_swat
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -1264,14 +1264,14 @@
 /obj/item/clothing/head/helmet/space/hardsuit/swat/captain
 	name = "captain's hardsuit helmet"
 	icon_state = "capspace"
-	item_state = "capspacehelmet"
+	inhand_icon_state = "capspacehelmet"
 	desc = "A tactical MK.II SWAT helmet boasting better protection and a horrible fashion sense."
 
 /obj/item/clothing/suit/space/hardsuit/swat/captain
 	name = "captain's SWAT suit"
 	desc = "A MK.II SWAT suit with streamlined joints and armor made out of superior materials, insulated against intense heat. The most advanced tactical armor available. Usually reserved for heavy hitter corporate security, this one has a regal finish in Nanotrasen company colors. Better not let the assistants get a hold of it."
 	icon_state = "caparmor"
-	item_state = "capspacesuit"
+	inhand_icon_state = "capspacesuit"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/swat/captain
 	cell = /obj/item/stock_parts/cell/super
 
@@ -1280,7 +1280,7 @@
 	name = "cosmohonk hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low-humor environment. Has radiation shielding."
 	icon_state = "hardsuit0-clown"
-	item_state = "hardsuit0-clown"
+	inhand_icon_state = "hardsuit0-clown"
 	armor_type = /datum/armor/hardsuit_clown
 	hardsuit_type = "clown"
 
@@ -1302,7 +1302,7 @@
 	name = "cosmohonk hardsuit"
 	desc = "A special suit that protects against hazardous, low humor environments. Has radiation shielding. Only a true clown can wear it."
 	icon_state = "hardsuit-clown"
-	item_state = "clown_hardsuit"
+	inhand_icon_state = "clown_hardsuit"
 	armor_type = /datum/armor/hardsuit_clown
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/clown
 
@@ -1336,7 +1336,7 @@
 	name = "prototype RIG hardsuit helmet"
 	desc = "Early prototype RIG hardsuit helmet, designed to quickly shift over a user's head. Design constraints of the helmet mean it has no inbuilt cameras, thus it restricts the users visability."
 	icon_state = "hardsuit0-ancient"
-	item_state = "anc_helm"
+	inhand_icon_state = "anc_helm"
 	armor_type = /datum/armor/hardsuit_ancient
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/recharge/kinetic_accelerator, /obj/item/gun/energy/plasmacutter, /obj/item/gun/energy/plasmacutter/adv, /obj/item/gun/energy/laser/retro, /obj/item/gun/energy/laser/retro/old, /obj/item/gun/energy/e_gun/old)
 	hardsuit_type = "ancient"
@@ -1360,7 +1360,7 @@
 	name = "prototype RIG hardsuit"
 	desc = "Prototype powered RIG hardsuit. Provides excellent protection from the elements of space while being comfortable to move around in, thanks to the powered locomotives. Remains very bulky however."
 	icon_state = "hardsuit-ancient"
-	item_state = "anc_hardsuit"
+	inhand_icon_state = "anc_hardsuit"
 	armor_type = /datum/armor/hardsuit_ancient
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/bag/ore, /obj/item/pickaxe, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/recharge/kinetic_accelerator, /obj/item/gun/energy/laser/retro, /obj/item/gun/energy/laser/retro/old, /obj/item/gun/energy/e_gun/old)
 	slowdown = 3
@@ -1464,14 +1464,14 @@
 // Regular
 /obj/item/clothing/suit/armor/vest/ctf/red
 	name = "red shielded vest"
-	item_state = "ert_security"
+	inhand_icon_state = "ert_security"
 	team_shield_icon = "shield-red"
 	greyscale_colors = COLOR_VIVID_RED
 
 // Light
 /obj/item/clothing/suit/armor/vest/ctf/light/red
 	name = "light red shielded vest"
-	item_state = "ert_security"
+	inhand_icon_state = "ert_security"
 	team_shield_icon = "shield-red"
 	greyscale_colors = COLOR_VIVID_RED
 
@@ -1481,14 +1481,14 @@
 // Regular
 /obj/item/clothing/suit/armor/vest/ctf/blue
 	name = "blue shielded vest"
-	item_state = "ert_command"
+	inhand_icon_state = "ert_command"
 	team_shield_icon = "shield-old"
 	greyscale_colors = COLOR_DARK_CYAN
 
 // Light
 /obj/item/clothing/suit/armor/vest/ctf/light/blue
 	name = "light blue shielded vest"
-	item_state = "ert_command"
+	inhand_icon_state = "ert_command"
 	team_shield_icon = "shield-old"
 	greyscale_colors = COLOR_DARK_CYAN
 
@@ -1499,7 +1499,7 @@
 	name = "blood-red hardsuit"
 	desc = "An advanced hardsuit with built in energy shielding."
 	icon_state = "hardsuit1-syndi"
-	item_state = "syndie_hardsuit"
+	inhand_icon_state = "syndie_hardsuit"
 	hardsuit_type = "syndi"
 	armor_type = /datum/armor/shielded_syndi
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
@@ -1541,7 +1541,7 @@
 	name = "blood-red hardsuit helmet"
 	desc = "An advanced hardsuit helmet with built in energy shielding."
 	icon_state = "hardsuit1-syndi"
-	item_state = "syndie_helm"
+	inhand_icon_state = "syndie_helm"
 	hardsuit_type = "syndi"
 	armor_type = /datum/armor/shielded_syndi
 	actions_types = list(
@@ -1580,7 +1580,7 @@
 	name = "death commando spacesuit"
 	desc = "An advanced hardsuit favored by commandos for use in special operations."
 	icon_state = "deathsquad"
-	item_state = "swat_suit"
+	inhand_icon_state = "swat_suit"
 	hardsuit_type = "syndi"
 	shield_integrity = 80
 	recharge_delay = 1.5 SECONDS
@@ -1612,7 +1612,7 @@
 	name = "death commando helmet"
 	desc = "A tactical helmet with built in energy shielding."
 	icon_state = "deathsquad"
-	item_state = "deathsquad"
+	inhand_icon_state = "deathsquad"
 	hardsuit_type = "syndi"
 	armor_type = /datum/armor/shielded_swat
 	strip_delay = 130
@@ -1637,7 +1637,7 @@
 	name = "honk squad spacesuit"
 	desc = "A hilarious hardsuit favored by HONK squad troopers for use in special pranks."
 	icon_state = "hardsuit-clown"
-	item_state = "clown_hardsuit"
+	inhand_icon_state = "clown_hardsuit"
 	hardsuit_type = "clown"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/swat/honk
 
@@ -1645,7 +1645,7 @@
 	name = "honk squad helmet"
 	desc = "A hilarious helmet with built in anti-mime propaganda shielding."
 	icon_state = "hardsuit0-clown"
-	item_state = "hardsuit0-clown"
+	inhand_icon_state = "hardsuit0-clown"
 	hardsuit_type = "clown"
 
 
@@ -1654,7 +1654,7 @@
 	name = "juggernaut armor"
 	desc = "A somehow spaceworthy set of armor with outstanding protection against almost everything. Comes in an oddly nostalgic green. "
 	icon_state = "doomguy"
-	item_state = "doomguy"
+	inhand_icon_state = "doomguy"
 	shield_integrity = 20
 	recharge_delay = 100
 	armor_type = /datum/armor/shielded_doomguy
@@ -1685,7 +1685,7 @@
 	name = "juggernaut helmet"
 	desc = "A dusty old helmet, somehow capable of resisting the strongest of blows."
 	icon_state = "doomguy"
-	item_state = "doomguy"
+	inhand_icon_state = "doomguy"
 	armor_type = /datum/armor/shielded_doomguy
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -21,7 +21,7 @@ Contains:
 	name = "MK.III SWAT Helmet"
 	desc = "An advanced tactical space helmet."
 	icon_state = "deathsquad"
-	item_state = "deathsquad"
+	inhand_icon_state = "deathsquad"
 	armor_type = /datum/armor/hardsuit_deathsquad
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -49,7 +49,7 @@ Contains:
 	name = "MK.III SWAT Suit"
 	desc = "A prototype designed to replace the ageing MK.II SWAT suit. Based on the streamlined MK.II model, the traditional ceramic and graphene plate construction was replaced with plasteel, allowing superior armor against most threats. There's room for some kind of energy projection device on the back."
 	icon_state = "deathsquad"
-	item_state = "swat_suit"
+	inhand_icon_state = "swat_suit"
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/knife/combat)
 	armor_type = /datum/armor/hardsuit_deathsquad
 	strip_delay = 130
@@ -111,7 +111,7 @@ Contains:
 	icon_state = "centcom_coat"
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'icons/mob/clothing/suits/jacket.dmi'
-	item_state = "centcom"
+	inhand_icon_state = "centcom"
 	blood_overlay_type = "coat"
 	slowdown = 0
 	flags_inv = 0
@@ -141,12 +141,12 @@ Contains:
 	name = "NASA Void Helmet"
 	desc = "An old, NASA CentCom branch designed, dark red space suit helmet."
 	icon_state = "void"
-	item_state = "void"
+	inhand_icon_state = "void"
 
 /obj/item/clothing/suit/space/nasavoid
 	name = "NASA Voidsuit"
 	icon_state = "void"
-	item_state = "void"
+	inhand_icon_state = "void"
 	desc = "An old, NASA CentCom branch designed, dark red space suit."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
 
@@ -154,12 +154,12 @@ Contains:
 	name = "Engineering Void Helmet"
 	desc = "A CentCom engineering dark red space suit helmet. While old and dusty, it still gets the job done."
 	icon_state = "void"
-	item_state = "void"
+	inhand_icon_state = "void"
 
 /obj/item/clothing/suit/space/nasavoid/old
 	name = "Engineering Voidsuit"
 	icon_state = "void"
-	item_state = "void"
+	inhand_icon_state = "void"
 	desc = "A CentCom engineering dark red space suit. Age has degraded the suit making is difficult to move around in."
 	slowdown = 4
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
@@ -171,7 +171,7 @@ Contains:
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "pirate"
-	item_state = "pirate"
+	inhand_icon_state = "pirate"
 	armor_type = /datum/armor/space_pirate
 	flags_inv = HIDEHAIR
 	strip_delay = 40
@@ -195,7 +195,7 @@ Contains:
 /obj/item/clothing/head/helmet/space/pirate/bandana
 	name = "pirate bandana"
 	icon_state = "bandana"
-	item_state = "bandana"
+	inhand_icon_state = "bandana"
 
 /obj/item/clothing/suit/space/pirate
 	name = "pirate coat"
@@ -203,7 +203,7 @@ Contains:
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
 	icon_state = "pirate"
-	item_state = "pirate"
+	inhand_icon_state = "pirate"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(
 		/obj/item/gun,
@@ -240,7 +240,7 @@ Contains:
 	name = "emergency response team commander helmet"
 	desc = "The integrated helmet of an ERT hardsuit, this one has blue highlights."
 	icon_state = "hardsuit0-ert_commander"
-	item_state = "hardsuit0-ert_commander"
+	inhand_icon_state = "hardsuit0-ert_commander"
 	hardsuit_type = "ert_commander"
 	armor_type = /datum/armor/hardsuit_ert
 	strip_delay = 130
@@ -286,7 +286,7 @@ Contains:
 	name = "emergency response team commander hardsuit"
 	desc = "The standard issue hardsuit of the ERT, this one has blue highlights. Offers superb protection against environmental hazards."
 	icon_state = "ert_command"
-	item_state = "ert_command"
+	inhand_icon_state = "ert_command"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
 	armor_type = /datum/armor/hardsuit_ert
@@ -325,7 +325,7 @@ Contains:
 	name = "emergency response team security helmet"
 	desc = "The integrated helmet of an ERT hardsuit, this one has red highlights."
 	icon_state = "hardsuit0-ert_security"
-	item_state = "hardsuit0-ert_security"
+	inhand_icon_state = "hardsuit0-ert_security"
 	hardsuit_type = "ert_security"
 	beacon_colour = "#ec4848"
 	beacon_zdiff_colour = "#ca7878"
@@ -334,7 +334,7 @@ Contains:
 	name = "emergency response team security hardsuit"
 	desc = "The standard issue hardsuit of the ERT, this one has red highlights. Offers superb protection against environmental hazards."
 	icon_state = "ert_security"
-	item_state = "ert_security"
+	inhand_icon_state = "ert_security"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/sec
 	jetpack = /obj/item/tank/jetpack/suit
 
@@ -343,7 +343,7 @@ Contains:
 	name = "emergency response team engineering helmet"
 	desc = "The integrated helmet of an ERT hardsuit, this one has orange highlights."
 	icon_state = "hardsuit0-ert_engineer"
-	item_state = "hardsuit0-ert_engineer"
+	inhand_icon_state = "hardsuit0-ert_engineer"
 	hardsuit_type = "ert_engineer"
 	beacon_colour = "#ecaa48"
 	beacon_zdiff_colour = "#daa960"
@@ -352,7 +352,7 @@ Contains:
 	name = "emergency response team engineering hardsuit"
 	desc = "The standard issue hardsuit of the ERT, this one has orange highlights. Offers superb protection against environmental hazards."
 	icon_state = "ert_engineer"
-	item_state = "ert_engineer"
+	inhand_icon_state = "ert_engineer"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/engi
 	jetpack = /obj/item/tank/jetpack/suit
 
@@ -361,7 +361,7 @@ Contains:
 	name = "emergency response team medical helmet"
 	desc = "The integrated helmet of an ERT hardsuit, this one has white highlights."
 	icon_state = "hardsuit0-ert_medical"
-	item_state = "hardsuit0-ert_medical"
+	inhand_icon_state = "hardsuit0-ert_medical"
 	hardsuit_type = "ert_medical"
 	beacon_colour = "#88ecec"
 	beacon_zdiff_colour = "#4f8888"
@@ -370,7 +370,7 @@ Contains:
 	name = "emergency response team medical hardsuit"
 	desc = "The standard issue hardsuit of the ERT, this one has white highlights. Offers superb protection against environmental hazards."
 	icon_state = "ert_medical"
-	item_state = "ert_medical"
+	inhand_icon_state = "ert_medical"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/med
 	jetpack = /obj/item/tank/jetpack/suit
 
@@ -379,7 +379,7 @@ Contains:
 	name = "emergency response team janitorial helmet"
 	desc = "The integrated helmet of an ERT hardsuit, this one has purple highlights."
 	icon_state = "hardsuit0-ert_janitor"
-	item_state = "hardsuit0-ert_janitor"
+	inhand_icon_state = "hardsuit0-ert_janitor"
 	hardsuit_type = "ert_janitor"
 	beacon_colour = "#be43ce"
 	beacon_zdiff_colour = "#895d8f"
@@ -388,14 +388,14 @@ Contains:
 	name = "emergency response team janitorial hardsuit"
 	desc = "The standard issue hardsuit of the ERT, this one has purple highlights. Offers superb protection against environmental hazards. This one has extra clips for holding various janitorial tools."
 	icon_state = "ert_janitor"
-	item_state = "ert_janitor"
+	inhand_icon_state = "ert_janitor"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/jani
 	allowed = list(/obj/item/storage/bag/trash, /obj/item/melee/flyswatter, /obj/item/mop, /obj/item/holosign_creator/janibarrier, /obj/item/reagent_containers/cup/bucket, /obj/item/reagent_containers/spray/chemsprayer/janitor)
 
 /obj/item/clothing/suit/space/eva
 	name = "EVA suit"
 	icon_state = "space"
-	item_state = "eva_suit"
+	inhand_icon_state = "eva_suit"
 	desc = "A lightweight space suit with the basic ability to protect the wearer from the vacuum of space during emergencies."
 	armor_type = /datum/armor/space_eva
 
@@ -410,7 +410,7 @@ Contains:
 /obj/item/clothing/head/helmet/space/eva
 	name = "EVA helmet"
 	icon_state = "space"
-	item_state = "eva_helmet"
+	inhand_icon_state = "eva_helmet"
 	desc = "A lightweight space helmet with the basic ability to protect the wearer from the vacuum of space during emergencies."
 	flash_protect = 0
 	armor_type = /datum/armor/space_eva
@@ -429,7 +429,7 @@ Contains:
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "griffinhat"
-	item_state = null
+	inhand_icon_state = null
 	armor_type = /datum/armor/space_freedom
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -453,7 +453,7 @@ Contains:
 	name = "eagle suit"
 	desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit and the wings appear to be stuck in 'freedom' mode."
 	icon_state = "freedom"
-	item_state = "freedom"
+	inhand_icon_state = "freedom"
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
 	armor_type = /datum/armor/space_freedom
 	strip_delay = 130
@@ -479,7 +479,7 @@ Contains:
 	name = "paranormal response team helmet"
 	desc = "A helmet worn by those who deal with paranormal threats for a living."
 	icon_state = "hardsuit0-prt"
-	item_state = "hardsuit0-prt"
+	inhand_icon_state = "hardsuit0-prt"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	actions_types = list()
 	resistance_flags = FIRE_PROOF
@@ -490,7 +490,7 @@ Contains:
 	name = "paranormal response team hardsuit"
 	desc = "Powerful wards are built into this hardsuit, protecting the user from all manner of paranormal threats."
 	icon_state = "knight_grey"
-	item_state = "knight_grey"
+	inhand_icon_state = "knight_grey"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
@@ -512,44 +512,44 @@ Contains:
 	name = "champion's hardsuit"
 	desc = "Voices echo from the hardsuit, driving the user insane."
 	icon_state = "hardsuit-beserker"
-	item_state = "hardsuit-beserker"
+	inhand_icon_state = "hardsuit-beserker"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/lavaland/beserker
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/lavaland/beserker
 	name = "champion's helmet"
 	desc = "Peering into the eyes of the helmet is enough to seal damnation."
 	icon_state = "hardsuit0-beserker"
-	item_state = "hardsuit0-beserker"
+	inhand_icon_state = "hardsuit0-beserker"
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/lavaland/inquisitor
 	name = "inquisitor's hardsuit"
 	icon_state = "hardsuit-inq"
-	item_state = "hardsuit-inq"
+	inhand_icon_state = "hardsuit-inq"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/lavaland/inquisitor
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/lavaland/inquisitor
 	name = "inquisitor's helmet"
 	icon_state = "hardsuit0-inq"
-	item_state = "hardsuit0-inq"
+	inhand_icon_state = "hardsuit0-inq"
 
 //End lavaland suits
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
 	name = "inquisitor's hardsuit"
 	icon_state = "hardsuit-inq"
-	item_state = "hardsuit-inq"
+	inhand_icon_state = "hardsuit-inq"
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor
 
 /obj/item/clothing/head/helmet/space/hardsuit/ert/paranormal/inquisitor
 	name = "inquisitor's helmet"
 	icon_state = "hardsuit0-inq"
-	item_state = "hardsuit0-inq"
+	inhand_icon_state = "hardsuit0-inq"
 
 /obj/item/clothing/head/helmet/space/fragile
 	name = "emergency space helmet"
 	desc = "A bulky, air-tight helmet meant to protect the user during emergency situations. It doesn't look very durable."
 	icon_state = "syndicate-helm-orange"
-	item_state = "syndicate-helm-orange"
+	inhand_icon_state = "syndicate-helm-orange"
 	armor_type = /datum/armor/space_fragile
 	strip_delay = 65
 	flash_protect = 0
@@ -566,7 +566,7 @@ Contains:
 	desc = "A bulky, air-tight suit meant to protect the user during emergency situations. It doesn't look very durable."
 	var/torn = FALSE
 	icon_state = "syndicate-orange"
-	item_state = "syndicate-orange"
+	inhand_icon_state = "syndicate-orange"
 	slowdown = 2
 	armor_type = /datum/armor/space_fragile
 	strip_delay = 65
@@ -593,7 +593,7 @@ Contains:
 	name = "bounty hunting suit"
 	desc = "A custom version of the MK.II SWAT suit, modified to look rugged and tough. Works as a space suit, if you can find a helmet."
 	icon_state = "hunter"
-	item_state = "swat_suit"
+	inhand_icon_state = "swat_suit"
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/knife/combat)
 	armor_type = /datum/armor/space_hunter
 	strip_delay = 130
@@ -619,7 +619,7 @@ Contains:
 	icon = 'icons/obj/clothing/head/spacehelm.dmi'
 	worn_icon = 'icons/mob/clothing/head/spacehelm.dmi'
 	icon_state = "skinsuit_helmet"
-	item_state = "skinsuit_helmet"
+	inhand_icon_state = "skinsuit_helmet"
 	max_integrity = 200
 	desc = "An airtight helmet meant to protect the wearer during emergency situations."
 	armor_type = /datum/armor/hardsuit_skinsuit
@@ -649,7 +649,7 @@ Contains:
 	icon = 'icons/obj/clothing/suits/spacesuit.dmi'
 	worn_icon = 'icons/mob/clothing/suits/spacesuit.dmi'
 	icon_state = "skinsuit"
-	item_state = "s_suit"
+	inhand_icon_state = "s_suit"
 	max_integrity = 200
 	slowdown = 3 //Higher is slower
 	clothing_flags = STOPSPRESSUREDAMAGE
@@ -674,7 +674,7 @@ Contains:
 	name = "bounty hunting helmet"
 	desc = "A custom tactical space helmet with decals added."
 	icon_state = "hunter"
-	item_state = "hunter"
+	inhand_icon_state = "hunter"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor_type = /datum/armor/space_hunter
 

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -8,7 +8,7 @@
 	armor_type = /datum/armor/eva_plasmaman
 	resistance_flags = FIRE_PROOF
 	icon_state = "plasmaman_suit"
-	item_state = "plasmaman_suit"
+	inhand_icon_state = "plasmaman_suit"
 	var/next_extinguish = 0
 	var/extinguish_cooldown = 100
 	var/extinguishes_left = 10
@@ -48,7 +48,7 @@
 	icon = 'icons/obj/clothing/head/plasmaman_hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/plasmaman_head.dmi'
 	icon_state = "helmet"
-	item_state = "helmet"
+	inhand_icon_state = "helmet"
 	greyscale_colors = "#DF5900#A349A4#DF5900"
 	greyscale_config = /datum/greyscale_config/plasmaman_helmet_default
 	greyscale_config_inhand_left = /datum/greyscale_config/plasmaman_helmet_default_inhand_left
@@ -346,7 +346,7 @@
 	greyscale_config_inhand_right = null
 	greyscale_config_worn = null
 	icon_state = "prototype_envirohelm"
-	item_state = "prototype_envirohelm"
+	inhand_icon_state = "prototype_envirohelm"
 	smile_state = "prototype_smile"
 
 /obj/item/clothing/head/helmet/space/plasmaman/botany
@@ -374,7 +374,7 @@
 	greyscale_config_inhand_right = null
 	greyscale_config_worn = null
 	icon_state = "mime_envirohelm"
-	item_state = "mime_envirohelm"
+	inhand_icon_state = "mime_envirohelm"
 	visor_state = "mime_visor"
 
 /obj/item/clothing/head/helmet/space/plasmaman/honk
@@ -386,7 +386,7 @@
 	greyscale_config_inhand_right = null
 	greyscale_config_worn = null
 	icon_state = "honk_envirohelm"
-	item_state = "honk_envirohelm"
+	inhand_icon_state = "honk_envirohelm"
 	smile_state = "clown_smile"
 	visor_state = "clown_visor"
 
@@ -633,7 +633,7 @@
 	greyscale_config_inhand_right = null
 	greyscale_config_worn = null
 	icon_state = "mime_mark2"
-	item_state = "mime_mark2"
+	inhand_icon_state = "mime_mark2"
 	visor_state = "mime_visor_mk2"
 
 /obj/item/clothing/head/helmet/space/plasmaman/mark2/clown
@@ -645,7 +645,7 @@
 	greyscale_config_inhand_right = null
 	greyscale_config_worn = null
 	icon_state = "clown_mark2"
-	item_state = "clown_mark2"
+	inhand_icon_state = "clown_mark2"
 	visor_state = "clown_visor_mk2"
 
 /obj/item/clothing/head/helmet/space/plasmaman/mark2/bartender/Initialize(mapload)

--- a/code/modules/clothing/spacesuits/santa.dm
+++ b/code/modules/clothing/spacesuits/santa.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/head/wizard.dmi'
 	worn_icon = 'icons/mob/clothing/head/wizard.dmi'
 	icon_state = "santahat"
-	item_state = "santahat"
+	inhand_icon_state = "santahat"
 	flags_cover = HEADCOVERSEYES
 	dog_fashion = /datum/dog_fashion/head/santa
 
@@ -14,6 +14,6 @@
 	icon_state = "santa"
 	icon = 'icons/obj/clothing/suits/wizard.dmi'
 	worn_icon = 'icons/mob/clothing/suits/wizard.dmi'
-	item_state = "santa"
+	inhand_icon_state = "santa"
 	slowdown = 0
 	allowed = list(/obj/item) //for stuffing exta special presents

--- a/code/modules/clothing/spacesuits/swat.dm
+++ b/code/modules/clothing/spacesuits/swat.dm
@@ -2,7 +2,7 @@
 	name = "MK.I SWAT Suit"
 	desc = "A tactical space suit first developed in a joint effort by the defunct IS-ERI and Nanotrasen in 20XX for military space operations. A tried and true workhorse, it is very difficult to move in but offers robust protection against all threats!"
 	icon_state = "heavy"
-	item_state = "swat_suit"
+	inhand_icon_state = "swat_suit"
 	allowed = list(
 		/obj/item/gun,
 		/obj/item/ammo_box,

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -2,7 +2,7 @@
 /obj/item/clothing/head/helmet/space/syndicate
 	name = "red space helmet"
 	icon_state = "syndicate"
-	item_state = "syndicate"
+	inhand_icon_state = "syndicate"
 	desc = "Has a tag on it: Totally not property of an enemy corporation, honest!"
 	armor_type = /datum/armor/space_syndicate
 
@@ -23,7 +23,7 @@
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"
 	icon_state = "syndicate"
-	item_state = "space_suit_syndicate"
+	inhand_icon_state = "space_suit_syndicate"
 	desc = "Has a tag on it: Totally not property of an enemy corporation, honest!"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
@@ -48,119 +48,119 @@
 /obj/item/clothing/head/helmet/space/syndicate/green
 	name = "green space helmet"
 	icon_state = "syndicate-helm-green"
-	item_state = "syndicate-helm-green"
+	inhand_icon_state = "syndicate-helm-green"
 
 /obj/item/clothing/suit/space/syndicate/green
 	name = "green space suit"
 	icon_state = "syndicate-green"
-	item_state = "syndicate-green"
+	inhand_icon_state = "syndicate-green"
 
 
 //Dark green syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/green/dark
 	name = "dark green space helmet"
 	icon_state = "syndicate-helm-green-dark"
-	item_state = "syndicate-helm-green-dark"
+	inhand_icon_state = "syndicate-helm-green-dark"
 
 /obj/item/clothing/suit/space/syndicate/green/dark
 	name = "dark green space suit"
 	icon_state = "syndicate-green-dark"
-	item_state = "syndicate-green-dark"
+	inhand_icon_state = "syndicate-green-dark"
 
 
 //Orange syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/orange
 	name = "orange space helmet"
 	icon_state = "syndicate-helm-orange"
-	item_state = "syndicate-helm-orange"
+	inhand_icon_state = "syndicate-helm-orange"
 
 /obj/item/clothing/suit/space/syndicate/orange
 	name = "orange space suit"
 	icon_state = "syndicate-orange"
-	item_state = "syndicate-orange"
+	inhand_icon_state = "syndicate-orange"
 
 //Blue syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/blue
 	name = "blue space helmet"
 	icon_state = "syndicate-helm-blue"
-	item_state = "syndicate-helm-blue"
+	inhand_icon_state = "syndicate-helm-blue"
 
 /obj/item/clothing/suit/space/syndicate/blue
 	name = "blue space suit"
 	icon_state = "syndicate-blue"
-	item_state = "syndicate-blue"
+	inhand_icon_state = "syndicate-blue"
 
 
 //Black syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black
 	name = "black space helmet"
 	icon_state = "syndicate-helm-black"
-	item_state = "syndicate-helm-black"
+	inhand_icon_state = "syndicate-helm-black"
 
 /obj/item/clothing/suit/space/syndicate/black
 	name = "black space suit"
 	icon_state = "syndicate-black"
-	item_state = "syndicate-black"
+	inhand_icon_state = "syndicate-black"
 
 
 //Black-green syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/green
 	name = "black space helmet"
 	icon_state = "syndicate-helm-black-green"
-	item_state = "syndicate-helm-black-green"
+	inhand_icon_state = "syndicate-helm-black-green"
 
 /obj/item/clothing/suit/space/syndicate/black/green
 	name = "black and green space suit"
 	icon_state = "syndicate-black-green"
-	item_state = "syndicate-black-green"
+	inhand_icon_state = "syndicate-black-green"
 
 
 //Black-blue syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/blue
 	name = "black space helmet"
 	icon_state = "syndicate-helm-black-blue"
-	item_state = "syndicate-helm-black-blue"
+	inhand_icon_state = "syndicate-helm-black-blue"
 
 /obj/item/clothing/suit/space/syndicate/black/blue
 	name = "black and blue space suit"
 	icon_state = "syndicate-black-blue"
-	item_state = "syndicate-black-blue"
+	inhand_icon_state = "syndicate-black-blue"
 
 
 //Black medical syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/med
 	name = "black space helmet"
 	icon_state = "syndicate-helm-black-med"
-	item_state = "syndicate-helm-black"
+	inhand_icon_state = "syndicate-helm-black"
 
 /obj/item/clothing/suit/space/syndicate/black/med
 	name = "green space suit"
 	icon_state = "syndicate-black-med"
-	item_state = "syndicate-black"
+	inhand_icon_state = "syndicate-black"
 
 
 //Black-orange syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/orange
 	name = "black space helmet"
 	icon_state = "syndicate-helm-black-orange"
-	item_state = "syndicate-helm-black"
+	inhand_icon_state = "syndicate-helm-black"
 
 /obj/item/clothing/suit/space/syndicate/black/orange
 	name = "black and orange space suit"
 	icon_state = "syndicate-black-orange"
-	item_state = "syndicate-black"
+	inhand_icon_state = "syndicate-black"
 
 
 //Black-red syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/red
 	name = "black space helmet"
 	icon_state = "syndicate-helm-black-red"
-	item_state = "syndicate-helm-black-red"
+	inhand_icon_state = "syndicate-helm-black-red"
 
 /obj/item/clothing/suit/space/syndicate/black/red
 	name = "black and red space suit"
 	icon_state = "syndicate-black-red"
-	item_state = "syndicate-black-red"
+	inhand_icon_state = "syndicate-black-red"
 
 //Black-red syndicate contract varient
 /obj/item/clothing/head/helmet/space/syndicate/contract
@@ -168,7 +168,7 @@
 	desc = "A specialised black and gold helmet that's more compact than its standard Syndicate counterpart. Can be ultra-compressed into even the tightest of spaces."
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "syndicate-contract-helm"
-	item_state = "syndicate-contract-helm"
+	inhand_icon_state = "syndicate-contract-helm"
 
 /obj/item/clothing/suit/space/syndicate/contract
 	name = "contractor space suit"
@@ -176,15 +176,15 @@
 	slowdown = 0.55
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "syndicate-contract"
-	item_state = "syndicate-contract"
+	inhand_icon_state = "syndicate-contract"
 
 //Black with yellow/red engineering syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/engie
 	name = "black space helmet"
 	icon_state = "syndicate-helm-black-engie"
-	item_state = "syndicate-helm-black"
+	inhand_icon_state = "syndicate-helm-black"
 
 /obj/item/clothing/suit/space/syndicate/black/engie
 	name = "black engineering space suit"
 	icon_state = "syndicate-black-engie"
-	item_state = "syndicate-black"
+	inhand_icon_state = "syndicate-black"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -36,27 +36,27 @@
 	name = "armor vest"
 	desc = "A slim Type I-A armored vest that provides decent protection against most types of damage."
 	icon_state = "armoralt"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	blood_overlay_type = "armor"
 	dog_fashion = /datum/dog_fashion/back/armorvest
 
 /obj/item/clothing/suit/armor/vest/alt
 	desc = "An alternate style Type I-B armored vest that provides decent protection against most types of damage. They perform identically in the field."
 	icon_state = "armor"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 
 /obj/item/clothing/suit/armor/vest/old
 	name = "degrading armor vest"
 	desc = "Older generation Type 1 armored vest. Due to degradation over time the vest is far less maneuverable to move in."
 	icon_state = "armor"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	slowdown = 1
 
 /obj/item/clothing/suit/armor/vest/blueshirt
 	name = "large armor vest"
 	desc = "A type H-L armored vest which provides greater protection than its I-A counterpart, at the cost of being bulkier."
 	icon_state = "blueshift"
-	item_state = null
+	inhand_icon_state = null
 	custom_premium_price = 600
 	armor_type = /datum/armor/vest_blueshirt
 	slowdown = 0.14
@@ -76,7 +76,7 @@
 	name = "corporate Jacket"
 	desc = "A Stylish Corporate Jacket which also provides Protection."
 	icon_state = "secjacket"
-	item_state = "secjacket"
+	inhand_icon_state = "secjacket"
 	body_parts_covered = CHEST|ARMS
 	armor_type = /datum/armor/vest_corporate
 	slowdown = 0.02
@@ -97,7 +97,7 @@
 	name = "armored greatcoat"
 	desc = "A greatcoat enhanced with a special alloy for some extra protection and style for those with a commanding presence."
 	icon_state = "hos"
-	item_state = "greatcoat"
+	inhand_icon_state = "greatcoat"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	armor_type = /datum/armor/armor_hos
 	cold_protection = CHEST|GROIN|LEGS|ARMS
@@ -121,7 +121,7 @@
 	name = "armored trenchcoat"
 	desc = "A trenchcoat enhanced with a special lightweight kevlar. The epitome of tactical plainclothes."
 	icon_state = "hostrench"
-	item_state = "hostrench"
+	inhand_icon_state = "hostrench"
 	flags_inv = 0
 	strip_delay = 80
 
@@ -129,7 +129,7 @@
 	name = "warden's jacket"
 	desc = "A navy-blue armored jacket with blue shoulder designations and '/Warden/' stitched into one of the chest pockets."
 	icon_state = "warden_alt"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS|HANDS
 	heat_protection = CHEST|GROIN|ARMS|HANDS
@@ -150,7 +150,7 @@
 	name = "security overcoat"
 	desc = "Lightly armored leather overcoat meant as casual wear for high-ranking officers. Bears the crest of Nanotrasen Security."
 	icon_state = "leathercoat-sec"
-	item_state = "hostrench"
+	inhand_icon_state = "hostrench"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
@@ -160,7 +160,7 @@
 	name = "captain's carapace"
 	desc = "A fireproof armored chestpiece reinforced with ceramic plates and plasteel pauldrons to provide additional protection whilst still offering maximum mobility and flexibility. Issued only to the station's finest, although it does chafe your nipples."
 	icon_state = "capcarapace"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	body_parts_covered = CHEST|GROIN
 	armor_type = /datum/armor/vest_capcarapace
 	dog_fashion = null
@@ -187,14 +187,14 @@
 	name = "captain's parade coat"
 	desc = "For when an armoured vest isn't fashionable enough."
 	icon_state = "capformal"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS
 
 /obj/item/clothing/suit/armor/vest/capcarapace/jacket
 	name = "captain's jacket"
 	desc = "An armored Jacket in the Captains colors"
 	icon_state = "capjacket"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS
 	armor_type = /datum/armor/capcarapace_jacket
 
@@ -214,7 +214,7 @@
 	name = "riot suit"
 	desc = "A suit of semi-flexible polycarbonate body armor with heavy padding to protect against melee attacks. Helps the wearer resist shoving in close quarters."
 	icon_state = "riot"
-	item_state = "swat_suit"
+	inhand_icon_state = "swat_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -240,7 +240,7 @@
 	name = "bone armor"
 	desc = "A tribal armor plate, crafted from animal bone."
 	icon_state = "bonearmor"
-	item_state = "bonearmor"
+	inhand_icon_state = "bonearmor"
 	blood_overlay_type = "armor"
 	armor_type = /datum/armor/armor_bone
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
@@ -262,7 +262,7 @@
 	name = "bulletproof armor"
 	desc = "A Type III heavy bulletproof vest that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "bulletproof"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	blood_overlay_type = "armor"
 	armor_type = /datum/armor/armor_bulletproof
 	strip_delay = 70
@@ -284,7 +284,7 @@
 	name = "reflector vest"
 	desc = "A vest that excels in protecting the wearer against energy projectiles, as well as occasionally reflecting them."
 	icon_state = "armor_reflec"
-	item_state = "armor_reflec"
+	inhand_icon_state = "armor_reflec"
 	blood_overlay_type = "armor"
 	armor_type = /datum/armor/armor_laserproof
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
@@ -323,7 +323,7 @@
 	name = "heavy armor"
 	desc = "A heavily armored suit that protects against moderate damage."
 	icon_state = "heavy"
-	item_state = "swat_suit"
+	inhand_icon_state = "swat_suit"
 	w_class = WEIGHT_CLASS_BULKY
 	gas_transfer_coefficient = 0.9
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -371,13 +371,13 @@
 	name = "thunderdome suit"
 	desc = "Reddish armor."
 	icon_state = "tdred"
-	item_state = "tdred"
+	inhand_icon_state = "tdred"
 
 /obj/item/clothing/suit/armor/tdome/green
 	name = "thunderdome suit"
 	desc = "Pukish armor."	//classy.
 	icon_state = "tdgreen"
-	item_state = "tdgreen"
+	inhand_icon_state = "tdgreen"
 
 /obj/item/clothing/suit/armor/tdome/holosuit
 	name = "thunderdome suit"
@@ -393,38 +393,38 @@
 /obj/item/clothing/suit/armor/tdome/holosuit/red
 	desc = "Reddish armor."
 	icon_state = "tdred"
-	item_state = "tdred"
+	inhand_icon_state = "tdred"
 
 /obj/item/clothing/suit/armor/tdome/holosuit/green
 	desc = "Pukish armor."
 	icon_state = "tdgreen"
-	item_state = "tdgreen"
+	inhand_icon_state = "tdgreen"
 
 /obj/item/clothing/suit/armor/riot/knight
 	name = "plate armour"
 	desc = "A classic suit of plate armour, highly effective at stopping melee attacks."
 	icon_state = "knight_green"
-	item_state = "knight_green"
+	inhand_icon_state = "knight_green"
 	move_sound = null
 	slowdown = 0.08
 
 /obj/item/clothing/suit/armor/riot/knight/yellow
 	icon_state = "knight_yellow"
-	item_state = "knight_yellow"
+	inhand_icon_state = "knight_yellow"
 
 /obj/item/clothing/suit/armor/riot/knight/blue
 	icon_state = "knight_blue"
-	item_state = "knight_blue"
+	inhand_icon_state = "knight_blue"
 
 /obj/item/clothing/suit/armor/riot/knight/red
 	icon_state = "knight_red"
-	item_state = "knight_red"
+	inhand_icon_state = "knight_red"
 
 /obj/item/clothing/suit/armor/vest/durathread
 	name = "durathread vest"
 	desc = "A bulletproof vest made from durathread, an inexpesive but relatively effective form of protection."
 	icon_state = "durathread"
-	item_state = "durathread"
+	inhand_icon_state = "durathread"
 	strip_delay = 60
 	equip_delay_other = 40
 	max_integrity = 200
@@ -448,7 +448,7 @@
 	name = "russian vest"
 	desc = "A bulletproof vest with forest camo. Good thing there's plenty of forests to hide in around here, right?"
 	icon_state = "rus_armor"
-	item_state = "rus_armor"
+	inhand_icon_state = "rus_armor"
 	armor_type = /datum/armor/vest_russian
 	slowdown = 0.05
 	dog_fashion = null
@@ -469,7 +469,7 @@
 	name = "russian battle coat"
 	desc = "Used in extremly cold fronts, made out of real bears."
 	icon_state = "rus_coat"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
@@ -494,7 +494,7 @@
 	name = "\improper CentCom formal coat"
 	desc = "A stylish coat given to CentCom Commanders. Perfect for sending ERTs to suicide missions with style!"
 	icon_state = "centcom_formal"
-	item_state = "centcom"
+	inhand_icon_state = "centcom"
 	body_parts_covered = CHEST|GROIN|ARMS
 	armor_type = /datum/armor/armor_centcom_formal
 

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/clothing/head/bio.dmi'
 	worn_icon = 'icons/mob/clothing/head/bio.dmi'
 	icon_state = "bio"
-	item_state = "bio_hood"
+	inhand_icon_state = "bio_hood"
 	clothing_flags = THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT
 	armor_type = /datum/armor/head_bio_hood
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
@@ -26,7 +26,7 @@
 	icon = 'icons/obj/clothing/suits/bio.dmi'
 	icon_state = "bio"
 	worn_icon = 'icons/mob/clothing/suits/bio.dmi'
-	item_state = "bio_suit"
+	inhand_icon_state = "bio_suit"
 	w_class = WEIGHT_CLASS_BULKY
 	gas_transfer_coefficient = 0.01
 	clothing_flags = THICKMATERIAL
@@ -132,6 +132,6 @@
 	name = "plague doctor suit"
 	desc = "It protected doctors from the Black Death, back then. You bet your arse it's gonna help you against viruses."
 	icon_state = "plaguedoctor"
-	item_state = "bio_suit"
+	inhand_icon_state = "bio_suit"
 	strip_delay = 40
 	equip_delay_other = 20

--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -31,7 +31,7 @@
 	name = "holiday priest"
 	desc = "This is a nice holiday, my son."
 	icon_state = "holidaypriest"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 
@@ -39,7 +39,7 @@
 	name = "nun robe"
 	desc = "Maximum piety in this star system."
 	icon_state = "nun"
-	item_state = "nun"
+	inhand_icon_state = "nun"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 
@@ -47,27 +47,27 @@
 	name = "bishop's robes"
 	desc = "Glad to see the tithes you collected were well spent."
 	icon_state = "bishoprobe"
-	item_state = "bishoprobe"
+	inhand_icon_state = "bishoprobe"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/chaplainsuit/bishoprobe/black
 	name = "black bishop's robes"
 	icon_state = "blackbishoprobe"
-	item_state = "blackbishoprobe"
+	inhand_icon_state = "blackbishoprobe"
 
 /obj/item/clothing/suit/chaplainsuit/armor/studentuni
 	name = "student robe"
 	desc = "The uniform of a bygone institute of learning."
 	icon_state = "studentuni"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = ARMS|CHEST
 
 /obj/item/clothing/suit/chaplainsuit/armor/witchhunter
 	name = "witchunter garb"
 	desc = "This worn outfit saw much use back in the day."
 	icon_state = "witchhunter"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 
 /obj/item/clothing/suit/hooded/chaplainsuit/monkfrock
@@ -76,7 +76,7 @@
 	icon_state = "monkfrock"
 	icon = 'icons/obj/clothing/suits/chaplain.dmi'
 	worn_icon = 'icons/mob/clothing/suits/chaplain.dmi'
-	item_state = "monkfrock"
+	inhand_icon_state = "monkfrock"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 	hoodtype = /obj/item/clothing/head/hooded/monkfrock
@@ -87,7 +87,7 @@
 	icon = 'icons/obj/clothing/head/chaplain.dmi'
 	worn_icon = 'icons/mob/clothing/head/chaplain.dmi'
 	icon_state = "monkhood"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEEARS
 
@@ -95,7 +95,7 @@
 	name = "eastern monk's robes"
 	desc = "Best combined with a shaved head."
 	icon_state = "monkrobeeast"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = GROIN|LEGS
 	flags_inv = HIDEJUMPSUIT
 
@@ -103,7 +103,7 @@
 	name = "white robe"
 	desc = "Good for clerics and sleepy crewmembers."
 	icon_state = "whiterobe"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 
@@ -111,7 +111,7 @@
 	name = "Robes of the Honkmother"
 	desc = "Meant for a clown of the cloth."
 	icon_state = "clownpriest"
-	item_state = "clownpriest"
+	inhand_icon_state = "clownpriest"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/megaphone/clown, /obj/item/soap, /obj/item/food/pie/cream, /obj/item/bikehorn, /obj/item/bikehorn/golden, /obj/item/bikehorn/airhorn, /obj/item/instrument/bikehorn, /obj/item/reagent_containers/cup/soda_cans/canned_laughter, /obj/item/toy/crayon, /obj/item/toy/crayon/spraycan, /obj/item/toy/crayon/spraycan/lubecan, /obj/item/grown/bananapeel, /obj/item/food/grown/banana)
@@ -124,7 +124,7 @@
 	icon = 'icons/obj/clothing/head/chaplain.dmi'
 	worn_icon = 'icons/mob/clothing/head/chaplain.dmi'
 	icon_state = "knight_templar"
-	item_state = null
+	inhand_icon_state = null
 	armor_type = /datum/armor/helmet_chaplain
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
@@ -145,7 +145,7 @@
 	name = "crusader armour"
 	desc = "God wills it!"
 	icon_state = "knight_templar"
-	item_state = null
+	inhand_icon_state = null
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 	slowdown = 0
 	move_sound = null
@@ -156,7 +156,7 @@
 	icon = 'icons/obj/clothing/head/chaplain.dmi'
 	worn_icon = 'icons/mob/clothing/head/chaplain.dmi'
 	icon_state = "crusader"
-	item_state = null
+	inhand_icon_state = null
 	w_class = WEIGHT_CLASS_NORMAL
 	flags_inv = HIDEHAIR|HIDEEARS|HIDEFACE
 	armor_type = /datum/armor/plate_crusader
@@ -175,11 +175,11 @@
 
 /obj/item/clothing/head/helmet/plate/crusader/blue
 	icon_state = "crusader-blue"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/helmet/plate/crusader/red
 	icon_state = "crusader-red"
-	item_state = null
+	inhand_icon_state = null
 
 //Prophet helmet
 /obj/item/clothing/head/helmet/plate/crusader/prophet
@@ -187,7 +187,7 @@
 	desc = "A religious-looking hat."
 	icon_state = null
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
-	item_state = null
+	inhand_icon_state = null
 	flags_1 = 0
 	armor_type = /datum/armor/crusader_prophet
 	worn_y_offset = 6
@@ -208,18 +208,18 @@
 
 /obj/item/clothing/head/helmet/plate/crusader/prophet/red
 	icon_state = "prophet-red"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/helmet/plate/crusader/prophet/blue
 	icon_state = "prophet-blue"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/helmet/chaplain/cage
 	name = "cage"
 	desc = "A cage that restrains the will of the self, allowing one to see the profane world for what it is."
 	flags_inv = NONE
 	icon_state = "cage"
-	item_state = null
+	inhand_icon_state = null
 	dynamic_hair_suffix = ""
 	worn_y_offset = 7
 
@@ -227,19 +227,19 @@
 	name = "ancient helmet"
 	desc = "None may pass!"
 	icon_state = "knight_ancient"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/chaplainsuit/armor/ancient
 	name = "ancient armour"
 	desc = "Defend the treasure..."
 	icon_state = "knight_ancient"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/head/helmet/chaplain/witchunter_hat
 	name = "witchunter hat"
 	desc = "This hat saw much use back in the day."
 	icon_state = "witchhunterhat"
-	item_state = null
+	inhand_icon_state = null
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEEYES
 
@@ -247,7 +247,7 @@
 	name = "adept hood"
 	desc = "Its only heretical when others do it."
 	icon_state = "crusader"
-	item_state = null
+	inhand_icon_state = null
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 
@@ -255,7 +255,7 @@
 	name = "adept robes"
 	desc = "The ideal outfit for burning the unfaithful."
 	icon_state = "crusader"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/chaplainsuit/armor/crusader
 	name = "Crusader's Armour"
@@ -289,7 +289,7 @@
 	icon_state = "chaplain_hoodie"
 	icon = 'icons/obj/clothing/suits/chaplain.dmi'
 	worn_icon = 'icons/mob/clothing/suits/chaplain.dmi'
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 	hoodtype = /obj/item/clothing/head/hooded/chaplain_hood
@@ -307,7 +307,7 @@
 	name = "leader hoodie"
 	desc = "Now you're ready for some 50 dollar bling water."
 	icon_state = "chaplain_hoodie_leader"
-	item_state = null
+	inhand_icon_state = null
 	hoodtype = /obj/item/clothing/head/hooded/chaplain_hood/leader
 
 /obj/item/clothing/head/hooded/chaplain_hood/leader
@@ -319,7 +319,7 @@
 	name = "grave robber coat"
 	desc = "To those with a keen eye, gold gleams like a dagger's point."
 	icon_state = "graverobber_coat"
-	item_state = "graverobber_coat"
+	inhand_icon_state = "graverobber_coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 
 
@@ -328,7 +328,7 @@
 	name = "grave robber hat"
 	desc = "A tattered leather hat. It reeks of death."
 	icon_state = "graverobber_hat"
-	item_state = "graverobber_hat"
+	inhand_icon_state = "graverobber_hat"
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR|HIDEEARS
 
@@ -336,7 +336,7 @@
 	name = "grave robber gloves"
 	desc = "A pair of leather gloves in poor condition."
 	icon_state = "graverobber-gloves"
-	item_state = "graverobber-gloves"
+	inhand_icon_state = "graverobber-gloves"
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
@@ -354,5 +354,5 @@
 	name = "grave robber uniform"
 	desc = "A shirt and some leather pants in poor condition."
 	icon_state = "graverobber_under"
-	item_state = "graverobber_under"
+	inhand_icon_state = "graverobber_under"
 	can_adjust = FALSE

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -5,7 +5,7 @@
 	desc = "It's a cape that can be worn around your neck."
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	icon_state = "qmcloak"
-	item_state = "qmcloak"
+	inhand_icon_state = "qmcloak"
 	w_class = WEIGHT_CLASS_SMALL
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDESUITSTORAGE

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -8,7 +8,7 @@
 	icon_state = "flashsuit"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	body_parts_covered = CHEST|GROIN
 	hoodtype = /obj/item/clothing/head/hooded/flashsuit
 
@@ -16,7 +16,7 @@
 	name = "pirate coat"
 	desc = "Yarr."
 	icon_state = "pirate"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS
 	allowed = list(
 		/obj/item/melee/energy/sword/pirate,
@@ -28,13 +28,13 @@
 	name = "pirate captain coat"
 	desc = "Yarr."
 	icon_state = "hgpirate"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/cyborg_suit //unavailable save for adminbus
 	name = "cyborg suit"
 	desc = "Suit for a cyborg costume."
 	icon_state = "death"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|FEET
 	flags_1 = CONDUCT_1
 	fire_resist = T0C+5200
@@ -45,7 +45,7 @@
 	name = "justice suit"
 	desc = "this pretty much looks ridiculous" //Needs no fixing
 	icon_state = "justice"
-	item_state = "justice"
+	inhand_icon_state = "justice"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 
@@ -54,7 +54,7 @@
 	name = "judge's robe"
 	desc = "This robe commands authority."
 	icon_state = "judge"
-	item_state = "judge"
+	inhand_icon_state = "judge"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(/obj/item/storage/fancy/cigarettes, /obj/item/stack/spacecash)
 	flags_inv = HIDEJUMPSUIT
@@ -64,14 +64,14 @@
 	name = "coveralls"
 	desc = "A set of denim overalls."
 	icon_state = "overalls"
-	item_state = "overalls"
+	inhand_icon_state = "overalls"
 	body_parts_covered = CHEST|GROIN|LEGS
 
 /obj/item/clothing/suit/apron/purple_bartender
 	name = "purple bartender apron"
 	desc = "A fancy purple apron for a stylish person."
 	icon_state = "purplebartenderapron"
-	item_state = "purplebartenderapron"
+	inhand_icon_state = "purplebartenderapron"
 	body_parts_covered = CHEST|GROIN|LEGS
 
 /obj/item/clothing/suit/syndicatefake
@@ -79,7 +79,7 @@
 	icon_state = "syndicate-black-red"
 	icon = 'icons/obj/clothing/suits/spacesuit.dmi'
 	worn_icon = 'icons/mob/clothing/suits/spacesuit.dmi'
-	item_state = "syndicate-black-red"
+	inhand_icon_state = "syndicate-black-red"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|FEET
 	desc = "A plastic replica of the Syndicate space suit. You'll look just like a real murderous Syndicate agent in this! This is a toy, it is not made for use in space!"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -91,7 +91,7 @@
 	name = "\improper Hastur's robe"
 	desc = "Robes not meant to be worn by man."
 	icon_state = "hastur"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 
@@ -101,7 +101,7 @@
 	icon_state = "hastur"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	hoodtype = /obj/item/clothing/head/hooded/hasturhood
@@ -110,7 +110,7 @@
 	name = "\improper Imperium monk suit"
 	desc = "Have YOU killed a xeno today?"
 	icon_state = "imperium_monk"
-	item_state = "imperium_monk"
+	inhand_icon_state = "imperium_monk"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen)
@@ -119,7 +119,7 @@
 	name = "chicken suit"
 	desc = "A suit made long ago by the ancient empire KFC."
 	icon_state = "chickensuit"
-	item_state = "chickensuit"
+	inhand_icon_state = "chickensuit"
 	body_parts_covered = CHEST|ARMS|GROIN|LEGS|FEET
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 
@@ -127,7 +127,7 @@
 	name = "monkey suit"
 	desc = "A suit that looks like a primate."
 	icon_state = "monkeysuit"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS|GROIN|LEGS|FEET|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 
@@ -137,7 +137,7 @@
 	icon_state = "owl_wings"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = null
+	inhand_icon_state = null
 	toggle_noun = "wings"
 	body_parts_covered = ARMS|CHEST
 
@@ -149,13 +149,13 @@
 	name = "griffon cloak"
 	desc = "A plush white cloak made of synthetic feathers. Soft to the touch, stylish, and a 2 meter wing span that will drive your captives mad."
 	icon_state = "griffin_wings"
-	item_state = "griffin_wings"
+	inhand_icon_state = "griffin_wings"
 
 /obj/item/clothing/suit/costume/cardborg
 	name = "cardborg suit"
 	desc = "An ordinary cardboard box with holes cut in the sides."
 	icon_state = "cardborg"
-	item_state = "cardborg"
+	inhand_icon_state = "cardborg"
 	body_parts_covered = CHEST|GROIN
 	flags_inv = HIDEJUMPSUIT
 	dog_fashion = /datum/dog_fashion/back
@@ -184,7 +184,7 @@
 	name = "snowman outfit"
 	desc = "Two white spheres covered in white glitter. 'Tis the season."
 	icon_state = "snowman"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN
 	flags_inv = HIDEJUMPSUIT
 
@@ -192,25 +192,25 @@
 	name = "poncho"
 	desc = "Your classic, non-racist poncho."
 	icon_state = "classicponcho"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/poncho/green
 	name = "green poncho"
 	desc = "Your classic, non-racist poncho. This one is green."
 	icon_state = "greenponcho"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/poncho/red
 	name = "red poncho"
 	desc = "Your classic, non-racist poncho. This one is red."
 	icon_state = "redponcho"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/poncho/ponchoshame
 	name = "poncho of shame"
 	desc = "Forced to live on your shameful acting as a fake Mexican, you and your poncho have grown inseparable. Literally."
 	icon_state = "ponchoshame"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/poncho/ponchoshame/Initialize(mapload)
 	. = ..()
@@ -219,7 +219,7 @@
 /obj/item/clothing/suit/costume/poncho/ponchoshame/outlaw
 	desc = "You broke the rules of the duel, and drew your gun before High Noon. This poncho will rest on your shoulders eternally, just like your shame."
 	icon_state = "ponchoshame_alt"
-	item_state = "ponchoshame_alt"
+	inhand_icon_state = "ponchoshame_alt"
 	armor_type = /datum/armor/ponchoshame_outlaw
 	body_parts_covered = CHEST|GROIN
 	allowed = list(/obj/item/gun/ballistic/shotgun/lever_action, /obj/item/gun/ballistic/rifle/leveraction, /obj/item/gun/ballistic/revolver)
@@ -240,7 +240,7 @@
 	name = "white dress"
 	desc = "A fancy white dress."
 	icon_state = "white_dress"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
 	flags_inv = HIDEJUMPSUIT|HIDESHOES
 
@@ -250,7 +250,7 @@
 	icon_state = "carp_casual"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = "labcoat"
+	inhand_icon_state = "labcoat"
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT	//Space carp like space, so you should too
@@ -263,7 +263,7 @@
 	name = "carp space suit"
 	desc = "A slimming piece of dubious space carp technology."
 	icon_state = "carp_suit"
-	item_state = "space_suit_syndicate"
+	inhand_icon_state = "space_suit_syndicate"
 	slowdown = 0	//Space carp magic, never stop believing
 	armor_type = /datum/armor/carp_costume_spaceproof
 	allowed = list(
@@ -302,7 +302,7 @@
 	icon_state = "ian"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = "labcoat"
+	inhand_icon_state = "labcoat"
 	body_parts_covered = CHEST|GROIN|ARMS
 	//cold_protection = CHEST|GROIN|ARMS
 	//min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
@@ -316,7 +316,7 @@
 	icon_state = "bee"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = "labcoat"
+	inhand_icon_state = "labcoat"
 	body_parts_covered = CHEST|GROIN|ARMS
 	clothing_flags = THICKMATERIAL
 	hoodtype = /obj/item/clothing/head/hooded/bee_hood
@@ -327,7 +327,7 @@
 	icon_state = "lingspacesuit"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = "labcoat"
+	inhand_icon_state = "labcoat"
 	body_parts_covered = CHEST|GROIN|ARMS
 	allowed = list()
 	actions_types = list(/datum/action/item_action/toggle_human_head)
@@ -337,31 +337,31 @@
 	name = "striped sweater"
 	desc = "Reminds you of someone, but you just can't put your finger on it..."
 	icon_state = "waldo_shirt"
-	item_state = "waldo_shirt"
+	inhand_icon_state = "waldo_shirt"
 
 /obj/item/clothing/suit/costume/dracula
 	name = "dracula coat"
 	desc = "Looks like this belongs in a very old movie set."
 	icon_state = "draculacoat"
-	item_state = "draculacoat"
+	inhand_icon_state = "draculacoat"
 
 /obj/item/clothing/suit/costume/drfreeze_coat
 	name = "doctor freeze's labcoat"
 	desc = "A labcoat imbued with the power of features and freezes."
 	icon_state = "drfreeze_coat"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/gothcoat
 	name = "gothic coat"
 	desc = "Perfect for those who want stalk in a corner of a bar."
 	icon_state = "gothcoat"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/xenos
 	name = "xenos suit"
 	desc = "A suit made out of chitinous alien hide."
 	icon_state = "xenos"
-	item_state = "xenos_helm"
+	inhand_icon_state = "xenos_helm"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	allowed = list(/obj/item/clothing/mask/facehugger/toy)

--- a/code/modules/clothing/suits/donator.dm
+++ b/code/modules/clothing/suits/donator.dm
@@ -35,7 +35,7 @@
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'icons/mob/clothing/suits/jacket.dmi'
 	icon_state = "softshell"
-	item_state = "softshell"
+	inhand_icon_state = "softshell"
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/t_scanner, /obj/item/radio)
 	armor_type = /datum/armor/toggle_softshell
 	toggle_noun = "zipper"

--- a/code/modules/clothing/suits/ghostsheet.dm
+++ b/code/modules/clothing/suits/ghostsheet.dm
@@ -2,7 +2,7 @@
 	name = "ghost sheet"
 	desc = "The hands float by themselves, so it's extra spooky."
 	icon_state = "ghost_sheet"
-	item_state = null
+	inhand_icon_state = null
 	throwforce = 0
 	throw_speed = 1
 	throw_range = 2

--- a/code/modules/clothing/suits/hoodies.dm
+++ b/code/modules/clothing/suits/hoodies.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'icons/mob/clothing/suits/jacket.dmi'
 	icon_state = "hoodie"
-	item_state = "hoodie"
+	inhand_icon_state = "hoodie"
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -18,7 +18,7 @@
 	name = "leather jacket"
 	desc = "Pompadour not included."
 	icon_state = "leatherjacket"
-	item_state = "hostrench"
+	inhand_icon_state = "hostrench"
 	resistance_flags = NONE
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/gun/ballistic/automatic/pistol, /obj/item/gun/ballistic/revolver, /obj/item/gun/ballistic/revolver/detective, /obj/item/radio)
@@ -34,13 +34,13 @@
 	name = "bomber jacket"
 	desc = "Aviators not included."
 	icon_state = "bomberjacket"
-	item_state = "brownjsuit"
+	inhand_icon_state = "brownjsuit"
 
 /obj/item/clothing/suit/jacket/puffer
 	name = "puffer jacket"
 	desc = "A thick jacket with a rubbery, water-resistant shell."
 	icon_state = "pufferjacket"
-	item_state = "hostrench"
+	inhand_icon_state = "hostrench"
 	armor_type = /datum/armor/jacket_puffer
 
 
@@ -51,7 +51,7 @@
 	name = "puffer vest"
 	desc = "A thick vest with a rubbery, water-resistant shell."
 	icon_state = "puffervest"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	body_parts_covered = CHEST|GROIN
 	cold_protection = CHEST|GROIN
 	armor_type = /datum/armor/puffer_vest
@@ -64,32 +64,32 @@
 	name = "military jacket"
 	desc = "A canvas jacket styled after classical American military garb. Feels sturdy, yet comfortable."
 	icon_state = "militaryjacket"
-	item_state = null
+	inhand_icon_state = null
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/gun/ballistic/automatic/pistol, /obj/item/gun/ballistic/revolver, /obj/item/radio)
 
 /obj/item/clothing/suit/jacket/letterman
 	name = "letterman jacket"
 	desc = "A classic brown letterman jacket. Looks pretty hot and heavy."
 	icon_state = "letterman"
-	item_state = "letterman"
+	inhand_icon_state = "letterman"
 
 /obj/item/clothing/suit/jacket/letterman_red
 	name = "red letterman jacket"
 	desc = "A letterman jacket in a sick red color. Radical."
 	icon_state = "letterman_red"
-	item_state = "letterman_red"
+	inhand_icon_state = "letterman_red"
 
 /obj/item/clothing/suit/jacket/letterman_syndie
 	name = "blood-red letterman jacket"
 	desc = "Oddly, this jacket seems to have a large S on the back..."
 	icon_state = "letterman_s"
-	item_state = "letterman_s"
+	inhand_icon_state = "letterman_s"
 
 /obj/item/clothing/suit/jacket/letterman_nanotrasen
 	name = "blue letterman jacket"
 	desc = "A blue letterman jacket with a proud Nanotrasen N on the back. The tag says that it was made in Space China."
 	icon_state = "letterman_n"
-	item_state = "letterman_n"
+	inhand_icon_state = "letterman_n"
 
 //Aristocrat coats
 
@@ -97,47 +97,47 @@
 	name = "orange aristocrat coat"
 	desc = "A fancy coat made of silk. This one is orange."
 	icon_state = "aristo_orange"
-	item_state = "aristo_orange"
+	inhand_icon_state = "aristo_orange"
 
 /obj/item/clothing/suit/jacket/aristocrat/red
 	name = "red aristocrat coat"
 	desc = "A fancy coat made of silk. This one is red."
 	icon_state = "aristo_red"
-	item_state = "aristo_red"
+	inhand_icon_state = "aristo_red"
 
 /obj/item/clothing/suit/jacket/aristocrat/brown
 	name = "brown aristocrat coat"
 	desc = "A fancy coat made of silk. This one is brown."
 	icon_state = "aristo_brown"
-	item_state = "aristo_brown"
+	inhand_icon_state = "aristo_brown"
 
 /obj/item/clothing/suit/jacket/aristocrat/blue
 	name = "blue aristocrat coat"
 	desc = "A fancy coat made of silk. This one is blue."
 	icon_state = "aristo_blue"
-	item_state = "aristo_blue"
+	inhand_icon_state = "aristo_blue"
 
 // New COOL jackets
 /obj/item/clothing/suit/jacket/undergroundserpents //www.youtube.com/watch?v=S0ximxe4XtU&t=61s
 	name = "Underground Serpents jacket"
 	desc = "Underground Serpents Jacket rules, we are the underground serpents. That's us, and we rule! ."
 	icon_state = "userpents_jacket"
-	item_state = "userpents_jacket"
+	inhand_icon_state = "userpents_jacket"
 
 /obj/item/clothing/suit/jacket/teenbiker
 	name = "Teen biker jacket"
 	desc = "A red jacket with a pill on its back."
 	icon_state = "teenbiker_jacket"
-	item_state = "teenbiker_jacket"
+	inhand_icon_state = "teenbiker_jacket"
 
 /obj/item/clothing/suit/jacket/driver
 	name = "Driver jacket"
 	desc = "A white and black jacket with a golden scorpion on its back. Perfect for driving through the night."
 	icon_state = "driver_jacket"
-	item_state = "driver_jacket"
+	inhand_icon_state = "driver_jacket"
 
 /obj/item/clothing/suit/jacket/lieutenant
 	name = "Lieutenant Vest"
 	desc = "A short orange vest that once belonged to a lieutenant."
 	icon_state = "lieutenant_jacket"
-	item_state = "lieutenant_jacket"
+	inhand_icon_state = "lieutenant_jacket"

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -9,7 +9,7 @@
 	icon_state = "apron"
 	icon = 'icons/obj/clothing/suits/utility.dmi'
 	worn_icon = 'icons/mob/clothing/suits/utility.dmi'
-	item_state = null
+	inhand_icon_state = null
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST|GROIN
 	pockets = FALSE
@@ -36,7 +36,7 @@
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	icon_state = "captunic"
-	item_state = "bio_suit"
+	inhand_icon_state = "bio_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/disk, /obj/item/stamp, /obj/item/reagent_containers/cup/glass/flask, /obj/item/melee, /obj/item/storage/lockbox/medal, /obj/item/assembly/flash/handheld, /obj/item/storage/box/matches, /obj/item/lighter, /obj/item/clothing/mask/cigarette, /obj/item/storage/fancy/cigarettes, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
@@ -46,7 +46,7 @@
 	name = "chef's apron"
 	desc = "An apron-jacket used by a high class chef."
 	icon_state = "chef"
-	item_state = "chef"
+	inhand_icon_state = "chef"
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'icons/mob/clothing/suits/jacket.dmi'
 	gas_transfer_coefficient = 0.9
@@ -67,7 +67,7 @@
 	name = "cook's apron"
 	desc = "A basic, dull, white chef's apron."
 	icon_state = "apronchef"
-	item_state = null
+	inhand_icon_state = null
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST|GROIN
 	allowed = list(
@@ -80,7 +80,7 @@
 	name = "trenchcoat"
 	desc = "An 18th-century multi-purpose trenchcoat. Someone who wears this means serious business."
 	icon_state = "detective"
-	item_state = "det_suit"
+	inhand_icon_state = "det_suit"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|ARMS
 	armor_type = /datum/armor/jacket_det_suit
@@ -111,13 +111,13 @@
 	name = "noir trenchcoat"
 	desc = "A hard-boiled private investigator's grey trenchcoat."
 	icon_state = "greydet"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/jacket/det_suit/noir
 	name = "noir suit coat"
 	desc = "A dapper private investigator's grey suit coat."
 	icon_state = "detsuit"
-	item_state = null
+	inhand_icon_state = null
 
 //Brig Phys
 /obj/item/clothing/suit/hazardvest/brig_physician
@@ -126,7 +126,7 @@
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	icon_state = "brig_phys_vest"
-	item_state = "sec_helm"//looks kinda similar, I guess
+	inhand_icon_state = "sec_helm"//looks kinda similar, I guess
 	allowed = list(/obj/item/analyzer, /obj/item/stack/medical, /obj/item/storage/firstaid, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/healthanalyzer, /obj/item/flashlight/pen, /obj/item/reagent_containers/cup/bottle, /obj/item/reagent_containers/cup/beaker, /obj/item/reagent_containers/pill, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/police/telescopic, /obj/item/soap, /obj/item/sensor_device, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 	armor_type = /datum/armor/hazardvest_brig_physician
 
@@ -146,7 +146,7 @@
 	icon_state = "hazard"
 	icon = 'icons/obj/clothing/suits/utility.dmi'
 	worn_icon = 'icons/mob/clothing/suits/utility.dmi'
-	item_state = null
+	inhand_icon_state = null
 	blood_overlay_type = "armor"
 	allowed = list(
 		/obj/item/flashlight,
@@ -168,7 +168,7 @@
 	icon_state = "suitjacket_blue"
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'icons/mob/clothing/suits/jacket.dmi'
-	item_state = null
+	inhand_icon_state = null
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
 
@@ -176,13 +176,13 @@
 	name = "purple suit jacket"
 	desc = "A foppish dress jacket."
 	icon_state = "suitjacket_purp"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/toggle/lawyer/black
 	name = "black suit jacket"
 	desc = "A professional suit jacket."
 	icon_state = "suitjacket_black"
-	item_state = "ro_suit"
+	inhand_icon_state = "ro_suit"
 
 //Mime
 /obj/item/clothing/suit/suspenders
@@ -199,42 +199,42 @@
 	name = "security officer's jacket"
 	desc = "This jacket is for those special occasions when a security officer isn't required to wear their armor."
 	icon_state = "officerbluejacket"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS
 
 /obj/item/clothing/suit/jacket/officer/tan
 	name = "security officer's jacket"
 	desc = "This jacket is for those special occasions when a security officer isn't required to wear their armor."
 	icon_state = "officertanjacket"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS
 
 /obj/item/clothing/suit/jacket/warden/blue
 	name = "warden's jacket"
 	desc = "Perfectly suited for the warden that wants to leave an impression of style on those who visit the brig."
 	icon_state = "wardenbluejacket"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS
 
 /obj/item/clothing/suit/jacket/warden/tan
 	name = "warden's jacket"
 	desc = "Perfectly suited for the warden that wants to leave an impression of style on those who visit the brig."
 	icon_state = "wardenbluejacket"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS
 
 /obj/item/clothing/suit/jacket/hos/blue
 	name = "head of security's jacket"
 	desc = "This piece of clothing was specifically designed for asserting superior authority."
 	icon_state = "hosbluejacket"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS
 
 /obj/item/clothing/suit/jacket/hos/tan
 	name = "head of security's jacket"
 	desc = "This piece of clothing was specifically designed for asserting superior authority."
 	icon_state = "hostanjacket"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|ARMS
 
 //Surgeon
@@ -255,7 +255,7 @@
 	name = "treasure hunter's coat"
 	desc = "Both fashionable and lightly armoured, this jacket is favoured by treasure hunters the galaxy over."
 	icon_state = "curator"
-	item_state = null
+	inhand_icon_state = null
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
 	allowed = list(
@@ -284,7 +284,7 @@
 	icon_state = "techpriest"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	hoodtype = /obj/item/clothing/head/hooded/techpriest
 
@@ -294,6 +294,6 @@
 	icon = 'icons/obj/clothing/head/costume.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "techpriesthood"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEEARS

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -4,7 +4,7 @@
 	icon_state = "labcoat"
 	icon = 'icons/obj/clothing/suits/labcoat.dmi'
 	worn_icon = 'icons/mob/clothing/suits/labcoat.dmi'
-	item_state = "labcoat"
+	inhand_icon_state = "labcoat"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
 	allowed = list(
@@ -42,18 +42,18 @@
 	name = "chief medical officer's labcoat"
 	desc = "Bluer than the standard model. Issued to Chief Medical Officers, keeping them visible at all times among the sea of the wounded and other doctors."
 	icon_state = "labcoat_cmo"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/toggle/labcoat/paramedic
 	name = "\improper EMT's jacket"
 	desc = "A dark blue jacket with reflective strips for emergency medical technicians."
 	icon_state = "labcoat_emt"
-	item_state = "labcoat_cmo"
+	inhand_icon_state = "labcoat_cmo"
 
 /obj/item/clothing/suit/toggle/labcoat/brig_physician
 	name = "security medic's labcoat"
 	icon_state = "labcoat_sec"
-	item_state = "labcoat_sec"
+	inhand_icon_state = "labcoat_sec"
 	armor_type = /datum/armor/labcoat_brig_physician
 
 
@@ -69,7 +69,7 @@
 	name = "\proper The Mad's labcoat"
 	desc = "It makes you look capable of konking someone on the noggin and shooting them into space."
 	icon_state = "labgreen"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/toggle/labcoat/genetics
 	name = "geneticist labcoat"
@@ -95,4 +95,4 @@
 	name = "research director's labcoat"
 	desc = "Popped collar, ancient science fair medal from middle school.. worn out buttons that barely keep the coat closed? Oh yeah, its plasma research time. Has a legacy purple U stripe along the back."
 	icon_state = "labcoat_rd"
-	item_state = "labcoat_tox"
+	inhand_icon_state = "labcoat_tox"

--- a/code/modules/clothing/suits/lasertag.dm
+++ b/code/modules/clothing/suits/lasertag.dm
@@ -4,7 +4,7 @@
 	icon_state = "bluetag"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = null
+	inhand_icon_state = null
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST
 	allowed = list (/obj/item/gun/energy/laser/bluetag)
@@ -16,7 +16,7 @@
 	icon_state = "redtag"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = null
+	inhand_icon_state = null
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST
 	allowed = list (/obj/item/gun/energy/laser/redtag)

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -31,7 +31,7 @@
 	name = "reactive armor"
 	desc = "Doesn't seem to do much for some reason."
 	icon_state = "reactiveoff"
-	item_state = "reactiveoff"
+	inhand_icon_state = "reactiveoff"
 	blood_overlay_type = "armor"
 	armor_type = /datum/armor/armor_reactive
 	actions_types = list(/datum/action/item_action/toggle)
@@ -62,11 +62,11 @@
 	if(active)
 		to_chat(user, span_notice("[src] is now active."))
 		icon_state = "reactive"
-		item_state = "reactive"
+		inhand_icon_state = "reactive"
 	else
 		to_chat(user, span_notice("[src] is now inactive."))
 		icon_state = "reactiveoff"
-		item_state = "reactiveoff"
+		inhand_icon_state = "reactiveoff"
 	add_fingerprint(user)
 	return
 

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -2,16 +2,16 @@
 	name = "worn shirt"
 	desc = "A worn out, curiously comfortable t-shirt with a picture of Ian. You wouldn't go so far as to say it feels like being hugged when you wear it, but it's pretty close. Good for sleeping in."
 	icon_state = "ianshirt"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/nerdshirt
 	name = "gamer shirt"
 	desc = "A baggy shirt with vintage game character Phanic the Weasel. Why would anyone wear this?"
 	icon_state = "nerdshirt"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/vapeshirt //wearing this is asking to get beat.
 	name = "Vape Naysh shirt"
 	desc = "A cheap white T-shirt with a big tacky \"VN\" on the front, Why would you wear this unironically?"
 	icon_state = "vapeshirt"
-	item_state = null
+	inhand_icon_state = null

--- a/code/modules/clothing/suits/straightjacket.dm
+++ b/code/modules/clothing/suits/straightjacket.dm
@@ -2,7 +2,7 @@
 	name = "straight jacket"
 	desc = "A suit that completely restrains the wearer. Manufactured by Antyphun Corp." //Straight jacket is antifun
 	icon_state = "straight_jacket"
-	item_state = "straight_jacket"
+	inhand_icon_state = "straight_jacket"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	equip_delay_self = 50

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -18,7 +18,7 @@
 	name = "emergency firesuit"
 	desc = "A suit that helps protect against fire and heat."
 	icon_state = "fire"
-	item_state = "ro_suit"
+	inhand_icon_state = "ro_suit"
 	w_class = WEIGHT_CLASS_BULKY
 	gas_transfer_coefficient = 0.9
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -58,20 +58,20 @@
 
 /obj/item/clothing/suit/utility/fire/firefighter
 	icon_state = "firesuit"
-	item_state = "firefighter"
+	inhand_icon_state = "firefighter"
 
 /obj/item/clothing/suit/utility/fire/heavy
 	name = "heavy firesuit"
 	desc = "An old, bulky thermal protection suit."
 	icon_state = "thermal"
-	item_state = "ro_suit"
+	inhand_icon_state = "ro_suit"
 	slowdown = 1.5
 
 /obj/item/clothing/suit/utility/fire/atmos
 	name = "firesuit"
 	desc = "An expensive firesuit that protects against even the most deadly of station fires. Designed to protect even if the wearer is set aflame."
 	icon_state = "atmos_firesuit"
-	item_state = "firesuit_atmos"
+	inhand_icon_state = "firesuit_atmos"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	allowed = list(/obj/item/flashlight, /obj/item/extinguisher, /obj/item/crowbar, /obj/item/tank/internals, /obj/item/powertool/jaws_of_life)
 
@@ -112,7 +112,7 @@
 	name = "bomb suit"
 	desc = "A suit designed for safety when handling explosives."
 	icon_state = "bombsuit"
-	item_state = "bombsuit"
+	inhand_icon_state = "bombsuit"
 	w_class = WEIGHT_CLASS_BULKY
 	gas_transfer_coefficient = 0.01
 	clothing_flags = THICKMATERIAL
@@ -142,21 +142,21 @@
 
 /obj/item/clothing/head/utility/bomb_hood/security
 	icon_state = "bombsuit_sec"
-	item_state = "bombsuit_sec"
+	inhand_icon_state = "bombsuit_sec"
 
 /obj/item/clothing/suit/utility/bomb_suit/security
 	icon_state = "bombsuit_sec"
-	item_state = "bombsuit_sec"
+	inhand_icon_state = "bombsuit_sec"
 	allowed = list(/obj/item/gun/energy, /obj/item/melee/baton, /obj/item/restraints/handcuffs)
 
 
 /obj/item/clothing/head/utility/bomb_hood/white
 	icon_state = "bombsuit_white"
-	item_state = "bombsuit_white"
+	inhand_icon_state = "bombsuit_white"
 
 /obj/item/clothing/suit/utility/bomb_suit/white
 	icon_state = "bombsuit_white"
-	item_state = "bombsuit_white"
+	inhand_icon_state = "bombsuit_white"
 
 /*
 * Radiation protection
@@ -187,7 +187,7 @@
 	name = "radiation suit"
 	desc = "A suit that protects against radiation. The label reads, 'Made with lead. Please do not consume insulation.'"
 	icon_state = "rad"
-	item_state = "rad_suit"
+	inhand_icon_state = "rad_suit"
 	w_class = WEIGHT_CLASS_BULKY
 	gas_transfer_coefficient = 0.9
 	clothing_flags = THICKMATERIAL

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/clothing/suits/wintercoat.dmi'
 	icon_state = "coatwinter"
 	worn_icon = 'icons/mob/clothing/suits/wintercoat.dmi'
-	item_state = "coatwinter"
+	inhand_icon_state = "coatwinter"
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
@@ -47,7 +47,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/captain
 	name = "captain's winter coat"
 	icon_state = "coatcaptain"
-	item_state = "coatcaptain"
+	inhand_icon_state = "coatcaptain"
 	armor_type = /datum/armor/wintercoat_captain
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain
 
@@ -72,7 +72,7 @@
 	name = "security winter coat"
 	desc = "A thick jacket made from a light, fire-resistant kevlar-like material which provides some protection to the user. It is particularly effective against energy-based threats due to its thickness and insulation."
 	icon_state = "coatsecurity"
-	item_state = "coatsecurity"
+	inhand_icon_state = "coatsecurity"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/security
 	armor_type = /datum/armor/wintercoat_security
 	slowdown = 0.04
@@ -110,7 +110,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/detective
 	name = "detective winter coat"
 	icon_state = "coatdetective"
-	item_state = "coatdetective"
+	inhand_icon_state = "coatdetective"
 	allowed = list(
 		/obj/item/tank/internals,
 		/obj/item/melee/classic_baton,
@@ -156,7 +156,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/brigphys
 	name = "brig physician winter coat"
 	icon_state = "coatbrigphys"
-	item_state = "coatbrigphys"
+	inhand_icon_state = "coatbrigphys"
 	allowed = list(
 		/obj/item/analyzer,
 		/obj/item/dnainjector,
@@ -209,7 +209,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/medical
 	name = "medical winter coat"
 	icon_state = "coatmedical"
-	item_state = "coatmedical"
+	inhand_icon_state = "coatmedical"
 	allowed = list(
 		/obj/item/analyzer,
 		/obj/item/dnainjector,
@@ -249,7 +249,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/virologist
 	name = "virology winter coat"
 	icon_state = "coatviro"
-	item_state = "coatviro"
+	inhand_icon_state = "coatviro"
 	allowed = list(
 		/obj/item/extrapolator,
 		/obj/item/analyzer,
@@ -295,7 +295,7 @@
 	name = "chemist winter coat"
 	desc = "A heavy jacket made from hardy 'synthetic' animal furs capable of enduring most chemical mishaps."
 	icon_state = "coatchem"
-	item_state = "coatchem"
+	inhand_icon_state = "coatchem"
 	allowed = list(
 		/obj/item/grenade/chem_grenade,
 		/obj/item/analyzer,
@@ -341,7 +341,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/geneticist
 	name = "geneticist winter coat"
 	icon_state = "coatgene"
-	item_state = "coatgene"
+	inhand_icon_state = "coatgene"
 	allowed = list(
 		/obj/item/dnainjector,
 		/obj/item/sequence_scanner,
@@ -383,7 +383,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/science
 	name = "science winter coat"
 	icon_state = "coatscience"
-	item_state = "coatscience"
+	inhand_icon_state = "coatscience"
 	allowed = list(/obj/item/analyzer, /obj/item/stack/medical, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/healthanalyzer, /obj/item/flashlight/pen, /obj/item/reagent_containers/cup/bottle, /obj/item/reagent_containers/cup/beaker, /obj/item/reagent_containers/pill, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/police/telescopic, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 	armor_type = /datum/armor/wintercoat_science
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science
@@ -398,7 +398,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering
 	name = "engineering winter coat"
 	icon_state = "coatengineer"
-	item_state = "coatengineer"
+	inhand_icon_state = "coatengineer"
 	armor_type = /datum/armor/wintercoat_engineering
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/t_scanner, /obj/item/construction/rcd, /obj/item/pipe_dispenser, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering
@@ -415,7 +415,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
 	name = "atmospherics winter coat"
 	icon_state = "coatatmos"
-	item_state = "coatatmos"
+	inhand_icon_state = "coatatmos"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering/atmos
 
 /obj/item/clothing/head/hooded/winterhood/engineering/atmos
@@ -424,7 +424,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/hydro
 	name = "hydroponics winter coat"
 	icon_state = "coathydro"
-	item_state = "coathydro"
+	inhand_icon_state = "coathydro"
 	allowed = list(/obj/item/reagent_containers/spray/plantbgone, /obj/item/plant_analyzer, /obj/item/seeds, /obj/item/reagent_containers/cup/bottle, /obj/item/cultivator, /obj/item/reagent_containers/spray/pestspray, /obj/item/hatchet, /obj/item/storage/bag/plants, /obj/item/toy, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/storage/fancy/cigarettes, /obj/item/lighter)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/hydro
 
@@ -435,7 +435,7 @@
 	name = "cargo winter coat"
 	desc = "A heavy jacket made from 'synthetic' animal furs. It's especially tailored to hold Cargo related items." // Cargo players if I missed anything let me know
 	icon_state = "coatcargo"
-	item_state = "coatcargo"
+	inhand_icon_state = "coatcargo"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/cargo
 	allowed = list(
 		/obj/item/hand_labeler,
@@ -461,7 +461,7 @@
 	name = "mining winter coat"
 	desc = "A heavy jacket made from 'synthetic' animal furs. It is quite armoured and well suited to explore harsh environments."
 	icon_state = "coatminer"
-	item_state = "coatminer"
+	inhand_icon_state = "coatminer"
 	allowed = list(
 		/obj/item/pickaxe,
 		/obj/item/flashlight,
@@ -608,7 +608,7 @@
 	name = "centcom winter coat"
 	desc = "A luxurious winter coat woven in the bright green and gold colours of Central Command. It has a small pin in the shape of the Nanotrasen logo for a zipper."
 	icon_state = "coatcentcom"
-	item_state = "coatcentcom"
+	inhand_icon_state = "coatcentcom"
 	armor_type = /datum/armor/wintercoat_centcom
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/centcom
 

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/head/wizard.dmi'
 	worn_icon = 'icons/mob/clothing/head/wizard.dmi'
 	icon_state = "wizard"
-	item_state = "wizhat"
+	inhand_icon_state = "wizhat"
 	gas_transfer_coefficient = 0.01 // IT'S MAGICAL OKAY JEEZ +1 TO NOT DIE
 	armor_type = /datum/armor/head_wizard
 	strip_delay = 50
@@ -65,14 +65,14 @@
 	name = "\improper Magus helm"
 	desc = "A mysterious helmet that hums with an unearthly power."
 	icon_state = "magus"
-	item_state = null
+	inhand_icon_state = null
 	dog_fashion = null
 
 /obj/item/clothing/head/wizard/santa
 	name = "Santa's hat"
 	desc = "Ho ho ho. Merrry X-mas!"
 	icon_state = "santahat"
-	item_state = "santahat"
+	inhand_icon_state = "santahat"
 	flags_inv = HIDEHAIR|HIDEFACIALHAIR
 	dog_fashion = null
 
@@ -82,7 +82,7 @@
 	icon = 'icons/obj/clothing/suits/wizard.dmi'
 	icon_state = "wizard"
 	worn_icon = 'icons/mob/clothing/suits/wizard.dmi'
-	item_state = "wizrobe"
+	inhand_icon_state = "wizrobe"
 	gas_transfer_coefficient = 0.01
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	armor_type = /datum/armor/suit_wizrobe
@@ -122,50 +122,50 @@
 	name = "red wizard robe"
 	desc = "A magnificent red gem-lined robe that seems to radiate power."
 	icon_state = "redwizard"
-	item_state = "redwizrobe"
+	inhand_icon_state = "redwizrobe"
 
 /obj/item/clothing/suit/wizrobe/yellow
 	name = "yellow wizard robe"
 	desc = "A magnificent yellow gem-lined robe that seems to radiate power."
 	icon_state = "yellowwizard"
-	item_state = "yellowwizrobe"
+	inhand_icon_state = "yellowwizrobe"
 
 /obj/item/clothing/suit/wizrobe/black
 	name = "black wizard robe"
 	desc = "An unnerving black gem-lined robe that reeks of death and decay."
 	icon_state = "blackwizard"
-	item_state = "blackwizrobe"
+	inhand_icon_state = "blackwizrobe"
 
 /obj/item/clothing/suit/wizrobe/marisa
 	name = "witch robe"
 	desc = "Magic is all about the spell power, ZE!"
 	icon_state = "marisa"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/suit/wizrobe/magusblue
 	name = "\improper Magus robe"
 	desc = "A set of armored robes that seem to radiate a dark power."
 	icon_state = "magusblue"
-	item_state = "magusblue"
+	inhand_icon_state = "magusblue"
 
 /obj/item/clothing/suit/wizrobe/magusred
 	name = "\improper Magus robe"
 	desc = "A set of armored robes that seem to radiate a dark power."
 	icon_state = "magusred"
-	item_state = "magusred"
+	inhand_icon_state = "magusred"
 
 
 /obj/item/clothing/suit/wizrobe/santa
 	name = "Santa's suit"
 	desc = "Festive!"
 	icon_state = "santa"
-	item_state = "santa"
+	inhand_icon_state = "santa"
 
 /obj/item/clothing/suit/wizrobe/fake
 	name = "wizard robe"
 	desc = "A rather dull blue robe meant to mimick real wizard robes."
 	icon_state = "wizard-fake"
-	item_state = "wizrobe"
+	inhand_icon_state = "wizrobe"
 	gas_transfer_coefficient = 1
 	armor_type = /datum/armor/none
 	resistance_flags = FLAMMABLE
@@ -184,7 +184,7 @@
 	name = "witch robe"
 	desc = "Magic is all about the spell power, ZE!"
 	icon_state = "marisa"
-	item_state = "marisarobe"
+	inhand_icon_state = "marisarobe"
 	gas_transfer_coefficient = 1
 	armor_type = /datum/armor/none
 	resistance_flags = FLAMMABLE
@@ -194,7 +194,7 @@
 	name = "papier-mache robe" // no non-latin characters!
 	desc = "A robe held together by various bits of clear-tape and paste."
 	icon_state = "wizard-paper"
-	item_state = "wizard-paper"
+	inhand_icon_state = "wizard-paper"
 	var/robe_charge = TRUE
 	actions_types = list(/datum/action/item_action/stickmen)
 	clothing_flags = NONE
@@ -231,7 +231,7 @@
 	name = "battlemage armour"
 	desc = "Not all wizards are afraid of getting up close and personal."
 	icon_state = "battlemage"
-	item_state = "battlemage"
+	inhand_icon_state = "battlemage"
 	recharge_delay = 0 // no auto-recharge
 	shield_integrity = 300
 	shield_icon = "shield-red"
@@ -276,7 +276,7 @@
 	name = "battlemage helmet"
 	desc = "A suitably impressive helmet.."
 	icon_state = "battlemage"
-	item_state = "battlemage"
+	inhand_icon_state = "battlemage"
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	clothing_flags = CASTING_CLOTHES

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -3,7 +3,7 @@
 	desc = "Something has gone wrong!"
 	icon = 'icons/obj/clothing/accessories.dmi'
 	icon_state = "plasma"
-	item_state = ""	//no inhands
+	inhand_icon_state = ""	//no inhands
 	slot_flags = 0
 	w_class = WEIGHT_CLASS_SMALL
 	var/above_suit = FALSE
@@ -81,7 +81,7 @@
 	name = "waistcoat"
 	desc = "For some classy, murderous fun."
 	icon_state = "waistcoat"
-	item_state = "waistcoat"
+	inhand_icon_state = "waistcoat"
 	minimize_when_attached = FALSE
 	attachment_slot = null
 
@@ -89,7 +89,7 @@
 	name = "maid apron"
 	desc = "The best part of a maid costume."
 	icon_state = "maidapron"
-	item_state = "maidapron"
+	inhand_icon_state = "maidapron"
 	minimize_when_attached = FALSE
 	attachment_slot = null
 
@@ -396,7 +396,7 @@
 	name = "shoulder holster"
 	desc = "A holster to carry a handgun and ammo. WARNING: Badasses only."
 	icon_state = "holster"
-	item_state = "holster"
+	inhand_icon_state = "holster"
 	worn_icon_state = "holster"
 	slot_flags = ITEM_SLOT_SUITSTORE|ITEM_SLOT_BELT
 	var/holstertype = /datum/storage/pockets/holster

--- a/code/modules/clothing/under/cluwne.dm
+++ b/code/modules/clothing/under/cluwne.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/under/civilian.dmi'
 	worn_icon = 'icons/mob/clothing/under/civilian.dmi'
 	icon_state = "greenclown"
-	item_state = "greenclown"
+	inhand_icon_state = "greenclown"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	item_flags = DROPDEL
 	can_adjust = 0

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -9,7 +9,7 @@
 	greyscale_config_worn = /datum/greyscale_config/jumpsuit_worn
 	icon = 'icons/obj/clothing/under/color.dmi'
 	icon_state = "jumpsuit"
-	item_state = "jumpsuit"
+	inhand_icon_state = "jumpsuit"
 	worn_icon_state = "jumpsuit"
 	worn_icon = 'icons/mob/clothing/under/color.dmi'
 	supports_variations = DIGITIGRADE_VARIATION
@@ -76,7 +76,7 @@
 	name = "ancient jumpsuit"
 	desc = "A terribly ragged and frayed grey jumpsuit. It looks like it hasn't been washed in over a decade."
 	icon_state = "grey_ancient"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 	greyscale_colors = null
 	greyscale_config = null
 	greyscale_config_inhand_left = null
@@ -258,7 +258,7 @@
 	name = "rainbow jumpsuit"
 	desc = "A multi-colored jumpsuit!"
 	icon_state = "rainbow"
-	item_state = "rainbow"
+	inhand_icon_state = "rainbow"
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
@@ -269,7 +269,7 @@
 	name = "rainbow jumpskirt"
 	desc = "A multi-colored jumpskirt!"
 	icon_state = "rainbow_skirt"
-	item_state = "rainbow"
+	inhand_icon_state = "rainbow"
 	greyscale_config = null
 	greyscale_config_inhand_left = null
 	greyscale_config_inhand_right = null
@@ -280,7 +280,7 @@
 	name = "ERROR jumpsuit"
 	desc = "An error! A glitch! Wearing this for too long will make you go insane..."
 	icon_state = "denied"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/color/rainbow/denied/skirt
 	name = "ERROR jumpskirt"

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -6,7 +6,7 @@
 	name = "\improper Roman armor"
 	desc = "Ancient Roman armor. Made of metallic and leather straps."
 	icon_state = "roman"
-	item_state = "armor"
+	inhand_icon_state = "armor"
 	can_adjust = FALSE
 	strip_delay = 100
 	resistance_flags = NONE
@@ -15,7 +15,7 @@
 	name = "jabroni outfit"
 	desc = "The leather club is two sectors down."
 	icon_state = "darkholme"
-	item_state = null
+	inhand_icon_state = null
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/owl
@@ -39,7 +39,7 @@
 	name = "blue schoolgirl uniform"
 	desc = "It's just like one of my Japanese animes!"
 	icon_state = "schoolgirl"
-	item_state = "schoolgirl"
+	inhand_icon_state = "schoolgirl"
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
@@ -48,37 +48,37 @@
 /obj/item/clothing/under/costume/schoolgirl/red
 	name = "red schoolgirl uniform"
 	icon_state = "schoolgirlred"
-	item_state = "schoolgirlred"
+	inhand_icon_state = "schoolgirlred"
 
 /obj/item/clothing/under/costume/schoolgirl/green
 	name = "green schoolgirl uniform"
 	icon_state = "schoolgirlgreen"
-	item_state = "schoolgirlgreen"
+	inhand_icon_state = "schoolgirlgreen"
 
 /obj/item/clothing/under/costume/schoolgirl/orange
 	name = "orange schoolgirl uniform"
 	icon_state = "schoolgirlorange"
-	item_state = "schoolgirlorange"
+	inhand_icon_state = "schoolgirlorange"
 
 /obj/item/clothing/under/costume/pirate
 	name = "pirate outfit"
 	desc = "Yarr."
 	icon_state = "pirate"
-	item_state = "pirate"
+	inhand_icon_state = "pirate"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/soviet
 	name = "soviet uniform"
 	desc = "For the Motherland!"
 	icon_state = "soviet"
-	item_state = "soviet"
+	inhand_icon_state = "soviet"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/kilt
 	name = "kilt"
 	desc = "Includes shoes and plaid."
 	icon_state = "kilt"
-	item_state = "kilt"
+	inhand_icon_state = "kilt"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
@@ -95,7 +95,7 @@
 	name = "gladiator uniform"
 	desc = "Are you not entertained? Is that not why you are here?"
 	icon_state = "gladiator"
-	item_state = "gladiator"
+	inhand_icon_state = "gladiator"
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
@@ -110,7 +110,7 @@
 	name = "maid costume"
 	desc = "Maid in China."
 	icon_state = "maid"
-	item_state = "maid"
+	inhand_icon_state = "maid"
 	body_parts_covered = CHEST|GROIN
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
@@ -148,7 +148,7 @@
 	name = "black kimono"
 	desc = "A luxurious black silk kimono with traditional flair, ideal for elegant festive occasions."
 	icon_state = "kimono1"
-	item_state = "yukata1"
+	inhand_icon_state = "yukata1"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
@@ -179,7 +179,7 @@
 	name = "sailor suit"
 	desc = "Skipper's in the wardroom drinkin gin'."
 	icon_state = "sailor"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/singer
@@ -191,20 +191,20 @@
 /obj/item/clothing/under/costume/singer/yellow
 	name = "yellow performer's outfit"
 	icon_state = "ysing"
-	item_state = "ysing"
+	inhand_icon_state = "ysing"
 	female_sprite_flags = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/costume/singer/blue
 	name = "blue performer's outfit"
 	icon_state = "bsing"
-	item_state = "bsing"
+	inhand_icon_state = "bsing"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 
 /obj/item/clothing/under/costume/mummy
 	name = "mummy wrapping"
 	desc = "Return the slab or suffer my stale references."
 	icon_state = "mummy"
-	item_state = "mummy"
+	inhand_icon_state = "mummy"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
@@ -214,7 +214,7 @@
 	name = "scarecrow clothes"
 	desc = "Perfect camouflage for hiding in botany."
 	icon_state = "scarecrow"
-	item_state = "scarecrow"
+	inhand_icon_state = "scarecrow"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
@@ -224,7 +224,7 @@
 	name = "draculass coat"
 	desc = "A dress inspired by the ancient \"Victorian\" era."
 	icon_state = "draculass"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
@@ -233,14 +233,14 @@
 	name = "doctor freeze's jumpsuit"
 	desc = "A modified scientist jumpsuit to look extra cool."
 	icon_state = "drfreeze"
-	item_state = "drfreeze"
+	inhand_icon_state = "drfreeze"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/lobster
 	name = "foam lobster suit"
 	desc = "Who beheaded the college mascot?"
 	icon_state = "lobster"
-	item_state = "lobster"
+	inhand_icon_state = "lobster"
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 
@@ -248,14 +248,14 @@
 	name = "gondola hide suit"
 	desc = "Now you're cooking."
 	icon_state = "gondola"
-	item_state = "lb_suit"
+	inhand_icon_state = "lb_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/skeleton
 	name = "skeleton jumpsuit"
 	desc = "A black jumpsuit with a white bone pattern printed on it. Spooky!"
 	icon_state = "skeleton"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
@@ -265,7 +265,7 @@
 	name = "red mech pilot's suit"
 	desc = "A red mech pilot's suit. Might make your butt look big."
 	icon_state = "red_mech_suit"
-	item_state = "red_mech_suit"
+	inhand_icon_state = "red_mech_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	female_sprite_flags = NO_FEMALE_UNIFORM
@@ -276,20 +276,20 @@
 	name = "white mech pilot's suit"
 	desc = "A white mech pilot's suit. Very fetching."
 	icon_state = "white_mech_suit"
-	item_state = "white_mech_suit"
+	inhand_icon_state = "white_mech_suit"
 
 /obj/item/clothing/under/costume/mech_suit/blue
 	name = "blue mech pilot's suit"
 	desc = "A blue mech pilot's suit. For the more reluctant mech pilots."
 	icon_state = "blue_mech_suit"
-	item_state = "blue_mech_suit"
+	inhand_icon_state = "blue_mech_suit"
 
 /obj/item/clothing/under/costume/russian_officer
 	name = "\improper Russian officer's uniform"
 	desc = "The latest in fashionable russian outfits."
 	icon = 'icons/obj/clothing/under/security.dmi'
 	icon_state = "hostanclothes"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon = 'icons/mob/clothing/under/security.dmi'
 	alt_covers_chest = TRUE
 	armor_type = /datum/armor/costume_russian_officer
@@ -310,7 +310,7 @@
 	name = "swag outfit"
 	desc = "Why don't you go secure some bitches?"
 	icon_state = "SwagOutfit"
-	item_state = "SwagOutfit"
+	inhand_icon_state = "SwagOutfit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/joker

--- a/code/modules/clothing/under/jobs/Plasmaman/centcom.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/centcom.dm
@@ -2,16 +2,16 @@
 	name = "CentCom commander envirosuit"
 	desc = "An envirosuit worn by CentCom's highest-tier Commanders."
 	icon_state = "commander_envirosuit"
-	item_state = "commander_envirosuit"
+	inhand_icon_state = "commander_envirosuit"
 
 /obj/item/clothing/under/plasmaman/official
 	name = "CentCom official envirosuit"
 	desc = "An envirosuit worn by CentCom Officers."
 	icon_state = "official_envirosuit"
-	item_state = "official_envirosuit"
+	inhand_icon_state = "official_envirosuit"
 
 /obj/item/clothing/under/plasmaman/intern
 	name = "CentCom intern envirosuit"
 	desc = "An envirosuit worn by those interning for CentCom. The top is styled after a polo shirt for easy identification."
 	icon_state = "intern_envirosuit"
-	item_state = "intern_envirosuit"
+	inhand_icon_state = "intern_envirosuit"

--- a/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
@@ -2,7 +2,7 @@
 	name = "plasma envirosuit"
 	desc = "A special containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy."
 	icon_state = "plasmaman"
-	item_state = "plasmaman"
+	inhand_icon_state = "plasmaman"
 	icon = 'icons/obj/clothing/under/plasmaman.dmi'
 	worn_icon = 'icons/mob/clothing/under/plasmaman.dmi'
 	armor_type = /datum/armor/under_plasmaman
@@ -57,73 +57,73 @@
 	name = "cargo plasma envirosuit"
 	desc = "A joint envirosuit used by plasmamen quartermasters and cargo techs alike, due to the logistical problems of differenciating the two with the length of their pant legs."
 	icon_state = "cargo_envirosuit"
-	item_state = "cargo_envirosuit"
+	inhand_icon_state = "cargo_envirosuit"
 
 /obj/item/clothing/under/plasmaman/mailman
 	name = "mailman plasma envirosuit"
 	desc = "<i>'Special hazardous delivery!'</i>"
 	icon_state = "mailman_envirosuit"
-	item_state = "mailman_envirosuit"
+	inhand_icon_state = "mailman_envirosuit"
 
 /obj/item/clothing/under/plasmaman/mining
 	name = "mining plasma envirosuit"
 	desc = "An air-tight khaki suit designed for operations on lavaland by plasmamen."
 	icon_state = "explorer_envirosuit"
-	item_state = "explorer_envirosuit"
+	inhand_icon_state = "explorer_envirosuit"
 
 /obj/item/clothing/under/plasmaman/chef
 	name = "chef's plasma envirosuit"
 	desc = "A white plasmaman envirosuit designed for cullinary practices. One might question why a member of a species that doesn't need to eat would become a chef."
 	icon_state = "chef_envirosuit"
-	item_state = "chef_envirosuit"
+	inhand_icon_state = "chef_envirosuit"
 
 /obj/item/clothing/under/plasmaman/enviroslacks
 	name = "enviroslacks"
 	desc = "The pet project of a particularly posh plasmaman, this custom suit was quickly appropriated by Nano-Trasen for it's detectives, lawyers, and bar-tenders alike."
 	icon_state = "enviroslacks"
-	item_state = "enviroslacks"
+	inhand_icon_state = "enviroslacks"
 
 /obj/item/clothing/under/plasmaman/tux
 	name = "envirotux"
 	desc = "A flashy suit blended into an envirosuit."
 	icon_state = "envirotux"
-	item_state = "envirotux"
+	inhand_icon_state = "envirotux"
 
 /obj/item/clothing/under/plasmaman/gold //yes, you can sell this for ludicrous mony
 	name = "designer envirosuit"
 	desc = "A flashy gold-trimmed envirosuit, complete with a suit jacket outerwear. This is a designer model, worth a few thousand credits."
 	icon_state = "gold_envirosuit"
-	item_state = "gold_envirosuit"
+	inhand_icon_state = "gold_envirosuit"
 
 /obj/item/clothing/under/plasmaman/chaplain
 	name = "chaplain's plasma envirosuit"
 	desc = "An envirosuit specially designed for only the most pious of plasmamen."
 	icon_state = "chap_envirosuit"
-	item_state = "chap_envirosuit"
+	inhand_icon_state = "chap_envirosuit"
 
 /obj/item/clothing/under/plasmaman/curator
 	name = "curator's plasma envirosuit"
 	desc = "Made out of a modified voidsuit, this suit was Nano-Trasen's first solution to the *logistical problems* that come with employing plasmamen. Due to the modifications, the suit is no longer space-worthy. Despite their limitations, these suits are still in used by historian and old-styled plasmamen alike."
 	icon_state = "prototype_envirosuit"
-	item_state = "prototype_envirosuit"
+	inhand_icon_state = "prototype_envirosuit"
 
 /obj/item/clothing/under/plasmaman/janitor
 	name = "janitor's plasma envirosuit"
 	desc = "A grey and purple envirosuit designated for plasmamen janitors."
 	icon_state = "janitor_envirosuit"
-	item_state = "janitor_envirosuit"
+	inhand_icon_state = "janitor_envirosuit"
 
 /obj/item/clothing/under/plasmaman/botany
 	name = "botany plasma envirosuit"
 	desc = "A green and blue envirosuit designed to protect plasmamen from minor plant-related injuries."
 	icon_state = "botany_envirosuit"
-	item_state = "botany_envirosuit"
+	inhand_icon_state = "botany_envirosuit"
 
 /obj/item/clothing/under/plasmaman/command //fun fact, captains uniforms don't get the sec uniform defense buff, pretty stupid
 	name = "captains plasma envirosuit"
 	desc = "A blue envirosuit with gold trimmings. A suit made for those who demand respect from their subordinates."
 	icon_state = "command_envirosuit"
-	item_state = "command_envirosuit"
+	inhand_icon_state = "command_envirosuit"
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 
@@ -131,16 +131,16 @@
 	name = "head of personnel plasma envirosuit"
 	desc = "The head of personnels blue envirosuit, complete with red trimmings and adorned with various medals."
 	icon_state = "hop_envirosuit"
-	item_state = "hop_envirosuit"
+	inhand_icon_state = "hop_envirosuit"
 
 /obj/item/clothing/under/plasmaman/mime
 	name = "mime envirosuit"
 	desc = "A black and white envirosuit, your bones may rattle but that won't stop your silent shinanigains!."
 	icon_state = "mime_envirosuit"
-	item_state = "mime_envirosuit"
+	inhand_icon_state = "mime_envirosuit"
 
 /obj/item/clothing/under/plasmaman/honk
 	name = "Clowns plasma envirosuit"
 	desc = "A rainbow colored envirosuit, it reaks of bananas and cheap rubber horns."
 	icon_state = "honk_envirosuit"
-	item_state = "honk_envirosuit"
+	inhand_icon_state = "honk_envirosuit"

--- a/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/engineering.dm
@@ -2,7 +2,7 @@
 	name = "engineering plasma envirosuit"
 	desc = "An air-tight suit designed to be used by plasmamen exployed as engineers, the usual purple stripes being replaced by engineer's orange. It protects the user from fire and acid damage."
 	icon_state = "engineer_envirosuit"
-	item_state = "engineer_envirosuit"
+	inhand_icon_state = "engineer_envirosuit"
 	armor_type = /datum/armor/plasmaman_engineering
 
 
@@ -17,10 +17,10 @@
 	name = "atmospherics plasma envirosuit"
 	desc = "An air-tight suit designed to be used by plasmamen exployed as atmos technicians, the usual purple stripes being replaced by atmos's blue."
 	icon_state = "atmos_envirosuit"
-	item_state = "atmos_envirosuit"
+	inhand_icon_state = "atmos_envirosuit"
 
 /obj/item/clothing/under/plasmaman/engineering/ce
 	name = "chief engineers envirosuit"
 	desc = "An air-tight suit designed to be used by plasmamen exployed to overesee the stations engineering division. It protects the user from fire and acid damage."
 	icon_state = "ce_envirosuit"
-	item_state = "ce_envirosuit"
+	inhand_icon_state = "ce_envirosuit"

--- a/code/modules/clothing/under/jobs/Plasmaman/medsci.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/medsci.dm
@@ -2,58 +2,58 @@
 	name = "medical plasma envirosuit"
 	desc = "A suit designed for the station's more plasma-based doctors."
 	icon_state = "doctor_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/science
 	name = "science plasma envirosuit"
 	desc = "A plasmaman envirosuit designed for scientists."
 	icon_state = "scientist_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/robotics
 	name = "robotics plasma envirosuit"
 	desc = "A plasmaman envirosuit designed for roboticists."
 	icon_state = "roboticist_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/viro
 	name = "virology plasma envirosuit"
 	desc = "The suit worn by the safest people on the station, those who are completely immune to the monstrosities they create."
 	icon_state = "virologist_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/genetics
 	name = "genetics plasma envirosuit"
 	desc = "A plasmaman envirosuit designed for geneticists."
 	icon_state = "geneticist_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/chemist
 	name = "chemistry plasma envirosuit"
 	desc = "A plasmaman envirosuit designed for chemists."
 	icon_state = "chemist_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/cmo
 	name = "chief medical officers envirosuit"
 	desc = "An envirosuit designed primarily of nitryl, for the medical savvy plasmamen."
 	icon_state = "cmo_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/rd
 	name = "research directors envirosuit"
 	desc = "An envirosuit specially designed for the research director with with advanced magnetic nanofibre seams, giving it a more natual look."
 	icon_state = "rd_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/paramedic
 	name = "paramedic plasma envirosuit"
 	desc = "A plasmaman envirosuit designed for emergency medical technicians."
 	icon_state = "paramedic_envirosuit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/plasmaman/exploration
 	name = "exploration plasma envirosuit"
 	desc = "A plasmaman envirosuit designed for the exploration crew."
 	icon_state = "exploration_envirosuit"
-	item_state = null
+	inhand_icon_state = null

--- a/code/modules/clothing/under/jobs/Plasmaman/security.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/security.dm
@@ -2,7 +2,7 @@
 	name = "security plasma envirosuit"
 	desc = "A plasmaman containment suit designed for security officers, offering a limited amount of extra protection."
 	icon_state = "security_envirosuit"
-	item_state = "security_envirosuit"
+	inhand_icon_state = "security_envirosuit"
 	armor_type = /datum/armor/plasmaman_security
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
@@ -20,19 +20,19 @@
 	name = "warden plasma envirosuit"
 	desc = "A plasmaman containment suit designed for the warden, white stripes being added to differeciate them from other members of security."
 	icon_state = "warden_envirosuit"
-	item_state = "warden_envirosuit"
+	inhand_icon_state = "warden_envirosuit"
 //looking back at it now I probably coulda grouped the command suits together under one for less clutter.
 /obj/item/clothing/under/plasmaman/security/hos
 	name = "head of security plasma envirosuit"
 	desc = "A black padded envirosuit designed for the head of security, its gold stripes and black pallete instills fear and respect."
 	icon_state = "hos_envirosuit"
-	item_state = "hos_envirosuit"
+	inhand_icon_state = "hos_envirosuit"
 
 /obj/item/clothing/under/plasmaman/security/secmed
 	name = "security plasma envirosuit"
 	desc = "A plasmaman containment suit designed for brig physicians. It has a red cross emblasoned on the chest."
 	icon_state = "secmed_envirosuit"
-	item_state = "secmed_envirosuit"
+	inhand_icon_state = "secmed_envirosuit"
 	armor_type = /datum/armor/security_secmed
 
 

--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -6,13 +6,13 @@
 	name = "quartermaster's jumpsuit"
 	desc = "It's a jumpsuit worn by the quartermaster. It's specially designed to prevent back injuries caused by pushing paper."
 	icon_state = "qm"
-	item_state = "qm"
+	inhand_icon_state = "qm"
 
 /obj/item/clothing/under/rank/cargo/quartermaster/skirt
 	name = "quartermaster's jumpskirt"
 	desc = "It's a jumpskirt worn by the quartermaster. It's specially designed to prevent back injuries caused by pushing paper."
 	icon_state = "qm_skirt"
-	item_state = "lb_suit"
+	inhand_icon_state = "lb_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -23,7 +23,7 @@
 	name = "quartermaster's turtleneck"
 	desc = "A snug turtleneck sweater worn by the Quartermaster, characterized by the expensive-looking pair of suit pants."
 	icon_state = "qmturtle"
-	item_state = "qmturtle"
+	inhand_icon_state = "qmturtle"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 
@@ -31,7 +31,7 @@
 	name = "quartermaster's turtleneck skirt"
 	desc = "A snug turtleneck sweater worn by the Quartermaster, as shown by the elegant double-lining of its silk skirt."
 	icon_state = "qmturtle_skirt"
-	item_state = "qmturtle_skirt"
+	inhand_icon_state = "qmturtle_skirt"
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
@@ -41,7 +41,7 @@
 	name = "cargo technician's jumpsuit"
 	desc = "Shooooorts! They're comfy and easy to wear!"
 	icon_state = "cargotech"
-	item_state = "cargo"
+	inhand_icon_state = "cargo"
 	body_parts_covered = CHEST|GROIN|ARMS
 	supports_variations = DIGITIGRADE_VARIATION
 	alt_covers_chest = TRUE
@@ -50,7 +50,7 @@
 	name = "cargo technician's jumpskirt"
 	desc = "Skiiiiirts! They're comfy and easy to wear!"
 	icon_state = "cargo_skirt"
-	item_state = "lb_suit"
+	inhand_icon_state = "lb_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -61,7 +61,7 @@
 	desc = "It's a snappy jumpsuit with a sturdy set of overalls. It is very dirty."
 	name = "shaft miner's jumpsuit"
 	icon_state = "miner"
-	item_state = "miner"
+	inhand_icon_state = "miner"
 	armor_type = /datum/armor/cargo_miner
 
 
@@ -74,7 +74,7 @@
 	desc = "A green uniform for operating in hazardous environments."
 	name = "shaft miner's jumpsuit"
 	icon_state = "explorer"
-	item_state = "explorer"
+	inhand_icon_state = "explorer"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/cargo/exploration
@@ -83,20 +83,20 @@
 	icon = 'icons/obj/clothing/under/civilian.dmi'
 	icon_state = "curator"
 	worn_icon = 'icons/mob/clothing/under/civilian.dmi'
-	item_state = null
+	inhand_icon_state = null
 	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/mailman
 	name = "mailman's jumpsuit"
 	desc = "<i>'Special delivery!'</i>"
 	icon_state = "mailman"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 
 /obj/item/clothing/under/misc/mailman/skirt
 	name = "mailman's jumpskirt"
 	desc = "<i>'Special delivery!'</i> Beware of spacewind."
 	icon_state = "mailman_skirt"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY

--- a/code/modules/clothing/under/jobs/centcom.dm
+++ b/code/modules/clothing/under/jobs/centcom.dm
@@ -6,26 +6,26 @@
 	name = "\improper CentCom commander's suit"
 	desc = "It's a suit worn by CentCom's highest-tier Commanders."
 	icon_state = "centcom"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 
 /obj/item/clothing/under/rank/centcom/official
 	name = "\improper CentCom official's suit"
 	desc = "A suit worn by CentCom Officials, with a silver belt buckle to indicate their rank from a glance."
 	icon_state = "official"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 
 /obj/item/clothing/under/rank/centcom/intern
 	name = "\improper CentCom intern's jumpsuit"
 	desc = "It's a jumpsuit worn by those interning for CentCom. The top is styled after a polo shirt for easy identification."
 	icon_state = "intern"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/centcom/officer
 	name = "\improper CentCom turtleneck suit"
 	desc = "A casual, yet refined green turtleneck, used by CentCom Officers. It has a fragrance of aloe."
 	icon_state = "officer"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/centcom/officer/replica
@@ -36,7 +36,7 @@
 	name = "\improper CentCom turtleneck skirt"
 	desc = "A skirt version of the CentCom turtleneck, rarer and more sought after than the original."
 	icon_state = "officer_skirt"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 	alt_covers_chest = TRUE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	body_parts_covered = CHEST|GROIN|ARMS
@@ -49,6 +49,6 @@
 	name = "\improper CentCom commander's suitskirt"
 	desc = "It's a suitskirt worn by CentCom's highest-tier Commanders."
 	icon_state = "centcom_skirt"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	body_parts_covered = CHEST|GROIN|ARMS

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -8,14 +8,14 @@
 	desc = "It looks like it could use some more flair."
 	name = "bartender's uniform"
 	icon_state = "barman"
-	item_state = "bar_suit"
+	inhand_icon_state = "bar_suit"
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/civilian/bartender/skirt
 	name = "bartender's skirt"
 	desc = "It looks like it could use some more flair."
 	icon_state = "barman_skirt"
-	item_state = "bar_suit"
+	inhand_icon_state = "bar_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -26,7 +26,7 @@
 	desc = "It looks like it has lots of flair!"
 	name = "purple bartender's skirt"
 	icon_state = "purplebartender"
-	item_state = "purplebartender"
+	inhand_icon_state = "purplebartender"
 	can_adjust = FALSE
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 
@@ -34,14 +34,14 @@
 	desc = "It's a black jumpsuit, often worn by religious folk."
 	name = "chaplain's jumpsuit"
 	icon_state = "chaplain"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/civilian/chaplain/skirt
 	name = "chaplain's jumpskirt"
 	desc = "It's a black jumpskirt, often worn by religious folk."
 	icon_state = "chapblack_skirt"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -74,14 +74,14 @@
 	desc = "It's a jumpsuit worn by someone who works in the position of \"Head of Personnel\"."
 	name = "head of personnel's jumpsuit"
 	icon_state = "hop"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/civilian/head_of_personnel/skirt
 	name = "head of personnel's jumpskirt"
 	desc = "It's a jumpskirt worn by someone who works in the position of \"Head of Personnel\"."
 	icon_state = "hop_skirt"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -92,14 +92,14 @@
 	name = "head of personnel's teal jumpsuit"
 	desc = "A teal suit and yellow necktie. An authoritative yet tacky ensemble."
 	icon_state = "teal_suit"
-	item_state = "g_suit"
+	inhand_icon_state = "g_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/civilian/head_of_personnel/alt/skirt
 	name = "head of personnel's teal jumpskirt"
 	desc = "A teal skirt and yellow necktie. An authoritative yet tacky ensemble."
 	icon_state = "teal_suit_skirt"
-	item_state = "g_suit"
+	inhand_icon_state = "g_suit"
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
@@ -108,7 +108,7 @@
 	desc = "It's a jumpsuit designed to protect against minor plant-related hazards."
 	name = "botanist's jumpsuit"
 	icon_state = "hydroponics"
-	item_state = "g_suit"
+	inhand_icon_state = "g_suit"
 	armor_type = /datum/armor/civilian_hydroponics
 
 
@@ -119,7 +119,7 @@
 	name = "botanist's jumpskirt"
 	desc = "It's a jumpskirt designed to protect against minor plant-related hazards."
 	icon_state = "hydroponics_skirt"
-	item_state = "g_suit"
+	inhand_icon_state = "g_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -151,7 +151,7 @@
 	name = "maid uniform"
 	desc = "A simple maid uniform for housekeeping."
 	icon_state = "janimaid"
-	item_state = "janimaid"
+	inhand_icon_state = "janimaid"
 	body_parts_covered = CHEST|GROIN
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
@@ -164,12 +164,12 @@
 /obj/item/clothing/under/rank/civilian/lawyer/black
 	name = "lawyer black suit"
 	icon_state = "lawyer_black"
-	item_state = "lawyer_black"
+	inhand_icon_state = "lawyer_black"
 
 /obj/item/clothing/under/rank/civilian/lawyer/black/skirt
 	name = "lawyer black suitskirt"
 	icon_state = "lawyer_black_skirt"
-	item_state = "lawyer_black"
+	inhand_icon_state = "lawyer_black"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	dying_key = DYE_REGISTRY_JUMPSKIRT
@@ -177,12 +177,12 @@
 /obj/item/clothing/under/rank/civilian/lawyer/female
 	name = "female black suit"
 	icon_state = "black_suit_fem"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 
 /obj/item/clothing/under/rank/civilian/lawyer/female/skirt
 	name = "female black suitskirt"
 	icon_state = "black_suit_fem_skirt"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	can_adjust = FALSE
@@ -191,12 +191,12 @@
 /obj/item/clothing/under/rank/civilian/lawyer/red
 	name = "lawyer red suit"
 	icon_state = "lawyer_red"
-	item_state = "lawyer_red"
+	inhand_icon_state = "lawyer_red"
 
 /obj/item/clothing/under/rank/civilian/lawyer/red/skirt
 	name = "lawyer red suitskirt"
 	icon_state = "lawyer_red_skirt"
-	item_state = "lawyer_red"
+	inhand_icon_state = "lawyer_red"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	dying_key = DYE_REGISTRY_JUMPSKIRT
@@ -204,12 +204,12 @@
 /obj/item/clothing/under/rank/civilian/lawyer/blue
 	name = "lawyer blue suit"
 	icon_state = "lawyer_blue"
-	item_state = "lawyer_blue"
+	inhand_icon_state = "lawyer_blue"
 
 /obj/item/clothing/under/rank/civilian/lawyer/blue/skirt
 	name = "lawyer blue suitskirt"
 	icon_state = "lawyer_blue_skirt"
-	item_state = "lawyer_blue"
+	inhand_icon_state = "lawyer_blue"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 	dying_key = DYE_REGISTRY_JUMPSKIRT
@@ -218,7 +218,7 @@
 	name = "blue slacks"
 	desc = "A pair of comfortable freshly pressed slacks and an equally sharp dress shirt. Tie and suit coat not included."
 	icon_state = "blueslacks"
-	item_state = "blueslacks"
+	inhand_icon_state = "blueslacks"
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
 
@@ -226,7 +226,7 @@
 	name = "blue suitskirt"
 	desc = "A classy suitskirt and tie."
 	icon_state = "bluesuit_skirt"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -236,7 +236,7 @@
 /obj/item/clothing/under/rank/civilian/lawyer/purpsuit
 	name = "purple suit"
 	icon_state = "lawyer_purp"
-	item_state = "p_suit"
+	inhand_icon_state = "p_suit"
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
@@ -244,7 +244,7 @@
 /obj/item/clothing/under/rank/civilian/lawyer/purpsuit/skirt
 	name = "purple suitskirt"
 	icon_state = "lawyer_purp_skirt"
-	item_state = "p_suit"
+	inhand_icon_state = "p_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY

--- a/code/modules/clothing/under/jobs/civilian/clown_mime.dm
+++ b/code/modules/clothing/under/jobs/civilian/clown_mime.dm
@@ -3,12 +3,12 @@
 	name = "mime's outfit"
 	desc = "It's not very colourful."
 	icon_state = "mime"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/rank/civilian/mime/skirt
 	name = "mime's skirt"
 	icon_state = "mime_skirt"
-	item_state = "mime"
+	inhand_icon_state = "mime"
 	body_parts_covered = CHEST|GROIN|ARMS
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -18,7 +18,7 @@
 	name = "sexy mime outfit"
 	desc = "The only time when you DON'T enjoy looking at someone's rack."
 	icon_state = "sexymime"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
@@ -27,7 +27,7 @@
 	name = "clown suit"
 	desc = "<i>'HONK!'</i>"
 	icon_state = "clown"
-	item_state = "clown"
+	inhand_icon_state = "clown"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	can_adjust = FALSE
 	//supports_variations_flags = CLOTHING_NO_VARIATION
@@ -40,37 +40,37 @@
 	name = "blue clown suit"
 	desc = "<i>'BLUE HONK!'</i>"
 	icon_state = "blueclown"
-	item_state = "blueclown"
+	inhand_icon_state = "blueclown"
 
 /obj/item/clothing/under/rank/civilian/clown/green
 	name = "green clown suit"
 	desc = "<i>'GREEN HONK!'</i>"
 	icon_state = "greenclown"
-	item_state = "greenclown"
+	inhand_icon_state = "greenclown"
 
 /obj/item/clothing/under/rank/civilian/clown/yellow
 	name = "yellow clown suit"
 	desc = "<i>'YELLOW HONK!'</i>"
 	icon_state = "yellowclown"
-	item_state = "yellowclown"
+	inhand_icon_state = "yellowclown"
 
 /obj/item/clothing/under/rank/civilian/clown/purple
 	name = "purple clown suit"
 	desc = "<i>'PURPLE HONK!'</i>"
 	icon_state = "purpleclown"
-	item_state = "purpleclown"
+	inhand_icon_state = "purpleclown"
 
 /obj/item/clothing/under/rank/civilian/clown/orange
 	name = "orange clown suit"
 	desc = "<i>'ORANGE HONK!'</i>"
 	icon_state = "orangeclown"
-	item_state = "orangeclown"
+	inhand_icon_state = "orangeclown"
 
 /obj/item/clothing/under/rank/civilian/clown/rainbow
 	name = "rainbow clown suit"
 	desc = "<i>'R A I N B O W HONK!'</i>"
 	icon_state = "rainbowclown"
-	item_state = "rainbowclown"
+	inhand_icon_state = "rainbowclown"
 
 /obj/item/clothing/under/rank/civilian/clown/jester
 	name = "jester suit"
@@ -85,6 +85,6 @@
 	name = "sexy-clown suit"
 	desc = "It makes you look HONKable!"
 	icon_state = "sexyclown"
-	item_state = "sexyclown"
+	inhand_icon_state = "sexyclown"
 	can_adjust = FALSE
 	dying_key = DYE_REGISTRY_JUMPSKIRT

--- a/code/modules/clothing/under/jobs/civilian/curator.dm
+++ b/code/modules/clothing/under/jobs/civilian/curator.dm
@@ -3,7 +3,7 @@
 	desc = "It's very... sensible."
 	icon = 'icons/obj/clothing/under/suits.dmi'
 	icon_state = "red_suit"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon = 'icons/mob/clothing/under/suits.dmi'
 	can_adjust = FALSE
 
@@ -12,7 +12,7 @@
 	desc = "It's very... sensible."
 	icon = 'icons/obj/clothing/under/suits.dmi'
 	icon_state = "red_suit_skirt"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon = 'icons/mob/clothing/under/suits.dmi'
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
@@ -24,14 +24,14 @@
 	desc = "A rugged uniform suitable for treasure hunting."
 	icon = 'icons/obj/clothing/under/civilian.dmi'
 	icon_state = "curator"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon = 'icons/mob/clothing/under/civilian.dmi'
 
 /obj/item/clothing/under/rank/civilian/curator/nasa
 	name = "\improper NASA jumpsuit"
 	desc = "It has a NASA logo on it and is made of space-proofed materials."
 	icon_state = "jumpsuit"
-	item_state = "jumpsuit"
+	inhand_icon_state = "jumpsuit"
 	worn_icon_state = "jumpsuit"
 	greyscale_colors = "#3f3f3f"
 	greyscale_config = /datum/greyscale_config/jumpsuit

--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -2,7 +2,7 @@
 	desc = "It's a blue jumpsuit with some gold markings denoting the rank of \"Captain\"."
 	name = "captain's jumpsuit"
 	icon_state = "captain"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	armor_type = /datum/armor/rank_captain
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
@@ -22,7 +22,7 @@
 	name = "captain's jumpskirt"
 	desc = "It's a blue jumpskirt with some gold markings denoting the rank of \"Captain\"."
 	icon_state = "captain_skirt"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -33,12 +33,12 @@
 	name = "captain's suit"
 	desc = "A green suit and yellow necktie. Exemplifies authority."
 	icon_state = "green_suit"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/captain/parade
 	name = "captain's parade uniform"
 	desc = "A captain's luxury-wear, for special occasions."
 	icon_state = "captain_parade"
-	item_state = "by_suit"
+	inhand_icon_state = "by_suit"
 	can_adjust = FALSE

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -17,7 +17,7 @@
 	desc = "It's a high visibility jumpsuit given to those engineers insane enough to achieve the rank of \"Chief Engineer\". It has minor radiation shielding."
 	name = "chief engineer's jumpsuit"
 	icon_state = "chiefengineer"
-	item_state = "gy_suit"	//TODO replace it
+	inhand_icon_state = "gy_suit"	//TODO replace it
 	worn_icon_state = "chiefengineer"
 	armor_type = /datum/armor/engineering_chief_engineer
 	resistance_flags = NONE
@@ -34,7 +34,7 @@
 	desc = "It's a high visibility jumpskirt given to those engineers insane enough to achieve the rank of \"Chief Engineer\". It has very minor radiation shielding."
 	name = "chief engineer's jumpskirt"
 	icon_state = "chiefengineer_skirt"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 	armor_type = /datum/armor/chief_engineer_skirt
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
@@ -53,14 +53,14 @@
 	desc = "It's a jumpsuit worn by atmospheric technicians."
 	name = "atmospheric technician's jumpsuit"
 	icon_state = "atmos"
-	item_state = "atmos_suit"
+	inhand_icon_state = "atmos_suit"
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/engineering/atmospheric_technician/skirt
 	desc = "It's a jumpskirt worn by atmospheric technicians."
 	name = "atmospheric technician's jumpskirt"
 	icon_state = "atmos_skirt"
-	item_state = "atmos_suit"
+	inhand_icon_state = "atmos_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -71,7 +71,7 @@
 	desc = "It's an orange high visibility jumpsuit worn by engineers. It has minor radiation shielding."
 	name = "engineer's jumpsuit"
 	icon_state = "engine"
-	item_state = "engi_suit"
+	inhand_icon_state = "engi_suit"
 	armor_type = /datum/armor/engineering_engineer
 	resistance_flags = NONE
 
@@ -86,14 +86,14 @@
 	name = "engineer's hazard jumpsuit"
 	desc = "A high visibility jumpsuit made from heat and radiation resistant materials."
 	icon_state = "hazard"
-	item_state = "syndicate-orange"
+	inhand_icon_state = "syndicate-orange"
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/engineering/engineer/skirt
 	desc = "It's an orange high visibility jumpskirt worn by engineers. It has minor radiation shielding."
 	name = "engineer's jumpskirt"
 	icon_state = "engine_skirt"
-	item_state = "engi_suit"
+	inhand_icon_state = "engi_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -11,13 +11,13 @@
 	desc = "It's a jumpsuit worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
 	name = "chief medical officer's jumpsuit"
 	icon_state = "cmo"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/skirt
 	name = "chief medical officer's jumpskirt"
 	desc = "It's a jumpskirt worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
 	icon_state = "cmo_skirt"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -28,13 +28,13 @@
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a genetics rank stripe on it."
 	name = "geneticist's jumpsuit"
 	icon_state = "genetics"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 
 /obj/item/clothing/under/rank/medical/geneticist/skirt
 	name = "geneticist's jumpskirt"
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a genetics rank stripe on it."
 	icon_state = "geneticswhite_skirt"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -45,13 +45,13 @@
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a virologist rank stripe on it."
 	name = "virologist's jumpsuit"
 	icon_state = "virology"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 
 /obj/item/clothing/under/rank/medical/virologist/skirt
 	name = "virologist's jumpskirt"
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a virologist rank stripe on it."
 	icon_state = "virologywhite_skirt"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -68,7 +68,7 @@
 	name = "paramedic's jumpskirt"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a dark blue cross on the chest denoting that the wearer is a trained paramedic."
 	icon_state = "paramedic_skirt"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -79,7 +79,7 @@
 	desc = "It's a jumpsuit commonly worn by nursing staff in the medical department."
 	name = "nurse's suit"
 	icon_state = "nursesuit"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
@@ -88,13 +88,13 @@
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a cross on the chest denoting that the wearer is trained medical personnel."
 	name = "medical doctor's jumpsuit"
 	icon_state = "medical"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 
 /obj/item/clothing/under/rank/medical/doctor/skirt
 	name = "medical doctor's jumpskirt"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a cross on the chest denoting that the wearer is trained medical personnel."
 	icon_state = "medical_skirt"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -123,7 +123,7 @@
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a chemist rank stripe on it."
 	name = "chemist's jumpsuit"
 	icon_state = "chemistry"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	armor_type = /datum/armor/medical_chemist
 
 
@@ -137,7 +137,7 @@
 	name = "chemist's jumpskirt"
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a chemist rank stripe on it."
 	icon_state = "chemistrywhite_skirt"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -6,7 +6,7 @@
 	name = "research director's jumpsuit"
 	desc = "It's a jumpsuit worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."
 	icon_state = "director"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	armor_type = /datum/armor/rnd_research_director
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
@@ -22,7 +22,7 @@
 	name = "research director's jumpskirt"
 	desc = "It's a jumpskirt worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."
 	icon_state = "director_skirt"
-	item_state = "lb_suit"
+	inhand_icon_state = "lb_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -33,7 +33,7 @@
 	desc = "Maybe you'll engineer your own half-man, half-pig creature some day. Its fabric provides minor protection from biological contaminants."
 	name = "research director's tan suit"
 	icon_state = "rdwhimsy"
-	item_state = "rdwhimsy"
+	inhand_icon_state = "rdwhimsy"
 	armor_type = /datum/armor/research_director_alt
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
@@ -48,7 +48,7 @@
 	name = "research director's tan suitskirt"
 	desc = "Maybe you'll engineer your own half-man, half-pig creature some day. Its fabric provides minor protection from biological contaminants."
 	icon_state = "rdwhimsy_skirt"
-	item_state = "rdwhimsy"
+	inhand_icon_state = "rdwhimsy"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -59,7 +59,7 @@
 	desc = "A dark purple turtleneck and tan khakis, for a director with a superior sense of style."
 	name = "research director's turtleneck"
 	icon_state = "rdturtle"
-	item_state = "p_suit"
+	inhand_icon_state = "p_suit"
 	armor_type = /datum/armor/research_director_turtleneck
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
@@ -74,7 +74,7 @@
 	name = "research director's turtleneck skirt"
 	desc = "A dark purple turtleneck and tan khaki skirt, for a director with a superior sense of style."
 	icon_state = "rdturtle_skirt"
-	item_state = "p_suit"
+	inhand_icon_state = "p_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -85,14 +85,14 @@
 	desc = "It's made of a special fiber that provides minor protection against biohazards. Though never formally retired, the standard issue Research Director's vest suit is a rare sight."
 	name = "research director's vest suit"
 	icon_state = "rd_vest"
-	item_state = "lb_suit"
+	inhand_icon_state = "lb_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/rnd/scientist
 	desc = "It's made of a special fiber that provides minor protection against explosives. It has markings that denote the wearer as a scientist."
 	name = "scientist's jumpsuit"
 	icon_state = "toxinswhite"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	worn_icon_state = "toxinswhite"
 	armor_type = /datum/armor/rnd_scientist
 
@@ -106,7 +106,7 @@
 	name = "scientist's jumpskirt"
 	desc = "It's made of a special fiber that provides minor protection against explosives. It has markings that denote the wearer as a scientist."
 	icon_state = "toxinswhite_skirt"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -117,14 +117,14 @@
 	desc = "It's a slimming black jumpsuit with reinforced seams; great for industrial work."
 	name = "roboticist's jumpsuit"
 	icon_state = "robotics"
-	item_state = "robotics"
+	inhand_icon_state = "robotics"
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/rnd/roboticist/skirt
 	name = "roboticist's jumpskirt"
 	desc = "It's a slimming black jumpskirt with reinforced seams; great for industrial work."
 	icon_state = "robotics_skirt"
-	item_state = "robotics"
+	inhand_icon_state = "robotics"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -135,7 +135,7 @@
 	desc = "It's a slimming black jumpsuit with reinforced seams; great for industrial work. Vintage design, modern look, and the gloves are just for show."
 	name = "roboticist's retro jumpsuit"
 	icon_state = "robotics_retro"
-	item_state = "robotics"
+	inhand_icon_state = "robotics"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	alternate_worn_layer = GLOVES_LAYER

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -29,7 +29,7 @@
 	name = "security jumpsuit"
 	desc = "A tactical security jumpsuit for officers complete with Nanotrasen belt buckle."
 	icon_state = "rsecurity"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	armor_type = /datum/armor/security_officer
 	alt_covers_chest = TRUE
 
@@ -45,20 +45,20 @@
 	name = "white security jumpsuit"
 	desc = "A tactical relic of years past before Nanotrasen decided it was cheaper to dye the suits red instead of washing out the blood."
 	icon_state = "security"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 
 /obj/item/clothing/under/rank/security/officer/corporate
 	name = "corporate security jumpsuit"
 	desc = "A tactical security jumpsuit in black."
 	icon_state = "sec_corporate_s"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/security/officer/skirt
 	name = "security jumpskirt"
 	desc = "A \"tactical\" security jumpsuit with the legs replaced by a skirt."
 	icon_state = "secskirt"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
@@ -68,14 +68,14 @@
 	name = "blue shirt and tie"
 	desc = "I'm a little busy right now, Calhoun."
 	icon_state = "blueshift"
-	item_state = null
+	inhand_icon_state = null
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/security/officer/formal
 	name = "security officer's formal uniform"
 	desc = "The latest in fashionable security outfits."
 	icon_state = "officerblueclothes"
-	item_state = null
+	inhand_icon_state = null
 	alt_covers_chest = TRUE
 
 /*
@@ -86,7 +86,7 @@
 	name = "security suit"
 	desc = "A formal security suit for officers complete with Nanotrasen belt buckle."
 	icon_state = "rwarden"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	armor_type = /datum/armor/security_warden
 
 
@@ -101,13 +101,13 @@
 	name = "white security suit"
 	desc = "A formal relic of years past before Nanotrasen decided it was cheaper to dye the suits red instead of washing out the blood."
 	icon_state = "warden"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 
 /obj/item/clothing/under/rank/security/warden/skirt
 	name = "warden's suitskirt"
 	desc = "A formal security suitskirt for officers complete with Nanotrasen belt buckle."
 	icon_state = "rwarden_skirt"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -118,7 +118,7 @@
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Warden."
 	name = "warden's formal uniform"
 	icon_state = "wardenblueclothes"
-	item_state = null
+	inhand_icon_state = null
 	alt_covers_chest = TRUE
 
 /*
@@ -128,7 +128,7 @@
 	name = "hard-worn suit"
 	desc = "Someone who wears this means business."
 	icon_state = "detective"
-	item_state = "det"
+	inhand_icon_state = "det"
 	armor_type = /datum/armor/security_detective
 	strip_delay = 50
 	alt_covers_chest = TRUE
@@ -147,7 +147,7 @@
 	name = "detective's suitskirt"
 	desc = "Someone who wears this means business."
 	icon_state = "detective_skirt"
-	item_state = "det"
+	inhand_icon_state = "det"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -158,14 +158,14 @@
 	name = "noir suit"
 	desc = "A hard-boiled private investigator's grey suit, complete with tie clip."
 	icon_state = "greydet"
-	item_state = "greydet"
+	inhand_icon_state = "greydet"
 	alt_covers_chest = TRUE
 
 /obj/item/clothing/under/rank/security/detective/grey/skirt
 	name = "noir suitskirt"
 	desc = "A hard-boiled private investigator's grey suitskirt, complete with tie clip."
 	icon_state = "greydet_skirt"
-	item_state = "greydet"
+	inhand_icon_state = "greydet"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -179,7 +179,7 @@
 	name = "head of security's jumpsuit"
 	desc = "A security jumpsuit decorated for those few with the dedication to achieve the position of Head of Security."
 	icon_state = "rhos"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	armor_type = /datum/armor/security_head_of_security
 	strip_delay = 60
 	alt_covers_chest = TRUE
@@ -199,7 +199,7 @@
 	name = "head of security's jumpskirt"
 	desc = "A security jumpskirt decorated for those few with the dedication to achieve the position of Head of Security."
 	icon_state = "rhos_skirt"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -210,19 +210,19 @@
 	name = "head of security's white jumpsuit"
 	desc = "There are old men, and there are bold men, but there are very few old, bold men."
 	icon_state = "hos"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 
 /obj/item/clothing/under/rank/security/head_of_security/alt
 	name = "head of security's turtleneck"
 	desc = "A stylish alternative to the normal head of security jumpsuit, complete with tactical pants."
 	icon_state = "hosalt"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 
 /obj/item/clothing/under/rank/security/head_of_security/alt/skirt
 	name = "head of security's turtleneck skirt"
 	desc = "A stylish alternative to the normal head of security jumpsuit, complete with a tactical skirt."
 	icon_state = "hosalt_skirt"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -233,21 +233,21 @@
 	name = "head of security's parade uniform"
 	desc = "An head of security's luxury-wear, for special occasions."
 	icon_state = "hos_parade_male"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/security/head_of_security/parade/female
 	name = "head of security's parade uniform"
 	desc = "A female head of security's luxury-wear, for special occasions."
 	icon_state = "hos_parade_fem"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 
 /obj/item/clothing/under/rank/security/head_of_security/formal
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Head of Security."
 	name = "head of security's formal uniform"
 	icon_state = "hosblueclothes"
-	item_state = null
+	inhand_icon_state = null
 	alt_covers_chest = TRUE
 
 /*
@@ -260,7 +260,7 @@
 	icon = 'icons/obj/clothing/under/security.dmi'
 	worn_icon = 'icons/mob/clothing/under/security.dmi'
 	icon_state = "brig_phys"
-	item_state = "labcoat_sec"
+	inhand_icon_state = "labcoat_sec"
 
 /obj/item/clothing/under/rank/brig_physician/skirt
 	name = "brig physician's jumpskirt"
@@ -268,7 +268,7 @@
 	icon = 'icons/obj/clothing/under/security.dmi'
 	worn_icon = 'icons/mob/clothing/under/security.dmi'
 	icon_state = "brig_phys_skirt"
-	item_state = "labcoat_sec"
+	inhand_icon_state = "labcoat_sec"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
@@ -283,14 +283,14 @@
 	name = "police uniform"
 	desc = "Space not controlled by megacorporations, planets, or pirates is under the jurisdiction of Spacepol."
 	icon_state = "spacepol"
-	item_state = "spacepol"
+	inhand_icon_state = "spacepol"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/prisoner
 	name = "prison jumpsuit"
 	desc = "It's standardised Nanotrasen prisoner-wear. Its suit sensors are stuck in the \"Fully On\" position."
 	icon_state = "jumpsuit"
-	item_state = "jumpsuit"
+	inhand_icon_state = "jumpsuit"
 	greyscale_colors = "#ff8300"
 	greyscale_config = /datum/greyscale_config/jumpsuit_prison
 	greyscale_config_inhand_left = /datum/greyscale_config/jumpsuit_prison_inhand_left
@@ -309,7 +309,7 @@
 	name = "NT mall cop uniform"
 	desc = "The radio and badge are sewn on, what a crappy knock off. Secway not included."
 	icon_state = "mallcop"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/security/officer/mallcop/deputy

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -8,33 +8,33 @@
 
 /obj/item/clothing/under/misc/pj/red
 	icon_state = "red_pyjamas"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/pj/blue
 	icon_state = "blue_pyjamas"
-	item_state = "w_suit"
+	inhand_icon_state = "w_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/patriotsuit
 	name = "Patriotic Suit"
 	desc = "Motorcycle not included."
 	icon_state = "ek"
-	item_state = "ek"
+	inhand_icon_state = "ek"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/vice_officer
 	name = "vice officer's jumpsuit"
 	desc = "It's the standard issue pretty-boy outfit, as seen on Holo-Vision."
 	icon_state = "vice"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/adminsuit
 	name = "administrative cybernetic jumpsuit"
 	icon = 'icons/obj/clothing/under/syndicate.dmi'
 	icon_state = "syndicate"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	worn_icon = 'icons/mob/clothing/under/syndicate.dmi'
 	desc = "A cybernetically enhanced jumpsuit used for administrative duties."
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -65,7 +65,7 @@
 	name = "burial garments"
 	desc = "Traditional burial garments from the early 22nd century."
 	icon_state = "burial"
-	item_state = "burial"
+	inhand_icon_state = "burial"
 	can_adjust = FALSE
 	has_sensor = NO_SENSORS
 
@@ -73,7 +73,7 @@
 	name = "laborer's overalls"
 	desc = "A set of durable overalls for getting the job done."
 	icon_state = "overalls"
-	item_state = "lb_suit"
+	inhand_icon_state = "lb_suit"
 	can_adjust = FALSE
 	custom_price = 20
 
@@ -81,7 +81,7 @@
 	name = "assistant's formal uniform"
 	desc = "An assistant's formal-wear. Why an assistant needs formal-wear is still unknown."
 	icon_state = "assistant_formal"
-	item_state = "gy_suit"
+	inhand_icon_state = "gy_suit"
 	can_adjust = FALSE
 
 /obj/item/extinguisher_refill

--- a/code/modules/clothing/under/skirt_dress.dm
+++ b/code/modules/clothing/under/skirt_dress.dm
@@ -11,65 +11,65 @@
 	name = "sundress"
 	desc = "Makes you want to frolic in a field of daisies."
 	icon_state = "sundress"
-	item_state = "sundress"
+	inhand_icon_state = "sundress"
 
 /obj/item/clothing/under/dress/blacktango
 	name = "black tango dress"
 	desc = "Filled with Latin fire."
 	icon_state = "black_tango"
-	item_state = "wcoat"
+	inhand_icon_state = "wcoat"
 
 /obj/item/clothing/under/dress/striped
 	name = "striped dress"
 	desc = "Fashion in space."
 	icon_state = "striped_dress"
-	item_state = "stripeddress"
+	inhand_icon_state = "stripeddress"
 	female_sprite_flags = FEMALE_UNIFORM_FULL
 
 /obj/item/clothing/under/dress/sailor
 	name = "sailor dress"
 	desc = "Formal wear for a leading lady."
 	icon_state = "sailor_dress"
-	item_state = "sailordress"
+	inhand_icon_state = "sailordress"
 
 /obj/item/clothing/under/dress/redeveninggown
 	name = "red evening gown"
 	desc = "Fancy dress for space bar singers."
 	icon_state = "red_evening_gown"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/dress/skirt
 	name = "black skirt"
 	desc = "A black skirt, very fancy!"
 	icon_state = "blackskirt"
-	item_state = "blackskirt"
+	inhand_icon_state = "blackskirt"
 
 /obj/item/clothing/under/dress/skirt/blue
 	name = "blue skirt"
 	desc = "A blue, casual skirt."
 	icon_state = "blueskirt"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 	custom_price = 25
 
 /obj/item/clothing/under/dress/skirt/red
 	name = "red skirt"
 	desc = "A red, casual skirt."
 	icon_state = "redskirt"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	custom_price = 25
 
 /obj/item/clothing/under/dress/skirt/purple
 	name = "purple skirt"
 	desc = "A purple, casual skirt."
 	icon_state = "purpleskirt"
-	item_state = "p_suit"
+	inhand_icon_state = "p_suit"
 	custom_price = 25
 
 /obj/item/clothing/under/dress/skirt/plaid
 	name = "red plaid skirt"
 	desc = "A preppy red skirt with a white blouse."
 	icon_state = "plaid_red"
-	item_state = "plaid_red"
+	inhand_icon_state = "plaid_red"
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
 	custom_price = 25
@@ -78,19 +78,19 @@
 	name = "blue plaid skirt"
 	desc = "A preppy blue skirt with a white blouse."
 	icon_state = "plaid_blue"
-	item_state = "plaid_blue"
+	inhand_icon_state = "plaid_blue"
 
 /obj/item/clothing/under/dress/skirt/plaid/purple
 	name = "purple plaid skirt"
 	desc = "A preppy purple skirt with a white blouse."
 	icon_state = "plaid_purple"
-	item_state = "plaid_purple"
+	inhand_icon_state = "plaid_purple"
 
 /obj/item/clothing/under/dress/skirt/plaid/green
 	name = "green plaid skirt"
 	desc = "A preppy green skirt with a white blouse."
 	icon_state = "plaid_green"
-	item_state = "plaid_green"
+	inhand_icon_state = "plaid_green"
 
 /////////////////
 //DONATOR ITEMS//

--- a/code/modules/clothing/under/suits.dm
+++ b/code/modules/clothing/under/suits.dm
@@ -4,7 +4,7 @@
 	name = "white suit"
 	desc = "A white suit."
 	icon_state = "scratch"
-	item_state = "scratch"
+	inhand_icon_state = "scratch"
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_NO_BREASTS
 	dying_key = DYE_REGISTRY_SUITS
@@ -13,7 +13,7 @@
 	name = "white suit"
 	desc = "A white suit, suitable for an excellent host."
 	icon_state = "scratch"
-	item_state = "scratch"
+	inhand_icon_state = "scratch"
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY|FEMALE_UNIFORM_NO_BREASTS
 
 /obj/item/clothing/under/suit/sl
@@ -25,27 +25,27 @@
 	name = "waiter's outfit"
 	desc = "It's a very smart uniform with a special pocket for tip."
 	icon_state = "waiter"
-	item_state = "waiter"
+	inhand_icon_state = "waiter"
 
 /obj/item/clothing/under/suit/black
 	name = "black slacks"
 	desc = "A professional set of black slacks and a white dress shirt. Nanotrasen Investigation Bureau approved! Tie and suit coat not included."
 	icon_state = "blackslacks"
-	item_state = "blackslacks"
+	inhand_icon_state = "blackslacks"
 	can_adjust = TRUE
 
 /obj/item/clothing/under/suit/relaxed
 	name = "relaxed slacks"
 	desc = "A somewhat less professional set of black slacks and a white dress shirt."
 	icon_state = "relaxed"
-	item_state = "relaxed"
+	inhand_icon_state = "relaxed"
 	can_adjust = TRUE
 
 /obj/item/clothing/under/suit/black/skirt
 	name = "black suitskirt"
 	desc = "A professional black suit. Nanotrasen Investigation Bureau approved!"
 	icon_state = "blacksuit_skirt"
-	item_state = "bar_suit"
+	inhand_icon_state = "bar_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY|FEMALE_UNIFORM_NO_BREASTS
@@ -55,13 +55,13 @@
 	name = "executive suit"
 	desc = "A formal black suit and red tie, intended for the station's finest."
 	icon_state = "really_black_suit"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 
 /obj/item/clothing/under/suit/black_really/skirt
 	name = "executive suitskirt"
 	desc = "A formal black suitskirt and red tie, intended for the station's finest."
 	icon_state = "reallyblack_suit_skirt"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY|FEMALE_UNIFORM_NO_BREASTS
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
@@ -70,7 +70,7 @@
 	name = "executive suit"
 	desc = "A formal trouser suit for women, intended for the station's finest."
 	icon_state = "black_suit_fem"
-	item_state = "black_suit_fem"
+	inhand_icon_state = "black_suit_fem"
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY|FEMALE_UNIFORM_NO_BREASTS
 	//There is no alt sprite
@@ -81,47 +81,47 @@
 	desc = "A green suit and yellow necktie. Baller."
 	icon = 'icons/obj/clothing/under/captain.dmi'
 	icon_state = "green_suit"
-	item_state = "dg_suit"
+	inhand_icon_state = "dg_suit"
 	worn_icon = 'icons/mob/clothing/under/captain.dmi'
 
 /obj/item/clothing/under/suit/red
 	name = "red suit"
 	desc = "A red suit and blue tie. Somewhat formal."
 	icon_state = "red_suit"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 
 /obj/item/clothing/under/suit/charcoal
 	name = "charcoal suit"
 	desc = "A charcoal suit and red tie. Very professional."
 	icon_state = "charcoal_suit"
-	item_state = "charcoal_suit"
+	inhand_icon_state = "charcoal_suit"
 
 /obj/item/clothing/under/suit/navy
 	name = "navy suit"
 	desc = "A navy suit and red tie, intended for the station's finest."
 	icon_state = "navy_suit"
-	item_state = null
+	inhand_icon_state = null
 
 /obj/item/clothing/under/suit/burgundy
 	name = "burgundy suit"
 	desc = "A burgundy suit and black tie. Somewhat formal."
 	icon_state = "burgundy_suit"
-	item_state = "burgundy_suit"
+	inhand_icon_state = "burgundy_suit"
 
 /obj/item/clothing/under/suit/checkered
 	name = "checkered suit"
 	desc = "That's a very nice suit you have there. Shame if something were to happen to it, eh?"
 	icon_state = "checkered_suit"
-	item_state = "checkered_suit"
+	inhand_icon_state = "checkered_suit"
 
 /obj/item/clothing/under/suit/tan
 	name = "tan suit"
 	desc = "A tan suit with a yellow tie. Smart, but casual."
 	icon_state = "tan_suit"
-	item_state = "tan_suit"
+	inhand_icon_state = "tan_suit"
 
 /obj/item/clothing/under/suit/white
 	name = "white suit"
 	desc = "A white suit and jacket with a blue shirt. You wanna play rough? OKAY!"
 	icon_state = "white_suit"
-	item_state = "white_suit"
+	inhand_icon_state = "white_suit"

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -2,7 +2,7 @@
 	name = "tactical turtleneck"
 	desc = "A non-descript and slightly suspicious looking turtleneck with digital camouflage cargo pants."
 	icon_state = "syndicate"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	has_sensor = NO_SENSORS
 	armor_type = /datum/armor/under_syndicate
 	alt_covers_chest = TRUE
@@ -22,7 +22,7 @@
 	name = "tacticool turtleneck"
 	desc = "Just looking at it makes you want to buy an SKS, go into the woods, and -operate-."
 	icon_state = "tactifool"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	armor_type = /datum/armor/syndicate_tacticool
 
 
@@ -36,14 +36,14 @@
 	name = "Tactical turtleneck suit"
 	desc = "A double seamed tactical turtleneck disguised as a civilian grade silk suit. Intended for the most formal operator. The collar is really sharp."
 	icon_state = "tactical_suit"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/syndicate/camo
 	name = "camouflage fatigues"
 	desc = "A green military camouflage uniform."
 	icon_state = "camogreen"
-	item_state = "g_suit"
+	inhand_icon_state = "g_suit"
 	can_adjust = FALSE
 
 /obj/item/clothing/under/syndicate/soviet

--- a/code/modules/clothing/under/trek.dm
+++ b/code/modules/clothing/under/trek.dm
@@ -11,13 +11,13 @@
 	name = "command uniform"
 	desc = "The uniform worn by command officers."
 	icon_state = "trek_command"
-	item_state = "y_suit"
+	inhand_icon_state = "y_suit"
 
 /obj/item/clothing/under/trek/engsec
 	name = "engsec uniform"
 	desc = "The uniform worn by engineering/security officers."
 	icon_state = "trek_engsec"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 	armor_type = /datum/armor/trek_engsec
 	strip_delay = 50
 
@@ -31,17 +31,17 @@
 	name = "medsci uniform"
 	desc = "The uniform worn by medical/science officers."
 	icon_state = "trek_medsci"
-	item_state = "b_suit"
+	inhand_icon_state = "b_suit"
 
 
 //TNG
 /obj/item/clothing/under/trek/command/next
 	icon_state = "trek_next_command"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"
 
 /obj/item/clothing/under/trek/engsec/next
 	icon_state = "trek_next_engsec"
-	item_state = "y_suit"
+	inhand_icon_state = "y_suit"
 
 /obj/item/clothing/under/trek/medsci/next
 	icon_state = "trek_next_medsci"
@@ -50,15 +50,15 @@
 //ENT
 /obj/item/clothing/under/trek/command/ent
 	icon_state = "trek_ent_command"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 
 /obj/item/clothing/under/trek/engsec/ent
 	icon_state = "trek_ent_engsec"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 
 /obj/item/clothing/under/trek/medsci/ent
 	icon_state = "trek_ent_medsci"
-	item_state = "bl_suit"
+	inhand_icon_state = "bl_suit"
 
 
 //Q
@@ -66,4 +66,4 @@
 	name = "french marshall's uniform"
 	desc = "Something about it feels off..."
 	icon_state = "trek_Q"
-	item_state = "r_suit"
+	inhand_icon_state = "r_suit"

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -5,7 +5,7 @@
 	desc = "An empty evidence bag."
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "evidenceobj"
-	item_state = ""
+	inhand_icon_state = ""
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/evidencebag/afterattack(obj/item/I, mob/user,proximity)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "forensicnew"
 	w_class = WEIGHT_CLASS_SMALL
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/modules/exploration_crew/discovery_research/discovery_scanner.dm
+++ b/code/modules/exploration_crew/discovery_research/discovery_scanner.dm
@@ -3,7 +3,7 @@
 	desc = "A scanner used by scientists to collect research data about unknown artifacts and specimins."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "discovery"
-	item_state = "discoveryscanner"
+	inhand_icon_state = "discoveryscanner"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/exploration_crew/exploration_explosives.dm
+++ b/code/modules/exploration_crew/exploration_explosives.dm
@@ -2,7 +2,7 @@
 	name = "breaching charges"
 	desc = "Used by exploration crews to breach and demolish unknown places. Requires a nearby detonator to be triggered."
 	icon_state = "plastic-explosive0"
-	item_state = "plastic-explosive"
+	inhand_icon_state = "plastic-explosive"
 	lefthand_file = 'icons/mob/inhands/weapons/bombs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/bombs_righthand.dmi'
 	item_flags = NOBLUDGEON
@@ -17,7 +17,7 @@
 
 /obj/item/grenade/exploration/Initialize(mapload)
 	. = ..()
-	plastic_overlay = mutable_appearance(icon, "[item_state]2", HIGH_OBJ_LAYER)
+	plastic_overlay = mutable_appearance(icon, "[inhand_icon_state]2", HIGH_OBJ_LAYER)
 
 /obj/item/grenade/exploration/Destroy()
 	for(var/obj/item/exploration_detonator/detonator in attached_detonators)

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -2,7 +2,7 @@
 	name = "pizza bomb"
 	desc = "Special delivery!"
 	icon_state = "pizzabomb_inactive"
-	item_state = "eshield0"
+	inhand_icon_state = "eshield0"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 
@@ -11,7 +11,7 @@
 	desc = "A box suited for pizzas."
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "pizzabox"
-	item_state = "pizzabox"
+	inhand_icon_state = "pizzabox"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 
@@ -100,7 +100,7 @@
 	var/current_offset = 2
 	if(isinhands)
 		for(var/V in boxes) //add EXTRA BOX per box
-			var/mutable_appearance/M = mutable_appearance(icon_file, item_state, item_layer)
+			var/mutable_appearance/M = mutable_appearance(icon_file, inhand_icon_state, item_layer)
 			M.pixel_y = current_offset
 			current_offset += 2
 			. += M

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -93,7 +93,7 @@
 /obj/item/clothing/head/costume/bunnyhead
 	name = "Easter Bunny Head"
 	icon_state = "bunnyhead"
-	item_state = null
+	inhand_icon_state = null
 	desc = "Considerably more cute than 'Frank'."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
@@ -103,7 +103,7 @@
 	icon_state = "bunnysuit"
 	icon = 'icons/obj/clothing/suits/costume.dmi'
 	worn_icon = 'icons/mob/clothing/suits/costume.dmi'
-	item_state = null
+	inhand_icon_state = null
 	slowdown = -0.2
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -38,14 +38,14 @@
 	name = "basketball"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "basketball"
-	item_state = "basketball"
+	inhand_icon_state = "basketball"
 	desc = "Here's your chance, do your dance at the Space Jam."
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
 
 /obj/item/toy/beach_ball/holoball/dodgeball
 	name = "dodgeball"
 	icon_state = "dodgeball"
-	item_state = "dodgeball"
+	inhand_icon_state = "dodgeball"
 	desc = "Used for playing the most violent and degrading of childhood games."
 
 /obj/item/toy/beach_ball/holoball/dodgeball/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
+++ b/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
@@ -3,7 +3,7 @@
 	name = "beekeeper hat"
 	desc = "Keeps the lil buzzing buggers out of your eyes."
 	icon_state = "beekeeper"
-	item_state = null
+	inhand_icon_state = null
 	clothing_flags = THICKMATERIAL | SNUG_FIT
 
 
@@ -11,7 +11,7 @@
 	name = "beekeeper suit"
 	desc = "Keeps the lil buzzing buggers away from your squishy bits."
 	icon_state = "beekeeper"
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	clothing_flags = THICKMATERIAL
 	allowed = list(/obj/item/melee/flyswatter, /obj/item/reagent_containers/spray/plantbgone, /obj/item/plant_analyzer, /obj/item/seeds, /obj/item/reagent_containers/cup/bottle, /obj/item/reagent_containers/cup/beaker, /obj/item/cultivator, /obj/item/reagent_containers/spray/pestspray, /obj/item/hatchet, /obj/item/storage/bag/plants)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -19,7 +19,7 @@
 	name = "banana"
 	desc = "It's an excellent prop for a clown."
 	icon_state = "banana"
-	item_state = "banana"
+	inhand_icon_state = "banana"
 	trash_type = /obj/item/grown/bananapeel
 	bite_consumption_mod = 3
 	foodtypes = FRUIT
@@ -57,7 +57,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	icon_state = "banana_peel"
-	item_state = "banana_peel"
+	inhand_icon_state = "banana_peel"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 0
 	throw_speed = 3
@@ -97,7 +97,7 @@
 	name = "mimana peel"
 	desc = "A mimana peel."
 	icon_state = "mimana_peel"
-	item_state = "mimana_peel"
+	inhand_icon_state = "mimana_peel"
 
 // Bluespace Banana
 /obj/item/seeds/banana/bluespace
@@ -117,7 +117,7 @@
 	seed = /obj/item/seeds/banana/bluespace
 	name = "bluespace banana"
 	icon_state = "banana_blue"
-	item_state = "bluespace_peel"
+	inhand_icon_state = "bluespace_peel"
 	trash_type = /obj/item/grown/bananapeel/bluespace
 	tastes = list("banana" = 1)
 	wine_power = 60

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -38,7 +38,7 @@
 	name = "corn cob"
 	desc = "A reminder of meals gone by."
 	icon_state = "corncob"
-	item_state = "corncob"
+	inhand_icon_state = "corncob"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 0
 	throw_speed = 3
@@ -68,7 +68,7 @@
 	name = "snap corn"
 	desc = "A cob with snap pops."
 	icon_state = "snapcorn"
-	item_state = "corncob"
+	inhand_icon_state = "corncob"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 0
 	throw_speed = 3

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -131,7 +131,7 @@
 	name = "ballolon"
 	desc = "A organic balloon, lighter then air."
 	icon_state = "ballolon"
-	item_state = "ballolon"
+	inhand_icon_state = "ballolon"
 	lefthand_file = 'icons/mob/inhands/antag/balloons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/balloons_righthand.dmi'
 	filling_color = "#e35b6f"

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -4,7 +4,7 @@
 	desc = "A scanner used to evaluate a plant's various areas of growth."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hydro"
-	item_state = "analyzer"
+	inhand_icon_state = "analyzer"
 	worn_icon_state = "plantanalyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -22,7 +22,7 @@
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	name = "weed spray"
 	icon_state = "weedspray"
-	item_state = "spraycan"
+	inhand_icon_state = "spraycan"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
@@ -37,7 +37,7 @@
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	name = "pest spray"
 	icon_state = "pestspray"
-	item_state = "plantbgone"
+	inhand_icon_state = "plantbgone"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
@@ -52,7 +52,7 @@
 	desc = "It's used for removing weeds or scratching your back."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "cultivator"
-	item_state = "cultivator"
+	inhand_icon_state = "cultivator"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	flags_1 = CONDUCT_1
@@ -73,7 +73,7 @@
 	desc = "A very sharp axe blade upon a short fibremetal handle. It has a long history of chopping things, but now it is used for chopping wood."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "hatchet"
-	item_state = "hatchet"
+	inhand_icon_state = "hatchet"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -45,7 +45,7 @@
 	name = "space violin"
 	desc = "A wooden musical instrument with four strings and a bow. \"The devil went down to space, he was looking for an assistant to grief.\""
 	icon_state = "violin"
-	item_state = "violin"
+	inhand_icon_state = "violin"
 	hitsound = "swing_hit"
 	allowed_instrument_ids = "violin"
 
@@ -53,14 +53,14 @@
 	name = "golden violin"
 	desc = "A golden musical instrument with four strings and a bow. \"The devil went down to space, he was looking for an assistant to grief.\""
 	icon_state = "golden_violin"
-	item_state = "golden_violin"
+	inhand_icon_state = "golden_violin"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/instrument/piano_synth
 	name = "synthesizer"
 	desc = "An advanced electronic synthesizer that can be used as various instruments."
 	icon_state = "synth"
-	item_state = "synth"
+	inhand_icon_state = "synth"
 	allowed_instrument_ids = "piano"
 
 /obj/item/instrument/piano_synth/Initialize(mapload)
@@ -71,7 +71,7 @@
 	name = "banjo"
 	desc = "A 'Mura' brand banjo. It's pretty much just a drum with a neck and strings."
 	icon_state = "banjo"
-	item_state = "banjo"
+	inhand_icon_state = "banjo"
 	attack_verb_continuous = list("scruggs-styles", "hum-diggitys", "shin-digs", "clawhammers")
 	attack_verb_simple = list("scruggs-style", "hum-diggity", "shin-dig", "clawhammer")
 	hitsound = 'sound/weapons/banjoslap.ogg'
@@ -81,7 +81,7 @@
 	name = "guitar"
 	desc = "It's made of wood and has bronze strings."
 	icon_state = "guitar"
-	item_state = "guitar"
+	inhand_icon_state = "guitar"
 	attack_verb_continuous = list("plays metal on", "serenades", "crashes", "smashes")
 	attack_verb_simple = list("play metal on", "serenade", "crash", "smash")
 	hitsound = 'sound/weapons/stringsmash.ogg'
@@ -91,7 +91,7 @@
 	name = "electric guitar"
 	desc = "Makes all your shredding needs possible."
 	icon_state = "eguitar"
-	item_state = "eguitar"
+	inhand_icon_state = "eguitar"
 	force = 12
 	attack_verb_continuous = list("plays metal on", "shreds", "crashes", "smashes")
 	attack_verb_simple = list("play metal on", "shred", "crash", "smash")
@@ -102,28 +102,28 @@
 	name = "glockenspiel"
 	desc = "Smooth metal bars perfect for any marching band."
 	icon_state = "glockenspiel"
-	item_state = "glockenspiel"
+	inhand_icon_state = "glockenspiel"
 	allowed_instrument_ids = list("glockenspiel","crvibr", "sgmmbox", "r3celeste")
 
 /obj/item/instrument/accordion
 	name = "accordion"
 	desc = "Pun-Pun not included."
 	icon_state = "accordion"
-	item_state = "accordion"
+	inhand_icon_state = "accordion"
 	allowed_instrument_ids = list("crack", "crtango", "accordion")
 
 /obj/item/instrument/trumpet
 	name = "trumpet"
 	desc = "To announce the arrival of the king!"
 	icon_state = "trumpet"
-	item_state = "trombone"
+	inhand_icon_state = "trombone"
 	allowed_instrument_ids = "crtrumpet"
 
 /obj/item/instrument/trumpet/spectral
 	name = "spectral trumpet"
 	desc = "Things are about to get spooky!"
 	icon_state = "trumpet"
-	item_state = "trombone"
+	inhand_icon_state = "trombone"
 	force = 0
 	attack_verb_continuous = list("plays", "jazzes", "trumpets", "mourns", "doots", "spooks")
 	attack_verb_simple = list("play", "jazz", "trumpet", "mourn", "doot", "spook")
@@ -140,14 +140,14 @@
 	name = "saxophone"
 	desc = "This soothing sound will be sure to leave your audience in tears."
 	icon_state = "saxophone"
-	item_state = "saxophone"
+	inhand_icon_state = "saxophone"
 	allowed_instrument_ids = "saxophone"
 
 /obj/item/instrument/saxophone/spectral
 	name = "spectral saxophone"
 	desc = "This spooky sound will be sure to leave mortals in bones."
 	icon_state = "saxophone"
-	item_state = "saxophone"
+	inhand_icon_state = "saxophone"
 	allowed_instrument_ids = "saxophone"
 	force = 0
 	attack_verb_continuous = list("plays", "jazzes", "saxxes", "mourns", "doots", "spooks")
@@ -165,14 +165,14 @@
 	name = "trombone"
 	desc = "How can any pool table ever hope to compete?"
 	icon_state = "trombone"
-	item_state = "trombone"
+	inhand_icon_state = "trombone"
 	allowed_instrument_ids = list("crtrombone", "crbrass", "trombone")
 
 /obj/item/instrument/trombone/spectral
 	name = "spectral trombone"
 	desc = "A skeleton's favorite instrument. Apply directly on the mortals."
 	icon_state = "trombone"
-	item_state = "trombone"
+	inhand_icon_state = "trombone"
 	force = 0
 	attack_verb_continuous = list("plays", "jazzes", "trombones", "mourns", "doots", "spooks")
 	attack_verb_simple = list("play", "jazz", "trombone", "mourn", "doot", "spook")
@@ -190,14 +190,14 @@
 	desc = "Just like in school, playing ability and all."
 	force = 5
 	icon_state = "recorder"
-	item_state = "recorder"
+	inhand_icon_state = "recorder"
 	allowed_instrument_ids = "recorder"
 
 /obj/item/instrument/harmonica
 	name = "harmonica"
 	desc = "For when you get a bad case of the space blues."
 	icon_state = "harmonica"
-	item_state = "harmonica"
+	inhand_icon_state = "harmonica"
 	allowed_instrument_ids = list("harmonica", "crharmony")
 	slot_flags = ITEM_SLOT_MASK
 	force = 5
@@ -234,7 +234,7 @@
 	name = "gilded bike horn"
 	desc = "An exquisitely decorated bike horn, capable of honking in a variety of notes."
 	icon_state = "bike_horn"
-	item_state = "bike_horn"
+	inhand_icon_state = "bike_horn"
 	lefthand_file = 'icons/mob/inhands/equipment/horns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/horns_righthand.dmi'
 	attack_verb_continuous = list("beautifully honks")

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -44,7 +44,7 @@
 		B.deity_name = GLOB.deity
 		B.name = GLOB.bible_name
 		B.icon_state = GLOB.bible_icon_state
-		B.item_state = GLOB.bible_item_state
+		B.inhand_icon_state = GLOB.bible_inhand_icon_state
 		to_chat(H, "There is already an established religion onboard the station. You are an acolyte of [GLOB.deity]. Defer to the Chaplain.")
 		H.equip_to_slot_or_del(B, ITEM_SLOT_BACKPACK)
 		GLOB.religious_sect?.on_conversion(H)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -534,9 +534,9 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 	if(href_list["printbible"])
 		if(cooldown < world.time)
 			var/obj/item/storage/book/bible/B = new /obj/item/storage/book/bible(src.loc)
-			if(GLOB.bible_icon_state && GLOB.bible_item_state)
+			if(GLOB.bible_icon_state && GLOB.bible_inhand_icon_state)
 				B.icon_state = GLOB.bible_icon_state
-				B.item_state = GLOB.bible_item_state
+				B.inhand_icon_state = GLOB.bible_inhand_icon_state
 				B.name = GLOB.bible_name
 				B.deity_name = GLOB.deity
 			cooldown = world.time + PRINTER_COOLDOWN

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -188,7 +188,7 @@ interface with the mining shuttle at the landing site if a mobile beacon is also
 /obj/item/assault_pod/mining
 	name = "Landing Field Designator"
 	icon_state = "gangtool-purple"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	desc = "Deploy to designate the landing zone of the auxillary base."

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -104,9 +104,13 @@
 /obj/item/clothing/mask/gas/explorer/attack_self(mob/user)
 	adjustmask(user)
 
-/obj/item/clothing/mask/gas/explorer/adjustmask(user)
-	..()
+/obj/item/clothing/mask/gas/explorer/adjustmask(mob/user)
+	. = ..()
+	// adjusted = out of the way = smaller = can fit in boxes
 	w_class = mask_adjusted ? WEIGHT_CLASS_SMALL : WEIGHT_CLASS_NORMAL
+	inhand_icon_state = mask_adjusted ? "[initial(inhand_icon_state)]_up" : initial(inhand_icon_state)
+	if(user)
+		user.update_held_items()
 
 /obj/item/clothing/mask/gas/explorer/folded/Initialize(mapload)
 	. = ..()

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -5,7 +5,7 @@
 	icon_state = "explorer"
 	icon = 'icons/obj/clothing/suits/utility.dmi'
 	worn_icon = 'icons/mob/clothing/suits/utility.dmi'
-	item_state = null
+	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
@@ -80,7 +80,7 @@
 	name = "explorer gas mask"
 	desc = "A military-grade gas mask that can be connected to an air supply."
 	icon_state = "gas_mining"
-	item_state = "explorer_gasmask"
+	inhand_icon_state = "explorer_gasmask"
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR
@@ -118,7 +118,7 @@
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	icon_state = "hostile_env"
-	item_state = "hostile_env"
+	inhand_icon_state = "hostile_env"
 	clothing_flags = THICKMATERIAL //not spaceproof
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
@@ -160,7 +160,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	desc = "Hostile Environiment Cross-Kinetic Helmet: A helmet designed to withstand the wide variety of hazards from Lavaland. It wasn't enough for its last owner."
 	icon_state = "hostile_env"
-	item_state = "hostile_env"
+	inhand_icon_state = "hostile_env"
 	w_class = WEIGHT_CLASS_NORMAL
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	clothing_flags = THICKMATERIAL // no space protection

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -2,7 +2,7 @@
 /obj/item/kinetic_crusher
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "crusher"
-	item_state = "crusher0"
+	inhand_icon_state = "crusher0"
 	lefthand_file = 'icons/mob/inhands/weapons/hammers_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/hammers_righthand.dmi'
 	name = "proto-kinetic crusher"
@@ -155,7 +155,7 @@
 	update_appearance()
 
 /obj/item/kinetic_crusher/update_icon_state()
-	item_state = "crusher[HAS_TRAIT(src, TRAIT_WIELDED)]" // this is not icon_state and not supported by 2hcomponent
+	inhand_icon_state = "crusher[HAS_TRAIT(src, TRAIT_WIELDED)]" // this is not icon_state and not supported by 2hcomponent
 	return ..()
 
 /obj/item/kinetic_crusher/update_overlays()

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -4,7 +4,7 @@
 	desc = "An injector with a cocktail of nanomachines and chemicals, this device can seemingly raise animals from the dead. Testing has shown inconsistent results and the animals with especially strong wills may attack the person reviving them."
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "lazarus_hypo"
-	item_state = "hypo"
+	inhand_icon_state = "hypo"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	throwforce = 0

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -4,7 +4,7 @@
 	name = "manual mining scanner"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "miningmanual"
-	item_state = "analyzer"
+	inhand_icon_state = "analyzer"
 	worn_icon_state = "analyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -45,7 +45,7 @@
 	desc = "A scanner that automatically checks surrounding rock for useful minerals; it can also be used to stop gibtonite detonations. This one has an extended range.\nIt has a speaker that can be toggled with <b>alt+click</b>"
 	name = "advanced automatic mining scanner"
 	icon_state = "adv_mining0"
-	item_state = "analyzer"
+	inhand_icon_state = "analyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -3,7 +3,7 @@
 	name = "pickaxe"
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "pickaxe"
-	item_state = "pickaxe"
+	inhand_icon_state = "pickaxe"
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	attack_weight = 2
@@ -50,7 +50,7 @@
 /obj/item/pickaxe/silver
 	name = "silver-plated pickaxe"
 	icon_state = "spickaxe"
-	item_state = "spickaxe"
+	inhand_icon_state = "spickaxe"
 	worn_icon_state = "spickaxe"
 	toolspeed = 0.5
 	stamina_use = 3 //costs less stamina because silver is lighter??
@@ -60,7 +60,7 @@
 /obj/item/pickaxe/diamond
 	name = "diamond-tipped pickaxe"
 	icon_state = "dpickaxe"
-	item_state = "dpickaxe"
+	inhand_icon_state = "dpickaxe"
 	worn_icon_state = "dpickaxe"
 	toolspeed = 0.3
 	stamina_use = 3
@@ -70,7 +70,7 @@
 /obj/item/pickaxe/drill
 	name = "mining drill"
 	icon_state = "handdrill"
-	item_state = "jackhammer"
+	inhand_icon_state = "jackhammer"
 	worn_icon_state = "jackhammer"
 	slot_flags = ITEM_SLOT_BELT
 	toolspeed = 0.5
@@ -102,7 +102,7 @@
 /obj/item/pickaxe/drill/jackhammer
 	name = "sonic jackhammer"
 	icon_state = "jackhammer"
-	item_state = "jackhammer"
+	inhand_icon_state = "jackhammer"
 	worn_icon_state = "jackhammer"
 	toolspeed = 0.1 //the epitome of powertools. extremely fast mining, laughs at puny walls
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
@@ -114,7 +114,7 @@
 	desc = "A large tool for digging and moving dirt."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "shovel"
-	item_state = "shovel"
+	inhand_icon_state = "shovel"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	flags_1 = CONDUCT_1
@@ -145,7 +145,7 @@
 	name = "spade"
 	desc = "A small tool for digging and moving dirt."
 	icon_state = "spade"
-	item_state = "spade"
+	inhand_icon_state = "spade"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	force = 5

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -70,7 +70,7 @@
 /obj/item/pickaxe/drill
 	name = "mining drill"
 	icon_state = "handdrill"
-	inhand_icon_state = "jackhammer"
+	inhand_icon_state = "handdrill"
 	worn_icon_state = "jackhammer"
 	slot_flags = ITEM_SLOT_BELT
 	toolspeed = 0.5
@@ -91,12 +91,14 @@
 /obj/item/pickaxe/drill/diamonddrill
 	name = "diamond-tipped mining drill"
 	icon_state = "diamonddrill"
+	inhand_icon_state = "diamonddrill"
 	toolspeed = 0.2
 	desc = "Yours is the drill that will pierce the heavens!"
 
 /obj/item/pickaxe/drill/cyborg/diamond //This is the BORG version!
 	name = "diamond-tipped cyborg mining drill" //To inherit the NODROP_1 flag, and easier to change borg specific drill mechanics.
 	icon_state = "diamonddrill"
+	inhand_icon_state = "diamonddrill"
 	toolspeed = 0.2
 
 /obj/item/pickaxe/drill/jackhammer

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -3,7 +3,7 @@
 	name = "resonator"
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "resonator"
-	item_state = "resonator"
+	inhand_icon_state = "resonator"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It does increased damage in low pressure."
@@ -19,7 +19,7 @@
 	name = "upgraded resonator"
 	desc = "An upgraded version of the resonator that can produce more fields at once, as well as having no damage penalty for bursting a resonance field early."
 	icon_state = "resonator_u"
-	item_state = "resonator_u"
+	inhand_icon_state = "resonator_u"
 	fieldlimit = 6
 	quick_burst_mod = 1
 

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -382,4 +382,4 @@
 	icon = initial(I.icon)
 	desc = initial(I.desc)
 	icon_state = initial(I.icon_state)
-	item_state = initial(I.item_state)
+	inhand_icon_state = initial(I.inhand_icon_state)

--- a/code/modules/mining/equipment/vendor_items.dm
+++ b/code/modules/mining/equipment/vendor_items.dm
@@ -3,7 +3,7 @@
 
 /**********************Facehugger toy**********************/
 /obj/item/clothing/mask/facehugger/toy
-	item_state = "facehugger_inactive"
+	inhand_icon_state = "facehugger_inactive"
 	desc = "A toy often used to play pranks on other miners by putting it in their beds. It takes a bit to recharge after latching onto something."
 	throwforce = 0
 	real = 0

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -4,7 +4,7 @@
 	desc = "A single use device harnessing outdated wormhole technology, Nanotrasen has since turned its eyes to bluespace for more accurate teleportation. The wormholes it creates are unpleasant to travel through, to say the least.\nThis jaunter can be worn on the belt to provide protection from chasms."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "Jaunter"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'

--- a/code/modules/mining/gibtonite.dm
+++ b/code/modules/mining/gibtonite.dm
@@ -7,7 +7,7 @@
 	desc = "Extremely explosive if struck with mining equipment, Gibtonite is often used by miners to speed up their work by using it as a mining charge. This material is illegal to possess by unauthorized personnel under space law."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "Gibtonite ore"
-	item_state = "Gibtonite ore"
+	inhand_icon_state = "Gibtonite ore"
 	w_class = WEIGHT_CLASS_BULKY
 	throw_range = 0
 	var/primed = FALSE

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -74,7 +74,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	icon_state = "asclepius_dormant"
-	item_state = "asclepius_dormant"
+	inhand_icon_state = "asclepius_dormant"
 	block_upgrade_walk = 1
 	block_level = 1
 	block_power = 40 //blocks very well to encourage using it. Just because you're a pacifist doesn't mean you can't defend yourself
@@ -131,7 +131,7 @@
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 	desc = "A short wooden rod with a mystical snake inseparably gripping itself and the rod to your forearm. It flows with a healing energy that disperses amongst yourself and those around you. "
 	icon_state = "asclepius_active"
-	item_state = "asclepius_active"
+	inhand_icon_state = "asclepius_active"
 	activated = TRUE
 
 //Memento Mori
@@ -199,7 +199,7 @@
 	desc = "This lantern gives off no light, but is home to a friendly wisp."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "lantern-blue"
-	item_state = "lantern"
+	inhand_icon_state = "lantern"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	var/obj/effect/wisp/wisp
@@ -393,7 +393,7 @@
 	desc = "Mid or feed."
 	ammo_type = /obj/item/ammo_casing/magic/hook
 	icon_state = "hook"
-	item_state = "chain"
+	inhand_icon_state = "chain"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	fire_sound = 'sound/weapons/batonextend.ogg'
@@ -675,7 +675,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/shared_storage/blue)
 	desc = "Pickaxes... for your hands!"
 	icon_state = "concussive_gauntlets"
 	worn_icon_state = "concussive_gauntlets"
-	item_state = "combatgloves"
+	inhand_icon_state = "combatgloves"
 	toolspeed = 0.1 //Sonic jackhammer, but only works on minerals.
 	strip_delay = 40
 	equip_delay_other = 20
@@ -883,7 +883,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/shared_storage/blue)
 	name = "\improper spectral blade"
 	desc = "A rusted and dulled blade. It doesn't look like it'd do much damage. It glows weakly."
 	icon_state = "spectral"
-	item_state = "spectral"
+	inhand_icon_state = "spectral"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
@@ -1029,7 +1029,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/shared_storage/blue)
 	name = "staff of lava"
 	desc = "The power to manipulate lava. What more could you want out of life?"
 	icon_state = "staffofstorms"
-	item_state = "staffofstorms"
+	inhand_icon_state = "staffofstorms"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	icon = 'icons/obj/guns/magic.dmi'
@@ -1188,7 +1188,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/shared_storage/blue)
 	name = "hierophant club"
 	desc = "The strange technology of this large club allows various nigh-magical feats. It used to beat you, but now you can set the beat."
 	icon_state = "hierophant_club_ready_beacon"
-	item_state = "hierophant_club_ready_beacon"
+	inhand_icon_state = "hierophant_club_ready_beacon"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
@@ -1283,7 +1283,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/shared_storage/blue)
 
 /obj/item/hierophant_club/update_icon()
 	icon_state = "hierophant_club[timer <= world.time ? "_ready":""][(beacon && !QDELETED(beacon)) ? "":"_beacon"]"
-	item_state = icon_state
+	inhand_icon_state = icon_state
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_inv_hands()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -80,7 +80,23 @@
 	block_power = 40 //blocks very well to encourage using it. Just because you're a pacifist doesn't mean you can't defend yourself
 	block_flags = null //not active, so it's null
 	var/activated = FALSE
-	var/usedHand
+
+/obj/item/rod_of_asclepius/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/update_icon_updates_onmob)
+
+/obj/item/rod_of_asclepius/update_desc(updates)
+	. = ..()
+	desc = activated ? "A short wooden rod with a mystical snake inseparably gripping itself and the rod to your forearm. It flows with a healing energy that disperses amongst yourself and those around you." : initial(desc)
+
+/obj/item/rod_of_asclepius/update_icon_state()
+	. = ..()
+	icon_state = inhand_icon_state = "ascelpius_[activated ? "active" : "dormant"]"
+
+/obj/item/rod_of_asclepius/vv_edit_var(vname, vval)
+	. = ..()
+	if(vname == NAMEOF(src, activated) && activated)
+		activated()
 
 /obj/item/rod_of_asclepius/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
 	if(!activated)
@@ -94,7 +110,7 @@
 		to_chat(user, span_warning("The snake carving seems to come alive, if only for a moment, before returning to its dormant state, almost as if it finds you incapable of holding its oath."))
 		return
 	var/mob/living/carbon/itemUser = user
-	usedHand = itemUser.get_held_index_of_item(src)
+	var/usedHand = itemUser.get_held_index_of_item(src)
 	if(itemUser.has_status_effect(/datum/status_effect/hippocratic_oath))
 		to_chat(user, span_warning("You can't possibly handle the responsibility of more than one rod!"))
 		return
@@ -129,10 +145,8 @@
 /obj/item/rod_of_asclepius/proc/activated()
 	item_flags = DROPDEL
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
-	desc = "A short wooden rod with a mystical snake inseparably gripping itself and the rod to your forearm. It flows with a healing energy that disperses amongst yourself and those around you. "
-	icon_state = "asclepius_active"
-	inhand_icon_state = "asclepius_active"
 	activated = TRUE
+	update_appearance()
 
 //Memento Mori
 /obj/item/clothing/neck/necklace/memento_mori

--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -76,14 +76,14 @@
 
 	var/obj/item/l_hand = get_item_for_held_index(1)
 	if(l_hand)
-		var/itm_state = l_hand.item_state
+		var/itm_state = l_hand.inhand_icon_state
 		if(!itm_state)
 			itm_state = l_hand.icon_state
 		hands += mutable_appearance(alt_inhands_file, "[itm_state][caste]_l", CALCULATE_MOB_OVERLAY_LAYER(HANDS_LAYER))
 
 	var/obj/item/r_hand = get_item_for_held_index(2)
 	if(r_hand)
-		var/itm_state = r_hand.item_state
+		var/itm_state = r_hand.inhand_icon_state
 		if(!itm_state)
 			itm_state = r_hand.icon_state
 		hands += mutable_appearance(alt_inhands_file, "[itm_state][caste]_r", CALCULATE_MOB_OVERLAY_LAYER(HANDS_LAYER))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -13,7 +13,7 @@
 	desc = "It has some sort of a tube at the end of its tail."
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "facehugger"
-	item_state = "facehugger"
+	inhand_icon_state = "facehugger"
 	w_class = WEIGHT_CLASS_TINY //note: can be picked up by aliens unlike most other items of w_class below 4
 	clothing_flags = MASKINTERNALS
 	throw_range = 5
@@ -53,13 +53,13 @@
 
 /obj/item/clothing/mask/facehugger/dead
 	icon_state = "facehugger_dead"
-	item_state = "facehugger_inactive"
+	inhand_icon_state = "facehugger_inactive"
 	worn_icon_state = "facehugger_dead"
 	stat = DEAD
 
 /obj/item/clothing/mask/facehugger/impregnated
 	icon_state = "facehugger_impregnated"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon_state = "facehugger_impregnated"
 	stat = DEAD
 
@@ -255,7 +255,7 @@
 		return
 
 	icon_state = "[initial(icon_state)]_dead"
-	item_state = "facehugger_inactive"
+	inhand_icon_state = "facehugger_inactive"
 	stat = DEAD
 
 	visible_message(span_danger("[src] curls up into a ball!"))

--- a/code/modules/mob/living/carbon/human/species_types/debug.dm
+++ b/code/modules/mob/living/carbon/human/species_types/debug.dm
@@ -37,5 +37,5 @@
 	desc = "The Return"
 	flags_inv = HIDEEARS|HIDEHAIR
 	icon_state = "ushankadown"
-	item_state = "ushankadown"
+	inhand_icon_state = "ushankadown"
 	sprite_sheets = FLAG_DEBUG_SPECIES //The small emblem on the ushanka will appear green for the debug species instead of red

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -229,7 +229,7 @@
 	name = "light eater" //as opposed to heavy eater
 	icon = 'icons/obj/changeling_items.dmi'
 	icon_state = "arm_blade"
-	item_state = "arm_blade"
+	inhand_icon_state = "arm_blade"
 	force = 25
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	armour_penetration = 35

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -57,7 +57,7 @@
 	name = "snail shell"
 	desc = "Worn by snails as armor and storage compartment."
 	icon_state = "snailshell"
-	item_state = "snailshell"
+	inhand_icon_state = "snailshell"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	armor_type = /datum/armor/backpack_snail

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -57,7 +57,7 @@
 	name = "snail shell"
 	desc = "Worn by snails as armor and storage compartment."
 	icon_state = "snailshell"
-	inhand_icon_state = "snailshell"
+	inhand_icon_state = null
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	armor_type = /datum/armor/backpack_snail

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -385,7 +385,7 @@ There are several things that need to be remembered:
 		if(client && hud_used && hud_used.hud_shown)
 			client.screen += s_store
 		update_observer_view(s_store)
-		var/t_state = s_store.item_state
+		var/t_state = s_store.inhand_icon_state
 		if(!t_state)
 			t_state = s_store.icon_state
 		overlays_standing[SUIT_STORE_LAYER]	= mutable_appearance('icons/mob/clothing/belt_mirror.dmi', t_state, -SUIT_STORE_LAYER)
@@ -602,7 +602,7 @@ There are several things that need to be remembered:
 							observers = null
 							break
 
-		var/t_state = I.item_state
+		var/t_state = I.inhand_icon_state
 		if(!t_state)
 			t_state = I.icon_state
 
@@ -704,7 +704,7 @@ generate/load female uniform sprites matching all previously decided variables
 	if(override_state)
 		t_state = override_state
 	else
-		t_state = !isinhands ? (worn_icon_state ? worn_icon_state : icon_state) : (item_state ? item_state : icon_state)
+		t_state = !isinhands ? (worn_icon_state ? worn_icon_state : icon_state) : (inhand_icon_state ? inhand_icon_state : icon_state)
 
 	//Find a valid icon file from variables+arguments
 	var/file2use = !isinhands ? (worn_icon ? worn_icon : default_icon_file) : default_icon_file

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -19,7 +19,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/clothing/head/mob_holder)
 	if(head_icon)
 		worn_icon = head_icon
 	if(worn_state)
-		item_state = worn_state
+		inhand_icon_state = worn_state
 	if(lh_icon)
 		lefthand_file = lh_icon
 	if(rh_icon)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "std_mod"
 	w_class = WEIGHT_CLASS_GIGANTIC
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -76,7 +76,7 @@
 	name = "incomplete ED-209 assembly"
 	desc = "Some sort of bizarre assembly."
 	icon_state = "ed209_frame"
-	item_state = "ed209_frame"
+	inhand_icon_state = "ed209_frame"
 	created_name = "ED-209 Security Robot" //To preserve the name if it's a unique securitron I guess
 	var/lasercolor = ""
 	var/vest_type = /obj/item/clothing/suit/armor/vest
@@ -92,10 +92,10 @@
 				qdel(W)
 				name = "legs/frame assembly"
 				if(build_step == ASSEMBLY_FIRST_STEP)
-					item_state = "ed209_leg"
+					inhand_icon_state = "ed209_leg"
 					icon_state = "ed209_leg"
 				else
-					item_state = "ed209_legs"
+					inhand_icon_state = "ed209_legs"
 					icon_state = "ed209_legs"
 				build_step++
 
@@ -113,7 +113,7 @@
 				to_chat(user, span_notice("You add [W] to [src]."))
 				qdel(W)
 				name = "vest/legs/frame assembly"
-				item_state = "[lasercolor]ed209_shell"
+				inhand_icon_state = "[lasercolor]ed209_shell"
 				icon_state = "[lasercolor]ed209_shell"
 				build_step++
 
@@ -143,7 +143,7 @@
 			to_chat(user, span_notice("You add [W] to [src]."))
 			qdel(W)
 			name = "covered and shielded frame assembly"
-			item_state = "[lasercolor]ed209_hat"
+			inhand_icon_state = "[lasercolor]ed209_hat"
 			icon_state = "[lasercolor]ed209_hat"
 			build_step++
 
@@ -155,7 +155,7 @@
 				to_chat(user, span_notice("You add [W] to [src]."))
 				qdel(W)
 				name = "covered, shielded and sensored frame assembly"
-				item_state = "[lasercolor]ed209_prox"
+				inhand_icon_state = "[lasercolor]ed209_prox"
 				icon_state = "[lasercolor]ed209_prox"
 
 		if(6)
@@ -189,7 +189,7 @@
 				return
 			name = "[W.name] ED-209 assembly"
 			to_chat(user, span_notice("You add [W] to [src]."))
-			item_state = "[lasercolor]ed209_taser"
+			inhand_icon_state = "[lasercolor]ed209_taser"
 			icon_state = "[lasercolor]ed209_taser"
 			qdel(W)
 			build_step++
@@ -349,7 +349,7 @@
 	name = "incomplete securitron assembly"
 	desc = "Some sort of bizarre assembly made from a proximity sensor, helmet, and signaler."
 	icon_state = "helmet_signaler"
-	item_state = "helmet"
+	inhand_icon_state = "helmet"
 	created_name = "Securitron" //To preserve the name if it's a unique securitron I guess
 	var/swordamt = 0 //If you're converting it into a grievousbot, how many swords have you attached
 	var/toyswordamt = 0 //honk

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -76,7 +76,7 @@
 	name = "incomplete ED-209 assembly"
 	desc = "Some sort of bizarre assembly."
 	icon_state = "ed209_frame"
-	inhand_icon_state = "ed209_frame"
+	inhand_icon_state = null
 	created_name = "ED-209 Security Robot" //To preserve the name if it's a unique securitron I guess
 	var/lasercolor = ""
 	var/vest_type = /obj/item/clothing/suit/armor/vest
@@ -350,6 +350,8 @@
 	desc = "Some sort of bizarre assembly made from a proximity sensor, helmet, and signaler."
 	icon_state = "helmet_signaler"
 	inhand_icon_state = "helmet"
+	lefthand_file = 'icons/mob/inhands/clothing/hats_righthand.dmi'
+	righthand_file = 'icons/mob/inhands/clothing/hats_lefthand.dmi'
 	created_name = "Securitron" //To preserve the name if it's a unique securitron I guess
 	var/swordamt = 0 //If you're converting it into a grievousbot, how many swords have you attached
 	var/toyswordamt = 0 //honk

--- a/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
@@ -30,7 +30,7 @@
 
 	if(r_hand)
 
-		var/r_state = r_hand.item_state
+		var/r_state = r_hand.inhand_icon_state
 		if(!r_state)
 			r_state = r_hand.icon_state
 
@@ -47,7 +47,7 @@
 
 	if(l_hand)
 
-		var/l_state = l_hand.item_state
+		var/l_state = l_hand.inhand_icon_state
 		if(!l_state)
 			l_state = l_hand.icon_state
 

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -267,7 +267,7 @@
 	name = "queen bee"
 	desc = "She's the queen of bees, BZZ BZZ!"
 	icon_state = "queen_item"
-	item_state = ""
+	inhand_icon_state = ""
 	icon = 'icons/mob/bees.dmi'
 	var/mob/living/simple_animal/hostile/poison/bees/queen/queen
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -170,7 +170,7 @@ Difficulty: Medium
 	name = "staff of storms"
 	desc = "An ancient staff retrieved from the remains of Legion. The wind stirs as you move it."
 	icon_state = "staffofstorms"
-	item_state = "staffofstorms"
+	inhand_icon_state = "staffofstorms"
 	icon = 'icons/obj/guns/magic.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -286,7 +286,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	icon_state = "crevice_shard"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	item_state = "screwdriver_head"
+	inhand_icon_state = "screwdriver_head"
 	throwforce = 5
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -2,7 +2,7 @@
 	name = "energy katana"
 	desc = "A katana infused with strong energy. Right-click to dash."
 	icon_state = "energy_katana"
-	item_state = "energy_katana"
+	inhand_icon_state = "energy_katana"
 	worn_icon_state = "energy_katana"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'

--- a/code/modules/ninja/suit/gloves.dm
+++ b/code/modules/ninja/suit/gloves.dm
@@ -24,7 +24,7 @@
 	desc = "These nano-enhanced gloves insulate from electricity and provide fire resistance."
 	name = "ninja gloves"
 	icon_state = "s-ninja"
-	item_state = "s-ninja"
+	inhand_icon_state = "s-ninja"
 	siemens_coefficient = 0
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT

--- a/code/modules/ninja/suit/head.dm
+++ b/code/modules/ninja/suit/head.dm
@@ -2,7 +2,7 @@
 	desc = "What may appear to be a simple black garment is in fact a highly sophisticated nano-weave helmet. Standard issue ninja gear."
 	name = "ninja hood"
 	icon_state = "s-ninja"
-	item_state = "s-ninja_mask"
+	inhand_icon_state = "s-ninja_mask"
 	armor_type = /datum/armor/space_space_ninja
 	strip_delay = 12
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/modules/ninja/suit/mask.dm
+++ b/code/modules/ninja/suit/mask.dm
@@ -14,6 +14,6 @@ Contents:
 	name = "ninja mask"
 	desc = "A close-fitting mask that acts both as an air filter and a post-modern fashion statement."
 	icon_state = "s-ninja"
-	item_state = "s-ninja_mask"
+	inhand_icon_state = "s-ninja_mask"
 	strip_delay = 120
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/modules/ninja/suit/mask.dm
+++ b/code/modules/ninja/suit/mask.dm
@@ -14,6 +14,6 @@ Contents:
 	name = "ninja mask"
 	desc = "A close-fitting mask that acts both as an air filter and a post-modern fashion statement."
 	icon_state = "s-ninja"
-	inhand_icon_state = "s-ninja_mask"
+	inhand_icon_state = "sechailer"
 	strip_delay = 120
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -3,7 +3,7 @@
 	name = "ninja shoes"
 	desc = "A pair of running shoes. Excellent for running and even better for smashing skulls."
 	icon_state = "s-ninja"
-	item_state = "secshoes"
+	inhand_icon_state = "secshoes"
 	clothing_flags = NOSLIP
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	armor_type = /datum/armor/shoes_space_ninja

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -15,7 +15,7 @@ Contents:
 	name = "ninja suit"
 	desc = "A unique, vacuum-proof suit of nano-enhanced armor designed specifically for Spider Clan assassins."
 	icon_state = "s-ninja"
-	item_state = "s-ninja_suit"
+	inhand_icon_state = "s-ninja_suit"
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/stock_parts/cell)
 	slowdown = 1
 	resistance_flags = LAVA_PROOF | ACID_PROOF
@@ -188,7 +188,7 @@ Contents:
 /obj/item/clothing/suit/space/space_ninja/proc/lockIcons(mob/living/carbon/human/H)
 	icon_state = H.dna.features["body_model"] == FEMALE ? "s-ninjanf" : "s-ninjan"
 	H.gloves.icon_state = "s-ninjan"
-	H.gloves.item_state = "s-ninjan"
+	H.gloves.inhand_icon_state = "s-ninjan"
 
 
 //This proc allows the suit to be taken off.
@@ -204,7 +204,7 @@ Contents:
 		n_shoes.slowdown++
 	if(n_gloves)
 		n_gloves.icon_state = "s-ninja"
-		n_gloves.item_state = "s-ninja"
+		n_gloves.inhand_icon_state = "s-ninja"
 		REMOVE_TRAIT(n_gloves, TRAIT_NODROP, NINJA_SUIT_TRAIT)
 		n_gloves.candrain = FALSE
 		n_gloves.draining = FALSE

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -5,7 +5,7 @@
 	name = "clipboard"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "clipboard"
-	item_state = "clipboard"
+	inhand_icon_state = "clipboard"
 	worn_icon_state = "clipboard"
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -3,7 +3,7 @@
 	desc = "A combined label printer and applicator in a portable device, designed to be easy to operate and use."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
-	item_state = "flight"
+	inhand_icon_state = "flight"
 	w_class = WEIGHT_CLASS_TINY
 	var/label = null
 	var/labels_left = 30
@@ -117,7 +117,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	desc = "A roll of paper. Use it on a hand labeler to refill it."
 	icon_state = "labeler_refill"
-	item_state = "electropack"
+	inhand_icon_state = "electropack"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -3,7 +3,7 @@
 	desc = "A combined label printer and applicator in a portable device, designed to be easy to operate and use."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
-	inhand_icon_state = "flight"
+	inhand_icon_state = null
 	w_class = WEIGHT_CLASS_TINY
 	var/label = null
 	var/labels_left = 30

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -15,7 +15,7 @@
 	gender = NEUTER
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
-	item_state = "paper"
+	inhand_icon_state = "paper"
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	worn_icon_state = "paper"
 	custom_fire_overlay = "paper_onfire_overlay"

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -129,6 +129,6 @@
 	desc = "The blade of a paper cutter. Most likely removed for polishing or sharpening."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "cutterblade"
-	item_state = "knife"
+	inhand_icon_state = "knife"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -3,7 +3,7 @@
 	desc = "Contains all the paper you'll never need."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper_bin1"
-	item_state = "sheet-metal"
+	inhand_icon_state = "sheet-metal"
 	lefthand_file = 'icons/mob/inhands/misc/sheets_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/sheets_righthand.dmi'
 	throwforce = 0

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -16,7 +16,7 @@
 	name = "pen"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "pen"
-	item_state = "pen"
+	inhand_icon_state = "pen"
 	worn_icon_state = "pen"
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_EARS
 	throwforce = 0
@@ -265,14 +265,14 @@
 	if(active)
 		name = hidden_name
 		icon_state = "edagger"
-		item_state = "edagger"
+		inhand_icon_state = "edagger"
 		lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 		righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 		embedding = list(embed_chance = 100) // Rule of cool
 	else
 		name = initial(name)
 		icon_state = initial(icon_state)
-		item_state = initial(item_state)
+		inhand_icon_state = initial(inhand_icon_state)
 		lefthand_file = initial(lefthand_file)
 		righthand_file = initial(righthand_file)
 		embedding = list(embed_chance = EMBED_CHANCE)
@@ -325,4 +325,4 @@
 /obj/item/pen/screwdriver/update_icon_state()
 	. = ..()
 	icon_state = "[initial(icon_state)][HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE) ? "_out" : null]"
-	item_state = initial(item_state) //since transforming component switches the icon.
+	inhand_icon_state = initial(inhand_icon_state) //since transforming component switches the icon.

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -3,7 +3,7 @@
 	desc = "A rubber stamp for stamping important documents."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "stamp-ok"
-	item_state = "stamp"
+	inhand_icon_state = "stamp"
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	desc = "A polaroid camera."
 	icon_state = "camera"
-	item_state = "camera"
+	inhand_icon_state = "camera"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	light_system = MOVABLE_LIGHT //Used as a flash here.

--- a/code/modules/photography/camera/film.dm
+++ b/code/modules/photography/camera/film.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	desc = "A camera film cartridge. Insert it into a camera to reload it."
 	icon_state = "film"
-	item_state = "electropack"
+	inhand_icon_state = "electropack"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -5,7 +5,7 @@
 	name = "photo album"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "album"
-	item_state = "briefcase"
+	inhand_icon_state = "briefcase"
 	lefthand_file = 'icons/mob/inhands/equipment/case_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/case_righthand.dmi'
 	resistance_flags = FLAMMABLE

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -5,7 +5,7 @@
 	name = "photo"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "photo"
-	item_state = "paper"
+	inhand_icon_state = "paper"
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 50

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -1,15 +1,3 @@
-GLOBAL_LIST_INIT(cable_colors, list(
-	"yellow" = "#ffff00",
-	"green" = "#00aa00",
-	"blue" = "#1919c8",
-	"pink" = "#ff3cc8",
-	"orange" = "#ff8000",
-	"cyan" = "#00ffff",
-	"white" = "#ffffff",
-	"red" = "#ff0000"
-	))
-
-
 ///////////////////////////////
 //CABLE STRUCTURE
 ///////////////////////////////
@@ -43,6 +31,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT | ON_BLUEPRINTS
 	flags_1 = STAT_UNIQUE_1
+	color = CABLE_HEX_COLOR_RED
+	var/cable_color = CABLE_COLOR_RED
 	var/d1 = 0   // cable direction 1 (see above)
 	var/d2 = 1   // cable direction 2 (see above)
 	var/datum/powernet/powernet
@@ -53,36 +43,37 @@ By design, d1 is the smallest direction and d2 is the highest
 		pipe_group = "cable-[cable_color]"\
 	)
 
-	var/cable_color = "red"
-	color = "#ff0000"
-
 /obj/structure/cable/yellow
-	cable_color = "yellow"
-	color = "#ffff00"
+	color = CABLE_HEX_COLOR_YELLOW
+	cable_color = CABLE_COLOR_YELLOW
 
 /obj/structure/cable/green
-	cable_color = "green"
-	color = "#00aa00"
+	color = CABLE_HEX_COLOR_GREEN
+	cable_color = CABLE_COLOR_GREEN
 
 /obj/structure/cable/blue
-	cable_color = "blue"
-	color = "#1919c8"
+	color = CABLE_HEX_COLOR_BLUE
+	cable_color = CABLE_COLOR_BLUE
 
 /obj/structure/cable/pink
-	cable_color = "pink"
-	color = "#ff3cc8"
+	color = CABLE_HEX_COLOR_PINK
+	cable_color = CABLE_COLOR_YELLOW
 
 /obj/structure/cable/orange
-	cable_color = "orange"
-	color = "#ff8000"
+	color = CABLE_HEX_COLOR_ORANGE
+	cable_color = CABLE_COLOR_ORANGE
 
 /obj/structure/cable/cyan
-	cable_color = "cyan"
-	color = "#00ffff"
+	color = CABLE_HEX_COLOR_CYAN
+	cable_color = CABLE_COLOR_CYAN
 
 /obj/structure/cable/white
-	cable_color = "white"
-	color = "#ffffff"
+	color = CABLE_HEX_COLOR_WHITE
+	cable_color = CABLE_COLOR_WHITE
+
+/obj/structure/cable/brown
+	color = CABLE_HEX_COLOR_BROWN
+	cable_color = CABLE_COLOR_BROWN
 
 // the power cable object
 CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/cable)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -482,7 +482,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 	gender = NEUTER //That's a cable coil sounds better than that's some cable coils
 	icon = 'icons/obj/power.dmi'
 	icon_state = "coil"
-	item_state = "coil"
+	inhand_icon_state = "coil"
 	novariants = FALSE
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -544,7 +544,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stack/cable_coil)
 ///////////////////////////////////
 
 /obj/item/stack/cable_coil/update_icon()
-	icon_state = "[initial(item_state)][amount < 3 ? amount : ""]"
+	icon_state = "[initial(inhand_icon_state)][amount < 3 ? amount : ""]"
 	name = "cable [amount < 3 ? "piece" : "coil"]"
 	color = null
 	add_atom_colour(cable_color, FIXED_COLOUR_PRIORITY)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -3,7 +3,7 @@
 	desc = "A rechargeable electrochemical power cell."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "cell"
-	item_state = "cell"
+	inhand_icon_state = "cell"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	force = 5

--- a/code/modules/power/lighting/light_items.dm
+++ b/code/modules/power/lighting/light_items.dm
@@ -27,7 +27,7 @@
 	desc = "A replacement light tube."
 	icon_state = "ltube"
 	base_state = "ltube"
-	item_state = "c_tube"
+	inhand_icon_state = "c_tube"
 	brightness = 11
 
 /obj/item/light/tube/broken
@@ -38,7 +38,7 @@
 	desc = "A replacement light bulb."
 	icon_state = "lbulb"
 	base_state = "lbulb"
-	item_state = "contvapour"
+	inhand_icon_state = "contvapour"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	brightness = 6

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -181,7 +181,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/machinery/power/solar)
 	desc = "A solar panel assembly kit, allows constructions of a solar panel, or with a tracking circuit board, a solar tracker."
 	icon = 'goon/icons/obj/power.dmi'
 	icon_state = "sp_base"
-	item_state = "electropack"
+	inhand_icon_state = "electropack"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY // Pretty big!

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/ammo.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	item_state = "syringe_kit"
+	inhand_icon_state = "syringe_kit"
 	worn_icon_state = "ammobox"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -7,7 +7,7 @@
 	desc = "It's a gun. It's pretty terrible, though."
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "detective"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	worn_icon_state = "gun"
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -536,9 +536,9 @@
 		inhand_y_dimension = 32
 		w_class = WEIGHT_CLASS_LARGE
 		if (sawn_item_state)
-			item_state = sawn_item_state
+			inhand_icon_state = sawn_item_state
 		else
-			item_state = "gun"
+			inhand_icon_state = "gun"
 		worn_icon_state = "gun"
 		slot_flags &= ~ITEM_SLOT_BACK	//you can't sling it on your back
 		slot_flags |= ITEM_SLOT_BELT	//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -60,7 +60,7 @@
 	name = "\improper C-20r SMG"
 	desc = "A bullpup two-round burst .45 SMG, designated 'C-20r'. Has a 'Scarborough Arms - Per falcis, per pravitas' buttstamp."
 	icon_state = "c20r"
-	item_state = "c20r"
+	inhand_icon_state = "c20r"
 	mag_type = /obj/item/ammo_box/magazine/smgm45
 	fire_delay = 2
 	burst_size = 2
@@ -85,7 +85,7 @@
 	name = "security auto rifle"
 	desc = "An outdated personal defence weapon. Uses 4.6x30mm rounds and is designated the WT-550 Automatic Rifle."
 	icon_state = "wt550"
-	item_state = "arg"
+	inhand_icon_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	can_suppress = FALSE
 	actions_types = list()
@@ -117,7 +117,7 @@
 	name = "\improper M-90gl Carbine"
 	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher which can be fired using right click."
 	icon_state = "m90"
-	item_state = "m90"
+	inhand_icon_state = "m90"
 	mag_type = /obj/item/ammo_box/magazine/m556
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	can_suppress = FALSE
@@ -184,7 +184,7 @@
 	name = "\improper Thompson SMG"
 	desc = "Based on the classic 'Chicago Typewriter'."
 	icon_state = "tommygun"
-	item_state = "shotgun"
+	inhand_icon_state = "shotgun"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/tommygunm45
@@ -197,7 +197,7 @@
 	name = "\improper NT-ARG 'Boarder'"
 	desc = "A robust assault rifle used by Nanotrasen fighting forces."
 	icon_state = "arg"
-	item_state = "arg"
+	inhand_icon_state = "arg"
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/m556
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
@@ -211,7 +211,7 @@
 	name = "\improper L6 SAW"
 	desc = "A heavily modified 7.12x82mm light machine gun, designated 'L6 SAW'. Has 'Aussec Armoury - 2531' engraved on the receiver below the designation."
 	icon_state = "l6"
-	item_state = "l6closedmag"
+	inhand_icon_state = "l6closedmag"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = 0
 	mag_type = /obj/item/ammo_box/magazine/mm712x82
@@ -288,7 +288,7 @@
 	name = "Surplus Rifle"
 	desc = "One of countless obsolete ballistic rifles that still sees use as a cheap deterrent. Uses 10mm ammo and its bulky frame prevents one-hand firing."
 	icon_state = "surplus"
-	item_state = "moistnugget"
+	inhand_icon_state = "moistnugget"
 	worn_icon_state = null
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/m10mm/rifle
@@ -307,7 +307,7 @@
 	name = "pipe carbine"
 	desc = "A much more sophisticated improvised firearm, loaded from a removable magazine and automatically cycling cartridges. It's a shame it only takes 9mm ammo."
 	icon_state = "pipesmg"
-	item_state = "arg"
+	inhand_icon_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/pipem9mm
 	special_mags = TRUE
 	caliber = "9mm"
@@ -327,7 +327,7 @@
 	name = "laser rifle"
 	desc = "Though sometimes mocked for the relatively weak firepower of their energy weapons, the logistic miracle of rechargeable ammunition has given Nanotrasen a decisive edge over many a foe."
 	icon_state = "oldrifle"
-	item_state = "arg"
+	inhand_icon_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/recharge
 	can_suppress = FALSE
 	actions_types = list()

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -3,7 +3,7 @@
 	desc = "some sort of primitive projectile weapon. used to fire arrows."
 	icon_state = "bow"
 	icon_state_preview = "bow_unloaded"
-	item_state = "bow"
+	inhand_icon_state = "bow"
 	worn_icon_state = "baguette"
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY //need both hands to fire
@@ -59,7 +59,7 @@
 	name = "Bone Bow"
 	desc = "Some sort of primitive projectile weapon made of bone and wrapped sinew."
 	icon_state = "ashenbow"
-	item_state = "ashenbow"
+	inhand_icon_state = "ashenbow"
 	icon_state_preview = "ashenbow_unloaded"
 	force = 8
 
@@ -67,6 +67,6 @@
 	name = "Pipe Bow"
 	desc = "A crude projectile weapon made from silk string, pipe and lots of bending."
 	icon_state = "pipebow"
-	item_state = "pipebow"
+	inhand_icon_state = "pipebow"
 	icon_state_preview = "pipebow_unloaded"
 	force = 7

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -5,7 +5,7 @@
 	desc = "A break-operated grenade launcher."
 	name = "grenade launcher"
 	icon_state = "dshotgun_sawn"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	mag_type = /obj/item/ammo_box/magazine/internal/grenadelauncher
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
 	w_class = WEIGHT_CLASS_LARGE
@@ -48,7 +48,7 @@
 	name = "\improper PML-9"
 	desc = "A reusable rocket propelled grenade launcher. The words \"NT this way\" and an arrow have been written near the barrel."
 	icon_state = "rocketlauncher"
-	item_state = "rocketlauncher"
+	inhand_icon_state = "rocketlauncher"
 	mag_type = /obj/item/ammo_box/magazine/internal/rocketlauncher
 	fire_sound = 'sound/weapons/rocketlaunch.ogg'
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -34,7 +34,7 @@
 	desc = "An 'Infiltrator' double-barreled derringer, chambered in the powerful .357. Useful in a pinch but inadequate for longer engagements."
 	icon_state = "derringer"
 	w_class = WEIGHT_CLASS_SMALL
-	item_state = null //Too small to show in hand, unless examined
+	inhand_icon_state = null //Too small to show in hand, unless examined
 	throwforce = 0 //Derringers are light and tiny, no hurtie
 	mag_type = /obj/item/ammo_box/magazine/internal/der38
 	load_sound = 'sound/weapons/revolverload.ogg'
@@ -83,12 +83,12 @@
 /obj/item/gun/ballistic/automatic/pistol/deagle/gold
 	desc = "A gold plated Desert Eagle folded over a million times by superior martian gunsmiths. Uses .50 AE ammo."
 	icon_state = "deagleg"
-	item_state = "deagleg"
+	inhand_icon_state = "deagleg"
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/camo
 	desc = "A Deagle brand Deagle for operators operating operationally. Uses .50 AE ammo."
 	icon_state = "deaglecamo"
-	item_state = "deagleg"
+	inhand_icon_state = "deagleg"
 
 /obj/item/gun/ballistic/automatic/pistol/APS
 	name = "stechkin APS pistol"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -2,7 +2,7 @@
 	name = "Bolt Rifle"
 	desc = "Some kind of bolt action rifle. You get the feeling you shouldn't have this."
 	icon_state = "moistnugget"
-	item_state = "moistnugget"
+	inhand_icon_state = "moistnugget"
 	worn_icon_state = "moistnugget"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction
 	bolt_wording = "bolt"
@@ -36,7 +36,7 @@
 	name = "\improper Mosin Nagant"
 	desc = "This piece of junk looks like something that could have been used 700 years ago. It feels slightly moist."
 	icon_state = "moistnugget"
-	item_state = "moistnugget"
+	inhand_icon_state = "moistnugget"
 	can_sawoff = TRUE
 	sawn_name = "\improper Mosin Obrez"
 	sawn_desc = "A hand cannon of a rifle, try not to break your wrists."
@@ -76,7 +76,7 @@
 	fire_sound = 'sound/weapons/emitter.ogg'
 	pin = /obj/item/firing_pin/magic
 	icon_state = "arcane_barrage"
-	item_state = "arcane_barrage"
+	inhand_icon_state = "arcane_barrage"
 	slot_flags = null
 	can_bayonet = FALSE
 	item_flags = NEEDS_PERMIT | DROPDEL | ABSTRACT | NOBLUDGEON
@@ -121,7 +121,7 @@
 	icon_state = "leverrifle"
 	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/64x_guns_right.dmi'
-	item_state = "leveraction"
+	inhand_icon_state = "leveraction"
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	slot_flags = ITEM_SLOT_BACK
@@ -151,7 +151,7 @@
 	icon_state = "piperifle"
 	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/64x_guns_right.dmi'
-	item_state = "shotgun_improv"
+	inhand_icon_state = "shotgun_improv"
 	sawn_item_state = "shotgun_improv_shorty"
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -105,6 +105,9 @@
 	name = "cycler shotgun"
 	desc = "An advanced shotgun with two separate magazine tubes, allowing you to quickly toggle between ammo types."
 	icon_state = "cycler"
+	inhand_icon_state = "bulldog"
+	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	worn_icon_state = "cshotgun"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube
 	w_class = WEIGHT_CLASS_HUGE

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -5,7 +5,7 @@
 	worn_icon_state = null
 	lefthand_file = 'icons/mob/inhands/weapons/64x_guns_left.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/64x_guns_right.dmi'
-	item_state = "shotgun"
+	inhand_icon_state = "shotgun"
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	fire_sound = "sound/weapons/shotgunshot.ogg"
@@ -41,7 +41,7 @@
 	name = "riot shotgun"
 	desc = "A sturdy shotgun with a longer magazine and a fixed tactical stock designed for non-lethal riot control."
 	icon_state = "riotshotgun"
-	item_state = "shotgun"
+	inhand_icon_state = "shotgun"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	can_sawoff = TRUE
 	sawn_desc = "Come with me if you want to live."
@@ -57,7 +57,7 @@
 	name = "combat shotgun"
 	desc = "A semi automatic shotgun with tactical furniture and a six-shell capacity underneath."
 	icon_state = "cshotgun"
-	item_state = "shotgun_combat"
+	inhand_icon_state = "shotgun_combat"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
 
@@ -149,7 +149,7 @@
 	name = "\improper Bulldog Shotgun"
 	desc = "A semi-auto, mag-fed shotgun for combat in narrow corridors with a built in recoil dampening system, nicknamed 'Bulldog' by boarding parties. Compatible only with specialized 8-round drum magazines."
 	icon_state = "bulldog"
-	item_state = "bulldog"
+	inhand_icon_state = "bulldog"
 	worn_icon_state = "cshotgun"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
@@ -184,7 +184,7 @@
 	name = "double-barreled shotgun"
 	desc = "A true classic."
 	icon_state = "dshotgun"
-	item_state = "shotgun_db"
+	inhand_icon_state = "shotgun_db"
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 	force = 10
@@ -234,7 +234,7 @@
 	name = "improvised shotgun"
 	desc = "Essentially a tube that aims shotgun shells."
 	icon_state = "ishotgun"
-	item_state = "shotgun_improv"
+	inhand_icon_state = "shotgun_improv"
 	sawn_item_state = "shotgun_improv_shorty"
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
@@ -327,7 +327,7 @@
 	name = "sawn-off improvised shotgun"
 	desc = "A single-shot shotgun. Better not miss."
 	icon_state = "ishotgun"
-	item_state = "shotgun_improv_shorty"
+	inhand_icon_state = "shotgun_improv_shorty"
 	worn_icon_state = "gun"
 	w_class = WEIGHT_CLASS_LARGE
 	sawn_off = TRUE
@@ -338,7 +338,7 @@
 	name = "hook modified sawn-off shotgun"
 	desc = "Range isn't an issue when you can bring your victim to you."
 	icon_state = "hookshotgun"
-	item_state = "shotgun"
+	inhand_icon_state = "shotgun"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	inhand_x_dimension = 32
@@ -376,7 +376,7 @@
 	w_class = WEIGHT_CLASS_LARGE
 	dual_wield_spread = 0
 	fire_sound_volume = 60    //tried on 90 my eardrums said goodbye
-	item_state = "leveraction"
+	inhand_icon_state = "leveraction"
 	icon_state = "leveraction"
 	worn_icon_state = "shotgun"
 	rack_sound = "sound/weapons/leveractionrack.ogg"

--- a/code/modules/projectiles/guns/ballistic/sniper.dm
+++ b/code/modules/projectiles/guns/ballistic/sniper.dm
@@ -4,7 +4,7 @@
 	name = "sniper rifle"
 	desc = "A long ranged weapon that does significant damage. No, you can't quickscope."
 	icon_state = "sniper"
-	item_state = "sniper"
+	inhand_icon_state = "sniper"
 	worn_icon_state = "sniper"
 	fire_sound = "sound/weapons/sniper_shot.ogg"
 	fire_sound_volume = 90

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -2,7 +2,7 @@
 	name = "foam force SMG"
 	desc = "A prototype three-round burst toy submachine gun. Ages 8 and up."
 	icon_state = "saber"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	mag_type = /obj/item/ammo_box/magazine/toy/smg
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	force = 0
@@ -82,7 +82,7 @@
 	desc = "A weapon favored by many overactive children. Ages 8 and up."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "foamcrossbow"
-	item_state = "crossbow"
+	inhand_icon_state = "crossbow"
 	worn_icon_state = "gun"
 	worn_icon = null
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy/crossbow

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -83,6 +83,8 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "foamcrossbow"
 	inhand_icon_state = "crossbow"
+	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	worn_icon_state = "gun"
 	worn_icon = null
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy/crossbow

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -192,7 +192,7 @@
 	update_appearance()
 
 /obj/item/gun/energy/update_icon_state()
-	var/skip_inhand = initial(item_state) //only build if we aren't using a preset inhand icon
+	var/skip_inhand = initial(inhand_icon_state) //only build if we aren't using a preset inhand icon
 	var/skip_worn_icon = initial(worn_icon_state) //only build if we aren't using a preset worn icon
 
 	if(skip_inhand && skip_worn_icon) //if we don't have either, don't do the math.
@@ -211,7 +211,7 @@
 
 	temp_icon_to_use += "[ratio]"
 	if(!skip_inhand)
-		item_state = temp_icon_to_use
+		inhand_icon_state = temp_icon_to_use
 	if(!skip_worn_icon)
 		worn_icon_state = temp_icon_to_use
 	return ..()

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -132,7 +132,7 @@
 	name = "dueling pistol"
 	desc = "High-tech dueling pistol. Launches chaff and projectile according to preset settings."
 	icon_state = "dueling_pistol"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	ammo_x_offset = 2
 	w_class = WEIGHT_CLASS_SMALL
 	ammo_type = list(/obj/item/ammo_casing/energy/duel)
@@ -301,7 +301,7 @@
 	name = "dueling pistol case"
 	desc = "Let's solve this like gentlespacemen."
 	icon_state = "medalbox+l"
-	item_state = "medalbox+l"
+	inhand_icon_state = "medalbox+l"
 	base_icon_state = "medalbox"
 	w_class = WEIGHT_CLASS_LARGE
 	req_access = list(ACCESS_CAPTAIN)

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -3,7 +3,7 @@
 	desc = "A basic hybrid energy gun with two settings: disable and kill."
 	icon_state = "energy"
 	w_class = WEIGHT_CLASS_BULKY	//powergaming is kill
-	item_state = null	//so the human update icon uses the icon_state instead.
+	inhand_icon_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
 	modifystate = 1
 	ammo_x_offset = 3
@@ -21,7 +21,7 @@
 	name = "miniature energy gun"
 	desc = "A small, pistol-sized energy gun with a built-in flashlight. It has two settings: disable and kill."
 	icon_state = "mini"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	w_class = WEIGHT_CLASS_SMALL
 	gun_charge = 600
 	ammo_x_offset = 2
@@ -85,7 +85,7 @@
 	name = "\improper DRAGnet"
 	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology."
 	icon_state = "dragnet"
-	item_state = "dragnet"
+	inhand_icon_state = "dragnet"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
@@ -105,7 +105,7 @@
 	name = "hybrid turret gun"
 	desc = "A heavy hybrid energy cannon with two settings: Stun and kill."
 	icon_state = "turretlaser"
-	item_state = "turretlaser"
+	inhand_icon_state = "turretlaser"
 	slot_flags = null
 	w_class = WEIGHT_CLASS_HUGE
 	gun_charge = 10000
@@ -123,7 +123,7 @@
 	name = "advanced energy gun"
 	desc = "An energy gun with an experimental miniaturized nuclear reactor that automatically charges the internal power cell."
 	icon_state = "nucgun"
-	item_state = "nucgun"
+	inhand_icon_state = "nucgun"
 	charge_delay = 10
 	pin = null
 	can_charge = FALSE

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -2,7 +2,7 @@
 	name = "proto-kinetic accelerator"
 	desc = "A self recharging, ranged mining tool that does increased damage in low pressure."
 	icon_state = "kineticgun"
-	item_state = "kineticgun"
+	inhand_icon_state = "kineticgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)
 	item_flags = NONE
 	obj_flags = UNIQUE_RENAME

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -2,7 +2,7 @@
 	name = "laser gun"
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
-	item_state = "laser"
+	inhand_icon_state = "laser"
 	w_class = WEIGHT_CLASS_BULKY
 	custom_materials = list(/datum/material/iron=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
@@ -33,7 +33,7 @@
 /obj/item/gun/energy/laser/repeater
 	name = "NT LRR Model 2284"
 	icon_state = "repeater"
-	item_state = null
+	inhand_icon_state = null
 	desc = "An experimental laser repeater rifle that uses a built-in bluespace dynamo to recharge its battery, crank it and fire!"
 	gun_charge = 200
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/repeater)
@@ -71,7 +71,7 @@
 /obj/item/gun/energy/laser/captain
 	name = "antique laser gun"
 	icon_state = "caplaser"
-	item_state = "caplaser"
+	inhand_icon_state = "caplaser"
 	w_class = WEIGHT_CLASS_LARGE
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13 with the words NTSSGolden engraved. The station is exploding."
 	force = 10
@@ -93,7 +93,7 @@
 /obj/item/gun/energy/laser/captain/scattershot
 	name = "scatter shot laser rifle"
 	icon_state = "lasercannon"
-	item_state = "laser"
+	inhand_icon_state = "laser"
 	desc = "An industrial-grade heavy-duty laser rifle with a modified laser lens to scatter its shot into multiple smaller lasers. The inner-core can self-charge for theoretically infinite use."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
 	shaded_charge = FALSE
@@ -119,7 +119,7 @@
 	name = "energy shotgun"
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "cshotgun"
-	item_state = "shotgun"
+	inhand_icon_state = "shotgun"
 	desc = "A combat shotgun gutted and refitted with an internal laser system. Can switch between taser and scattered disabler shots."
 	shaded_charge = FALSE
 	pin = /obj/item/firing_pin/implant/mindshield
@@ -132,7 +132,7 @@
 	name = "accelerator laser cannon"
 	desc = "An advanced laser cannon that does more damage the farther away the target is."
 	icon_state = "lasercannon"
-	item_state = "laser"
+	inhand_icon_state = "laser"
 	worn_icon_state = null
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
@@ -162,7 +162,7 @@
 	name = "\improper X-ray laser gun"
 	desc = "A high-power laser gun capable of expelling concentrated X-ray blasts that pass through multiple soft targets and heavier materials."
 	icon_state = "xray"
-	item_state = null
+	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
 	pin = null
 	ammo_x_offset = 3

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -6,7 +6,7 @@
 	desc = "The massive external power source for the laser gatling gun."
 	icon = 'icons/obj/guns/minigun.dmi'
 	icon_state = "holstered"
-	item_state = "backpack"
+	inhand_icon_state = "backpack"
 	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
@@ -97,7 +97,7 @@
 	desc = "An advanced laser cannon with an incredible rate of fire. Requires a bulky backpack power source to use."
 	icon = 'icons/obj/guns/minigun.dmi'
 	icon_state = "minigun_spin"
-	item_state = "minigun"
+	inhand_icon_state = "minigun"
 	flags_1 = CONDUCT_1
 	slowdown = 1
 	slot_flags = null

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -3,7 +3,7 @@
 	desc = "An arm mounted dual-mode weapon that fires electrodes and disabler shots."
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "taser"
-	item_state = "armcannonstun4"
+	inhand_icon_state = "armcannonstun4"
 	display_empty = FALSE
 	force = 5
 	selfcharge = 1
@@ -17,7 +17,7 @@
 	desc = "An arm mounted cannon that fires lethal lasers."
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "laser_cyborg"
-	item_state = "armcannonlase"
+	inhand_icon_state = "armcannonlase"
 	force = 5
 	selfcharge = 1
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -2,7 +2,7 @@
 	name = "pulse rifle"
 	desc = "A heavy-duty, multifaceted energy rifle with three modes. Preferred by front-line combat personnel."
 	icon_state = "pulse"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon_state = null
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
@@ -37,7 +37,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	icon_state = "pulse_carbine"
 	worn_icon_state = "gun"
-	item_state = null
+	inhand_icon_state = null
 	cell_type = "/obj/item/stock_parts/cell/pulse/carbine"
 
 /obj/item/gun/energy/pulse/carbine/add_seclight_point()
@@ -56,7 +56,7 @@
 	w_class = WEIGHT_CLASS_LARGE
 	slot_flags = ITEM_SLOT_BELT
 	icon_state = "pulse_carbine"
-	item_state = null
+	inhand_icon_state = null
 	cell_type = "/obj/item/stock_parts/cell/pulse/carbine"
 
 //Handling seclights would be weird/why would borgs need seclights.
@@ -71,7 +71,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	icon_state = "pulse_pistol"
 	worn_icon_state = "gun"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	cell_type = "/obj/item/stock_parts/cell/pulse/pistol"
 	automatic = 0
 	fire_rate = 1.5
@@ -94,5 +94,5 @@
 	name = "\improper M1911-P"
 	desc = "A compact pulse core in a classic handgun frame for Nanotrasen officers. It's not the size of the gun, it's the size of the hole it puts through people."
 	icon_state = "m1911"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	cell_type = "/obj/item/stock_parts/cell/infinite"

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -102,7 +102,7 @@
 	desc = "A weapon favored by syndicate stealth specialists."
 	icon_state = "crossbow"
 	base_icon_state = "crossbow"
-	item_state = "crossbow"
+	inhand_icon_state = "crossbow"
 	no_charge_state = "crossbow_empty"
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=2000)
@@ -139,7 +139,7 @@
 	name = "gamma bow"
 	desc = "A weapon favored by Madmen."
 	icon_state = "crossbow"
-	item_state = "crossbow"
+	inhand_icon_state = "crossbow"
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/radbolt)
 	recharge_time = 250
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -2,7 +2,7 @@
 	name = "ion rifle"
 	desc = "A man-portable anti-armor weapon designed to disable mechanical threats at range."
 	icon_state = "ionrifle"
-	item_state = null //so the human update icon uses the icon_state instead.
+	inhand_icon_state = null //so the human update icon uses the icon_state instead.
 	worn_icon_state = null
 	w_class = WEIGHT_CLASS_HUGE
 	flags_1 =  CONDUCT_1
@@ -65,7 +65,7 @@
 	name = "floral somatoray"
 	desc = "A tool that discharges controlled radiation which induces mutation in plant cells."
 	icon_state = "flora"
-	item_state = "gun"
+	inhand_icon_state = "gun"
 	ammo_type = list(/obj/item/ammo_casing/energy/flora/yield, /obj/item/ammo_casing/energy/flora/mut)
 	modifystate = 1
 	ammo_x_offset = 1
@@ -75,7 +75,7 @@
 	name = "meteor gun"
 	desc = "For the love of god, make sure you're aiming this the right way!"
 	icon_state = "meteor_gun"
-	item_state = "c20r"
+	inhand_icon_state = "c20r"
 	w_class = WEIGHT_CLASS_BULKY
 	ammo_type = list(/obj/item/ammo_casing/energy/meteor)
 	cell_type = "/obj/item/stock_parts/cell/potato"
@@ -88,7 +88,7 @@
 	desc = "The pen is mightier than the sword."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "pen"
-	item_state = "pen"
+	inhand_icon_state = "pen"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
@@ -98,7 +98,7 @@
 	name = "\improper Mind Flayer"
 	desc = "A prototype weapon recovered from the ruins of Research-Station Epsilon."
 	icon_state = "xray"
-	item_state = null
+	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/mindflayer)
 	ammo_x_offset = 2
 
@@ -106,7 +106,7 @@
 	name = "plasma cutter"
 	desc = "A mining tool capable of expelling concentrated plasma bursts. You could use it to cut limbs off xenos! Or, you know, mine stuff."
 	icon_state = "plasmacutter"
-	item_state = "plasmacutter"
+	inhand_icon_state = "plasmacutter"
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
 	flags_1 = CONDUCT_1
 	attack_verb_continuous = list("attacks", "slashes", "cuts", "slices")
@@ -207,7 +207,7 @@
 /obj/item/gun/energy/plasmacutter/adv
 	name = "advanced plasma cutter"
 	icon_state = "adv_plasmacutter"
-	item_state = "adv_plasmacutter"
+	inhand_icon_state = "adv_plasmacutter"
 	force = 15
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv)
 
@@ -225,7 +225,7 @@
 	name = "bluespace wormhole projector"
 	desc = "A projector that emits high density quantum-coupled bluespace beams."
 	ammo_type = list(/obj/item/ammo_casing/energy/wormhole, /obj/item/ammo_casing/energy/wormhole/orange)
-	item_state = null
+	inhand_icon_state = null
 	icon_state = "wormhole_projector"
 	automatic_charge_overlays = FALSE
 	var/obj/effect/portal/p_blue
@@ -234,7 +234,7 @@
 
 /obj/item/gun/energy/wormhole_projector/update_icon()
 	icon_state = "[initial(icon_state)][select]"
-	item_state = icon_state
+	inhand_icon_state = icon_state
 
 /obj/item/gun/energy/wormhole_projector/update_ammo_types()
 	. = ..()
@@ -332,7 +332,7 @@
 /obj/item/gun/energy/laser/instakill
 	name = "instakill rifle"
 	icon_state = "instagib"
-	item_state = "instagib"
+	inhand_icon_state = "instagib"
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit."
 	ammo_type = list(/obj/item/ammo_casing/energy/instakill)
 	force = 60
@@ -343,13 +343,13 @@
 /obj/item/gun/energy/laser/instakill/red
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a red design."
 	icon_state = "instagibred"
-	item_state = "instagibred"
+	inhand_icon_state = "instagibred"
 	ammo_type = list(/obj/item/ammo_casing/energy/instakill/red)
 
 /obj/item/gun/energy/laser/instakill/blue
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a blue design."
 	icon_state = "instagibblue"
-	item_state = "instagibblue"
+	inhand_icon_state = "instagibblue"
 	ammo_type = list(/obj/item/ammo_casing/energy/instakill/blue)
 
 /obj/item/gun/energy/laser/instakill/emp_act() //implying you could stop the instagib
@@ -359,7 +359,7 @@
 	name = "one-point bluespace-gravitational manipulator"
 	desc = "An experimental, multi-mode device that fires bolts of Zero-Point Energy, causing local distortions in gravity."
 	ammo_type = list(/obj/item/ammo_casing/energy/gravity/repulse, /obj/item/ammo_casing/energy/gravity/attract, /obj/item/ammo_casing/energy/gravity/chaos)
-	item_state = "gravity_gun"
+	inhand_icon_state = "gravity_gun"
 	icon_state = "gravity_gun"
 	automatic_charge_overlays = FALSE
 	var/power = 4

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -2,7 +2,7 @@
 	name = "taser gun"
 	desc = "A low-capacity, energy-based stun gun used by security teams to subdue targets at range."
 	icon_state = "taser"
-	item_state = null	//so the human update icon uses the icon_state instead.
+	inhand_icon_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 3
 
@@ -10,7 +10,7 @@
 	name = "tesla gun"
 	desc = "An experimental gun based on an experimental engine, it's about as likely to kill its operator as it is the target."
 	icon_state = "tesla"
-	item_state = "tesla"
+	inhand_icon_state = "tesla"
 	ammo_type = list(/obj/item/ammo_casing/energy/tesla_revolver)
 	pin = null
 	shaded_charge = TRUE
@@ -48,7 +48,7 @@
 	name = "disabler"
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
 	icon_state = "disabler"
-	item_state = null
+	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 2
 

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -3,7 +3,7 @@
 	desc = "This staff is boring to watch because even though it came first you've seen everything it can do in other staves for years."
 	icon = 'icons/obj/guns/magic.dmi'
 	icon_state = "staffofnothing"
-	item_state = "staff"
+	inhand_icon_state = "staff"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	fire_sound = 'sound/weapons/emitter.ogg'

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -16,7 +16,7 @@
 	fire_sound = 'sound/magic/staff_change.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/change
 	icon_state = "staffofchange"
-	item_state = "staffofchange"
+	inhand_icon_state = "staffofchange"
 
 /obj/item/gun/magic/staff/animate
 	name = "staff of animation"
@@ -24,7 +24,7 @@
 	fire_sound = 'sound/magic/staff_animation.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/animate
 	icon_state = "staffofanimation"
-	item_state = "staffofanimation"
+	inhand_icon_state = "staffofanimation"
 
 /obj/item/gun/magic/staff/healing
 	name = "staff of healing"
@@ -32,7 +32,7 @@
 	fire_sound = 'sound/magic/staff_healing.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/heal
 	icon_state = "staffofhealing"
-	item_state = "staffofhealing"
+	inhand_icon_state = "staffofhealing"
 
 /obj/item/gun/magic/staff/healing/handle_suicide() //Stops people trying to commit suicide to heal themselves
 	return
@@ -43,7 +43,7 @@
 	fire_sound = 'sound/magic/staff_chaos.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/chaos
 	icon_state = "staffofchaos"
-	item_state = "staffofchaos"
+	inhand_icon_state = "staffofchaos"
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
@@ -79,7 +79,7 @@
 	fire_sound = 'sound/magic/staff_door.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/door
 	icon_state = "staffofdoor"
-	item_state = "staffofdoor"
+	inhand_icon_state = "staffofdoor"
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
@@ -90,7 +90,7 @@
 	fire_sound = 'sound/items/airhorn.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/honk
 	icon_state = "honker"
-	item_state = "honker"
+	inhand_icon_state = "honker"
 	max_charges = 4
 	recharge_rate = 8
 
@@ -100,7 +100,7 @@
 	fire_sound = 'sound/magic/fireball.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/spellblade
 	icon_state = "spellblade"
-	item_state = "spellblade"
+	inhand_icon_state = "spellblade"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	hitsound = 'sound/weapons/rapierhit.ogg'
@@ -126,7 +126,7 @@
 	fire_sound = 'sound/magic/staff_change.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/locker
 	icon_state = "locker"
-	item_state = "locker"
+	inhand_icon_state = "locker"
 	worn_icon_state = "lockerstaff"
 	max_charges = 6
 	recharge_rate = 4
@@ -139,7 +139,7 @@
 	fire_sound = 'sound/magic/staff_healing.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/flying
 	icon_state = "staffofflight"
-	item_state = "staffofflight"
+	inhand_icon_state = "staffofflight"
 	worn_icon_state = "flightstaff"
 
 /obj/item/gun/magic/staff/sapping
@@ -148,7 +148,7 @@
 	fire_sound = 'sound/magic/staff_change.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/sapping
 	icon_state = "staffofsapping"
-	item_state = "staffofsapping"
+	inhand_icon_state = "staffofsapping"
 	worn_icon_state = "staff"
 
 /obj/item/gun/magic/staff/necropotence
@@ -157,7 +157,7 @@
 	fire_sound = 'sound/magic/staff_change.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/necropotence
 	icon_state = "staffofnecropotence"
-	item_state = "staffofnecropotence"
+	inhand_icon_state = "staffofnecropotence"
 	worn_icon_state = "necrostaff"
 
 /obj/item/gun/magic/staff/wipe
@@ -166,5 +166,5 @@
 	fire_sound = 'sound/magic/staff_change.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/wipe
 	icon_state = "staffofwipe"
-	item_state = "staffofwipe"
+	inhand_icon_state = "staffofwipe"
 	worn_icon_state = "wipestaff"

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -3,7 +3,7 @@
 	desc = "It's not just a stick, it's a MAGIC stick!"
 	ammo_type = /obj/item/ammo_casing/magic
 	icon_state = "nothingwand"
-	item_state = "wand"
+	inhand_icon_state = "wand"
 	w_class = WEIGHT_CLASS_SMALL
 	weapon_weight = WEAPON_LIGHT
 	can_charge = FALSE

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -4,6 +4,8 @@
 	ammo_type = /obj/item/ammo_casing/magic
 	icon_state = "nothingwand"
 	inhand_icon_state = "wand"
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	weapon_weight = WEAPON_LIGHT
 	can_charge = FALSE

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -13,7 +13,7 @@
 	desc = "An energy-based anti material marksman rifle that uses highly charged particle beams moving at extreme velocities to decimate whatever is unfortunate enough to be targeted by one." + span_boldnotice("Hold down left click while scoped to aim, when weapon is fully aimed (Tracer goes from red to green as it charges), release to fire. Moving while aiming or changing where you're pointing at while aiming will delay the aiming process depending on how much you changed.")
 	icon = 'icons/obj/guns/energy.dmi'
 	icon_state = "esniper"
-	item_state = null
+	inhand_icon_state = null
 	worn_icon_state = null
 	fire_sound = 'sound/weapons/beam_sniper.ogg'
 	slot_flags = ITEM_SLOT_BACK

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -3,7 +3,7 @@
 	desc = "A pipe welded onto a gun stock, with a mechanical trigger. The pipe has an opening near the top, and there seems to be a spring loaded wheel in the hole."
 	icon_state = "empty_blastcannon"
 	var/icon_state_loaded = "loaded_blastcannon"
-	item_state = "blastcannon_empty"
+	inhand_icon_state = "blastcannon_empty"
 	w_class = WEIGHT_CLASS_LARGE
 	force = 10
 	fire_sound = 'sound/weapons/blastcannon.ogg'

--- a/code/modules/projectiles/guns/misc/chem_gun.dm
+++ b/code/modules/projectiles/guns/misc/chem_gun.dm
@@ -4,7 +4,7 @@
 	name = "reagent gun"
 	desc = "A Nanotrasen syringe gun, modified to automatically synthesise chemical darts, and instead hold reagents."
 	icon_state = "chemgun"
-	item_state = "chemgun"
+	inhand_icon_state = "chemgun"
 	w_class = WEIGHT_CLASS_LARGE
 	throw_speed = 3
 	throw_range = 7
@@ -51,7 +51,7 @@
 	name = "bee gun"
 	desc = "An odd piece of BLF tech, which fires bees filled with whatever reagents may be in the gun's reservoir, or venom if there are none."
 	icon_state = "beegun"
-	item_state = "chemgun"
+	inhand_icon_state = "chemgun"
 	fire_sound = 'sound/creatures/bee.ogg'
 	automatic = 1
 	fire_rate = 5

--- a/code/modules/projectiles/guns/misc/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/misc/grenade_launcher.dm
@@ -3,7 +3,7 @@
 	desc = "A terrible, terrible thing. It's really awful!"
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "riotgun"
-	item_state = "riotgun"
+	inhand_icon_state = "riotgun"
 	w_class = WEIGHT_CLASS_BULKY
 	throw_speed = 2
 	throw_range = 7

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -3,7 +3,7 @@
 	desc = "Don't cross the streams!"
 	icon = 'icons/obj/chronos.dmi'
 	icon_state = "chronogun"
-	item_state = "chronogun"
+	inhand_icon_state = "chronogun"
 	w_class = WEIGHT_CLASS_NORMAL
 	requires_wielding = FALSE
 	equip_time = 0

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -2,7 +2,7 @@
 	name = "syringe gun"
 	desc = "A spring loaded rifle designed to fit syringes, used to incapacitate unruly patients from a distance."
 	icon_state = "syringegun"
-	item_state = "syringegun"
+	inhand_icon_state = "syringegun"
 	w_class = WEIGHT_CLASS_LARGE
 	throw_speed = 3
 	throw_range = 7
@@ -93,7 +93,7 @@
 	name = "dart pistol"
 	desc = "A small spring-loaded sidearm that functions identically to a syringe gun."
 	icon_state = "syringe_pistol"
-	item_state = "gun" //Smaller inhand
+	inhand_icon_state = "gun" //Smaller inhand
 	w_class = WEIGHT_CLASS_SMALL
 	force = 2 //Also very weak because it's smaller
 	suppressed = TRUE //Softer fire sound
@@ -131,7 +131,7 @@
 	desc = "Fire syringes at a short distance."
 	icon_state = "blowgun"
 	has_syringe_overlay = FALSE
-	item_state = "blowgun"
+	inhand_icon_state = "blowgun"
 	fire_sound = 'sound/items/syringeproj.ogg'
 	no_pin_required = TRUE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -3,7 +3,7 @@
 	desc = "A small authentication device, to be inserted into a firearm receiver to allow operation. NT safety regulations require all new designs to incorporate one."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "firing_pin"
-	item_state = "pen"
+	inhand_icon_state = "pen"
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb_continuous = list("pokes")

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -561,8 +561,8 @@
   * 		?"generate_name" = <if truthy, autogenerates default name from reagents instead of using "name">,
   * 		?"icon_empty" = <icon_state when empty>,
   * 		?"fill_icon_thresholds" = <list of thresholds for reagentfillings, no tresholds if not provided or falsy>,
-  * 		?"item_state" = <inhand icon_state, falsy - no icon, not provided - whatever is initial (currently "beer")>,
-  * 		?"lefthand_file" = <file for inhand icon for left hand, ignored if "item_state" not provided>,
+  * 		?"inhand_icon_state" = <inhand icon_state, falsy - no icon, not provided - whatever is initial (currently "beer")>,
+  * 		?"lefthand_file" = <file for inhand icon for left hand, ignored if "inhand_icon_state" not provided>,
   * 		?"righthand_file" = <same as "lefthand_file" but for right hand>,
   * 	),
   * 	..
@@ -584,11 +584,11 @@
 			"frostoil" = list("icon_state" = "coldsauce", "icon_empty" = "", "name" = "coldsauce bottle", "desc" = "Leaves the tongue numb from its passage."),
 			"mayonnaise" = list("icon_state" = "mayonnaise", "icon_empty" = "", "name" = "mayonnaise bottle", "desc" = "An oily condiment made from egg yolks."),
 			"ketchup" = list("icon_state" = "ketchup", "icon_empty" = "", "name" = "ketchup bottle", "desc" = "A tomato slurry in a tall plastic bottle. Somehow still vaguely American."),
-			"blackpepper" = list("icon_state" = "peppermillsmall", "item_state" = "", "icon_empty" = "emptyshaker", "name" = "pepper mill", "desc" = "Often used to flavor food or make people sneeze."),
-			"sodiumchloride" = list("icon_state" = "saltshakersmall", "item_state" = "", "icon_empty" = "emptyshaker", "name" = "salt shaker", "desc" = "Salt. From dead crew, presumably."),
+			"blackpepper" = list("icon_state" = "peppermillsmall", "inhand_icon_state" = "", "icon_empty" = "emptyshaker", "name" = "pepper mill", "desc" = "Often used to flavor food or make people sneeze."),
+			"sodiumchloride" = list("icon_state" = "saltshakersmall", "inhand_icon_state" = "", "icon_empty" = "emptyshaker", "name" = "salt shaker", "desc" = "Salt. From dead crew, presumably."),
 			"milk" = list("icon_state" = "milk", "icon_empty" = "", "name" = "space milk", "desc" = "It's milk. White and nutritious goodness!"),
 			"soymilk" = list("icon_state" = "soymilk", "icon_empty" = "", "name" = "soy milk", "desc" = "It's soy milk. White and nutritious goodness!"),
-			"soysauce" = list("icon_state" = "soysauce", "item_state" = "", "icon_empty" = "", "name" = "soy sauce bottle", "desc" = "A salty soy-based flavoring."),
+			"soysauce" = list("icon_state" = "soysauce", "inhand_icon_state" = "", "icon_empty" = "", "name" = "soy sauce bottle", "desc" = "A salty soy-based flavoring."),
 			"bbqsauce" = list("icon_state" = "bbqsauce", "icon_empty" = "", "name" = "bbq sauce bottle", "desc" = "Hand wipes not included."),
 			"oliveoil" = list("icon_state" = "oliveoil", "icon_empty" = "", "name" = "olive oil bottle", "desc" = "A delicious oil made from olives."),
 			"cooking_oil" = list("icon_state" = "cooking_oil", "icon_empty" = "", "name" = "cooking oil bottle", "desc" = "A cooking oil for deep frying."),
@@ -597,7 +597,7 @@
 			"honey" = list("icon_state" = "honey", "icon_empty" = "", "name" = "honey bottle", "desc" = "A cheerful bear-shaped bottle of tasty honey."),
 		)
 		var/list/carton_in_hand = list(
-			"item_state" = "carton",
+			"inhand_icon_state" = "carton",
 			"lefthand_file" = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi',
 			"righthand_file" = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 		)
@@ -644,8 +644,8 @@
 	container.icon_state = style["icon_state"]
 	container.icon_empty = style["icon_empty"]
 	container.fill_icon_thresholds = style["fill_icon_thresholds"]
-	if ("item_state" in style)
-		container.item_state = style["item_state"]
+	if ("inhand_icon_state" in style)
+		container.inhand_icon_state = style["inhand_icon_state"]
 		if (style["lefthand_file"] || style["righthand_file"])
 			container.lefthand_file = style["lefthand_file"]
 			container.righthand_file = style["righthand_file"]

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -12,7 +12,7 @@ Borg Hypospray
 	name = "cyborg hypospray"
 	desc = "An advanced chemical synthesizer and injection system, designed for heavy-duty medical equipment."
 	icon = 'icons/obj/syringe.dmi'
-	item_state = "hypo"
+	inhand_icon_state = "hypo"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	icon_state = "borghypo"

--- a/code/modules/reagents/reagent_containers/chem_heirloom.dm
+++ b/code/modules/reagents/reagent_containers/chem_heirloom.dm
@@ -7,7 +7,7 @@
 	reagent_flags = NONE
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "hard_locked_closed"
-	item_state = "hard_locked_closed"
+	inhand_icon_state = "hard_locked_closed"
 	var/locked = TRUE
 	var/datum/reagent/rand_cont //Reagent of choice
 	var/datum/callback/roundend_callback
@@ -48,7 +48,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/reagent_containers/cup/chem_heirloom)
 	desc = "An opened bottle of [initial(rand_cont.name)]."
 	name = "bottle of [initial(rand_cont.name)]"
 	volume = CHEM_H_VOL
-	item_state = "hard_locked_open"
+	inhand_icon_state = "hard_locked_open"
 	icon_state = "hard_locked_open"
 	locked = FALSE
 	spillable = TRUE

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -10,7 +10,7 @@
 	desc = "Just your average condiment bottle."
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "bottle"
-	item_state = "beer" //Generic held-item sprite until unique ones are made.
+	inhand_icon_state = "beer" //Generic held-item sprite until unique ones are made.
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	reagent_flags = OPENCONTAINER
@@ -114,7 +114,7 @@
 	name = "sugar sack"
 	desc = "Tasty spacey sugar!"
 	icon_state = "sugar"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	list_reagents = list(/datum/reagent/consumable/sugar = 50)
@@ -133,7 +133,7 @@
 	desc = "Salt. From space oceans, presumably."
 	icon_state = "saltshakersmall"
 	icon_empty = "emptyshaker"
-	item_state = ""
+	inhand_icon_state = ""
 	possible_transfer_amounts = list(1,20) //for clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 20
@@ -167,7 +167,7 @@
 	desc = "Often used to flavor food or make people sneeze."
 	icon_state = "peppermillsmall"
 	icon_empty = "emptyshaker"
-	item_state = ""
+	inhand_icon_state = ""
 	possible_transfer_amounts = list(1,20) //for clown turning the lid off
 	amount_per_transfer_from_this = 1
 	volume = 20
@@ -178,7 +178,7 @@
 	name = "space milk"
 	desc = "It's milk. White and nutritious goodness!"
 	icon_state = "milk"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	list_reagents = list(/datum/reagent/consumable/milk = 50)
@@ -196,7 +196,7 @@
 	name = "flour sack"
 	desc = "A big bag of flour. Good for baking!"
 	icon_state = "flour"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	list_reagents = list(/datum/reagent/consumable/flour = 50)
@@ -219,7 +219,7 @@
 	name = "soy milk"
 	desc = "It's soy milk. White and nutritious goodness!"
 	icon_state = "soymilk"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	list_reagents = list(/datum/reagent/consumable/soymilk = 50)
@@ -229,7 +229,7 @@
 	name = "rice sack"
 	desc = "A big bag of rice. Good for cooking!"
 	icon_state = "rice"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	list_reagents = list(/datum/reagent/consumable/rice = 50)
@@ -240,7 +240,7 @@
 	name = "cornmeal box"
 	desc = "A big box of cornmeal. Great for southern style cooking."
 	icon_state = "cornmeal"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	lefthand_file = 'icons/mob/inhands/misc/drinks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/drinks_righthand.dmi'
 	list_reagents = list(/datum/reagent/consumable/cornmeal = 30)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -164,6 +164,8 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "beaker"
 	inhand_icon_state = "beaker"
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	worn_icon_state = "beaker"
 	custom_materials = list(/datum/material/glass=500)
 	fill_icon_thresholds = list(1, 10, 20, 40, 60, 80, 100)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -163,7 +163,7 @@
 	desc = "A beaker. It can hold up to 50 units."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "beaker"
-	item_state = "beaker"
+	inhand_icon_state = "beaker"
 	worn_icon_state = "beaker"
 	custom_materials = list(/datum/material/glass=500)
 	fill_icon_thresholds = list(1, 10, 20, 40, 60, 80, 100)
@@ -285,7 +285,7 @@
 	icon = 'icons/obj/janitor.dmi'
 	worn_icon = 'icons/mob/clothing/head/utility.dmi'
 	icon_state = "bucket"
-	item_state = "bucket"
+	inhand_icon_state = "bucket"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	custom_materials = list(/datum/material/iron=200)

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -5,7 +5,7 @@
 	desc = "A small bottle."
 	icon_state = "bottle"
 	fill_icon_state = "bottle"
-	item_state = "atoxinbottle"
+	inhand_icon_state = "atoxinbottle"
 	possible_transfer_amounts = list(5,10,15,25,30)
 	volume = 30
 	fill_icon_thresholds = list(1, 10, 20, 40, 60, 80, 100)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -129,7 +129,7 @@
 	name = "mug"
 	desc = "A drink served in a classy mug."
 	icon_state = "tea"
-	item_state = "coffee"
+	inhand_icon_state = "coffee"
 	spillable = TRUE
 
 /obj/item/reagent_containers/cup/glass/mug/update_icon_state()
@@ -164,7 +164,7 @@
 	desc = "A bottle of water filled at an old Earth bottling facility."
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "smallbottle"
-	item_state = "bottle"
+	inhand_icon_state = "bottle"
 	list_reagents = list(/datum/reagent/water = 49.5, /datum/reagent/fluorine = 0.5)//see desc, don't think about it too hard
 	custom_materials = list(/datum/material/plastic=1000)
 	volume = 50
@@ -428,7 +428,7 @@
 	desc = "A cheap, mass produced style of cup, typically used at parties. They never seem to come out red, for some reason..."
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "colocup"
-	item_state = "colocup"
+	inhand_icon_state = "colocup"
 	custom_materials = list(/datum/material/plastic = 1000)
 	possible_transfer_amounts = list(5, 10, 15, 20)
 	volume = 20

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -57,6 +57,7 @@
 	name = "gold cup"
 	desc = "You're winner!"
 	icon_state = "golden_cup"
+	inhand_icon_state = "golden_cup"
 	w_class = WEIGHT_CLASS_BULKY
 	force = 14
 	throwforce = 10
@@ -164,7 +165,7 @@
 	desc = "A bottle of water filled at an old Earth bottling facility."
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "smallbottle"
-	inhand_icon_state = "bottle"
+	inhand_icon_state = null
 	list_reagents = list(/datum/reagent/water = 49.5, /datum/reagent/fluorine = 0.5)//see desc, don't think about it too hard
 	custom_materials = list(/datum/material/plastic=1000)
 	volume = 50

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -561,6 +561,8 @@
 /obj/item/reagent_containers/cup/glass/bottle/juice
 	custom_price = PAYCHECK_MEDIUM
 	inhand_icon_state = "carton"
+	lefthand_file = 'icons/mob/inhands/items/drinks_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items/drinks_righthand.dmi'
 	isGlass = FALSE
 
 /obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -15,8 +15,8 @@
 	volume = 100
 	force = 15 //Smashing bottles over someone's head hurts.
 	throwforce = 15
-	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
-	var/broken_item_state = "broken_beer"
+	inhand_icon_state = "broken_beer" //Generic held-item sprite until unique ones are made.
+	var/broken_inhand_icon_state = "broken_beer"
 	lefthand_file = 'icons/mob/inhands/misc/drinks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/drinks_righthand.dmi'
 	drink_type = ALCOHOL
@@ -39,7 +39,7 @@
 	if(!ranged && thrower)
 		thrower.put_in_hands(B)
 	B.mimic_broken(src, target)
-	B.item_state = broken_item_state
+	B.inhand_icon_state = broken_inhand_icon_state
 
 	qdel(src)
 	target.Bumped(B)
@@ -120,7 +120,7 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
-	item_state = "broken_beer"
+	inhand_icon_state = "broken_beer"
 	lefthand_file = 'icons/mob/inhands/misc/drinks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/drinks_righthand.dmi'
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -409,7 +409,7 @@
 	name = "carton of synthflesh"
 	desc = "A No-Name carton of synthflesh. It seems moldy. And it seems that YOUR INCOMPETENT ASS IS THE ONLY FUCKING REASON THIS THING EVEN EXISTS!!!!"
 	icon_state = "synthflesh"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/medicine/synthflesh = 100)
 
@@ -417,7 +417,7 @@
 	name = "carton of virus food"
 	desc = "A carton of ready-mixed virus food. Do not drink."
 	icon_state = "virusfood"
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	isGlass = FALSE
 	list_reagents = list(/datum/reagent/consumable/virus_food = 100)
 
@@ -560,7 +560,7 @@
  */
 /obj/item/reagent_containers/cup/glass/bottle/juice
 	custom_price = PAYCHECK_MEDIUM
-	item_state = "carton"
+	inhand_icon_state = "carton"
 	isGlass = FALSE
 
 /obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -245,7 +245,7 @@
 	name = "Monkey Energy"
 	desc = "Unleash the ape!"
 	icon_state = "monkey_energy"
-	item_state = "monkey_energy"
+	inhand_icon_state = "monkey_energy"
 	list_reagents = list(/datum/reagent/consumable/monkey_energy = 50)
 	drink_type = SUGAR | JUNKFOOD
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -6,7 +6,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	icon_state = "hypo"
 	worn_icon_state = "hypo"
-	item_state = "hypo"
+	inhand_icon_state = "hypo"
 	amount_per_transfer_from_this = 5
 	volume = 30
 	possible_transfer_amounts = list(1,5,15)
@@ -78,7 +78,7 @@
 	name = "combat stimulant injector"
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
 	amount_per_transfer_from_this = 10
-	item_state = "combat_hypo"
+	inhand_icon_state = "combat_hypo"
 	icon_state = "combat_hypo"
 	volume = 90
 	possible_transfer_amounts = list(10,15,30,45)
@@ -88,7 +88,7 @@
 /obj/item/reagent_containers/hypospray/combat/nanites
 	name = "experimental combat stimulant injector"
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with experimental medical nanites and a stimulant for rapid healing and a combat boost."
-	item_state = "nanite_hypo"
+	inhand_icon_state = "nanite_hypo"
 	icon_state = "nanite_hypo"
 	volume = 100
 	possible_transfer_amounts = list(5,10,15,30,50)
@@ -103,7 +103,7 @@
 /obj/item/reagent_containers/hypospray/combat/heresypurge
 	name = "holy water piercing injector"
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with 5 doses of a holy water and pacifier mixture. Not for use on your teammates."
-	item_state = "holy_hypo"
+	inhand_icon_state = "holy_hypo"
 	icon_state = "holy_hypo"
 	volume = 250
 	possible_transfer_amounts = list(25,50,100)
@@ -116,7 +116,7 @@
 	name = "epinephrine medipen"
 	desc = "A rapid and safe way to stabilize patients in critical condition for personnel without advanced medical knowledge. Contains a powerful preservative that can delay decomposition when applied to a dead body."
 	icon_state = "medipen"
-	item_state = "medipen"
+	inhand_icon_state = "medipen"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	amount_per_transfer_from_this = 13
@@ -161,7 +161,7 @@
 	name = "stimpack medipen"
 	desc = "A rapid way to stimulate your body's adrenaline, allowing for freer movement in restrictive armor."
 	icon_state = "stimpen"
-	item_state = "stimpen"
+	inhand_icon_state = "stimpen"
 	volume = 20
 	amount_per_transfer_from_this = 20
 	list_reagents = list(/datum/reagent/medicine/ephedrine = 10, /datum/reagent/consumable/coffee = 10)
@@ -174,7 +174,7 @@
 	name = "pumpup medipen"
 	desc = "Contains a very large amount of an incredibly powerful stimulant, vastly increasing your immunity and recovery from slowdowns for around five minutes. Do not take if pregnant."
 	icon_state = "syndipen"
-	item_state = "tbpen"
+	inhand_icon_state = "tbpen"
 	volume = 50
 	amount_per_transfer_from_this = 50
 	list_reagents = list(/datum/reagent/medicine/pumpup = 50)
@@ -183,7 +183,7 @@
 	name = "stimulant medipen"
 	desc = "Contains a very large amount of an incredibly powerful stimulant, vastly increasing your movement speed and reducing stuns by a very large amount for around five minutes. Do not take if pregnant."
 	icon_state = "syndipen"
-	item_state = "tbpen"
+	inhand_icon_state = "tbpen"
 	volume = 50
 	amount_per_transfer_from_this = 50
 	list_reagents = list(/datum/reagent/medicine/amphetamine = 50)
@@ -192,13 +192,13 @@
 	name = "morphine medipen"
 	desc = "A rapid way to get you out of a tight situation and fast! You'll feel rather drowsy, though."
 	icon_state = "morphen"
-	item_state = "morphen"
+	inhand_icon_state = "morphen"
 	list_reagents = list(/datum/reagent/medicine/morphine = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/dexalin
 	name = "dexalin medipen"
 	icon_state = "dexpen"
-	item_state = "dexpen"
+	inhand_icon_state = "dexpen"
 	desc = "A autoinjector containing dexalin, used to heal oxygen damage quickly."
 	list_reagents = list(/datum/reagent/medicine/dexalin = 10)
 
@@ -206,7 +206,7 @@
 	name = "BVAK autoinjector"
 	desc = "Bio Virus Antidote Kit autoinjector. Has a two use system for yourself, and someone else. Inject when infected."
 	icon_state = "tbpen"
-	item_state = "tbpen"
+	inhand_icon_state = "tbpen"
 	volume = 60
 	amount_per_transfer_from_this = 30
 	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/salbutamol = 20, /datum/reagent/medicine/spaceacillin = 20)
@@ -223,7 +223,7 @@
 	name = "survival medipen"
 	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
 	icon_state = "survpen"
-	item_state = "survpen"
+	inhand_icon_state = "survpen"
 	volume = 57
 	amount_per_transfer_from_this = 57
 	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/regen_jelly = 15, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/lavaland_extract = 2, /datum/reagent/medicine/omnizine = 5)
@@ -232,7 +232,7 @@
 	name = "atropine autoinjector"
 	desc = "A rapid way to save a person from a critical injury state!"
 	icon_state = "atropen"
-	item_state = "atropen"
+	inhand_icon_state = "atropen"
 	list_reagents = list(/datum/reagent/medicine/atropine = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/snail
@@ -240,13 +240,13 @@
 	desc = "All-purpose snail medicine! Do not use on non-snails!"
 	list_reagents = list(/datum/reagent/snail = 10)
 	icon_state = "snail"
-	item_state = "snail"
+	inhand_icon_state = "snail"
 
 /obj/item/reagent_containers/hypospray/medipen/magillitis
 	name = "experimental autoinjector"
 	desc = "A custom-frame needle injector with a small single-use reservoir, containing an experimental serum. Unlike the more common medipen frame, it cannot pierce through protective armor or hardsuits, nor can the chemical inside be extracted."
 	icon_state = "gorillapen"
-	item_state = "gorillapen"
+	inhand_icon_state = "gorillapen"
 	volume = 5
 	ignore_flags = 0
 	reagent_flags = NONE
@@ -256,7 +256,7 @@
 	name = "Shadow Person mutator autoinjector"
 	desc = "Become one with the shadows, and change your race to a Shadow Person today!"
 	icon_state = "syndipen"
-	item_state = "tbpen"
+	inhand_icon_state = "tbpen"
 	volume = 10
 	amount_per_transfer_from_this = 10
 	list_reagents = list(/datum/reagent/mutationtoxin/shadow = 10)

--- a/code/modules/reagents/reagent_containers/medspray.dm
+++ b/code/modules/reagents/reagent_containers/medspray.dm
@@ -3,7 +3,7 @@
 	desc = "A medical spray bottle, designed for precision application, with an unscrewable cap."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "medspray"
-	item_state = "spraycan"
+	inhand_icon_state = "spraycan"
 	worn_icon_state = "spraycan"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -3,7 +3,7 @@
 	desc = "A chemical patch for touch based applications."
 	icon = 'icons/obj/medicine_containers.dmi'
 	icon_state = "bandaid_small_cross"
-	item_state = "bandaid_small_cross"
+	inhand_icon_state = "bandaid_small_cross"
 	volume = 40
 	apply_type = PATCH
 	apply_method = "apply"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -3,7 +3,7 @@
 	desc = "A tablet or capsule."
 	icon = 'icons/obj/medicine_containers.dmi'
 	icon_state = "pill_shape_capsule_purple_pink"
-	item_state = "pill_shape_capsule_purple_pink"
+	inhand_icon_state = "pill_shape_capsule_purple_pink"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	has_variable_transfer_amount = FALSE

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -3,7 +3,7 @@
 	desc = "A spray bottle, with an unscrewable top."
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "cleaner"
-	item_state = "cleaner"
+	inhand_icon_state = "cleaner"
 	worn_icon_state = "spraybottle"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
@@ -176,7 +176,7 @@
 	desc = "A seemingly innocent sunflower...with a twist."
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "sunflower"
-	item_state = "sunflower"
+	inhand_icon_state = "sunflower"
 	amount_per_transfer_from_this = 1
 	has_variable_transfer_amount = FALSE
 	can_toggle_range = FALSE
@@ -238,7 +238,7 @@
 	desc = "A utility used to spray large amounts of reagents in a given area."
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "chemsprayer"
-	item_state = "chemsprayer"
+	inhand_icon_state = "chemsprayer"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	throwforce = 0
@@ -276,7 +276,7 @@
 	name = "janitor chem sprayer"
 	desc = "A utility used to spray large amounts of cleaning reagents in a given area. It regenerates space cleaner by itself but it's unable to be fueled by normal means."
 	icon_state = "chemsprayer_janitor"
-	item_state = "chemsprayer_janitor"
+	inhand_icon_state = "chemsprayer_janitor"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	reagent_flags = NONE
@@ -306,7 +306,7 @@
 	name = "lubinator 8000"
 	desc = "A modified industrial cleaning sprayer, capable of coating entire hallways in high performance lubricant, honk!"
 	icon_state = "chemsprayer"
-	item_state = "chemsprayer"
+	inhand_icon_state = "chemsprayer"
 	list_reagents = list(/datum/reagent/lube = 1000)
 	generate_type = /datum/reagent/lube
 
@@ -316,7 +316,7 @@
 	desc = "Kills those pesky weeds!"
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "plantbgone"
-	item_state = "plantbgone"
+	inhand_icon_state = "plantbgone"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
@@ -360,7 +360,7 @@ CREATION_TEST_IGNORE_SELF(/obj/item/reagent_containers/spray/cyborg)
 	desc = "A bottle of weed killer spray for stopping kudzu-based harm."
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "plantbgone"
-	item_state = "plantbgone"
+	inhand_icon_state = "plantbgone"
 	set_reagent = /datum/reagent/toxin/plantbgone
 
 /obj/item/reagent_containers/spray/cyborg/lube

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -177,6 +177,8 @@
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "sunflower"
 	inhand_icon_state = "sunflower"
+	lefthand_file = 'icons/mob/inhands/weapons/plants_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/plants_righthand.dmi'
 	amount_per_transfer_from_this = 1
 	has_variable_transfer_amount = FALSE
 	can_toggle_range = FALSE

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -2,7 +2,7 @@
 	name = "syringe"
 	desc = "A syringe that can hold up to 15 units."
 	icon = 'icons/obj/syringe.dmi'
-	item_state = "syringe_0"
+	inhand_icon_state = "syringe_0"
 	base_icon_state = "syringe"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
@@ -155,7 +155,7 @@
 	else
 		rounded_vol = 0
 	icon_state = "[base_icon_state]_[rounded_vol]"
-	item_state = "[base_icon_state]_[rounded_vol]"
+	inhand_icon_state = "[base_icon_state]_[rounded_vol]"
 
 /obj/item/reagent_containers/syringe/proc/embed(mob/living/carbon/C, injectmult = 1)
 	C.apply_status_effect(/datum/status_effect/syringe, src, injectmult)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -95,7 +95,7 @@
 	desc = "A brown paper delivery parcel."
 	icon = 'icons/obj/storage/wrapping.dmi'
 	icon_state = "deliverypackage3"
-	item_state = "deliverypackage"
+	inhand_icon_state = "deliverypackage"
 	var/giftwrapped = 0
 	var/sortTag = 0
 
@@ -181,7 +181,7 @@
 	var/currTag = 0 //Destinations are stored in code\globalvars\lists\flavor_misc.dm
 	var/locked_destination = FALSE //if true, users can't open the destination tag window to prevent changing the tagger's current destination
 	w_class = WEIGHT_CLASS_TINY
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/modules/religion/sects/necro_sect.dm
+++ b/code/modules/religion/sects/necro_sect.dm
@@ -142,7 +142,7 @@
 		B.deity_name = GLOB.deity
 		B.name = GLOB.bible_name
 		B.icon_state = GLOB.bible_icon_state
-		B.item_state = GLOB.bible_item_state
+		B.inhand_icon_state = GLOB.bible_inhand_icon_state
 		to_chat(undead, "There is already an established religion onboard the station. You are an acolyte of [GLOB.deity]. Defer to the Chaplain.")
 		undead.equip_to_slot_or_del(B, ITEM_SLOT_BACKPACK)
 		GLOB.religious_sect?.on_conversion(undead)

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -180,6 +180,6 @@
 	sharpness = SHARP_DISMEMBER
 	icon = 'icons/obj/nanite.dmi'
 	icon_state = "nanite_blade"
-	item_state = "nanite_blade"
+	inhand_icon_state = "nanite_blade"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -6,7 +6,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "RPED"
-	item_state = "RPED"
+	inhand_icon_state = "RPED"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
@@ -86,7 +86,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	name = "bluespace rapid part exchange device (BSRPED)"
 	desc = "A version of the RPED that allows for replacement of parts and scanning from a distance, along with higher capacity for parts."
 	icon_state = "BS_RPED"
-	item_state = "BS_RPED"
+	inhand_icon_state = "BS_RPED"
 	w_class = WEIGHT_CLASS_NORMAL
 	works_from_distance = TRUE
 	pshoom_or_beepboopblorpzingshadashwoosh = 'sound/items/pshoom.ogg'
@@ -211,7 +211,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	name = "rapid part exchange device"
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
 	icon_state = "borgrped"
-	item_state = "RPED"
+	inhand_icon_state = "RPED"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -9,7 +9,7 @@ Slimecrossing Armor
 	name = "rebreather mask"
 	desc = "A transparent mask, resembling a conventional breath mask, but made of bluish slime. Seems to lack any air supply tube, though."
 	icon_state = "slime"
-	inhand_icon_state = "slime"
+	inhand_icon_state = "b_mask"
 	body_parts_covered = NONE
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0
@@ -140,7 +140,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/light_prism)
 	name = "adamantine armor"
 	desc = "A full suit of adamantine plate armor. Impressively resistant to damage, but weighs about as much as you do. The locked joints appear to move under their own power, making this suit of armor impossible to speed up."
 	icon_state = "adamsuit"
-	inhand_icon_state = "adamsuit"
+	inhand_icon_state = null
 	flags_inv = NONE
 	slowdown = 0 //slowdown is handled in the equipped proc
 	var/hit_reflect_chance = 40

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -9,7 +9,7 @@ Slimecrossing Armor
 	name = "rebreather mask"
 	desc = "A transparent mask, resembling a conventional breath mask, but made of bluish slime. Seems to lack any air supply tube, though."
 	icon_state = "slime"
-	item_state = "slime"
+	inhand_icon_state = "slime"
 	body_parts_covered = NONE
 	w_class = WEIGHT_CLASS_SMALL
 	gas_transfer_coefficient = 0
@@ -105,7 +105,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/light_prism)
 	icon = 'icons/obj/slimecrossing.dmi'
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "peaceflower"
-	item_state = null
+	inhand_icon_state = null
 	slot_flags = ITEM_SLOT_HEAD
 	clothing_flags = EFFECT_HAT | SNUG_FIT
 	body_parts_covered = NONE
@@ -140,7 +140,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/light_prism)
 	name = "adamantine armor"
 	desc = "A full suit of adamantine plate armor. Impressively resistant to damage, but weighs about as much as you do. The locked joints appear to move under their own power, making this suit of armor impossible to speed up."
 	icon_state = "adamsuit"
-	item_state = "adamsuit"
+	inhand_icon_state = "adamsuit"
 	flags_inv = NONE
 	slowdown = 0 //slowdown is handled in the equipped proc
 	var/hit_reflect_chance = 40

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -29,7 +29,7 @@ Slimecrossing Weapons
 	desc = "A strange, transparent knife which constantly shifts color. It hums slightly when moved."
 	icon = 'icons/obj/knives.dmi'
 	icon_state = "rainbowknife"
-	item_state = "rainbowknife"
+	inhand_icon_state = "rainbowknife"
 	force = 15
 	throwforce = 15
 	damtype = BRUTE
@@ -66,7 +66,7 @@ Slimecrossing Weapons
 	desc = "A gigantic shield made of solid adamantium."
 	icon = 'icons/obj/slimecrossing.dmi'
 	icon_state = "adamshield"
-	item_state = "adamshield"
+	inhand_icon_state = "adamshield"
 	w_class = WEIGHT_CLASS_HUGE
 	armor_type = /datum/armor/shield_adamantineshield
 	slot_flags = ITEM_SLOT_BACK
@@ -101,7 +101,7 @@ Slimecrossing Weapons
 	desc = "A horrifying weapon made of your own bone and blood vessels. It shoots slowing globules of your own blood. Ech."
 	icon = 'icons/obj/slimecrossing.dmi'
 	icon_state = "bloodgun"
-	item_state = "bloodgun"
+	inhand_icon_state = "bloodgun"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -1117,7 +1117,7 @@
 	singular_name = "floor tile"
 	desc = "Through a series of micro-teleports these tiles let people move at incredible speeds."
 	icon_state = "tile-bluespace"
-	item_state = "tile-bluespace"
+	inhand_icon_state = "tile-bluespace"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 6
 	mats_per_unit = list(/datum/material/iron=500)
@@ -1134,7 +1134,7 @@
 	singular_name = "floor tile"
 	desc = "Time seems to flow very slowly around these tiles."
 	icon_state = "tile_sepia"
-	item_state = "tile-sepia"
+	inhand_icon_state = "tile-sepia"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 6
 	mats_per_unit = list(/datum/material/iron=500)

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -127,7 +127,7 @@
 	desc = "Their success will be yours."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
-	item_state = "knife"
+	inhand_icon_state = "knife"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
 	force = 18

--- a/code/modules/security/genpop.dm
+++ b/code/modules/security/genpop.dm
@@ -695,7 +695,7 @@ GLOBAL_LIST_EMPTY(prisoner_ids)
 
 /obj/item/card/id/prisoner //renamed existing prisonner id to id/gulag
 	icon_state = "orange"
-	item_state = "orange-id"
+	inhand_icon_state = "orange-id"
 	assignment = "convict"
 	hud_state = JOB_HUD_PRISONER
 	var/served_time = 0 //Seconds.

--- a/code/modules/security/prison_scanner.dm
+++ b/code/modules/security/prison_scanner.dm
@@ -5,7 +5,7 @@
 	desc = "A device used to check objects made in the workshop, to have them cashed out for sentence reductions."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "export_scanner"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	item_flags = NOBLUDGEON

--- a/code/modules/shuttle/assault_pod.dm
+++ b/code/modules/shuttle/assault_pod.dm
@@ -21,7 +21,7 @@
 	name = "Assault Pod Targeting Device"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-red"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	desc = "Used to select a landing zone for assault pods."

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -676,13 +676,13 @@
 /obj/item/clothing/head/helmet/space/orange
 	name = "emergency space helmet"
 	icon_state = "syndicate-helm-orange"
-	item_state = "syndicate-helm-orange"
+	inhand_icon_state = "syndicate-helm-orange"
 	flash_protect = 0
 
 /obj/item/clothing/suit/space/orange
 	name = "emergency space suit"
 	icon_state = "syndicate-orange"
-	item_state = "syndicate-orange"
+	inhand_icon_state = "syndicate-orange"
 	slowdown = 3
 
 /obj/item/pickaxe/emergency

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/vortex_rifle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/vortex_rifle.dm
@@ -2,7 +2,7 @@
 	name = "vortex rifle"
 	desc = "A powerful rifle of alien origin that fires powerful energy darts."
 	icon_state = "vortex"
-	item_state = null
+	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/vortex)
 
 /obj/item/gun/energy/vortex/examine(mob/user)

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -308,7 +308,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
 	icon_state = "latexballon"
-	item_state = null
+	inhand_icon_state = null
 	item_flags = NEEDS_PERMIT | ABSTRACT
 	w_class = WEIGHT_CLASS_HUGE
 	force = 0

--- a/code/modules/spells/spell_types/touch/flesh_to_stone.dm
+++ b/code/modules/spells/spell_types/touch/flesh_to_stone.dm
@@ -29,4 +29,4 @@
 	name = "\improper petrifying touch"
 	desc = "That's the bottom line, because flesh to stone said so!"
 	icon_state = "fleshtostone"
-	item_state = "fleshtostone"
+	inhand_icon_state = "fleshtostone"

--- a/code/modules/spells/spell_types/touch/smite.dm
+++ b/code/modules/spells/spell_types/touch/smite.dm
@@ -55,4 +55,4 @@
 	name = "\improper smiting touch"
 	desc = "This hand of mine glows with an awesome power!"
 	icon_state = "disintegrate"
-	item_state = "disintegrate"
+	inhand_icon_state = "disintegrate"

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -65,7 +65,7 @@
 	name = "DNA Sampler"
 	desc = "Can be used to take chemical and genetic samples of pretty much anything."
 	icon = 'icons/obj/syringe.dmi'
-	item_state = "hypo"
+	inhand_icon_state = "hypo"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	icon_state = "hypo"

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -16,7 +16,7 @@
 	limb_id = "robotic"
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	item_state = "buildpipe"
+	inhand_icon_state = "buildpipe"
 	static_icon = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
 	flags_1 = CONDUCT_1
@@ -42,7 +42,7 @@
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	item_state = "buildpipe"
+	inhand_icon_state = "buildpipe"
 	static_icon = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
@@ -69,7 +69,7 @@
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	item_state = "buildpipe"
+	inhand_icon_state = "buildpipe"
 	static_icon = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
@@ -96,7 +96,7 @@
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	item_state = "buildpipe"
+	inhand_icon_state = "buildpipe"
 	static_icon = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
@@ -121,7 +121,7 @@
 /obj/item/bodypart/chest/robot
 	name = "cyborg torso"
 	desc = "A heavily reinforced case containing cyborg logic boards, with space for a standard power cell."
-	item_state = "buildpipe"
+	inhand_icon_state = "buildpipe"
 	static_icon = 'icons/mob/augmentation/augments.dmi'
 	icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
@@ -228,7 +228,7 @@
 /obj/item/bodypart/head/robot
 	name = "cyborg head"
 	desc = "A standard reinforced braincase, with spine-plugged neural socket and sensor gimbals."
-	item_state = "buildpipe"
+	inhand_icon_state = "buildpipe"
 	static_icon = 'icons/mob/augmentation/augments.dmi'
 	limb_id = "robotic"
 	icon = null

--- a/code/modules/surgery/latex_glove_box.dm
+++ b/code/modules/surgery/latex_glove_box.dm
@@ -3,7 +3,7 @@
 	desc = "A box of latex gloves, useful for quick cleanup after surgery."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "latex_glove_box"
-	item_state = "deliverypackage"
+	inhand_icon_state = "deliverypackage"
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	throwforce = 0

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -5,7 +5,7 @@
 	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants/organs and a screwdriver slot for removing accidentally added items."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "autoimplanter"
-	item_state = "nothing"
+	inhand_icon_state = "nothing"
 	w_class = WEIGHT_CLASS_SMALL
 	var/list/obj/item/organ/storedorgan
 	var/organ_type = /obj/item/organ

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -5,7 +5,7 @@
 	icon_state = "retractor"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	item_state = "clamps"
+	inhand_icon_state = "clamps"
 	custom_materials = list(/datum/material/iron=6000, /datum/material/glass=3000)
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
@@ -31,7 +31,7 @@
 	icon_state = "hemostat"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	item_state = "clamps"
+	inhand_icon_state = "clamps"
 	custom_materials = list(/datum/material/iron=5000, /datum/material/glass=2500)
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
@@ -61,7 +61,7 @@
 	icon_state = "cautery"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	item_state = "cautery"
+	inhand_icon_state = "cautery"
 	custom_materials = list(/datum/material/iron=2500, /datum/material/glass=750)
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
@@ -184,7 +184,7 @@
 	icon_state = "scalpel"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	item_state = "scalpel"
+	inhand_icon_state = "scalpel"
 	flags_1 = CONDUCT_1
 	force = 10
 	w_class = WEIGHT_CLASS_TINY
@@ -283,7 +283,7 @@
 	throwhitsound =  'sound/weapons/pierce.ogg'
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	item_state = "wrench"
+	inhand_icon_state = "wrench"
 	flags_1 = CONDUCT_1
 	force = 7
 	w_class = WEIGHT_CLASS_NORMAL
@@ -305,7 +305,7 @@
 	icon_state = "surgical_drapes"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	item_state = "drapes"
+	inhand_icon_state = "drapes"
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb_continuous = list("slaps")
 	attack_verb_simple = list("slap")

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -3,6 +3,7 @@
 	desc = "Retracts stuff."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "retractor"
+	inhand_icon_state = "retractor"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	inhand_icon_state = "clamps"
@@ -29,6 +30,7 @@
 	desc = "You think you have seen this before."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "hemostat"
+	inhand_icon_state = "hemostat"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	inhand_icon_state = "clamps"
@@ -59,6 +61,7 @@
 	desc = "This stops bleeding."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "cautery"
+	inhand_icon_state = "cautery"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	inhand_icon_state = "cautery"
@@ -88,6 +91,7 @@
 	desc = "It projects a high power laser used for medical applications."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "e_cautery"
+	inhand_icon_state = "e_cautery"
 	hitsound = 'sound/items/welder.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
@@ -143,6 +147,7 @@
 	desc = "You can drill using this item. You dig?"
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "drill"
+	inhand_icon_state = "drill"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	hitsound = 'sound/weapons/circsawhit.ogg'
@@ -182,6 +187,7 @@
 	desc = "Cut, cut, and once more cut."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
+	inhand_icon_state = "scalpel"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	inhand_icon_state = "scalpel"
@@ -232,6 +238,7 @@
 	desc = "For heavy duty cutting."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "saw"
+	inhand_icon_state = "saw"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	hitsound = 'sound/weapons/circsawhit.ogg'
@@ -390,6 +397,7 @@
 	desc = "An advanced scalpel which uses laser technology to cut."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "e_scalpel"
+	inhand_icon_state = "e_scalpel"
 	hitsound = 'sound/weapons/blade1.ogg'
 	force = 16
 	toolspeed = 0.7
@@ -440,6 +448,9 @@
 	desc = "An agglomerate of rods and gears."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "adv_retractor"
+	inhand_icon_state = "adv_retractor"
+	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	toolspeed = 0.7
 
 /obj/item/retractor/advanced/Initialize(mapload)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -47,6 +47,7 @@
 #include "heretic_rituals.dm"
 #include "hydroponics_extractor_storage.dm"
 #include "icon_smoothing_unit_test.dm"
+#include "inhands.dm"
 #include "janky_actions.dm"
 #include "keybinding_init.dm"
 #include "language_transfer.dm"

--- a/code/modules/unit_tests/greyscale_config.dm
+++ b/code/modules/unit_tests/greyscale_config.dm
@@ -5,7 +5,7 @@
 	for(var/obj/item/item_path as anything in subtypesof(/obj/item))
 		if(isnull(initial(item_path.greyscale_colors)))
 			continue //All configs depend on greyscale_colors being defined.
-		var/held_icon_state = initial(item_path.item_state) || initial(item_path.icon_state)
+		var/held_icon_state = initial(item_path.inhand_icon_state) || initial(item_path.icon_state)
 
 		var/datum/greyscale_config/lefthand = SSgreyscale.configurations["[initial(item_path.greyscale_config_inhand_left)]"]
 		if(lefthand && !lefthand.icon_states[held_icon_state])

--- a/code/modules/unit_tests/inhands.dm
+++ b/code/modules/unit_tests/inhands.dm
@@ -1,0 +1,90 @@
+/// Makes sure items with defined inhand_icon_states... actually have icons that exist!
+/datum/unit_test/defined_inhand_icon_states
+	var/static/list/possible_icon_states = list()
+	var/fallback_log_message
+	var/unset_inhand_var_message
+
+/datum/unit_test/defined_inhand_icon_states/proc/generate_possible_icon_states_list(directory_path)
+	if(!directory_path)
+		directory_path = "icons/mob/inhands/"
+	for(var/file_path in flist(directory_path))
+		if(findtext(file_path, ".dmi"))
+			for(var/sprite_icon in icon_states("[directory_path][file_path]", 1)) //2nd arg = 1 enables 64x64+ icon support, otherwise you'll end up with "sword0_1" instead of "sword"
+				possible_icon_states[sprite_icon] += list("[directory_path][file_path]")
+		else
+			possible_icon_states += generate_possible_icon_states_list("[directory_path][file_path]")
+
+/datum/unit_test/defined_inhand_icon_states/Run()
+	generate_possible_icon_states_list()
+
+	for(var/obj/item/item_path as anything in subtypesof(/obj/item))
+		if(initial(item_path.item_flags) & ABSTRACT)
+			continue
+
+		var/skip_left
+		var/skip_right
+		if(initial(item_path.greyscale_colors)) //greyscale stuff has it's own unit test.
+			skip_left = initial(item_path.greyscale_config_inhand_left)
+			skip_right = initial(item_path.greyscale_config_inhand_right)
+			if(skip_left && skip_right)
+				continue
+
+		var/lefthand_file = initial(item_path.lefthand_file)
+		var/righthand_file = initial(item_path.righthand_file)
+
+		var/held_icon_state = initial(item_path.inhand_icon_state)
+		if(!held_icon_state)
+			var/base_icon_state = initial(item_path.icon_state)
+			if(!isnull(base_icon_state) && lefthand_file && righthand_file) //Suggest inhand icons that match with the icon_state var.
+				var/missing_var_message
+				if(base_icon_state in possible_icon_states)
+					for(var/file_place in possible_icon_states[base_icon_state])
+						missing_var_message += (missing_var_message ? " & '[file_place]'" : " - Possible matching sprites for \"[base_icon_state]\" found in: '[file_place]'")
+					unset_inhand_var_message += "\n\t[item_path] does not have an inhand_icon_state value[missing_var_message]"
+			continue
+
+		var/match_message = (held_icon_state in possible_icon_states) ? TRUE : null
+		if(match_message)
+			match_message = null
+			for(var/file_place in possible_icon_states[held_icon_state])
+				match_message += (match_message ? " & '[file_place]'" : " - Matching sprite found in: '[file_place]'")
+
+		if(!(skip_left || skip_right) && !lefthand_file && !righthand_file)
+			TEST_FAIL("Missing both icon files for [item_path].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
+			continue
+
+		var/missing_left
+		var/left_fallback
+		if(!skip_left)
+			if(!lefthand_file)
+				TEST_FAIL("Missing left inhand icon file for [item_path].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
+			else
+				missing_left = !("[lefthand_file]" in possible_icon_states[held_icon_state])
+				if(missing_left && ("[lefthand_file]" in possible_icon_states[""]))
+					left_fallback = TRUE
+
+		var/missing_right
+		var/right_fallback
+		if(!skip_right)
+			if(!righthand_file)
+				TEST_FAIL("Missing right inhand icon file for [item_path].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
+			else
+				missing_right = !("[righthand_file]" in possible_icon_states[held_icon_state])
+				if(missing_right && ("[righthand_file]" in possible_icon_states[""]))
+					right_fallback = TRUE
+
+		if(missing_right && missing_left)
+			if(!match_message && right_fallback && left_fallback)
+				fallback_log_message += "\n\t[item_path] has invalid value, using fallback icon.\n\tinhand_icon_state = \"[held_icon_state]\""
+				continue
+			TEST_FAIL("Missing inhand sprites for [item_path] in both '[lefthand_file]' & '[righthand_file]'.\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
+		else if(missing_left)
+			TEST_FAIL("Missing left inhand sprite for [item_path] in '[lefthand_file]'[left_fallback ? ", using fallback icon" : null].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
+		else if(missing_right)
+			TEST_FAIL("Missing right inhand sprite for [item_path] in '[righthand_file]'[right_fallback ? ", using fallback icon" : null].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
+
+	if(fallback_log_message)
+		TEST_FAIL("Invalid inhand_icon_state values should be set to null if there isn't a valid icon.[fallback_log_message]")
+
+	if(unset_inhand_var_message)
+		log_test("\tNotice - Possible inhand icon matches found. It is best to be explicit with inhand sprite values.[unset_inhand_var_message]")

--- a/code/modules/unit_tests/inhands.dm
+++ b/code/modules/unit_tests/inhands.dm
@@ -3,6 +3,10 @@
 	var/static/list/possible_icon_states = list()
 	var/fallback_log_message
 	var/unset_inhand_var_message
+	/// additional_inhands_location is for downstream modularity support. as an example, for skyrat's usage, set additional_inhands_location = "modular_skyrat/master_files/icons/mob/inhands/"
+	/// Make sure this location is also present in tools/deploy.sh
+	/// If you need additional paths ontop of this second one, you can add another generate_possible_icon_states_list("your/folder/path/inhands/") below the if(additional_inhands_location) block in Run(), and make sure to add that path to tools/deploy.sh as well.
+	var/additional_inhands_location = null
 
 /datum/unit_test/defined_inhand_icon_states/proc/generate_possible_icon_states_list(directory_path)
 	if(!directory_path)
@@ -16,6 +20,11 @@
 
 /datum/unit_test/defined_inhand_icon_states/Run()
 	generate_possible_icon_states_list()
+	if(additional_inhands_location)
+		generate_possible_icon_states_list(additional_inhands_location)
+
+	//Add EVEN MORE paths if needed here!
+	//generate_possible_icon_states_list("your/folder/path/inhands/")
 
 	for(var/obj/item/item_path as anything in subtypesof(/obj/item))
 		if(initial(item_path.item_flags) & ABSTRACT)
@@ -23,7 +32,7 @@
 
 		var/skip_left
 		var/skip_right
-		if(initial(item_path.greyscale_colors)) //greyscale stuff has it's own unit test.
+		if(initial(item_path.greyscale_colors)) //greyscale stuff has its own unit test.
 			skip_left = initial(item_path.greyscale_config_inhand_left)
 			skip_right = initial(item_path.greyscale_config_inhand_right)
 			if(skip_left && skip_right)
@@ -43,9 +52,8 @@
 					unset_inhand_var_message += "\n\t[item_path] does not have an inhand_icon_state value[missing_var_message]"
 			continue
 
-		var/match_message = (held_icon_state in possible_icon_states) ? TRUE : null
-		if(match_message)
-			match_message = null
+		var/match_message
+		if(held_icon_state in possible_icon_states)
 			for(var/file_place in possible_icon_states[held_icon_state])
 				match_message += (match_message ? " & '[file_place]'" : " - Matching sprite found in: '[file_place]'")
 
@@ -59,8 +67,8 @@
 			if(!lefthand_file)
 				TEST_FAIL("Missing left inhand icon file for [item_path].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
 			else
-				missing_left = !("[lefthand_file]" in possible_icon_states[held_icon_state])
-				if(missing_left && ("[lefthand_file]" in possible_icon_states[""]))
+				missing_left = !icon_exists(lefthand_file, held_icon_state)
+				if(missing_left && icon_exists(lefthand_file, ""))
 					left_fallback = TRUE
 
 		var/missing_right
@@ -69,8 +77,8 @@
 			if(!righthand_file)
 				TEST_FAIL("Missing right inhand icon file for [item_path].\n\tinhand_icon_state = \"[held_icon_state]\"[match_message]")
 			else
-				missing_right = !("[righthand_file]" in possible_icon_states[held_icon_state])
-				if(missing_right && ("[righthand_file]" in possible_icon_states[""]))
+				missing_right = !icon_exists(righthand_file, held_icon_state)
+				if(missing_right && icon_exists(righthand_file, ""))
 					right_fallback = TRUE
 
 		if(missing_right && missing_left)

--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -7,7 +7,7 @@
 	name = "station bounced radio"
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "radio"
-	item_state = "radio"
+	inhand_icon_state = "radio"
 	worn_icon_state = "radio"
 	desc = "A basic handheld radio that communicates with local telecommunication networks."
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -17,7 +17,7 @@
 	name = "oar"
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "oar"
-	item_state = "oar"
+	inhand_icon_state = "oar"
 	lefthand_file = 'icons/mob/inhands/misc/lavaland_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/lavaland_righthand.dmi'
 	desc = "Not to be confused with the kind Research hassles you for."

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -124,7 +124,7 @@
 	name = "217-D Heavy Plasma Cutter"
 	desc = "A device that shoots resonant plasma bursts at extreme velocity. The blasts are capable of crushing rock and demolishing solid obstacles."
 	icon_state = "mecha_plasmacutter"
-	item_state = "plasmacutter"
+	inhand_icon_state = "plasmacutter"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	energy_drain = 30

--- a/code/modules/vehicles/mecha/mecha_parts.dm
+++ b/code/modules/vehicles/mecha/mecha_parts.dm
@@ -294,7 +294,7 @@
 	name = "exosuit circuit board"
 	icon = 'icons/obj/module.dmi'
 	icon_state = "std_mod"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -11,7 +11,7 @@
 	name = COMPONENT_DEFAULT_NAME
 	icon = 'icons/obj/module.dmi'
 	icon_state = "component"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_TINY
 
 	/// The name of the component shown on the UI

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -12,6 +12,8 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "component"
 	inhand_icon_state = "electronic"
+	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 
 	/// The name of the component shown on the UI

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	desc = "By inserting components and a cell into this, wiring them up, and putting them into a shell, anyone can pretend to be a programmer."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "integrated_circuit"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
 
 	/// The name that appears on the shell.

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -14,6 +14,8 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	icon = 'icons/obj/module.dmi'
 	icon_state = "integrated_circuit"
 	inhand_icon_state = "electronic"
+	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 
 	/// The name that appears on the shell.

--- a/code/modules/wiremod/core/usb_cable.dm
+++ b/code/modules/wiremod/core/usb_cable.dm
@@ -4,7 +4,7 @@
 	desc = "A cable that can connect integrated circuits to anything with a USB port, such as computers and machines."
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "usb_cable"
-	item_state = "coil"
+	inhand_icon_state = "coil"
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/iron = 75)
 	var/usb_range = USB_CABLE_MAX_RANGE

--- a/code/modules/wiremod/core/usb_cable.dm
+++ b/code/modules/wiremod/core/usb_cable.dm
@@ -4,7 +4,9 @@
 	desc = "A cable that can connect integrated circuits to anything with a USB port, such as computers and machines."
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "usb_cable"
-	inhand_icon_state = "coil"
+	inhand_icon_state = "coil_yellow"
+	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/iron = 75)
 	var/usb_range = USB_CABLE_MAX_RANGE

--- a/code/modules/wiremod/shell/assembly.dm
+++ b/code/modules/wiremod/shell/assembly.dm
@@ -8,7 +8,7 @@
 	name = "modular assembly"
 	desc = "a modified remote signalling device with its wiring removed and adapted for integrated circuitry."
 	icon_state = "wiremod"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 

--- a/code/modules/wiremod/shell/compact_remote.dm
+++ b/code/modules/wiremod/shell/compact_remote.dm
@@ -8,7 +8,7 @@
 	desc = "A smaller handheld device with one big button."
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "setup_small_simple"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_TINY
 	//worn_icon_state = "electronic"		//remember to change it later lol
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -9,7 +9,7 @@
 	desc = "A handheld device with three buttons."
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "setup_small_calc"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
 	//worn_icon_state = "electronic"	//remember to change it
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'

--- a/code/modules/wiremod/shell/scanner.dm
+++ b/code/modules/wiremod/shell/scanner.dm
@@ -8,7 +8,7 @@
 	desc = "A handheld device that lets you scan people"
 	icon = 'icons/obj/wiremod.dmi'
 	icon_state = "setup_small"
-	item_state = "electronic"
+	inhand_icon_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames confusing "item_state" var name to "inhand_icon_state" to match their .dmi names.

Unit tests all inhands.

Ports:
- https://github.com/tgstation/tgstation/pull/51060
- https://github.com/tgstation/tgstation/pull/70037

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We refer to item icons in a mobs hand as "inhands", not "items". This is proper convention with their current .dmi file names, so rather than continuing this confusion for people learning DM coding, we just make the names match.


Checking inhands working properly is good.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

None yet

</details>

## Changelog
:cl: rkz, nemvar, ShizCalev
code: renames "item_state" to "inhand_icon_state" to more properly reflect its use
fix: all items should now properly have a inhand, or explicitly in the code be told to be null
code: adds a unit test to enforce the above
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
