### PR TITLE
CC Teleport Fix

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/swapper,
 		/obj/item/mail,
 		/obj/docking_port,
-		/obj/effect/warped_rune // no teleporting to cc for you
+		/obj/effect/warped_rune, // no teleporting to cc for you
 		/obj/structure/slime_crystal/bluespace // Dang it, you still teleported to CC!
 	)))
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -28,6 +28,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/mail,
 		/obj/docking_port,
 		/obj/effect/warped_rune // no teleporting to cc for you
+		/obj/structure/slime_crystal/bluespace // Dang it, you still teleported to CC!
 	)))
 
 /obj/docking_port/mobile/supply


### PR DESCRIPTION
## About The Pull Request
Adds the `/obj/structure/slime_crystal/bluespace` to the Cargo blacklist.

Fixes #12549

## Why It's Good For The Game
Normal players getting to the CC level without admin permission is bad.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/410347e4-153a-4510-a812-4b3a517490c4)

</details>

## Changelog
:cl:
fix: Fixed yet another method of getting to CC.
/:cl:
