### PR TITLE
Fixes two bugs with paper markdown

### DIFF
--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -617,7 +617,7 @@ export class PreviewView extends Component<PreviewViewProps> {
 
   // Wraps the given raw text in a font span based on the supplied props.
   setFontInText = (text: string, font: string, color: string, bold: boolean = false): string => {
-    return `<span style={{color:${color};font-family:${font};${bold ? 'font-weight: bold;' : ''}}}>${text}</span>`;
+    return `<span style="color:${color};font-family:${font};${bold ? 'font-weight: bold;' : ''}">${text}</span>`;
   };
 
   // Parses the given raw text through marked for applying markdown.
@@ -882,7 +882,7 @@ export class PreviewView extends Component<PreviewViewProps> {
     const { scrollableRef, handleOnScroll } = this.props;
 
     return (
-      <Section fill fitted scrollable scrollableRef={scrollableRef} onScroll={handleOnScroll}>
+      <Section fill fitted scrollable ref={scrollableRef} onScroll={handleOnScroll}>
         <Box
           fillPositionedParent
           position="relative"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #12305 

Ports:
- https://github.com/tgstation/tgstation/pull/80255
- https://github.com/tgstation/tgstation/pull/81429

#12204 Ported React for TGUI and some related fixes. However, https://github.com/tgstation/tgstation/pull/80255 was not ported completely, as a one line change in PaperSheet.tsx was omitted. This PR completes the fix and solves the issue.

While testing, I noticed that the font and color for the pen used when writing on a sheet were reflected in the editing box, but not on the paper itself. After some digging, this ended up being another one line fix, which had already been implemented on tg but overlooked by our React port.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix, stamps should be placed at the cursor's position and writing font and color should depend on the pencil used.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![paperfix](https://github.com/user-attachments/assets/9e83fc4c-c318-44eb-8970-5f3d456ecacf)

</details>

## Changelog
:cl: beelover, jlsnow301, 00-Steven
fix: Stamps can be placed anywhere on a paper sheet again
fix: The type of pencil used when writing on a sheet affects the font and color of the result again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
