### PR TITLE
Upping blob tesla shock priority

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -259,27 +259,27 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/anomaly/energy_ball)
 			continue
 		else if(priority <= 2)
 			continue
-		else if(priority >= 3 && isliving(A))
-			var/mob/living/L = A
+		else if(priority >= 3 && istype(A, /obj/structure/blob))
+			var/obj/o = A
 			var/dist = get_dist(source, A)
-			if(dist <= zap_range && (dist < closest_dist || !(priority == 3)) && L.stat != DEAD && !(L.flags_1 & TESLA_IGNORE_1))
+			if(dist <= zap_range && (dist < closest_dist || !(priority == 3)) && !(o.obj_flags & BEING_SHOCKED))
 				closest_atom = A
 				closest_dist = dist
 				priority = 3
 			continue
 		else if(priority <= 3)
 			continue
-		else if(priority >= 4 && istype(A, /obj/machinery))
-			var/obj/o = A
+		else if(priority >= 4 && isliving(A))
+			var/mob/living/L = A
 			var/dist = get_dist(source, A)
-			if(dist <= zap_range && (dist < closest_dist || !(priority == 4)) && !(o.obj_flags & BEING_SHOCKED))
+			if(dist <= zap_range && (dist < closest_dist || !(priority == 4)) && L.stat != DEAD && !(L.flags_1 & TESLA_IGNORE_1))
 				closest_atom = A
 				closest_dist = dist
 				priority = 4
 			continue
 		else if(priority <= 4)
 			continue
-		else if(priority >= 5 && istype(A, /obj/structure/blob))
+		else if(priority >= 5 && istype(A, /obj/machinery))
 			var/obj/o = A
 			var/dist = get_dist(source, A)
 			if(dist <= zap_range && (dist < closest_dist || !(priority == 5)) && !(o.obj_flags & BEING_SHOCKED))
@@ -308,7 +308,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/anomaly/energy_ball)
 			. = zapdir
 
 	//per type stuff:
-		if(priority == 3)
+		if(priority == 4)
 			var/mob/living/m = closest_atom
 			var/shock_damage = (tesla_flags & TESLA_MOB_DAMAGE)? (min(round(power/600), 90) + rand(-5, 5)) : 0
 			m.electrocute_act(shock_damage, source, 1, SHOCK_TESLA | ((tesla_flags & TESLA_MOB_STUN) ? NONE : SHOCK_NOSTUN))
@@ -321,6 +321,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/anomaly/energy_ball)
 		else
 			var/obj/o = closest_atom
 			o.tesla_act(power, tesla_flags, shocked_targets)
+
 #undef TESLA_MAX_BALLS
 
 #undef TESLA_DEFAULT_POWER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Upped the blob tesla shock priority from under the machines to above mobs (it goes: generator, grounding, blob, mob, machine, turf    now)
Unrelated, i now can setup turbine in less then a minute thanks to all the testing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Did you ever seen blob get shocked? I decided to test it when i realised it has its own code for being shocked and i learned its nearly impossible to get it shocked. I tried everything, from tesla coils though tesla pistol to even making the giant tesla ball, nothing shocked it. It's nearly impossible to use shock against the blob because its so low in targeting priority.
From testing after the change: tesla coil is really effective, but cant be spammed since the recent nerfed made multiple tesla coils steal power from each other (+ its fairly low range).  A entire charged magazine of tesla pistol killed 2 blob tiles (it really needs a buff). Didn't test big tesla but it should murder everything and i assume it will.
I could be convinced to put blob under mobs instead, it would make it much harder to use tesla coils against blob, but not impossible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Works on mashines
![Zrzut ekranu (123)](https://github.com/user-attachments/assets/2d582e2a-5ddc-4a9f-b548-6c37a6d47d7b)

Works on humans
![Zrzut ekranu (124)](https://github.com/user-attachments/assets/3807a25a-2893-4614-b899-3d449725f043)

Blob gets shocked instead of being completely safe
![Zrzut ekranu (121)](https://github.com/user-attachments/assets/1691ed30-74b3-4203-b6c9-8662ac7ee403)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Blob is now actually shocked by tesla arcs, instead of being targeted only if alternative would be a standard wall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
