### PR TITLE
Fixes /mob/living/get_contents() which also fixes the admin "Check Contents" Verb

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -621,8 +621,7 @@
 	ret |= contents //add our contents
 	for(var/i in ret.Copy()) //iterate storage objects
 		var/atom/A = i
-		if(A.atom_storage)
-			A.atom_storage.return_inv(ret)
+		A.atom_storage?.return_inv(ret)
 	for(var/obj/item/folder/F in ret.Copy())		//very snowflakey-ly iterate folders
 		ret |= F.contents
 	return ret

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -621,7 +621,8 @@
 	ret |= contents //add our contents
 	for(var/i in ret.Copy()) //iterate storage objects
 		var/atom/A = i
-		A.atom_storage.return_inv(ret)
+		if(A.atom_storage)
+			A.atom_storage.return_inv(ret)
 	for(var/obj/item/folder/F in ret.Copy())		//very snowflakey-ly iterate folders
 		ret |= F.contents
 	return ret


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/12473

The recent PR that datumized storage from components (https://github.com/BeeStation/BeeStation-Hornet/pull/11894) changed get_contents() as seen below:

![grafik](https://github.com/user-attachments/assets/3bba0b5c-87d7-437a-b0ef-b14adc56f339)

Which also matches with when the issue first appeared from what I can tell.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

get_contents() is used quite often so it not breaking whenever it's being called on an atom where atom_storage is NULL is important.

This should fix the issue with crew objectives (like botanists having certain drugs/plants) being impossible to complete.

This also specifically fixes the admin Check Contents verb which is pretty important as it is way faster than going through VV manually. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![grafik](https://github.com/user-attachments/assets/f61af898-3bd8-4e2c-babb-3fc73d51eb24)


## Changelog
:cl:
fix: Fixed /mob/living/get_contents()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
