### PR TITLE
Pre-Assembled RBMK

### DIFF
--- a/code/modules/power/rbmk/rbmk_parts.dm
+++ b/code/modules/power/rbmk/rbmk_parts.dm
@@ -216,10 +216,17 @@
 
 /obj/item/RBMK_box/core/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
+	var/list/parts = get_parts()
+
+	if(length(parts) == 8)
+		var/obj/machinery/atmospherics/components/unary/rbmk/core/newCore = build_reactor(parts)
+		newCore.user_activate(user)
+	return
+
+/obj/item/RBMK_box/core/proc/get_parts()
 	var/list/parts = list()
 	var/types_seen = list()
 	for(var/obj/item/RBMK_box/box in orange(1,src))
-
 		var/direction = get_dir(src, box)
 		box.dir = direction
 		if(box.box_type in list("coolant_input", "waste_output", "moderator_input"))
@@ -231,9 +238,15 @@
 					types_seen += box.box_type
 		else
 			parts |= box
+	return parts
+
+/obj/item/RBMK_box/core/pre_assemble_reactor/Initialize(mapload)
+	. = ..()
+	var/list/parts = get_parts()
+
 	if(length(parts) == 8)
 		var/obj/machinery/atmospherics/components/unary/rbmk/core/newCore = build_reactor(parts)
-		newCore.activate(user)
+		newCore.activate()
 	return
 
 /obj/item/RBMK_box/core/proc/build_reactor(list/parts)

--- a/code/modules/power/rbmk/rbmk_procs.dm
+++ b/code/modules/power/rbmk/rbmk_procs.dm
@@ -153,11 +153,14 @@ Arguments:
 * -user: the player doing the action
 */
 
-/obj/machinery/atmospherics/components/unary/rbmk/core/proc/activate(mob/living/user)
+/obj/machinery/atmospherics/components/unary/rbmk/core/proc/user_activate(mob/living/user)
 	if(active)
 		to_chat(user, span_notice("You already activated the machine."))
 		return
 	to_chat(user, span_notice("You activate the machine."))
+	activate()
+
+/obj/machinery/atmospherics/components/unary/rbmk/core/proc/activate()
 	active = TRUE
 	start_power = TRUE
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request
Allows mappers to add a fully assembled RBMK without leaving the parts in their part form.

## Why It's Good For The Game
For when you want a full assembled RBMK that can't be moved.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Thorough testing.

![image](https://github.com/user-attachments/assets/1df951f7-e785-434b-982b-7babde70dfce)

Making it yourself from scratch still works.

![image](https://github.com/user-attachments/assets/6083314e-4fac-433c-9cdb-3e7ae98bace2)

</details>

## Changelog
:cl:
add: Added an RBMK core which when map loaded will assemble itself.
/:cl:
