### PR TITLE
Removes Aquisition Ability of WheelyHeelys via GamesVendor

### DIFF
--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -30,7 +30,6 @@
 		/obj/item/melee/skateboard/pro = 3,
 		/obj/item/canvas/twentyfour_twentyfour = 5,
 		/obj/item/airlock_painter = 1,
-		/obj/item/clothing/shoes/wheelys= 3,
 		/obj/item/melee/skateboard/hoverboard = 1
 	)
 	refill_canister = /obj/item/vending_refill/games


### PR DESCRIPTION
## About The Pull Request

Tis, is but a humble, simple PR, one of which does little more than REMOVE, the innate ability, shared by all crew to access the GAMES vendor in the library, and buy the Wheelys.  By ELIMINATING the purchase option for the wheely of heelys, they NO LONGER are easily accessible for crew, and return the shoes of speed, to the maintence backrooms, where they must remain in the sake of balance.

## Why It's Good For The Game

Personally, its not. Shoes that go ZOOMIES are fun! BUTTTTTT, they are also too fast, unreasonably so, and apparently quicker than the Bike, the 1,000,000credit cargo purchase. Which SHOULD be the best vehicle given its price. But even disregarding the superiority these have on the bike, they themselves are too fast, breaking any semblance of balance if they have the room to use them as its not a catchable speed. Removing these, makes not only the item rarer, a mantience loot, but just removes the ability to purchase, for 25credits an insane speedboost stuck to your feet.


## Testing Photographs and Procedure

<details>
<summary> A Picture Of The Vendor and NOT Me Crying </summary>

![No Wheelys](https://github.com/user-attachments/assets/0c465cd1-12f2-4007-9e77-d594930f2656)


</details>

## Changelog
:cl:
tweak: Removed Wheely Heelys from Library Vendor
/:cl:
