### PR TITLE
Handcuff balance changes

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -25,7 +25,7 @@
 	throw_speed = 3
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=500)
-	breakouttime = 1 MINUTES
+	breakouttime = 35 SECONDS
 	armor_type = /datum/armor/restraints_handcuffs
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	var/trashtype = null //for disposable cuffs
@@ -97,7 +97,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	custom_materials = list(/datum/material/iron=150, /datum/material/glass=75)
-	breakouttime = 30 SECONDS
+	breakouttime = 25 SECONDS
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/restraints/handcuffs/cable/red
@@ -179,7 +179,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	custom_materials = null
-	breakouttime = 450 //Deciseconds = 45s
+	breakouttime = 250 //Deciseconds = 45s
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 	color = null
 

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -179,7 +179,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	custom_materials = null
-	breakouttime = 250 //Deciseconds = 45s
+	breakouttime = 25 SECONDS
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 	color = null
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -316,6 +316,16 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 		. = clear_cuffs(cuffs, cuff_break)
 	cuffs.item_flags &= ~BEING_REMOVED
 
+	if(grabbedby || buckled)
+		if(prob(10))
+			if(grabbedby)
+				grabbedby.release_grab()
+				to_chat(src, span_notice("You manage to escape the grab with a quick motion!"))
+			if(buckled)
+				buckled.user_unbuckle_mob(src, src)
+				to_chat(src, span_notice("You manage to unbuckle yourself with a quick motion!"))
+			return
+
 /mob/living/carbon/proc/uncuff()
 	if (handcuffed)
 		var/obj/item/W = handcuffed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds more chances to handcuffed people to get away from those who capture them. This PR is not 100% done but I wanted to see initial reactions before continuing to sink effort into it.
This PR lowers the required amount of time to break free from handcuffs, unbuckle yourself from a seat while buckled and handcuffed and also introduces a small chance to instantly break free from someone else's grip while cuffed (NOT TO INSTANTLY UNCUFF YOURSELF) and and to instantly break free from being unbuckled to somewhere.

## Why It's Good For The Game

Being cuffed is too punishing. If you manage to somehow evade security or whomever cuffed you, you now need to spend an entire minute before breaking free. If you think this change is too much, I encourage you to boot up a local server, cuff yourself, and then watch the entire lenght of the uncuffing process without doing nothing else, stare at the screen and think how much time you would have to spend unnoticed by whomever is after you in order to be able to paly the game again. Also it's not fun either to be carried around cuffed permanently until whoever cuffed you decides is time to now either uncuff you or get buckled into somewhere else. Now you have a chance to break free from the grip and try to get out. It's not an instant win and you will probably be just grabbed back, but ey, it's a small chance for you to escape. Why is the chance to break free from buckle bigger than the one to break free from grip? Because you only have one chance when being buckled to run this odds, while being dragged around you get multiple chances to try to break away from the grip

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: handcuffs now take 35 seconds to break free from
balance: zipties now take 25 seconds to break free from
balance: While handcuffed, if you are being dragged around by someone and resist, there's a 1/30 chance you break free from their grip and are able to run away. Keep in mind you are still handcuffed
balance: While handcuffed, if you are buckled somewhere resist, there's a 1/15 chance you instantly unbuckle yourself and are able to run away. Keep in mind you are still handcuffed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
