### PR TITLE
Revert "Adjusts deadchat color to more closely match the previous purple"

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -466,7 +466,7 @@ em {
 }
 
 .deadsay {
-  color: #c482ff;
+  color: #e2c1ff;
 }
 .binarysay {
   color: #20c20e;


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#12419

Reverts the adjustment to the dchat colour, as it unintentionally makes dchat indistinguishable from the science chat's colours. This makes it very annoying as a ghost trying to browse through d-chat while scientists are talking.

This is what we changed it to:

![image](https://github.com/user-attachments/assets/7f78da17-11b4-43aa-afb1-51a4f95dca9c)

## Testing Evidence

This is a reversion, but I'll do this in a bit.

:cl:
tweak: Reverts back to the brigher pink of dchat.
/:cl: