### PR TITLE
Rad Mining Shuttle Fix

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3921,7 +3921,7 @@
 "Ct" = (
 /obj/docking_port/stationary{
 	dir = 2;
-	dwidth = 3;
+	dwidth = 4;
 	height = 10;
 	id = "mining_away";
 	name = "lavaland mine";


### PR DESCRIPTION
## About The Pull Request
Fixed Rad mining shuttle docking at Lavaland.

Closes #12590.

## Why It's Good For The Game
Bug bad.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/7d8c3547-ff6a-49c3-b785-7059afd662dc)

</details>

## Changelog
:cl:
fix: fixed Rad mining shuttle docking at Lavaland.
/:cl:
