### PR TITLE
Makes buildmode del rclick usable

### DIFF
--- a/code/modules/buildmode/submodes/delete.dm
+++ b/code/modules/buildmode/submodes/delete.dm
@@ -23,14 +23,14 @@
 		if(isturf(object))
 			return
 		var/atom/deleting = object
-		var/action_type = alert(usr,"Strict type ([deleting.type]) or type and all subtypes?","Strict type","Type and subtypes","Cancel")
+		var/action_type = tgui_alert(usr,"Strict type ([deleting.type]) or type and all subtypes?",,list("Strict type","Type and subtypes","Cancel"))
 		if(action_type == "Cancel" || !action_type)
 			return
 
-		if(alert(usr,"Are you really sure you want to delete all instances of type [deleting.type]?","Yes","No") != "Yes")
+		if(tgui_alert(usr,"Are you really sure you want to delete all instances of type [deleting.type]?",,list("Yes","No")) != "Yes")
 			return
 
-		if(alert(usr,"Second confirmation required. Delete?","Yes","No") != "Yes")
+		if(tgui_alert(usr,"Second confirmation required. Delete?",,list("Yes","No")) != "Yes")
 			return
 
 		var/O_type = deleting.type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Whoever added this didn't know how alert() choices worked, meaning an rclick would always bring up a prompt with only No selected.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to purge, say, all the cherry bombs in the game at a few button clicks is pretty damn important.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/1c4b180e-e9ee-4f45-ae7f-dff667c60370



</details>

## Changelog
:cl:
fix: fix buildmode qdel rclick functionality
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
