### PR TITLE
Let water wapor and stimulum be sellable + some price rearranging. 

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -130,7 +130,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	moles_visible = MOLES_GAS_VISIBLE
 	fusion_power = 10
 	rarity = 50
-	base_value = 2.5
+	base_value = 5
 	desc = "The most noble gas of them all. High quantities of hyper-noblium actively prevents reactions from occurring."
 	primary_color = COLOR_TEAL
 
@@ -201,7 +201,7 @@ GLOBAL_LIST_INIT(hardcoded_gases, list(/datum/gas/oxygen, /datum/gas/nitrogen, /
 	specific_heat = 80
 	name = "Stimulum"
 	rarity = 200
-	base_value = 3
+	base_value = 5
 	desc = "An experimental gas that makes you stun and sleep immune and slightly regenerates stamina, but also causes suffocation the longer you've been breathing it."
 	primary_color = "#ffc0cb"
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -153,6 +153,8 @@
 								/datum/gas/hypernoblium,
 								/datum/gas/tritium,
 								/datum/gas/pluoxium,
+								/datum/gas/water_vapor,
+								/datum/gas/stimulum,
 								)
 
 	for(var/gasID in gases_to_check)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Water wapor and stimulum are now sellable in cargo
Stimulum and Hypernoblium are now worth more when selling
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hypernoll sells for less than tritium, its main advanced ingredient. Now it doesnt
Stimulum couldn't be sold (propably linda) now it can be as other advanced gasses
Water wapor is made in most high temperature reactions (trit burns realy easly) and has 2 uses (murder ozlings make floor slipery) now it has a way to utilise, and since it is extremely cheap it shouldn't influence cargo that much.
Stimulum was cheap and since its a reaction above the nitril with is requred for it and cost more, i incresed the price a bit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Sold one canister of water wapor and one of stimulum
![Zrzut ekranu (140)](https://github.com/user-attachments/assets/356ff91e-923b-40b5-bda0-0865e0aec39d)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Water wapor and stimulum can now be sold in cargo
balance: Increased selling price of Hypernoblium and stimulum
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
