### PR TITLE
Nerfed syringe bleed and damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -1,8 +1,8 @@
 /obj/projectile/bullet/dart
 	name = "dart"
 	icon_state = "cbbolt"
-	damage = 6
-	bleed_force = BLEED_SURFACE
+	damage = 5
+	bleed_force = BLEED_SCRATCH
 	var/piercing = FALSE
 	var/obj/item/reagent_containers/syringe/syringe = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Syringe bleed nerfed from surfarce to scrath bleading (1.5 -> 0.8) and damage (6 -> 5)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I want to open the syringe gun to more not sleeping or killing purposes, and a big bleeding amount they inflict is a problem for any helpful uses. The damage nerf is very minor and i just added it since it fits this use. I very much doubt that anyone will particularly miss this .7 bleed or 1 damage from the syringes, their purpose is the delivery of chemicals and this shouldn't affect the combat use of them negatively. 
Also why does a syringe embeding into someone cause similar amount of bleeding to being shot with a revolver?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Zrzut ekranu (152)](https://github.com/user-attachments/assets/64b4ef96-957a-4af9-b996-25efd37978c8)


Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: reduced bleeding and damaged caused by syringe gun 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
