### PR TITLE
Hotfixes storage implant's storage datum to match it's description

### DIFF
--- a/code/datums/storage/subtypes/implant.dm
+++ b/code/datums/storage/subtypes/implant.dm
@@ -1,6 +1,7 @@
 /datum/storage/implant
 	max_specific_storage = WEIGHT_CLASS_NORMAL
-	max_total_storage = 6
+	//desc states "two big items"
+	max_total_storage = (WEIGHT_CLASS_LARGE + WEIGHT_CLASS_LARGE)
 	max_slots = 2
 	silent = TRUE
 	allow_big_nesting = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The description states it can fit "two big items".

This calculates that by adding two large weight classes together (8/e) and resulting in a max_total_storage weight of 16.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unintended regression from storage datumization, futureproofing.

Storage implant can still only hold Normal size items and below, this does not affect that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Fitting two normal size items (4+4 weight)

![image](https://github.com/user-attachments/assets/723982c9-3ee1-4451-9c75-d2c10d7f2275)



</details>

## Changelog
:cl:
balance: doubles storage implant total storage to a weight of 16, matching its description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
