### PR TITLE
Buff blood filtering surgeries a bit

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -64,7 +64,7 @@
 			target.reagents.remove_reagent(chem.type, min(chem.volume * chem_purge_factor, 10)) //Removes more reagent for higher amounts
 		if(tox_loss <= limited_healing)
 			if(antispam_two)
-				to_chat(user, span_notice("You can't fix any more of toxin damage"))
+				to_chat(user, span_notice("You can't fix any more toxin damage"))
 				antispam_two = FALSE
 			if(!target.reagents.total_volume)
 				return FALSE

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -40,7 +40,7 @@
 	time = 2.5 SECONDS
 	success_sound = 'sound/machines/ping.ogg'
 	var/chem_purge_factor = 0.2
-	var/tox_heal_factor = 0
+	var/tox_heal_factor = 0.025
 
 /datum/surgery_step/filter_blood/preop(mob/user, mob/living/carbon/target, obj/item/tool, datum/surgery/surgery)
 	if(istype(surgery,/datum/surgery/blood_filter))
@@ -112,3 +112,4 @@
 
 /datum/surgery_step/filter_blood/upgraded/femto
 	time = 1 SECONDS
+	tox_heal_factor = 0.15

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -1,6 +1,6 @@
 /datum/surgery/blood_filter
 	name = "Filter Blood"
-	desc = "A surgical procedure that filters toxins from the patient's blood. Does not undo any toxin damage, however."
+	desc = "A surgical procedure that filters toxins from the patient's blood. Barely undoes any toxin damage, however."
 	steps = list(/datum/surgery_step/incise,
 				/datum/surgery_step/retract_skin,
 				/datum/surgery_step/incise,
@@ -9,7 +9,6 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-	requires_bodypart_type = TRUE
 	ignore_clothes = FALSE
 	replaced_by = /datum/surgery/blood_filter/upgraded
 	var/antispam = FALSE
@@ -102,6 +101,7 @@
 /datum/surgery_step/filter_blood/upgraded
 	time = 1.85 SECONDS
 	tox_heal_factor = 0.075
+	chem_purge_factor = 0.3
 
 /datum/surgery/blood_filter/femto
 	name = "Filter Blood (Exp.)"
@@ -113,3 +113,4 @@
 /datum/surgery_step/filter_blood/upgraded/femto
 	time = 1 SECONDS
 	tox_heal_factor = 0.15
+	chem_purge_factor = 0.4

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -38,7 +38,7 @@
 	success_sound = 'sound/machines/ping.ogg'
 	var/chem_purge_factor = 0.2
 	var/tox_heal_factor = 0.025
-	var/limited_healing = 80 // Cant heal toxin damage under this treshold
+	var/limited_healing = 100 // Cant heal toxin damage under this treshold
 
 
 /datum/surgery_step/filter_blood/preop(mob/user, mob/living/carbon/target, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Base blood filtering surgery heals toxin damage at 1/3 (not counting longer steps with make it even worse) of the rate of upgraded surgery and expert surgery heals at *2 speed (again not counting the step speed)
Upgraded surgeries also purge chems somewhat faster (0.2 -> 0.3 -> 0.4)
Base filtering surgery cant heal under 100 toxin damage
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Base filtration cant heal toxin damage at all, it just purges chems with has very little practical application given calomel and charcoal exists.  This should let it still be used as a surgical way of healing toxins without a operating computer, while being much much worse than any upgraded version making chem treatment still preferable.
For the changes to upgraded surgeries, other then tox healing starting from T2, they were all identical with only time per step changing. Now the difrences in how much each step heals exist making the upgrade more noticeable then just shaving 0.7 second of a step. Shouldn't affect the surgery much in terms of power, its still very good for big toxin damage, and really bad for low.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

This is pure numbers change. It compiles.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Standard blood filtering now very slowly heals toxin damage if its above 100.
balance: Higher levels of blood filtering now heal more toxin damage and purge more chems per step, instead of just shortening steps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
