### PR TITLE
Fixes the bounty reward displayed amount

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(economy)
 	var/list/dep_cards = list()
 	///The modifier multiplied to the value of bounties paid out.
 	///Multiplied as they go to all department accounts rather than just cargo.
-	var/bounty_modifier = 3
+	var/bounty_modifier = 9
 
 	/// Number of mail items generated.
 	var/mail_waiting
@@ -132,11 +132,16 @@ SUBSYSTEM_DEF(economy)
 /datum/bank_account/department/proc/is_nonstation_account() // It's better to read than if(D.nonstation_account)
 	return nonstation_account
 
-/datum/controller/subsystem/economy/proc/distribute_funds(amount)
+/// Returns the total amount of shares into which distributed funds are split
+/datum/controller/subsystem/economy/proc/distribution_sum()
 	var/distribution_sum = 0
 	for(var/datum/bank_account/department/D in budget_accounts)
 		distribution_sum += D.budget_ratio
-	var/single_part = round(amount / distribution_sum)
+	return distribution_sum
+
+/// Distributes funds to every budget according to its budget ratio
+/datum/controller/subsystem/economy/proc/distribute_funds(amount)
+	var/single_part = round(amount / distribution_sum())
 	for(var/datum/bank_account/department/D in budget_accounts)
 		D.adjust_money(single_part * D.budget_ratio)
 		if(D.nonstation_account)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

During the bank system refactor (#7559), the payout method for cargo bounties was changed to give a share to each department's budget. However, since this new distribution method is more complex, the amounts shown in the "Value" column of the bounty console did not reflect the amount of money gained by cargo when claiming a bounty. Specifically, the console showed twice the actual payout for cargo, giving the impression of receiving half the reward when claiming bounties. This PR makes the displayed value calculated using the same formula as the function that actually grants the money, solving this problem.

This PR also removes a hardcoded multiplier to the reward when claiming a bounty, and compensates for it by changing the bounty_modifier value of the economy subsystem.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The bounty console should accurately display the value of a bounty for the cargo budget. It is very frustrating to claim a bounty, only to see cargo's balance go up by half the promised amount.

For the bounty_modifier change, the role of SSeconomy.bounty_modifier is to be the value by which the reward is multiplied before. There shouldn't be an undocumented magic number that also modifies the bounty amount.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Before claiming a bounty, cargo budget empty: 
![before](https://github.com/user-attachments/assets/c3e9117e-fbf4-43fc-bfa3-ad407b3ef454)

After claiming the bounty, the cargo budget increased by the same amount as the bounty value: 
![after](https://github.com/user-attachments/assets/fc8f18bd-1f3d-4119-9a92-d9363ec66228)

The empty budget of every department before claiming a bounty:
![deptsbefore](https://github.com/user-attachments/assets/392c5917-34a7-4327-bda6-807c8d2a5446)

The budgets after claiming the bounty. As expected, the reward is split among every department, with Civilian and Service receiving one share, and every other department receiving two:
![deptsafter](https://github.com/user-attachments/assets/3d11fbdb-748d-4615-90d5-856d5de0c793)

</details>

## Changelog
:cl:
fix: The bounty consoles now accurately display the bounty values
code: Removes a hardcoded multiplier to the bounty reward amount, and compensates for it by changing the actual modifier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
