### PR TITLE
Adds a safety net for invalid number of positive quirks

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -43,18 +43,21 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 /datum/controller/subsystem/processing/quirks/proc/AssignQuirks(datum/mind/user, client/cli, spawn_effects)
 	var/list/bad_quirks = list()
+	var/positive_quirks = 0
 	for(var/V in cli.prefs.all_quirks)
 		var/datum/quirk/Q = quirks[V]
 		if(Q)
 			user.add_quirk(Q, spawn_effects)
+			if(Q.quirk_value > 0) //Tally up the total of all of the positive quirks, future-proofing for when we re-add 2-point positive quirks
+				positive_quirks += Q.quirk_value
 		else
 			stack_trace("Invalid quirk \"[V]\" in client [cli.ckey] preferences. the game has reset their quirks automatically.")
 			bad_quirks += V
-	if(length(bad_quirks)) // negative & zero value = calculation good / positive quirk value = something's wrong
+	if(length(bad_quirks) || positive_quirks > MAX_POSITIVE_QUIRKS)
 		cli.prefs.all_quirks = list()
 		// save the new cleared quirks.
 		cli.prefs.mark_undatumized_dirty_character()
-		client_alert(cli, "You have one or more outdated quirks[length(bad_quirks) ? ": [english_list(bad_quirks)]" : ""]. Your eligible quirks are kept at this round, but your character preference has been reset. Please review them at any time.", "Oh, no!")
+		client_alert(cli, "You have invalid quirks: ([length(bad_quirks) ? ": [english_list(bad_quirks)]" : "Too many positive quirks"]). Your quirks are kept at this round, but your character preference has been reset. Please review them at any time.", "Oh, no!")
 
 /// Takes a list of quirk names and returns a new list of quirks that would
 /// be valid.

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -57,7 +57,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		cli.prefs.all_quirks = list()
 		// save the new cleared quirks.
 		cli.prefs.mark_undatumized_dirty_character()
-		client_alert(cli, "You have invalid quirks: ([length(bad_quirks) ? ": [english_list(bad_quirks)]" : "Too many positive quirks"]). Your quirks are kept at this round, but your character preference has been reset. Please review them at any time.", "Oh, no!")
+		client_alert(cli, "You have invalid quirks: [length(bad_quirks) ? ": [english_list(bad_quirks)]" : "Too many positive quirks"]. Your quirks are kept at this round, but your character preference has been reset. Please review them at any time.", "Oh, no!")
 
 /// Takes a list of quirk names and returns a new list of quirks that would
 /// be valid.

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -57,7 +57,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		cli.prefs.all_quirks = list()
 		// save the new cleared quirks.
 		cli.prefs.mark_undatumized_dirty_character()
-		client_alert(cli, "You have invalid quirks: [length(bad_quirks) ? ": [english_list(bad_quirks)]" : "Too many positive quirks"]. Your quirks are kept at this round, but your character preference has been reset. Please review them at any time.", "Oh, no!")
+		client_alert(cli, "You have invalid quirks: [length(bad_quirks) ? "[english_list(bad_quirks)]" : "Too many positive quirks"]. Your quirks are kept at this round, but your character preference has been reset. Please review them at any time.", "Oh, no!")
 
 /// Takes a list of quirk names and returns a new list of quirks that would
 /// be valid.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Closes #12644
Adds a failsafe check to ensure players do not have too many positive quirks

## Why It's Good For The Game

While it is impossible to add too many quirks to a fresh or newly editted character, it is still possible to have a character previously set up with too many positive quirks if you didn't play between the initial change and the first hotfix where I accidentally removed more code than I should have. 

This should fix that, and also fix players being unable to save new loadouts if they were affected by this. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

I am unable to test this without both setting up and intentionally corrupting a local database. 

</details>

## Changelog
:cl:
fix: Characters which have too many positive quirks saved somehow will now have their quirks reset after the next time that character plays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
