### PR TITLE
Removing a bunch of ghost powers (bugs)

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -63,7 +63,8 @@ GENE SCANNER
 	return ..()
 
 /obj/item/t_scanner/AltClick(mob/user)
-	toggle_mode(user)
+	if(user.canUseTopic(src, BE_CLOSE))
+		toggle_mode(user)
 
 /obj/item/t_scanner/attack_self(mob/user)
 	toggle_on()

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -184,6 +184,8 @@
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	var/obj/item/lighter = locate(/obj/item/lighter) in contents
 	if(lighter)
 		quick_remove_item(lighter, user)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -455,7 +455,7 @@
 
 
 /obj/item/extinguisher/mini/nozzle/AltClick(mob/user)
-	if(tank?.upgrade_flags & FIREPACK_UPGRADE_SMARTFOAM)
+	if(tank?.upgrade_flags & FIREPACK_UPGRADE_SMARTFOAM & user.canUseTopic(src, BE_CLOSE))
 		toggled = !toggled
 		balloon_alert(user, "[toggled ? "Advanced" : "Normal"] foam mode")
 		playsound(src, 'sound/machines/click.ogg', 50)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -455,7 +455,7 @@
 
 
 /obj/item/extinguisher/mini/nozzle/AltClick(mob/user)
-	if(tank?.upgrade_flags & FIREPACK_UPGRADE_SMARTFOAM & user.canUseTopic(src, BE_CLOSE))
+	if((tank?.upgrade_flags & FIREPACK_UPGRADE_SMARTFOAM) && user.canUseTopic(src, BE_CLOSE))
 		toggled = !toggled
 		balloon_alert(user, "[toggled ? "Advanced" : "Normal"] foam mode")
 		playsound(src, 'sound/machines/click.ogg', 50)

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -41,24 +41,26 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/atmospherics/components/unary/outlet_inject
 	. += span_notice("You can link it with an air sensor using a multitool.")
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/CtrlClick(mob/user)
-	if(is_operational)
-		on = !on
-		balloon_alert(user, "turned [on ? "on" : "off"]")
-		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
-		update_icon()
-		ui_update()
-	return TRUE
-
-/obj/machinery/atmospherics/components/unary/outlet_injector/AltClick(mob/user)
-	if(volume_rate == MAX_TRANSFER_RATE)
+	if(can_interact(user))
+		if(is_operational)
+			on = !on
+			balloon_alert(user, "turned [on ? "on" : "off"]")
+			investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
+			update_icon()
+			ui_update()
 		return TRUE
 
-	volume_rate = MAX_TRANSFER_RATE
-	investigate_log("was set to [volume_rate] L/s by [key_name(user)]", INVESTIGATE_ATMOS)
-	balloon_alert(user, "You set the volume rate to [volume_rate] L/s.")
-	update_icon()
-	ui_update()
-	return TRUE
+/obj/machinery/atmospherics/components/unary/outlet_injector/AltClick(mob/user)
+
+	if(volume_rate == MAX_TRANSFER_RATE)
+		return TRUE
+	if(can_interact(user))
+		volume_rate = MAX_TRANSFER_RATE
+		investigate_log("was set to [volume_rate] L/s by [key_name(user)]", INVESTIGATE_ATMOS)
+		balloon_alert(user, "You set the volume rate to [volume_rate] L/s.")
+		update_icon()
+		ui_update()
+		return TRUE
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/update_icon_nopipes()
 	cut_overlays()

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -25,11 +25,6 @@
 /obj/item/clothing/mask/breath/attack_self(mob/user)
 	adjustmask(user)
 
-/obj/item/clothing/mask/breath/AltClick(mob/user)
-	..()
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
-		adjustmask(user)
-
 /obj/item/clothing/mask/breath/examine(mob/user)
 	. = ..()
 	. += span_notice("Alt-click [src] to adjust it.")

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -272,6 +272,7 @@
 	return voice_change ? "Unknown" : default_name
 
 /obj/item/clothing/mask/gas/old/modulator/examine()
+	. = ..()
 	. += span_notice("It was modified to make the user's voice sound robotic.")
 	. += "The modulator is currently [voice_change ? "<b>ON</b>" : "<b>OFF</b>"]."
 
@@ -280,5 +281,6 @@
 	to_chat(user, span_notice("The modulator is now [voice_change ? "on" : "off"]!"))
 
 /obj/item/clothing/mask/gas/old/modulator/AltClick(mob/user)
-	voice_change = !voice_change
-	to_chat(user, span_notice("The modulator is now [voice_change ? "on" : "off"]!"))
+	if(user.canUseTopic(src, BE_CLOSE))
+		voice_change = !voice_change
+		to_chat(user, span_notice("The modulator is now [voice_change ? "on" : "off"]!"))

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -202,6 +202,8 @@
 
 /obj/item/reagent_containers/cup/glass/waterbottle/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(cap_lost)
 		to_chat(user, span_warning("The cap seems to be missing! Where did it go?"))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After this PR, ghosts can **no longer** do the following:
* Turn on/off gas injectors
* Max out gas injector output
* Toggle T-rays to blueprint mode
* Remove lighters or cigarettes from cigarette packs
* Toggle smartfoam on upgraded foam sprayers
* Turn on/off hand crafted modulator masks
* Adjust breath masks up and down
(Also fixed the description on modulator masks while I was at it).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These are all control or alt click interactions that didn't check if the user was allowed to do it. Which means ghosts could do all of these to objects on the ground or even in people's inventory. Ghosts being able to lower breathmasks on people using them or turning off distro via the injector is a bit silly isn't it?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Spawned in all the relevant items:
![image](https://github.com/user-attachments/assets/01fcad0f-1ec8-4cea-9ee7-3772b2e78150)
The fuctions still work as a normal human, but not as a ghost (except for the breathmask adjusting with alt click that's just gone since you can already use in hand or use the action key while wearing it), and no other masks adjust with alt-click).

</details>

## Changelog
:cl: Gilgax
fix: Ghosts can no longer mess with people in ways they shouldn't (breath masks, t-rayscanners, cigarettes packs, gas injectors, smartfoam upgrades and modulator masks)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
