### PR TITLE
Removes the single use limit from the sepia-toned camera

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -98,6 +98,19 @@
 	item_path = /obj/item/scrying
 	category = "Defensive"
 
+/datum/spellbook_entry/item/rewind_camera
+	name = "Rewind Camera"
+	desc = "A camera that reverts the subject of a photo back to when the photo was taken, after a time. Restores limbs and injuries, but not death. Refillable with film, and comes with three shots."
+	item_path = /obj/item/camera/rewind
+	category = "Defensive"
+	cost = 1
+
+/datum/spellbook_entry/item/rewind_camera/buy_spell(mob/living/carbon/human/user, obj/item/spellbook/book)
+	new /obj/item/camera_film(get_turf(user)) //the camera only natively has one shot, so we'll give some reloads until they can raid the library
+	new /obj/item/camera_film(get_turf(user))
+	new /obj/item/camera_film(get_turf(user))
+	. = ..()
+
 /datum/spellbook_entry/item/wands
 	name = "Wand Assortment"
 	desc = "A collection of wands that allow for a wide variety of utility. \

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -12,7 +12,6 @@ Slimecrossing Items
 	pictures_max = 1
 	can_customise = FALSE
 	default_picture_name = "A nostalgic picture"
-	var/used = FALSE
 
 /datum/saved_bodypart
 	var/obj/item/bodypart/old_part
@@ -57,16 +56,14 @@ Slimecrossing Items
 /obj/item/camera/rewind/afterattack(atom/target, mob/user, flag)
 	if(!on || !pictures_left || !isturf(target.loc))
 		return
-	if(!used)//selfie time
-		if(user == target)
-			to_chat(user, span_notice("You take a selfie!"))
-		else
-			to_chat(user, span_notice("You take a photo with [target]!"))
-			to_chat(target, span_notice("[user] takes a photo with you!"))
-		to_chat(target, span_notice("You'll remember this moment forever!"))
+	if(user == target)
+		to_chat(user, span_notice("You take a selfie!"))
+	else
+		to_chat(user, span_notice("You take a photo with [target]!"))
+		to_chat(target, span_notice("[user] takes a photo with you!"))
+	to_chat(target, span_notice("You'll remember this moment forever!"))
 
-		used = TRUE
-		target.AddComponent(/datum/component/dejavu, 2)
+	target.AddComponent(/datum/component/dejavu, 2)
 	.=..()
 
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2258,6 +2258,13 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	cost = 6
 	restricted_roles = list(JOB_NAME_CURATOR)
 
+/datum/uplink_item/role_restricted/rewind_camera
+	name = "Sepia-toned Camera"
+	desc = "A camera that rewinds subjects to the time that their photograph was taken after a while. It won't revive them, but wounds will close and limbs will re-attach. Can be refilled with any old film."
+	item = /obj/item/camera/rewind
+	cost = 7
+	restricted_roles = list(JOB_NAME_CURATOR, JOB_NAME_CHAPLAIN)
+
 /datum/uplink_item/role_restricted/his_grace
 	name = "His Grace"
 	desc = "An incredibly dangerous weapon recovered from a station overcome by the grey tide. Once activated, He will thirst for blood and must be used to kill to sate that thirst. \


### PR DESCRIPTION
## About The Pull Request
This removes the **used** var from the sepiatoned camera, meaning it can be refilled with more film and used repeatedly. It also adds the camera to the wizard spellbook and the curator/chaplain traitor uplink, for 1 point and 7tc respectively. (Ignore the cost in the testing evidence I did a typo)

## Why It's Good For The Game
This camera is difficult to use for gimmicks or traitors, because every time you use it you need to get a new one. This makes refilling it easier, and lets it be more broadly applicable as a tool, as well as fixing the issue that it being single-use was never really clearly communicated to the players. I had to check code, which made me want to do this in the first place.

The **used** var is retained on the admin only timestop camera because jesus fucking christ why was that thing ever added in the first place, kill it with fire.


## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/01825dbb-574e-4cc3-ab43-a218e39c38f2

https://github.com/user-attachments/assets/471f4df9-9113-400f-8d12-38307af30280

![image](https://github.com/user-attachments/assets/097ee9c4-6a3b-4e4b-b8e9-4a852abc0d7a)

![image](https://github.com/user-attachments/assets/b7d5706d-3272-4cbc-9099-017463ffb35b)

</details>

## Changelog
:cl:
balance: The Sepia-toned camera can now be reloaded, instead of having to toss it and get another one from somewhere
/:cl: