### PR TITLE
Grenades are now a little bit more fair

### DIFF
--- a/code/datums/components/crafting/crafting_lists/weaponry/weapons.dm
+++ b/code/datums/components/crafting/crafting_lists/weaponry/weapons.dm
@@ -336,29 +336,12 @@
 	dangerous_craft = TRUE
 
 /datum/crafting_recipe/chemical_payload
-	name = "Chemical Payload (C4)"
-	result = /obj/item/bombcore/chemical
-	time = 3 SECONDS
-	reqs = list(
-		/obj/item/stock_parts/matter_bin = 1,
-		/obj/item/grenade/plastic/c4 = 1,
-		/obj/item/grenade/chem_grenade = 2
-	)
-	parts = list(
-		/obj/item/stock_parts/matter_bin = 1,
-		/obj/item/grenade/chem_grenade = 2
-	)
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-	dangerous_craft = TRUE
-
-/datum/crafting_recipe/chemical_payload2
-	name = "Chemical Payload (Gibtonite)"
+	name = "Chemical Payload"
 	result = /obj/item/bombcore/chemical
 	time = 5 SECONDS
 	reqs = list(
 		/obj/item/stock_parts/matter_bin = 1,
-		/obj/item/gibtonite = 1,
+		/obj/item/assembly/igniter = 1,
 		/obj/item/grenade/chem_grenade = 2
 	)
 	parts = list(

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -28,11 +28,7 @@
 		return TRUE
 
 /datum/wires/explosive/chem_grenade/attach_assembly(color, obj/item/assembly/S)
-	if(istype(S,/obj/item/assembly/timer))
-		var/obj/item/grenade/chem_grenade/G = holder
-		var/obj/item/assembly/timer/T = S
-		G.det_time = T.saved_time*10
-	else if(istype(S,/obj/item/assembly/prox_sensor))
+	if(istype(S,/obj/item/assembly/prox_sensor))
 		var/obj/item/assembly/prox_sensor/sensor = S
 		var/obj/item/grenade/chem_grenade/grenade = holder
 		grenade.landminemode = sensor

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -49,7 +49,7 @@
 	var/mob/M = get_mob_by_ckey(fingerprint)
 	var/turf/T = get_turf(M)
 	grenade.log_grenade(M, T)
-	grenade.prime()
+	grenade.preprime()
 
 /datum/wires/explosive/chem_grenade/detach_assembly(color)
 	var/obj/item/grenade/chem_grenade/grenade = holder

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -114,6 +114,7 @@
 	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)
 	active = TRUE
 	icon_state = initial(icon_state) + "_active"
+	det_time *= (0.1 * (rand(6, 14))) //between 60% and 140% of set time
 	SEND_SIGNAL(src, COMSIG_GRENADE_ARMED, det_time, delayoverride)
 	addtimer(CALLBACK(src, PROC_REF(prime)), isnull(delayoverride)? det_time : delayoverride)
 

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -23,10 +23,6 @@
 	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10 K upon ignition." // Appears when examining empty casings.
 	var/obj/item/assembly/prox_sensor/landminemode = null
 
-/obj/item/grenade/chem_grenade/ComponentInitialize()
-	. = ..()
-	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
-
 /obj/item/grenade/chem_grenade/Initialize(mapload)
 	. = ..()
 	create_reagents(1000)
@@ -82,11 +78,11 @@
 			else
 				to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
 		else if(stage == GRENADE_READY)
-			det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
+			det_time = det_time == 5 SECONDS ? 3 SECONDS : 5 SECONDS //toggle between 30 and 50
 			if(landminemode)
 				landminemode.time = det_time * 0.1	//overwrites the proxy sensor activation timer
 
-			to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
+			to_chat(user, span_notice("You modify the time delay, it's now set for [DisplayTimeText(det_time)]. Actual detonation delay may vary by up to 40%."))
 		else
 			to_chat(user, span_warning("You need to add a wire!"))
 		return
@@ -112,7 +108,7 @@
 	else if(stage == GRENADE_EMPTY && istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
 		if (C.use(1))
-			det_time = 50 // In case the cable_coil was removed and readded.
+			det_time = 5 SECONDS // In case the cable_coil was removed and readded.
 			stage_change(GRENADE_WIRED)
 			to_chat(user, span_notice("You rig the [initial(name)] assembly."))
 		else
@@ -183,7 +179,8 @@
 			if(landminemode)
 				to_chat(user, span_warning("You prime [src], activating its proximity sensor."))
 			else
-				to_chat(user, span_warning("You prime [src]! [DisplayTimeText(det_time)]!"))
+				to_chat(user, span_warning("You prime [src]!"))
+	det_time *= (0.1 * (rand(6, 14))) //between 60% and 140% of set time
 	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)
 	icon_state = initial(icon_state) + "_active"
 	if(landminemode)
@@ -233,7 +230,6 @@
 		/obj/item/reagent_containers/condiment,
 		/obj/item/reagent_containers/cup/glass,
 	)
-	banned_containers = list()
 	affected_area = 5
 	ignition_temp = 25 // Large grenades are slightly more effective at setting off heat-sensitive mixtures than smaller grenades.
 	threatscale = 1.1	// 10% more effective.

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -60,12 +60,6 @@
 	if(stage == GRENADE_WIRED)
 		wires.interact(user)
 
-
-/obj/item/grenade/chem_grenade/large/attackby(obj/item/I, mob/user, params)
-
-	else
-		return ..()
-
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/slime_extract) && stage == GRENADE_WIRED)
 		if(!user.transferItemToLoc(I, src))

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -242,16 +242,6 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
-/datum/design/large_grenade
-	name = "Large Grenade"
-	desc = "A grenade that affects a larger area and use larger containers."
-	id = "large_Grenade"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 3000)
-	build_path = /obj/item/grenade/chem_grenade/large
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_MEDICAL
-
 /datum/design/pyro_grenade
 	name = "Pyro Grenade"
 	desc = "An advanced grenade that is able to self ignite its mixture."

--- a/code/modules/ruins/lavalandruin_code/syndicate_base.dm
+++ b/code/modules/ruins/lavalandruin_code/syndicate_base.dm
@@ -13,7 +13,6 @@
 					/obj/item/assembly/health = 5,
 					/obj/item/assembly/infra = 5,
 					/obj/item/grenade/chem_grenade = 5,
-					/obj/item/grenade/chem_grenade/large = 5,
 					/obj/item/grenade/chem_grenade/pyro = 5,
 					/obj/item/grenade/chem_grenade/cryo = 5,
 					/obj/item/grenade/chem_grenade/adv_release = 5,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1) Grenades now have a variable +/- 40% on their fuse timing
2) Timers attached to grenades no longer directly affect the detonation timer and may no longer be used to bypass the removal of instant detonation from chemical grenades
3) Grenades that have their wire pulsed no longer detonate instantly, instead triggering with the fuse (and beeping) as if it were activated by hand
4) Large grenades have been removed, all other chemical grenades have inherited their ability to hold slime cores
5) Chemical grenade wires are no longer resistant to EMP
6) Chemical payload (for use in bombs) takes an igniter instead of C4 or Gibtonite now

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1, 2 and 3 - because being able to precisely detonate grenades without warning is not fun, engaging or fair for the receiving end of the detonation. Instant detonation was intentionally removed from chemical grenades which have a much greater power potential than most pre-made ones. A grenade is an area denial tool moreso than a "die instantly with no recourse" tool with these changes. 
4 - Because grenades continue to be so powerful that precision isn't even necessary. 600u grenades are capable of an insane amount of destruction for an easily concealable item. 
5 - Because it's funny mostly. Note that this does not affect non-chemical grenades which do not have wires. Syndicate EMP grenades will not trigger each other, but a stockpile of EMP grenades will now.
6 - To ensure that large scale explosives are at least possible for the majority of antagonists to access. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
![image](https://github.com/user-attachments/assets/eaec4b0a-adda-4b02-872a-9bf5fc4ec712)
![image](https://github.com/user-attachments/assets/ba1b09fd-5044-48f6-ac73-697ab82665a1)
![image](https://github.com/user-attachments/assets/a702a459-edf3-412c-be0f-068efcc4e9ba)

EMP triggers the tear gas grenades which are chemical grenades
![image](https://github.com/user-attachments/assets/3bfb1ed7-82fe-4e35-9963-d59f76e27610)


</details>

## Changelog
:cl:
balance: grenades are generally more fair for the receiving end now. 
tweak: Pulsing the wires of a chemical grenade no longer instantly detonates it, instead triggering the grenade as if the pin was pulled
tweak: Timers may no longer be used to override the fuse length on a grenade
tweak: Grenade fuses are variable by up to +/- 40% to reduce the efficacy and increase risk of cooking a grenade. This gives players who have a grenade thrown at them a better chance to respond.
del: Large grenades have been removed, which functionally removes the ability to add bluespace beakers to grenades.
tweak: All chemical grenades now accept slime cores, to preserve this functionality from large grenades
tweak: Grenades with wires are no longer immune to EMP. Most pre-made grenades such as those ordered via uplink do not have wires, this primarily affects custom chemical grenades and tear gas grenades.
tweak: Chemical payloads (for use in large bombs) now take igniters to craft instead of gibtonite and C4. This also means they only have a single recipe now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
