### PR TITLE
added dieting quirk

### DIFF
--- a/code/datums/traits/negative_quirk.dm
+++ b/code/datums/traits/negative_quirk.dm
@@ -128,6 +128,35 @@
 	if(DT_PROB(0.05, delta_time))
 		SEND_SIGNAL(quirk_target, COMSIG_ADD_MOOD_EVENT, "depression", /datum/mood_event/depression)
 
+		/datum/quirk/dieting
+	name = "Dieting"
+	desc = "You are on a diet! Junk food and cakes are off the menu."
+	icon = "burger"
+	gain_text = span_notice("You are on a diet! You need to cut out the calories.")
+	lose_text = span_notice("You give up on your diet, just exercise!.")
+	medical_record_text = "Patient reports a low-calorie diet."
+
+/datum/quirk/dieting/add()
+	var/mob/living/carbon/human/H = quirk_target
+	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+	T?.liked_food &= ~(JUNKFOOD | SUGAR)
+	T?.disliked_food |= (JUNKFOOD | SUGAR)
+
+/datum/quirk/dieting/remove()
+	var/mob/living/carbon/human/H = quirk_target
+	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+	if(H)
+		if(initial(T.liked_food) & JUNKFOOD)
+			T?.liked_food |= JUNKFOOD
+		if(!(initial(T.disliked_food) & JUNKFOOD))
+			T?.disliked_food &= ~JUNKFOOD
+
+		if(initial(T.liked_food) & SUGAR)
+			T?.liked_food |= SUGAR
+		if(!(initial(T.disliked_food) & SUGAR))
+			T?.disliked_food &= ~SUGAR
+
+
 /datum/quirk/family_heirloom
 	name = "Family Heirloom"
 	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"

--- a/code/datums/traits/neutral_quirk.dm
+++ b/code/datums/traits/neutral_quirk.dm
@@ -41,6 +41,34 @@
 		if(!(initial(T.disliked_food) & MEAT))
 			T?.disliked_food &= ~MEAT
 
+/datum/quirk/dieting
+	name = "Dieting"
+	desc = "You are on a diet! Junk food and cakes are off the menu."
+	icon = "burger"
+	gain_text = span_notice("You are on a diet! You need to cut out the calories.")
+	lose_text = span_notice("You give up on your diet, just exercise!.")
+	medical_record_text = "Patient reports a low-calorie diet."
+
+/datum/quirk/dieting/add()
+	var/mob/living/carbon/human/H = quirk_target
+	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+	T?.liked_food &= ~(JUNKFOOD | SUGAR)
+	T?.disliked_food |= (JUNKFOOD | SUGAR)
+
+/datum/quirk/dieting/remove()
+	var/mob/living/carbon/human/H = quirk_target
+	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
+	if(H)
+		if(initial(T.liked_food) & JUNKFOOD)
+			T?.liked_food |= JUNKFOOD
+		if(!(initial(T.disliked_food) & JUNKFOOD))
+			T?.disliked_food &= ~JUNKFOOD
+
+		if(initial(T.liked_food) & SUGAR)
+			T?.liked_food |= SUGAR
+		if(!(initial(T.disliked_food) & SUGAR))
+			T?.disliked_food &= ~SUGAR
+
 /datum/quirk/pineapple_liker
 	name = "Ananas Affinity"
 	desc = "You find yourself greatly enjoying fruits of the ananas genus. You can't seem to ever get enough of their sweet goodness!"


### PR DESCRIPTION
Intended to restrict diet similar to how vegetarian works, but targeting JUNKFOOD and SUGAR

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a new quirk, intended to prevent the player from eating junk food or sugary food. The intent is to encourage seeking out properly cooked food from the kitchen or botanist rather than relying on vending machines.

## Why It's Good For The Game

There are some situations where people become complacent with the hunger needs of crew, demands for 'real' food are responded to with statements boiling down to 'just eat chips' which feels very odd and inefficient in the long run. Having crew members which cannot eat junk food will pressure the station to provide better alternatives.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Added a new 'Dieting' quirk. No more junk food!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
