### PR TITLE
Fix cyborg swapping.

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -102,6 +102,7 @@
 			power_station.teleporter_hub.update_icon()
 			power_station.teleporter_hub.calibrated = FALSE
 			reset_regime()
+			balloon_alert_to_viewers("Regime reset")
 			. = TRUE
 		if("settarget")
 			power_station.engaged = FALSE
@@ -226,7 +227,9 @@
 				if(is_eligible(I))
 					L[avoid_assoc_duplicate_keys("[M.real_name] ([get_area(M)])", areaindex)] = I
 
-		var/desc = input("Please select a location to lock in.", "Locking Computer") as null|anything in sort_list(L)
+		var/desc = tgui_input_list(usr, "Select a location to lock in", "Locking Computer", sort_list(L))
+		if(isnull(desc)|| !user.canUseTopic(src, be_close = !issilicon(user)))
+			return
 		target_ref = WEAKREF(L[desc])
 		var/turf/T = get_turf(L[desc])
 		log_game("[key_name(user)] has set the teleporter target to [L[desc]] at [AREACOORD(T)]")
@@ -240,7 +243,9 @@
 		if(!L.len)
 			to_chat(user, span_alert("No active connected stations located."))
 			return
-		var/desc = input("Please select a station to lock in.", "Locking Computer") as null|anything in sort_list(L)
+		var/desc = tgui_input_list(usr, "Select a station to lock in", "Locking Computer", sort_list(L))
+		if(isnull(desc)|| !user.canUseTopic(src, be_close = !issilicon(user)))
+			return
 		var/obj/machinery/teleport/station/target_station = L[desc]
 		if(!target_station || !target_station.teleporter_hub)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes #12420 

closes #12668

Probably didnt work that well in the original #11899 , but it did work. I tested it.

Likely compounded and truly broken in https://github.com/BeeStation/BeeStation-Hornet/pull/12378 That PR can be considered reverted as of this one.

The genericization of humans and cyborg check doesn't work. They both need their own check.

Minor fix on teleporter's shitty inputs, barely worth mentioning.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes pushing of AI/silicons in general

Keep in mind, pulling a mob while on harm intent will elevate the pulling behavior and mob density ABOVE whatever expected behavior of the intent you are on. 

So if you are trying to, say, push the AI into a teleporter, let go first.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/335cd8d4-cc05-4c67-9620-2688e72ff844



</details>

## Changelog
:cl:
fix: fix silicon shoving. AI's should be able to be pushed into teleporters again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
