### PR TITLE
Adds Advanced Hair Dye

### DIFF
--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -352,6 +352,7 @@
 					playsound(user, 'sound/effects/spray2.ogg', 50, 1)
 					H.hair_color = sanitize_hexcolor(new_color)
 					H.update_hair()
+					H.update_mutant_bodyparts()
 			if("Gradient")
 				var/new_color = tgui_color_picker(user, "Select the new gradient color", "Dyeing", null)
 				if(new_color && do_after(user, 6 SECONDS, target = H))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1754,6 +1754,7 @@
 			H.hair_color = pick(potential_colors)
 			H.facial_hair_color = pick(potential_colors)
 			H.update_hair()
+			H.update_mutant_bodyparts()
 
 /datum/reagent/barbers_aid
 	name = "Barber's Aid"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds Advanced Hair Dye, which unlike it's regular variant, allows hair to be changed to the color that the user specifies as well as the gradient color and style.

https://github.com/user-attachments/assets/8189aa24-6076-4150-b198-ad5b359d2f2a

Additional changes are razor's input being TGUIfied and making it so users are warned whenever their hair is being shaved or changed. As well as fixing an issue where characters with mutant bodyparts would not have their mutant organs (cat ears) reflecting the changes.

todo:
[ ] Unique sprite
[ ] Make the item obtainable through cargo, barber role, barbershop, chameleon kits, contractor kit, etc.
[ ] Sounds?

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
The intention of this PR is add a new tool that allows a fairly robust midround customization to be done that may hopefully make Barbers more useful and less of a role that gets ignored by everyone. I see that people change their characters' hair quite often, be it through the hair dye chem or manually on character preferences, which makes believe this change would be welcomed by people who want to change their hair later into the round. This could also be considered a buff to antagging too as it makes disguising much easier for them.

As a backup, it'll be available on the barbershop and cargo if there are no existing barbers during the round.

As for the additional changes, it's a bit weird how subtle being shaving or hairstyle is when everything else tends to be a big red text applied to you.

Lastly, this has been part of something I've been intending to implement first as part of a Barber Overhaul I've had written a year ago which may be read below. No guarantees most of this will go through.
https://hackmd.io/@Hardly/Bkovgp5qT

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Hardly
add: Added Advanced Hair Dye for Barbers, Barbershop, Cargo, and Syndicate chameleon and contractor kits
fix: Fixed felinid ears not changing color when applied with hair dye
code: Targets are warned when their hair are being shaved/changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
