### PR TITLE
Makes the Service/Officer Pistol do stamina damage only

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -40,7 +40,7 @@
 	icon_state = "officer-12"
 	max_ammo = 12
 	multiple_sprites = 1
-	ammo_type = /obj/item/ammo_casing/caseless/laser/lesslethal
+	ammo_type = /obj/item/ammo_casing/energy/disabler
 
 /obj/item/ammo_box/magazine/recharge/service/update_icon()
 	..()


### PR DESCRIPTION
## About The Pull Request

Takes the Officer pistol out of the weird middle ground that makes it too lethal to use for detaining people that break into your department and not lethal enough to dissuade an armed assailant. 

Makes it do the same damage as a disabler. Makes the color of the bolt clearly reflect its nature as a nonlethal laser.

## Why It's Good For The Game

Weapons like this should have clear, defined use cases. 
In this case, the concept of "less lethal" is vague, because there's no way to judge how much someone has been doing weight training, how much someone has been doing bath salts, etc, meaning there's no way to know how many shots are going to put them into stamcrit for long enough to get the cuffs on them. As a result it encourages mag dumping, and if you magdump you can be held accountable for using the less lethal weapon with lethal intent.

"players can still use ... non-lethals with clearly lethal intent, and this is the sort of thing that shows up in logs." - recent discussion in a report.

Either you make it all stam damage or all lethal damage, or you may as well just remove the weapon, because anyone that's allowed to is going to swap it out for a disabler, etc. to avoid the possibility of getting told off by staff.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>


(was aiming at the arm on the first guy, oops)

https://github.com/user-attachments/assets/2f56f17d-298a-461e-9e67-01af75b6f162

</details>

## Changelog
:cl:colonelorion
tweak: Officer's pistol now does stamina damage only, equivalent to the disabler.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
