### PR TITLE
[Hotfix] Disable Artifact Animal Trait

### DIFF
--- a/code/modules/xenoarchaeology/misc/items.dm
+++ b/code/modules/xenoarchaeology/misc/items.dm
@@ -68,7 +68,7 @@
 	sticker.pixel_x = rand(-5, 5)
 
 /obj/item/xenoartifact/tutorial/add_artifact_component()
-	AddComponent(/datum/component/xenoartifact, /datum/xenoartifact_material/bluespace, list(/datum/xenoartifact_trait/activator/sturdy, /datum/xenoartifact_trait/minor/slippery, /datum/xenoartifact_trait/minor/charged, /datum/xenoartifact_trait/minor/cooling, /datum/xenoartifact_trait/major/animalize))
+	AddComponent(/datum/component/xenoartifact, /datum/xenoartifact_material/bluespace, list(/datum/xenoartifact_trait/activator/sturdy, /datum/xenoartifact_trait/minor/slippery, /datum/xenoartifact_trait/minor/charged, /datum/xenoartifact_trait/minor/cooling, /datum/xenoartifact_trait/major/projectile))
 
 /*
 	Pre-labeled variant

--- a/code/modules/xenoarchaeology/traits/majors/animalize.dm
+++ b/code/modules/xenoarchaeology/traits/majors/animalize.dm
@@ -6,6 +6,7 @@
 	label_name = "Bestialized"
 	label_desc = "Bestialized: The artifact contains transforming components. Triggering these components transforms the target into an animal."
 	//flags = XENOA_BLUESPACE_TRAIT | XENOA_BANANIUM_TRAIT | XENOA_PEARL_TRAIT
+	flags = XENOA_MISC_TRAIT | XENOA_HIDE_TRAIT
 	cooldown = XENOA_TRAIT_COOLDOWN_GAMER
 	weight = 15
 	conductivity = 12


### PR DESCRIPTION
## About The Pull Request

Temporarily disables the artifact animal trait.
This was supposed to be the case earlier, but the mammoth of a system found a way to sneak it in.

## Why It's Good For The Game

The trait currently makes you deaf.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Disabled Artifact Animal Trait
/:cl:

