### PR TITLE
Stops xenoarch from breaking half the tests

### DIFF
--- a/code/modules/xenoarchaeology/misc/items.dm
+++ b/code/modules/xenoarchaeology/misc/items.dm
@@ -1,3 +1,5 @@
+CREATION_TEST_IGNORE_SUBTYPES(/obj/item/xenoartifact)
+
 /*
 	generic artifact
 */

--- a/code/modules/xenoarchaeology/traits/_misc.dm
+++ b/code/modules/xenoarchaeology/traits/_misc.dm
@@ -60,6 +60,8 @@
 	component_parent.trigger()
 	return TRUE
 
+CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/closet/artifact)
+
 /obj/structure/closet/artifact
 	name = "The Bishop" //Proper name
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xenoarchaology things are no longer spawned for testing.

## Why It's Good For The Game

This shit breaks all the time, not closing the issues since they are still broken and runtiming.

## Testing Photographs and Procedure

If this passes merge queue it worked.

## Changelog
:cl:
fix: Xenoartifacts no longer cause random unit test failures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
