### PR TITLE
Provides a user agent when downloading Byond

### DIFF
--- a/tools/ci/download_byond.sh
+++ b/tools/ci/download_byond.sh
@@ -2,4 +2,4 @@
 set -e
 source dependencies.sh
 echo "Downloading BYOND version $BYOND_MAJOR.$BYOND_MINOR"
-curl "http://www.byond.com/download/build/$BYOND_MAJOR/$BYOND_MAJOR.${BYOND_MINOR}_byond.zip" -o C:/byond.zip
+curl "http://www.byond.com/download/build/$BYOND_MAJOR/$BYOND_MAJOR.${BYOND_MINOR}_byond.zip" -o C:/byond.zip -H "User-Agent: Beestation/1.0 Continuous Integration"

--- a/tools/ci/download_byond.sh
+++ b/tools/ci/download_byond.sh
@@ -2,4 +2,4 @@
 set -e
 source dependencies.sh
 echo "Downloading BYOND version $BYOND_MAJOR.$BYOND_MINOR"
-curl "http://www.byond.com/download/build/$BYOND_MAJOR/$BYOND_MAJOR.${BYOND_MINOR}_byond.zip" -o C:/byond.zip -H "User-Agent: Beestation/1.0 Continuous Integration"
+curl "http://www.byond.com/download/build/$BYOND_MAJOR/$BYOND_MAJOR.${BYOND_MINOR}_byond.zip" -o C:/byond.zip -A "Beestation/1.0 Continuous Integration"


### PR DESCRIPTION
Tells the Byond server that we are downloading on behalf of Beestation continuous integration. For some reason the Byond servers seems to block github runners when they don't provide a user agent. When I perform a curl locally without a user-agent, it doesn't get blocked so I have no idea what is going on here.

Credit goes to tako1337 on the Byond discord for suggesting providing user agents.