### PR TITLE
Fix TGUI say focus

### DIFF
--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -58,6 +58,7 @@
 		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED] mainwindow.macro=old_default")
 
 	update_special_keybinds()
+	winset(src, "tgui_say.browser", "focus=true")
 
 
 /**

--- a/tgui/packages/tgui-say/handlers/componentMount.tsx
+++ b/tgui/packages/tgui-say/handlers/componentMount.tsx
@@ -22,6 +22,8 @@ export const handleComponentMount = function (this: Modal) {
       this.fields.innerRef.current?.focus();
     }, 1);
     windowOpen(CHANNELS[channel]);
+    const input = this.fields.innerRef.current;
+    input?.focus();
   });
   Byond.subscribeTo('close', () => {
     windowClose();

--- a/tgui/packages/tgui-say/styles/button.scss
+++ b/tgui/packages/tgui-say/styles/button.scss
@@ -7,6 +7,7 @@
   border: thin solid;
   border-radius: 3px;
   color: colors.$background;
+  user-select: none;
   font-family: 'Consolas', monospace;
   font-weight: bolder;
   font-size: 1rem;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #12622

TGUI say will now auto-focus when launching for the first time.

Uses some code from https://github.com/tgstation/tgstation/pull/90395 and https://github.com/tgstation/tgstation/pull/90608

## Why It's Good For The Game

516 support

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/19f51781-5a4d-4abf-9538-afeb45db987d)


## Changelog
:cl:
fix: TGUI say will now auto-focus when first loading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
