### PR TITLE
Fixes the ability to create fines

### DIFF
--- a/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/CrimeWatcher.tsx
@@ -237,7 +237,7 @@ const CrimeAuthor = (props) => {
       </Stack.Item>
       <Stack.Item color="label">
         Fine (leave blank to arrest)
-        <RestrictedInput onEnter={(_, value) => setCrimeFine(value)} fluid maxValue={1000} />
+        <RestrictedInput onChange={(_, value) => setCrimeFine(value)} fluid maxValue={1000} />
       </Stack.Item>
       <Stack.Item>
         <Button.Confirm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #12709

The fines UI has been using onEnter, which requires the user to press the enter key to accept the value entered. This means that if they enter a value, and click off of it without pressing the enter key then the fine will not have a value and will be created as an arrest warrant.

Now, the fine gets set when the input value changes, so you don't need to press enter.

## Why It's Good For The Game

This confusing part of the UI makes it appear broken.

## Testing Photographs and Procedure

I did not press enter:

![image](https://github.com/user-attachments/assets/e7fbf75e-f817-4959-b299-5377dea2e9d9)

![image](https://github.com/user-attachments/assets/aa31a226-71ff-4d1f-8729-914d2fc69009)


## Changelog
:cl:
fix: Fixes fines not correctly inputting if you do not press the enter key.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
