### PR TITLE
Fixes Burning Black

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_mobs.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_mobs.dm
@@ -9,13 +9,14 @@ Slimecrossing Mobs
 	name = "Slime Transformation"
 	desc = "Transform from a human to a slime, or back again!"
 	button_icon_state = "transformslime"
-	cooldown_time = 0 SECONDS
 
+	cooldown_time = 0 SECONDS
+	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE
 
 	convert_damage = TRUE
 	convert_damage_type = CLONE
-	possible_shapes = list(/mob/living/simple_animal/slime/transformed_slime)
+	shapeshift_type = /mob/living/simple_animal/slime/transformed_slime
 
 	/// If TRUE, we self-delete (remove ourselves) the next time we turn back into a human
 	var/remove_on_restore = FALSE


### PR DESCRIPTION

## About The Pull Request
back to one line changes

This PR changes /shapeshift/slime, a spell that only originates from the Burning Black extract. Broken by #11527, fixed by me. It removes the wizard requirement, and changes the possible_shapes list to shapeshift_type.

<details>
<summary>Why I Did That</summary>

When you use the extract, burning black, it casts the spell and turns you into a slime. Or at least it's supposed to. possible_shapes is converted into a shapeshift_type var during the pre_cast of the spell, and when you use burning black, it doesn't pre_cast, it just skips straight to the casting bit of the spell, which then tries to turn you into a null object, which obviously doesn't work. Funnily enough, this lets you keep the spell and activate it later, which is a true balancing nightmare.

Rather than having a janky duplicate piece of code inside the cast proc, I figured it was better to just manually set the shapeshift type, since if this spell is ever turning you into anything other than a slime then something is very deeply wrong.

</details>


## Why It's Good For The Game

Things should function as intended, arguably.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/446d96ba-6458-4cb5-b9b3-78c87c072d2f

</details>

## Changelog
:cl:
fix: burning black works again
/:cl:
