### PR TITLE
Nerfs excessive speed buffs from stabilized extracts.

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -440,28 +440,43 @@
 //////////////////STABILIZED EXTRACTS//////////////////
 ///////////////////////////////////////////////////////
 
+/atom/movable/screen/alert/status_effect/stabilized
+	name = "Stabililzed"
+	icon_state = "template"
+
 /datum/status_effect/stabilized //The base stabilized extract effect, has no effect of its' own.
 	id = "stabilizedbase"
 	duration = -1
-	alert_type = null
+	alert_type = /atom/movable/screen/alert/status_effect/stabilized
+	status_type = STATUS_EFFECT_REPLACE
 	var/obj/item/slimecross/stabilized/linked_extract
 	var/colour = "null"
 
+/datum/status_effect/stabilized/proc/link_extract(obj/item/slimecross/stabilized/linked_extract)
+	src.linked_extract = linked_extract
+	if (linked_extract && linked_alert)
+		linked_alert.name = linked_extract.name
+		linked_alert.desc = linked_extract.desc
+		linked_alert.add_overlay(linked_extract)
+
 /datum/status_effect/stabilized/tick()
+	if (duration != -1)
+		return ..()
 	if(!linked_extract || !linked_extract.loc) //Sanity checking
-		qdel(src)
-		return
+		duration = world.time + 15 SECONDS
+		START_PROCESSING(SSfastprocess, src)
+		return ..()
 	if(linked_extract.loc != owner && linked_extract.loc.loc != owner)
 		linked_extract.linked_effect = null
 		if(!QDELETED(linked_extract))
 			linked_extract.owner = null
 			START_PROCESSING(SSobj,linked_extract)
-		qdel(src)
+		duration = world.time + 15 SECONDS
+		START_PROCESSING(SSfastprocess, src)
 	return ..()
 
 /datum/status_effect/stabilized/null //This shouldn't ever happen, but just in case.
 	id = "stabilizednull"
-
 
 //Stabilized effects start below.
 /datum/status_effect/stabilized/grey
@@ -692,11 +707,11 @@
 /datum/status_effect/stabilized/sepia/tick()
 	if(prob(50) && mod > -1)
 		mod--
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -1)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = -0.5)
 	else if(mod < 1)
 		mod++
 		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly
-		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = 0)
+		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/status_effect/sepia, multiplicative_slowdown = 0.5)
 	return ..()
 
 /datum/status_effect/stabilized/sepia/on_remove()

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -39,13 +39,12 @@ Stabilized extracts:
 		if(initial(S.colour) == colour)
 			effectpath = S
 			break
-	if(!H.has_status_effect(effectpath))
+	var/datum/status_effect/stabilized/current_effect = H.has_status_effect(effectpath)
+	if(!current_effect || current_effect.duration != -1)
 		var/datum/status_effect/stabilized/S = H.apply_status_effect(effectpath)
 		owner = H
 		S.link_extract(src)
 		STOP_PROCESSING(SSobj,src)
-
-
 
 //Colors and subtypes:
 /obj/item/slimecross/stabilized/grey

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -42,7 +42,7 @@ Stabilized extracts:
 	if(!H.has_status_effect(effectpath))
 		var/datum/status_effect/stabilized/S = H.apply_status_effect(effectpath)
 		owner = H
-		S.linked_extract = src
+		S.link_extract(src)
 		STOP_PROCESSING(SSobj,src)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Speed buffs are a very powerful tool, one that makes you almost impossible to counter. They should always be from temporary sources. There are 2 extracts in particular whose effects are too strong:
- Stabilized sepia: Provides a huge increase in speed which randomly toggles on and off.
- Stabilized light pink: Provides a reasonable increase in speed at the cost of pacifism.

This PR makes the following changes:
- Sepia used to reduce the run delay from 2 to 1, it now reduces it to 1.5.
- Sepia extract now provides a slight slowdown during the time it is not providing a speed-up.
- All stabilized extracts continue to apply their effects for 15 seconds after they are dropped.

This change means that you cannot run to a location with light pink, drop it and then enter combat. To be honest, the extracts should be made into items which require usage and provide a temporary but powerful bonus, but this was easier as I do not care particularly much for xenobiology.

## Why It's Good For The Game

Dealing with high speed users is not particularly fun for other players involved, and is typically used as an innocent tool to get around powergaming rules. We need to be careful what we give speed-ups to and generally limit them to temporary effects. Xenobiology should provide some fun and powerful effects, but these still need to be fair and speed-ups in the hands of non-antagonists feels very unfair. This is a particular issue with departments like xenobiology, since their design typically means that a small number of players are competent in the department, and tends to be running on the side of the station.

I don't want to go too crazy with nerfs, but the speed of the sepia extract was just crazy before. Remember that these effects can be stacked.

## Testing Photographs and Procedure

As you can see this isn't a huge nerf, and the speed increases are still pretty substantial.

https://github.com/user-attachments/assets/9bc854cd-d725-4e5d-9b67-602a80b893e2

## Changelog
:cl:
balance: Reduces the speed increase caused by sepia extracts.
balance: Stabilized sepia extract now provides slowdown as well as speed-up.
balance: All stabilized extracts now provide their effects for 15 seconds after they are dropped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
