### PR TITLE
Fix the stabilised black drain

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -29,20 +29,20 @@
 			adjustStaminaLoss(damage_amount, forced = forced)
 	return 1
 
-/mob/living/proc/apply_damage_type(damage = 0, damagetype = BRUTE) //like apply damage except it always uses the damage procs
+/mob/living/proc/apply_damage_type(damage = 0, damagetype = BRUTE, forced = FALSE) //like apply damage except it always uses the damage procs
 	switch(damagetype)
 		if(BRUTE)
-			return adjustBruteLoss(damage)
+			return adjustBruteLoss(damage, forced = forced)
 		if(BURN)
-			return adjustFireLoss(damage)
+			return adjustFireLoss(damage, forced = forced)
 		if(TOX)
-			return adjustToxLoss(damage)
+			return adjustToxLoss(damage, forced = forced)
 		if(OXY)
-			return adjustOxyLoss(damage)
+			return adjustOxyLoss(damage, forced = forced)
 		if(CLONE)
-			return adjustCloneLoss(damage)
+			return adjustCloneLoss(damage, forced = forced)
 		if(STAMINA)
-			return adjustStaminaLoss(damage)
+			return adjustStaminaLoss(damage, forced = forced)
 
 /mob/living/proc/get_damage_amount(damagetype = BRUTE)
 	switch(damagetype)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -892,12 +892,12 @@
 		if(owner.getFireLoss() > 0)
 			healing_types += BURN
 		if(owner.getToxLoss() > 0)
-			owner.adjustToxLoss(-heal_amount, forced = TRUE)
+			healing_types += TOX
 		if(owner.getCloneLoss() > 0)
 			healing_types += CLONE
 
 		if(LAZYLEN(healing_types) != 0)
-			owner.apply_damage_type(-heal_amount, damagetype=pick(healing_types))
+			owner.apply_damage_type(-heal_amount, damagetype=pick(healing_types), forced = TRUE)
 		owner.adjust_nutrition(3)
 		M.adjustCloneLoss(heal_amount * 1.2) //This way, two people can't just convert each other's damage away.
 	else

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -896,7 +896,8 @@
 		if(owner.getCloneLoss() > 0)
 			healing_types += CLONE
 
-		owner.apply_damage_type(-heal_amount, damagetype=pick(healing_types))
+		if(LAZYLEN(healing_types) != 0)
+			owner.apply_damage_type(-heal_amount, damagetype=pick(healing_types))
 		owner.adjust_nutrition(3)
 		M.adjustCloneLoss(heal_amount * 1.2) //This way, two people can't just convert each other's damage away.
 	else

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -874,7 +874,7 @@
 	id = "stabilizedblack"
 	colour = "black"
 	var/messagedelivered = FALSE
-	var/heal_amount = 2
+	var/heal_amount = 1
 
 /datum/status_effect/stabilized/black/tick()
 	if(owner.pulling && isliving(owner.pulling) && owner.grab_state == GRAB_KILL)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -874,7 +874,7 @@
 	id = "stabilizedblack"
 	colour = "black"
 	var/messagedelivered = FALSE
-	var/heal_amount = 1
+	var/heal_amount = 2
 
 /datum/status_effect/stabilized/black/tick()
 	if(owner.pulling && isliving(owner.pulling) && owner.grab_state == GRAB_KILL)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -892,7 +892,7 @@
 		if(owner.getFireLoss() > 0)
 			healing_types += BURN
 		if(owner.getToxLoss() > 0)
-			healing_types += TOX
+			owner.adjustToxLoss(-heal_amount, forced = TRUE)
 		if(owner.getCloneLoss() > 0)
 			healing_types += CLONE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the bug where ozlings die because of toxin damage when using stabilised black (drain health and heal (like a slime) on choking). Fixes a random runtime i found when the choker isnt damaged. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I believe ozlings killing themselves with toxin damage is unintended because why would it be.
Less runtimes = good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
This  is after testing on both human and ozling, the scan is of the drained person
![Zrzut ekranu (162)](https://github.com/user-attachments/assets/620d8ad7-37cb-4e97-9883-ace3902bd5cb)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
Fix: Stabilized black extract no longer kills you if you are Oozeling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
