### PR TITLE
Fix: powertools not working on init

### DIFF
--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -31,6 +31,7 @@
 		w_class_on = w_class, \
 		clumsy_check = FALSE)
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, PROC_REF(on_transform))
+	tool_behaviour = tool_act_off
 
 /*
  * Signal proc for [COMSIG_TRANSFORMING_ON_TRANSFORM].


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updated powertools.dm to add `tool_behaviour = tool_act_off` to the init

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix good 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Spawned it in using the spawn command and tried opening an air alarm (worked):
<img width="134" alt="dreamseeker_1nFxdG7XJq" src="https://github.com/user-attachments/assets/93c375e2-6c34-4a12-b95a-df32f3dfc6cf" />

Also tried switching to the wrench mode and still works:
<img width="131" alt="dreamseeker_LCp3Ne9GMK" src="https://github.com/user-attachments/assets/6289504c-6b0f-4ea5-a8d9-13cace3a9ea4" />
<img width="55" alt="dreamseeker_i9rXnmz2xz" src="https://github.com/user-attachments/assets/80153dfd-c963-4839-b296-cc5a3d3c7956" />


</details>

## Changelog
:cl: Gilgax
fix: Powertools default tool work properly when spawned in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
