### PR TITLE
Added emergency access control to buttons

### DIFF
--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -7821,6 +7821,15 @@
 	pixel_x = -26;
 	pixel_y = -27
 	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Public Access Control";
+	normaldoorcontrol = 1;
+	pixel_x = -26;
+	pixel_y = -39;
+	specialfunctions = 32
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dFz" = (

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -36,6 +36,7 @@
 #define BOLTS	(1<<2)
 #define SHOCK	(1<<3)
 #define SAFE	(1<<4)
+#define EMERGENCY (1<<5)
 
 //used in design to specify which machine can build it
 #define IMPRINTER		(1<<0)	//For circuits. Uses glass/chemicals.

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -43,6 +43,7 @@
 				4= bolts (BOLTS)
 				8= shock (SHOCK)
 				16= door safties (SAFE)
+				32= emergency mode (EMERGENCY)
 	*/
 
 /obj/item/assembly/control/airlock/activate()
@@ -70,6 +71,9 @@
 					D.set_electrified(MACHINE_NOT_ELECTRIFIED, usr)
 			if(specialfunctions & SAFE)
 				D.safe = !D.safe
+			if(specialfunctions & EMERGENCY)
+				D.emergency = !D.emergency
+				D.update_icon()
 
 	for(var/D in open_or_close)
 		INVOKE_ASYNC(D, doors_need_closing ? TYPE_PROC_REF(/obj/machinery/door/airlock, close) : TYPE_PROC_REF(/obj/machinery/door/airlock, open))


### PR DESCRIPTION
## About The Pull Request
Adds the ability for mappers to make buttons toggle emergency mode on doors by setting specialfunctions to 32.

## Why It's Good For The Game
More flexibility for mappers to give the crew more control of their environment.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/80f9c91e-48a5-4998-a3e4-078e3b838098)

![image](https://github.com/user-attachments/assets/8d4f773b-715b-40c1-8daa-7c428e00ad6b)

</details>

## Changelog
:cl:
add: Emergency access specialfunction to buttons.
tweak: (Echo) Added emergency access control button to Medbay.
/:cl:
