### PR TITLE
Checks will fail if TESTING or LOWMEMORYMODE is defined

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
+//#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE	//Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
@@ -89,7 +89,7 @@
 #endif				// 1 to use the default behaviour;
 					// 2 for preloading absolutely everything;
 
-#define LOWMEMORYMODE
+//#define LOWMEMORYMODE
 #ifdef LOWMEMORYMODE
 	#warn WARNING: Compiling with LOWMEMORYMODE.
 	#ifdef FORCE_MAP

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-//#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
+#define TESTING				//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE	//Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
@@ -89,13 +89,16 @@
 #endif				// 1 to use the default behaviour;
 					// 2 for preloading absolutely everything;
 
-//#define LOWMEMORYMODE
+#define LOWMEMORYMODE
 #ifdef LOWMEMORYMODE
 	#warn WARNING: Compiling with LOWMEMORYMODE.
 	#ifdef FORCE_MAP
 	#warn WARNING: FORCE_MAP is already defined.
 	#else
 	#define FORCE_MAP "runtimestation"
+	#endif
+	#ifdef CIBUILDING
+	#error LOWMEMORYMODE is enabled, disable this!
 	#endif
 #endif
 
@@ -118,6 +121,10 @@
 //Additional code for the above flags.
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.
+
+#ifdef CIBUILDING
+#error TESTING is enabled, disable this!
+#endif
 #endif
 
 #ifdef CIBUILDING


### PR DESCRIPTION
## About The Pull Request

Pretty simple, checks will fail if TESTING or LOWMEMORYMODE is defined

## Why It's Good For The Game

Maintainers can no longer fuck up and testmerge/fullmerge a pr with these icky defines

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/63fe8bb1-e2c0-448d-b2a6-29d9617d0cc0)

## Changelog
:cl:
code: checks will fail if TESTING or LOWMEMORYMODE is defined
/:cl: