### PR TITLE
Map-specific event configuration

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2706,6 +2706,7 @@
 #include "code\modules\events\anomaly_vortex.dm"
 #include "code\modules\events\asteroid_impact.dm"
 #include "code\modules\events\aurora_caelus.dm"
+#include "code\modules\events\bear_migration.dm"
 #include "code\modules\events\beer_clog.dm"
 #include "code\modules\events\blob.dm"
 #include "code\modules\events\brain_trauma.dm"

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -27,6 +27,9 @@
 	var/list/gamemode_blacklist = list() // Event won't happen in these gamemodes
 	var/list/gamemode_whitelist = list() // Event will happen ONLY in these gamemodes if not empty
 
+	var/list/map_blacklist = list() // Event won't happen on this map
+	var/list/map_whitelist = list() // Event will happen ONLY on this map if not empty
+
 	var/triggering	//admin cancellation
 	var/auto_add = TRUE				//Auto add to the event pool, if not you have to do it yourself!
 	var/can_malf_fake_alert = FALSE	//Can be faked by malf ai?
@@ -59,6 +62,10 @@
 	if(wizardevent != SSevents.wizardmode)
 		return FALSE
 	if(players_amt < min_players)
+		return FALSE
+	if(map_blacklist.len && (SSmapping.config.map_name in map_blacklist))
+		return FALSE
+	if(map_whitelist.len && !(SSmapping.config.map_name in map_whitelist))
 		return FALSE
 	if(gamemode_blacklist.len && (gamemode in gamemode_blacklist))
 		return FALSE

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -4,6 +4,7 @@
 
 	max_occurrences = 5
 	weight = 20
+	map_blacklist = list("Echo Station")
 
 /datum/round_event/anomaly/anomaly_pyro
 	startWhen = 3

--- a/code/modules/events/bear_migration.dm
+++ b/code/modules/events/bear_migration.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/bear_migration
-	name = "Carp Migration"
+	name = "Bear Migration"
 	typepath = /datum/round_event/bear_migration
 	weight = 15
 	min_players = 2
@@ -23,13 +23,13 @@
 	var/mob/living/simple_animal/hostile/bear/mammal
 	for(var/obj/effect/landmark/carpspawn/B in GLOB.landmarks_list)
 		if(prob(33))
-			mammal = new (C.loc)
+			mammal = new (B.loc)
 		else
-			fish = new /mob/living/simple_animal/hostile/bear/malnourished(C.loc)	//bears are much more dangerous than carps, so let's cut some slack.
+			mammal = new /mob/living/simple_animal/hostile/bear/malnourished(B.loc)	//bears are much more dangerous than carps, so let's cut some slack.
 
 	bearannounce(mammal)
 
-/datum/round_event/carp_migration/proc/bearannounce(atom/mammal)
+/datum/round_event/bear_migration/proc/bearannounce(atom/mammal)
 	if (!hasAnnounced)
 		announce_to_ghosts(mammal)
 		hasAnnounced = TRUE

--- a/code/modules/events/bear_migration.dm
+++ b/code/modules/events/bear_migration.dm
@@ -1,0 +1,36 @@
+/datum/round_event_control/bear_migration
+	name = "Carp Migration"
+	typepath = /datum/round_event/bear_migration
+	weight = 15
+	min_players = 2
+	earliest_start = 10 MINUTES
+	max_occurrences = 4
+	map_whitelist = list("Echo Station")
+
+/datum/round_event/bear_migration
+	announceWhen = 3
+	startWhen = 50
+	var/hasAnnounced = FALSE
+
+/datum/round_event/bear_migration/setup()
+	startWhen = rand(40, 60)
+
+/datum/round_event/bear_migration/announce(fake)
+	priority_announce("Unknown mammalian entities have been detected near [station_name()], please stand-by.", "Lifesign Alert", SSstation.announcer.get_rand_alert_sound())
+
+
+/datum/round_event/bear_migration/start()
+	var/mob/living/simple_animal/hostile/bear/mammal
+	for(var/obj/effect/landmark/carpspawn/B in GLOB.landmarks_list)
+		if(prob(33))
+			mammal = new (C.loc)
+		else
+			fish = new /mob/living/simple_animal/hostile/bear/malnourished(C.loc)	//bears are much more dangerous than carps, so let's cut some slack.
+
+	bearannounce(mammal)
+
+/datum/round_event/carp_migration/proc/bearannounce(atom/mammal)
+	if (!hasAnnounced)
+		announce_to_ghosts(mammal)
+		hasAnnounced = TRUE
+

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -5,6 +5,7 @@
 	min_players = 2
 	earliest_start = 10 MINUTES
 	max_occurrences = 6
+	map_blacklist = list("Echo Station")
 
 /datum/round_event_control/carp_migration/New()
 	. = ..()
@@ -41,3 +42,4 @@
 	if (!hasAnnounced)
 		announce_to_ghosts(fish) //Only anounce the first fish
 		hasAnnounced = TRUE
+

--- a/code/modules/events/dolphin_migration.dm
+++ b/code/modules/events/dolphin_migration.dm
@@ -4,6 +4,7 @@
 	weight = 15
 	earliest_start = 10 MINUTES
 	max_occurrences = 6
+	map_blacklist = list("Echo Station")
 
 /datum/round_event/dolphin_migration
 	announceWhen = 3

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -5,6 +5,7 @@
 	max_occurrences = 1000
 	earliest_start = 0 MINUTES
 	alert_observers = FALSE
+	map_blacklist = list("Echo Station")
 
 /datum/round_event/space_dust
 	startWhen		= 1

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -14,6 +14,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	max_occurrences = 5
 	var/atom/special_target
 	can_malf_fake_alert = TRUE
+	map_blacklist = list("Echo Station")
 
 
 /datum/round_event_control/immovable_rod/admin_setup()

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -8,6 +8,7 @@
 	max_occurrences = 3
 	earliest_start = 30 MINUTES
 	can_malf_fake_alert = TRUE
+	map_blacklist = list("Echo Station")
 
 /datum/round_event/meteor_wave
 	announceWhen	= 150


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now specify on events whitelisted and blacklisted maps for that event to happen!
Blacklists pyroclastic anomaly from Echo station, as it tends to make the entire underground part uninhabitable if spawned in a bad location.
Blacklists several other events that don't make much sense on a planetary outpost, or interact with it quite badly:
Carp Migration
Dolphin Migration
Space Dust
Meteor waves
Immovable rod

Adds a bear migration event currently exclusive to Echo Station to replace the carp and dolphin migration as more fitting.

## Why It's Good For The Game

Station randomly going up in flames in its entirety- bad. 
Map-specific configuration of possible events - good.
Bears - cool.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/18962236-8b4d-455f-8e1d-cfbe85cbc3d0)
</details>

## Changelog
:cl:
add: Added bear migration to Echo Station.
del: Removed Carp Migration from Echo Station.
del: Removed Dolphin Migration from Echo Station.
del: Removed all Meteor waves from Echo Station due to interacting with planets badly.
del: Removed Immovable rod event from Echo Station.
mapping: Added the ability to whitelist/blacklist events from specific station maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
