### PR TITLE
Fixes and tweaks to the sale of wood products

### DIFF
--- a/code/game/objects/items/stacks/sheets/organic/wood_recipes.dm
+++ b/code/game/objects/items/stacks/sheets/organic/wood_recipes.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	new/datum/stack_recipe("winged wooden chair",					/obj/structure/chair/wood/wings, 3, one_per_turf = TRUE, on_floor = TRUE, time = 3 SECONDS), \
 	new/datum/stack_recipe("wooden barricade",						/obj/structure/barricade/wooden, 5, one_per_turf = TRUE, on_floor = TRUE, time = 5 SECONDS), \
 	new/datum/stack_recipe("wooden door",							/obj/structure/mineral_door/wood, 10, one_per_turf = TRUE, on_floor = TRUE, time = 2 SECONDS), \
-	new/datum/stack_recipe("coffin",								/obj/structure/closet/crate/coffin, 5, one_per_turf = TRUE, on_floor = TRUE, time = 1.5 SECONDS), \
+	new/datum/stack_recipe("coffin",								/obj/structure/closet/crate/coffin, 5, one_per_turf = TRUE, on_floor = TRUE, time = 5 SECONDS), \
 	new/datum/stack_recipe("book case",								/obj/structure/bookcase, 4, one_per_turf = TRUE, on_floor = TRUE, time = 1.5 SECONDS), \
 	new/datum/stack_recipe("drying rack",							/obj/machinery/smartfridge/drying_rack, 10, one_per_turf = TRUE, on_floor = TRUE, time = 1.5 SECONDS), \
 	new/datum/stack_recipe("dog bed",								/obj/structure/bed/dogbed, 10, one_per_turf = TRUE, on_floor = TRUE, time = 1 SECONDS), \

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -3,7 +3,7 @@
 	k_elasticity = 0
 	unit_name = "crate"
 	export_types = list(/obj/structure/closet/crate)
-	exclude_types = list(/obj/structure/closet/crate/large, /obj/structure/closet/crate/wooden, /obj/structure/closet/crate/mail)
+	exclude_types = list(/obj/structure/closet/crate/large, /obj/structure/closet/crate/wooden, /obj/structure/closet/crate/coffin, /obj/structure/closet/crate/mail)
 
 /datum/export/large/crate/total_printout(datum/export_report/ex, notes = TRUE) // That's why a goddamn metal crate costs that much.
 	. = ..()
@@ -16,18 +16,28 @@
 	export_types = list(/obj/structure/closet/crate/large)
 	exclude_types = list()
 
-/datum/export/large/crate/wooden/ore
+/datum/export/large/ore_box
+	// Assuming you send back the crate and stamped manifest, wood can be ordered for 20cr/plank
+	// one ore box costs 4 planks = 80cr
+	// profit is 80cr per ore box, or 20cr/plank
+	cost = 160
 	unit_name = "ore box"
 	export_types = list(/obj/structure/ore_box)
 
 /datum/export/large/crate/wood
-	cost = 240
+	// Assuming you send back the crate and stamped manifest, wood can be ordered for 20cr/plank
+	// one wooden crate costs 6 planks = 120cr
+	// profit is 100cr per wooden crate, or ~17cr/plank
+	cost = 220
 	unit_name = "wooden crate"
 	export_types = list(/obj/structure/closet/crate/wooden)
 	exclude_types = list()
 
-/datum/export/large/crate/coffin
-	cost = 140 //50 wood costs 1700, makes 10 coffins, makes 1400 back. No free money allowed, considering they can be easlily stacked with disposal loops. Additionally you still get 600 credits from the box + manifest either way, for a total of 2000 back. Total of 300 profit for wasting your time building coffins.
+/datum/export/large/coffin
+	// Assuming you send back the crate and stamped manifest, wood can be ordered for 20cr/plank
+	// one coffin costs 5 planks = 100cr
+	// profit is 90cr per coffin, or 18cr/plank
+	cost = 190
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes and changes a few things relating to the selling of coffins and other wooden goods by cargo: 
- Coffins were not in the exclusion list for the export datum of crates, causing them to be sold at the same price as metal crates. This was fixed.
- The export datums for ore boxes and coffins were subtypes of the datum for crates (`/datum/export/large/crate`). This caused them to be immune to demand elasticity (more items sold -> price decrease), and printed a message in the cargo consoles mentioning the "Nanotrasen Crates Recycling Program". Neither of these made sense, so they were made into subtypes of `/datum/export/large` instead.
- Building coffins only took 1.5 seconds, while similar things like ore boxes and wooden crates took 5 seconds. The build time for coffins was therefore increased to 5 seconds.
- The selling prices for ore boxes, coffins and wooden crates seemed to be arbitrary. They were tweaked to provide a reasonable and realistic profit when processed from wooden planks.

Here are the changed prices:
- Ore box: 100cr -> 160cr (cost = 4 wood)
- Coffin: 140cr -> 190cr (cost = 5 wood)
- Wooden crate: 240cr -> 220cr (cost = 6 wood)

I followed these two principles for the changed prices:
1. Items with a higher wood cost should have higher profit per item
2. Since items with a lower wood cost take as long to make, they should have higher profit per plank used

These provide what I believe to be a reasonable profit if cargo wants to start processing wood: They can make up to 1980cr from a 1700cr wood crate, which returns 980cr of profit if the crate of wood and stamped manifest are sent back as well. This profit doesn't include the price falloff from demand elasticity, and doesn't take into account the transit time of the shuttle, the time making items from planks, and the time for CentCom to replendish its wood crate stock.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fixes good.

There is no reason for coffins to take significantly less time to build than similar sellable items like ore boxes and wooden crates.

The selling prices have been tweaked to provide what I think is a reasonable profit; cargo can earn a small income by turning wooden planks into processed goods.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

New Prices. The "Crates Recycling Program" message only appears after the wooden crate.
![sell-amounts](https://github.com/user-attachments/assets/0b613677-3173-44f6-9791-92d1b2d576b9)

Demand elasticity. Here, the price of coffins falls to an average of ~96cr/coffin.
![coffin-elasticity](https://github.com/user-attachments/assets/39c20013-2951-436d-b60c-ffba678e7e3e)

Coffin build time

https://github.com/user-attachments/assets/4e19f030-effa-4b27-ad96-548a6accc0e9



</details>

## Changelog
:cl:
fix: coffins are not mistaken for normal crates when sold
fix: coffins and ore boxes are now subject to demand elasticity, and don't mention the Crates Recycling Program when sold
tweak: The time to build a coffin is now 5 seconds
balance: The selling prices of ore boxes, coffins and wooden crates have been tweaked to give a reasonable profit when sold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
