### PR TITLE
Xenobio Nerf 2: Rat'var Strikes Back

### DIFF
--- a/code/modules/antagonists/clock_cult/enchantments/electricution.dm
+++ b/code/modules/antagonists/clock_cult/enchantments/electricution.dm
@@ -1,6 +1,6 @@
 /datum/component/enchantment/electricution
 	max_level = 3
-	var/tesla_flags = TESLA_MOB_DAMAGE
+	var/tesla_flags = TESLA_OBJ_DAMAGE
 	var/zap_range = 1
 	var/power = 10000
 


### PR DESCRIPTION
## About The Pull Request

hey so i fucked the balancing, this makes it so the tesla shock from the electricity enchantment now fucks up doors and APCs and electrical stuff rather than

## Why It's Good For The Game

that enchantment was fucked

## testing evidence

https://github.com/user-attachments/assets/383e85c9-1ca7-4cef-a6e4-0ebd253b6604


## Changelog
:cl:
balance: xenobio less strong in the powers of electricity
/:cl:


