### PR TITLE
Fixes processor recipes outputting the wrong item

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -42,13 +42,13 @@
 	else
 		qdel(what)
 
-/obj/machinery/processor/proc/select_recipe(X)
+/obj/machinery/processor/proc/select_recipe(input_item)
 	var/most_specific_type = /atom
-	for (var/recipe_type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
-		var/datum/food_processor_process/recipe = new recipe_type()
-		if (istype(src, recipe.required_machine) && istype(X, recipe.input) && ispath(recipe.input, most_specific_type))
-			most_specific_type = recipe.input
-			. = recipe
+	for (var/datum/food_processor_process/recipe as anything in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
+		var/recipe_input = initial(recipe.input)
+		if (istype(src, initial(recipe.required_machine)) && istype(input_item, recipe_input) && ispath(recipe_input, most_specific_type))
+			most_specific_type = recipe_input
+			. = new recipe()
 
 /obj/machinery/processor/attackby(obj/item/O, mob/living/user, params)
 	if(processing)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -43,10 +43,12 @@
 		qdel(what)
 
 /obj/machinery/processor/proc/select_recipe(X)
-	for (var/type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
-		var/datum/food_processor_process/recipe = new type()
-		if (istype(src, recipe.required_machine) && istype(X, recipe.input) && !(is_type_in_list(X, recipe.excluded_inputs)))
-			return recipe
+	var/most_specific_type = /atom
+	for (var/recipe_type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
+		var/datum/food_processor_process/recipe = new recipe_type()
+		if (istype(src, recipe.required_machine) && istype(X, recipe.input) && ispath(recipe.input, most_specific_type))
+			most_specific_type = recipe.input
+			. = recipe
 
 /obj/machinery/processor/attackby(obj/item/O, mob/living/user, params)
 	if(processing)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -45,9 +45,8 @@
 /obj/machinery/processor/proc/select_recipe(X)
 	for (var/type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
 		var/datum/food_processor_process/recipe = new type()
-		if (!istype(X, recipe.input) || !istype(src, recipe.required_machine))
-			continue
-		return recipe
+		if (istype(src, recipe.required_machine) && istype(X, recipe.input) && !(is_type_in_list(X, recipe.excluded_inputs)))
+			return recipe
 
 /obj/machinery/processor/attackby(obj/item/O, mob/living/user, params)
 	if(processing)

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,5 +1,7 @@
 /datum/food_processor_process
 	var/input
+	/// Subtypes of input that should not be processed, because a unique recipe exists for them
+	var/excluded_inputs = list()
 	var/output
 	var/time = 40
 	/// The machine required to do this recipe
@@ -9,27 +11,33 @@
 
 /datum/food_processor_process/meat
 	input = /obj/item/food/meat/slab
+	excluded_inputs = list(/obj/item/food/meat/slab/human, /obj/item/food/meat/slab/corgi, /obj/item/food/meat/slab/xeno, /obj/item/food/meat/slab/bear, /obj/item/food/meat/slab/chicken)
 	output = /obj/item/food/raw_meatball
 	food_multiplier = 3
 
 /datum/food_processor_process/cutlet
 	input = /obj/item/food/meat/cutlet/plain
+	excluded_inputs = list(/obj/item/food/meat/cutlet/plain/human)
 	output = /obj/item/food/raw_meatball
 
 /datum/food_processor_process/meat/human
 	input = /obj/item/food/meat/slab/human
+	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/human
 
 /datum/food_processor_process/cutlet/human
 	input = /obj/item/food/meat/cutlet/plain/human
+	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/human
 
 /datum/food_processor_process/meat/corgi
 	input = /obj/item/food/meat/slab/corgi
+	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/corgi
 
 /datum/food_processor_process/meat/xeno
 	input = /obj/item/food/meat/slab/xeno
+	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/xeno
 
 /datum/food_processor_process/cutlet/xeno
@@ -38,6 +46,7 @@
 
 /datum/food_processor_process/meat/bear
 	input = /obj/item/food/meat/slab/bear
+	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/bear
 
 /datum/food_processor_process/cutlet/bear
@@ -46,6 +55,7 @@
 
 /datum/food_processor_process/meat/chicken
 	input = /obj/item/food/meat/slab/chicken
+	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/chicken
 	food_multiplier = 3
 
@@ -67,6 +77,7 @@
 
 /datum/food_processor_process/potato
 	input = /obj/item/food/grown/potato
+	excluded_inputs = list(/obj/item/food/grown/potato/wedges, /obj/item/food/grown/potato/sweet)
 	output = /obj/item/food/tatortot
 
 /datum/food_processor_process/carrot

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,7 +1,5 @@
 /datum/food_processor_process
 	var/input
-	/// Subtypes of input that should not be processed, because a unique recipe exists for them
-	var/excluded_inputs = list()
 	var/output
 	var/time = 40
 	/// The machine required to do this recipe
@@ -11,33 +9,27 @@
 
 /datum/food_processor_process/meat
 	input = /obj/item/food/meat/slab
-	excluded_inputs = list(/obj/item/food/meat/slab/human, /obj/item/food/meat/slab/corgi, /obj/item/food/meat/slab/xeno, /obj/item/food/meat/slab/bear, /obj/item/food/meat/slab/chicken)
 	output = /obj/item/food/raw_meatball
 	food_multiplier = 3
 
 /datum/food_processor_process/cutlet
 	input = /obj/item/food/meat/cutlet/plain
-	excluded_inputs = list(/obj/item/food/meat/cutlet/plain/human)
 	output = /obj/item/food/raw_meatball
 
 /datum/food_processor_process/meat/human
 	input = /obj/item/food/meat/slab/human
-	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/human
 
 /datum/food_processor_process/cutlet/human
 	input = /obj/item/food/meat/cutlet/plain/human
-	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/human
 
 /datum/food_processor_process/meat/corgi
 	input = /obj/item/food/meat/slab/corgi
-	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/corgi
 
 /datum/food_processor_process/meat/xeno
 	input = /obj/item/food/meat/slab/xeno
-	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/xeno
 
 /datum/food_processor_process/cutlet/xeno
@@ -46,7 +38,6 @@
 
 /datum/food_processor_process/meat/bear
 	input = /obj/item/food/meat/slab/bear
-	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/bear
 
 /datum/food_processor_process/cutlet/bear
@@ -55,7 +46,6 @@
 
 /datum/food_processor_process/meat/chicken
 	input = /obj/item/food/meat/slab/chicken
-	excluded_inputs = list()
 	output = /obj/item/food/raw_meatball/chicken
 	food_multiplier = 3
 
@@ -77,7 +67,6 @@
 
 /datum/food_processor_process/potato
 	input = /obj/item/food/grown/potato
-	excluded_inputs = list(/obj/item/food/grown/potato/wedges, /obj/item/food/grown/potato/sweet)
 	output = /obj/item/food/tatortot
 
 /datum/food_processor_process/carrot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #12741.

The food processor has a list of recipes that give its valid inputs and outputs. In some cases, there are different recipes for an item type and its subtype (for example, there are separate recipes for `/obj/item/food/meat/slab` and `/obj/item/food/meat/slab/corgi`, which output raw meatballs and raw corgi meatballs respectively). However, since the input type is checked with `istype`, most of those subtype recipes were never accessible, since the processor would simply choose the recipe corresponding to the parent type (for example, putting corgi meat in the processor would return normal meatballs).

This PR fixes this bug by making the processor check every recipe, and keep the one with the most specific input that corresponds to the provided item.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix. There is no reason for some processor recipes to be inaccessible.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Regular raw meatballs
![normal-meatballs](https://github.com/user-attachments/assets/ae0a1bbd-f26e-4a7b-b248-71bd43649421)


Corgi raw meatballs
![corgi-meatballs](https://github.com/user-attachments/assets/256bdcb8-9e0c-45c5-921c-d2e10da5ce34)


I individually checked every other affected recipe, and found no unexpected behavior.

</details>

## Changelog
:cl:
fix: processing special meat (human, corgi, xeno, bear, chicken) into meatballs now outputs the correct meatball type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
