### PR TITLE
Adjusts the Colors, Badges, and Descriptions of Departmental Berets

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -456,15 +456,11 @@
 	name = "science beret"
 	desc = "A purple beret with the science insignia emblazoned on it. It has that authentic burning plasma smell."
 	armor_type = /datum/armor/beret_sci
-	greyscale_colors = "#8D008F"
-	flags_1 = NONE
-
-/obj/item/clothing/head/beret/science/fancy
-	desc = "A science-themed beret for our hardworking scientists. This one comes with a fancy badge!"
 	icon_state = "beret_badge"
 	greyscale_config = /datum/greyscale_config/beret_badge
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
-	greyscale_colors = "#8D008F#FFFFFF"
+	greyscale_colors = "#A04BD9#FFFFFF"
+	flags_1 = NONE
 
 /datum/armor/beret_sci
 	bomb = 5
@@ -476,8 +472,11 @@
 
 /obj/item/clothing/head/beret/medical
 	name = "medical beret"
-	desc = "A medical-flavored beret for the doctor in you!"
-	greyscale_colors = "#FFFFFF"
+	desc = "A white beret with a blue cross finely threaded into it. It has that sterile smell about it."
+	icon_state = "beret_badge"
+	greyscale_config = /datum/greyscale_config/beret_badge
+	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
+	greyscale_colors = "#E1E1E1#EDCC6A"
 	armor_type = /datum/armor/beret_med
 	flags_1 = NONE
 
@@ -491,8 +490,11 @@
 
 /obj/item/clothing/head/beret/medical/cmo
 	name = "chief medical officer beret"
-	desc = "A beret in a distinct surgical turquoise!"
-	greyscale_colors = "#5EB8B8"
+	desc = "A baby blue beret with the insignia of Medistan. It smells very sterile."
+	icon_state = "beret_badge"
+	greyscale_config = /datum/greyscale_config/beret_badge
+	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
+	greyscale_colors = "#73B1D7#FFFFFF"
 	armor_type = /datum/armor/beret_cmo
 
 /datum/armor/beret_cmo
@@ -505,7 +507,10 @@
 	name = "engineering beret"
 	desc = "A beret with the engineering insignia emblazoned on it. For engineers that are more inclined towards style than safety."
 	armor_type = /datum/armor/beret_eng
-	greyscale_colors = "#FFBC30"
+	icon_state = "beret_badge"
+	greyscale_config = /datum/greyscale_config/beret_badge
+	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
+	greyscale_colors = "#FFBC30#FFFFFF"
 	flags_1 = NONE
 
 /datum/armor/beret_eng
@@ -516,7 +521,10 @@
 	name = "atmospherics beret"
 	desc = "A beret for those who have shown immaculate proficiency in piping. Or plumbing."
 	armor_type = /datum/armor/beret_atmos
-	greyscale_colors = "#FFDE15"
+	icon_state = "beret_badge"
+	greyscale_config = /datum/greyscale_config/beret_badge
+	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
+	greyscale_colors = "#E56A0A#FFFFFF"
 	flags_1 = NONE
 
 /datum/armor/beret_atmos
@@ -529,7 +537,7 @@
 	icon_state = "beret_badge"
 	greyscale_config = /datum/greyscale_config/beret_badge
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
-	greyscale_colors = "#E1E1E1#D0D000"
+	greyscale_colors = "#E1E1E1#EDCC6A"
 	armor_type = /datum/armor/beret_ce
 	flags_1 = NONE
 
@@ -541,7 +549,10 @@
 	name = "cargo beret"
 	desc = "A brown beret with the supply insignia emblazoned on it. You can't help but wonder how much it'd sell for."
 	armor_type = /datum/armor/beret_supply
-	greyscale_colors = "#ECCA30"
+	icon_state = "beret_badge"
+	greyscale_config = /datum/greyscale_config/beret_badge
+	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
+	greyscale_colors = "#63400E#9AA10B"
 	flags_1 = NONE
 
 //Curator

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -486,7 +486,7 @@
 /obj/item/clothing/head/beret/medical/paramedic
 	name = "paramedic beret"
 	desc = "For finding corpses in style!"
-	greyscale_colors = "#16313D"
+	greyscale_colors = "#2C3A4E#FFFFFF"
 
 /obj/item/clothing/head/beret/medical/cmo
 	name = "chief medical officer beret"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -241,7 +241,6 @@
 					/obj/item/radio/headset/headset_sci = 3,
 					/obj/item/clothing/mask/gas = 3,
 					/obj/item/clothing/head/beret/science = 3,
-					/obj/item/clothing/head/beret/science/fancy = 3,
 					/obj/item/clothing/head/cowboy/science = 3)
 	contraband = list(/obj/item/clothing/suit/hooded/wintercoat/science/old = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->Re-colors some of the new GAGS berets to better fit our current sprites.  Also removes the fancy science beret in order to keep things consistent with the rest of the departments, since the recolored berets all have badges again.  Reverts some descriptions to match the changes.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->Our color choices in departments are different than /tg/'s, so our colors on berets should be different than /tg/'s.  Our CMO is not turquoise, for example.  See the testing evidence for comparisons.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

From top to bottom:  Pre-GAGS berets, current berets, and proposed berets.

![image](https://github.com/user-attachments/assets/4da7d4f8-0efc-4b37-8e13-6eb1c06a799b)

Including a resprited paramedic beret, something that was missed in the initial pass:

![image](https://github.com/user-attachments/assets/c9d91e68-7282-46a5-a7eb-df565f156a36)

Testing that the vendor no longer stocks the fancy science beret:

![image](https://github.com/user-attachments/assets/cc5a5ec8-d32a-47c0-9abd-d7e3532f2d4f)



</details>

## Changelog
:cl: h42
del: Removed science's fancy beret, since they're all fancy now.
tweak: Recolored a handful of and added badges to the department berets
tweak: Reverted the descriptions of the medical berets to fit the recolor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
