### PR TITLE
Rebalances TC fuel rods for the RMBK by removing the Nitrium interaction

### DIFF
--- a/code/modules/power/rbmk/rbmk_core.dm
+++ b/code/modules/power/rbmk/rbmk_core.dm
@@ -20,8 +20,6 @@ BZ: Increases your reactor's ability to transfer its heat to the coolant, thus l
 Water Vapour: More efficient permeability modifier
 Hyper Noblium: Extremely efficient permeability increase. (10x as efficient as bz)
 
-Depletion type:
-Nitrium: When you need weapons grade plutonium yesterday. Causes your fuel to deplete much, much faster. Not a huge amount of use outside of sabotage.
 
 Sabotage:
 

--- a/code/modules/power/rbmk/rbmk_main_processes.dm
+++ b/code/modules/power/rbmk/rbmk_main_processes.dm
@@ -71,10 +71,6 @@
 			if(total_permeability_moles >= minimum_coolant_level)
 				var/permeability_bonus = total_permeability_moles / 500
 				gas_absorption_effectiveness = gas_absorption_constant + permeability_bonus
-			var/total_degradation_moles = GET_MOLES(/datum/gas/nitrium, moderator_input) //Because it's quite hard to get.
-			if(total_degradation_moles >= minimum_coolant_level*0.5) //I'll be nice.
-				depletion_modifier += total_degradation_moles / 15 //Oops! All depletion. This causes your fuel rods to get SPICY.
-				playsound(src, pick('sound/machines/sm/accent/normal/1.ogg','sound/machines/sm/accent/normal/2.ogg','sound/machines/sm/accent/normal/3.ogg','sound/machines/sm/accent/normal/4.ogg','sound/machines/sm/accent/normal/5.ogg'), 100, TRUE)
 			//From this point onwards, we clear out the remaining gasses.
 			moderator_input.remove(moderator_input_total_mols) //Woosh. And the soul is gone.
 			rate_of_reaction += total_fuel_moles / 1000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

3 line removal of the Nitrium RMBK interaction (Nitrium caused fuel decay scaling with mols added)

## Why It's Good For The Game

Fixes #12588

700TC in a round is nearing debug uplink amounts. I do not believe it requires consideration why this could be bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2025-05-19 182444](https://github.com/user-attachments/assets/0e580e9c-38ba-4a71-b3da-bdec917dc8dc)

Showing RMBK still works and the interaction is actually removed.
</details>

## Changelog
:cl:
del: Removed RMBK Nitrium interaction
balance: Removed RMBK Nitrium interaction to balance TC Fuel Rods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
