### PR TITLE
Fixes a typo that bothers only me.

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -51,8 +51,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		item_state = "cigon"
 		name = "lit [initial(name)]"
 		desc = "A [initial(name)]. This one is lit."
-		attack_verb_continuous = list("burns", "sings")
-		attack_verb_simple = list("burn", "sing")
+		attack_verb_continuous = list("burns", "singes")
+		attack_verb_simple = list("burn", "singe")
 		START_PROCESSING(SSobj, src)
 		update_icon()
 
@@ -235,8 +235,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	lit = TRUE
 	name = "lit [name]"
-	attack_verb_continuous = list("burns", "sings")
-	attack_verb_simple = list("burn", "sing")
+	attack_verb_continuous = list("burns", "singes")
+	attack_verb_simple = list("burn", "singe")
 	hitsound = 'sound/items/welder.ogg'
 	damtype = BURN
 	force = 4
@@ -690,8 +690,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		force = 5
 		damtype = BURN
 		hitsound = 'sound/items/welder.ogg'
-		attack_verb_continuous = list("burns", "sings")
-		attack_verb_simple = list("burn", "sing")
+		attack_verb_continuous = list("burns", "singes")
+		attack_verb_simple = list("burn", "singe")
 		START_PROCESSING(SSobj, src)
 	else
 		hitsound = "swing_hit"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -851,8 +851,8 @@
 			attack_verb_simple = list("slash", "slice", "cut")
 		if(BURN)
 			hitsound = 'sound/weapons/sear.ogg'
-			attack_verb_continuous = list("burns", "sings", "heats")
-			attack_verb_simple = list("burn", "sing", "heat")
+			attack_verb_continuous = list("burns", "singes", "heats")
+			attack_verb_simple = list("burn", "singe", "heat")
 		if(TOX)
 			hitsound = 'sound/weapons/pierce.ogg'
 			attack_verb_continuous = list("poisons", "doses", "toxifies")

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -44,8 +44,8 @@ Slimecrossing Weapons
 			attack_verb_simple = list("slash", "slice", "cut")
 		if(BURN)
 			hitsound = 'sound/weapons/sear.ogg'
-			attack_verb_continuous = list("burns", "sings", "heats")
-			attack_verb_simple = list("burn", "sing", "heat")
+			attack_verb_continuous = list("burns", "singes", "heats")
+			attack_verb_simple = list("burn", "singe", "heat")
 		if(TOX)
 			hitsound = 'sound/weapons/pierce.ogg'
 			attack_verb_continuous = list("poisons", "doses", "toxifies")


### PR DESCRIPTION
## About The Pull Request
This PR replaces all instances with "sing" and "sings" in relation to fire with "singe" and "singes"
For instance
> "Marco sings Polo with the lit match!"

would become
> "Marco singes Polo with the lit match!"

## Why It's Good For The Game
![cooltext482991741748230](https://github.com/user-attachments/assets/b44fce68-f903-4611-b393-c06cc6271f0c)


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/f672c249-dfd0-40b1-bb1e-837490f4d1bf)
![image](https://github.com/user-attachments/assets/10de1a51-9dc1-419b-8b7b-24a049d392dd)

</details>

## Changelog
:cl:
tweak: You can now properly singe people with fire based weapons, instead of singing them a tune.
/:cl:

