### PR TITLE
Fixes broken antagonist code

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -202,16 +202,13 @@
 	barf_contents()
 	..()
 
+//TODO Componentize this
 /mob/living/simple_animal/hostile/morph/proc/barf_contents()
 	for(var/atom/movable/AM in src)
 		RemoveContents(AM)
 		if(prob(90))
 			step(AM, pick(GLOB.alldirs))
 	morph_stomach.ui_update()
-
-/mob/living/simple_animal/hostile/morph/wabbajack_act(mob/living/new_mob)
-	barf_contents()
-	. = ..()
 
 /mob/living/simple_animal/hostile/morph/Aggro() // automated only
 	..()

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -199,6 +199,18 @@
 		visible_message(span_warning("[src] twists and dissolves into a pile of green flesh!"), \
 						span_userdanger("Your skin ruptures! Your flesh breaks apart! No disguise can ward off de--"))
 		restore()
+	barf_contents()
+	..()
+
+/mob/living/simple_animal/hostile/morph/proc/barf_contents()
+	for(var/atom/movable/AM in src)
+		RemoveContents(AM)
+		if(prob(90))
+			step(AM, pick(GLOB.alldirs))
+	morph_stomach.ui_update()
+
+/mob/living/simple_animal/hostile/morph/wabbajack_act(mob/living/new_mob)
+	barf_contents()
 	. = ..()
 
 /mob/living/simple_animal/hostile/morph/Aggro() // automated only

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -233,6 +233,7 @@
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
+	organ_traits = null
 
 /obj/item/organ/brain/diona
 	name = "diona nymph"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -20,7 +20,7 @@
 			if(reagents && !reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1)) // No organ decay if the body contains formaldehyde.
 				for(var/V in internal_organs)
 					var/obj/item/organ/O = V
-					O.on_death() //Needed so organs decay while inside the body.
+					O.on_death(delta_time, times_fired) //Needed so organs decay while inside the body.
 
 		. = ..()
 		if(QDELETED(src))

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -97,6 +97,7 @@
 	if(!isliving(source))
 		return
 	var/mob/living/mob = source
+	//TODO Componentize this
 	if(mob in src)
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 		visible_message(span_danger("[src] vomits up [mob]!"))
@@ -175,10 +176,6 @@
 /mob/living/simple_animal/hostile/space_dragon/revive(full_heal, admin_revive)
 	. = ..()
 	update_dragon_overlay()
-
-/mob/living/simple_animal/hostile/space_dragon/wabbajack_act(mob/living/new_mob)
-	empty_contents()
-	. = ..()
 
 /mob/living/simple_animal/hostile/space_dragon/ex_act(severity, target, origin)
 	set waitfor = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -168,12 +168,17 @@
 	fire_stream()
 
 /mob/living/simple_animal/hostile/space_dragon/death(gibbed)
-	. = ..()
+	empty_contents()
+	..()
 	update_dragon_overlay()
 
 /mob/living/simple_animal/hostile/space_dragon/revive(full_heal, admin_revive)
 	. = ..()
 	update_dragon_overlay()
+
+/mob/living/simple_animal/hostile/space_dragon/wabbajack_act(mob/living/new_mob)
+	empty_contents()
+	. = ..()
 
 /mob/living/simple_animal/hostile/space_dragon/ex_act(severity, target, origin)
 	set waitfor = FALSE
@@ -343,6 +348,18 @@
 		A.forceMove(src)
 		return TRUE
 	return FALSE
+
+/**
+  * Disperses the contents of the mob on the surrounding tiles.
+  *
+  * Randomly places the contents of the mob onto surrounding tiles.
+  * Has a 10% chance to place on the same tile as the mob.
+  */
+/mob/living/simple_animal/hostile/space_dragon/proc/empty_contents()
+	for(var/atom/movable/AM in src)
+		AM.forceMove(loc)
+		if(prob(90))
+			step(AM, pick(GLOB.alldirs))
 
 /**
   * Resets Space Dragon's status after using wing gust.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I broke xenos with incorrect trait inheritance, and broke dragons and morphs spewing their contents.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Oops

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/1216a4ee-e5e7-4a1f-a3e2-30a4edc58f25



</details>

## Changelog
:cl:
fix: fixes xenos unrestricted hand use
fix: fixes morph/dragon contents dropping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
