### PR TITLE
Fixes z mimic holodeck lighting

### DIFF
--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -239,11 +239,6 @@ SUBSYSTEM_DEF(zcopy)
 			T.opacity = FALSE
 			//T.underlays = underlay_copy
 			T.plane = t_target
-			var/area/A = T.loc
-			if(!IS_DYNAMIC_LIGHTING(A))
-				T.shadower.icon_state = "transparent"
-			else
-				T.shadower.icon_state = "dark"
 		else
 			// Some openturfs have icons, so we can't overwrite their appearance.
 			if (!T.below.mimic_proxy)
@@ -275,11 +270,12 @@ SUBSYSTEM_DEF(zcopy)
 		else if (T.below.mimic_above_copy)
 			QDEL_NULL(T.below.mimic_above_copy)
 
+		T.shadower.copy_lighting(T.below.lighting_object, T.below.loc, T.below)
+
 		// Add everything below us to the update queue.
 		for (var/thing in T.below)
 			var/atom/movable/object = thing
 			if(istype(object, /atom/movable/lighting_object))
-				T.shadower.copy_lighting(T.below.lighting_object, T.below.loc)
 				continue
 
 			if (QDELETED(object) || (object.zmm_flags & ZMM_IGNORE) || object.loc != T.below || object.invisibility == INVISIBILITY_ABSTRACT)

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -152,7 +152,7 @@
 
 	if (myturf.above)
 		if(myturf.above.shadower)
-			myturf.above.shadower.copy_lighting(src, myturf.loc)
+			myturf.above.shadower.copy_lighting(src, myturf.loc, myturf)
 		else
 			myturf.above.update_mimic()
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -106,8 +106,14 @@
 
 	return ..()
 
-/atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_object/LO, area/A)
-	ASSERT(LO != null)
+/atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_object/LO, area/A, turf/below)
+	if (!LO)
+		icon_state = "transparent"
+		return
+	if (below.shadower)
+		icon_state = below.shadower.icon_state
+	else
+		icon_state = "dark"
 	// Underlay lighting stuff, if it gets ported: appearance = LO.current_underlay
 	appearance = LO
 	layer = MIMICKED_LIGHTING_LAYER

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -109,8 +109,10 @@
 /atom/movable/openspace/multiplier/proc/copy_lighting(atom/movable/lighting_object/LO, area/A, turf/below)
 	if (!LO)
 		icon_state = "transparent"
+		luminosity = 1
 		return
 	icon_state = "dark"
+	luminosity = 0
 	// Underlay lighting stuff, if it gets ported: appearance = LO.current_underlay
 	appearance = LO
 	layer = MIMICKED_LIGHTING_LAYER

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -110,10 +110,7 @@
 	if (!LO)
 		icon_state = "transparent"
 		return
-	if (below.shadower)
-		icon_state = below.shadower.icon_state
-	else
-		icon_state = "dark"
+	icon_state = "dark"
 	// Underlay lighting stuff, if it gets ported: appearance = LO.current_underlay
 	appearance = LO
 	layer = MIMICKED_LIGHTING_LAYER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes z-mimic lighting when there is no lighting object below.

Note that due to the way z-mimic handles lighting, anything more than 1 layer above uses the lighting of the tile below. 

## Why It's Good For The Game

Fixes the black void on echostation (why does holodeck have no lighting though?)

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/27a8790a-d8e1-4f13-ac8f-895fd1d3aec6

## Changelog
:cl:
fix: Fixes how z-mimic handles tiles with no lighting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
