### PR TITLE
Stop infective exolocomotion from overriding other nanites 

### DIFF
--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -262,9 +262,11 @@
 		COOLDOWN_START(src, spread_cooldown, 2 SECONDS)
 		return
 	var/mob/living/infectee = pick(target_hosts)
+	if(SEND_SIGNAL(infectee, COMSIG_HAS_NANITES))
+		COOLDOWN_START(src, spread_cooldown, 2 SECONDS)
+		return
 	if(prob(100 - (infectee.getarmor(null, BIO))))
 		COOLDOWN_START(src, spread_cooldown, 7.5 SECONDS)
-		//this will potentially take over existing nanites!
 		infectee.AddComponent(/datum/component/nanites, 10)
 		SEND_SIGNAL(infectee, COMSIG_NANITE_SYNC, nanites)
 		infectee.investigate_log("was infected by spreading nanites by [key_name(host_mob)] at [AREACOORD(infectee)].", INVESTIGATE_NANITES)
@@ -292,7 +294,6 @@
 		return
 	var/mob/living/infectee = pick(target_hosts)
 	if(prob(100 - (infectee.getarmor(null, BIO))))
-		//unlike with Infective Exo-Locomotion, this can't take over existing nanites, because Nanite Sting only targets non-hosts.
 		infectee.AddComponent(/datum/component/nanites, 5)
 		SEND_SIGNAL(infectee, COMSIG_NANITE_SYNC, nanites)
 		infectee.investigate_log("was infected by a nanite cluster by [key_name(host_mob)] at [AREACOORD(infectee)].", INVESTIGATE_NANITES)

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -286,7 +286,7 @@
 	for(var/mob/living/L in oview(1, host_mob))
 		if(!(MOB_ORGANIC in L.mob_biotypes) && !(MOB_UNDEAD in L.mob_biotypes) && !HAS_TRAIT(host_mob, TRAIT_NANITECOMPATIBLE))
 			continue
-		if(SEND_SIGNAL(L, COMSIG_HAS_NANITES) || !L.Adjacent(host_mob))
+		if(!L.Adjacent(host_mob))
 			continue
 		target_hosts += L
 	if(!target_hosts.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Infective exolocomotion will no longer override other nanites
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I was really temped to put that in as a bug fix but comments suggest this was a intentional working. I will give description of how this program works currently and I think it will explain this change:
Infective exolocomotion infects people in 5 tile range with nanites. If said person has nanites it will override them changing thier cloud id and all their programs to the ones of the infecting nanites. If said nanites get updated by cloud then the newly infected nanites will override them back keeping the program. If somone gets his nanites removed person removing them will propably infect them again with nanites he was propably infected with. If you try to swith to clear cloud it will get instantly overriten. 
TLDR: Changing nanites will become impossible, removing them similarly hard (bio armour actually works but there are 5-6 on them on the station).

With this change, there will be no more ways of dealing with that or changing nanites after the infecting program was added. If you got completely clean nanites you are now fully immune to the spread. They also cant be corrupted do to not being anything so that's just a basically free vaccine. No longer there will be infinite chain of infections stoping all cloud updates from changing anything. In general the problems caused by this program will be much more manageable without hurting its main utility.

If you want to still override other nanites there is program for that still so the option isn't out of the table completely, it just is no longer combined with another program with together can cause apocalyptic outbreaks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Zrzut ekranu (173)](https://github.com/user-attachments/assets/15349c94-3b4e-48db-81d3-ae691971a0f3)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Infective exolocomotion will no longer override other nanites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
