### PR TITLE
Fixes Advanced Roasting Sticks (Plus Buff)

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -825,7 +825,7 @@
  */
 /obj/item/melee/roastingstick/proc/on_transform(obj/item/source, mob/user, active)
 	SIGNAL_HANDLER
-
+	icon_state = active ? "roastingstick_1" : "roastingstick_0"
 	item_state = active ? "nullrod" : null
 	if(user)
 		balloon_alert(user, "[active ? "extended" : "collapsed"] [src]")
@@ -834,17 +834,21 @@
 
 /obj/item/melee/roastingstick/attackby(atom/target, mob/user)
 	..()
-	if (istype(target, /obj/item/food/sausage))
-		if (!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
-			to_chat(user, span_warning("You must extend [src] to attach anything to it!"))
-			return
-		if (held_sausage)
-			to_chat(user, span_warning("[held_sausage] is already attached to [src]!"))
-			return
-		if (user.transferItemToLoc(target, src))
-			held_sausage = target
+	if (istype(target, /obj/item/food))
+		var/obj/item/food/target_sausage = target
+		if( ( target_sausage.foodtypes & MEAT ) && !( target_sausage.foodtypes & RAW ) )
+			if (!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
+				to_chat(user, span_warning("You must extend [src] to attach anything to it!"))
+				return
+			if (held_sausage)
+				to_chat(user, span_warning("[held_sausage] is already attached to [src]!"))
+				return
+			if (user.transferItemToLoc(target, src))
+				held_sausage = target
+			else
+				to_chat(user, span_warning("[target] doesn't seem to want to get on [src]!"))
 		else
-			to_chat(user, span_warning("[target] doesn't seem to want to get on [src]!"))
+			to_chat(user, span_warning("[target] can't be roasted using [src]!"))
 	update_appearance()
 
 /obj/item/melee/roastingstick/attack_hand(mob/user, list/modifiers)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -834,9 +834,9 @@
 
 /obj/item/melee/roastingstick/attackby(atom/target, mob/user)
 	..()
-	if (istype(target, /obj/item/food))
+	if (istype(target, /obj/item/food/meat) || istype(target, /obj/item/food/sausage))
 		var/obj/item/food/target_sausage = target
-		if( ( target_sausage.foodtypes & MEAT ) && !( target_sausage.foodtypes & RAW ) )
+		if ( !( target_sausage.foodtypes & RAW ) &&  !( target_sausage.foodtypes & FRIED ) ) // ONLY COOKED MEATS, NO RAW, NO FRIED.
 			if (!HAS_TRAIT(src, TRAIT_TRANSFORM_ACTIVE))
 				to_chat(user, span_warning("You must extend [src] to attach anything to it!"))
 				return
@@ -848,7 +848,9 @@
 			else
 				to_chat(user, span_warning("[target] doesn't seem to want to get on [src]!"))
 		else
-			to_chat(user, span_warning("[target] can't be roasted using [src]!"))
+			to_chat(user, span_warning("[target] can't be roasted using [src]! Pre-cook the meat!"))
+	else
+		to_chat(user, span_warning("[target] can't be roasted using [src]!"))
 	update_appearance()
 
 /obj/item/melee/roastingstick/attack_hand(mob/user, list/modifiers)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#11324 did not fully implement transforming for this item. The Icon state was never set, leading to the stick failing to... do anything really. This fixes that issue, and also expands the amount of things that can be roasted on the stick.

Fixes #12800 

## Why It's Good For The Game

I want to roast.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://github.com/user-attachments/assets/5923ada5-e7d4-406a-8c62-33ee921bf808)

Extended/Collapsed
![image](https://github.com/user-attachments/assets/2e368584-51f8-4a25-b373-eb276606527b)
![image](https://github.com/user-attachments/assets/8cde56c2-b3cf-40d5-9041-b58964baff66)

Roasted and unroasted foods:
![image](https://github.com/user-attachments/assets/ad790ea2-63c8-49bc-9250-d3ff7e9702b8)


</details>

## Changelog
:cl:
fix: Roasting Sticks work again
tweak: Roasting sticks can now roast more than just sausages over things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
