### PR TITLE
Fixes Nuclear Bomb gibbing incorrect z level

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -413,10 +413,6 @@ SUBSYSTEM_DEF(ticker)
 	else
 		LAZYADD(round_end_events, cb)
 
-/datum/controller/subsystem/ticker/proc/station_explosion_detonation(atom/bomb)
-	if(bomb)
-		qdel(bomb)
-
 /datum/controller/subsystem/ticker/proc/create_characters()
 	for(var/mob/dead/new_player/player in GLOB.player_list)
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -414,12 +414,8 @@ SUBSYSTEM_DEF(ticker)
 		LAZYADD(round_end_events, cb)
 
 /datum/controller/subsystem/ticker/proc/station_explosion_detonation(atom/bomb)
-	if(bomb)	//BOOM
+	if(bomb)
 		qdel(bomb)
-		for(var/mob/M in GLOB.mob_list)
-			var/turf/T = get_turf(M)
-			if(T && is_station_level(T.z) && !istype(M.loc, /obj/structure/closet/secure_closet/freezer)) //protip: freezers protect you from nukes
-				M.gib(TRUE)
 
 /datum/controller/subsystem/ticker/proc/create_characters()
 	for(var/mob/dead/new_player/player in GLOB.player_list)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -534,7 +534,7 @@
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
 	Cinematic(get_cinematic_type(off_station),world)
-	ASSERT(!isnull(bomb_z_level), "/obj/machinery/nuclearbomb/really_actually_explode() was called without a z level!"
+	ASSERT(!isnull(bomb_z_level), "/obj/machinery/nuclearbomb/really_actually_explode() was called without a z level!")
 	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(kill_everyone_on_z_group), bomb_z_level)
 	qdel(src)
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -534,8 +534,7 @@
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
 	Cinematic(get_cinematic_type(off_station),world)
-	if (!bomb_z_level)
-		bomb_z_level = 0 // just in case it hasn't been set by anything
+	ASSERT(!isnull(bomb_z_level), "/obj/machinery/nuclearbomb/really_actually_explode() was called without a z level!"
 	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(kill_everyone_on_z_group), bomb_z_level)
 	qdel(src)
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -618,11 +618,8 @@
 /proc/KillEveryoneOnZLevel(z)
 	if(!z)
 		return
-	// check whether we're exploding on the station, if so we should include multi-z station levels
-	var/isOnStation = is_station_level(z)
 	for(var/mob/M in GLOB.mob_list)
-		var/mobZlevel = M.get_virtual_z_level()
-		if ((mobZlevel == z) || (isOnStation && is_station_level(mobZlevel)))
+		if (compare_z(M.get_virtual_z_level(), z)) // check whether we're exploding on the station, if so we should include multi-z station levels
 			if(M.stat != DEAD && !istype(M.loc, /obj/structure/closet/secure_closet/freezer))
 				to_chat(M, span_userdanger("You are shredded to atoms!"))
 				M.investigate_log("has been gibbed by a nuclear blast.", INVESTIGATE_DEATHS)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -521,9 +521,7 @@
 	else
 		off_station = NUKE_MISS_STATION
 
-	bomb_z_level = get_virtual_z_level() // store for really_actually_explode (src loc gets lost in callback), try virtual level first
-	if (!bomb_z_level)
-		bomb_z_level = bomb_location.z
+	bomb_z_level = get_virtual_z_level() // store for really_actually_explode (src loc gets lost in callback) and hope this is not null
 
 	if(off_station < 2)
 		SSshuttle.registerHostileEnvironment(src)
@@ -538,7 +536,7 @@
 	Cinematic(get_cinematic_type(off_station),world)
 	if (!bomb_z_level)
 		bomb_z_level = 0 // just in case it hasn't been set by anything
-	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZCategory), bomb_z_level)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(kill_everyone_on_z_group), bomb_z_level)
 	qdel(src)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
@@ -615,11 +613,12 @@
 /obj/machinery/nuclearbomb/beer/really_actually_explode()
 	disarm()
 
-/proc/KillEveryoneOnZCategory(zLevel)
-	if(!zLevel)
+/proc/kill_everyone_on_z_group(zGroup)
+	// take in a z level as a number, and kill everyone on the same 'z orbital map' or z group
+	if(!zGroup)
 		return
 	for(var/mob/M in GLOB.mob_list)
-		if (compare_z(M.get_virtual_z_level(), zLevel)) // check whether the mob is on the same z category as the input level
+		if (compare_z(M.get_virtual_z_level(), zGroup)) // check whether the mob is on the same z orbital map as the input level (as in multi-z stations etc)
 			if(M.stat != DEAD && !istype(M.loc, /obj/structure/closet/secure_closet/freezer))
 				to_chat(M, span_userdanger("You are shredded to atoms!"))
 				M.investigate_log("has been gibbed by a nuclear blast.", INVESTIGATE_DEATHS)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -538,7 +538,7 @@
 	Cinematic(get_cinematic_type(off_station),world)
 	if (!bomb_z_level)
 		bomb_z_level = 0 // just in case it hasn't been set by anything
-	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZLevel), bomb_z_level)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZCategory), bomb_z_level)
 	qdel(src)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
@@ -615,11 +615,11 @@
 /obj/machinery/nuclearbomb/beer/really_actually_explode()
 	disarm()
 
-/proc/KillEveryoneOnZLevel(z)
-	if(!z)
+/proc/KillEveryoneOnZCategory(zLevel)
+	if(!zLevel)
 		return
 	for(var/mob/M in GLOB.mob_list)
-		if (compare_z(M.get_virtual_z_level(), z)) // check whether we're exploding on the station, if so we should include multi-z station levels
+		if (compare_z(M.get_virtual_z_level(), zLevel)) // check whether the mob is on the same z category as the input level
 			if(M.stat != DEAD && !istype(M.loc, /obj/structure/closet/secure_closet/freezer))
 				to_chat(M, span_userdanger("You are shredded to atoms!"))
 				M.investigate_log("has been gibbed by a nuclear blast.", INVESTIGATE_DEATHS)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -618,11 +618,15 @@
 /proc/KillEveryoneOnZLevel(z)
 	if(!z)
 		return
+	// check whether we're exploding on the station, if so we should include multi-z station levels
+	var/isOnStation = is_station_level(z)
 	for(var/mob/M in GLOB.mob_list)
-		if(M.stat != DEAD && M.get_virtual_z_level() == z && !istype(M.loc, /obj/structure/closet/secure_closet/freezer)) //protip: freezers protect you from nukes)
-			to_chat(M, span_userdanger("You are shredded to atoms!"))
-			M.investigate_log("has been gibbed by a nuclear blast.", INVESTIGATE_DEATHS)
-			M.gib()
+		var/mobZlevel = M.get_virtual_z_level()
+		if ((mobZlevel == z) || (isOnStation && is_station_level(mobZlevel)))
+			if(M.stat != DEAD && !istype(M.loc, /obj/structure/closet/secure_closet/freezer))
+				to_chat(M, span_userdanger("You are shredded to atoms!"))
+				M.investigate_log("has been gibbed by a nuclear blast.", INVESTIGATE_DEATHS)
+				M.gib()
 
 /*
 This is here to make the tiles around the station mininuke change when it's armed.

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -521,7 +521,7 @@
 	else
 		off_station = NUKE_MISS_STATION
 
-	bomb_z_level = get_virtual_z_level() // store for really_actually_explode (src will be lost due to async callback), try virtual level first
+	bomb_z_level = get_virtual_z_level() // store for really_actually_explode (src loc gets lost in callback), try virtual level first
 	if (!bomb_z_level)
 		bomb_z_level = bomb_location.z
 
@@ -535,10 +535,11 @@
 	SSticker.roundend_check_paused = FALSE
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
-	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation), src))
+	Cinematic(get_cinematic_type(off_station),world)
 	if (!bomb_z_level)
 		bomb_z_level = 0 // just in case it hasn't been set by anything
 	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZLevel), bomb_z_level)
+	qdel(src)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
 	if(off_station < 2)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -122,6 +122,6 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 /obj/machinery/nuclearbomb/decomission/actually_explode()
 	SSticker.roundend_check_paused = FALSE
 	linked_objective.complete_objective()
-	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZCategory), target_z)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(kill_everyone_on_z_group), target_z)
 	QDEL_NULL(linked_objective.linked_beacon)
 	qdel(src)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -122,6 +122,6 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 /obj/machinery/nuclearbomb/decomission/actually_explode()
 	SSticker.roundend_check_paused = FALSE
 	linked_objective.complete_objective()
-	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZLevel), target_z)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZCategory), target_z)
 	QDEL_NULL(linked_objective.linked_beacon)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

Fixes the z-level checking so that when a nuclearbomb is exploded, only those on the same z-level (or virtual z level) are gibbed.

There was originally two paths for gibbing to occur - once in the bomb code and once as a callback in the ticker. I've removed the ticker code in favor of keeping everything contained within the nuclearbomb file.

## Why It's Good For The Game

Fixes #12796, bomb should blow up correctly!

## Testing Photographs and Procedure

- [x]  Checked nuclearbomb on syndicate base
- [x]  Checked nuclearbomb on station
- [x] Checked nuclearbomb on shuttle transit
- [x] Checked explorer nuclear mission

<details>
<summary>Screenshots&Videos</summary>

On mission off-station: https://youtu.be/m20t3LRUmjE
On shuttle in-transit (virtual z-level): https://youtu.be/rlY6hEeO42U
On station: https://youtu.be/ZKjtmEZbVzI
On syndicate station: https://youtu.be/l_zC5aIEW-M
On station (nuclear mode): https://youtu.be/p8yet4fXIh4
On syndicate station (nuclear mode): https://youtu.be/nc_RFK8N9dY

</details>

## Changelog
:cl:
fix: Exploding nuclear bombs now correctly gib those that are unfortunate enough to be on the same z-level
/:cl:

