### PR TITLE
Fixes Wands Only Shooting Once

### DIFF
--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -57,7 +57,6 @@
 		chambered.newshot()
 
 /obj/item/gun/magic/on_chamber_fired()
-	..()
 	// Drain the charge and recharge
 	charges--
 	recharge_newshot()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A gun PR cleaned up some gun code. Good overall, but the on_chamber_fired proc nulled the chambered charge. This caused the wands to not have anything in the "chamber" even though they had charges. Removing the parent call to completely override the chamber nulling fixed it.

Fixes #12631
Fixes #12791
Fixes #12789

## Why It's Good For The Game

Wands now work

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/ef4903da-8be2-43c3-ba5a-caf20b19786b)

![image](https://github.com/user-attachments/assets/ac4aec59-daa3-4f5f-8a91-5794aa491154)

Debug Wand Recharges
![image](https://github.com/user-attachments/assets/7e512ef9-04f1-47a4-a655-e2e62c0d41c4)

</details>

## Changelog
:cl:
fix: Wands can fire all their charges once again. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
