### PR TITLE
Fixes sticky movement keys caused by TGUI passthrough

### DIFF
--- a/tgui/packages/tgui/events.ts
+++ b/tgui/packages/tgui/events.ts
@@ -57,12 +57,14 @@ const stealFocus = (node: HTMLElement) => {
   releaseStolenFocus();
   focusStolenBy = node;
   focusStolenBy.addEventListener('blur', releaseStolenFocus);
+  globalEvents.emit('input-focus');
 };
 
 const releaseStolenFocus = () => {
   if (focusStolenBy) {
     focusStolenBy.removeEventListener('blur', releaseStolenFocus);
     focusStolenBy = null;
+    globalEvents.emit('input-blur');
   }
 };
 
@@ -103,7 +105,7 @@ const focusNearestTrackedParent = (node: HTMLElement | null) => {
   }
 };
 
-window.addEventListener('mousemove', (e) => {
+window.addEventListener('mousemove', (e: FocusEvent) => {
   const node = e.target as HTMLElement;
   if (node !== lastVisitedNode) {
     lastVisitedNode = node;
@@ -114,27 +116,47 @@ window.addEventListener('mousemove', (e) => {
 // Focus event hooks
 // --------------------------------------------------------
 
-window.addEventListener('focusin', (e) => {
-  lastVisitedNode = null;
-  focusedNode = e.target as HTMLElement;
+// Handle stealing focus for textbox elements
+document.addEventListener(
+  'focus',
+  (e: FocusEvent) => {
+    // Window
+    if (!(e.target instanceof Element)) {
+      lastVisitedNode = null;
+      focusedNode = null;
+      return;
+    }
+    lastVisitedNode = null;
+    focusedNode = e.target as HTMLElement;
+    if (canStealFocus(e.target as HTMLElement)) {
+      stealFocus(e.target as HTMLElement);
+    }
+  },
+  true
+);
+
+// When we click on any element on the page, untrack the last
+// visited node.
+document.addEventListener(
+  'blur',
+  (e) => {
+    lastVisitedNode = null;
+  },
+  true
+);
+
+// Handle setting the window focus
+window.addEventListener('focus', () => {
   setWindowFocus(true);
-  if (canStealFocus(e.target as HTMLElement)) {
-    stealFocus(e.target as HTMLElement);
-    return;
-  }
 });
 
-window.addEventListener('focusout', (e) => {
-  lastVisitedNode = null;
-  setWindowFocus(false, true);
-});
-
+// If we blur any element, the window may have unfocused if we didn't
+// click on the background
 window.addEventListener('blur', (e) => {
-  lastVisitedNode = null;
   setWindowFocus(false, true);
 });
 
-window.addEventListener('beforeunload', (e) => {
+window.addEventListener('close', (e) => {
   setWindowFocus(false);
 });
 

--- a/tgui/packages/tgui/events.ts
+++ b/tgui/packages/tgui/events.ts
@@ -105,7 +105,7 @@ const focusNearestTrackedParent = (node: HTMLElement | null) => {
   }
 };
 
-window.addEventListener('mousemove', (e: FocusEvent) => {
+window.addEventListener('mousemove', (e) => {
   const node = e.target as HTMLElement;
   if (node !== lastVisitedNode) {
     lastVisitedNode = node;

--- a/tgui/packages/tgui/hotkeys.ts
+++ b/tgui/packages/tgui/hotkeys.ts
@@ -192,6 +192,9 @@ export const setupHotKeys = () => {
   globalEvents.on('window-blur', () => {
     releaseHeldKeys();
   });
+  globalEvents.on('input-focus', () => {
+    releaseHeldKeys();
+  });
   globalEvents.on('key', (key: KeyEvent) => {
     for (const keyListener of keyListeners) {
       keyListener(key);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #12822

Special thanks for affected arc for mentioning that this is related to TGUI passthrough, which got me started looking for ways to replicate it

## About The Pull Request

TGUI has a feature where it passes through hotkeys to the game. When the user clicks off of a window, the TGUI window needs to know that it should send a 'keyup' event to Byond, so that transfer can be passed over to Byond. If the TGUI window cannot correctly determine whether or not the user has it in focus, then the keyup command will not be sent to Byond, resulting in a stuck movement key.

This PR refactors the logic for how TGUI windows determine if they are in focus. It now seperates the window focus, from an element such as a textbox stealing focus. It also stops using events that aren't fully supported in Javascript, as this change in behaviour is what results in the difference in behaviour between 515 and 516.

## Replication

You could replicate the issue using the following steps:
- Focus a TGUI window
- Tap a movement key and then immediately click the Byond window.

On 516 the event for the window being focused was never being picked up and was actually being fired way too early. This meant that when you clicked off the window, the TGUI window would never actually send the key up event. The reason why you have to tap the movement key is because if you hold the key after focusing the Byond window, Byond accepts that it has responsibility for the keys and fires the keyup event itself.

This issue is easy to replicate and can be performed almost every time. It has some slight timing to it, but the timing is pretty easy to get.

## Why It's Good For The Game

Sticky keys are really, really annoying and common.

## Testing Photographs and Procedure

REQUIRES 515 TESTING ONE SECOND PLEASE

516 Issue:

https://github.com/user-attachments/assets/5ade1eeb-decd-44d1-a56f-63915a17e0b1

516 Fix:

https://github.com/user-attachments/assets/4245845a-7abe-4648-8355-22ca1b6594c9

515 compatability:

https://github.com/user-attachments/assets/ff9d3a8f-7b44-4614-b129-c09442c18171


## Changelog
:cl:
fix: Fixes movement keys being stuck
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
