### PR TITLE
:Visual Fix -  Restored Corners

### DIFF
--- a/_maps/shuttles/emergency/emergency_theatre.dmm
+++ b/_maps/shuttles/emergency/emergency_theatre.dmm
@@ -283,7 +283,7 @@
 /area/shuttle/escape)
 "HP" = (
 /obj/machinery/vending/boozeomat,
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "IK" = (
 /obj/item/scalpel{
@@ -492,6 +492,9 @@
 "PH" = (
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape)
+"PK" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
 "Rv" = (
 /obj/structure/shuttle/engine/propulsion,
 /obj/effect/turf_decal/stripes/line{
@@ -581,7 +584,7 @@ fI
 "}
 (2,1,1) = {"
 DN
-DN
+PK
 Tx
 Tx
 Tx
@@ -596,7 +599,7 @@ Js
 qn
 Jn
 qn
-DN
+PK
 DN
 fI
 "}
@@ -670,14 +673,14 @@ xm
 xm
 xm
 xm
-DN
+PK
 LQ
 RK
 RK
 RK
 qn
 qn
-DN
+PK
 xm
 xm
 DN
@@ -838,14 +841,14 @@ xm
 xm
 xm
 xm
-DN
+PK
 yG
 sV
 sV
 sV
 qn
 qn
-DN
+PK
 xm
 xm
 DN
@@ -932,7 +935,7 @@ Js
 qn
 NH
 qn
-DN
+PK
 DN
 fI
 "}


### PR DESCRIPTION
## About The Pull Request
Simply turns a few walls in the emergency shuttle into non diagonal thus improving certain textures and visual asthetic
## Why It's Good For The Game

Removes ugly visually distasteful textures and immsersion breaking settings and fixes a small issue 

closes https://github.com/BeeStation/BeeStation-Hornet/issues/12835


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![image](https://github.com/user-attachments/assets/2c04f97a-d4bc-49c1-8b02-397bebe33c59)
![image](https://github.com/user-attachments/assets/a3a4f7ce-fdd2-4600-802d-bf0da27ae048)
from
![image](https://github.com/user-attachments/assets/e83116e6-acd3-4069-aac4-1cbca6691ab7)
![image](https://github.com/user-attachments/assets/961c1003-3cc2-4e4a-b828-72b9fc8788a1)



</details>

## Changelog
:cl:
Tweaks:Emergency Theatre Shuttle
Adds: 6 New non Diagonal Walls
/:cl:
