### PR TITLE
Cleans up xenomorph attack interactions

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -72,11 +72,11 @@ In all, this is a lot like the monkey code. /N
 			user.disarm(src)
 			return TRUE
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
-			to_chat(user, "<span class='notice'>You don't want to hurt [src]!</span>")
+			to_chat(user, span_notice("You don't want to hurt [src]!"))
 			return
 		playsound(loc, "punch", 25, 1, -1)
-		visible_message("<span class='danger'>[user] punches [src]!</span>", \
-				"<span class='userdanger'>[user] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
+		visible_message(span_danger("[user] punches [src]!"), \
+				span_userdanger("[user] punches you!"), null, COMBAT_MESSAGE_RANGE)
 		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.get_combat_bodyzone(src)))
 		apply_damage(user.dna.species.punchdamage, BRUTE, affecting)
 		log_combat(user, src, "attacked", user)

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -11,6 +11,13 @@
 /mob/living/carbon/alien/is_shove_knockdown_blocked()
 	return TRUE
 
+/mob/living/carbon/alien/disarm_aftereffect(mob/living/carbon/target)
+	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(src.get_combat_bodyzone(target)))
+	if(!affecting)
+		affecting = target.get_bodypart(BODY_ZONE_CHEST)
+	var/armor_block = target.run_armor_check(affecting, MELEE,"","",10)
+	target.apply_damage(30, STAMINA, affecting, armor_block)
+
 /*Code for aliens attacking aliens. Because aliens act on a hivemind, I don't see them as very aggressive with each other.
 As such, they can either help or harm other aliens. Help works like the human help command while harm is a simple nibble.
 In all, this is a lot like the monkey code. /N

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -7,6 +7,9 @@
 /mob/living/carbon/alien/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	..(AM, skipcatch = TRUE, hitpush = FALSE)
 
+//You cant knock down aliens through shoving
+/mob/living/carbon/alien/is_shove_knockdown_blocked()
+	return TRUE
 
 /*Code for aliens attacking aliens. Because aliens act on a hivemind, I don't see them as very aggressive with each other.
 As such, they can either help or harm other aliens. Help works like the human help command while harm is a simple nibble.
@@ -66,20 +69,25 @@ In all, this is a lot like the monkey code. /N
 
 	if(user.combat_mode)
 		if(LAZYACCESS(modifiers, RIGHT_CLICK))
-			if(HAS_TRAIT(user, TRAIT_PACIFISM))
-				to_chat(user, "<span class='notice'>You don't want to hurt [src]!</span>")
-				return
-			playsound(loc, "punch", 25, 1, -1)
-			visible_message("<span class='danger'>[user] punches [src]!</span>", \
-					"<span class='userdanger'>[user] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.get_combat_bodyzone(src)))
-			apply_damage(user.dna.species.punchdamage, BRUTE, affecting)
-			log_combat(user, src, "attacked", user)
-			user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
+			user.disarm(src)
+			return TRUE
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			to_chat(user, "<span class='notice'>You don't want to hurt [src]!</span>")
+			return
+		playsound(loc, "punch", 25, 1, -1)
+		visible_message("<span class='danger'>[user] punches [src]!</span>", \
+				"<span class='userdanger'>[user] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
+		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.get_combat_bodyzone(src)))
+		apply_damage(user.dna.species.punchdamage, BRUTE, affecting)
+		log_combat(user, src, "attacked", user)
 		user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 		return TRUE
 	else
-		help_shake_act(user)
+		if(LAZYACCESS(modifiers, RIGHT_CLICK))
+			user.disarm(src)
+			return TRUE
+		else
+			help_shake_act(user)
 
 /mob/living/carbon/alien/attack_animal(mob/living/simple_animal/M)
 	if(!..())

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -11,13 +11,6 @@
 /mob/living/carbon/alien/is_shove_knockdown_blocked()
 	return TRUE
 
-/mob/living/carbon/alien/disarm_aftereffect(mob/living/carbon/target)
-	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(src.get_combat_bodyzone(target)))
-	if(!affecting)
-		affecting = target.get_bodypart(BODY_ZONE_CHEST)
-	var/armor_block = target.run_armor_check(affecting, MELEE,"","",10)
-	target.apply_damage(30, STAMINA, affecting, armor_block)
-
 /*Code for aliens attacking aliens. Because aliens act on a hivemind, I don't see them as very aggressive with each other.
 As such, they can either help or harm other aliens. Help works like the human help command while harm is a simple nibble.
 In all, this is a lot like the monkey code. /N

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -271,7 +271,6 @@
 
 	SEND_SIGNAL(target, COMSIG_HUMAN_DISARM_HIT, src, get_combat_bodyzone(target))
 	target.disarm_effect(src)
-	disarm_aftereffect(target) //lets add additional behavior based on what mob is doing it
 
 /mob/living/carbon/is_shove_knockdown_blocked() //If you want to add more things that block shove knockdown, extend this
 	for (var/obj/item/clothing/clothing in get_equipped_items())

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -260,6 +260,7 @@
  * Attempt to disarm the target mob.
  * Will shove the target mob back, and drop them if they're in front of something dense
  * or another carbon.
+ * src is the attacker
 */
 /mob/living/carbon/proc/disarm(mob/living/carbon/target)
 	do_attack_animation(target, ATTACK_EFFECT_DISARM)
@@ -270,6 +271,7 @@
 
 	SEND_SIGNAL(target, COMSIG_HUMAN_DISARM_HIT, src, get_combat_bodyzone(target))
 	target.disarm_effect(src)
+	disarm_aftereffect(target) //lets add additional behavior based on what mob is doing it
 
 /mob/living/carbon/is_shove_knockdown_blocked() //If you want to add more things that block shove knockdown, extend this
 	for (var/obj/item/clothing/clothing in get_equipped_items())

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -246,11 +246,11 @@
 				apply_damage(damage, BRUTE, affecting, run_armor_check(affecting, MELEE))
 		return TRUE
 
-/mob/living/carbon/human/attack_alien(mob/living/carbon/alien/humanoid/M, list/modifiers)
-	if(check_shields(M, 20, "the [M.name]", UNARMED_ATTACK))
-		visible_message("<span class='danger'>[M] attempts to touch [src]!</span>", \
-						"<span class='danger'>[M] attempts to touch you!</span>", "<span class='hear'>You hear a swoosh!</span>", null, M)
-		to_chat(M, "<span class='warning'>You attempt to touch [src]!</span>")
+/mob/living/carbon/human/attack_alien(mob/living/carbon/alien/humanoid/user, list/modifiers)
+	if(check_shields(user, 20, "the [user.name]", UNARMED_ATTACK))
+		visible_message(span_danger("[user] attempts to touch [src]!"), \
+						span_danger("[user] attempts to touch you!"), span_hear("You hear a swoosh!"), null, user)
+		to_chat(user, span_warning("You attempt to touch [src]!"))
 		return FALSE
 	. = ..()
 	if(!.)
@@ -260,70 +260,70 @@
 		var/obj/item/I = get_active_held_item()
 		if(I && dropItemToGround(I))
 			playsound(loc, 'sound/weapons/slash.ogg', 25, TRUE, -1)
-			visible_message("<span class='danger'>[M] disarms [src]!</span>", \
-							"<span class='userdanger'>[M] disarms you!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", null, M)
-			to_chat(M, "<span class='danger'>You disarm [src]!</span>")
+			visible_message(span_danger("[user] disarms [src]!"), \
+							span_userdanger("[user] disarms you!"), span_hear("You hear aggressive shuffling!"), null, user)
+			to_chat(user, span_danger("You disarm [src]!"))
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, TRUE, -1)
-			Knockdown(20)
-			log_combat(M, src, "tackled")
-			visible_message("<span class='danger'>[M] tackles [src] down!</span>", \
-							"<span class='userdanger'>[M] tackles you down!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", null, M)
-			to_chat(M, "<span class='danger'>You tackle [src] down!</span>")
+			user.disarm(src)
 		return TRUE
 
-	if(M.combat_mode)
+	if(user.combat_mode)
 		if (w_uniform)
-			w_uniform.add_fingerprint(M)
-		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.get_combat_bodyzone(src)))
+			w_uniform.add_fingerprint(user)
+		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.get_combat_bodyzone(src)))
 		if(!affecting)
 			affecting = get_bodypart(BODY_ZONE_CHEST)
 		var/armor_block = run_armor_check(affecting, MELEE,"","",10)
 
 		playsound(loc, 'sound/weapons/slice.ogg', 25, TRUE, -1)
-		visible_message("<span class='danger'>[M] slashes at [src]!</span>", \
-						"<span class='userdanger'>[M] slashes at you!</span>", "<span class='hear'>You hear a sickening sound of a slice!</span>", null, M)
-		to_chat(M, "<span class='danger'>You slash at [src]!</span>")
-		log_combat(M, src, "attacked", M)
-		if(!dismembering_strike(M, M.get_combat_bodyzone(src))) //Dismemberment successful
+		visible_message(span_danger("[user] slashes at [src]!"), \
+						span_userdanger("[user] slashes at you!"), span_hear("You hear a sickening sound of a slice!"), null, user)
+		to_chat(user, span_danger("You slash at [src]!"))
+		log_combat(user, src, "attacked", user)
+		if(!dismembering_strike(user, user.get_combat_bodyzone(src))) //Dismemberment successful
 			return TRUE
 		apply_damage(20, BRUTE, affecting, armor_block)
 
 
 /mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/L, list/modifiers)
-	if(..()) //successful larva bite.
-		var/damage = rand(1, 3)
-		if(check_shields(L, damage, "the [L.name]"))
-			return 0
-		if(stat != DEAD)
-			L.amount_grown = min(L.amount_grown + damage, L.max_grown)
-			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(L.get_combat_bodyzone(src)))
-			if(!affecting)
-				affecting = get_bodypart(BODY_ZONE_CHEST)
-			var/armor_block = run_armor_check(affecting, MELEE)
-			apply_damage(damage, BRUTE, affecting, armor_block)
-
-/mob/living/carbon/human/attack_slime(mob/living/simple_animal/slime/M, list/modifiers)
-	if(..()) //successful slime attack
-		var/damage = 20
-		if(M.is_adult)
-			damage = 30
-
-		if(M.transformeffects & SLIME_EFFECT_RED)
-			damage *= 1.1
-
-		if(check_shields(M, damage, "the [M.name]"))
-			return 0
-
-		var/dam_zone = dismembering_strike(M, pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
-		if(!dam_zone) //Dismemberment successful
-			return 1
-
-		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(dam_zone))
+	. = ..()
+	if(!.)
+		return //successful larva bite.
+	var/damage = rand(1, 3)
+	if(check_shields(L, damage, "the [L.name]"))
+		return 0
+	if(stat != DEAD)
+		L.amount_grown = min(L.amount_grown + damage, L.max_grown)
+		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(L.get_combat_bodyzone(src)))
 		if(!affecting)
 			affecting = get_bodypart(BODY_ZONE_CHEST)
 		var/armor_block = run_armor_check(affecting, MELEE)
 		apply_damage(damage, BRUTE, affecting, armor_block)
+
+/mob/living/carbon/human/attack_slime(mob/living/simple_animal/slime/M, list/modifiers)
+	. = ..()
+	if(!.)
+		return //successful slime attack
+	var/damage = 20
+	if(M.is_adult)
+		damage = 30
+
+	if(M.transformeffects & SLIME_EFFECT_RED)
+		damage *= 1.1
+
+	if(check_shields(M, damage, "the [M.name]"))
+		return FALSE
+
+	var/dam_zone = dismembering_strike(M, pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
+	if(!dam_zone) //Dismemberment successful
+		return TRUE
+
+	var/obj/item/bodypart/affecting = get_bodypart(ran_zone(dam_zone))
+	if(!affecting)
+		affecting = get_bodypart(BODY_ZONE_CHEST)
+	var/armor_block = run_armor_check(affecting, MELEE)
+	apply_damage(damage, BRUTE, affecting, armor_block)
 
 /mob/living/carbon/human/ex_act(severity, target, origin)
 	if(TRAIT_BOMBIMMUNE in dna.species.species_traits)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -257,8 +257,8 @@
 		return
 
 	if(LAZYACCESS(modifiers, RIGHT_CLICK)) //Always drop item in hand, if no item, get stun instead.
-		var/obj/item/I = get_active_held_item()
-		if(I && dropItemToGround(I))
+		var/obj/item/held_item = get_active_held_item()
+		if(held_item && dropItemToGround(held_item))
 			playsound(loc, 'sound/weapons/slash.ogg', 25, TRUE, -1)
 			visible_message(span_danger("[user] disarms [src]!"), \
 							span_userdanger("[user] disarms you!"), span_hear("You hear aggressive shuffling!"), null, user)
@@ -292,7 +292,7 @@
 		return //successful larva bite.
 	var/damage = rand(1, 3)
 	if(check_shields(L, damage, "the [L.name]"))
-		return 0
+		return FALSE
 	if(stat != DEAD)
 		L.amount_grown = min(L.amount_grown + damage, L.max_grown)
 		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(L.get_combat_bodyzone(src)))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -265,7 +265,16 @@
 			to_chat(user, span_danger("You disarm [src]!"))
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, TRUE, -1)
-			user.disarm(src)
+			Knockdown(20)
+			log_combat(user, src, "tackled")
+			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.get_combat_bodyzone(src)))
+			if(!affecting)
+				affecting = get_bodypart(BODY_ZONE_CHEST)
+			var/armor_block = run_armor_check(affecting, MELEE,"","",10)
+			apply_damage(30, STAMINA, affecting, armor_block)
+			visible_message(span_danger("[user] tackles [src] down!"), \
+					span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
+			to_chat(user, span_danger("You tackle [src] down!"))
 		return TRUE
 
 	if(user.combat_mode)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -265,7 +265,7 @@
 			to_chat(M, "<span class='danger'>You disarm [src]!</span>")
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, TRUE, -1)
-			Paralyze(100)
+			Knockdown(20)
 			log_combat(M, src, "tackled")
 			visible_message("<span class='danger'>[M] tackles [src] down!</span>", \
 							"<span class='userdanger'>[M] tackles you down!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", null, M)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -346,21 +346,21 @@
 		return FALSE
 	return FALSE
 
-/mob/living/attack_alien(mob/living/carbon/alien/humanoid/M, modifiers)
-	SEND_SIGNAL(src, COMSIG_MOB_ATTACK_ALIEN, M, modifiers)
+/mob/living/attack_alien(mob/living/carbon/alien/humanoid/user, modifiers)
+	SEND_SIGNAL(src, COMSIG_MOB_ATTACK_ALIEN, user, modifiers)
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		M.do_attack_animation(src, ATTACK_EFFECT_DISARM)
+		user.do_attack_animation(src, ATTACK_EFFECT_DISARM)
 		return TRUE
-	if(M.combat_mode)
-		if(HAS_TRAIT(M, TRAIT_PACIFISM))
-			to_chat(M, "<span class='warning'>You don't want to hurt anyone!</span>")
+	if(user.combat_mode)
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			to_chat(user, span_warning("You don't want to hurt anyone!"))
 			return FALSE
-		M.do_attack_animation(src)
+		user.do_attack_animation(src)
 		return TRUE
 	else
-		visible_message("<span class='notice'>[M] caresses [src] with its scythe-like arm.</span>", \
-						"<span class='notice'>[M] caresses you with its scythe-like arm.</span>", null, null, M)
-		to_chat(M, "<span class='notice'>You caress [src] with your scythe-like arm.</span>")
+		visible_message(span_notice("[user] caresses [src] with its scythe-like arm."), \
+						span_notice("[user] caresses you with its scythe-like arm."), null, null, user)
+		to_chat(user, span_notice("You caress [src] with your scythe-like arm."))
 		return FALSE
 
 /mob/living/ex_act(severity, target, origin)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -631,13 +631,6 @@
 				span_danger("You shove [name]!"), null, COMBAT_MESSAGE_RANGE)
 		log_combat(attacker, src, "shoved", "disarm")
 
-
-/// Allows us to append additional disarm behavior, dependent on our species
-/// src is our attacker
-/mob/living/proc/disarm_aftereffect(mob/living/carbon/target)
-	return
-
-
 /** Handles exposing a mob to reagents.
   *
   * If the method is INGEST the mob tastes the reagents.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -542,9 +542,9 @@
 
 /// Universal disarm effect, can be used by other components that also want a similar effect to pushback
 /// and stun.
-/mob/living/proc/disarm_effect(mob/living/carbon/user, silent = FALSE)
+/mob/living/proc/disarm_effect(mob/living/carbon/attacker, silent = FALSE)
 	var/turf/target_oldturf = loc
-	var/shove_dir = get_dir(user.loc, target_oldturf)
+	var/shove_dir = get_dir(attacker.loc, target_oldturf)
 	var/turf/target_shove_turf = get_step(loc, shove_dir)
 	var/mob/living/carbon/human/target_collateral_human
 	var/obj/structure/table/target_table
@@ -568,14 +568,14 @@
 		var/target_held_item = get_active_held_item()
 		if(target_held_item)
 			if (!silent)
-				visible_message(span_danger("[user.name] kicks \the [target_held_item] out of [src]'s hand!"),
-								span_danger("[user.name] kicks \the [target_held_item] out of your hand!"), null, COMBAT_MESSAGE_RANGE)
-			log_combat(user, src, "disarms [target_held_item]", "disarm")
+				visible_message(span_danger("[attacker.name] kicks \the [target_held_item] out of [src]'s hand!"),
+								span_danger("[attacker.name] kicks \the [target_held_item] out of your hand!"), null, COMBAT_MESSAGE_RANGE)
+			log_combat(attacker, src, "disarms [target_held_item]", "disarm")
 		else
 			if (!silent)
-				visible_message(span_danger("[user.name] kicks [name] onto [p_their()] side!"),
-								span_danger("[user.name] kicks you onto your side!"), null, COMBAT_MESSAGE_RANGE)
-			log_combat(user, src, "kicks", "disarm", "onto their side (paralyzing)")
+				visible_message(span_danger("[attacker.name] kicks [name] onto [p_their()] side!"),
+								span_danger("[attacker.name] kicks you onto your side!"), null, COMBAT_MESSAGE_RANGE)
+			log_combat(attacker, src, "kicks", "disarm", "onto their side (paralyzing)")
 		Paralyze(SHOVE_CHAIN_PARALYZE) //duration slightly shorter than disarm cd
 	if(shove_blocked && !is_shove_knockdown_blocked() && !buckled)
 		var/directional_blocked = FALSE
@@ -594,42 +594,49 @@
 			Knockdown(SHOVE_KNOCKDOWN_SOLID)
 			Immobilize(SHOVE_IMMOBILIZE_SOLID)
 			if (!silent)
-				user.visible_message(span_danger("[user.name] shoves [name], knocking [p_them()] down!"),
+				attacker.visible_message(span_danger("[attacker.name] shoves [name], knocking [p_them()] down!"),
 					span_danger("You shove [name], knocking [p_them()] down!"), null, COMBAT_MESSAGE_RANGE)
-			log_combat(user, src, "shoved", "disarm", "knocking them down")
+			log_combat(attacker, src, "shoved", "disarm", "knocking them down")
 		else if(target_table)
 			Paralyze(SHOVE_KNOCKDOWN_TABLE)
 			if (!silent)
-				user.visible_message(span_danger("[user.name] shoves [name] onto \the [target_table]!"),
+				attacker.visible_message(span_danger("[attacker.name] shoves [name] onto \the [target_table]!"),
 					span_danger("You shove [name] onto \the [target_table]!"), null, COMBAT_MESSAGE_RANGE)
 			throw_at(target_table, 1, 1, null, FALSE) //1 speed throws with no spin are basically just forcemoves with a hard collision check
-			log_combat(user, src, "shoved", "disarm", "onto [target_table] (table)")
+			log_combat(attacker, src, "shoved", "disarm", "onto [target_table] (table)")
 		else if(target_collateral_human)
 			Knockdown(SHOVE_KNOCKDOWN_HUMAN)
 			target_collateral_human.Knockdown(SHOVE_KNOCKDOWN_COLLATERAL)
 			if (!silent)
-				user.visible_message(span_danger("[user.name] shoves [name] into [target_collateral_human.name]!"),
+				attacker.visible_message(span_danger("[attacker.name] shoves [name] into [target_collateral_human.name]!"),
 					span_danger("You shove [name] into [target_collateral_human.name]!"), null, COMBAT_MESSAGE_RANGE)
-			log_combat(user, src, "shoved", "disarm", "into [target_collateral_human.name]")
+			log_combat(attacker, src, "shoved", "disarm", "into [target_collateral_human.name]")
 		else if(target_disposal_bin)
 			Knockdown(SHOVE_KNOCKDOWN_SOLID)
 			forceMove(target_disposal_bin)
 			if (!silent)
-				user.visible_message(span_danger("[user.name] shoves [name] into \the [target_disposal_bin]!"),
+				attacker.visible_message(span_danger("[attacker.name] shoves [name] into \the [target_disposal_bin]!"),
 					span_danger("You shove [name] into \the [target_disposal_bin]!"), null, COMBAT_MESSAGE_RANGE)
-			log_combat(user, src, "shoved", "disarm", "into [target_disposal_bin] (disposal bin)")
+			log_combat(attacker, src, "shoved", "disarm", "into [target_disposal_bin] (disposal bin)")
 		else if(target_pool)
 			Knockdown(SHOVE_KNOCKDOWN_SOLID)
 			forceMove(target_pool)
 			if (!silent)
-				user.visible_message(span_danger("[user.name] shoves [name] into \the [target_pool]!"),
+				attacker.visible_message(span_danger("[attacker.name] shoves [name] into \the [target_pool]!"),
 					span_danger("You shove [name] into \the [target_pool]!"), null, COMBAT_MESSAGE_RANGE)
-			log_combat(user, src, "shoved", "disarm", "into [target_pool] (swimming pool)")
+			log_combat(attacker, src, "shoved", "disarm", "into [target_pool] (swimming pool)")
 	else
 		if (!silent)
-			user.visible_message(span_danger("[user.name] shoves [name]!"),
+			attacker.visible_message(span_danger("[attacker.name] shoves [name]!"),
 				span_danger("You shove [name]!"), null, COMBAT_MESSAGE_RANGE)
-		log_combat(user, src, "shoved", "disarm")
+		log_combat(attacker, src, "shoved", "disarm")
+
+
+/// Allows us to append additional disarm behavior, dependent on our species
+/// src is our attacker
+/mob/living/proc/disarm_aftereffect(mob/living/carbon/target)
+	return
+
 
 /** Handles exposing a mob to reagents.
   *


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This cleans up the attack interactions (combat mode lclick and rclick) for and against xenos.

Simply, disarm now is something that happens to all carbontypes (humans, aliens, monkeys) through the same carbon proc. This PR removes the hardstun that xenos do against mobs in favor of this.

Humans also can shove xenos like any other carbon, just that xenos have been marked as not able to be knocked down.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game 

I made xenos hardstun by accident in combat mode, but the previous implementation was lazy too, so instead I've just centralized the code like it should be.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I sthlammed my xe-nnith, in the car door


https://github.com/user-attachments/assets/d246c8e6-adfe-44f6-a09d-9e3a311105db



https://github.com/user-attachments/assets/524d2fda-a661-408c-8848-df67e1b6717a


</details>

## Changelog
:cl:
fix: fix attack interactions from and against xenos
balance: removes erroneous hardstun from xenos, they use normal disarm() proc now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
