### PR TITLE
Hotfix Artifact Gibbing

### DIFF
--- a/code/modules/xenoarchaeology/traits/majors/animalize.dm
+++ b/code/modules/xenoarchaeology/traits/majors/animalize.dm
@@ -41,6 +41,7 @@
 	//Restore every swap holder
 	for(var/mob/living/target in focus)
 		var/mob/living/form = target.loc
+		form.forceMove(get_turf(form))
 		form?.do_unshapeshift()
 		target.Knockdown(2 SECONDS)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where the bestialized trait could gib someone if they were held at the time of transform.
This was an issue with transform code working as intended.

## Why It's Good For The Game

Artifacts should not gib people, not this way at-least

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/941884b0-bca3-4836-80ba-d334e9322b75)
![image](https://github.com/user-attachments/assets/d6e832a6-0728-4525-854d-1078a9d411d1)

</details>

## Changelog
:cl:
fix: Fix artifact bestialized trait gibbing people
/:cl: