### PR TITLE
Fixes syndicate penetrator turrets not shooting station cyborgs

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -450,17 +450,17 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/porta_turret)
 				if(ispAI(A))
 					continue
 
-				if(target_cyborgs && sillycone.stat != DEAD && iscyborg(sillycone))
-					targets += sillycone
-					continue
-
-				if(sillycone.stat || in_faction(sillycone))
+				if(sillycone.stat == DEAD || in_faction(sillycone))
 					continue
 
 				if(iscyborg(sillycone))
 					var/mob/living/silicon/robot/sillyconerobot = A
 					if((FACTION_SYNDICATE in faction) && sillyconerobot.emagged == TRUE)
 						continue
+
+				if(target_cyborgs && iscyborg(sillycone))
+					targets += sillycone
+					continue
 
 			else if(iscarbon(A))
 				var/mob/living/carbon/C = A
@@ -718,6 +718,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/porta_turret)
 	base_icon_state = "syndie"
 	faction = list(FACTION_SYNDICATE)
 	desc = "A ballistic machine gun auto-turret."
+	target_cyborgs = TRUE
 
 /obj/machinery/porta_turret/syndicate/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes Syndicate shuttle penetrator turrets not targeting cyborgs, allowing them to trivially enter the ship.

## Why It's Good For The Game

A nukie round shouldn't be over because a station cyborg drove onto the ship.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/c3f0df48-b15b-4129-8bcc-967447d353d8)

![image](https://github.com/user-attachments/assets/7a3d9c7e-c04e-4454-ae86-491fd49c6076)


## Changelog
:cl:
fix: Fixes turrets not correctly targeting cyborgs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
