### PR TITLE
Detective Locker Cleanup

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -51268,17 +51268,6 @@
 /area/engine/atmos)
 "rli" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/clothing/under/rank/security/detective{
-	icon_state = "curator"
-	},
-/obj/item/clothing/suit/jacket/det_suit{
-	icon_state = "curator"
-	},
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
-	},
-/obj/item/assembly/flash/handheld,
-/obj/item/restraints/handcuffs,
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},

--- a/_maps/map_files/CardinalStation/CardinalStation.dmm
+++ b/_maps/map_files/CardinalStation/CardinalStation.dmm
@@ -10730,26 +10730,8 @@
 /area/bridge)
 "cgJ" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
-	},
-/obj/item/clothing/under/rank/security/detective,
-/obj/item/camera/detective,
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/fluff/paper,
-/obj/item/storage/briefcase{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/secure/briefcase,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/flash/handheld,
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
-	},
-/obj/item/clothing/suit/jacket/det_suit{
-	icon_state = "curator"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54801,18 +54801,9 @@
 /turf/open/floor/iron/white,
 /area/crew_quarters/heads/cmo)
 "lHS" = (
-/obj/item/clothing/under/rank/security/detective{
-	icon_state = "curator"
-	},
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
-	},
 /obj/structure/closet/secure_closet/detective,
 /obj/effect/turf_decal/tile/neutral/fourcorners/contrasted,
 /obj/machinery/light/small,
-/obj/item/clothing/suit/jacket/det_suit{
-	icon_state = "curator"
-	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "lHU" = (

--- a/_maps/map_files/EchoStation/EchoStation.dmm
+++ b/_maps/map_files/EchoStation/EchoStation.dmm
@@ -16154,20 +16154,12 @@
 /area/quartermaster/storage)
 "hDU" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/storage/box/evidence{
-	pixel_y = 5
-	},
-/obj/item/flashlight/seclite,
-/obj/item/restraints/handcuffs,
-/obj/item/taperecorder,
 /obj/machinery/requests_console{
 	department = "Detective's office";
 	name = "Detective RC";
 	pixel_y = 30
 	},
-/obj/item/camera/detective,
 /obj/machinery/camera/directional/north,
-/obj/item/holosign_creator/security,
 /obj/machinery/computer/security/telescreen/station{
 	dir = 8;
 	pixel_x = 32

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -32710,16 +32710,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/detective,
-/obj/item/clothing/under/rank/security/detective{
-	icon_state = "curator"
-	},
-/obj/item/clothing/suit/jacket/det_suit{
-	icon_state = "curator"
-	},
-/obj/item/clothing/head/fedora/det_hat{
-	icon_state = "curator"
-	},
-/obj/item/holosign_creator/security,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/security/detectives_office)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -13023,7 +13023,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/siding/wood/corner,
-/obj/item/holosign_creator/security,
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "cGd" = (

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1317,3 +1317,27 @@
 	new /obj/item/encryptionkey/heads/ce/fake(src)
 	new /obj/item/encryptionkey/heads/cmo/fake(src)
 	new /obj/item/encryptionkey/heads/hop/fake(src)
+
+/obj/item/storage/box/locker
+	name = "locker box"
+	desc = "A solution to locker clutter. A box. Science's best achievement."
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/box/locker/security
+	name = "security locker box"
+	icon_state = "secbox"
+
+/obj/item/storage/box/locker/security/detective
+	name = "detective essentials"
+	desc = "The necessary equipment for any detective!"
+	illustration = "fpen"
+
+/obj/item/storage/box/locker/security/detective/PopulateContents()
+	new /obj/item/camera/detective(src)
+	new /obj/item/taperecorder(src)
+	new /obj/item/pinpointer/crew(src)
+	new /obj/item/binoculars(src)
+	new /obj/item/detective_scanner(src)
+	new /obj/item/flashlight/seclite(src)
+	new /obj/item/holosign_creator/security(src)
+	new /obj/item/reagent_containers/peppercloud_deployer(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -280,19 +280,13 @@
 
 /obj/structure/closet/secure_closet/detective/PopulateContents()
 	..()
+	new /obj/item/storage/box/rxglasses/spyglasskit(src)
 	new /obj/item/storage/box/evidence(src)
-	new /obj/item/radio/headset/headset_sec(src)
-	new /obj/item/detective_scanner(src)
-	new /obj/item/flashlight/seclite(src)
-	new /obj/item/reagent_containers/peppercloud_deployer(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
 	new /obj/item/clothing/accessory/holster/detective(src)
-	new /obj/item/pinpointer/crew(src)
-	new /obj/item/binoculars(src)
-	new /obj/item/clothing/neck/tie/red(src)
-	new	/obj/item/clothing/neck/tie/black(src)
-	new /obj/item/clothing/neck/tie/detective(src)
-	new /obj/item/storage/box/rxglasses/spyglasskit(src)
+	new /obj/item/storage/box/locker/security/detective(src)
+	new /obj/item/radio/headset/headset_sec(src)
+	new /obj/item/clothing/glasses/hud/security(src)
 
 /obj/structure/closet/secure_closet/deputy
 	name = "deputy's locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### What this is

This is part of an effort to clean up lockers a little bit.

When we join a round as a role that has a locker we will be flooded with items. Every piece of clothing under the sun made for that role, every little piece of equipment or items that may be even slightly related to the role... Captain is the worst offender in this.

I've decided to start with Detective, since there was a bug in some maps with items that were placed there.

### What this does

1 - Removed all items added trough mapping to the Detective locker.
It is common place to copy lockers from one map to another when creating a new map or changing something.
This leads to errors such as:

![image](https://github.com/user-attachments/assets/6e89b0a4-784a-47c9-884c-ae53afa6997f)

Changes to lockers should be done trough code, except when adding an item is actually a quirk of a specific map.

2 - Created a box where Detective equipment can be found and added it to the Detective locker via code.
This includes:

Camera
Tape recorder
Scanner
Crew Pinpointer
Sec Holosign
Binoculars
Seclight
Peper Spray

This is done so that the detectives equipment is more consistent and the locker is less cluttered.

3 - Removed items, such as Coats, fedoras and assortments of ties from the locker.
The inclusion of items that could otherwise be obtained in the Detective wardrobe was a major reason for clutter, and offered no actual benefit nor did it serve a purpose.

4 - Added a sec hud to the detective locker
This is outside of the Detective equipment box because, just like the headset it is a piece of clothing, which doesn't really fit for the vibe of the equipment box and serves the locker just fine!

## Why It's Good For The Game

Less Visual clutter, better mapping and coding etiquette.
Benefits players mappers and coders.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

![image](https://github.com/user-attachments/assets/3de17caf-2b92-4a9b-8525-b099eaed0c9c)

**This was before spawning locker contents were re-organized**

![image](https://github.com/user-attachments/assets/09f2be5f-4024-427a-96e3-b50a0a22f5ca)

</details>

## Changelog
:cl:
add: Added a Box for Detective equipment and put it inside the Detective locker
tweak: Detective lockers will now all have the same items available regardless of the station its in
tweak: Removed Detective equipment added directly trough mapping, favoring coding additions instead
tweak: Removed clutter inside the Detective locker including clothing already available in the Det vendor
fix: There is no longer an ERROR item in the Detective locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
