### PR TITLE
fix lights from bioluminescent plants being offset incorrectly

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -298,7 +298,7 @@
 	var/glow_color = "#C3E381"
 
 /datum/plant_gene/trait/glow/proc/glow_range(obj/item/seeds/S)
-	return 1.4 + S.potency*rate
+	return round(1.4 + S.potency*rate) //lights with non-integer ranges aren't centered properly
 
 /datum/plant_gene/trait/glow/proc/glow_power(obj/item/seeds/S)
 	return max(S.potency*(rate + 0.01), 0.1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The range of lights created by bioluminescence is rounded to the nearest integer, which fixes them being offset from the produce they're created by.  There is likely a more elegant (and complicated) way to fix this but actual lighting code is beyond me and a more competent coder is very unlikely to fix this any time soon.

## Why It's Good For The Game
bugfix good (this has been an issue for multiple years).

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Grew glow-berry plants with varying potency, as seen below. The seeds were spawned, but the produce was grown in trays and modified with chems as normal.

Left: 100 potency

Right: 78 potency

![image](https://github.com/user-attachments/assets/51dfc73a-b556-4f30-92b9-84763b2325e3)

</details>

## Changelog
:cl:
fix: fixed lights from bioluminescent plants being massively offset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
