### PR TITLE
fix throw_at callbacks (including hunter leaps)

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -108,11 +108,11 @@
 	if(gentle)
 		rider.visible_message(span_warning("[rider] is thrown clear of [movable_parent]!"), \
 		span_warning("You're thrown clear of [movable_parent]!"))
-		rider.throw_at(target, 8, 3, movable_parent, gentle = TRUE)
+		rider.throw_at(target, 8, 3, movable_parent)
 	else
 		rider.visible_message(span_warning("[rider] is thrown violently from [movable_parent]!"), \
 		span_warning("You're thrown violently from [movable_parent]!"))
-		rider.throw_at(target, 14, 5, movable_parent, gentle = FALSE)
+		rider.throw_at(target, 14, 5, movable_parent)
 
 /// If we're a cyborg or animal and we spin, we yeet whoever's on us off us
 /datum/component/riding/creature/proc/check_emote(mob/living/user, datum/emote/emote)
@@ -127,7 +127,7 @@
 /datum/component/riding/creature/proc/setup_abilities(mob/living/rider)
 	if(!isliving(parent))
 		return
-		
+
 	var/mob/living/ridden_creature = parent
 
 	for(var/datum/action/action as anything in ridden_creature.actions)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -782,13 +782,13 @@
 		step(src, AM.dir)
 	..(AM, skipcatch, hitpush, blocked, throwingdatum)
 
-/atom/movable/proc/safe_throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, gentle = FALSE)
+/atom/movable/proc/safe_throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG)
 	if((force < (move_resist * MOVE_FORCE_THROW_RATIO)) || (move_resist == INFINITY))
 		return
-	return throw_at(target, range, speed, thrower, spin, diagonals_first, callback, force, gentle)
+	return throw_at(target, range, speed, thrower, spin, diagonals_first, callback, force)
 
 ///If this returns FALSE then callback will not be called.
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, gentle = FALSE, quickstart = TRUE)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, quickstart = TRUE)
 	. = FALSE
 
 	if(QDELETED(src))
@@ -840,7 +840,7 @@
 	else
 		target_zone = thrower.get_combat_bodyzone(target)
 
-	var/datum/thrownthing/TT = new(src, target, get_dir(src, target), range, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
+	var/datum/thrownthing/TT = new(src, target, get_dir(src, target), range, speed, thrower, diagonals_first, force, callback, target_zone)
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes an arg that shouldn't be in throw preventing the callback passed to `throw_at()` ever actually being called.

most notably, this fixes the `leap_end()` callback that clears the lava immunity and resets the pixel offset of xenomorph hunters when their leap is finished.

closes #12830
closes #12759

## Why It's Good For The Game

something something bugfix good (also a step towards xenomorphs being re-enabled)

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/595cdb22-698f-4fc7-9b84-afb4f047b3b8

https://github.com/user-attachments/assets/f6aca013-715e-4f12-b334-7c6943d73c8a

https://github.com/user-attachments/assets/230f9baf-ce92-4f9d-8967-cae8c02b58cc

https://github.com/user-attachments/assets/aa7a03ba-9237-48c9-a08b-a69ad5577925

fyi the runtime here is unrelated to this PR

</details>

## Changelog
:cl:
fix: fix xenomorph hunters being permanently offset downwards by a tile after leaping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
