### PR TITLE
Disable Shadowsect 3rd grand ritual

### DIFF
--- a/code/modules/religion/sects/shadow_sect.dm
+++ b/code/modules/religion/sects/shadow_sect.dm
@@ -688,7 +688,7 @@
 				var/datum/species/shadow/S = M.dna.species
 				S.change_hearts_ritual(M)
 	sect.rites_list -= /datum/religion_rites/grand_ritual_two
-	sect.rites_list += /datum/religion_rites/grand_ritual_three
+	//sect.rites_list += /datum/religion_rites/grand_ritual_three
 	return ..()
 
 /datum/religion_rites/grand_ritual_two/proc/handle_obelisks()
@@ -711,6 +711,7 @@
 			obelisk.set_light(sect.light_reach, sect.light_power, DARKNESS_INVERSE_COLOR)
 	sect.grand_ritual_in_progress = FALSE
 
+/*
 /datum/religion_rites/grand_ritual_three
 	name = "Grand ritual: Welcoming shadows"
 	desc = "Final grand ritual. Let shadows come into this world fully, letting their tender care resurrect any kin, help them move and let others join their glorious family. BE WARNED gathering all shadows for this rite will let the light spread much further than normal."
@@ -820,5 +821,6 @@
 			T.light_range = 0
 			T.set_light_color(null)
 			T.update_light()
+*/
 
 #undef DARKNESS_INVERSE_COLOR


### PR DESCRIPTION

I have gotten multiple reports from players (and an admin ping) about the 3rd shadowsect ritual making the server lag to shit.

This ritual's effect should be lessened or changed so it doesnt cause performance issues that impact the server.

This is a temporary stopgap to prevent players from being impacted with this in the code. 
If it isn't fixed within in a week or so, this should be merged so we dont have a constant TM hanging over us.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->



## Changelog
:cl:
del: disables shadowsect 3rd grand ritual
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
