### PR TITLE
Fake radiation storms set the station status displays to the radiation symbol

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -16,5 +16,18 @@
 	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", "Anomaly Alert", ANNOUNCER_RADIATION)
 	//sound not longer matches the text, but an audible warning is probably good
 
+	// Copied from `radiation_storm.dm`
+	if(fake)
+		var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)
+		if(!frequency)
+			return
+
+		var/datum/signal/signal = new
+		signal.data["command"] = "alert"
+		signal.data["picture_state"] = "radiation"
+
+		var/atom/movable/virtualspeaker/virt = new(null)
+		frequency.post_signal(virt, signal)
+
 /datum/round_event/radiation_storm/start()
 	SSweather.run_weather(/datum/weather/rad_storm)


### PR DESCRIPTION
## About The Pull Request

A fake radiation storm will set the status displays to the radiation symbol

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/7cf8afe9-ac3d-4e39-978e-b92b48d26cf0)

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/3df3368d-69bf-41be-b3dd-4cec606c86a8

## Changelog
:cl:
tweak: fake radiation storms now set the station status displays to the radiation symbol
/:cl:
