### PR TITLE
Buffs, bugfixes and tweaks for motorized wheelchairs.

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -270,7 +270,9 @@
 /datum/component/riding/vehicle/wheelchair/motorized/handle_ride(mob/user, direction)
 	. = ..()
 	var/obj/vehicle/ridden/wheelchair/motorized/our_chair = parent
-	if(istype(our_chair) && our_chair.power_cell)
+	if(!istype(our_chair))
+		return
+	if(our_chair.power_cell)
 		our_chair.power_cell.use(our_chair.power_usage)
 	if(!our_chair.low_power_alerted && our_chair.power_cell.charge <= (our_chair.power_cell.maxcharge / 4))
 		playsound(src, 'sound/machines/twobeep.ogg', 30, 1)

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -263,15 +263,20 @@
 
 /datum/component/riding/vehicle/wheelchair/motorized/driver_move(obj/vehicle/vehicle_parent, mob/living/user, direction)
 	var/delay_multiplier = 6.7 // magic number from wheelchair code
-
-	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / parent.speed
+	var/obj/vehicle/ridden/wheelchair/motorized/our_chair = parent
+	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / our_chair.speed
 	return ..()
 
 /datum/component/riding/vehicle/wheelchair/motorized/handle_ride(mob/user, direction)
 	. = ..()
 	var/obj/vehicle/ridden/wheelchair/motorized/our_chair = parent
 	if(istype(our_chair) && our_chair.power_cell)
-		our_chair.power_cell.use(our_chair.power_usage / max(our_chair.power_efficiency, 1) * 0.05)
+		our_chair.power_cell.use(our_chair.power_usage)
+	if(!our_chair.low_power_alerted && our_chair.power_cell.charge <= (our_chair.power_cell.maxcharge / 4))
+		playsound(src, 'sound/machines/twobeep.ogg', 30, 1)
+		our_chair.say("Warning: Power low!")
+		our_chair.low_power_alerted = TRUE
+
 
 /datum/component/riding/vehicle/proc/on_emp_act(datum/source, severity)
 	SIGNAL_HANDLER

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -262,9 +262,8 @@
 	empable = TRUE
 
 /datum/component/riding/vehicle/wheelchair/motorized/driver_move(obj/vehicle/vehicle_parent, mob/living/user, direction)
-	var/delay_multiplier = 6.7 // magic number from wheelchair code
 	var/obj/vehicle/ridden/wheelchair/motorized/our_chair = parent
-	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / our_chair.speed
+	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * our_chair.speed)
 	return ..()
 
 /datum/component/riding/vehicle/wheelchair/motorized/handle_ride(mob/user, direction)

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -262,13 +262,9 @@
 	empable = TRUE
 
 /datum/component/riding/vehicle/wheelchair/motorized/driver_move(obj/vehicle/vehicle_parent, mob/living/user, direction)
-	var/speed = 1 // Should never be under 1
 	var/delay_multiplier = 6.7 // magic number from wheelchair code
 
-	var/obj/vehicle/ridden/wheelchair/motorized/our_chair = parent
-	for(var/obj/item/stock_parts/manipulator/M in our_chair.contents)
-		speed += M.rating
-	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / speed
+	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / parent.speed
 	return ..()
 
 /datum/component/riding/vehicle/wheelchair/motorized/handle_ride(mob/user, direction)

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -19,11 +19,10 @@
 /obj/vehicle/ridden/wheelchair/motorized/Initialize(mapload)
 	. = ..()
 	//default parts, removed in checkparts if it was actually crafted
-	power_cell = new /obj/item/stock_parts/cell/high()
-	contents += power_cell
-	contents += new /obj/item/stock_parts/manipulator()
-	contents += new /obj/item/stock_parts/manipulator()
-	contents += new /obj/item/stock_parts/capacitor()
+	power_cell = new /obj/item/stock_parts/cell/high(src)
+	new /obj/item/stock_parts/manipulator(src)
+	new /obj/item/stock_parts/manipulator(src)
+	new /obj/item/stock_parts/capacitor(src)
 	refresh_parts()
 
 /obj/vehicle/ridden/wheelchair/motorized/make_ridable()

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -3,9 +3,11 @@
 	desc = "A chair with big wheels. It seems to have a motor in it."
 	max_integrity = 150
 	move_resist = MOVE_FORCE_DEFAULT
-	var/speed = 1
+	var/speed = 1 //vehicle_move_delay multiplier. this is set in refresh_parts(), the value set here has no impact.
+	var/speed_limit_safe = 1
+	var/speed_limit_unsafe = 0.89
 	var/manip_rating_sum = 0
-	var/power_usage = 25
+	var/power_usage = 25 // power draw per tile moved, same as speed, the value here is not used.
 	var/panel_open = FALSE
 	var/list/required_parts = list(/obj/item/stock_parts/manipulator,
 							/obj/item/stock_parts/manipulator,
@@ -41,7 +43,7 @@
 	for(var/obj/item/stock_parts/capacitor/C in contents)
 		power_usage = LERP(20, 10, (C.rating - 1) / 3) // 20 with worst parts, 10 with best parts
 
-	speed = max(0.6 + (0.1 * (8 - manip_rating_sum)**2), safeties ? 1 : 0.8) //t1 : 4.2 t2: 2.2 t3: 1 t4: 0.6 (clamped to 0.8). lower is better.
+	speed = max(0.8 + (0.2 * ((8 - manip_rating_sum) / 2) ** 2), safeties ? speed_limit_safe : speed_limit_unsafe) //t1 : 2.6 t2: 1.6 t3: 1 t4: 0.6 (clamped to unsafe speed limit at best). lower is better.
 
 /obj/vehicle/ridden/wheelchair/motorized/get_cell()
 	return power_cell
@@ -161,7 +163,7 @@
 /obj/vehicle/ridden/wheelchair/motorized/Bump(atom/movable/M)
 	. = ..()
 	// If the speed is higher than delay_multiplier throw the person on the wheelchair away
-	if(M.density && speed < 1 && has_buckled_mobs())
+	if(M.density && speed < speed_limit_safe && has_buckled_mobs())
 		var/mob/living/H = buckled_mobs[1]
 		var/atom/throw_target = get_edge_target_turf(H, pick(GLOB.cardinals))
 		unbuckle_mob(H)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -69,6 +69,14 @@
 /obj/vehicle/ridden/wheelchair/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
 
+/atom/movable/attack_hand(mob/living/user, list/modifiers)
+	if(LAZYLEN(buckled_mobs) && !(user in buckled_mobs)) //if there's mobs buckled that are not the user...
+		to_chat(user, span_notice("You start trying to unbuckle [buckled_mobs[1]]..."))
+		if(!do_after(user, 2 SECONDS, src)) //....and we don't fail the do_after...
+			to_chat(user, span_warning("You fail to unbuckle [buckled_mobs[1]]!"))
+			return
+	. = ..() //...then unbuckle any occupants
+
 /obj/vehicle/ridden/wheelchair/proc/handle_rotation(direction)
 	if(has_buckled_mobs())
 		handle_rotation_overlayed()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -69,14 +69,6 @@
 /obj/vehicle/ridden/wheelchair/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
 
-/atom/movable/attack_hand(mob/living/user, list/modifiers)
-	if(LAZYLEN(buckled_mobs) && !(user in buckled_mobs)) //if there's mobs buckled that are not the user...
-		to_chat(user, span_notice("You start trying to unbuckle [buckled_mobs[1]]..."))
-		if(!do_after(user, 2 SECONDS, src)) //....and we don't fail the do_after...
-			to_chat(user, span_warning("You fail to unbuckle [buckled_mobs[1]]!"))
-			return
-	. = ..() //...then unbuckle any occupants
-
 /obj/vehicle/ridden/wheelchair/proc/handle_rotation(direction)
 	if(has_buckled_mobs())
 		handle_rotation_overlayed()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Speed has generally been increased, but is capped at normal run speed unless safeties are overridden with a multitool. Uncapped speeds are faster than run speed.
- Energy consumption has been adjusted: lower tier parts have better consumption than before, but higher tier parts consume more power than before. (I have also fixed a bug that doubled all power consumption unintentionally, so in practice _all_ consumption is much lower).

Additionally, a number of bugs have been fixed (check the CL)

## Why It's Good For The Game

Lots of bugfixes and more intuitive examine text. Motorized chair speed increases were requested by maintainer.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Various states of maintenance.

![image](https://github.com/user-attachments/assets/5d8820b5-9e30-4b89-9f29-10701efcc4d3)

Speed with T1 parts

https://github.com/user-attachments/assets/491b1a66-a8ab-45ac-805e-ef9dece3e9c6

Speed with T4 parts, safeties enabled. This is also the exact same speed as T3 parts, regardless of safeties.

https://github.com/user-attachments/assets/57886bb1-28ff-4002-ab91-fd1d50d39568

Speed with T4 parts, safeties disabled.

https://github.com/user-attachments/assets/0979ddd1-411c-4a7e-a7cc-5fa51b138faa



Dragging motorized chair, no power consumed.

https://github.com/user-attachments/assets/4bdab520-dce7-47a7-ac39-bc5cf88feaac

</details>

## Changelog
:cl:
balance: Motorized wheelchair speed has been rebalanced, they can go up to normal run speed at t3 parts without risk of crashing, and can go even faster than regular humans if T4 parts are used and the safeties are overridden with a multitool, at the risk (or bonus, if you see it that way) of crashing violently if they bump into anything.
tweak: Examining motorized wheelchairs gives a more accurate view of their speed, power consumption and shows what tools can be used on them.
tweak: Motorized wheelchairs consume less power with T1 parts, but consume slightly more than before at T4.
fix: Motorized wheelchairs consume the correct amount of power when moving, and no longer consume power when dragged, along with no longer causing countless runtimes when dragged around without a cell. They also no longer spam the chat when they are missing a power cell or are simply out of charge.
fix: Motorized wheelchairs spawned on maps or by admins are now fully functional, albeit with only T1 parts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
