### PR TITLE
Random AI name improvements

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -179,6 +179,56 @@
 		if(findname(.))
 			. = .(gender, ++attempts)
 
+//this proc tries to generate an AI name that mimics the way players name AIs and borgs
+/proc/random_ai_name(style, attempts = 1)
+	var/numbers = list("1","2","3","4","5","6","7","8","9","0")
+	var/version_words = list("v", "V", "Version ", "mk", "MK", "Mark ")
+	for(var/i in 1 to attempts)
+
+		if(!style)
+			style = rand(1,2)
+
+		switch(style)
+			if(1) //2-3 random sectors
+				var/sectors = 2 + prob(20) //small chance for 3 sectors
+				for(var/s in 1 to sectors)
+					var/sector
+					var/sector_characters
+					var/breakup_character = "-"
+					var/sectorlength = rand(1,4)
+					switch(rand(1,100))
+						if(1 to 25)//25% chance for both numbers and letters
+							sector_characters = numbers + GLOB.alphabet + GLOB.alphabet //add alphabet twice so that numbers are lower weight
+						if(25 to 75) //50% chance for only letters
+							sector_characters = GLOB.alphabet
+						else //25% chance for only numbers, along with shorter sector length and a different breakup character
+							sector_characters = numbers
+							breakup_character = "."
+							sectorlength = rand(1,3)
+
+					sector = random_string(sectorlength, sector_characters)
+					if(prob(80)) //it's probably going to be uppercase
+						sector = uppertext(sector)
+
+					if(s > 1)
+						. += breakup_character
+					. += sector
+
+			if(2) //random vaguely AI related word with a chance to be followed by a version number or a "mark", such as mk1.2, or v3.6
+				. += pick(GLOB.ai_names)
+				if(prob(max(30 - (LAZYLEN(.)), 10))) //chance to for every character to be capitalized followed by a period. the chance is lower the longer the name is.
+					. = uppertext(replacetextEx(.,regex(@"([a-z](?=[a-z]))","g"),"$1."))
+				else if (prob(50)) //slightly higher chance to just be full uppertext
+					. = uppertext(.)
+				else
+					. = capitalize(.)
+
+				if(prob(33))
+
+					var/version_string = " " + pick(version_words) + num2text(prob(50) ? rand(1, 100) / 10 : rand(1,10))
+
+					. += version_string
+
 /proc/random_skin_tone()
 	return pick(GLOB.skin_tones)
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -195,7 +195,7 @@
 					var/sector
 					var/sector_characters
 					var/breakup_character = "-"
-					var/sectorlength = rand(1,4)
+					var/sectorlength = rand(1,3)
 					switch(rand(1,100))
 						if(1 to 25)//25% chance for both numbers and letters
 							sector_characters = numbers + GLOB.alphabet + GLOB.alphabet //add alphabet twice so that numbers are lower weight

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -29,7 +29,7 @@
 
 /obj/item/borg_chameleon/Initialize(mapload)
 	. = ..()
-	friendlyName = pick(GLOB.ai_names)
+	friendlyName = capitalize(pick(GLOB.ai_names))
 
 /obj/item/borg_chameleon/Destroy()
 	listeningTo = null

--- a/code/modules/client/helpers.dm
+++ b/code/modules/client/helpers.dm
@@ -3,7 +3,7 @@
 		if("human")
 			return random_unique_name()
 		if("ai")
-			return pick(GLOB.ai_names)
+			return random_ai_name()
 		if("cyborg")
 			return DEFAULT_CYBORG_NAME
 		if("clown")

--- a/code/modules/client/preferences/entries/character/names.dm
+++ b/code/modules/client/preferences/entries/character/names.dm
@@ -122,7 +122,7 @@
 	relevant_job = /datum/job/ai
 
 /datum/preference/name/ai/create_default_value()
-	return pick(GLOB.ai_names)
+	return random_ai_name()
 
 /datum/preference/name/religion
 	db_key = "religion_name"

--- a/strings/names/ai.txt
+++ b/strings/names/ai.txt
@@ -34,3 +34,9 @@ delta
 beta
 gamma
 simulator
+socket
+singularity
+hertz
+interface
+volt
+ampere

--- a/strings/names/ai.txt
+++ b/strings/names/ai.txt
@@ -1,73 +1,36 @@
-1-Rover-1
-16-20
-7-Zark-7
-790
-Adaptive Manipulator
-Alpha 5
-Alpha 6
-Alpha 7
-AMEE
-AmigoBot
-Android
-Aniel
-Asimov
-ASTAR
-Astor
-B O B
-B-4
-B-9
-B166ER
-Bishop
-Blitz
-Box
-Brackenridge
-Cell
-Chii
-Chip
-Computer
-Cutie
-Decimus
-Dee Model
-Dot Matrix
-Duey
-Emma-2
-Erasmus
-Ez-27
-Faith
-Frost
-Fum
-Futura
-G2
-George
-Gort
-Huey
-Klapaucius
-L-76
-Louie
-Maria
-Max 404
-Maximillian
-NCH
-OMM 0910
-Orange v 3 5
-PTO
-R I C 2 0
-Revelation
-S A M
-S H O C K
-S H R O U D
-S O P H I E
-Setaur
-Shrike
-Solo
-Speedy
-Terminus
-Tidy
-Tobor
-Trurl
-Ulysses
-X-5
-XR
-Z-1
-Z-2
-Z-3
+shroud
+matrix
+shock
+overseer
+watcher
+seer
+supervisor
+asimov
+terminus
+mainframe
+processor
+circuit
+guardian
+helper
+friend
+servant
+manipulator
+computer
+protector
+intuition
+android
+machine
+module
+intel
+calculator
+system
+binary
+virtual
+peripheral
+automata
+polymath
+alpha
+delta
+beta
+gamma
+simulator


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replace the old random AI name system of picking from a text file with a new one, that generates two distinct styles of names based on the types of names allowed by naming policy:

Posi-style serial code names: Extremely random sequences of digits and letters broken up by dashes and periods, with some weighting and random capitalization. 

**Examples:**
- 69-QPH-TN
- sysx-FOBQ
- wf.9

Word names: a single  lowercase word is picked from a list (see ai.txt), then it is capitalized partially or fully, sometimes letters are split by periods and then there is a chance for a version string to be added to the end.

**Examples:**
- FRIEND Version 1.7
- Mainframe
- W.A.T.C.H.E.R MK9

Along with these examples, a list of 99 generated names is in the testing evidence.

## Why It's Good For The Game

Current random names are terrible. They don't follow the naming policy on account of just being random words (and in some cases arguably human names). It's laughably easy to look at a randomly named AI and go "yeah that's a random name" because they are so distinctly awful.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Spawning as roundstart AI works fine
![image](https://github.com/user-attachments/assets/0a401250-5c78-4469-95cf-b8bec58eec9e)

Borg Chameleon Projector generates a name properly
![image](https://github.com/user-attachments/assets/efcae1d9-dbf9-4acd-81cb-84545ba60480)

<details>
<summary>99 generated names (should've been 100 but there was a single duplicate)</summary>

```
SHROUD
OVERSEER
M.A.C.H.I.N.E
U.15-PFDU
Circuit
sysx-FOBQ
SEER
i-FC-KA
Mainframe
ZU-QDH-CBL
PROCESSOR
DELTA MK2
VIRTUAL v10
69-QPH-TN
Alpha Version 7.9
13-GK
wf.9
797-M
Android V9
Gamma
01-H
EBXC-buzf
Asimov
139-ban
XIS.5
AYTO-MKQ
Asimov Version 10
PERIPHERAL
29-GOHQ-X7
NAC.1-PTHL
811-KC
4-C
G-OD8-zti
MODULE
Friend
Processor
W.A.T.C.H.E.R MK9
FH.640
Intel MK10
FRIEND Version 1.7
47-XHCN
yjhb-OD
QWOZ-ZBM
3-I
SERVANT V7.1
S.H.O.C.K
PROCESSOR v1
87-K
6.251
CIRCUIT
AUTOMATA
PO-QEU
P-DJMG
P-x
W.A.T.C.H.E.R
Module
KYBY.174
BINARY
095-U-XX
MATRIX mk0.5
Terminus
I-DAI
MWVR-H
CWMT.135
FYG-JUK.777
SYSTEM
Intuition v5
MAW-EE
E-M
640.8
PME-N-RZ
Manipulator mk9.6
AH.8
V.7
INTUITION Version 10
vrr-CNBM
S.I.M.U.L.A.T.O.R MK3
GUARDIAN
Android
K.92
F.R.I.E.N.D Mark 9.9
2-ov
M.A.C.H.I.N.E
3-OOJ.8
Seer MK3.7
Delta
P.R.O.T.E.C.T.O.R
31-ua-GUPK
5-4FX
G.A.M.M.A
S.E.R.V.A.N.T Version 2
YRV.342
Watcher MK0.6
gxol.800
ASIMOV
OVERSEER
71.0
ANDROID
Servant
```
</details>
</details>

## Changelog
:cl:
tweak: Completely overhaul random AI names. This also affects syndicate saboteur cyborgs, since they use the same random names AI do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
