### PR TITLE
fixed the lavaland syndicate base turrets shooting the pet rabbit

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2117,7 +2117,7 @@
 /area/ruin/unpowered/syndicate_lava_base/arrivals)
 "tV" = (
 /mob/living/simple_animal/chicken/rabbit{
-	faction = list("syndicate");
+	faction = list("Syndicate");
 	desc = "Just a mildly evil rabbit."
 	},
 /turf/open/floor/wood,


### PR DESCRIPTION
## About The Pull Request

Lavaland syndicate base no longer shoots the rabbit inside the bar

## Why Its good for the game

closes #12846

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/dce6fe27-f4ee-4db5-8c28-8f8cb2a8d2c8

## Changelog
:cl:
fix: fixed the lavaland syndicate base turrets shooting the pet rabbit
/:cl:
