### PR TITLE
Fixes 516 client fix_viewport runtime when logging in

### DIFF
--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -46,7 +46,11 @@
 			winset(client, "status_bar_wide", "is-visible=true")
 			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
 			winset(client, "status_bar", "is-visible=false")
-		INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
+
+		if(client.fully_created)
+			INVOKE_ASYNC(client, TYPE_VERB_REF(/client, fit_viewport))
+		else
+			addtimer(CALLBACK(client, TYPE_VERB_REF(/client, fit_viewport), 1 SECONDS))
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")


### PR DESCRIPTION
## About The Pull Request

Fixes the runtime when a 516 client connects to the game.

Instead of blindly calling `fix_viewport` when loading in, we now check if the client is fully created. 
If the client is not completely initialized, call `fix_viewport` in one second.

## Why It's Good For The Game

One tiny step towards greater 516 stability

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/3b478f9c-5551-4062-b593-44d69d249b60

## Changelog
:cl:
fix: fixed 516 clients throwing a runtime when joining
/:cl:

