### PR TITLE
Fix: Hostile mobs (like Blob spore Zombies) keeping hostile AI for a few seconds

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -167,11 +167,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/hostile/blob/blobspore)
 	if(!key)
 		set_playable(ROLE_BLOB)
 
-/mob/living/simple_animal/hostile/blob/blobspore/give_mind(mob/user)
-	..()
-	LoseTarget()
-	return TRUE
-
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
 	// On death, create a small smoke of harmful gas (s-Acid)
 	var/datum/effect_system/smoke_spread/chem/S = new

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -167,6 +167,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/hostile/blob/blobspore)
 	if(!key)
 		set_playable(ROLE_BLOB)
 
+/mob/living/simple_animal/hostile/blob/blobspore/give_mind(mob/user)
+	..()
+	LoseTarget()
+	return TRUE
+
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
 	// On death, create a small smoke of harmful gas (s-Acid)
 	var/datum/effect_system/smoke_spread/chem/S = new

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -611,4 +611,9 @@
 	if(target)
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(handle_target_del))
 
+/mob/living/simple_animal/hostile/Login(mob/user) // We add a LosetTarget() here to stop the mob from chasing down targets after it has been given over to a player
+	..()
+	LoseTarget()
+	return TRUE
+
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #11999, #7161 and #6945 (I might've missed a couple more issues on this since this is an OLD bug)

Added a LoseTarget() proc to the login proc inside the hostile simplemob code
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix good, no more having the AI suicide bomb while you're in control

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Videos</summary>

https://github.com/user-attachments/assets/ca0eea32-c9ed-43b0-b85f-9f4db72fa1dc

https://github.com/user-attachments/assets/e432ef99-0d5b-40a0-aaf5-f04012398b45

(note that the vines still being attached is a bit out of scope)

https://github.com/user-attachments/assets/faef8d2a-5d17-4c33-b5c1-189acc7efab0

They all immedietly stopped trying to chase the human after I took command of it.

</details>

## Changelog
:cl: Gilgax
fix: Fixed hostile mobs (like blob spore zombies) keeping their AI for a few seconds when taking control of them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
