### PR TITLE
516: Fix menu bar hidden even when fullscreen is disabled

### DIFF
--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -42,7 +42,7 @@
 			winset(client, "status_bar_wide", "is-visible=false")
 			winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
 		else
-			winset(client, "mainwindow", "menu=;is-fullscreen=false")
+			winset(client, "mainwindow", "menu=\"menu\";is-fullscreen=false")
 			winset(client, "status_bar_wide", "is-visible=true")
 			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
 			winset(client, "status_bar", "is-visible=false")


### PR DESCRIPTION
## About The Pull Request

Seems like the 516 fullscreen had a failed copypasta and forgot to re-add the menu bar. #12215

Closes #12785

## Why It's Good For The Game

Having the menu bar when you want a menu bar is good

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Non-fullscreen
![image](https://github.com/user-attachments/assets/a5772feb-fb38-44cb-9282-c2e6ca58de62)

Fullscreen
![image](https://github.com/user-attachments/assets/0b936360-8e02-4808-838b-d8b944e6d9a4)


</details>

## Changelog
:cl:
fix: Re-added menu bar for non-fullscreen 516 clients
/:cl:
