### PR TITLE
516: TGUI Say DPI scaling support

### DIFF
--- a/tgui/packages/tgui-say/handlers/componentMount.tsx
+++ b/tgui/packages/tgui-say/handlers/componentMount.tsx
@@ -1,9 +1,14 @@
-import { CHANNELS, RADIO_PREFIXES } from '../constants';
-import { windowClose, windowLoad, windowOpen } from '../helpers';
+import { CHANNELS, RADIO_PREFIXES, WINDOW_SIZES } from '../constants';
+import { windowClose, windowLoad, windowOpen, windowSet } from '../helpers';
 import { Modal } from '../types';
 
 /** Attach listeners, sets window size just in case */
 export const handleComponentMount = function (this: Modal) {
+  Byond.winget(Byond.windowId, 'dpi').then((dpi: number | null) => {
+    this.fields.dpi = dpi || 1;
+    windowSet(this.state.size, this.fields.dpi);
+  });
+
   Byond.subscribeTo('props', (data) => {
     this.fields.maxLength = data.maxLength;
     this.fields.lightMode = !!data.lightMode;
@@ -21,12 +26,12 @@ export const handleComponentMount = function (this: Modal) {
     setTimeout(() => {
       this.fields.innerRef.current?.focus();
     }, 1);
-    windowOpen(CHANNELS[channel]);
+    windowOpen(CHANNELS[channel], this.fields.dpi);
     const input = this.fields.innerRef.current;
     input?.focus();
   });
   Byond.subscribeTo('close', () => {
-    windowClose();
+    windowClose(this.fields.dpi);
   });
-  windowLoad();
+  windowLoad(this.fields.dpi);
 };

--- a/tgui/packages/tgui-say/handlers/enter.tsx
+++ b/tgui/packages/tgui-say/handlers/enter.tsx
@@ -21,5 +21,5 @@ export const handleEnter = function (this: Modal, event: KeyboardEvent, value: s
     });
   }
   this.events.onReset();
-  windowClose();
+  windowClose(this.fields.dpi);
 };

--- a/tgui/packages/tgui-say/handlers/escape.tsx
+++ b/tgui/packages/tgui-say/handlers/escape.tsx
@@ -4,5 +4,5 @@ import { Modal } from '../types';
 /** User presses escape, closes the window */
 export const handleEscape = function (this: Modal) {
   this.events.onReset();
-  windowClose();
+  windowClose(this.fields.dpi);
 };

--- a/tgui/packages/tgui-say/handlers/force.tsx
+++ b/tgui/packages/tgui-say/handlers/force.tsx
@@ -5,7 +5,7 @@ import { Modal } from '../types';
 /** Sends the current input to byond and purges it */
 export const handleForce = function (this: Modal) {
   const { channel, size } = this.state;
-  const { radioPrefix, value } = this.fields;
+  const { radioPrefix, value, dpi } = this.fields;
   if (value && channel < 2) {
     this.timers.forceDebounce({
       channel: CHANNELS[channel],
@@ -13,7 +13,7 @@ export const handleForce = function (this: Modal) {
     });
     this.events.onReset(channel);
     if (size !== WINDOW_SIZES.small) {
-      windowSet();
+      windowSet(WINDOW_SIZES.small, dpi);
     }
   }
 };

--- a/tgui/packages/tgui-say/handlers/setSize.tsx
+++ b/tgui/packages/tgui-say/handlers/setSize.tsx
@@ -5,14 +5,15 @@ import { Modal } from '../types';
 /**  Adjusts window sized based on event.target.value */
 export const handleSetSize = function (this: Modal, value: number) {
   const { size } = this.state;
+  const { dpi } = this.fields;
   if (value > LINE_LENGTHS.medium && size !== WINDOW_SIZES.large) {
     this.setState({ size: WINDOW_SIZES.large });
-    windowSet(WINDOW_SIZES.large);
+    windowSet(WINDOW_SIZES.large, dpi);
   } else if (value <= LINE_LENGTHS.medium && value > LINE_LENGTHS.small && size !== WINDOW_SIZES.medium) {
     this.setState({ size: WINDOW_SIZES.medium });
-    windowSet(WINDOW_SIZES.medium);
+    windowSet(WINDOW_SIZES.medium, dpi);
   } else if (value <= LINE_LENGTHS.small && size !== WINDOW_SIZES.small) {
     this.setState({ size: WINDOW_SIZES.small });
-    windowSet(WINDOW_SIZES.small);
+    windowSet(WINDOW_SIZES.small, dpi);
   }
 };

--- a/tgui/packages/tgui-say/helpers/index.tsx
+++ b/tgui/packages/tgui-say/helpers/index.tsx
@@ -10,8 +10,8 @@ import { debounce, throttle } from 'common/timer';
  * Once byond signals this via keystroke, it
  * ensures window size, visibility, and focus.
  */
-export const windowOpen = (channel: string) => {
-  setOpen();
+export const windowOpen = (channel: string, dpi: number) => {
+  setOpen(dpi);
   Byond.sendMessage('open', { channel });
 };
 
@@ -19,17 +19,17 @@ export const windowOpen = (channel: string) => {
  * Resets the state of the window and hides it from user view.
  * Sending "close" logs it server side.
  */
-export const windowClose = () => {
-  setClosed();
+export const windowClose = (dpi: number) => {
+  setClosed(dpi);
   Byond.sendMessage('close');
 };
 
 /** Some QoL to hide the window on load. Doesn't log this event */
-export const windowLoad = () => {
+export const windowLoad = (dpi: number) => {
   Byond.winset(Byond.windowId, {
     pos: '848,500',
   });
-  setClosed();
+  setClosed(dpi);
 };
 
 /**
@@ -38,29 +38,29 @@ export const windowLoad = () => {
  * Parameters:
  *  size - The size of the window in pixels. Optional.
  */
-export const windowSet = (size: number = WINDOW_SIZES.small) => {
-  Byond.winset(Byond.windowId, { size: `${WINDOW_SIZES.width}x${size}` });
-  Byond.winset(`${Byond.windowId}.browser`, { size: `${WINDOW_SIZES.width}x${size}` });
+export const windowSet = (size: number = WINDOW_SIZES.small, dpi: number) => {
+  Byond.winset(Byond.windowId, { size: `${Math.round(WINDOW_SIZES.width * dpi)}x${Math.round(size * dpi)}` });
+  Byond.winset(`${Byond.windowId}.browser`, { size: `${Math.round(WINDOW_SIZES.width * dpi)}x${Math.round(size * dpi)}` });
 };
 
 /** Private functions */
 /** Sets the skin props as opened. Focus might be a placebo here. */
-const setOpen = () => {
+const setOpen = (dpi: number) => {
   Byond.winset(Byond.windowId, {
     'is-visible': true,
-    size: `${WINDOW_SIZES.width}x${WINDOW_SIZES.small}`,
+    size: `${Math.round(WINDOW_SIZES.width * dpi)}x${Math.round(WINDOW_SIZES.small * dpi)}`,
   });
   Byond.winset(`${Byond.windowId}.browser`, {
     'is-visible': true,
-    size: `${WINDOW_SIZES.width}x${WINDOW_SIZES.small}`,
+    size: `${Math.round(WINDOW_SIZES.width * dpi)}x${Math.round(WINDOW_SIZES.small * dpi)}`,
   });
 };
 
 /** Sets the skin props as closed.  */
-const setClosed = () => {
+const setClosed = (dpi: number) => {
   Byond.winset(Byond.windowId, {
     'is-visible': false,
-    size: `${WINDOW_SIZES.width}x${WINDOW_SIZES.small}`,
+    size: `${Math.round(WINDOW_SIZES.width * dpi)}x${Math.round(WINDOW_SIZES.small * dpi)}`,
   });
   Byond.winset('map', {
     focus: true,

--- a/tgui/packages/tgui-say/interfaces/TguiSay.tsx
+++ b/tgui/packages/tgui-say/interfaces/TguiSay.tsx
@@ -15,6 +15,7 @@ export class TguiSay extends Component<{}, State> {
     innerRef: createRef(),
     lightMode: false,
     showRadioPrefix: false,
+    dpi: 1,
     maxLength: 1024,
     radioPrefix: '',
     tempHistory: '',

--- a/tgui/packages/tgui-say/types/index.tsx
+++ b/tgui/packages/tgui-say/types/index.tsx
@@ -33,6 +33,7 @@ type Fields = {
   innerRef: RefObject<HTMLInputElement>;
   lightMode: boolean;
   showRadioPrefix: boolean;
+  dpi: number;
   maxLength: number;
   radioPrefix: string;
   tempHistory: string;


### PR DESCRIPTION
## About The Pull Request

If your system has DPI scaling enabled at all, TGUI say will have a scroll bar attached to its side and generally be quite ugly.

This uses the new 516 `dpi` skin parameter to scale the window to match your system DPI.

## Why It's Good For The Game

Makes TGUI say more function for people with ultra high res displays or laptops.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Works great with my laptop on 125%

![image](https://github.com/user-attachments/assets/03803647-66cd-4392-b768-cf9a7b93820c)

![image](https://github.com/user-attachments/assets/3ec9b932-05bc-4201-855d-f824054a4550)

tried a really stupid DPI (175%), it works great while every other UI breaks horribly
![image](https://github.com/user-attachments/assets/b3dd9001-d947-41e4-a28e-77d4a231fa5a)


</details>

## Changelog
:cl:
add: TGUI Say now supports system DPI scaling on BYOND 516, and will no longer display at the incorrect size.
/:cl: