### PR TITLE
Fixes antag rolling system assigning antags

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -457,7 +457,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		var/mob/dead/new_player/player = i
 		if(!player.mind || player.ready == PLAYER_READY_TO_OBSERVE)
 			continue
-		if(player.ready == PLAYER_READY_TO_PLAY)
+		if(player.ready == PLAYER_READY_TO_PLAY && player.check_preferences())
 			roundstart_pop_ready++
 			candidates.Add(player)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #12934

The system designed to prevent antag rolling was designed in such a way that it was absolutely perfect for antag rolling. It worked as follows:
- Antags are assigned
- The antag rolling system kicks in, preventing you from joining the game
- Rejected player is given an antagonist role on the main menu, allowing them to choose any job they want

## Why It's Good For The Game

Fortunately, antag rolling is nowhere near as much of an issue as it was initially thought, given that this system hasn't been abused. Now you won't be able to cause bugs using it though.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/99278202-cc41-4b01-9454-95e537a31e67)

## Changelog
:cl:
fix: Fixes antagonist roles being assigned to players on the main menu if they did not have any valid jobs available.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
