### PR TITLE
fix some opendream and dreamchecker lints

### DIFF
--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -22,9 +22,9 @@
 /// Deactivates the functionality defines by the element on the given datum
 /datum/element/proc/Detach(datum/source, ...)
 	SIGNAL_HANDLER
+	SHOULD_CALL_PARENT(TRUE)
 
 	SEND_SIGNAL(source, COMSIG_ELEMENT_DETACH, src)
-	SHOULD_CALL_PARENT(TRUE)
 	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 
 /datum/element/Destroy(force)

--- a/code/datums/elements/obj_regen.dm
+++ b/code/datums/elements/obj_regen.dm
@@ -28,6 +28,7 @@
 		processing |= target
 
 /datum/element/obj_regen/Detach(obj/target)
+	. = ..()
 	UnregisterSignal(target, COMSIG_ATOM_TAKE_DAMAGE)
 	processing -= target
 	if(!length(processing))

--- a/tools/ci/od_lints.dm
+++ b/tools/ci/od_lints.dm
@@ -37,6 +37,7 @@
 #pragma AmbiguousResourcePath error
 #pragma SuspiciousSwitchCase error
 #pragma PointlessPositionalArgument error
+#pragma UnsupportedAccess disabled
 // NOTE: The next few pragmas are for OpenDream's experimental type checker
 // This feature is still in development, elevating these pragmas outside of local testing is discouraged
 // An RFC to finalize this feature is coming soon(TM)


### PR DESCRIPTION
## About The Pull Request

https://github.com/SpaceManiac/SpacemanDMM/pull/435 added a new dreamchecker lint, for SDMM `set` statements not at the top of the proc.

While this lint isn't in the current SDMM _release_, I was testing it out earlier and saw these issues, so might as well fix them before they even become an issue.

also fixed a Detach() override that didn't call parent, which was never caught due to `SHOULD_CALL_PARENT` not being at the top

---

ports https://github.com/tgstation/tgstation/pull/91845

this disables the `UnsupportedAccess` warning in opendream linting, so we stop getting these warnings for every opendream lint:
```
Warning: OD2801: /world.IsSubscribed() is unsupported: OpenDream does not have a premium tier
Warning: OD2801: /client.IsByondMember() is unsupported: OpenDream has no premium tier.
Warning: OD2801: /client.IsByondMember() is unsupported: OpenDream has no premium tier.
Warning: OD2801: /client.IsByondMember() is unsupported: OpenDream has no premium tier.
```

I checked, everything that trips `UnsupportedAccess` is related to BYOND hub stuff - byond premium, hub scores/medals/credits, pager messages, and subscribing to games. _unimplemented_ methods are a different lint.

(search `set opendream_unsupported` in the OD codebase to see specifics)

## Why It's Good For The Game

![aimi-omega-strikers](https://github.com/user-attachments/assets/b8f54093-94a9-4952-a3b2-f88e7ae5c705)

## Testing Photographs and Procedure

just linting fixes, no actual in-game changes

## Changelog

no user-facing changes
