### PR TITLE
Updates piercing syringes & pierce protection (+fixes syringe gun not working)

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -46,7 +46,7 @@
 #define BLOCK_GAS_SMOKE_EFFECT	(1<<2)	//! blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY!
 #define MASKINTERNALS		    (1<<3)	//! mask allows internals
 #define NOSLIP                  (1<<4)  //! prevents from slipping on wet floors, in space etc
-#define THICKMATERIAL			(1<<5)	//! prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body.
+#define THICKMATERIAL			(1<<5)	//! prevent piercing syringes from penetrating them.
 #define VOICEBOX_TOGGLABLE      (1<<6)  //! The voicebox in this clothing can be toggled.
 #define VOICEBOX_DISABLED       (1<<7)  //! The voicebox is currently turned off.
 #define SNUG_FIT                (1<<9)  //! prevents hat throwing from knocking this hat off

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -70,7 +70,7 @@
 	if (!reagents.total_volume || !M.reagents)
 		return
 	var/amount_inject = amount_per_transfer_from_this
-	if(!M.can_inject(user, 1))
+	if(!M.can_inject(user, user.get_combat_bodyzone(), INJECT_CHECK_PENETRATE_THICK))
 		amount_inject = 1
 	var/amount = min(amount_inject/reagents.total_volume,1)
 	reagents.expose(M,INJECT,amount)

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -24,6 +24,7 @@
 		/obj/item/restraints/handcuffs
 		)
 	slowdown = 0
+	clothing_flags = THICKMATERIAL
 	var/mode = VEST_STEALTH
 	var/stealth_active = FALSE
 	/// Cooldown in seconds

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -502,6 +502,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/gun/magic/tentacle)
 	heat_protection = 0
 	blocks_shove_knockdown = TRUE
 	slowdown = 0
+	clothing_flags = THICKMATERIAL
 
 
 /datum/armor/armor_changeling

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -321,7 +321,7 @@
 	. = ..()
 	if (clothing_flags & THICKMATERIAL)
 		.["thick"] = "Extremely thick, protecting from piercing injections and sprays."
-	else if (get_armor().get_rating(MELEE) || get_armor().get_rating(BULLET))
+	else if (get_armor().get_rating(MELEE) >= 10 || get_armor().get_rating(BULLET) >= 10)
 		.["rigid"] = "Protects from some injections and sprays."
 	if (clothing_flags & CASTING_CLOTHES)
 		.["magical"] = "Allows magical beings to cast spells when wearing [src]."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -320,7 +320,9 @@
 /obj/item/clothing/examine_tags(mob/user)
 	. = ..()
 	if (clothing_flags & THICKMATERIAL)
-		.["thick"] = "Protects from most injections and sprays."
+		.["thick"] = "Extremely thick, protecting from piercing injections and sprays."
+	else if (get_armor().get_rating(MELEE) || get_armor().get_rating(BULLET))
+		.["rigid"] = "Protects from some injections and sprays."
 	if (clothing_flags & CASTING_CLOTHES)
 		.["magical"] = "Allows magical beings to cast spells when wearing [src]."
 	if((clothing_flags & STOPSPRESSUREDAMAGE) || (visor_flags & STOPSPRESSUREDAMAGE))

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -16,6 +16,7 @@
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
 	bang_protect = 1
+	// Much thicker and more rigid than body armour, able to block even piercing syringes
 	clothing_flags = THICKMATERIAL
 
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1439,6 +1439,7 @@
 	greyscale_config = /datum/greyscale_config/ctf_standard
 	greyscale_config_worn = /datum/greyscale_config/ctf_standard_worn
 	greyscale_colors = "#ffffff"
+	clothing_flags = THICKMATERIAL
 
 	///Icon state to be fed into the shielded component
 	var/team_shield_icon = "shield-old"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -12,7 +12,6 @@
 	max_integrity = 250
 	resistance_flags = NONE
 	armor_type = /datum/armor/suit_armor
-	clothing_flags = THICKMATERIAL
 	slowdown = 0.08
 
 
@@ -144,6 +143,7 @@
 	armor_type = /datum/armor/vest_capcarapace
 	dog_fashion = null
 	resistance_flags = FIRE_PROOF
+	clothing_flags = THICKMATERIAL
 
 
 /datum/armor/vest_capcarapace
@@ -168,6 +168,7 @@
 	icon_state = "capformal"
 	item_state = null
 	body_parts_covered = CHEST|GROIN|ARMS
+	clothing_flags = NONE
 
 /obj/item/clothing/suit/armor/vest/capcarapace/jacket
 	name = "captain's jacket"
@@ -176,6 +177,7 @@
 	item_state = null
 	body_parts_covered = CHEST|ARMS
 	armor_type = /datum/armor/capcarapace_jacket
+	clothing_flags = NONE
 
 
 /datum/armor/capcarapace_jacket
@@ -203,6 +205,7 @@
 	equip_delay_other = 60
 	slowdown = 0.15
 	move_sound = list('sound/effects/suitstep1.ogg', 'sound/effects/suitstep2.ogg')
+	clothing_flags = THICKMATERIAL
 
 
 /datum/armor/armor_riot
@@ -224,6 +227,7 @@
 	armor_type = /datum/armor/armor_bone
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	slowdown = 0.1
+	clothing_flags = THICKMATERIAL
 
 
 /datum/armor/armor_bone
@@ -246,6 +250,7 @@
 	armor_type = /datum/armor/armor_bulletproof
 	strip_delay = 70
 	equip_delay_other = 50
+	clothing_flags = THICKMATERIAL
 
 
 /datum/armor/armor_bulletproof
@@ -311,6 +316,7 @@
 	armor_type = /datum/armor/armor_heavy
 	move_sound = list('sound/effects/suitstep1.ogg', 'sound/effects/suitstep2.ogg')
 	slowdown = 0.3
+	clothing_flags = THICKMATERIAL
 
 
 /datum/armor/armor_heavy
@@ -410,6 +416,7 @@
 	resistance_flags = FLAMMABLE
 	armor_type = /datum/armor/vest_durathread
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 
 /datum/armor/vest_durathread

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -31,11 +31,11 @@
 	icon_state = "rsecurity"
 	item_state = "r_suit"
 	armor_type = /datum/armor/security_officer
-	alt_covers_chest = TRUE
+	alt_covers_chest = FALSE
 
 
 /datum/armor/security_officer
-	melee = 10
+	melee = 5
 	fire = 30
 	acid = 30
 	stamina = 10

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -210,7 +210,7 @@
 		help_shake_act(M)
 		return FALSE
 
-	if(..() && can_inject(M, TRUE)) //successful monkey bite.
+	if(..() && can_inject(M, get_combat_bodyzone(), INJECT_CHECK_PENETRATE_THICK | INJECT_TRY_SHOW_ERROR_MESSAGE)) //successful monkey bite.
 		for(var/thing in M.diseases)
 			var/datum/disease/D = thing
 			ForceContractDisease(D)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -352,24 +352,30 @@
 	. = TRUE // Default to returning true.
 	if(user && !target_zone)
 		target_zone = user.get_combat_bodyzone()
+	var/obj/item/bodypart/the_part = get_bodypart(target_zone) || get_bodypart(BODY_ZONE_CHEST)
 	// we may choose to ignore species trait pierce immunity in case we still want to check skellies for thick clothing without insta failing them (wounds)
 	if(injection_flags & INJECT_CHECK_IGNORE_SPECIES)
 		if(HAS_TRAIT_NOT_FROM(src, TRAIT_PIERCEIMMUNE, SPECIES_TRAIT))
-			. = FALSE
+			if (user && (injection_flags & INJECT_TRY_SHOW_ERROR_MESSAGE))
+				to_chat(user, span_alert("The skin on [p_their()] [the_part.name] is too thick!"))
+			return FALSE
 	else if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
-		. = FALSE
-	var/obj/item/bodypart/the_part = get_bodypart(target_zone) || get_bodypart(BODY_ZONE_CHEST)
+		if (user && (injection_flags & INJECT_TRY_SHOW_ERROR_MESSAGE))
+			to_chat(user, span_alert("The skin on [p_their()] [the_part.name] is too thick!"))
+		return FALSE
 	// Loop through the clothing covering this bodypart and see if there's any thiccmaterials
 	var/require_thickness = (injection_flags & INJECT_CHECK_PENETRATE_THICK)
 	for(var/obj/item/clothing/iter_clothing in clothingonpart(the_part))
 		// If it has armour, it has enough thickness to block basic things
-		if(!require_thickness && (iter_clothing.get_armor().get_rating(MELEE) || iter_clothing.get_armor().get_rating(BULLET)))
-			. = FALSE
-			break
+		if(!require_thickness && (iter_clothing.get_armor().get_rating(MELEE) >= 10 || iter_clothing.get_armor().get_rating(BULLET) >= 10))
+			if (user && (injection_flags & INJECT_TRY_SHOW_ERROR_MESSAGE))
+				to_chat(user, span_alert("The clothing on [p_their()] [the_part.name] is too thick!"))
+			return FALSE
 		// If it is ultra thick, then block piercing syringes
 		if(iter_clothing.clothing_flags & THICKMATERIAL)
-			. = FALSE
-			break
+			if (user && (injection_flags & INJECT_TRY_SHOW_ERROR_MESSAGE))
+				to_chat(user, span_alert("The clothing on [p_their()] [the_part.name] is too thick!"))
+			return FALSE
 
 /mob/living/carbon/human/try_inject(mob/user, target_zone, injection_flags)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -360,11 +360,16 @@
 		. = FALSE
 	var/obj/item/bodypart/the_part = get_bodypart(target_zone) || get_bodypart(BODY_ZONE_CHEST)
 	// Loop through the clothing covering this bodypart and see if there's any thiccmaterials
-	if(!(injection_flags & INJECT_CHECK_PENETRATE_THICK))
-		for(var/obj/item/clothing/iter_clothing in clothingonpart(the_part))
-			if(iter_clothing.clothing_flags & THICKMATERIAL)
-				. = FALSE
-				break
+	var/require_thickness = (injection_flags & INJECT_CHECK_PENETRATE_THICK)
+	for(var/obj/item/clothing/iter_clothing in clothingonpart(the_part))
+		// If it has armour, it has enough thickness to block basic things
+		if(!require_thickness && (iter_clothing.get_armor().get_rating(MELEE) || iter_clothing.get_armor().get_rating(BULLET)))
+			. = FALSE
+			break
+		// If it is ultra thick, then block piercing syringes
+		if(iter_clothing.clothing_flags & THICKMATERIAL)
+			. = FALSE
+			break
 
 /mob/living/carbon/human/try_inject(mob/user, target_zone, injection_flags)
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -658,7 +658,7 @@
  *   Check __DEFINES/injection.dm for more details. Unlike can_inject, the INJECT_TRY_* defines will behave differently.
  */
 /mob/living/proc/try_inject(mob/user, target_zone, injection_flags)
-	return can_inject(user, target_zone, injection_flags)
+	return can_inject(user, target_zone, injection_flags & ~(INJECT_TRY_SHOW_ERROR_MESSAGE))
 
 /mob/living/is_injectable(mob/user, allowmobs = TRUE)
 	return (allowmobs && reagents && can_inject(user))

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -23,7 +23,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
-			if(M.can_inject(firer, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+			if(M.can_inject(firer, def_zone, piercing ? INJECT_CHECK_PENETRATE_THICK : NONE)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
 				if(syringe)
 					syringe.embed(M)

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -34,7 +34,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
-			if(M.can_inject(null, FALSE, def_zone,)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+			if(M.can_inject(null, def_zone, INJECT_CHECK_PENETRATE_THICK)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
 				reagents.expose(M, INJECT)
 				reagents.trans_to(M, reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -295,7 +295,7 @@
 
 /obj/item/reagent_containers/syringe/piercing
 	name = "piercing syringe"
-	desc = "A diamond-tipped syringe that pierces armor. It can hold up to 10 units."
+	desc = "A diamond-tipped syringe that pierces clothing, but not heavy armor. It can hold up to 10 units."
 	icon_state = "piercing_0"
 	base_icon_state = "piercing"
 	volume = 10

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -104,7 +104,7 @@
 
 /datum/design/piercesyringe
 	name = "Piercing Syringe"
-	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
+	desc = "A diamond-tipped syringe that pierces clothing, but not heavy armor, when launched at high velocity. It can hold up to 10 units."
 	id = "piercesyringe"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/glass = 2000, /datum/material/diamond = 1000)

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -143,6 +143,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/structure/light_prism)
 	item_state = "adamsuit"
 	flags_inv = NONE
 	slowdown = 0 //slowdown is handled in the equipped proc
+	clothing_flags = THICKMATERIAL
 	var/hit_reflect_chance = 40
 
 /obj/item/clothing/suit/armor/heavy/adamantine/equipped(mob/user, slot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There are now 2 levels to thickness:
- Any clothes that have either 10 melee or 10 bullet armour will be immune to basic piercing. This includes normal syringes, as well as anything that respects the thick material flag, including bruise packs and ointment.
- Any clothes with the thick material flag are now immune to piercing syringes.

Heavy armours including hardsuits, riot armour and bulletproof armour will now be capable of blocking piercing syringes. This makes it much harder to use unfair chemical concoctions against an armoured and prepared antagonist opponent.

The standard security jumpsuit no longer blocks the chest when unzipped, as the sprite suggests.

Nerfs standard security jumpsuit armour to 5, so that it won't block healing (as this would get somewhat annoying).

Adds an error message to syringes when they cannot pull blood from someone.

## Why It's Good For The Game

Piercing syringes are a good tool for antagonists to be able to take on security, however their primary flaw is that in the hands of non-antagonists they can quickly take down an antagonist in a relatively unfair and uncounterable way. I do not want to remove the ability for piercing syringes to be used as an antagonist tool, so instead they will no longer penetrate heavy armour such as hardsuits and all antagonist armours but will be able to penetrate the standard security armour.

This also means that if a threat is known to be using piercing syringes, security can now prepare for the threat by taking on heavier armours.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/6b591d74-9992-4438-964f-2c9ee03ce254)

![image](https://github.com/user-attachments/assets/3086ad7b-daf2-45ed-8979-e4538efaf343)

![image](https://github.com/user-attachments/assets/fa16b28c-6e96-481a-8ee8-9fb9f4da5814)

![image](https://github.com/user-attachments/assets/ac303c19-0da6-42ce-9931-16f75876ea15)

Only the piercing syringe is capable of taking blood from an armoured security officer, and it cannot take from the helmet which is heavily protected.

![image](https://github.com/user-attachments/assets/1a92d801-e0d6-4a21-9947-a0594339ec3b)

Security armour does not deflect piercing:

![image](https://github.com/user-attachments/assets/623cfc5f-792b-446d-a1fa-db23d7493243)

Syndicate armour deflects piercing:

![image](https://github.com/user-attachments/assets/c982d5c5-9a2f-48db-8d79-5ab97362d1fe)


## Changelog
:cl:
balance: Antagonist and heavy armours will now block piercing syringes.
balance: Any clothing that has at least 10 bullet or melee armour will block standard syringes and injections.
fix: Fixes multiple incorrect uses of can_inject which would have caused syringe guns not to function
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
