### PR TITLE
Fixes a really stupid mistake I made with the runechat looc preference

### DIFF
--- a/code/modules/client/preferences/entries/player/runechat.dm
+++ b/code/modules/client/preferences/entries/player/runechat.dm
@@ -33,5 +33,5 @@
 	. = ..()
 	if(!CONFIG_GET(flag/looc_enabled))
 		return FALSE
-	if(preferences.read_player_preference(/datum/preference/toggle/enable_runechat))
+	if(!preferences.read_player_preference(/datum/preference/toggle/enable_runechat))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

This preference wasn't supposed to show up if runechat was disabled, I messed up and forgot a !

## Why It's Good For The Game

works as intended now

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/707f9caa-3150-4117-9958-037bd3e6410c

## Changelog
:cl:
fix: fixed the runechat looc preference not showing up sometimes
/:cl:
