### PR TITLE
[s] BeeAuth: Session Creation Nonces - Copycat Mitigation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@ Dockerfile @crossedfall
 /tgui/ @itsmeow
 /tgui/packages/tgui/interfaces/PlayerPanel.js @itsmeow
 /code/modules/multiz @itsmeow
+/code/modules/client/login @itsmeow
 
 # itsmeow (explicitly disowned)
 

--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -506,7 +506,7 @@ CREATE TABLE IF NOT EXISTS `SS13_schema_revision` (
   `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`major`,`minor`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (7, 4);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (7, 5);
 
 
 
@@ -522,6 +522,19 @@ CREATE TABLE IF NOT EXISTS `SS13_session` (
   `valid_until` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE INDEX `ip_token` (`ip`, `session_token`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- Dumping structure for table ss13tgdb.SS13_session_creation_nonce
+DROP TABLE IF EXISTS `SS13_session_creation_nonce`;
+CREATE TABLE IF NOT EXISTS `SS13_session_creation_nonce` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `ip` varchar(32) NOT NULL,
+  `seeker_port` SMALLINT UNSIGNED DEFAULT NULL,
+  `session_nonce` varchar(64) NOT NULL UNIQUE,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `ip_nonce` (`ip`, `session_nonce`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,28 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 7.4; The query to update the schema revision table is:
+The latest database version is 7.5; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (7, 4);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (7, 5);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (7, 4);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (7, 5);
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
+Version 7.5, 29 June 2025, by itsmeow
+Adds External Session Creation Nonces
+
+CREATE TABLE IF NOT EXISTS `SS13_session_creation_nonce` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `ip` varchar(32) NOT NULL,
+  `seeker_port` SMALLINT UNSIGNED DEFAULT NULL,
+  `session_nonce` varchar(64) NOT NULL UNIQUE,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `ip_nonce` (`ip`, `session_nonce`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-----------------------------------------------------
 
 -----------------------------------------------------
 Version 7.4, 23 June 2025, by itsmeow

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
   *
   * make sure you add an update to the schema_version stable in the db changelog
   */
-#define DB_MINOR_VERSION 4
+#define DB_MINOR_VERSION 5
 
 
 //! ## Timing subsystem

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -199,8 +199,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	return 1
 
 /client/proc/is_localhost()
-	var/static/list/localhost_addresses = list("127.0.0.1", "::1")
-	return isnull(address) || (address in localhost_addresses)
+	return isnull(address) || address == "127.0.0.1" || address == "::1"
 
 /client/proc/time_to_redirect()
 	var/redirect_address = CONFIG_GET(string/redirect_address)

--- a/code/modules/client/login/client_login_verbs.dm
+++ b/code/modules/client/login/client_login_verbs.dm
@@ -19,19 +19,6 @@
 	else
 		to_chat_immediate(src, span_danger("No authentication methods have been configured!"))
 
-/client/proc/login_with_method(datum/external_login_method/method)
-	if(!istype(method))
-		to_chat_immediate(src, span_danger("Method not implemented!"))
-		return
-	var/ip = src.address
-	if(is_localhost())
-		ip = "127.0.0.1"
-	var/link = method.get_url(ip, src.seeker_port)
-	if(istext(link))
-		src << link(link)
-	else
-		to_chat_immediate(src, span_danger("[method::name] authentication has not been configured!"))
-
 /client/verb/open_login()
 	set name = "Log In"
 	set category = "Login"

--- a/code/modules/client/login/external_login_methods.dm
+++ b/code/modules/client/login/external_login_methods.dm
@@ -9,15 +9,15 @@
 /datum/external_login_method/vv_edit_var(var_name, var_value)
 	return FALSE
 
-/datum/external_login_method/proc/get_url(ip, seeker_port)
+/datum/external_login_method/proc/get_url(ip, seeker_port, session_creation_nonce)
 	var/list/methods = CONFIG_GET(keyed_list/external_auth_method)
 	var/link = methods[src::id]
 	if(!istext(link))
 		return null
 	var/port_data = ""
 	if(isnum_safe(seeker_port))
-		port_data = "&seeker_port=[url_encode(seeker_port)]"
-	return "[link]?ip=[url_encode(ip)][port_data]"
+		port_data = "&seeker_port=[seeker_port]"
+	return "[link]?ip=[url_encode(ip)]&nonce=[session_creation_nonce][port_data]"
 
 /// use client.key_is_external where possible
 /datum/external_login_method/proc/is_fake_key(key)

--- a/code/modules/client/login/tgui_login.dm
+++ b/code/modules/client/login/tgui_login.dm
@@ -38,12 +38,13 @@
 	. = list()
 	if(!user.client)
 		return
-	var/ip = user.client.address
-	if(user.client.is_localhost())
-		ip = "127.0.0.1"
-	var/port_data = ""
-	if(isnum_safe(user.client.seeker_port))
-		port_data = "&seeker_port=[url_encode(user.client.seeker_port)]"
-	.["decorator"] = "?ip=[url_encode(ip)][port_data]"
 	.["authenticated_key"] = user.client.byond_authenticated_key
 
+/datum/tgui_login/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(. || !usr?.client || usr.client.logged_in || ui.user != usr)
+		return
+	if(action == "login")
+		var/method_id = params["method"]
+		if(istext(method_id) && length(method_id))
+			usr.client.login_with_method_id(method_id)

--- a/tgui/packages/tgui/interfaces/GameLogin.tsx
+++ b/tgui/packages/tgui/interfaces/GameLogin.tsx
@@ -3,23 +3,11 @@ import { useBackend } from 'tgui/backend';
 import { Box, Button, Flex, Icon, Input, Section, Stack } from 'tgui/components';
 import { Window } from 'tgui/layouts';
 
-const methodToComponent = (method: string, url: string): ReactElement => {
+const methodToComponent = (method: string, login: () => void): ReactElement => {
   switch (method) {
     case 'discord':
       return (
-        <Button
-          color="blurple"
-          fontSize="16px"
-          p={2}
-          onClick={() => {
-            if (url.startsWith('byond://')) {
-              return;
-            }
-            Byond.sendMessage({
-              type: 'openLink',
-              url,
-            });
-          }}>
+        <Button color="blurple" fontSize="16px" p={2} onClick={login}>
           <Box inline style={{ transform: 'translateY(1.5px)' }}>
             <Icon name="tg-discord" />
           </Box>{' '}
@@ -31,8 +19,7 @@ const methodToComponent = (method: string, url: string): ReactElement => {
 };
 
 export const GameLogin = (props) => {
-  const { act, data } =
-    useBackend<{ byond_enabled: boolean; methods: Record<string, string>; decorator: string; authenticated_key: string }>();
+  const { act, data } = useBackend<{ byond_enabled: boolean; methods: Record<string, string>; authenticated_key: string }>();
   const [showInput, setShowInput] = useState(false);
   const inputToken = useRef<string>('');
   const sendToken = (token: string) => {
@@ -80,8 +67,8 @@ export const GameLogin = (props) => {
                 <Flex.Item>
                   <Section fill fitted title="Methods">
                     <Flex direction="row" align="center" justify="center" height="100%" p={2}>
-                      {Object.entries(data.methods).map(([key, link]) => (
-                        <Flex.Item key={key}>{methodToComponent(key, link + data.decorator)}</Flex.Item>
+                      {Object.keys(data.methods).map((key) => (
+                        <Flex.Item key={key}>{methodToComponent(key, () => act('login', { method: key }))}</Flex.Item>
                       ))}
                     </Flex>
                   </Section>


### PR DESCRIPTION
## About The Pull Request

Security fix for #12927

Mitigates a potential attack where a copycat server directs the user to authenticate against bapi, replacing the (unverified) IP address query with the attacker's IP address, thus granting the owner of the copycat server a valid session token for their IP address to connect to our actual servers with.

Now, all session create requests are validated against a nonce stored in the game database. The nonce is issued when a player requests authentication, and includes IP and seeker port. The nonce expires after a configurable period, currently 4 minutes, making cracking or re-using nonces implausible

Also see https://github.com/BeeStation/bapi/pull/37

Added myself to CODEOWNERS because I don't want anyone messing with this system without me knowing.

## Why It's Good For The Game

High priority security update

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/d3c027de-4573-4382-8400-e744aa2de370)

![image](https://github.com/user-attachments/assets/daae5daa-b980-4790-b6f5-8fe119650635)

testing fake nonce
![image](https://github.com/user-attachments/assets/47ffe5fa-8abc-4f40-9a4a-e18efdc7e8b8)

testing expired nonce
![image](https://github.com/user-attachments/assets/4fbbe304-52e2-49d7-af8a-888b2b73334b)

## Changelog
:cl:
fix: Mitigated security vulnerability related to servers pretending to be BeeStation on the hub being able to issue valid session tokens for a malicious IP address.
server: Added SS13_session_creation_nonce table
/:cl: