### PR TITLE
Fix get_step_multiz UP always returning UP instead of a turf

### DIFF
--- a/code/__HELPERS/multiz_helpers.dm
+++ b/code/__HELPERS/multiz_helpers.dm
@@ -1,7 +1,7 @@
 GLOBAL_DATUM(temporary_multiz_step_ref, /turf)
 
 #define get_step_multiz(ref, dir) \
-	(dir & UP ? ( \
+	((dir & UP) ? ( \
 		(GLOB.temporary_multiz_step_ref = get_turf(ref)) ? get_step(GET_TURF_ABOVE(GLOB.temporary_multiz_step_ref), dir & ~UP) : null \
 	) : ( \
 		(dir & DOWN) ? ( \


### PR DESCRIPTION
## About The Pull Request

Currently, `get_step_multiz(turf, UP)` runtimes, because it returns `16` (`UP`). This is because the bitwise `&` operator sucks.

## Why It's Good For The Game

Being able to step up is GOOD!

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Before
![image](https://github.com/user-attachments/assets/f516ea7b-5a49-4e14-add3-9b10837f7c0a)

After
![image](https://github.com/user-attachments/assets/51a1a5e4-8aeb-4b49-a611-b1bc3b3a6d59)

</details>

## Changelog
:cl:
fix: Fixed being unable to look up or locate turfs above you in Multi-Z
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
