### PR TITLE
Small firelock map changes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56038,13 +56038,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"pOu" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "pOJ" = (
 /obj/machinery/light,
 /obj/structure/rack,
@@ -104899,7 +104892,7 @@ tMi
 sRD
 eFh
 trD
-pOu
+pmD
 pmD
 uPm
 xSE

--- a/_maps/map_files/RadStation/RadStation.dmm
+++ b/_maps/map_files/RadStation/RadStation.dmm
@@ -31306,6 +31306,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "kla" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added a missing fire alarm in RadStation, deleted an extra one in MetaStation.

## Why It's Good For The Game
Rooms need fire alarms, rooms do not need more fire alarms than necessary.

## Testing Photographs and Procedure
![Sin título](https://github.com/user-attachments/assets/74de6d00-5aa8-49d5-8c80-4911b1ca23ed)

## Changelog
:cl:
add: Added a missing fire alarm in RadStation Brig, in the processing room.
del: Removed an extra unnecesary fire alarm in MetaStation, in medbay.
/:cl: