### PR TITLE
BeeAuth: BYOND-Authenticated External Account Re-Association, Login Improvements

### DIFF
--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -17,3 +17,6 @@ GLOBAL_VAR_INIT(byond_http, TRUE)
 #else
 GLOBAL_VAR_INIT(byond_http, FALSE)
 #endif
+
+GLOBAL_LIST_EMPTY(disconnected_mobs)
+GLOBAL_PROTECT(disconnected_mobs)

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -22,6 +22,15 @@ GLOBAL_LIST_EMPTY(ckey_redirects)
 	var/admin = FALSE
 	var/ckey = ckey(key)
 	var/client/C = GLOB.directory[ckey]
+#ifdef DISABLE_BYOND_AUTH
+	if(!CONFIG_GET(flag/enable_guest_external_auth))
+		return list("reason"="misconfigured", "desc"="The server is not currently authenticating BYOND connections and does not have any authentication methods enabled. \
+		This is insecure, nobody may connect.")
+	if (C && ckey == C.ckey && CONFIG_GET(flag/enable_guest_external_auth) && !real_bans_only && !from_auth)
+		// Note that it's probably possible to scrape connected CKEYs with this check, but whatever it's public anyway
+		// We have no way of verifying their connection CKEY is who they say they are, and no way to change their CKEY before login
+		return list("reason"="already connected", "desc"="A player is currently connected with your connection CKEY. Connect with a different CKEY or as a guest.")
+#endif
 	if (C && ckey == C.ckey && computer_id == C.computer_id && address == C.address && !from_auth)
 		return //don't recheck connected clients unless it's from the auth system
 

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -42,7 +42,7 @@
 	for(var/mob/player in mobs)
 		if(!player.ckey)
 			continue
-		var/normal_ckey = replacetext(player.ckey, "@DC!", "", 1, 5)
+		var/normal_ckey = replacetext(player.ckey, "@DC@", "", 1, 5)
 		var/list/data_entry = list()
 		if(isliving(player))
 			if(iscarbon(player))

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -42,6 +42,7 @@
 	for(var/mob/player in mobs)
 		if(!player.ckey)
 			continue
+		var/normal_ckey = replacetext(player.ckey, "@DC!", "", 1, 5)
 		var/list/data_entry = list()
 		if(isliving(player))
 			if(iscarbon(player))
@@ -74,7 +75,7 @@
 
 		data_entry["name"] = player.name
 		data_entry["real_name"] = player.real_name
-		var/ckey = ckey(player.ckey)
+		var/ckey = ckey(normal_ckey)
 		data_entry["ckey"] = ckey
 		var/search_data = "[player.name] [player.real_name] [ckey] [data_entry["job"]] "
 		var/datum/player_details/P = GLOB.player_details[ckey]

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -227,6 +227,10 @@
 			if(M?.ckey == target_ckey)
 				target_mob = M
 	if(!target_mob)
+		var/mob/disconnected_mob = GLOB.disconnected_mobs[target_ckey]
+		if(disconnected_mob)
+			target_mob = disconnected_mob
+	if(!target_mob)
 		return
 	switch(action)
 		if("open_player_panel")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -288,10 +288,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	GLOB.directory -= ckey
 	GLOB.clients -= src
 	GLOB.mentors -= src
-	// Disassociate, but DON'T DELETE.
-	// These are used to retain telemetry data for disconnected mobs.
-	if(!QDELETED(tgui_panel))
-		tgui_panel.client = null
 	log_access("Logout: [key_name(src)]")
 	GLOB.ahelp_tickets.ClientLogout(src)
 	GLOB.mhelp_tickets.ClientLogout(src)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -274,13 +274,18 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 /client/Del()
 	// We have a mob worth keeping and are authenticated
-	if(src.logged_in && ismob(mob) && !istype(mob, /mob/dead/new_player/pre_auth))
+	var/mob_logout = FALSE
+	var/mob/my_mob = src.mob
+	if(src.logged_in && ismob(my_mob) && !istype(my_mob, /mob/dead/new_player/pre_auth))
 		// Don't let the game reassociate with the mob without authenticating again.
-		var/mob/my_mob = src.mob
-		my_mob.key = "@DC@[my_mob.key]" // make sure this mob keeps a key that doesn't exist. Very similiar to the adminghost @
+		mob_logout = TRUE
 		GLOB.disconnected_mobs[src.key] = my_mob // now we know on login that we've signed out from this mob and can reassociate.
 	if(!gc_destroyed)
 		Destroy() //Clean up signals and timers.
+	if(mob_logout)
+		// Destroy() has to run first because it cleans up our references on the mob
+		// Changing the key calls /mob/Logout() which is supposed to run AFTER Destroy.
+		my_mob.key = "@DC@[my_mob.key]" // make sure this mob keeps a key that doesn't exist. Very similiar to the adminghost @
 	return ..()
 
 /client/Destroy()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -277,7 +277,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(src.logged_in && ismob(mob) && !istype(mob, /mob/dead/new_player/pre_auth))
 		// Don't let the game reassociate with the mob without authenticating again.
 		var/mob/my_mob = src.mob
-		my_mob.key = "@DC![my_mob.key]" // make sure this mob keeps a key that doesn't exist. Very similiar to the adminghost @
+		my_mob.key = "@DC@[my_mob.key]" // make sure this mob keeps a key that doesn't exist. Very similiar to the adminghost @
 		GLOB.disconnected_mobs[src.key] = my_mob // now we know on login that we've signed out from this mob and can reassociate.
 	if(!gc_destroyed)
 		Destroy() //Clean up signals and timers.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -273,6 +273,12 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 //////////////
 
 /client/Del()
+	// We have a mob worth keeping and are authenticated
+	if(src.logged_in && ismob(mob) && !istype(mob, /mob/dead/new_player/pre_auth))
+		// Don't let the game reassociate with the mob without authenticating again.
+		var/mob/my_mob = src.mob
+		my_mob.key = "@DC![my_mob.key]" // make sure this mob keeps a key that doesn't exist. Very similiar to the adminghost @
+		GLOB.disconnected_mobs[src.key] = my_mob // now we know on login that we've signed out from this mob and can reassociate.
 	if(!gc_destroyed)
 		Destroy() //Clean up signals and timers.
 	return ..()
@@ -282,6 +288,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	GLOB.directory -= ckey
 	GLOB.clients -= src
 	GLOB.mentors -= src
+	// Disassociate, but DON'T DELETE.
+	// These are used to retain telemetry data for disconnected mobs.
+	if(!QDELETED(tgui_panel))
+		tgui_panel.client = null
 	log_access("Logout: [key_name(src)]")
 	GLOB.ahelp_tickets.ClientLogout(src)
 	GLOB.mhelp_tickets.ClientLogout(src)
@@ -313,6 +323,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		var/atom/eye_thing = eye
 		LAZYREMOVE(eye_thing.eye_users, src)
 	GLOB.requests.client_logout(src)
+
 
 	SSambience.remove_ambience_client(src)
 	Master.UpdateTickRate()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(src.logged_in && ismob(my_mob) && !istype(my_mob, /mob/dead/new_player/pre_auth))
 		// Don't let the game reassociate with the mob without authenticating again.
 		mob_logout = TRUE
-		GLOB.disconnected_mobs[src.key] = my_mob // now we know on login that we've signed out from this mob and can reassociate.
+		GLOB.disconnected_mobs[src.ckey] = my_mob // now we know on login that we've signed out from this mob and can reassociate.
 	if(!gc_destroyed)
 		Destroy() //Clean up signals and timers.
 	if(mob_logout)

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -66,20 +66,17 @@
 	. = ..()	//calls mob.Login()
 
 	var/mob/logout_mob = GLOB.disconnected_mobs[src.key]
-	if(logged_in && istype(logout_mob))
+	if(logged_in && ismob(logout_mob) && !isnewplayer(logout_mob))
 		var/mob/original_mob = src.mob
 		GLOB.disconnected_mobs -= src.key
-		logout_mob.key = src.key
-		if(isnewplayer(original_mob))
-			qdel(original_mob)
+		transfer_preauthenticated_player_mob(original_mob, logout_mob)
 
 	if(QDELETED(src))
 		return null
 
 	// if the user logged in directly with a valid key, we can convert them now
 	if(logged_in && istype(mob, /mob/dead/new_player/pre_auth))
-		var/mob/dead/new_player/pre_auth/pre_auth_player = mob
-		pre_auth_player.convert_to_authed()
+		transfer_preauthenticated_player_mob(mob, null)
 
 	if(!client_post_login(logged_in, TRUE, logged_in && !!(holder || GLOB.deadmins[ckey])) || QDELETED(src))
 		return null

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -5,15 +5,14 @@
 	if(connection != "seeker" && connection != "web")//Invalid connection type.
 		return null
 
+	var/new_key = null
 #ifdef DISABLE_BYOND_AUTH
 	if(is_localhost() && CONFIG_GET(flag/localhost_auth_bypass))
 		logged_in = TRUE
 	else if(CONFIG_GET(flag/enable_guest_external_auth))
 		// If auth isn't set up, immediately change their key to a guest key
 		// IT IS VERY IMPORTANT THAT IS_GUEST_KEY RETURNS TRUE OTHERWISE THE DB WILL GET POLLUTED
-		var/new_key = "Guest-preauth-[computer_id]-[rand(1000,9999)]"
-		ckey = ckey(key)
-		key = new_key
+		new_key = "Guest-preauth-[computer_id]-[rand(1000,9999)]"
 		logged_in = FALSE
 	else
 		to_chat_immediate(src, span_dangerbold("Authorization is totally disabled! The game is configured to blindly trust connecting CKEYs!!!"))
@@ -26,9 +25,7 @@
 		else if(!CONFIG_GET(flag/guest_ban)) // guests are allowed to connect, no authorization necessary
 			logged_in = TRUE
 		else if(CONFIG_GET(flag/enable_guest_external_auth)) // guests need to authorize
-			var/new_key = "Guest-preauth-[computer_id]-[rand(1000,9999)]"
-			ckey = ckey(key)
-			key = new_key
+			new_key = "Guest-preauth-[computer_id]-[rand(1000,9999)]"
 			logged_in = FALSE
 		else // should be caught by IsBanned, but localhost can get to this point
 			src << "NOTICE: Guests are not currently allowed to connect!"
@@ -38,21 +35,43 @@
 			return null
 	else if(CONFIG_GET(flag/force_byond_external_auth) && CONFIG_GET(flag/enable_guest_external_auth))
 		byond_authenticated_key = key
-		var/new_key = "Guest-preauth-[computer_id]-[rand(1000,9999)]"
-		ckey = ckey(key)
-		key = new_key
+		new_key = "Guest-preauth-[computer_id]-[rand(1000,9999)]"
 		logged_in = FALSE
 	else
 		logged_in = TRUE
 #endif
+	var/old_key = key
+
+	// Our key has changed
+	if(!isnull(new_key))
+		src.ckey = ckey(new_key)
+		src.key = new_key
+
+	// We connected with a mob that isn't ours.
+	// The connection CKEY matches an existing logged in mob's key
+	// This means someone got kicked, but it's okay. We'll try to return it to them.
+	if(!logged_in && ismob(mob) && !istype(mob, /mob/dead/new_player/pre_auth))
+		var/mob/my_old_mob = src.mob
+		var/mob/dead/new_player/pre_auth/my_new_mob = new()
+		my_new_mob.key = src.key
+		my_old_mob.key = old_key // GIVE IT BACK
 
 	if(!logged_in)
 		tgui_login = new(src)
 
-	if(!client_pre_login(logged_in, TRUE))
+	if(!client_pre_login(logged_in, TRUE) || QDELETED(src))
 		return null
 
+
 	. = ..()	//calls mob.Login()
+
+	var/mob/logout_mob = GLOB.disconnected_mobs[src.key]
+	if(logged_in && istype(logout_mob))
+		var/mob/original_mob = src.mob
+		GLOB.disconnected_mobs -= src.key
+		logout_mob.key = src.key
+		if(isnewplayer(original_mob))
+			qdel(original_mob)
 
 	if(QDELETED(src))
 		return null
@@ -62,7 +81,7 @@
 		var/mob/dead/new_player/pre_auth/pre_auth_player = mob
 		pre_auth_player.convert_to_authed()
 
-	if(!client_post_login(logged_in, TRUE, logged_in && !!(holder || GLOB.deadmins[ckey])))
+	if(!client_post_login(logged_in, TRUE, logged_in && !!(holder || GLOB.deadmins[ckey])) || QDELETED(src))
 		return null
 	fully_created = TRUE
 	if(logged_in)
@@ -133,15 +152,19 @@
 
 			// Retrieve cached metabalance
 			get_metabalance_db()
+			if(QDELETED(src))
+				return FALSE
 			// Retrieve cached antag token count
 			get_antag_token_count_db()
-			if(QDELETED(src)) // Yes this is possible, because the procs above sleep.
+			if(QDELETED(src))
 				return FALSE
 		else
 			metabalance_cached = 0
 			antag_token_count_cached = 0
 		//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 		init_client_prefs()
+		if(QDELETED(src))
+			return FALSE
 		setup_player_details()
 
 		if(fexists(roundend_report_file()))
@@ -153,7 +176,8 @@
 			log_access("Login: [key_name(src)] from [address ? address : "localhost"]-[computer_id] || BYOND v[full_version]")
 		else
 			log_access("Pre-Login: [key_name(src)] from [address ? address : "localhost"]-[computer_id] || BYOND v[full_version]")
-
+	if(authenticated && src.external_uid)
+		to_chat_immediate(src, span_good("Successfully signed in as [span_bold("[src.display_name_chat()]")]"))
 	return TRUE
 
 /client/proc/client_post_login(authenticated, first_run, connecting_admin)
@@ -210,7 +234,7 @@
 		// We're done using this now
 		temp_topicdata = null
 		if(QDELETED(src))
-			return
+			return FALSE
 		// The following is only relevant to BYOND accounts.
 		if (isnum_safe(cached_player_age) && cached_player_age == -1) //first connection
 			player_age = 0
@@ -236,6 +260,8 @@
 	if(authenticated)
 		check_ip_intel()
 		sync_db_key_with_byond_key()
+		if(QDELETED(src))
+			return FALSE
 
 	// If we aren't already generating a ban cache, fire off a build request
 	// This way hopefully any users of request_ban_cache will never need to yield
@@ -244,6 +270,8 @@
 
 	if(authenticated && !is_guest)
 		fetch_uuid()
+		if(QDELETED(src))
+			return FALSE
 		add_verb(/client/proc/show_account_identifier)
 
 	if(first_run)
@@ -263,6 +291,8 @@
 
 	if(authenticated && !is_guest && CONFIG_GET(flag/autoconvert_notes))
 		convert_notes_sql(ckey)
+		if(QDELETED(src))
+			return FALSE
 	if(authenticated && !is_guest)
 		to_chat(src, get_message_output("message", ckey))
 	if(first_run)
@@ -297,11 +327,11 @@
 
 	if(!authenticated)
 		spawn(2 SECONDS) // wait a sec for the client to send a valid token
-			if(!src.logged_in) // client did not send a valid token in the last 2 seconds
+			if(!QDELETED(src) && !src.logged_in) // client did not send a valid token in the last 2 seconds
 				tgui_login?.open()
 
 	//Load the TGUI stat in case of TGUI subsystem not ready (startup)
-	mob.UpdateMobStat(TRUE)
+	mob?.UpdateMobStat(TRUE)
 	return TRUE
 
 /client/proc/check_client_blocked_byond_versions(connecting_admin)

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -404,12 +404,6 @@
 	if(istype(src.external_method))
 		external_uid = src.external_uid // link BYOND ckeys to external method
 		external_column = external_method::db_id_column_name
-		// Double check
-		var/list/acceptable_ids = list()
-		for(var/datum/external_login_method/method_path as anything in subtypesof(/datum/external_login_method))
-			acceptable_ids += method_path::db_id_column_name
-		if(!(external_column in acceptable_ids))
-			CRASH("PANIC! POSSIBLE SQL INJECTION! external_column value of [external_column] WAS NOT IN LIST OF ACCEPTABLE IDS [english_list(acceptable_ids)]")
 	var/external_column_selectable = istext(external_column) && length(external_column) ? external_column : "NULL"
 	related_accounts_ip = ""
 	if(!is_localhost())

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -65,10 +65,10 @@
 
 	. = ..()	//calls mob.Login()
 
-	var/mob/logout_mob = GLOB.disconnected_mobs[src.key]
+	var/mob/logout_mob = GLOB.disconnected_mobs[src.ckey]
 	if(logged_in && ismob(logout_mob) && !isnewplayer(logout_mob))
 		var/mob/original_mob = src.mob
-		GLOB.disconnected_mobs -= src.key
+		GLOB.disconnected_mobs -= src.ckey
 		transfer_preauthenticated_player_mob(original_mob, logout_mob)
 
 	if(QDELETED(src))

--- a/code/modules/client/login/new_player_preauth.dm
+++ b/code/modules/client/login/new_player_preauth.dm
@@ -1,21 +1,24 @@
-/mob/dead/new_player/pre_auth/proc/convert_to_authed()
+/proc/transfer_preauthenticated_player_mob(mob/source, mob/target)
 	if(IsAdminAdvancedProcCall())
-		log_admin_private("[key_name(usr)] attempted to auth bypass [key_name(src)] via convert_to_authed()")
+		log_admin_private("[key_name(usr)] attempted to auth bypass [key_name(source)] via transfer_preauthenticated_player_mob()")
 		return
-	if(QDELETED(client))
-		qdel(src)
+	if(isnewplayer(source) && QDELETED(source.client))
+		qdel(source)
 		return
-	var/mob/dead/new_player/authenticated/authed = new()
-	var/key = client.key
-	var/datum/tgui/login_window = SStgui.get_open_ui(src, client.tgui_login)
+	if(!ismob(target))
+		target = new /mob/dead/new_player/authenticated()
+	var/key = source.client.key
+	var/datum/tgui/login_window = SStgui.get_open_ui(source, source.client.tgui_login)
 	if(istype(login_window) && login_window.window?.id)
-		SStgui.force_close_window(src, login_window.window.id)
-	SStgui.on_transfer(src, authed)
-	authed.name = client.display_name()
-	authed.key = key
+		SStgui.force_close_window(source, login_window.window.id)
+	SStgui.on_transfer(source, target)
+	if(isnewplayer(target))
+		target.name = source.client.display_name()
+	target.key = key
 	if(istype(login_window) && login_window.window?.id)
-		SStgui.force_close_window(authed, login_window.window.id)
-	qdel(src)
+		SStgui.force_close_window(target, login_window.window.id)
+	if(isnewplayer(source))
+		qdel(source)
 
 /mob/dead/new_player/pre_auth/vv_edit_var(var_name, var_value)
 	return FALSE

--- a/code/modules/client/login/sessions.dm
+++ b/code/modules/client/login/sessions.dm
@@ -244,24 +244,15 @@
 		return FALSE
 
 	var/mob/logout_mob = GLOB.disconnected_mobs[src.key]
-	if(logged_in && istype(logout_mob))
+	if(ismob(logout_mob) && !isnewplayer(logout_mob))
 		var/mob/original_mob = src.mob
 		GLOB.disconnected_mobs -= src.key
-		var/datum/tgui/login_window = SStgui.get_open_ui(original_mob, src.tgui_login)
-		if(istype(login_window) && login_window.window?.id)
-			SStgui.force_close_window(src, login_window.window.id)
-		SStgui.on_transfer(original_mob, logout_mob)
-		logout_mob.key = src.key
-		if(istype(login_window) && login_window.window?.id)
-			SStgui.force_close_window(logout_mob, login_window.window.id)
-		if(isnewplayer(original_mob))
-			qdel(original_mob)
+		transfer_preauthenticated_player_mob(original_mob, logout_mob)
 	// Mob is ready
 	// calls /mob/dead/new_player/authenticated/Login()
 	// creates mind and such
 	else if(istype(my_mob, /mob/dead/new_player/pre_auth))
-		var/mob/dead/new_player/pre_auth/pre_auth_player = my_mob
-		pre_auth_player.convert_to_authed()
+		transfer_preauthenticated_player_mob(my_mob, null)
 
 	if(!client_post_login(TRUE, FALSE, !!(holder || GLOB.deadmins[ckey])))
 		return FALSE

--- a/code/modules/client/login/sessions.dm
+++ b/code/modules/client/login/sessions.dm
@@ -243,10 +243,23 @@
 	if(QDELETED(src))
 		return FALSE
 
+	var/mob/logout_mob = GLOB.disconnected_mobs[src.key]
+	if(logged_in && istype(logout_mob))
+		var/mob/original_mob = src.mob
+		GLOB.disconnected_mobs -= src.key
+		var/datum/tgui/login_window = SStgui.get_open_ui(original_mob, src.tgui_login)
+		if(istype(login_window) && login_window.window?.id)
+			SStgui.force_close_window(src, login_window.window.id)
+		SStgui.on_transfer(original_mob, logout_mob)
+		logout_mob.key = src.key
+		if(istype(login_window) && login_window.window?.id)
+			SStgui.force_close_window(logout_mob, login_window.window.id)
+		if(isnewplayer(original_mob))
+			qdel(original_mob)
 	// Mob is ready
 	// calls /mob/dead/new_player/authenticated/Login()
 	// creates mind and such
-	if(istype(my_mob, /mob/dead/new_player/pre_auth))
+	else if(istype(my_mob, /mob/dead/new_player/pre_auth))
 		var/mob/dead/new_player/pre_auth/pre_auth_player = my_mob
 		pre_auth_player.convert_to_authed()
 

--- a/code/modules/client/login/sessions.dm
+++ b/code/modules/client/login/sessions.dm
@@ -243,10 +243,10 @@
 	if(QDELETED(src))
 		return FALSE
 
-	var/mob/logout_mob = GLOB.disconnected_mobs[src.key]
+	var/mob/logout_mob = GLOB.disconnected_mobs[src.ckey]
 	if(ismob(logout_mob) && !isnewplayer(logout_mob))
 		var/mob/original_mob = src.mob
-		GLOB.disconnected_mobs -= src.key
+		GLOB.disconnected_mobs -= src.ckey
 		transfer_preauthenticated_player_mob(original_mob, logout_mob)
 	// Mob is ready
 	// calls /mob/dead/new_player/authenticated/Login()

--- a/code/modules/client/login/sessions.dm
+++ b/code/modules/client/login/sessions.dm
@@ -40,11 +40,11 @@
 	var/external_method_db = query_check_token.item[1]
 	var/external_uid = query_check_token.item[2]
 	var/external_display_name = query_check_token.item[3]
+	qdel(query_check_token)
 	var/new_key = ""
 	var/datum/external_login_method/external_method = GLOB.login_methods[external_method_db]
 	if(!istype(external_method) || isnull(external_uid))
 		to_chat_immediate(src, span_userdanger("Invalid login method: '[external_method_db]'."))
-		qdel(query_check_token)
 		return FALSE
 	var/list/existing_user = existing_user_for_uid(external_method, external_uid)
 	if(islist(existing_user) && length(existing_user) == 2) // External user has logged in before
@@ -66,16 +66,42 @@
 		else if(ckey(known_key) != known_ckey)
 			to_chat_immediate(src, span_userdanger("Your associated BYOND key ([known_key]) is inconsistent with your CKEY ([known_ckey]), which should be [ckey(known_key)]. This shouldn't be possible. Help."))
 			return FALSE
-		else
+		// External UID is associated with another account, but we verifiably own the current CKEY.
+		// Note that this occurs after checking if the old account is an external key - we can only unlink from BYOND CKEYs as unlinking an external key would break it.
+		else if(istext(src.byond_authenticated_key) && length(src.byond_authenticated_key) && ckey(src.byond_authenticated_key) != known_ckey)
+			// First let's let the admins know about the old CKEY.
+			message_admins("[key_name_admin(src)] is potentially multikeying. They connected under the BYOND Hub key <b>[byond_authenticated_key]</b>, but their [external_method::name] UID [external_uid] ([external_method.format_display_name(external_display_name)]) is already linked with the key <b>[known_key]</b>. Asking if they wish to unlink their [external_method::name] account from <b>[known_key]</b>.")
+			log_admin_private("POTENTIAL MULTIKEYING: [key_name(src)] authenticated with BYOND key [byond_authenticated_key] but their [external_method::name] UID [external_uid] ([external_method.format_display_name(external_display_name)]) is associated with the key [known_key]")
+			// Prompt user to unlink the external account from the other CKEY.
+			// If they choose not to unlink they will need a new external account to link and the login is cancelled.
+			var/link_choice = tgui_alert(src,
+				"Your [external_method::name] account is already associated with the CKEY \"[known_key]\". \
+				Would you like to unlink it from \"[known_key]\"?",
+				"Previous CKEY",
+				list("Unlink [known_key]", "Cancel Login")
+			)
+			if(link_choice != "Unlink [known_key]")
+				message_admins("[key_name_admin(src)] (authenticated by BYOND Hub as <b>[byond_authenticated_key]</b>) cancelled their login.")
+				return FALSE
+			var/external_column = external_method::db_id_column_name
+			if(!istext(external_column) || !length(external_column))
+				return FALSE
+			var/datum/db_query/query_update_external_uid = SSdbcore.NewQuery(
+				"UPDATE [format_table_name("player")] SET [external_column] = NULL WHERE ckey = :ckey",
+				list("ckey" = known_ckey)
+			)
+			query_update_external_uid.Execute()
+			var/msg = "You have unlinked your [external_method::name] account from the CKEY \"[known_key]\"."
+			to_chat_immediate(src, span_good(msg))
+			tgui_alert_async(src, msg, "Success", list("OK"))
+			qdel(query_update_external_uid)
+			message_admins("[key_name_admin(src)] (authenticated by BYOND Hub as <b>[byond_authenticated_key]</b>) unlinked [external_method::name] UID [external_uid] ([external_method.format_display_name(external_display_name)]) from the BYOND CKEY <b>[known_key]</b>. This is likely because they had a previous CKEY that is no longer used. Check that multikey policy is being followed.")
+			log_admin_private("[key_name(src)] (authenticated by BYOND HUB as [byond_authenticated_key]) unlinked [external_method::name] UID [external_uid] ([external_method.format_display_name(external_display_name)]) from the BYOND CKEY [known_key]")
+			new_key = src.byond_authenticated_key
+		else // The user just has a CKEY tied to this external UID and wants to sign into it. Expected use.
 			new_key = known_key
-			// Login CKEY and saved CKEY differ
-			if(istext(src.byond_authenticated_key) && length(src.byond_authenticated_key) && ckey(src.byond_authenticated_key) != known_ckey)
-				to_chat_immediate(src, span_userdanger("You connected with the key [byond_authenticated_key], but your [external_method::name] account is already linked to [known_key]! You have been signed in as [known_key]."))
-				message_admins("[key_name_admin(src)] is potentially multikeying. They connected under the BYOND key [byond_authenticated_key], but their [external_method::name] UID [external_uid] is already linked with the key [known_key].")
-				log_admin_private("POTENTIAL MULTIKEYING: [key_name(src)] connected with BYOND key [byond_authenticated_key] but their [external_method::name] UID [external_uid] is associated with the key [known_key]")
 	// More than one associated key. AHHHHHHHHHHHHHHHHHHHHHHHHHH
 	else if(isnum(existing_user) && existing_user == TRUE)
-		qdel(query_check_token)
 		var/message = "[key_name(src)] successfully authenticated with [external_method::name] UID [external_uid], but they have more than one associated CKEY!"
 		message_admins("[message] Tell a maintainer immedietaly!")
 		CRASH(message)
@@ -83,28 +109,15 @@
 		new_key = external_method.to_fake_key(external_uid)
 		if(istext(src.byond_authenticated_key) && length(src.byond_authenticated_key)) // they have a key already, let's associate it for them on login
 			new_key = src.byond_authenticated_key
-	if(length(new_key))
-		qdel(query_check_token)
+	if(length(new_key) && src.can_login_as(new_key) && src.byond_authenticated_update_external_uid(new_key, external_method, external_uid, external_display_name))
 		save_session_token(token)
 		return login_as(new_key, external_method, external_uid, external_display_name)
-	qdel(query_check_token)
 	return FALSE
 
-/// Equivalent of /client/New() for token login
-/// Fully migrates a user to the new key
-/client/proc/login_as(new_key, datum/external_login_method/external_method, external_uid, external_display_name)
-	if(IsAdminAdvancedProcCall())
-		log_admin_private("[key_name(usr)] attempted to log in [key_name(src)] as \"[new_key]\" (ckey: [ckey(new_key)])")
-		// WEEEWOOOWEEEEWOOOO
-		message_admins("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-		message_admins("Auth bypass attempted by [key_name(usr)] for [key_name(src)] (attempted CKEY: [ckey(new_key)])")
-		message_admins("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-		return FALSE
+/client/proc/can_login_as(new_key)
 	if(!CONFIG_GET(flag/enable_guest_external_auth))
 		return FALSE
 	if(logged_in)
-		return FALSE
-	if(!istype(external_method))
 		return FALSE
 	var/list/ban = world.IsBanned(new_key, src.address, src.computer_id, src.connection, FALSE, from_auth=TRUE)
 	if(islist(ban))
@@ -127,6 +140,80 @@
 		src << browse(HTML_SKELETON_TITLE("DANGER!", usr_msg), "window=multiconnect_notice")
 		spawn(5 SECONDS)
 			qdel(src)
+		return FALSE
+	return TRUE
+
+/// Allows BYOND authenticated users to relink their External UIDs.
+/// FALSE: No login allowed.
+/// TRUE: Continue
+/client/proc/byond_authenticated_update_external_uid(new_key, datum/external_login_method/external_method, external_uid, external_display_name)
+	if(IsAdminAdvancedProcCall())
+		return FALSE
+	if(IS_GUEST_KEY(new_key))
+		return FALSE
+	if(!SSdbcore.Connect())
+		return FALSE
+	if(!istype(external_method) || isnull(external_uid) || !length(external_uid))
+		return FALSE
+	if(external_method.is_fake_key(new_key))
+		return TRUE
+	// User has to have an authenticated key to overwrite their external UID.
+	// At this point we know that the external UID is not associated with any other account.
+	// We also know that the existing external UID only belongs to this authenticated CKEY
+	// So we can safely dissociate it and lose no data, as we know that the user who originally linked the account is just updating the link.
+	if(!istext(src.byond_authenticated_key) || !length(src.byond_authenticated_key))
+		// They didn't authenticate with BYOND, we can skip this check.
+		return TRUE
+	var/external_column = external_method::db_id_column_name
+	if(!istext(external_column) || !length(external_column))
+		return FALSE
+	// Check account linking assocation and update if they're BYOND authenticated
+	var/datum/db_query/query_current_external_uid = SSdbcore.NewQuery(
+		"SELECT [external_column] FROM [format_table_name("player")] WHERE ckey = :ckey",
+		list("ckey" = ckey(new_key))
+	)
+	if(!query_current_external_uid.Execute())
+		qdel(query_current_external_uid)
+		return FALSE
+	var/external_uid_from_db = null
+	if(query_current_external_uid.NextRow() && islist(query_current_external_uid.item) && length(query_current_external_uid.item) == 1)
+		external_uid_from_db = query_current_external_uid.item[1]
+	qdel(query_current_external_uid)
+	// CKEY doesn't exist in the database or has no associated external UID. We can associate it with the typical process.
+	if(isnull(external_uid_from_db) || !length(external_uid_from_db))
+		return TRUE
+	if(external_uid != external_uid_from_db)
+		var/formatted_display_name = external_method.format_display_name(external_display_name)
+		var/account_selection = tgui_alert(
+			src,
+			"Linking [external_method::name] account ID \"[external_uid]\" ([formatted_display_name]), \
+			will overwrite previous linked [external_method::name] account ID: \"[external_uid_from_db]\". \n\n\
+			Are you sure you want to unlink your previous [external_method::name] account?",
+			"Account Association",
+			list("Overwrite", "Cancel Login")
+		)
+		if(account_selection != "Overwrite")
+			return FALSE
+		var/datum/db_query/query_update_external_uid = SSdbcore.NewQuery(
+			"UPDATE [format_table_name("player")] SET [external_column] = :external_uid WHERE ckey = :ckey",
+			list("ckey" = ckey(new_key), "external_uid" = external_uid)
+		)
+		query_update_external_uid.Execute()
+		var/msg = "You have overwritten your account's associated [external_method::name] UID to [external_uid] ([external_method.format_display_name(external_display_name)])! Make sure you always log in with this [external_method::name] account from now on to retain your access."
+		to_chat_immediate(src, span_good(msg))
+		tgui_alert_async(src, msg, "Success", list("OK"))
+		qdel(query_update_external_uid)
+	return TRUE
+
+/// Equivalent of /client/New() for token login
+/// Fully migrates a user to the new key
+/client/proc/login_as(new_key, datum/external_login_method/external_method, external_uid, external_display_name)
+	if(IsAdminAdvancedProcCall())
+		log_admin_private("[key_name(usr)] attempted to log in [key_name(src)] as \"[new_key]\" (ckey: [ckey(new_key)])")
+		// WEEEWOOOWEEEEWOOOO
+		message_admins("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+		message_admins("Auth bypass attempted by [key_name(usr)] for [key_name(src)] (attempted CKEY: [ckey(new_key)])")
+		message_admins("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 		return FALSE
 	token_attempts = 0
 	remove_verb(/client/verb/get_token)

--- a/code/modules/client/login/sessions.dm
+++ b/code/modules/client/login/sessions.dm
@@ -230,7 +230,7 @@
 	src.external_uid = external_uid
 	src.external_display_name = external_display_name
 
-	log_access("Authentication: [key_name(src)] has authenticated as [new_key] (ckey: [ckey]) using [external_method] ID [external_uid]")
+	log_access("Authentication: [key_name(src)] has authenticated as [new_key] (ckey: [ckey(new_key)]) using [external_method] ID [external_uid]")
 	GLOB.directory -= src.ckey
 	var/mob/my_mob = src.mob
 	src.ckey = ckey

--- a/code/modules/client/login/sessions.dm
+++ b/code/modules/client/login/sessions.dm
@@ -164,6 +164,9 @@
 	if(!istext(src.byond_authenticated_key) || !length(src.byond_authenticated_key))
 		// They didn't authenticate with BYOND, we can skip this check.
 		return TRUE
+	// We can only update it if they're actually signing in with their BYOND authenticated key.
+	if(ckey(src.byond_authenticated_key) != ckey(new_key))
+		return TRUE // this check can't be hit at the time of writing, but may be necessary in the future
 	var/external_column = external_method::db_id_column_name
 	if(!istext(external_column) || !length(external_column))
 		return FALSE

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -22,9 +22,6 @@
 	if(!. || !client)
 		return FALSE
 
-	if(client.logged_in && client.external_uid)
-		to_chat(src, span_good("Successfully signed in as [span_bold("[client.display_name_chat()]")]"))
-
 	var/motd = global.config.motd
 	if(motd)
 		to_chat(src, "<div class=\"motd\">[motd]</div>", handle_whitespace=FALSE, allow_linkify = TRUE)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -33,20 +33,17 @@
 	// Both clients will get deleted which should ensure nobody uses a mob they don't have access to...
 	if(!istype(src, /mob/dead/new_player/pre_auth) && !client.logged_in)
 		var/msg = "/mob/Login() was called on [key_name(src)] without the assigned client being authenticated! Possible auth bypass! Caller: [key_name(usr)]"
-		log_admin_private(msg)
+		var/report_info = "Round ID: [GLOB.round_id] \n\
+		CKEY: [client.ckey] \n\
+		Key: [client.key] \n\
+		BYOND Authenticated Key: [client.byond_authenticated_key] \n\
+		External UID: [client.external_uid] \n\
+		Mob Type: [src.type] \n\
+		Mob Name: [src.name]"
+		log_admin_private("[msg]\n[report_info]")
+		send2tgs("Auth", "[msg]\n[report_info]")
 		message_admins(msg) // just so it's more likely to get reported to maints
-		client << browse(HTML_SKELETON_TITLE("Login Error", "<h2>Danger!</h2><p>You were logged into your mob without fully authenticating. Please report this issue to maintainers. \
-		Do not post the contents of this message in a public channel, as they may contain your private information (CID & IP).<br><br>\
-		Round ID: [GLOB.round_id]<br>\
-		Connecting IP: [client.address]<br>\
-		Connecting CID: [client.computer_id]<br>\
-		CKEY: [client.ckey]<br>\
-		Key: [client.key]<br>\
-		BYOND Authenticated Key: [client.byond_authenticated_key]<br>\
-		External UID: [client.external_uid]<br>\
-		Mob Type: [src.type]<br>\
-		Mob Name: [src.name]<br>\
-		</p>"))
+		client << browse(HTML_SKELETON_TITLE("Login Error", "<h2>Danger!</h2><p>You were logged into your mob without fully authenticating. Please report this issue to maintainers.</p><br><br><pre>[report_info]</pre>"))
 		spawn(1)
 			qdel(client)
 		. = FALSE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -40,7 +40,7 @@
 		External UID: [client.external_uid] \n\
 		Mob Type: [src.type] \n\
 		Mob Name: [src.name]"
-		log_admin_private("[msg]\n[report_info]")
+		log_access("[msg]\n[report_info]")
 		send2tgs("Auth", "[msg]\n[report_info]")
 		message_admins(msg) // just so it's more likely to get reported to maints
 		client << browse(HTML_SKELETON_TITLE("Login Error", "<h2>Danger!</h2><p>You were logged into your mob without fully authenticating. Please report this issue to maintainers.</p><br><br><pre>[report_info]</pre>"))

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -29,6 +29,28 @@
 /mob/Login()
 	if(!client)
 		return FALSE
+	// This can happen in some cases, mainly when a client logs in with the same CKEY as another client
+	// Both clients will get deleted which should ensure nobody uses a mob they don't have access to...
+	if(!istype(src, /mob/dead/new_player/pre_auth) && !client.logged_in)
+		var/msg = "/mob/Login() was called on [key_name(src)] without the assigned client being authenticated! Possible auth bypass! Caller: [key_name(usr)]"
+		log_admin_private(msg)
+		message_admins(msg) // just so it's more likely to get reported to maints
+		client << browse(HTML_SKELETON_TITLE("Login Error", "<h2>Danger!</h2><p>You were logged into your mob without fully authenticating. Please report this issue to maintainers. \
+		Do not post the contents of this message in a public channel, as they may contain your private information (CID & IP).<br><br>\
+		Round ID: [GLOB.round_id]<br>\
+		Connecting IP: [client.address]<br>\
+		Connecting CID: [client.computer_id]<br>\
+		CKEY: [client.ckey]<br>\
+		Key: [client.key]<br>\
+		BYOND Authenticated Key: [client.byond_authenticated_key]<br>\
+		External UID: [client.external_uid]<br>\
+		Mob Type: [src.type]<br>\
+		Mob Name: [src.name]<br>\
+		</p>"))
+		spawn(1)
+			qdel(client)
+		. = FALSE
+		CRASH(msg)
 	// set_eye() is important here, because your eye doesn't know if you're using them as your eye
 	// FALSE when weakref doesn't exist, to prevent using their current eye
 	client.set_eye(client.eye, client.eye_weakref?.resolve() || FALSE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -29,6 +29,8 @@
 	remove_from_dead_mob_list()
 	remove_from_alive_mob_list()
 	remove_from_mob_suicide_list()
+	remove_from_disconnected_mob_list()
+
 	focus = null
 	if(length(progressbars))
 		stack_trace("[src] destroyed with elements in its progressbars list")

--- a/code/modules/mob/mob_lists.dm
+++ b/code/modules/mob/mob_lists.dm
@@ -33,9 +33,9 @@
 ///Removes a mob references from the list of external logout mobs
 /mob/proc/remove_from_disconnected_mob_list()
 	var/saved_key = null
-	for(var/key in GLOB.disconnected_mobs)
-		if(GLOB.disconnected_mobs[key] == src)
-			saved_key = key
+	for(var/ckey in GLOB.disconnected_mobs)
+		if(GLOB.disconnected_mobs[ckey] == src)
+			saved_key = ckey
 			break
 	if(!isnull(saved_key))
 		GLOB.disconnected_mobs -= saved_key

--- a/code/modules/mob/mob_lists.dm
+++ b/code/modules/mob/mob_lists.dm
@@ -30,6 +30,16 @@
 /mob/proc/remove_from_mob_suicide_list()
 	GLOB.suicided_mob_list -= src
 
+///Removes a mob references from the list of external logout mobs
+/mob/proc/remove_from_disconnected_mob_list()
+	var/saved_key = null
+	for(var/key in GLOB.disconnected_mobs)
+		if(GLOB.disconnected_mobs[key] == src)
+			saved_key = key
+			break
+	if(!isnull(saved_key))
+		GLOB.disconnected_mobs -= saved_key
+
 ///Adds the mob reference to the list of all the dead mobs. If mob is cliented, it adds it to the list of all dead player-mobs.
 /mob/proc/add_to_dead_mob_list()
 	if(QDELETED(src))

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -22,7 +22,6 @@ GLOBAL_LIST_EMPTY(tgui_panels)
 	owner_ckey = ckey(client.ckey)
 	window = new(client, id)
 	window.subscribe(src, PROC_REF(on_message))
-	GLOB.tgui_panels += src
 
 /datum/tgui_panel/Del()
 	window.unsubscribe(src)

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_EMPTY(tgui_panels)
 	owner_ckey = ckey(client.ckey)
 	window = new(client, id)
 	window.subscribe(src, PROC_REF(on_message))
+	GLOB.tgui_panels += src
 
 /datum/tgui_panel/Del()
 	window.unsubscribe(src)

--- a/tgui/packages/tgui/interfaces/GameLogin.tsx
+++ b/tgui/packages/tgui/interfaces/GameLogin.tsx
@@ -48,11 +48,10 @@ export const GameLogin = (props) => {
                 </Box>
                 {data.authenticated_key ? (
                   <Box my={1}>
-                    Server policy requires that you authorize through Discord due to ongoing authentication issues with BYOND
-                    Hub. Your Discord account will be linked to this CKEY.
+                    Server policy requires that you link a second account to your CKEY due to ongoing sign-on issues with BYOND.
                   </Box>
                 ) : null}
-                <Box>
+                <Box mt={2.5}>
                   {`${
                     data.byond_enabled && !data.authenticated_key
                       ? ' Reconnect after signing into your BYOND account or '
@@ -91,7 +90,7 @@ export const GameLogin = (props) => {
                       />
                     </Stack.Item>
                     <Stack.Item>
-                      <Button py={0.95} onClick={() => sendToken(inputToken.current)}>
+                      <Button py={0.8} onClick={() => sendToken(inputToken.current)}>
                         Submit
                       </Button>
                     </Stack.Item>

--- a/tgui/packages/tgui/interfaces/GameLogin.tsx
+++ b/tgui/packages/tgui/interfaces/GameLogin.tsx
@@ -47,10 +47,9 @@ export const GameLogin = (props) => {
                   .
                 </Box>
                 {data.authenticated_key ? (
-                  <Box>
+                  <Box my={1}>
                     Server policy requires that you authorize through Discord due to ongoing authentication issues with BYOND
-                    Hub. Your Discord account will be permanently linked to this CKEY. You may not link more than one CKEY to a
-                    Discord account.
+                    Hub. Your Discord account will be linked to this CKEY.
                   </Box>
                 ) : null}
                 <Box>

--- a/tgui/packages/tgui/styles/themes/login.scss
+++ b/tgui/packages/tgui/styles/themes/login.scss
@@ -25,6 +25,14 @@ $title-bar-height: 48px;
     '../components/Button.scss',
     $with: ('color-default': black, 'border-radius': 0.16em, 'color-transparent-text': rgba(227, 240, 255, 0.75))
   );
+  .Button--color--default {
+    box-sizing: content-box;
+    border: 1px solid #100f0edd;
+  }
+  .Button--color--default:focus {
+    border: 1px solid #404040;
+    transition: color 100ms, background-color 100ms, border 100ms;
+  }
   @include meta.load-css(
     '../components/ColorSelectBox.scss',
     $with: ('color-default': color.scale($generic, $lightness: -20%))
@@ -46,6 +54,12 @@ $title-bar-height: 48px;
     '../components/Input.scss',
     $with: ('border-color': #100f0edd, 'background-color': black, 'input-height': 30px, 'font-size': 12px)
   );
+  .Input {
+    transition: border-color 0.05s linear;
+  }
+  .Input:focus-within {
+    border-color: #404040;
+  }
 
   // Layouts
   @include meta.load-css('../layouts/Layout.scss');


### PR DESCRIPTION
## About The Pull Request

Improvements and bugfixes for #12927

### Reassociation & Unlinking

Allows users who sign in directly with an authenticated BYOND account to change their linked Discord accounts. This works because we know the user owns both the CKEY they log in as and the Discord account they sign into.

If a BYOND-authenticated user signs in with a Discord that is already linked to another _real BYOND CKEY_ (Discord CKEYs not allowed), they can unlink it from that previous real BYOND CKEY. Note that this sends a warning to administrators and is a logged action, because it likely means they are multikeying or had an account that they no longer use. This appears to common enough that allowing it is likely not an issue, because admins will have banned their previous CKEYs already.

Furthermore, if a user is BYOND-authenticated, and signs in with a Discord account, but already has a different Discord account linked to their BYOND-authenticated CKEY, they can overwrite the linked Discord. No other class of user can do this, only ones who sign in directly with BYOND and then use a different Discord account than the one already linked.

### Mob Login Changes

Anytime a logged in client disconnects, their current mob's key will now be set to `@DC@Original Key`. This prevents the mob from immediately being assigned to a newly connecting player with that CKEY. The mob is then added to `GLOB.disconnected_mobs` and associated with its key.

When a client is created, it checks if its mob is bypassing authentication and reassigns itself a preauth new player. This will prevent the client from skipping authentication.

When the client is fully logged in, it checks `GLOB.disconnected_mobs` for a mob associated with its key and assigns it to the player. Otherwise, they are given an authenticated new player mob.

Adds a check if BYOND auth is disabled to prevent connections from actively playing CKEYs, it's impossible to verify them and you cannot change the CKEY prior to connection. Connecting under a CKEY that is currently in use, but not necessarily authorized, immediately deletes the previous player's client, which is problematic if BYOND auth is off. This still happens if you connect using your same CKEY, but it's acceptable because the pager should block connections that aren't from your genuine CKEY, so the only person you'd be kicking is yourself.

### Other Changes

Additionally, I removed some unnecessary validation as `::` is more than enough to ensure a value cannot be tampered with.

Splits some logic out into the proc `can_login_as` instead of having it at the top of `login_as`. This is helpful because the user's client will not save session tokens that they cannot log into anymore.

Improves Game login panel a bit and simplifies it to not confuse users.

## Why It's Good For The Game

Less confusion, let players manage their own accounts if they can. This doesn't cause any loss of data and just allows users to maintain which Discord account they want to use while signed into BYOND Hub.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

### Single Conflict Example (Previous Discord)

#### Prompt with Database

![image](https://github.com/user-attachments/assets/b1a9e8ce-2a76-41d4-93bf-c6eb8ba7d535)

#### Done!

![image](https://github.com/user-attachments/assets/7aa9b912-b499-4afc-bbb9-294ed098ff57)

#### Database (After)

![image](https://github.com/user-attachments/assets/aba583df-26c6-4bc8-91e9-56f1bc7bda72)



### Dual Conflict Example (Old CKEY with Current Discord + Previous Discord)

#### Step 1 w/ Database

![heidisql_qDhR8AMVqC](https://github.com/user-attachments/assets/07b5a6ca-d32d-499c-ae05-dc365b46a7d4)

#### After Step 1 See database. Step 2

![heidisql_afuGeIIhDY](https://github.com/user-attachments/assets/56aff296-ea38-4f16-85b7-080709212763)

#### Step 3 notice

![dreamseeker_YEsD9gBtmQ](https://github.com/user-attachments/assets/3a488759-48e7-4983-8164-3369ea05241d)

#### Final database

![heidisql_6TyZhKfqof](https://github.com/user-attachments/assets/c0ace49b-55ed-4c6a-b3b8-689d41d0bd89)


</details>

## Changelog
:cl:
add: You can now relink authenticated BYOND accounts to new Discord accounts at will, and unlink your Discord account from an old CKEY.
fix: Fixed unhelpful error message when using a Discord account that is already linked to a different CKEY, or a CKEY already linked to a different Discord than the one you signed in with.
tweak: Adjusted the information given in the login panel to be more useful and easier to understand.
tweak: Improved the look of the login panel's manual token entry input and submit button.
fix: When reconnecting, it is no longer possible to be assigned a mob that you aren't authorized to use / logged into.
admin: Disconnected user's mobs will now have their key changed to @DC@Original Key
/:cl:
