### PR TITLE
Small clown inventory changes

### DIFF
--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -217,7 +217,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4
-	distribute_pressure = 24
+	distribute_pressure = 17
 	volume = 1
 
 /obj/item/tank/internals/emergency_oxygen/clown/populate_gas()

--- a/code/game/objects/structures/crates_lockers/crates/wooden.dm
+++ b/code/game/objects/structures/crates_lockers/crates/wooden.dm
@@ -15,7 +15,6 @@
 
 /obj/structure/closet/crate/wooden/toy/PopulateContents()
 	. = ..()
-	new	/obj/item/megaphone/clown(src)
 	new	/obj/item/reagent_containers/cup/soda_cans/canned_laughter(src)
 	new /obj/item/pneumatic_cannon/pie(src)
 	new /obj/item/food/pie/cream(src)

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -53,6 +53,8 @@
 		/obj/item/reagent_containers/spray/waterflower = 1,
 		/obj/item/food/grown/banana = 1,
 		/obj/item/instrument/bikehorn = 1,
+		/obj/item/obj/item/food/pie/cream = 1,
+		/obj/item/megaphone/clown = 1,
 		)
 
 	implants = list(/obj/item/implant/sad_trombone)

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -53,7 +53,7 @@
 		/obj/item/reagent_containers/spray/waterflower = 1,
 		/obj/item/food/grown/banana = 1,
 		/obj/item/instrument/bikehorn = 1,
-		/obj/item/obj/item/food/pie/cream = 1,
+		/obj/item/food/pie/cream = 1,
 		/obj/item/megaphone/clown = 1,
 		)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives all clowns a pie and a clown megaphone in their backpack so they do not depend on prior station clowns or crewmembers not looting all goodies to be able to do fun stuff, and fixes the emergency prank tank making you go to sleep due to a very high pressure in the tank.

## Why It's Good For The Game

It's kind of frustrating latejoining to not see any pie or megaphone avaiable, and is even more frustrating the emergency tank just making you go to sleep when you activate it. Also, more mayhem if a lot of clowns join, which is funny.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/a0d28f30-4ba5-4954-a79c-6de843d12d6d)

## Changelog
:cl:
add: Added a clown megaphone and a pie to all clowns in their backpack.
fix: Fixed the clown emergency tank being set to a pressure  by default that just made you go to sleep.
remove: Removed the clown megaphone from the toy crate

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
