### PR TITLE
Skin cleanup & Issue fixes

### DIFF
--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -9,9 +9,6 @@
 		if (value)
 			// Delete the menu
 			winset(client, "mainwindow", "menu=\"\"")
-			// Switch to the cool status bar
-			winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
-			winset(client, "status_bar_wide", "is-visible=false")
 			// Switch to fullscreen mode
 			winset(client, "mainwindow","titlebar=false")
 			winset(client, "mainwindow","can-resize=false")
@@ -26,10 +23,6 @@
 		else
 			// Restore the menu
 			winset(client, "mainwindow", "menu=\"menu\"")
-			// Switch to the lame status bar
-			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
-			winset(client, "status_bar", "is-visible=false")
-			winset(client, "status_bar_wide", "is-visible=true")
 			// Exit fullscreen mode
 			winset(client, "mainwindow","titlebar=true")
 			winset(client, "mainwindow","can-resize=true")
@@ -39,13 +32,8 @@
 	else
 		if(value)
 			winset(client, "mainwindow", "menu=;is-fullscreen=true")
-			winset(client, "status_bar_wide", "is-visible=false")
-			winset(client, "mainwindow", "on-status=\".winset \\\"\[\[*]]=\\\"\\\" ? status_bar.text=\[\[*]] status_bar.is-visible=true : status_bar.is-visible=false\\\"\"")
 		else
 			winset(client, "mainwindow", "menu=\"menu\";is-fullscreen=false")
-			winset(client, "status_bar_wide", "is-visible=true")
-			winset(client, "mainwindow", "on-status=\".winset \\\"status_bar_wide.text = \[\[*]]\\\"\"")
-			winset(client, "status_bar", "is-visible=false")
 
 		if(client.fully_created)
 			INVOKE_ASYNC(client, TYPE_PROC_REF(/client, fit_viewport))

--- a/code/modules/client/preferences/entries/player/fullscreen.dm
+++ b/code/modules/client/preferences/entries/player/fullscreen.dm
@@ -6,39 +6,16 @@
 
 /datum/preference/toggle/fullscreen/apply_to_client(client/client, value)
 	if(client.byond_version <= 515 || client.byond_build <= 1630)
-		if (value)
-			// Delete the menu
-			winset(client, "mainwindow", "menu=\"\"")
-			// Switch to fullscreen mode
-			winset(client, "mainwindow","titlebar=false")
-			winset(client, "mainwindow","can-resize=false")
-			// Set it to minimized first because otherwise it doesn't enter fullscreen properly
-			// This line is important, and the game won't properly enter fullscreen mode otherwise
-			winset(client, "mainwindow","is-minimized=true")
-			winset(client, "mainwindow","is-maximized=true")
-			// Set the main window's size
-			winset(client, null, "split.size=mainwindow.size")
-			// Fit the viewport
-			INVOKE_ASYNC(client, TYPE_PROC_REF(/client, fit_viewport))
-		else
-			// Restore the menu
-			winset(client, "mainwindow", "menu=\"menu\"")
-			// Exit fullscreen mode
-			winset(client, "mainwindow","titlebar=true")
-			winset(client, "mainwindow","can-resize=true")
-			winset(client, "mainwindow","is-maximized=true")
-			// Fix the mapsize, turning off statusbar doesn't update scaling
-			INVOKE_ASYNC(src, PROC_REF(fix_mapsize), client)
+		return
+	if(value)
+		winset(client, "mainwindow", "menu=;is-fullscreen=true")
 	else
-		if(value)
-			winset(client, "mainwindow", "menu=;is-fullscreen=true")
-		else
-			winset(client, "mainwindow", "menu=\"menu\";is-fullscreen=false")
+		winset(client, "mainwindow", "menu=\"menu\";is-fullscreen=false")
 
-		if(client.fully_created)
-			INVOKE_ASYNC(client, TYPE_PROC_REF(/client, fit_viewport))
-		else
-			addtimer(CALLBACK(client, TYPE_PROC_REF(/client, fit_viewport), 1 SECONDS))
+	if(client.fully_created)
+		INVOKE_ASYNC(client, TYPE_PROC_REF(/client, fit_viewport))
+	else
+		addtimer(CALLBACK(client, TYPE_PROC_REF(/client, fit_viewport), 1 SECONDS))
 
 /datum/preference/toggle/fullscreen/proc/fix_mapsize(client/client)
 	var/windowsize = winget(client, "split", "size")

--- a/code/~overrides/quickstart.dm
+++ b/code/~overrides/quickstart.dm
@@ -10,6 +10,6 @@
 /datum/controller/subsystem/job/AssignRole(mob/dead/new_player/player, rank, latejoin = FALSE)
 	. = ..(player, "Debug Job", rank, latejoin)
 
-/mob/dead/new_player
+/mob/dead/new_player/authenticated
 	ready = TRUE
 #endif

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -77,7 +77,7 @@ menu "menu"
 window "mainwindow"
 	elem "mainwindow"
 		type = MAIN
-		pos = 281,0
+		pos = 0,0
 		size = 640x440
 		anchor1 = -1,-1
 		anchor2 = -1,-1
@@ -128,7 +128,7 @@ window "mainwindow"
 window "mapwindow"
 	elem "mapwindow"
 		type = MAIN
-		pos = 281,0
+		pos = 0,0
 		size = 640x480
 		anchor1 = -1,-1
 		anchor2 = -1,-1

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -77,10 +77,10 @@ menu "menu"
 window "mainwindow"
 	elem "mainwindow"
 		type = MAIN
-		pos = 372,0
+		pos = 281,0
 		size = 640x440
-		anchor1 = 0,0
-		anchor2 = 100,100
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		background-color = none
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
@@ -88,13 +88,10 @@ window "mainwindow"
 		macro = "default"
 		menu = "menu"
 		statusbar = false
-		on-status = ".winset \"status_bar_wide.text = [[*]]\""
-		outer-size = 656x518
-		inner-size = 640x459
 	elem "split"
 		type = CHILD
 		pos = 0,0
-		size = 640x424
+		size = 640x440
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = none
@@ -102,17 +99,6 @@ window "mainwindow"
 		left = "mapwindow"
 		right = "infowindow"
 		is-vert = true
-	elem "status_bar_wide"
-		type = LABEL
-		pos = 0,424
-		size=640x16
-		anchor1 = 0,100
-		anchor2 = 100,100
-		text = ""
-		align = left
-		background-color = #ffffff
-		text-color = #222222
-		border = sunken
 	elem "asset_cache_browser"
 		type = BROWSER
 		pos = 0,0
@@ -144,13 +130,11 @@ window "mapwindow"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = 0,0
-		anchor2 = 100,100
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
-		outer-size = 656x538
-		inner-size = 640x499
 	elem "map"
 		type = MAP
 		pos = 0,0
@@ -163,30 +147,17 @@ window "mapwindow"
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"
 		style=".center { text-align: center; } .small-icon IMG.icon {width: 16px; height: 16px} .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 9px; } .extremelybig { font-size: 10px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clowntext { color: #FF69Bf !important; font-size: 9px;  font-weight: bold; } .megaphone { font-size: 9px; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; } .emote { font-size: 6px; }"
-	elem "status_bar"
-		type = LABEL
-		pos = 0,464
-		size = 280x16
-		anchor1 = 0,100
-		is-visible = false
-		text = ""
-		align = left
-		background-color = #222222
-		text-color = #ffffff
-		border = line
 
 window "infowindow"
 	elem "infowindow"
 		type = MAIN
-		pos = 281,0
+		pos = 0,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = 0,0
+		anchor2 = 100,100
 		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
-		outer-size = 656x538
-		inner-size = 640x499
 	elem "discord"
 		type = BUTTON
 		pos = 607,5
@@ -282,15 +253,13 @@ window "infowindow"
 window "outputwindow"
 	elem "outputwindow"
 		type = MAIN
-		pos = 281,0
+		pos = 0,0
 		size = 640x960
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
-		outer-size = 656x1017
-		inner-size = 640x979
 	elem "input"
 		type = INPUT
 		pos = 0,940


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cleans up the Byond skin while trying to fix some issues with it we have been having:
- Removes the status bar, since this is completely pointless now that we have the context tips, and used up screen space for something totally useless.
- Cleans up some parts of the skin we have that don't really make much sense, as these are likely causing issues with 516.

During the creation of this PR, I looked at https://github.com/tgstation/tgstation/blob/master/interface/skin.dmf and took some elements of the code from it. Particularly the size of -1, -1. This was necessary as the Byond documentation is pretty lacking for skins, so I needed some examples from other codebases.

Fullscreen mode is no longer supported in 515, I just couldn't get Byond not to start growing voids at the bottom of the screen as setting the size will just completely mess the entire window up. Since we are on the path of phasing out 515 anyway, I don't think this is a big deal.

## Why It's Good For The Game

Cleans up the interface and hopefully fixes some issues that we have been having.

## Testing Photographs and Procedure

Since the issue with chat going off screen and the black bar appearing happens on and off and cannot be consistently reproduced, I will be testmerging this to ensure that the issue has actually been resolved.

516:

![image](https://github.com/user-attachments/assets/be038d96-5dc3-447f-82e5-2a3205641744)

![image](https://github.com/user-attachments/assets/b1b0fa54-d949-425c-ac3d-6e597cf8f1a9)

## Changelog
:cl:
fix: Fixes chat going off screen and a black bar appearing at the bottom of the screen
del: Removes the status bar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
