### PR TITLE
More granular metric client counts

### DIFF
--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -44,8 +44,8 @@ SUBSYSTEM_DEF(metrics)
 	out["elapsed_real"] = (REALTIMEOFDAY - world_init_time)
 	/// Current number of clients in the game
 	out["client_count"] = length(GLOB.clients_unsafe)
-	/// Current number of players who have joined as a standard job
-	out["crew_count"] = length(GLOB.joined_player_list)
+	/// Total number of players who have joined as a standard job
+	out["total_crew"] = length(GLOB.joined_player_list)
 	var/player_count = 0
 	var/living_count = 0
 	var/observer_count = 0

--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -46,16 +46,18 @@ SUBSYSTEM_DEF(metrics)
 	out["client_count"] = length(GLOB.clients_unsafe)
 	/// Current number of players who have joined as a standard job
 	out["crew_count"] = length(GLOB.joined_player_list)
-	/// Current number of players who are observers
-	out["observer_count"] = length(GLOB.dead_mob_list)
 	var/player_count = 0
 	var/living_count = 0
+	var/observer_count = 0
 	for (var/mob/player in GLOB.player_list)
 		if (isliving(player))
 			living_count ++
 			player_count ++
 		if (isobserver(player))
 			player_count ++
+			observer_count ++
+	/// Current number of players who are observers
+	out["observer_count"] = observer_count
 	/// Current number of players who are either observing or playing
 	out["player_count"] = player_count
 	/// Current number of players who are alive

--- a/code/modules/client/login/client_login.dm
+++ b/code/modules/client/login/client_login.dm
@@ -5,6 +5,8 @@
 	if(connection != "seeker" && connection != "web")//Invalid connection type.
 		return null
 
+	SSmetrics.unauthenticated_connections |= computer_id
+
 #ifdef DISABLE_BYOND_AUTH
 	if(is_localhost() && CONFIG_GET(flag/localhost_auth_bypass))
 		logged_in = TRUE
@@ -299,6 +301,10 @@
 		spawn(2 SECONDS) // wait a sec for the client to send a valid token
 			if(!src.logged_in) // client did not send a valid token in the last 2 seconds
 				tgui_login?.open()
+
+	/// Record the authentication
+	if(authenticated)
+		SSmetrics.authenticated_connections |= ckey
 
 	//Load the TGUI stat in case of TGUI subsystem not ready (startup)
 	mob.UpdateMobStat(TRUE)


### PR DESCRIPTION
Introduces tracking for authenticated and unauthenticated player connections, as well as new metrics for crew, observer, living, and total player counts. Updates metrics subsystem and client login to record and expose these statistics for improved monitoring.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Improves the detail of player metrics. This allows us to more closely monitor the population of the server through the metrics system, as we would be able to distinguish different types of behaviour from players.

The following information has been added:
- Client count: Number of clients currently connected, including unauthenticated
- Total crew: Number of players who have joined at roundstart
- Observer count: Number of clients who are currently observers and connected
- Player count: Number of currently connected clients who have made it past the main menu
- Living count: Number of currently connected clients who are playing a living mob
- Total unique hardware connections: Total number of unauthenticated connections to the server throughout the round
- Total authenticated connections: Total number of authenticated connections throughout the round

## Why It's Good For The Game

This data is very useful for high-level decision making and strategy.

## Testing Photographs and Procedure

Calling get metric json:

```
"client_count":1,"total_crew":0,"observer_count":0,"player_count":0,"living_count":0,"total_unique_hardware_connections":1,"total_authenticated_connections":1,
```

After joining the game:
```
client_count":1,"total_crew":1,"observer_count":0,"player_count":1,"living_count":1,"total_unique_hardware_connections":1,"total_authenticated_connections":1
```

After dying:
```
"client_count":1,"total_crew":1,"observer_count":1,"player_count":1,"living_count":0,"total_unique_hardware_connections":1,"total_authenticated_connections":1
```

## Changelog
:cl:
tweak: Adds additional granularity to the metric's player count reporting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
