### PR TITLE
Station objective Selection Rework

### DIFF
--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -7,6 +7,10 @@ GLOBAL_VAR(survivor_report) //! Contains shared survivor report for roundend rep
 GLOBAL_VAR_INIT(wavesecret, 0) //! meteor mode, delays wave progression, terrible name
 GLOBAL_DATUM(start_state, /datum/station_state) //! Used in round-end report
 
+GLOBAL_VAR_INIT(station_goal_selection_open, FALSE) //Stores whether the station goal selection menu is open.
+GLOBAL_VAR(selected_station_goal) //Stores the currently selected station goal. Initialized to null by default.
+
+
 //TODO clear this one up too
 GLOBAL_DATUM(cult_narsie, /obj/eldritch/narsie)
 

--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -8,8 +8,7 @@ GLOBAL_VAR_INIT(wavesecret, 0) //! meteor mode, delays wave progression, terribl
 GLOBAL_DATUM(start_state, /datum/station_state) //! Used in round-end report
 
 GLOBAL_VAR_INIT(station_goal_selection_open, FALSE) //Stores whether the station goal selection menu is open.
-GLOBAL_VAR(selected_station_goal) //Stores the currently selected station goal. Initialized to null by default.
-
+GLOBAL_VAR(selected_station_goal)//Stores the currently selected station goal. Initialized to null by default.
 
 //TODO clear this one up too
 GLOBAL_DATUM(cult_narsie, /obj/eldritch/narsie)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -759,60 +759,60 @@
 		rev.remove_revolutionary(TRUE)
 
 /datum/game_mode/proc/generate_station_goals()
-    GLOB.station_goal_selection_open = TRUE
-    GLOB.selected_station_goal = null
-    //Comms Message
-    var/datum/comm_message/msg = new
-    msg.title = "Nanotrasen Directive Selection"
-    msg.content = "Command staff must select a station directive within 20 minutes. Failure to do so will result in automatic assignment."
-    //Setup options
-    for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
-        if(config_tag in initial(G.gamemode_blacklist))
-            continue
-        msg.possible_answers += list("[initial(G.type)]" = "[initial(G.name)]") //tgui will convert the typepath to text regardless
-    //Await answer
-    msg.answer_callback = CALLBACK(src, PROC_REF(station_goal_selected), msg)
-    SScommunications.send_message(msg, unique=TRUE)
+	GLOB.station_goal_selection_open = TRUE
+	GLOB.selected_station_goal = null
+	//Comms Message
+	var/datum/comm_message/msg = new
+	msg.title = "Nanotrasen Directive Selection"
+	msg.content = "Command staff must select a station directive within 20 minutes. Failure to do so will result in automatic assignment."
+	//Setup options
+	for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
+		if(config_tag in initial(G.gamemode_blacklist))
+			continue
+		msg.possible_answers += list("[initial(G.type)]" = "[initial(G.name)]") //tgui will convert the typepath to text regardless
+	//Await answer
+	msg.answer_callback = CALLBACK(src, PROC_REF(station_goal_selected), msg)
+	SScommunications.send_message(msg, unique=TRUE)
 
-    // Set up a timer to automatically select a random goal after 20 minutes
-    addtimer(CALLBACK(src, PROC_REF(select_random_station_goal), msg), 20 SECONDS)
+	// Set up a timer to automatically select a random goal after 20 minutes
+	addtimer(CALLBACK(src, PROC_REF(select_random_station_goal), msg), 20 SECONDS)
 
 /datum/game_mode/proc/station_goal_selected(var/datum/comm_message/msg)
-    if(!GLOB.station_goal_selection_open)
-        // If a goal has already been selected automatically inform the player.
-        var/datum/comm_message/already_selected_msg = new
-        already_selected_msg.title = "Directive Assigned"
-        already_selected_msg.content = "Station directive has already been assigned by Central Command. Your selection was not taken into account." // You were too late, tell them their selection wont do anything.
-        SScommunications.send_message(already_selected_msg, unique=TRUE)
-        return // Prevent them from actually selecting a goal
+	if(!GLOB.station_goal_selection_open)
+		// If a goal has already been selected automatically inform the player.
+		var/datum/comm_message/already_selected_msg = new
+		already_selected_msg.title = "Directive Assigned"
+		already_selected_msg.content = "Station directive has already been assigned by Central Command. Your selection was not taken into account." // You were too late, tell them their selection wont do anything.
+		SScommunications.send_message(already_selected_msg, unique=TRUE)
+		return // Prevent them from actually selecting a goal
 
-    //Grab our choosen station goal
-    var/datum/station_goal/selected = text2path(msg.answered)
-    //Send it
-    selected = new selected
-    station_goals += selected
-    selected.prepare_report()
+	//Grab our choosen station goal
+	var/datum/station_goal/selected = text2path(msg.answered)
+	//Send it
+	selected = new selected
+	station_goals += selected
+	selected.prepare_report()
 
 /datum/game_mode/proc/select_random_station_goal(var/datum/comm_message/msg_to_clear)
 
-    if(!GLOB.station_goal_selection_open)
-        // If a goal has already been manually selected, do nothing.
-        return
+	if(!GLOB.station_goal_selection_open)
+		// If a goal has already been manually selected, do nothing.
+		return
 
-    GLOB.station_goal_selection_open = FALSE
+	GLOB.station_goal_selection_open = FALSE
 
-    // Select a random goal from the available options
-    var/list/available_goals = list()
-    for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
-        if(config_tag in initial(G.gamemode_blacklist))
-            continue
-        available_goals += initial(G.type)
+	// Select a random goal from the available options
+	var/list/available_goals = list()
+	for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
+		if(config_tag in initial(G.gamemode_blacklist))
+			continue
+		available_goals += initial(G.type)
 
-    var/datum/station_goal/selected = pick(available_goals) // Picks a random type path
-    selected = new selected // New goal acquired
+	var/datum/station_goal/selected = pick(available_goals) // Picks a random type path
+	selected = new selected // New goal acquired
 
-    station_goals += selected
-    selected.prepare_report()
+	station_goals += selected
+	selected.prepare_report()
 
 /datum/game_mode/proc/generate_report() //Generates a small text blurb for the gamemode in centcom report
 	return "Gamemode report for [name] not set.  Contact a coder."

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -765,7 +765,7 @@
 
 	GLOB.station_goal_selection_open = TRUE
 	GLOB.selected_station_goal = null
-    //Comms Message
+	//Comms Message
 	var/datum/comm_message/msg = new
 	msg.title = "Nanotrasen Directive Selection"
 	msg.content = "Command staff must select a station directive within 20 minutes. Failure to do so will result in automatic assignment."

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -603,7 +603,7 @@
 
 /datum/game_mode/proc/num_players()
 	. = 0
-	for(var/mob/dead/new_player/P in GLOB.player_list)
+	for(var/mob/dead/new_player/authenticated/P in GLOB.player_list)
 		if(P.client && P.ready == PLAYER_READY_TO_PLAY)
 			. ++
 
@@ -759,60 +759,18 @@
 		rev.remove_revolutionary(TRUE)
 
 /datum/game_mode/proc/generate_station_goals()
-    GLOB.station_goal_selection_open = TRUE
-    GLOB.selected_station_goal = null
-    //Comms Message
-    var/datum/comm_message/msg = new
-    msg.title = "Nanotrasen Directive Selection"
-    msg.content = "Command staff must select a station directive within 20 minutes. Failure to do so will result in automatic assignment."
-    //Setup options
-    for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
-        if(config_tag in initial(G.gamemode_blacklist))
-            continue
-        msg.possible_answers += list("[initial(G.type)]" = "[initial(G.name)]") //tgui will convert the typepath to text regardless
-    //Await answer
-    msg.answer_callback = CALLBACK(src, PROC_REF(station_goal_selected), msg)
-    SScommunications.send_message(msg, unique=TRUE)
+	var/list/possible = list()
+	for(var/T in subtypesof(/datum/station_goal))
+		var/datum/station_goal/G = T
+		if(config_tag in initial(G.gamemode_blacklist))
+			continue
+		possible += T
+	var/goal_weights = 0
+	while(possible.len && goal_weights < STATION_GOAL_BUDGET)
+		var/datum/station_goal/picked = pick_n_take(possible)
+		goal_weights += initial(picked.weight)
+		station_goals += new picked
 
-    // Set up a timer to automatically select a random goal after 20 minutes
-    addtimer(CALLBACK(src, PROC_REF(select_random_station_goal), msg), 20 SECONDS)
-
-/datum/game_mode/proc/station_goal_selected(var/datum/comm_message/msg)
-    if(!GLOB.station_goal_selection_open)
-        // If a goal has already been selected automatically inform the player.
-        var/datum/comm_message/already_selected_msg = new
-        already_selected_msg.title = "Directive Assigned"
-        already_selected_msg.content = "Station directive has already been assigned by Central Command. Your selection was not taken into account." // You were too late, tell them their selection wont do anything.
-        SScommunications.send_message(already_selected_msg, unique=TRUE)
-        return // Prevent them from actually selecting a goal
-
-    //Grab our choosen station goal
-    var/datum/station_goal/selected = text2path(msg.answered)
-    //Send it
-    selected = new selected
-    station_goals += selected
-    selected.prepare_report()
-
-/datum/game_mode/proc/select_random_station_goal(var/datum/comm_message/msg_to_clear)
-
-    if(!GLOB.station_goal_selection_open)
-        // If a goal has already been manually selected, do nothing.
-        return
-
-    GLOB.station_goal_selection_open = FALSE
-
-    // Select a random goal from the available options
-    var/list/available_goals = list()
-    for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
-        if(config_tag in initial(G.gamemode_blacklist))
-            continue
-        available_goals += initial(G.type)
-
-    var/datum/station_goal/selected = pick(available_goals) // Picks a random type path
-    selected = new selected // New goal acquired
-
-    station_goals += selected
-    selected.prepare_report()
 
 /datum/game_mode/proc/generate_report() //Generates a small text blurb for the gamemode in centcom report
 	return "Gamemode report for [name] not set.  Contact a coder."

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -759,18 +759,60 @@
 		rev.remove_revolutionary(TRUE)
 
 /datum/game_mode/proc/generate_station_goals()
-	var/list/possible = list()
-	for(var/T in subtypesof(/datum/station_goal))
-		var/datum/station_goal/G = T
-		if(config_tag in initial(G.gamemode_blacklist))
-			continue
-		possible += T
-	var/goal_weights = 0
-	while(possible.len && goal_weights < STATION_GOAL_BUDGET)
-		var/datum/station_goal/picked = pick_n_take(possible)
-		goal_weights += initial(picked.weight)
-		station_goals += new picked
+    GLOB.station_goal_selection_open = TRUE
+    GLOB.selected_station_goal = null
+    //Comms Message
+    var/datum/comm_message/msg = new
+    msg.title = "Nanotrasen Directive Selection"
+    msg.content = "Command staff must select a station directive within 20 minutes. Failure to do so will result in automatic assignment."
+    //Setup options
+    for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
+        if(config_tag in initial(G.gamemode_blacklist))
+            continue
+        msg.possible_answers += list("[initial(G.type)]" = "[initial(G.name)]") //tgui will convert the typepath to text regardless
+    //Await answer
+    msg.answer_callback = CALLBACK(src, PROC_REF(station_goal_selected), msg)
+    SScommunications.send_message(msg, unique=TRUE)
 
+    // Set up a timer to automatically select a random goal after 20 minutes
+    addtimer(CALLBACK(src, PROC_REF(select_random_station_goal), msg), 20 SECONDS)
+
+/datum/game_mode/proc/station_goal_selected(var/datum/comm_message/msg)
+    if(!GLOB.station_goal_selection_open)
+        // If a goal has already been selected automatically inform the player.
+        var/datum/comm_message/already_selected_msg = new
+        already_selected_msg.title = "Directive Assigned"
+        already_selected_msg.content = "Station directive has already been assigned by Central Command. Your selection was not taken into account." // You were too late, tell them their selection wont do anything.
+        SScommunications.send_message(already_selected_msg, unique=TRUE)
+        return // Prevent them from actually selecting a goal
+
+    //Grab our choosen station goal
+    var/datum/station_goal/selected = text2path(msg.answered)
+    //Send it
+    selected = new selected
+    station_goals += selected
+    selected.prepare_report()
+
+/datum/game_mode/proc/select_random_station_goal(var/datum/comm_message/msg_to_clear)
+
+    if(!GLOB.station_goal_selection_open)
+        // If a goal has already been manually selected, do nothing.
+        return
+
+    GLOB.station_goal_selection_open = FALSE
+
+    // Select a random goal from the available options
+    var/list/available_goals = list()
+    for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
+        if(config_tag in initial(G.gamemode_blacklist))
+            continue
+        available_goals += initial(G.type)
+
+    var/datum/station_goal/selected = pick(available_goals) // Picks a random type path
+    selected = new selected // New goal acquired
+
+    station_goals += selected
+    selected.prepare_report()
 
 /datum/game_mode/proc/generate_report() //Generates a small text blurb for the gamemode in centcom report
 	return "Gamemode report for [name] not set.  Contact a coder."

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -70,7 +70,7 @@
 ///Checks to see if the game can be setup and ran with the current number of players or whatnot.
 /datum/game_mode/proc/can_start()
 	var/playerC = 0
-	for(var/mob/dead/new_player/player in GLOB.player_list)
+	for(var/mob/dead/new_player/authenticated/player in GLOB.player_list)
 		if(player.client && (player.ready == PLAYER_READY_TO_PLAY) && player.check_preferences())
 			playerC++
 	if(!GLOB.Debug2)
@@ -506,7 +506,7 @@
 	var/datum/mind/applicant = null
 
 	// Ultimate randomizing code right here
-	for(var/mob/dead/new_player/player in GLOB.player_list)
+	for(var/mob/dead/new_player/authenticated/player in GLOB.player_list)
 		if(player.client && player.ready == PLAYER_READY_TO_PLAY)
 			players += player
 
@@ -514,7 +514,7 @@
 	// Goodbye antag dante
 	players = shuffle(players)
 
-	for(var/mob/dead/new_player/player in players)
+	for(var/mob/dead/new_player/authenticated/player in players)
 		if(!QDELETED(player) && player.client && player.ready == PLAYER_READY_TO_PLAY)
 			if(player.client.should_include_for_role(
 				banning_key = banning_key,
@@ -530,7 +530,7 @@
 					candidates -= player
 
 	if(candidates.len < recommended_enemies)
-		for(var/mob/dead/new_player/player in players)
+		for(var/mob/dead/new_player/authenticated/player in players)
 			if(!QDELETED(player) && player.client && player.ready == PLAYER_READY_TO_PLAY)
 				// We don't have enough people who want to be antagonist, make a separate list of people who don't want to be one but are otherwise eligible
 				if(player.client.should_include_for_role(
@@ -735,16 +735,16 @@
 			if(D.mind && D.mind.current == L)
 				if(L.stat == DEAD)
 					if(L.suiciding)	//Suicider
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] ([span_boldannounce("Suicide")])\n"
+						msg += "<b>[L.name]</b> ([ckey(D.mind.display_key())]), the [L.job] ([span_boldannounce("Suicide")])\n"
 						continue //Disconnected client
 					else
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (Dead)\n"
+						msg += "<b>[L.name]</b> ([ckey(D.mind.display_key())]), the [L.job] (Dead)\n"
 						continue //Dead mob, ghost abandoned
 				else
 					if(D.can_reenter_corpse)
 						continue //Adminghost, or cult/wizard ghost
 					else
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] ([span_boldannounce("Ghosted")])\n"
+						msg += "<b>[L.name]</b> ([ckey(D.mind.display_key())]), the [L.job] ([span_boldannounce("Ghosted")])\n"
 						continue //Ghosted while alive
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -759,23 +759,27 @@
 		rev.remove_revolutionary(TRUE)
 
 /datum/game_mode/proc/generate_station_goals()
+	// Check if the budget has already been met
+	if(station_goals.len >= STATION_GOAL_BUDGET)
+		return // No more goals can be generated
+
 	GLOB.station_goal_selection_open = TRUE
 	GLOB.selected_station_goal = null
-	//Comms Message
+    //Comms Message
 	var/datum/comm_message/msg = new
 	msg.title = "Nanotrasen Directive Selection"
 	msg.content = "Command staff must select a station directive within 20 minutes. Failure to do so will result in automatic assignment."
 	//Setup options
-	for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
-		if(config_tag in initial(G.gamemode_blacklist))
+	for(var/datum/station_goal/each_goal as anything in subtypesof(/datum/station_goal))
+		if(config_tag in initial(each_goal.gamemode_blacklist))
 			continue
-		msg.possible_answers += list("[initial(G.type)]" = "[initial(G.name)]") //tgui will convert the typepath to text regardless
+		msg.possible_answers += list("[initial(each_goal.type)]" = "[initial(each_goal.name)]") //tgui will convert the typepath to text regardless
 	//Await answer
 	msg.answer_callback = CALLBACK(src, PROC_REF(station_goal_selected), msg)
 	SScommunications.send_message(msg, unique=TRUE)
 
 	// Set up a timer to automatically select a random goal after 20 minutes
-	addtimer(CALLBACK(src, PROC_REF(select_random_station_goal), msg), 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(select_random_station_goal), msg), 20 MINUTES)
 
 /datum/game_mode/proc/station_goal_selected(var/datum/comm_message/msg)
 	if(!GLOB.station_goal_selection_open)
@@ -784,7 +788,11 @@
 		already_selected_msg.title = "Directive Assigned"
 		already_selected_msg.content = "Station directive has already been assigned by Central Command. Your selection was not taken into account." // You were too late, tell them their selection wont do anything.
 		SScommunications.send_message(already_selected_msg, unique=TRUE)
-		return // Prevent them from actually selecting a goal
+		return
+
+	// Check if adding this goal would exceed the budget
+	if(station_goals.len >= STATION_GOAL_BUDGET)
+		return
 
 	//Grab our choosen station goal
 	var/datum/station_goal/selected = text2path(msg.answered)
@@ -793,20 +801,30 @@
 	station_goals += selected
 	selected.prepare_report()
 
+	// If we've reached the budget, close further selection
+	if (station_goals.len >= STATION_GOAL_BUDGET)
+		GLOB.station_goal_selection_open = FALSE
+
+
 /datum/game_mode/proc/select_random_station_goal(var/datum/comm_message/msg_to_clear)
 
 	if(!GLOB.station_goal_selection_open)
 		// If a goal has already been manually selected, do nothing.
 		return
 
+	// Check if adding a random goal would exceed the budget
+	if(station_goals.len >= STATION_GOAL_BUDGET)
+		GLOB.station_goal_selection_open = FALSE // Close selection if budget met
+		return
+
 	GLOB.station_goal_selection_open = FALSE
 
 	// Select a random goal from the available options
 	var/list/available_goals = list()
-	for(var/datum/station_goal/G as anything in subtypesof(/datum/station_goal))
-		if(config_tag in initial(G.gamemode_blacklist))
+	for(var/datum/station_goal/each_goal as anything in subtypesof(/datum/station_goal))
+		if(config_tag in initial(each_goal.gamemode_blacklist))
 			continue
-		available_goals += initial(G.type)
+		available_goals += initial(each_goal.type)
 
 	var/datum/station_goal/selected = pick(available_goals) // Picks a random type path
 	selected = new selected // New goal acquired


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks the way Station Objectives are assigned, instead of it being fully random, gives heads of staff a way to coordinate with the station on which objective they wish to attempt to complete that shift, if no answer is provided within a time frame, it automatically chooses one as it previously was

## Why It's Good For The Game

Some station objectives are not fun to complete, let's give command a way to coordinate with the station to choose an objective to complete that shift, hopefully makes objectives be completed more often.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![image](https://github.com/user-attachments/assets/82af45d3-d423-4a84-bfba-a83a11b00417)

![image1](https://github.com/user-attachments/assets/5e4ea22a-232b-487f-a6d7-e99558483b74)

If someone attempts to choose an objective after the window has passed, they're met with this comment

![image](https://github.com/user-attachments/assets/a55f4d40-3fb7-4bf5-b200-37fa6cecc4b0)


</details>

## Changelog
:cl: Isaacnml

tweak: Tweaks how station objective selection works

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->