### PR TITLE
Adds Soy Sauce, BBQ Sauce and Mayonnaise to the Chef Vendor

### DIFF
--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -252,6 +252,7 @@
 	desc = "Hand wipes not included."
 	icon_state = "bbqsauce"
 	list_reagents = list(/datum/reagent/consumable/bbqsauce = 50)
+	custom_price = 25
 
 /obj/item/reagent_containers/condiment/soysauce
 	name = "soy sauce"
@@ -259,6 +260,7 @@
 	icon_state = "soysauce"
 	list_reagents = list(/datum/reagent/consumable/soysauce = 50)
 	fill_icon_thresholds = null
+	custom_price = 25
 
 /obj/item/reagent_containers/condiment/mayonnaise
 	name = "mayonnaise"
@@ -266,6 +268,7 @@
 	icon_state = "mayonnaise"
 	list_reagents = list(/datum/reagent/consumable/mayonnaise = 50)
 	fill_icon_thresholds = null
+	custom_price = 25
 
 /*
 /obj/item/reagent_containers/condiment/vinegar

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -47,6 +47,9 @@
 			"products" = list(
 				/obj/item/reagent_containers/condiment/enzyme = 2,
 				/obj/item/reagent_containers/condiment/cherryjelly = 2,
+				/obj/item/reagent_containers/condiment/bbqsauce = 2,
+				/obj/item/reagent_containers/condiment/soysauce = 2,
+				/obj/item/reagent_containers/condiment/mayonnaise = 2,
 				/obj/item/reagent_containers/condiment/honey = 2,
 				/obj/item/reagent_containers/cup/bottle/caramel = 2,
 				/obj/item/reagent_containers/condiment/vanilla = 2,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This was done by request:
![image](https://github.com/user-attachments/assets/0494c8a4-f526-45a4-9f9f-a108871553c2)

Ingame:
![image](https://github.com/user-attachments/assets/c89221b1-871a-4ff3-a73e-66d31a91c86c)

## Why It's Good For The Game

The balance change to the cook wasn't just meant to make the cook miserable. It was meant to give them easier access to some tools or ingredients at the cost of MONEY.

The more there are the more they can spend on!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

See above

</details>

## Changelog
:cl: Solene Yoon
add: Adds Soy Sauce, BBQ Sauce and Mayonnaise to the Chef Vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
