### PR TITLE
Personal Locker Owner wipe and effects

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -1,13 +1,11 @@
 /obj/structure/closet/secure_closet/personal
 	desc = "It's a secure locker for personnel. The first card swiped gains control."
 	name = "personal closet"
-	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 	var/registered_name = null
 
 /obj/structure/closet/secure_closet/personal/empty
 	desc = "It's a secure locker for personnel. The first card swiped gains control."
 	name = "personal closet"
-	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 
 /obj/structure/closet/secure_closet/personal/empty/PopulateContents()
 	return
@@ -46,21 +44,74 @@
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
 	var/obj/item/card/id/I = W.GetID()
-	if(istype(I))
-		if(broken)
-			to_chat(user, span_danger("It appears to be broken."))
-			return
-		if(!I || !I.registered_name)
-			return
-		if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
-			//they can open all lockers, or nobody owns this, or they own this locker
-			locked = !locked
-			update_icon()
-
-			if(!registered_name)
-				registered_name = I.registered_name
-				desc = "Owned by [I.registered_name]."
-		else
-			to_chat(user, span_danger("Access Denied."))
-	else
+	if(!istype(I) || !I.electric)
 		return ..()
+	if(broken)
+		broken_effect(user)
+		return
+	if(I.registered_name == registered_name)
+		togglelock(user, FALSE)
+		return
+	if(((ACCESS_CAPTAIN in I.access) || (ACCESS_ALL_PERSONAL_LOCKERS in I.access)) && registered_name)
+		registered_name = null
+		balloon_alert_to_viewers("<font color='#ec8907'>Warning!</font> ID registry <font color='#ad3098'>purged!</font>")
+		to_chat(user, "Locker ID registry purged.")
+		playsound(src, 'sound/machines/uplinkerror.ogg', 50, FALSE)
+		return
+	if(!I.registered_name)
+		balloon_alert_to_viewers("<font color='#ec0707'>Error!</font> ID lacks name to register!")
+		to_chat(user, "The ID lacks a name to register.")
+		playsound(src, 'sound/machines/uplinkerror.ogg', 50, FALSE)
+		return
+
+	if(!registered_name)
+		registered_name = I.registered_name
+		desc = "Owned by [registered_name]."
+		playsound(src, 'sound/machines/terminal_success.ogg', 50)
+		balloon_alert_to_viewers("ID registered! Welcome <font color='#ffea2d'>[registered_name]</font>!")
+		to_chat(user, "Locker registered under the name of <b>[registered_name]</b>.")
+		return
+
+	playsound(src, 'sound/machines/terminal_error.ogg', 50, FALSE)
+	balloon_alert_to_viewers("<font color='#ec0707'>Access denied!</font>")
+	to_chat(user, span_warning("Access denied!"))
+
+/obj/structure/closet/secure_closet/personal/allowed(mob/user)
+    if(issilicon(user) || IsAdminGhost(user))
+        return TRUE
+    if(!registered_name)
+        return ..()
+    var/obj/item/card/id/I = user.get_idcard()
+    if(!I)
+        return FALSE
+    if(I.registered_name == registered_name)
+        return TRUE
+    return FALSE
+
+/obj/structure/closet/secure_closet/personal/togglelock(mob/living/user, finger)
+	if(broken)
+		broken_effect(user)
+		return
+	if(!allowed(user))
+		playsound(src, 'sound/machines/terminal_error.ogg', 50, FALSE)
+		balloon_alert_to_viewers("<font color='#ec0707'>Access denied!</font>")
+		to_chat(user, span_warning("Access denied!"))
+		return
+	if(iscarbon(user) && finger)
+		add_fingerprint(user)
+	if(locked)
+		balloon_alert_to_viewers("Storage <font color='#70eb0c'>Unlocked!</font>")
+		playsound(src, 'sound/machines/terminal_select.ogg', 25, FALSE)
+		locked = FALSE
+	else
+		balloon_alert_to_viewers("Storage <font color='#eb0c0c'>Locked!</font>")
+		playsound(src, 'sound/machines/terminal_select.ogg', 25, FALSE)
+		locked = TRUE
+	to_chat(user, "You [locked ? null : "un"]lock [src].")
+	update_appearance()
+
+/obj/structure/closet/secure_closet/personal/proc/broken_effect(mob/living/user)
+	balloon_alert_to_viewers("<font color='#ec0707'>ERROR</font> LO/K MAL<font color='#22973c'>%$TI0</font>N!")
+	to_chat(user, span_danger("It appears to be broken."))
+	playsound(src, "sparks", 50, 1)
+	new /obj/effect/particle_effect/sparks(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -77,16 +77,16 @@
 	to_chat(user, span_warning("Access denied!"))
 
 /obj/structure/closet/secure_closet/personal/allowed(mob/user)
-    if(issilicon(user) || IsAdminGhost(user))
-        return TRUE
-    if(!registered_name)
-        return ..()
-    var/obj/item/card/id/I = user.get_idcard()
-    if(!I)
-        return FALSE
-    if(I.registered_name == registered_name)
-        return TRUE
-    return FALSE
+	if(issilicon(user) || IsAdminGhost(user))
+		return TRUE
+	if(!registered_name)
+		return ..()
+	var/obj/item/card/id/I = user.get_idcard()
+	if(!I)
+		return FALSE
+	if(I.registered_name == registered_name)
+		return TRUE
+	return FALSE
 
 /obj/structure/closet/secure_closet/personal/togglelock(mob/living/user, finger)
 	if(broken)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does Personal lockers in the same effect/visual way i did airlocks in #12977

Now ids with Captain and All Locker access can wipe the registered owner of a personal locker.

I added visuals and sounds to opening closing and all sorts of things.

Also unallowed paper slips, it was fun but could be used to open ANY locked personal locker by just using the same name.
Which kinda defeats the purpose of a secure locker if it can be beat with a piece of paper.



https://github.com/user-attachments/assets/4a11b215-764e-4b83-ba54-cee22a50c33b

Hat to double compress this.


## Why It's Good For The Game

Sometimes someone can just lock all lockers by themselves and that's not very cash money of them.
Also people opening with a paper slip is odd.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

video up

</details>

## Changelog
:cl: Solene
tweak: tweaked the visual and audio behavior of personal lockers
tweak: Captain, HoP and HoS id's can now wipe a owners registry from a personal locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
