### PR TITLE
fix transformative light pink extracts (and a related slime + spawner menu glitch)

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -253,8 +253,7 @@
 	if(transformeffects & SLIME_EFFECT_LIGHT_PINK)
 		GLOB.poi_list |= M
 		M.master = master
-		LAZYADD(GLOB.mob_spawners["[master.real_name]'s slime"], M)
-		SSmobs.update_spawners()
+		M.set_playable_slime(ROLE_SENTIENCE)
 	M.set_friends(Friends)
 	if(step_away)
 		step_away(M,src)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -570,6 +570,16 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime/random)
 	Friends[user] += SLIME_FRIENDSHIP_ATTACK * 2
 	master = user
 
+// edited version of set_playable to prevent spawner menu flooding
+/mob/living/simple_animal/slime/proc/set_playable_slime(ban_type = null, poll_ignore_key = null)
+	playable = TRUE
+	playable_bantype = ban_type
+	if (!key)	//check if there is nobody already inhibiting this mob
+		notify_ghosts("[name] can be controlled", null, enter_link="<a href='byond://?src=[REF(src)];activate=1'>(Click to play)</a>", source=src, action=NOTIFY_ATTACK, ignore_key = poll_ignore_key)
+		LAZYADD(GLOB.mob_spawners["[master ? "[src.master.real_name]'s slime" : "[name]"]"], src)
+		AddElement(/datum/element/point_of_interest)
+		SSmobs.update_spawners() // else prompt removed, ghosts do not need to know about occupied lab slimes
+
 CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime/rainbow)
 
 /mob/living/simple_animal/slime/rainbow/Initialize(mapload, new_colour = SLIME_TYPE_RAINBOW, new_is_adult)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -574,11 +574,11 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime/random)
 /mob/living/simple_animal/slime/proc/set_playable_slime(ban_type = null, poll_ignore_key = null)
 	playable = TRUE
 	playable_bantype = ban_type
-	if (!key)	//check if there is nobody already inhibiting this mob
+	LAZYADD(GLOB.mob_spawners["[master ? "[src.master.real_name]'s slime" : "[name]"]"], src)
+	SSmobs.update_spawners()
+	if (!key)	//ping only if there is no one inhabiting this mob
 		notify_ghosts("[name] can be controlled", null, enter_link="<a href='byond://?src=[REF(src)];activate=1'>(Click to play)</a>", source=src, action=NOTIFY_ATTACK, ignore_key = poll_ignore_key)
-		LAZYADD(GLOB.mob_spawners["[master ? "[src.master.real_name]'s slime" : "[name]"]"], src)
 		AddElement(/datum/element/point_of_interest)
-		SSmobs.update_spawners() // else prompt removed, ghosts do not need to know about occupied lab slimes
 
 CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime/rainbow)
 

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -153,6 +153,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime)
 	set_target(null)
 	set_leader(null)
 	clear_friends()
+	remove_from_spawner_menu()
 	return ..()
 
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)

--- a/code/modules/research/xenobiology/crossbreeding/transformative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/transformative.dm
@@ -161,8 +161,7 @@ transformative extracts:
 	..()
 	GLOB.poi_list |= S
 	S.make_master(user)
-	LAZYADD(GLOB.mob_spawners["[S.master.real_name]'s slime"], S)
-	SSmobs.update_spawners()
+	S.set_playable_slime(ROLE_SENTIENCE)
 
 /obj/item/slimecross/transformative/adamantine
 	colour = SLIME_TYPE_ADAMANTINE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #12922

This fixes xenobiology's transformative light pink hybrid extract, which is supposed to let ghosts control slimes, but did nothing except add them to the ghostspawn menu and eventually break it after splitting.

- A slime affected by a transformative light pink extract still appears in the spawner menu, but can now be controlled, either by clicking on it or using the menu's spawn button. The name of the list entry depends on the name of the slime's master, that being the person who gave the slime the extract.
- When a slime with a transformative light pink extract splits, its children are also ghost controllable, appearing in the same category as their parent and inheriting the same master.
- A slime that can be controlled by ghosts loses this property when it is deleted (for example, by splitting) to prevent lingering references completely breaking the spawner menu.
- If a slime controlled by a player ghosts, the position is reopened for other ghosts.
- When a slime has the extract applied, splits off new controllable slimes, or a controllable slime ghosts, other ghosts are notified of this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is good when bugs are fixed, especially ones that can empty the entire ghostrole spawner menu.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

the ghostspawn menu with a single transformed slime, the slime, and the popup when clicking on it:
![grafik](https://github.com/user-attachments/assets/20dd1a17-3ed3-4a09-be32-4c09ccc1e4ec)

slime compared with menu, before and after splitting:
![grafik](https://github.com/user-attachments/assets/96e5b7de-5ecf-4b2b-8afd-67efdd9324ef)
![grafik](https://github.com/user-attachments/assets/416ac401-fe12-458c-864c-a7969787c3d4)

ghost notification pictures and text:
![grafik](https://github.com/user-attachments/assets/1d95ca50-0dcb-4901-9806-0d7440746aeb)
![grafik](https://github.com/user-attachments/assets/bcdbcab6-8881-4ae0-a5bf-e22a5228b2e4)

</details>

## Changelog
:cl: Asdfagi
fix: ghost-controllable slimes splitting no longer leaves behind a nullspace slime that breaks the spawner menu
fix: the transformative light pink extract now actually allows a slime and its descendants to be controlled by ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
