### PR TITLE
Fixes sealed mech cabin air during internal air tank usage

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -207,8 +207,8 @@
 	cabin_air = new
 	cabin_air.temperature = T20C
 	cabin_air.volume = 200
-	SET_MOLES(/datum/gas/oxygen, cabin_air, O2STANDARD*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
-	SET_MOLES(/datum/gas/nitrogen, cabin_air, N2STANDARD*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
+	SET_MOLES(/datum/gas/oxygen, cabin_air, O2STANDARD*ONE_ATMOSPHERE*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
+	SET_MOLES(/datum/gas/nitrogen, cabin_air, N2STANDARD*ONE_ATMOSPHERE*cabin_air.return_volume()/(R_IDEAL_GAS_EQUATION*cabin_air.return_temperature()))
 
 	add_cell()
 	add_scanmod()
@@ -433,6 +433,20 @@
 		if(cabin_air && cabin_air.return_volume() > 0)
 			var/delta = cabin_air.return_temperature() - T20C
 			cabin_air.temperature = (cabin_air.return_temperature() - clamp(round(delta / 8, 0.1), -5, 5) * delta_time)
+
+	if(internal_tank)
+		var/datum/gas_mixture/tank_air = internal_tank.return_air()
+
+		var/release_pressure = internal_tank_valve
+		var/cabin_pressure = cabin_air.return_pressure()
+		var/pressure_delta = min(release_pressure - cabin_pressure, (tank_air.return_pressure() - cabin_pressure)/2)
+		if(pressure_delta > 0) //cabin pressure lower than release pressure
+			if(tank_air.return_temperature() > 0)
+				tank_air.pump_gas_to(cabin_air, release_pressure)
+		else if(pressure_delta < 0) //cabin pressure higher than release pressure
+			var/datum/gas_mixture/t_air = return_air()
+			if(pressure_delta > 0) //if location pressure is lower than cabin pressure
+				cabin_air.pump_gas_to(t_air, cabin_pressure)
 
 	for(var/mob/living/occupant as anything in occupants)
 		if(!enclosed && occupant?.incapacitated())  //no sides mean it's easy to just sorta fall out if you're incapacitated.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

During #11813, logic in sealed mechs related to internal air tank <-> cabin air equalization was removed in what I believe to be an error. From what I understand by reading TG sealed mech code, the cabin air they use solely relies on the air trapped at the moment of cabin sealing, without having an internal air tank. This PR restores the logic required for interaction between the two gas mixtures back into Bee code

It also fixes initial air mole count in the cabin by introducing the atmospheric pressure term which was neglected in the equations

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This should re-enable sealed mechs to host users without internals or space-proofed equipment in hostile environmental conditions, as opposed to behaving like vacuum as it does currently

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Tested:
- sealed mech without using internal tank
- sealed mech while using internal tank both in space and on station
- depletion of both cabin and tank air under normal use and during connection to a scrubbing gas port
- refill of tank air during connection to a gas port
NOT tested:
- air leaks as a result of damage (this logic was not affected to my knowledge)

https://github.com/user-attachments/assets/db4b0fe3-da82-4fc0-98e4-2236a2bc2287

</details>

## Changelog
:cl: Aramix
fix: Sealed mechs will now use internal tank contents to repressurize cabin during internal air tank usage once again
fix: Adjusted the initial air moles count in the cabin for sealed mechs to start with a cabin air pressure of one atmosphere
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
