### PR TITLE
Adjusts some very strong speed buffs (Nitrium, Wheelys)

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -166,7 +166,7 @@
 	set_vehicle_dir_layer(WEST, OBJ_LAYER)
 
 /datum/component/riding/vehicle/scooter/skateboard/wheelys
-	vehicle_move_delay = 0
+	vehicle_move_delay = 1.5
 
 /datum/component/riding/vehicle/scooter/skateboard/wheelys/handle_specials()
 	. = ..()

--- a/code/game/objects/items/nitrium_crystals.dm
+++ b/code/game/objects/items/nitrium_crystals.dm
@@ -10,8 +10,7 @@
 	var/datum/effect_system/smoke_spread/chem/smoke = new
 	var/turf/location = get_turf(src)
 	create_reagents(5)
-	reagents.add_reagent(/datum/reagent/nitrium_low_metabolization, 3)
-	reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, 2)
+	reagents.add_reagent(/datum/reagent/nitrium, 3)
 	smoke.attach(location)
 	smoke.set_up(reagents, cloud_size, location, silent = TRUE)
 	smoke.start()

--- a/code/game/objects/items/nitrium_crystals.dm
+++ b/code/game/objects/items/nitrium_crystals.dm
@@ -9,8 +9,9 @@
 	. = ..()
 	var/datum/effect_system/smoke_spread/chem/smoke = new
 	var/turf/location = get_turf(src)
-	create_reagents(5)
-	reagents.add_reagent(/datum/reagent/nitrium, 3)
+	create_reagents(10)
+	reagents.add_reagent(/datum/reagent/nitrium, 5)
+	reagents.add_reagent(/datum/reagent/nitrosyl_plasmide, 5)
 	smoke.attach(location)
 	smoke.set_up(reagents, cloud_size, location, silent = TRUE)
 	smoke.start()

--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -27,7 +27,11 @@
 	multiplicative_slowdown = -0.5
 
 /datum/movespeed_modifier/reagent/nitrium
-	multiplicative_slowdown = -0.5
+	multiplicative_slowdown = -0.4
+	blacklisted_movetypes=(FLYING|FLOATING)
+
+/datum/movespeed_modifier/reagent/nitrosyl_plasmide
+	multiplicative_slowdown = -0.25
 	blacklisted_movetypes=(FLYING|FLOATING)
 
 /datum/movespeed_modifier/reagent/modafil

--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -2,7 +2,7 @@
 	blacklisted_movetypes = (FLOATING)
 
 /datum/movespeed_modifier/reagent/stimulants
-	multiplicative_slowdown = -1
+	multiplicative_slowdown = -0.5
 
 /datum/movespeed_modifier/reagent/ephedrine
 	multiplicative_slowdown = -0.35
@@ -17,7 +17,7 @@
 	multiplicative_slowdown = -0.25
 
 /datum/movespeed_modifier/reagent/changelinghaste
-	multiplicative_slowdown = -2
+	multiplicative_slowdown = -0.5
 
 /datum/movespeed_modifier/reagent/amphetamine
 	multiplicative_slowdown=-0.5
@@ -27,7 +27,7 @@
 	multiplicative_slowdown = -0.5
 
 /datum/movespeed_modifier/reagent/nitrium
-	multiplicative_slowdown = -1
+	multiplicative_slowdown = -0.5
 	blacklisted_movetypes=(FLYING|FLOATING)
 
 /datum/movespeed_modifier/reagent/modafil

--- a/code/modules/movespeed/modifiers/reagent.dm
+++ b/code/modules/movespeed/modifiers/reagent.dm
@@ -2,7 +2,7 @@
 	blacklisted_movetypes = (FLOATING)
 
 /datum/movespeed_modifier/reagent/stimulants
-	multiplicative_slowdown = -0.5
+	multiplicative_slowdown = -1
 
 /datum/movespeed_modifier/reagent/ephedrine
 	multiplicative_slowdown = -0.35
@@ -17,7 +17,7 @@
 	multiplicative_slowdown = -0.25
 
 /datum/movespeed_modifier/reagent/changelinghaste
-	multiplicative_slowdown = -0.5
+	multiplicative_slowdown = -2
 
 /datum/movespeed_modifier/reagent/amphetamine
 	multiplicative_slowdown=-0.5

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1372,9 +1372,8 @@
 	return ..()
 
 /datum/reagent/nitrium/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustStaminaLoss((-12 + current_cycle) * REM * delta_time, 0)
-
-	if(!warned && current_cycle >= 13)
+	M.adjustStaminaLoss((clamp((-20 + current_cycle), -5, 5)) * REM * delta_time, 0)
+	if(!warned && current_cycle >= 21)
 		M.visible_message(span_danger("Your body aches!"))
 		warned = TRUE
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1375,9 +1375,9 @@
 /datum/reagent/nitrium/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 
 	//Stopped huffing and wearing off, but not all gone. No more stamina modifiers. Takes ~20 more seconds to fully metabolize
-	if(feeling_high && reagents.get_reagent_amount(/datum/reagent/water/nitrium) <= 2)
+	if(feeling_high && reagents.get_reagent_amount(/datum/reagent/nitrium) <= 2)
 		feeling_high = FALSE
-		L.visible_message(span_warning("You can feel your high starting to wear off"))
+		M.visible_message(span_warning("You can feel your high starting to wear off"))
 
 	//Whether they go back to huffing too soon, or they have just started huffing, this calculation will handle stamina restoration and exhaustion both.
 	else

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1386,6 +1386,8 @@
 		if(!warned && current_cycle >= 21)
 			M.visible_message(span_danger("Your body aches!"))
 			warned = TRUE
+	
+	return TRUE
 
 /////////////////////////Colorful Powder////////////////////////////
 //For colouring in /proc/mix_color_from_reagents

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1375,7 +1375,7 @@
 /datum/reagent/nitrium/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 
 	//Stopped huffing and wearing off, but not all gone. No more stamina modifiers. Takes ~20 more seconds to fully metabolize
-	if(feeling_high && reagents.get_reagent_amount(/datum/reagent/nitrium) <= 2)
+	if(feeling_high && M.reagents.get_reagent_amount(/datum/reagent/nitrium) <= 2)
 		feeling_high = FALSE
 		M.visible_message(span_warning("You can feel your high starting to wear off"))
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1373,6 +1373,7 @@
 	return ..()
 
 /datum/reagent/nitrium/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	. = ..()
 
 	//Stopped huffing and wearing off, but not all gone. No more stamina modifiers. Takes ~20 more seconds to fully metabolize
 	if(feeling_high && M.reagents.get_reagent_amount(/datum/reagent/nitrium) <= 2)
@@ -1385,7 +1386,6 @@
 		if(!warned && current_cycle >= 21)
 			M.visible_message(span_danger("Your body aches!"))
 			warned = TRUE
-	return ..()
 
 /////////////////////////Colorful Powder////////////////////////////
 //For colouring in /proc/mix_color_from_reagents

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1353,7 +1353,7 @@
 	var/warned = FALSE
 	var/feeling_high = FALSE
 	overdose_threshold = 10
-	addiction_threshold = 5 // You will be addicted if you huff too much at once
+	addiction_threshold = 4 //Nitrium is highly addictive
 
 /datum/reagent/nitrium/on_mob_metabolize(mob/living/L)
 	. = ..()
@@ -1380,7 +1380,7 @@
 
 	//Whether they go back to huffing too soon, or they have just started huffing, this calculation will handle stamina restoration and exhaustion both.
 	else
-		M.adjustStaminaLoss((clamp((-30 + current_cycle), -2, 2)) * REM * delta_time, 0)
+		M.adjustStaminaLoss((clamp((-30 + current_cycle), -2, 5)) * REM * delta_time, 0)
 		if(!warned && current_cycle >= 31)
 			M.visible_message(span_danger("Your body aches!"))
 			warned = TRUE
@@ -1390,13 +1390,6 @@
 /datum/reagent/nitrium/overdose_start(mob/living/M)
 	//Because otherwise it lasts for a punishingly long time if an overdose is reached
 	metabolization_rate = REAGENTS_METABOLISM
-
-/datum/reagent/nitrium/overdose_process(mob/living/M, delta_time, times_fired)
-	. = ..()
-	if(feeling_high)
-		M.adjustStaminaLoss(3 * REM * delta_time, 0)
-
-	return TRUE
 
 /datum/reagent/nitrosyl_plasmide
 	name = "Nitrosyl plasmide"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1351,6 +1351,7 @@
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY
 	taste_description = "burning"
 	var/warned = FALSE
+	var/feeling_high = FALSE
 
 
 /datum/reagent/nitrium/on_mob_metabolize(mob/living/L)
@@ -1361,6 +1362,7 @@
 	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
 	L.visible_message(span_warning("You feel like nothing can stop you!"))
+	feeling_high = TRUE
 
 /datum/reagent/nitrium/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
@@ -1368,14 +1370,21 @@
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
-	L.visible_message(span_warning("You can feel your brief high wearing off"))
 	return ..()
 
 /datum/reagent/nitrium/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustStaminaLoss((clamp((-20 + current_cycle), -5, 5)) * REM * delta_time, 0)
-	if(!warned && current_cycle >= 21)
-		M.visible_message(span_danger("Your body aches!"))
-		warned = TRUE
+
+	//Stopped huffing and wearing off, but not all gone. No more stamina modifiers. Takes ~20 more seconds to fully metabolize
+	if(feeling_high && reagents.get_reagent_amount(/datum/reagent/water/nitrium) <= 2)
+		feeling_high = FALSE
+		L.visible_message(span_warning("You can feel your high starting to wear off"))
+
+	//Whether they go back to huffing too soon, or they have just started huffing, this calculation will handle stamina restoration and exhaustion both.
+	else
+		M.adjustStaminaLoss((clamp((-20 + current_cycle), -5, 5)) * REM * delta_time, 0)
+		if(!warned && current_cycle >= 21)
+			M.visible_message(span_danger("Your body aches!"))
+			warned = TRUE
 	return ..()
 
 /////////////////////////Colorful Powder////////////////////////////

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1342,45 +1342,7 @@
 		M.confused = min(M.confused + 2, 5)
 	..()
 
-/datum/reagent/nitrium_high_metabolization
-	name = "Nitrosyl plasmide"
-	description = "A highly reactive byproduct that stops you from sleeping, while dealing increasing toxin damage over time."
-	reagent_state = GAS
-	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium are handled through gas breathing, metabolism must be lower for breathcode to keep up
-	color = "#E1A116"
-	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY
-	taste_description = "sourness"
-	///stores whether or not the mob has been warned that they are having difficulty breathing.
-	var/warned = FALSE
-
-/datum/reagent/nitrium_high_metabolization/on_mob_metabolize(mob/living/L)
-	. = ..()
-	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
-	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
-	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
-	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
-	L.visible_message(span_warning("You feel like nothing can stop you!"))
-
-/datum/reagent/nitrium_high_metabolization/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
-	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
-	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
-	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
-	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
-	L.visible_message(span_warning("You can feel your brief high wearing off"))
-	return ..()
-
-/datum/reagent/nitrium_high_metabolization/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustStaminaLoss(-2 * REM * delta_time, 0)
-	if(M.losebreath <= 10)
-		M.losebreath += min(current_cycle*0.05, 2) // gradually builds up suffocation, will not be noticeable for several ticks but effects will linger afterwards
-	if(M.losebreath > 2 && !warned)
-		M.visible_message(span_danger("You feel like you can't breathe!"))
-		warned = TRUE
-	return ..()
-
-/datum/reagent/nitrium_low_metabolization
+/datum/reagent/nitrium
 	name = "Nitrium"
 	description = "A highly reactive gas that makes you feel faster."
 	reagent_state = GAS
@@ -1388,13 +1350,33 @@
 	color = "#90560B"
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY
 	taste_description = "burning"
+	var/warned = FALSE
 
-/datum/reagent/nitrium_low_metabolization/on_mob_metabolize(mob/living/L)
+
+/datum/reagent/nitrium/on_mob_metabolize(mob/living/L)
 	. = ..()
 	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
+	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
+	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
+	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
+	L.visible_message(span_warning("You feel like nothing can stop you!"))
 
-/datum/reagent/nitrium_low_metabolization/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/nitrium/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
+	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
+	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
+	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
+	L.visible_message(span_warning("You can feel your brief high wearing off"))
+	return ..()
+
+/datum/reagent/nitrium/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	M.adjustStaminaLoss((-12 + current_cycle) * REM * delta_time, 0)
+
+	if(!warned && current_cycle >= 13)
+		M.visible_message(span_danger("Your body aches!"))
+		warned = TRUE
 	return ..()
 
 /////////////////////////Colorful Powder////////////////////////////

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1352,22 +1352,19 @@
 	taste_description = "burning"
 	var/warned = FALSE
 	var/feeling_high = FALSE
-
+	overdose_threshold = 10
+	addiction_threshold = 5 // You will be addicted if you huff too much at once
 
 /datum/reagent/nitrium/on_mob_metabolize(mob/living/L)
 	. = ..()
 	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
-	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
-	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
 	L.visible_message(span_warning("You feel like nothing can stop you!"))
 	feeling_high = TRUE
 
 /datum/reagent/nitrium/on_mob_end_metabolize(mob/living/L)
-	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
-	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
-	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium) //Just in case it doesn't get removed in mob_life
 	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
 	return ..()
@@ -1379,14 +1376,57 @@
 	if(feeling_high && M.reagents.get_reagent_amount(/datum/reagent/nitrium) <= 2)
 		feeling_high = FALSE
 		M.visible_message(span_warning("You can feel your high starting to wear off"))
+		M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrium)
 
 	//Whether they go back to huffing too soon, or they have just started huffing, this calculation will handle stamina restoration and exhaustion both.
 	else
-		M.adjustStaminaLoss((clamp((-20 + current_cycle), -5, 5)) * REM * delta_time, 0)
-		if(!warned && current_cycle >= 21)
+		M.adjustStaminaLoss((clamp((-30 + current_cycle), -2, 2)) * REM * delta_time, 0)
+		if(!warned && current_cycle >= 31)
 			M.visible_message(span_danger("Your body aches!"))
 			warned = TRUE
-	
+
+	return TRUE
+
+/datum/reagent/nitrium/overdose_start(mob/living/M)
+	//Because otherwise it lasts for a punishingly long time if an overdose is reached
+	metabolization_rate = REAGENTS_METABOLISM
+
+/datum/reagent/nitrium/overdose_process(mob/living/M, delta_time, times_fired)
+	. = ..()
+	if(feeling_high)
+		M.adjustStaminaLoss(3 * REM * delta_time, 0)
+
+	return TRUE
+
+/datum/reagent/nitrosyl_plasmide
+	name = "Nitrosyl plasmide"
+	description = "A highly reactive byproduct that stops you from sleeping"
+	reagent_state = GAS
+	metabolization_rate = REAGENTS_METABOLISM * 0.5
+	color = "#E1A116"
+	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY
+	taste_description = "sourness"
+	var/warned = FALSE
+
+/datum/reagent/nitrosyl_plasmide/on_mob_metabolize(mob/living/L)
+	. = ..()
+	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrosyl_plasmide)
+	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
+	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+
+/datum/reagent/nitrosyl_plasmide/on_mob_end_metabolize(mob/living/L)
+	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/nitrosyl_plasmide)
+	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
+	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	return ..()
+
+/datum/reagent/nitrosyl_plasmide/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	. = ..()
+	M.adjustStaminaLoss((clamp((-10 + current_cycle), -8, 3)) * REM * delta_time, 0)
+	if(!warned && current_cycle >= 13)
+		M.visible_message(span_danger("Your body feels like it's on fire!")) // Nitrosyl is now draining more than Nitrium is giving
+		warned = TRUE
+
 	return TRUE
 
 /////////////////////////Colorful Powder////////////////////////////

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -291,6 +291,10 @@
 		if (nitrium_pp > 5)
 			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitrium)
 			H.reagents.add_reagent(/datum/reagent/nitrium, max(0, 4 - existing))
+		if (nitrium_pp > 10)
+			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitrosyl_plasmide)
+			H.reagents.add_reagent(/datum/reagent/nitrosyl_plasmide, max(0, 4 - existing))
+			H.reagents.add_reagent(/datum/reagent/nitrium, 2) //Nitrium addiction and eventually overdose will come from this.
 
 		REMOVE_MOLES(/datum/gas/nitrium, breath, gas_breathed)
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -288,12 +288,9 @@
 			H.adjustOrganLoss(ORGAN_SLOT_LUNGS, nitrium_pp * 0.1)
 			to_chat(H, span_notice("You feel a burning sensation in your chest"))
 		gas_breathed = PP(breath, /datum/gas/nitrium)
-		if (nitrium_pp > 5)
-			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitrium_low_metabolization)
-			H.reagents.add_reagent(/datum/reagent/nitrium_low_metabolization, max(0, 2 - existing))
 		if (nitrium_pp > 10)
-			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitrium_high_metabolization)
-			H.reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, max(0, 1 - existing))
+			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitrium)
+			H.reagents.add_reagent(/datum/reagent/nitrium, max(0, 5 - existing))
 
 		REMOVE_MOLES(/datum/gas/nitrium, breath, gas_breathed)
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -294,7 +294,7 @@
 		if (nitrium_pp > 10)
 			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitrosyl_plasmide)
 			H.reagents.add_reagent(/datum/reagent/nitrosyl_plasmide, max(0, 4 - existing))
-			H.reagents.add_reagent(/datum/reagent/nitrium, 2) //Nitrium addiction and eventually overdose will come from this.
+			H.reagents.add_reagent(/datum/reagent/nitrium, 2) //Triggers overdose message primarily, so players aren't stuck in extreme slowdown for too long.
 
 		REMOVE_MOLES(/datum/gas/nitrium, breath, gas_breathed)
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -288,9 +288,9 @@
 			H.adjustOrganLoss(ORGAN_SLOT_LUNGS, nitrium_pp * 0.1)
 			to_chat(H, span_notice("You feel a burning sensation in your chest"))
 		gas_breathed = PP(breath, /datum/gas/nitrium)
-		if (nitrium_pp > 10)
+		if (nitrium_pp > 5)
 			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitrium)
-			H.reagents.add_reagent(/datum/reagent/nitrium, max(0, 5 - existing))
+			H.reagents.add_reagent(/datum/reagent/nitrium, max(0, 4 - existing))
 
 		REMOVE_MOLES(/datum/gas/nitrium, breath, gas_breathed)
 

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -30,6 +30,7 @@
 		)
 	premium = list(
 		/obj/item/melee/skateboard/pro = 3,
+		/obj/item/clothing/shoes/wheelys= 3,
 		/obj/item/canvas/twentyfour_twentyfour = 5,
 		/obj/item/airlock_painter = 1,
 		/obj/item/melee/skateboard/hoverboard = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Wheelys 
* Are now equal to skateboard speed. I did not fix the jittery vehicle motion as this is beyond the scope of what I aimed to do with this PR.
* Reverts #12581 which means they are now available from vendors again.

### Nitrium
* Now has two stages of speed boost, 0.4 at low dose and 0.75 at high dose
* No longer gives immunity to damage slowdown
* Low dose gives stamcrit and limb disable immunity now
* Starts out by restoring stamina, but as you continue to metabolize nitrium it switches to draining your stamina instead. High doses make this switch much sooner.
* Immunity to stamcrit means that slowdown will never go beyond being a slowdown, you can never become stuck in stamcrit and unable to switch internals off. 
* Nitrium is now extremely addictive - your first hit will have you hooked. There are no actual penalties for addiction though, just flavor messages for cravings.
* Nitrium also has an overdose now, though this again has no actual mechanical downsides. This serves almost purely as a warning for those still experimenting because an overdose will leave you moving like a snail for quite a while.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Wheelys barely even need an explanation, they are so unreasonably fast. 

Nitrium makes players too fast and can also be huffed indefinitely with no downsides if you get the ratio just right. This iteration of nitrium makes it the safest available move speed increase with the biggest downside being that you simply can't have it active at all times. I don't want to make it so nitrium isn't worth making/using, but I also don't want to see most of the server constantly nyooming around at twice meth speed with no drawbacks.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

First part of gif is normal speed, Nitrium kicks in just as I turn right at the top of the central hall.

![dreamseeker_3jzqumKaRz](https://github.com/user-attachments/assets/f3e141d8-9d06-4160-921d-919f71a1b8e3)

## Changelog
:cl:
balance: Wheelys now have the same speed as skateboards instead of lightspeed.
balance: Nitrium move speed buff has been reduced. High and low doses provide different boosts now as well, but both are lower than the old speed.
balance: Nitrium is no longer fatal in any capacity when misused, making it the safest available speed boosting "drug". 
balance: Nitrium no longer gives damage slowdown immunity, but has retained all other immunities.
tweak: Nitrium stops restoring stamina after a certain point, and instead starts to inflict stamina damage. This is indicated by the messages "Your body aches!" or "Your body feels like it's on fire!" when you are under the effects. (Note that nitrium still offers stamina crit immunity so you will never accidentally fall into stamcrit making you unable to switch your internals off)
tweak: Nitrium is now highly addicting and has an overdose threshold. These do not mechanically punish players and serve only as flavor and a clear warning respectively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
