### PR TITLE
Fixes Quickstart

### DIFF
--- a/code/~overrides/quickstart.dm
+++ b/code/~overrides/quickstart.dm
@@ -10,6 +10,6 @@
 /datum/controller/subsystem/job/AssignRole(mob/dead/new_player/player, rank, latejoin = FALSE)
 	. = ..(player, "Debug Job", rank, latejoin)
 
-/mob/dead/new_player
+/mob/dead/new_player/authenticated
 	ready = TRUE
 #endif


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #12964

Updated quickstart.dm, added "/authenticated" to the quickstart option that forced ready = true on everyone, since that's where the ready variable got moved to.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Doesn't break when you try to run the game in quickstart to test things quickly 👍 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots</summary>

the testing settings:
<img width="382" height="132" alt="GitHubDesktop_7vwnlOVtuT" src="https://github.com/user-attachments/assets/bb554f8d-d3c3-4d0d-9650-986a892c69e0" />

the game loading with quickstart:
<img width="1280" height="770" alt="dreamseeker_gHzu3YV6FO" src="https://github.com/user-attachments/assets/56cfc64b-830e-4af0-96e9-b9bd25417089" />

</details>

## Changelog
:cl: Gilgax
code: fixed the quickstart setting for easier debugging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
