### PR TITLE
grants pyroclastic anomaly slimes inheritable sentience

### DIFF
--- a/code/game/objects/effects/anomalies/anomaly_pyro.dm
+++ b/code/game/objects/effects/anomalies/anomaly_pyro.dm
@@ -33,4 +33,5 @@
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
 	S.flavor_text = FLAVOR_TEXT_EVIL
-	S.set_playable(ROLE_PYRO_SLIME)
+	S.transformeffects = SLIME_EFFECT_LIGHT_PINK
+	S.set_playable_slime(ROLE_PYRO_SLIME)

--- a/code/game/objects/effects/anomalies/anomaly_pyro.dm
+++ b/code/game/objects/effects/anomalies/anomaly_pyro.dm
@@ -27,7 +27,7 @@
 		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
 		log_game("A pyroclastic anomaly has detonated at [loc].")
 		message_admins("A pyroclastic anomaly has detonated at [ADMIN_VERBOSEJMP(loc)].")
-	var/new_colour = pick("red", "orange")
+	var/new_colour = pick(SLIME_TYPE_ORANGE, SLIME_TYPE_RED)
 	var/mob/living/simple_animal/slime/S = new(T, new_colour)
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -574,7 +574,7 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime/random)
 /mob/living/simple_animal/slime/proc/set_playable_slime(ban_type = null, poll_ignore_key = null)
 	playable = TRUE
 	playable_bantype = ban_type
-	LAZYADD(GLOB.mob_spawners["[master ? "[src.master.real_name]'s slime" : "[name]"]"], src)
+	LAZYADD(GLOB.mob_spawners["[master ? "[src.master.real_name]'s slime" : "free [src.colour] slime"]"], src)
 	SSmobs.update_spawners()
 	if (!key)	//ping only if there is no one inhabiting this mob
 		notify_ghosts("[name] can be controlled", null, enter_link="<a href='byond://?src=[REF(src)];activate=1'>(Click to play)</a>", source=src, action=NOTIFY_ATTACK, ignore_key = poll_ignore_key)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -561,10 +561,10 @@ CREATION_TEST_IGNORE_SUBTYPES(/mob/living/simple_animal/slime/random)
 	return .
 
 /mob/living/simple_animal/slime/get_spawner_desc()
-	return "be a slime[master ? " under the command of [master.real_name]" : ""]."
+	return "be a slime[master ? " under the command of [master.real_name]" : " with free will"]."
 
 /mob/living/simple_animal/slime/get_spawner_flavour_text()
-	return "You are a slime born and raised in a laboratory.[master ? " Your duty is to follow the orders of [master.real_name].": ""]"
+	return "You are a slime born and raised in a laboratory.[master ? " Your duty is to follow the orders of [master.real_name].": " You are not subject to anyone's commands, but the crew may not take kindly to a murderous slime!"]"
 
 /mob/living/simple_animal/slime/proc/make_master(mob/user)
 	Friends[user] += SLIME_FRIENDSHIP_ATTACK * 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Slimes spawned by a pyroclastic anomaly now start with a transformative light pink extract applied, allowing their offspring to be possessed as well.

Slime organisation is also improved slightly in the spawner menu, grouping together masterless slimes (currently only those that spawn from a pyroclastic anomaly) by colour.

The ghostspawn menu (as well as a message upon becoming a masterless slime) also reminds ghosts that a slime that does not have a master is not required to be nice to the crew, but also that the crew can and will retaliate against murderous slimes.

Suggested by Rukofamicom in #12981 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes the pyroclastic anomaly slime a bit more interesting by increasing the potential for mayhem while also giving more than one ghost something to do with it. Tweaks to the wording used in the ghostspawn menu will hopefully make it clearer what one is allowed to do as a slime without a master.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

two transformative light pink extract slimes - one created by xenobiology (top), one spawned from a pyroclastic anomaly (bottom):
<img width="691" height="210" alt="grafik" src="https://github.com/user-attachments/assets/fa146de1-dfd2-4439-912f-c3d9d60d359e" />

all entries for the slimes resulting from each splitting once, also demonstrating colour sorting for free slimes:
<img width="721" height="350" alt="grafik" src="https://github.com/user-attachments/assets/9bc2c9f3-b560-4c6d-bf06-eb50fca58f41" />

the free will reminder, repeated when possessing a free slime:
<img width="844" height="110" alt="grafik" src="https://github.com/user-attachments/assets/6649c6df-f369-47f8-b7a4-f538e2872afe" />

</details>

## Changelog
:cl: Asdfagi
tweak: pyroclastic anomaly slimes now spawn with a transformative light pink extract applied, meaning that their offspring can also become sentient
tweak: some wording for ghostspawn slimes without a master expanded for clarity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
