### PR TITLE
Stripping to hands

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1314,7 +1314,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return !HAS_TRAIT(src, TRAIT_NODROP)
 
 /obj/item/proc/doStrip(mob/stripper, mob/owner)
-	return owner.dropItemToGround(src)
+	. = owner.doUnEquip(src, force, drop_location(), FALSE)
+	return stripper.put_in_hands(src)
 
 /obj/item/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stripping just throws the items in the ground.

I thought this didn't make much sense. So I made them be put into the strippers hands instead.



https://github.com/user-attachments/assets/cb58e3ff-2d89-45b0-bab0-10bee5875b13


This code is a bit more complicated than I expected so, while it does work it stops stripping if your hands aren't full, because two items will be fighting over the same hand spot.

I don't exactly know how to change this but maybe its a good thing that discourages full stripping?

## Why It's Good For The Game

Pickpocketing is almost useless since the items drop from the persons pockets into the ground.

The target has to actually pretend he didn't see anything instead of... not being aware of it in truth.

This fixes that.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Up there.

</details>

## Changelog
:cl:
tweak: Stripping a mob now puts the item in the strippers hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
