### PR TITLE
Rodent Dormant Diseases

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -46,7 +46,10 @@
 	icon_dead = "mouse_[body_color]_dead"
 	held_state = "mouse_[body_color]"
 	if(prob(75))
-		rat_diseases += new /datum/disease/advance/random(rand(1, 6), 9, 1, infected = src)
+		var/datum/disease/advance/dormant_disease = new /datum/disease/advance/random(rand(1, 6), 9, 1, infected = src) // Dormant desiese
+		dormant_disease.dormant = TRUE
+		dormant_disease.spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+		rat_diseases += dormant_disease
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
@@ -62,15 +65,13 @@
 	death()
 
 /mob/living/simple_animal/mouse/death(gibbed, toast)
-	var/list/data = list("viruses" = rat_diseases)
 	if(!ckey)
 		..(1)
 		if(!gibbed)
 			var/obj/item/food/deadmouse/M = new(loc)
+			M.rat_diseases = rat_diseases
 			M.icon_state = icon_dead
 			M.name = name
-			if(CONFIG_GET(flag/biohazards_allowed))
-				M.reagents.add_reagent(/datum/reagent/blood, 2, data)
 			if(toast)
 				M.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
 				M.desc = "It's toast."
@@ -149,6 +150,11 @@
 	)
 	decomp_req_handle = TRUE
 	decomp_type = /obj/item/food/deadmouse/moldy
+	var/list/datum/disease/rat_diseases = list()
+
+/obj/item/food/deadmouse/extrapolator_act(mob/living/user, obj/item/extrapolator/extrapolator, dry_run = FALSE)
+	. = ..()
+	EXTRAPOLATOR_ACT_ADD_DISEASES(., rat_diseases)
 
 /obj/item/food/deadmouse/moldy
 	name = "moldy dead mouse"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rat diseases are now dormant and non contagious.

<img width="787" height="385" alt="image" src="https://github.com/user-attachments/assets/25b970a0-6fd3-424c-b031-f667e26fdc3f" />

Also, you can now use the extrapolator on dead mice. Since grinding trying to extract their diseases trough blood was impossible, in my testing.

## Why It's Good For The Game

This came after a conversation about species with @Rukofamicom and @siryoshimoto 

Felinids can now act like felinids and eats rats.

Virology is no longer a thing and sledom prepared for virus breakouts. Now a random guy eating a mice wont infect the whole station with space aids.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Screenshot up.

</details>

## Changelog
:cl: Solene & Mr.Yoshimoto
tweak: Mouse diseases are now always dormant, eating one won't infect anyone.
add: Extrapolators now work on dead mice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
