### PR TITLE
Queue deletion instead of immediately qdeling improperly placed maintenance rooms

### DIFF
--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -62,7 +62,7 @@
 					continue
 				// Check to see if we correctly placed ourselves on a wall
 				if (!isclosedturf(get_step(placed_object, placed_object.dir)))
-					qdel(placed_object)
+					SSatoms.prepare_deletion(placed_object)
 
 /obj/effect/spawner/room/special/tenxfive_terrestrial
 	name = "10x5 terrestrial room"


### PR DESCRIPTION
## About The Pull Request

#12930 was a band-aid solution to the issue of improperly placed objects being qdeleted before they were actually initialized. This PR applies the "correct" solution

## Why It's Good For The Game

Safeguard against potential future screwups involving weird roomspawner objects being qdeleted

## Testing Photographs and Procedure

can't feasibly get testing evidence

## Changelog

no player facing changes
