### PR TITLE
Venus trap decay increase

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -155,7 +155,7 @@
 		if(withering)
 			to_chat(src, span_notice(" The vines nourish you, healing your wounds."))
 			stop_automated_movement = 0
-		adjustHealth(-maxHealth*0.05)
+		adjustHealth(-maxHealth*0.1)
 		withering = FALSE
 		retreating = FALSE
 		return

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -155,7 +155,7 @@
 		if(withering)
 			to_chat(src, span_notice(" The vines nourish you, healing your wounds."))
 			stop_automated_movement = 0
-		adjustHealth(-maxHealth*0.1)
+		adjustHealth(-maxHealth*0.05)
 		withering = FALSE
 		retreating = FALSE
 		return
@@ -173,7 +173,7 @@
 			Goto(possible_retreat_turfs[rand(1,possible_retreat_turfs.len)], move_to_delay, 0)
 			retreating = TRUE
 	playsound(src.loc, 'sound/creatures/venus_trap_hurt.ogg', 50, 1)
-	adjustHealth(maxHealth*0.1)
+	adjustHealth(maxHealth*0.15)
 
 /mob/living/simple_animal/hostile/venus_human_trap/Moved(atom/OldLoc, Dir)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Venus human traps now lose 15% of their health per life tick outside of the vines

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This role is supposed to defend vines, not aggressively pursue crew and kill them. Something is wrong when they are aggressively chasing players entire screens away from vines without being at risk of dying. The increased health pool actually seems to need a further increased drain rate when they leave vines. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I can't really get a screencap of the health drain reliably, so take my word for it that it ticks at 15%

<img width="761" height="127" alt="image" src="https://github.com/user-attachments/assets/af74d1d4-43ef-4b78-bff0-a1a40dfd5453" />


</details>

## Changelog
:cl:
tweak: Venus human traps lose 15% of their health per tick upon leaving vines.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
