### PR TITLE
Fix borg brain disconnecting from MMI when deconstructing

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -845,6 +845,8 @@
 	if (cell) //Sanity check.
 		cell.forceMove(T)
 		cell = null
+	// Call destroy() before deleting to ensure that the borg's brain stays connected
+	Destroy()
 	qdel(src)
 
 ///This is the subtype that gets created by robot suits. It's needed so that those kind of borgs don't have a useless cell in them


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an issue where fully deconstructing a cyborg turns the borg player into a ghost, breaking the connection to the MMI.
Adds a single call to Destroy() as part of deconstruct(). Destroy() was previously being called during deletion, which is too late.
(closes #12542)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Without this fix, cyborg players can currently be taken out of the game indefinitely by mistake, leaving an orphaned MMI that has no purpose.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing procedure</summary>

To test, deconstruct a player-controlled cyborg with and without this new PR. This can be either manually with tools, or by directly calling the deconstruct() proc on the cyborg with no arguments.

Without the new PR, the cyborg player will be ghosted. With the new PR, they will retain control of the MMI.

</details>
<details>
<summary>Testing screenshots</summary>

**Execute deconstruct proc on self while playing roundstart borg**
<img width="484" height="288" alt="TestingProcedure" src="https://github.com/user-attachments/assets/494040c3-d667-401d-b23c-126d43e6061e" />

**Without fix (note ghost)**
<img width="243" height="207" alt="Ghost" src="https://github.com/user-attachments/assets/198e90f5-40aa-4592-ba2f-b5ac1a19a117" />

**With fix (note MMI talking)**
<img width="275" height="213" alt="NoGhost" src="https://github.com/user-attachments/assets/f1b392d1-2d4a-48fe-a54f-be2da8528c49" />

</details>

## Changelog
:cl:
fix: issue with fully deconstructing cyborgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
