### PR TITLE
Tackle RNG rebalanced

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -403,9 +403,9 @@
 		if(tackle_target.is_shove_knockdown_blocked()) // riot armor and such
 			defense_mod += 5
 		if(tackle_target.combat_mode) // they're ready for you
-			defense_mod += 4
+			defense_mod += 5
 		if(tackle_target.throw_mode) //they're REALLY ready for you
-			defense_mod += 4
+			defense_mod += 5
 
 		var/obj/item/organ/tail/lizard/el_tail = tackle_target.get_organ_slot(ORGAN_SLOT_TAIL)
 		if(HAS_TRAIT(tackle_target, TRAIT_TACKLING_TAILED_DEFENDER) && !el_tail)

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -286,7 +286,7 @@
 	user.SetKnockdown(0, ignore_canstun = TRUE)
 	user.get_up(TRUE)
 	adjust_staggered_up_to(user, STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
-	adjust_staggered_up_to(target, STAGGERED_SLOWDOWN_LENGTH * 2, 10 SECONDS) //okay maybe slightly good for the sacker, it's a mild benefit okay?
+	adjust_staggered_up_to(target, STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
 
 /**
  * Our negative tackling outcomes.
@@ -346,7 +346,6 @@
 			user.Paralyze(3 SECONDS)
 			user.apply_damage(80, STAMINA)
 			user.apply_damage(20, BRUTE, BODY_ZONE_HEAD)
-			user.gain_trauma(/datum/brain_trauma/mild/concussion)
 			adjust_staggered_up_to(user, STAGGERED_SLOWDOWN_LENGTH * 3, 10 SECONDS)
 
 /**
@@ -397,9 +396,9 @@
 		if(tackle_target.is_shove_knockdown_blocked()) // riot armor and such
 			defense_mod += 5
 		if(tackle_target.combat_mode) // they're ready for you
-			defense_mod += 5
+			defense_mod += 4
 		if(tackle_target.throw_mode) //they're REALLY ready for you
-			defense_mod += 5
+			defense_mod += 4
 
 		var/obj/item/organ/tail/lizard/el_tail = tackle_target.get_organ_slot(ORGAN_SLOT_TAIL)
 		if(HAS_TRAIT(tackle_target, TRAIT_TACKLING_TAILED_DEFENDER) && !el_tail)

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -396,6 +396,10 @@
 			defense_mod += 1
 		if(tackle_target.is_shove_knockdown_blocked()) // riot armor and such
 			defense_mod += 5
+		if(tackle_target.combat_mode) // they're ready for you
+			defense_mod += 5
+		if(tackle_target.throw_mode) //they're REALLY ready for you
+			defense_mod += 5
 
 		var/obj/item/organ/tail/lizard/el_tail = tackle_target.get_organ_slot(ORGAN_SLOT_TAIL)
 		if(HAS_TRAIT(tackle_target, TRAIT_TACKLING_TAILED_DEFENDER) && !el_tail)
@@ -435,8 +439,8 @@
 			attack_mod -= 2
 		var/datum/component/mood/human_sacker_sanity = human_sacker.GetComponent(/datum/component/mood)
 		if(human_sacker_sanity.sanity == SANITY_INSANE) //I've gone COMPLETELY INSANE
-			attack_mod += 15
-			human_sacker.adjustStaminaLoss(100) //AHAHAHAHAHAHAHAHA
+			attack_mod += 5
+			human_sacker.adjustStaminaLoss(150) //AHAHAHAHAHAHAHAHA
 
 		if(human_sacker.is_shove_knockdown_blocked()) // tackling with riot specialized armor, like riot armor, is effective but tiring
 			attack_mod += 2

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -380,8 +380,15 @@
 
 	if(HAS_TRAIT(target, TRAIT_GIANT))
 		defense_mod += 2
-	if(target.health < 50)
+
+	if(target.health < 80)
 		defense_mod -= 1
+	if(target.health < 60)
+		defense_mod -= 1
+	if(target.health < 40)
+		defense_mod -= 2
+	if(target.health < 20)
+		defense_mod -= 2
 
 	if(ishuman(target))
 		var/mob/living/carbon/human/tackle_target = target

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -381,8 +381,8 @@
 	if(HAS_TRAIT(target, TRAIT_GIANT))
 		defense_mod += 2
 
-	if(target.health < 80)
-		defense_mod -= 1
+	if(target.health >= 80)
+		defense_mod += 2
 	if(target.health < 60)
 		defense_mod -= 1
 	if(target.health < 40)

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -445,7 +445,7 @@
 			attack_mod += 2
 			human_sacker.adjustStaminaLoss(20)
 
-	var/randomized_tackle_roll = rand(-3, 3) - defense_mod + attack_mod + skill_mod
+	var/randomized_tackle_roll = rand(-6, 6) - defense_mod + attack_mod + skill_mod
 	return randomized_tackle_roll
 
 

--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -94,7 +94,7 @@
 	tackle_range = 10
 	min_distance = 7
 	tackle_speed = 6
-	skill_mod = 7
+	skill_mod = 0 //where's the "high risk" in having a +7 modifier here?!
 
 /obj/item/clothing/gloves/tackler/offbrand
 	name = "improvised gripper gloves"
@@ -104,4 +104,4 @@
 	tackle_stam_cost = 30
 	base_knockdown = 1.75 SECONDS
 	min_distance = 2
-	skill_mod = -1
+	skill_mod = 1

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -162,9 +162,6 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 
 /mob/living/carbon/proc/throw_mode_on(mode = THROW_MODE_TOGGLE)
 	throw_mode = mode
-	if(GetComponents(/datum/component/tackler))
-		balloon_alert_to_viewers("[src] looks ready to tackle!", ignored_mobs = list(src))
-		changeNext_move(CLICK_CD_THROW) //No instant tackling!
 	if(client && hud_used)
 		hud_used.throw_icon.icon_state = "act_throw_on"
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -164,6 +164,7 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 	throw_mode = mode
 	if(GetComponents(/datum/component/tackler))
 		balloon_alert_to_viewers("[src] looks ready to tackle!", ignored_mobs = list(src))
+		changeNext_move(CLICK_CD_THROW) //No instant tackling!
 	if(client && hud_used)
 		hud_used.throw_icon.icon_state = "act_throw_on"
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -162,6 +162,8 @@ CREATION_TEST_IGNORE_SELF(/mob/living/carbon)
 
 /mob/living/carbon/proc/throw_mode_on(mode = THROW_MODE_TOGGLE)
 	throw_mode = mode
+	if(GetComponents(/datum/component/tackler))
+		balloon_alert_to_viewers("[src] looks ready to tackle!", ignored_mobs = list(src))
 	if(client && hud_used)
 		hud_used.throw_icon.icon_state = "act_throw_on"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is mostly a nerf to tackling gloves hopefully without pushing them into obscurity. Exact changes include:
* Adding a defensive modifier of +5 for anyone in combat mode. Tackles are best done against people who are not ready for action.
* Adding a defensive modifier of +5 for anyone with throw_mode enabled when they are tackled, same counter for catching a thrown person as catching a thrown item
* Added three more health thresholds with modifiers at varying ranges, from +2 at full health all the way to -5 at 20 health. 
* Being insane no longer gives an unbelievable +15 modifier, and instead gives only a +5 modifier now. This modifier also puts the user into deep stamcrit instead of barely into stamcrit.
* Rocket gloves, the alleged high-risk and high-return gloves, no longer give a massive +7 modifier and are now set to 0.
* Makeshift gloves now have a +1 modifier instead of a -1 modifier. These gloves already have reduced range and impact.
* The final roll is now +/- 6 instead of +/- 3, allowing for more variance overall and less certainty of the outcome.
* Concussions are no longer a possibility when hitting a mob. Various disabilities can still happen from crashing into solid objects. 
* Neutral outcome rolls are no longer clearly tilted in favor of the person who tackled - both players will get up at the same time

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'm all in favor of RNG in combat, but I'm not in favor of it being substantially tilted toward the side of the player utilizing it like tackling gloves are, the +/- 3 modifier only applies if there are almost no outside conditions, or barely any and most gloves give enough of a modifier to mostly negate this variance on their own, making the outcomes fairly predictable. 

These changes put more of the weight in the hands of the player being tackled and how ready for combat they were, while also putting more weight into how much health the target has.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

### This screenshot is no longer truly accurate due to change request, but may return in a later update to the PR, or a separate PR depending on combat indicators. Without this change the PR is purely math changing. 

<img width="428" height="182" alt="image" src="https://github.com/user-attachments/assets/c03005d5-8b99-45d1-bc41-6fe979bc6acc" />


## Changelog
:cl:
balance: Tackling gloves are less effective against targets in combat mode and/or targets with throw enabled and have a higher variance when it comes to the RNG roll that determines the outcome of an attempted tackle.
balance: Tackling gloves are less effective at targets with no damage (real or stamina) and more effective as their health goes down.
tweak: Rocket gloves no longer give a positive modifier during the outcome roll. These gloves were said to be high-risk and high-reward but offered such a high positive bonus they nearly guaranteed a positive outcome.
tweak: improvised gripper gloves no longer have a negative modifier
tweak: Being insane no longer guarantees a successful tackle, but still provides a high modifier. It also sends you deeper into crit instead of barely into crit now. 
tweak: Neutral outcome roll is actually neutral instead of giving the person who tackled a major advantage on knockdown time. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
