### PR TITLE
Poisoned Knife buff

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -79,8 +79,8 @@
 
 	//Finally we need to make sure we actually have whatever our injection amount is left in the knife, and if not we use whatever is left
 	amount_to_inject = min(reagents.total_volume, amount_to_inject)
-	reagents.expose(M,INJECT,amount_to_inject)
-	reagents.trans_to(M,amount_to_inject)
+	reagents.expose(M, INJECT, amount_to_inject)
+	reagents.trans_to(M, amount_to_inject)
 
 /obj/item/knife/kitchen
 	name = "kitchen knife"

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -64,24 +64,6 @@
 	else
 		return ..()
 
-/obj/item/knife/poison/attack(mob/living/M, mob/user)
-	if (!istype(M))
-		return
-	. = ..()
-	if (!reagents.total_volume || !M.reagents)
-		return
-	//Get our preferred transfer amount
-	var/amount_to_inject = amount_per_transfer_from_this
-
-	//If the target is protected from injections, we will still inject anyway because it's a knife not a syringe, but a reduced amount.
-	if(!M.can_inject(user, user.get_combat_bodyzone(), INJECT_CHECK_PENETRATE_THICK))
-		amount_to_inject = amount_to_inject / 3
-
-	//Finally we need to make sure we actually have whatever our injection amount is left in the knife, and if not we use whatever is left
-	amount_to_inject = min(reagents.total_volume, amount_to_inject)
-	reagents.expose(M, INJECT, amount_to_inject)
-	reagents.trans_to(M, amount_to_inject)
-
 /obj/item/knife/kitchen
 	name = "kitchen knife"
 	desc = "A general purpose Chef's Knife made by SpaceCook Incorporated. Guaranteed to stay sharp for years to come."

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -70,12 +70,17 @@
 	. = ..()
 	if (!reagents.total_volume || !M.reagents)
 		return
-	var/amount_inject = amount_per_transfer_from_this
+	//Get our preferred transfer amount
+	var/amount_to_inject = amount_per_transfer_from_this
+
+	//If the target is protected from injections, we will still inject anyway because it's a knife not a syringe, but a reduced amount.
 	if(!M.can_inject(user, user.get_combat_bodyzone(), INJECT_CHECK_PENETRATE_THICK))
-		amount_inject = 1
-	var/amount = min(amount_inject/reagents.total_volume,1)
-	reagents.expose(M,INJECT,amount)
-	reagents.trans_to(M,amount_inject)
+		amount_to_inject = amount_to_inject / 3
+
+	//Finally we need to make sure we actually have whatever our injection amount is left in the knife, and if not we use whatever is left
+	amount_to_inject = min(reagents.total_volume, amount_to_inject)
+	reagents.expose(M,INJECT,amount_to_inject)
+	reagents.trans_to(M,amount_to_inject)
 
 /obj/item/knife/kitchen
 	name = "kitchen knife"

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -89,9 +89,8 @@
 /obj/item/knife/poison
 	name = "venom knife"
 	icon_state = "poisonknife"
-	icon = 'icons/obj/knives.dmi'
-	force = 12
-	throwforce = 15
+	force = 20
+	throwforce = 20
 	throw_speed = 5
 	throw_range = 7
 	var/amount_per_transfer_from_this = 10

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -117,9 +117,9 @@
 		reagents.trans_to(M, reagents.total_volume)
 
 /obj/item/knife/venom/attack(mob/living/M, mob/user)
+	. = ..()
 	if (!istype(M))
 		return
-	. = ..()
 	if (!reagents.total_volume || !M.reagents)
 		return
 	//Get our preferred transfer amount

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -87,7 +87,7 @@
 	force = 12
 
 /obj/item/knife/poison
-	name = "venom knife"
+	name = "poisoned knife"
 	icon_state = "poisonknife"
 	icon = 'icons/obj/knives.dmi'
 	force = 20

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -86,21 +86,23 @@
 	icon = 'icons/obj/knives.dmi'
 	force = 12
 
-/obj/item/knife/poison
-	name = "poisoned knife"
+/obj/item/knife/venom
+	name = "venom knife"
 	icon_state = "poisonknife"
 	icon = 'icons/obj/knives.dmi'
 	force = 20
 	throwforce = 20
 	throw_speed = 5
 	throw_range = 7
+	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "cuts")
+	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "cut")
 	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE, "armour_block" = 60)
 	var/amount_per_transfer_from_this = 10
 	var/list/possible_transfer_amounts
 	desc = "An infamous knife of syndicate design, it has a tiny hole going through the blade to the handle which stores toxins."
 	custom_materials = null
 
-/obj/item/knife/poison/embedded(atom/target)
+/obj/item/knife/venom/embedded(atom/target)
 	. = ..()
 	if(!reagents.total_volume)
 		return
@@ -114,7 +116,7 @@
 		reagents.expose(M, INJECT, reagents.total_volume)
 		reagents.trans_to(M, reagents.total_volume)
 
-/obj/item/knife/poison/attack(mob/living/M, mob/user)
+/obj/item/knife/venom/attack(mob/living/M, mob/user)
 	if (!istype(M))
 		return
 	. = ..()
@@ -132,12 +134,12 @@
 	reagents.expose(M, INJECT, amount_to_inject)
 	reagents.trans_to(M, amount_to_inject)
 
-/obj/item/knife/poison/Initialize(mapload)
+/obj/item/knife/venom/Initialize(mapload)
 	. = ..()
 	create_reagents(40,OPENCONTAINER)
 	possible_transfer_amounts = list(5, 10)
 
-/obj/item/knife/poison/attack_self(mob/user)
+/obj/item/knife/venom/attack_self(mob/user)
 	if(possible_transfer_amounts.len)
 		var/i=0
 		for(var/A in possible_transfer_amounts)

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -89,6 +89,7 @@
 /obj/item/knife/poison
 	name = "venom knife"
 	icon_state = "poisonknife"
+	icon = 'icons/obj/knives.dmi'
 	force = 20
 	throwforce = 20
 	throw_speed = 5

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -100,6 +100,38 @@
 	desc = "An infamous knife of syndicate design, it has a tiny hole going through the blade to the handle which stores toxins."
 	custom_materials = null
 
+/obj/item/knife/poison/embedded(atom/target)
+	. = ..()
+	if(!reagents.total_volume)
+		return
+
+	if(isliving(target))
+		var/mob/living/M = target
+		if(!M.reagents)
+			return
+
+		//If they were willing to throw the knife on a base 65% embed chance, give their target the entire payload
+		reagents.expose(M, INJECT, reagents.total_volume)
+		reagents.trans_to(M, reagents.total_volume)
+
+/obj/item/knife/poison/attack(mob/living/M, mob/user)
+	if (!istype(M))
+		return
+	. = ..()
+	if (!reagents.total_volume || !M.reagents)
+		return
+	//Get our preferred transfer amount
+	var/amount_to_inject = amount_per_transfer_from_this
+
+	//If the target is protected from injections, we will still inject anyway because it's a knife not a syringe, but a reduced amount.
+	if(!M.can_inject(user, user.get_combat_bodyzone(), INJECT_CHECK_PENETRATE_THICK))
+		amount_to_inject = amount_to_inject / 3
+
+	//Finally we need to make sure we actually have whatever our injection amount is left in the knife, and if not we use whatever is left
+	amount_to_inject = min(reagents.total_volume, amount_to_inject)
+	reagents.expose(M, INJECT, amount_to_inject)
+	reagents.trans_to(M, amount_to_inject)
+
 /obj/item/knife/poison/Initialize(mapload)
 	. = ..()
 	create_reagents(40,OPENCONTAINER)

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -94,6 +94,7 @@
 	throwforce = 20
 	throw_speed = 5
 	throw_range = 7
+	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE, "armour_block" = 60)
 	var/amount_per_transfer_from_this = 10
 	var/list/possible_transfer_amounts
 	desc = "An infamous knife of syndicate design, it has a tiny hole going through the blade to the handle which stores toxins."

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/soap,
 		/obj/item/knife/kitchen,
 		/obj/item/knife/combat,
-		/obj/item/knife/poison,
+		/obj/item/knife/venom,
 		/obj/item/throwing_star,
 		/obj/item/syndie_glue,
 		/obj/item/book_of_babel,

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -425,10 +425,10 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 /datum/uplink_item/dangerous
 	category = "Conspicuous Weapons"
 
-/datum/uplink_item/dangerous/poisonknife
-	name = "Poisoned Knife"
+/datum/uplink_item/dangerous/venomknife
+	name = "Venom Knife"
 	desc = "A knife that is made of two razor sharp blades, it has a secret compartment in the handle to store liquids which are injected when stabbing something. Can hold up to forty units of reagents but comes empty."
-	item = /obj/item/knife/poison
+	item = /obj/item/knife/venom
 	cost = 4
 
 /datum/uplink_item/dangerous/rawketlawnchair

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -429,7 +429,7 @@ GLOBAL_LIST_INIT(illegal_tech_blacklist, typecacheof(list(
 	name = "Poisoned Knife"
 	desc = "A knife that is made of two razor sharp blades, it has a secret compartment in the handle to store liquids which are injected when stabbing something. Can hold up to forty units of reagents but comes empty."
 	item = /obj/item/knife/poison
-	cost = 6 // all in all it's not super stealthy and you have to get some chemicals yourself
+	cost = 4
 
 /datum/uplink_item/dangerous/rawketlawnchair
 	name = "84mm Rocket Propelled Grenade Launcher"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Venom knife has been renamed to poisoned knife, for sake of consistency. This is what the uplink calls it as well as what it is called in code both. 
* Poisoned knife now costs 4 TC, down from 6
* Poisoned knife now has the same base damage (20) and embedding stats (65% chance) as the combat knife 
* Poisoned knife now injects 1/3 of its intended dosage when attacking a target that would block syringes, instead of only 1u
* If a thrown venom knife embeds, it will inject the entirety of its remaining contents. Considering this has a fairly high chance of failing to embed and then being used against you, I think this is a fair reward for a high-risk play.
* Cleaned up and commented the injection code to make it easier to read, and also moved it to the same file as the rest of the code. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If sleepy pen is being buffed again, there is no reason to pick this knife over the sleepy pen. This keeps the knife as a viable, less stealthy alternative to the sleepy pen.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Embedding a 40u water knife in an oozeling:
![dreamseeker_mUeenc7Oyu](https://github.com/user-attachments/assets/5431543d-b4b1-456c-a39f-1733a6b18335)

<img width="155" height="224" alt="image" src="https://github.com/user-attachments/assets/5cb725a4-1b7a-4555-8f30-2f2b2fa2f191" />


<img width="789" height="186" alt="image" src="https://github.com/user-attachments/assets/41c4321b-a454-41fb-93e1-52319808ac37" />

<img width="789" height="183" alt="image" src="https://github.com/user-attachments/assets/804310ab-522b-4629-a70a-8b7d1f1051b6" />

<img width="845" height="43" alt="image" src="https://github.com/user-attachments/assets/11093144-f37e-4e5d-8a6b-5d485e1fb6a0" />


## Changelog
:cl:
tweak: Poisoned knife costs 4 TC in uplinks now, down from 6.
balance: Poisoned knife now has the same damage and embedding chance as a combat knife (20 damage and 65% respectively)
add: Poisoned knives inject their entire remaining payload if they embed successfully, up to 40u. High reward rule of cool payoff for those that want to gamble on a 65% chance. 
tweak: Poisoned knife now delivers 1/3 of its intended payload to targets that are protected from injection (Previously this was 1u regardless of intended injection amount)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
