### PR TITLE
Fixes weighted pick selecting things with 0 weight and modifying the source list

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -336,9 +336,11 @@
 	var/total = 0
 	var/item
 	for(item in list_to_pick)
-		if(!list_to_pick[item])
-			list_to_pick[item] = 1
 		total += list_to_pick[item]
+
+	// If everything has no weight set, then perform a standard pick
+	if (!total)
+		return pick(list_to_pick)
 
 	total *= rand()
 	for(item in list_to_pick)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -349,22 +349,6 @@
 			return item
 
 	return null
-///The original pick_weight proc will sometimes pick entries with zero weight. I'm not sure if changing the original will break anything, so I left it be.
-/proc/pick_weight_allow_zero(list/list_to_pick)
-	var/total = 0
-	var/item
-	for(item in list_to_pick)
-		if(!list_to_pick[item])
-			list_to_pick[item] = 0
-		total += list_to_pick[item]
-
-	total *= rand()
-	for(item in list_to_pick)
-		total -= list_to_pick[item]
-		if(total <= 0 && list_to_pick[item])
-			return item
-
-	return null
 
 /// Takes a weighted list (see above) and expands it into raw entries
 /// This eats more memory, but saves time when actually picking from it

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -563,7 +563,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/round_start_budget_left = round_start_budget
 
 	while (round_start_budget_left > 0)
-		var/datum/dynamic_ruleset/roundstart/ruleset = pick_weight_allow_zero(drafted_rules)
+		var/datum/dynamic_ruleset/roundstart/ruleset = pick_weight(drafted_rules)
 		if (isnull(ruleset))
 			log_game("DYNAMIC: No more rules can be applied, stopping with [round_start_budget] left.")
 			break

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -52,6 +52,6 @@
 		var/datum/round_event_control/round_event_control = new round_event_control_type
 		addtimer(CALLBACK(round_event_control, TYPE_PROC_REF(/datum/round_event_control, runEvent)), delay)
 	else
-		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight_allow_zero(possible_heavies)
+		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight(possible_heavies)
 		dynamic_log("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")
 		picking_specific_rule(heavy_ruleset, forced = TRUE, ignore_cost = TRUE)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -382,7 +382,7 @@
 		reports += config.mode_reports[report_type]
 		Count++
 	for(var/i in Count to rand(3,5)) //Between three and five wrong entries on the list.
-		var/false_report_type = pick_weight_allow_zero(report_weights)
+		var/false_report_type = pick_weight(report_weights)
 		report_weights[false_report_type] = 0 //Make it so the same false report won't be selected twice
 		reports += config.mode_reports[false_report_type]
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Weighted pick has a pretty horrible logic issue in it where if anything is passed in with 0 as the weight, it modifies the source list and adds 1. This logic is perhaps some of the most stupid logic I have ever seen, and is the last thing you would want as a failsafe behaviour for a weighted pick. I have changed it so that if a non-weighted list is passed in, or all the options are 0 then it instead just picks a random item from the list.

## Why It's Good For The Game

Why on earth would you ever want to modify the source list in what should be a pure function? It is so stupid its crazy, and it causes bugs such as mapvote picking maps that nobody actually voted for.

## Testing Photographs and Procedure

This is quite difficult to show, so here is a mapvote with me:

<img width="418" height="497" alt="image" src="https://github.com/user-attachments/assets/c391c1e5-a41b-4df9-902a-a91f62f832ce" />

<img width="344" height="160" alt="image" src="https://github.com/user-attachments/assets/f55f29d1-0aa4-47c6-896d-22eb25a78420" />

Numbers which make sense? In my space station? no...

To show that it still works if someone uses this method wrong, here is the job scaling items spawns, which uses pickweight wrong:

<img width="631" height="529" alt="image" src="https://github.com/user-attachments/assets/d8ac7015-3a98-4d50-99c4-713b94ed1eab" />


## Changelog
:cl:
fix: Fixes a bug in the pickweight algorithm which caused maps to be selected that had 0 votes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
